### PR TITLE
feat(app): render Mermaid diagrams safely

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -75,7 +75,7 @@
     "marked": "^17.0.1",
     "marked-emoji": "^2.0.3",
     "marked-katex-extension": "^5.1.10",
-    "marked-shiki": "^1.2.1",
+    "mermaid": "^11.17.1",
     "motion": "^12.38.0",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -67,6 +67,14 @@ describe("deriveOpenTargets", () => {
     expect(targets[0]).toMatchObject({ value: "summary.md", preview: "markdown", confidence: 95 });
   });
 
+  it("opens standalone Mermaid files through the Markdown preview", () => {
+    const targets = deriveOpenTargets([
+      toolMessage("msg_tool", "write", { path: "diagrams/architecture.mmd" }, { path: "diagrams/architecture.mmd" }),
+    ]);
+
+    expect(targets[0]).toMatchObject({ value: "diagrams/architecture.mmd", preview: "markdown", confidence: 95 });
+  });
+
   it("extracts filePath metadata from write tools", () => {
     const targets = deriveOpenTargets([
       toolMessage("msg_tool", "write", { filePath: "reports/summary.md" }, { filePath: "reports/summary.md" }),

--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -1,8 +1,7 @@
 import DOMPurify from "dompurify";
 import emojiKeywords from "emojilib";
-import { Marked, type Tokens } from "marked";
+import { Marked, type MarkedExtension, type Token, type Tokens } from "marked";
 import { markedEmoji } from "marked-emoji";
-import markedShiki from "marked-shiki";
 import {
   transformerMetaHighlight,
   transformerMetaWordHighlight,
@@ -47,7 +46,7 @@ const CODE_WRAP_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" heigh
 const INLINE_CODE_FILE_EXTENSIONS = new Set([
   "astro", "bash", "c", "cc", "cpp", "cs", "css", "dart", "docx", "ex", "exs", "gif", "go", "graphql",
   "h", "hpp", "htm", "html", "java", "jpeg", "jpg", "js", "json", "jsonc", "jsx", "key", "kt", "kts",
-  "lua", "markdown", "md", "mdx", "mjs", "cjs", "odp", "ods", "pdf", "php", "png", "pot", "potx",
+  "lua", "markdown", "md", "mdx", "mmd", "mjs", "cjs", "odp", "ods", "pdf", "php", "png", "pot", "potx",
   "ppt", "pptm", "pptx", "prisma", "py", "rb", "rs", "scss", "sh", "sql", "svelte", "svg", "swift",
   "toml", "ts", "tsv", "tsx", "txt", "log", "vue", "webp", "xls", "xlsx", "xml", "yaml", "yml", "zig",
 ]);
@@ -165,6 +164,18 @@ function chatCodeBlockHtml(text: string, lang: string | undefined) {
 
 function surfaceCodeBlockHtml(text: string, lang: string | undefined) {
   return `<pre class="my-4 overflow-x-auto rounded-[18px] border border-dls-border/70 bg-gray-1/80 px-4 py-3 text-xs leading-6 text-muted-foreground"><code${codeLanguageClass(lang)}>${escapeHtml(text)}</code></pre>`;
+}
+
+function isMermaidLanguage(lang: string | undefined) {
+  return lang?.trim().split(/\s+/)[0]?.toLowerCase() === "mermaid";
+}
+
+function mermaidBlockHtml(text: string, presentation: MarkdownPresentation) {
+  const borderClass = presentation === "surface" ? "border-dls-border/70" : "border-border/70";
+  const backgroundClass = presentation === "surface" ? "bg-gray-1/80" : "bg-gray-2/60";
+  const buttonClass = "rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50";
+
+  return `<div data-openwork-mermaid="" data-openwork-mermaid-state="source" aria-busy="false" class="my-4 overflow-hidden rounded-[18px] border ${borderClass} ${backgroundClass}"><div class="flex min-h-10 items-center gap-2 border-b ${borderClass} px-3 py-2"><span class="me-auto text-xs font-medium text-muted-foreground">Mermaid diagram</span><div role="group" aria-label="Diagram view" class="flex items-center gap-1"><button type="button" data-openwork-mermaid-view="rendered" class="${buttonClass}" aria-pressed="false" disabled>Rendered</button><button type="button" data-openwork-mermaid-view="source" class="${buttonClass}" aria-pressed="true">Source</button><button type="button" data-openwork-mermaid-download="" class="${buttonClass}" aria-label="Download diagram as SVG" hidden>Download SVG</button></div></div><div data-openwork-mermaid-rendered="" class="overflow-auto p-4 [&amp;&gt;svg]:mx-auto [&amp;&gt;svg]:h-auto [&amp;&gt;svg]:max-w-full" hidden></div><pre data-openwork-mermaid-source="" class="overflow-x-auto p-4 text-xs leading-6 text-foreground"><code class="language-mermaid">${escapeHtml(text)}</code></pre><p data-openwork-mermaid-status="" class="border-t ${borderClass} px-3 py-2 text-xs text-muted-foreground" aria-live="polite">Diagram source</p></div>`;
 }
 
 function parseShikiLanguage(lang: string) {
@@ -347,7 +358,7 @@ function renderImage(profile: MarkdownProfile, href: string, title: string | nul
   return `<img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="my-4 max-w-full rounded-[18px] border border-dls-border/70">`;
 }
 
-function createMarkedOptions(profile: MarkdownProfile, isAsync: boolean) {
+function createMarkedOptions(profile: MarkdownProfile, presentation: MarkdownPresentation, isAsync: boolean) {
   return {
     async: isAsync,
     breaks: false,
@@ -382,6 +393,7 @@ function createMarkedOptions(profile: MarkdownProfile, isAsync: boolean) {
         return `<blockquote class="${profile.blockquoteClassName}">${this.parser.parse(tokens)}</blockquote>`;
       },
       code({ text, lang }) {
+        if (isMermaidLanguage(lang)) return mermaidBlockHtml(text, presentation);
         return profile.codeBlockHtml(text, lang);
       },
       codespan({ text }) {
@@ -439,9 +451,50 @@ function markdownTransformers() {
   ];
 }
 
+function isCodeToken(token: Token): token is Tokens.Code {
+  return token.type === "code" && "text" in token && typeof token.text === "string";
+}
+
+async function highlightedCodeHtml(
+  token: Tokens.Code,
+  profile: MarkdownProfile,
+) {
+  const [rawLanguage = "text", ...props] = token.lang?.split(" ") ?? [];
+  const language = parseShikiLanguage(rawLanguage);
+  const html = profile.shikiTheme.kind === "dual"
+    ? await codeToHtml(token.text, {
+      lang: language,
+      meta: { __raw: props.join(" ") },
+      themes: {
+        light: profile.shikiTheme.light,
+        dark: profile.shikiTheme.dark,
+      },
+      transformers: markdownTransformers(),
+    })
+    : await codeToHtml(token.text, {
+      lang: language,
+      meta: { __raw: props.join(" ") },
+      theme: profile.shikiTheme.theme,
+      transformers: markdownTransformers(),
+    });
+
+  return profile.shikiContainer.replace("%s", html);
+}
+
+function highlightedCodeExtension(profile: MarkdownProfile): MarkedExtension<string, string> {
+  return {
+    async: true,
+    async walkTokens(token) {
+      if (!isCodeToken(token) || isMermaidLanguage(token.lang)) return;
+      const html = await highlightedCodeHtml(token, profile);
+      Object.assign(token, { type: "html", block: true, text: `${html}\n` });
+    },
+  };
+}
+
 function createMarkdownParsers(presentation: MarkdownPresentation) {
   const profile = markdownProfileForPresentation(presentation);
-  const markdownParser = new Marked<string, string>(createMarkedOptions(profile, false)).use(
+  const markdownParser = new Marked<string, string>(createMarkedOptions(profile, presentation, false)).use(
     markedEmoji({
       emojis: emojiAliases,
       renderer: (token) => escapeHtml(token.emoji),
@@ -450,37 +503,13 @@ function createMarkdownParsers(presentation: MarkdownPresentation) {
   );
   // Math must be registered on both parsers, otherwise formulas would flicker away
   // when a message containing a fenced code block upgrades to the Shiki render.
-  const highlightedMarkdownParser = new Marked<string, string>(createMarkedOptions(profile, true)).use(
+  const highlightedMarkdownParser = new Marked<string, string>(createMarkedOptions(profile, presentation, true)).use(
     markedEmoji({
       emojis: emojiAliases,
       renderer: (token) => escapeHtml(token.emoji),
     }),
     markdownMath(),
-    markedShiki({
-      async highlight(code, lang, props) {
-        const language = parseShikiLanguage(lang);
-
-        if (profile.shikiTheme.kind === "dual") {
-          return codeToHtml(code, {
-            lang: language,
-            meta: { __raw: props.join(" ") },
-            themes: {
-              light: profile.shikiTheme.light,
-              dark: profile.shikiTheme.dark,
-            },
-            transformers: markdownTransformers(),
-          });
-        }
-
-        return codeToHtml(code, {
-          lang: language,
-          meta: { __raw: props.join(" ") },
-          theme: profile.shikiTheme.theme,
-          transformers: markdownTransformers(),
-        });
-      },
-      container: profile.shikiContainer,
-    }),
+    highlightedCodeExtension(profile),
   );
 
   return { markdownParser, highlightedMarkdownParser };

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -21,6 +21,7 @@ import {
   syncMarkdownImagePreviews,
 } from "./markdown-primitive";
 import { LinkActionMenu } from "./link-action-menu";
+import { useMermaidEnhancer } from "./mermaid";
 import { useSelectionStableValue } from "./selection-stability";
 
 export { renderHighlightedMarkdownHtml, renderMarkdownHtml } from "./markdown-primitive";
@@ -185,6 +186,7 @@ function MarkdownBlockInner({
   const candidateHtml = !streaming && highlightedHtml?.text === text ? highlightedHtml.html : syncHtml;
   const html = useSelectionStableValue(rootRef, candidateHtml);
   const stableInnerHtml = useMemo(() => ({ __html: html }), [html]);
+  useMermaidEnhancer(rootRef, html, !streaming);
 
   // Keep the innerHTML prop referentially stable too: a fresh wrapper object
   // can make an unrelated React render replace selected text nodes even when

--- a/apps/app/src/components/markdown/mermaid.ts
+++ b/apps/app/src/components/markdown/mermaid.ts
@@ -32,7 +32,7 @@ export type MermaidRenderResult =
   | { status: "rendered"; svg: string }
   | { status: "source"; reason: "size" | "complexity" | "unsafe" | "invalid" | "timeout" | "unavailable" };
 
-const MERMAID_ARROW_PATTERN = /(?:-->|---|-.->|==>|~~~|<-->|<==>)/g;
+const MERMAID_ARROW_PATTERN = /(?:--!?>|---|-.->|==>|~~~|<--!?>|<==>)/g;
 const MERMAID_NODE_DECLARATION_PATTERN = /\b([A-Za-z_][\w-]{0,63})\s*(?=\[|\(\(|\(\[|\{|>)/g;
 const MERMAID_PARTICIPANT_PATTERN = /^\s*(?:participant|actor|class|entity|state)\s+([A-Za-z_][\w-]{0,63})\b/gm;
 const MERMAID_URL_ATTRIBUTES = new Set([

--- a/apps/app/src/components/markdown/mermaid.ts
+++ b/apps/app/src/components/markdown/mermaid.ts
@@ -1,0 +1,417 @@
+import DOMPurify from "dompurify";
+import { useEffect, useSyncExternalStore, type RefObject } from "react";
+import type { MermaidConfig } from "mermaid";
+
+import {
+  getResolvedThemeMode,
+  subscribeToTheme,
+  type ResolvedThemeMode,
+} from "@/app/theme";
+
+export const MERMAID_LIMITS = {
+  maxSourceBytes: 50_000,
+  maxNodes: 250,
+  maxEdges: 400,
+  maxStatements: 400,
+  maxLines: 800,
+  renderTimeoutMs: 5_000,
+};
+
+export type MermaidGuardResult =
+  | { ok: true }
+  | { ok: false; reason: "size" | "complexity" | "unsafe"; message: string };
+
+export type MermaidRuntime = {
+  initialize: (config: MermaidConfig) => void;
+  render: (id: string, source: string) => Promise<{ svg: string }>;
+};
+
+export type MermaidRuntimeLoader = () => Promise<MermaidRuntime>;
+
+export type MermaidRenderResult =
+  | { status: "rendered"; svg: string }
+  | { status: "source"; reason: "size" | "complexity" | "unsafe" | "invalid" | "timeout" | "unavailable" };
+
+const MERMAID_ARROW_PATTERN = /(?:-->|---|-.->|==>|~~~|<-->|<==>)/g;
+const MERMAID_NODE_DECLARATION_PATTERN = /\b([A-Za-z_][\w-]{0,63})\s*(?=\[|\(\(|\(\[|\{|>)/g;
+const MERMAID_PARTICIPANT_PATTERN = /^\s*(?:participant|actor|class|entity|state)\s+([A-Za-z_][\w-]{0,63})\b/gm;
+const MERMAID_URL_ATTRIBUTES = new Set([
+  "clip-path",
+  "cursor",
+  "fill",
+  "filter",
+  "marker-end",
+  "marker-mid",
+  "marker-start",
+  "mask",
+  "stroke",
+]);
+const MERMAID_REDIRECT_ATTRIBUTES = new Set(["href", "src", "xlink:href"]);
+const MERMAID_FORBIDDEN_ELEMENTS = "a,foreignObject,image,iframe,object,embed,script,use";
+const mermaidSvgByElement = new WeakMap<HTMLElement, string>();
+
+let mermaidRuntimePromise: Promise<MermaidRuntime> | null = null;
+let mermaidRenderQueue: Promise<void> = Promise.resolve();
+let mermaidRenderId = 0;
+
+export function normalizeCssEscapes(value: string) {
+  return value
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\\(?:\r\n|[\n\r\f])/g, "")
+    .replace(
+      /\\([0-9a-fA-F]{1,6})[ \t\r\n\f]?|\\([^\n\r\f])/g,
+      (_match: string, hex: string | undefined, escaped: string | undefined) => {
+        if (!hex) return escaped ?? "";
+        const codePoint = Number.parseInt(hex, 16);
+        if (codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+          return "\uFFFD";
+        }
+        return String.fromCodePoint(codePoint);
+      },
+    );
+}
+
+function hasUnsafeMermaidSource(source: string) {
+  const normalized = normalizeCssEscapes(source);
+  if (/%%\s*\{\s*(?:init|config)\s*:/i.test(normalized)) return true;
+  if (/(?:^|[;\n\r])\s*click(?:\s|$)/i.test(normalized)) return true;
+
+  const frontmatter = /^\s*---[^\S\r\n]*(?:\r?\n)([\s\S]*?)(?:\r?\n)---/.exec(normalized);
+  if (frontmatter?.[1] && /(?:^|\n)\s*config\s*:/i.test(frontmatter[1])) return true;
+
+  return /(?:javascript|data|blob|file|https?|wss?|ftp)\s*:|\/\/|@import\b|\burl\s*\(|\b(?:href|src|xlink:href)\s*=/i
+    .test(normalized);
+}
+
+function countMermaidStatements(source: string) {
+  let count = 0;
+  for (const statement of source.split(/[;\n]/)) {
+    const trimmed = statement.trim();
+    if (trimmed && !trimmed.startsWith("%%")) count += 1;
+  }
+  return count;
+}
+
+function estimateMermaidNodes(source: string) {
+  const nodes = new Set<string>();
+
+  for (const match of source.matchAll(MERMAID_NODE_DECLARATION_PATTERN)) {
+    if (match[1]) nodes.add(match[1]);
+  }
+
+  for (const match of source.matchAll(MERMAID_PARTICIPANT_PATTERN)) {
+    if (match[1]) nodes.add(match[1]);
+  }
+
+  for (const line of source.split("\n")) {
+    if (!MERMAID_ARROW_PATTERN.test(line)) {
+      MERMAID_ARROW_PATTERN.lastIndex = 0;
+      continue;
+    }
+    MERMAID_ARROW_PATTERN.lastIndex = 0;
+    const withoutLabels = line.replace(/\[[^\]\n]*\]|\([^\)\n]*\)|\{[^}\n]*\}/g, "");
+    const segments = withoutLabels.split(MERMAID_ARROW_PATTERN);
+    MERMAID_ARROW_PATTERN.lastIndex = 0;
+
+    for (const segment of segments) {
+      const identifiers = segment.match(/[A-Za-z_][\w-]{0,63}/g);
+      const identifier = identifiers?.at(-1);
+      if (identifier) nodes.add(identifier);
+    }
+  }
+
+  return nodes.size;
+}
+
+export function guardMermaidSource(source: string): MermaidGuardResult {
+  if (source.length > MERMAID_LIMITS.maxSourceBytes) {
+    return { ok: false, reason: "size", message: "Diagram source is too large to render safely." };
+  }
+  const sourceBytes = new TextEncoder().encode(source).byteLength;
+  if (sourceBytes > MERMAID_LIMITS.maxSourceBytes) {
+    return { ok: false, reason: "size", message: "Diagram source is too large to render safely." };
+  }
+
+  if (hasUnsafeMermaidSource(source)) {
+    return { ok: false, reason: "unsafe", message: "Diagram source contains unsafe directives or resources." };
+  }
+
+  const lines = source.split("\n").length;
+  const statements = countMermaidStatements(source);
+  const edges = source.match(MERMAID_ARROW_PATTERN)?.length ?? 0;
+  MERMAID_ARROW_PATTERN.lastIndex = 0;
+  const nodes = estimateMermaidNodes(source);
+  if (
+    lines > MERMAID_LIMITS.maxLines ||
+    statements > MERMAID_LIMITS.maxStatements ||
+    edges > MERMAID_LIMITS.maxEdges ||
+    nodes > MERMAID_LIMITS.maxNodes
+  ) {
+    return { ok: false, reason: "complexity", message: "Diagram is too complex to render safely." };
+  }
+
+  return { ok: true };
+}
+
+export function mermaidConfigForTheme(theme: ResolvedThemeMode): MermaidConfig {
+  return {
+    arrowMarkerAbsolute: false,
+    deterministicIds: false,
+    flowchart: { htmlLabels: false },
+    htmlLabels: false,
+    logLevel: "fatal",
+    maxEdges: MERMAID_LIMITS.maxEdges,
+    maxTextSize: MERMAID_LIMITS.maxSourceBytes,
+    secure: [
+      "dompurifyConfig",
+      "flowchart",
+      "htmlLabels",
+      "maxEdges",
+      "maxTextSize",
+      "secure",
+      "securityLevel",
+      "startOnLoad",
+      "theme",
+      "themeCSS",
+      "themeVariables",
+    ],
+    securityLevel: "strict",
+    startOnLoad: false,
+    suppressErrorRendering: true,
+    theme: theme === "dark" ? "dark" : "default",
+  };
+}
+
+export function isSafeMermaidSvgReference(value: string) {
+  const normalized = normalizeCssEscapes(value).trim();
+  if (!normalized) return true;
+  if (/@import|(?:expression|behavior)\s*\(|-moz-binding/i.test(normalized)) return false;
+  if (/(?:javascript|data|blob|file|https?|ftp):|(?:^|[\s("'=])\/\//i.test(normalized)) return false;
+
+  for (const match of normalized.matchAll(/url\(\s*(['"]?)(.*?)\1\s*\)/gi)) {
+    if (!/^#[A-Za-z_][\w:.-]*$/.test(match[2]?.trim() ?? "")) return false;
+  }
+
+  return true;
+}
+
+export function sanitizeMermaidSvg(svg: string) {
+  if (typeof DOMPurify.sanitize !== "function" || typeof DOMParser === "undefined" || typeof XMLSerializer === "undefined") {
+    throw new MermaidSanitizerUnavailableError();
+  }
+
+  const clean = DOMPurify.sanitize(svg, {
+    ALLOW_UNKNOWN_PROTOCOLS: false,
+    FORBID_ATTR: ["href", "src", "xlink:href"],
+    FORBID_TAGS: ["a", "embed", "foreignObject", "iframe", "image", "object", "script", "use"],
+    USE_PROFILES: { svg: true, svgFilters: true },
+  });
+  const parsed = new DOMParser().parseFromString(clean, "image/svg+xml");
+  const root = parsed.documentElement;
+  if (root.localName !== "svg" || parsed.querySelector("parsererror")) {
+    throw new Error("Mermaid returned invalid SVG.");
+  }
+
+  for (const forbidden of Array.from(root.querySelectorAll(MERMAID_FORBIDDEN_ELEMENTS))) {
+    forbidden.remove();
+  }
+
+  for (const element of [root, ...Array.from(root.querySelectorAll("*"))]) {
+    for (const attribute of Array.from(element.attributes)) {
+      const name = attribute.name.toLowerCase();
+      if (
+        name.startsWith("on") ||
+        MERMAID_REDIRECT_ATTRIBUTES.has(name) ||
+        ((name === "style" || MERMAID_URL_ATTRIBUTES.has(name)) && !isSafeMermaidSvgReference(attribute.value))
+      ) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+
+    if (element.localName === "style" && !isSafeMermaidSvgReference(element.textContent ?? "")) {
+      element.remove();
+    }
+  }
+
+  if (!root.hasAttribute("xmlns")) root.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  return new XMLSerializer().serializeToString(root);
+}
+
+class MermaidTimeoutError extends Error {}
+class MermaidSanitizerUnavailableError extends Error {}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  return new Promise<T>((resolve, reject) => {
+    const timer = globalThis.setTimeout(() => reject(new MermaidTimeoutError()), timeoutMs);
+    void promise.then(resolve, reject).finally(() => globalThis.clearTimeout(timer));
+  });
+}
+
+async function loadMermaidRuntime() {
+  mermaidRuntimePromise ??= import("mermaid").then((module) => module.default);
+  try {
+    return await mermaidRuntimePromise;
+  } catch (cause) {
+    mermaidRuntimePromise = null;
+    throw cause;
+  }
+}
+
+function enqueueMermaidRender<T>(render: () => Promise<T>) {
+  const result = mermaidRenderQueue.then(render, render);
+  mermaidRenderQueue = result.then(() => undefined, () => undefined);
+  return result;
+}
+
+export async function renderMermaidSource(
+  source: string,
+  theme: ResolvedThemeMode,
+  options: { loadRuntime?: MermaidRuntimeLoader; timeoutMs?: number } = {},
+): Promise<MermaidRenderResult> {
+  const guard = guardMermaidSource(source);
+  if (!guard.ok) return { status: "source", reason: guard.reason };
+
+  const loadRuntime = options.loadRuntime ?? loadMermaidRuntime;
+  const timeoutMs = options.timeoutMs ?? MERMAID_LIMITS.renderTimeoutMs;
+
+  return enqueueMermaidRender(async () => {
+    let loaded = false;
+    try {
+      const rendered = await withTimeout((async () => {
+        const runtime = await loadRuntime();
+        loaded = true;
+        runtime.initialize(mermaidConfigForTheme(theme));
+        mermaidRenderId += 1;
+        return runtime.render(`openwork-mermaid-${mermaidRenderId}`, source);
+      })(), timeoutMs);
+
+      return { status: "rendered", svg: sanitizeMermaidSvg(rendered.svg) };
+    } catch (cause) {
+      if (cause instanceof MermaidTimeoutError) return { status: "source", reason: "timeout" };
+      if (cause instanceof MermaidSanitizerUnavailableError || !loaded) return { status: "source", reason: "unavailable" };
+      return { status: "source", reason: "invalid" };
+    }
+  });
+}
+
+function sourceStatus(reason: Exclude<MermaidRenderResult, { status: "rendered" }>["reason"]) {
+  if (reason === "size") return "Diagram source is too large. Showing source.";
+  if (reason === "complexity") return "Diagram is too complex. Showing source.";
+  if (reason === "unsafe") return "Diagram contains unsafe directives or resources. Showing source.";
+  if (reason === "timeout") return "Diagram rendering timed out. Showing source.";
+  if (reason === "unavailable") return "Diagram rendering is unavailable. Showing source.";
+  return "Diagram could not be rendered. Showing source.";
+}
+
+function setMermaidView(element: HTMLElement, view: "rendered" | "source") {
+  const rendered = element.querySelector("[data-openwork-mermaid-rendered]");
+  const source = element.querySelector("[data-openwork-mermaid-source]");
+  const renderedButton = element.querySelector("[data-openwork-mermaid-view='rendered']");
+  const sourceButton = element.querySelector("[data-openwork-mermaid-view='source']");
+  if (!(rendered instanceof HTMLElement) || !(source instanceof HTMLElement)) return;
+
+  const showRendered = view === "rendered" && mermaidSvgByElement.has(element);
+  rendered.hidden = !showRendered;
+  source.hidden = showRendered;
+  element.dataset.openworkMermaidState = showRendered ? "rendered" : "source";
+  renderedButton?.setAttribute("aria-pressed", String(showRendered));
+  sourceButton?.setAttribute("aria-pressed", String(!showRendered));
+  renderedButton?.classList.toggle("bg-muted", showRendered);
+  renderedButton?.classList.toggle("text-foreground", showRendered);
+  sourceButton?.classList.toggle("bg-muted", !showRendered);
+  sourceButton?.classList.toggle("text-foreground", !showRendered);
+}
+
+async function enhanceMermaidElement(element: HTMLElement, theme: ResolvedThemeMode, signal: AbortSignal) {
+  const code = element.querySelector("[data-openwork-mermaid-source] code");
+  const renderedPane = element.querySelector("[data-openwork-mermaid-rendered]");
+  const renderedButton = element.querySelector("[data-openwork-mermaid-view='rendered']");
+  const downloadButton = element.querySelector("[data-openwork-mermaid-download]");
+  const status = element.querySelector("[data-openwork-mermaid-status]");
+  if (!(code instanceof HTMLElement) || !(renderedPane instanceof HTMLElement)) return;
+
+  element.setAttribute("aria-busy", "true");
+  if (status instanceof HTMLElement) {
+    status.hidden = false;
+    status.textContent = "Rendering diagram…";
+  }
+
+  const result = await renderMermaidSource(code.textContent ?? "", theme);
+  if (signal.aborted || !element.isConnected) return;
+  const preserveSource = mermaidSvgByElement.has(element) && element.dataset.openworkMermaidState === "source";
+
+  element.setAttribute("aria-busy", "false");
+  if (result.status === "source") {
+    mermaidSvgByElement.delete(element);
+    renderedPane.replaceChildren();
+    element.dataset.openworkMermaidReason = result.reason;
+    if (renderedButton instanceof HTMLButtonElement) renderedButton.disabled = true;
+    if (downloadButton instanceof HTMLButtonElement) downloadButton.hidden = true;
+    if (status instanceof HTMLElement) status.textContent = sourceStatus(result.reason);
+    setMermaidView(element, "source");
+    return;
+  }
+
+  delete element.dataset.openworkMermaidReason;
+  renderedPane.innerHTML = result.svg;
+  mermaidSvgByElement.set(element, result.svg);
+  element.dataset.openworkMermaidTheme = theme;
+  if (renderedButton instanceof HTMLButtonElement) renderedButton.disabled = false;
+  if (downloadButton instanceof HTMLButtonElement) downloadButton.hidden = false;
+  if (status instanceof HTMLElement) status.hidden = true;
+  setMermaidView(element, preserveSource ? "source" : "rendered");
+}
+
+export function useMermaidEnhancer(
+  rootRef: RefObject<HTMLElement | null>,
+  html: string,
+  enabled = true,
+) {
+  const theme = useSyncExternalStore(subscribeToTheme, getResolvedThemeMode, getResolvedThemeMode);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root || !enabled) return;
+
+    const controller = new AbortController();
+    const diagrams = Array.from(root.querySelectorAll("[data-openwork-mermaid]"))
+      .filter((element): element is HTMLElement => element instanceof HTMLElement);
+
+    const handleClick = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) return;
+      const button = event.target.closest("button");
+      const diagram = button?.closest("[data-openwork-mermaid]");
+      if (!(button instanceof HTMLButtonElement) || !(diagram instanceof HTMLElement)) return;
+
+      const view = button.dataset.openworkMermaidView;
+      if (view === "source" || view === "rendered") {
+        event.preventDefault();
+        setMermaidView(diagram, view);
+        return;
+      }
+
+      if (!button.hasAttribute("data-openwork-mermaid-download")) return;
+      const svg = mermaidSvgByElement.get(diagram);
+      if (!svg) return;
+
+      event.preventDefault();
+      const index = diagrams.indexOf(diagram) + 1;
+      const url = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `diagram-${Math.max(1, index)}.svg`;
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1_000);
+    };
+
+    root.addEventListener("click", handleClick);
+    for (const diagram of diagrams) void enhanceMermaidElement(diagram, theme, controller.signal);
+
+    return () => {
+      controller.abort();
+      root.removeEventListener("click", handleClick);
+    };
+  }, [enabled, html, rootRef, theme]);
+}

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -35,7 +35,7 @@ const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
 const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i;
 
 export function isMarkdownPreviewSupported(extension: string) {
-  return ["md", "markdown", "mdx"].includes(extension);
+  return ["md", "markdown", "mdx", "mmd"].includes(extension);
 }
 
 export function isSheetPreviewSupported(extension: string) {
@@ -69,7 +69,7 @@ export function getArtifactType(filename: string): ArtifactType {
     return "unknown";
   }
 
-  if (["md", "markdown", "mdx", "rmd", "rst"].includes(extension)) {
+  if (["md", "markdown", "mdx", "mmd", "rmd", "rst"].includes(extension)) {
     return "markdown";
   }
 

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -33,17 +33,6 @@ const WorkspaceFileTree = lazy(() =>
 );
 
 const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
-const MARKDOWN_PRIMITIVE_EVAL_ARTIFACT_PATH = "artifacts/markdown-primitive-proof.md";
-const MARKDOWN_PRIMITIVE_EVAL_ARTIFACT_NAME = "markdown-primitive-proof.md";
-
-function isMarkdownPrimitiveEvalArtifact(target: OpenTarget) {
-  return import.meta.env.DEV &&
-    target.kind === "file" &&
-    target.reason === "eval" &&
-    target.value === MARKDOWN_PRIMITIVE_EVAL_ARTIFACT_PATH &&
-    target.name === MARKDOWN_PRIMITIVE_EVAL_ARTIFACT_NAME;
-}
-
 type ArtifactPanelProps = {
   sessionId: string;
   tab: ArtifactPanelTab;
@@ -111,11 +100,10 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
   const [draft, setDraft] = useState("");
   const lastSyncedRef = useRef<string | null>(null);
   const failedDraftRef = useRef<string | null>(null);
-  // Markdown and plain text open straight into the CodeMirror editor, and
-  // code opens straight into Pierre's highlighted editor. Only HTML stays
-  // behind the Edit toggle, because its default view is the rendered page.
-  const isDirectTextEdit = isTextContent(target) &&
-    (target.preview === "text" || (target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target)));
+  const isMermaidArtifact = target.kind === "file" && /\.mmd$/i.test(target.value);
+  // Plain text opens directly in CodeMirror. Markdown and HTML default to
+  // their rendered previews and retain the existing Edit toggle.
+  const isDirectTextEdit = isTextContent(target) && target.preview === "text";
   const isDirectCodeEdit = target.kind === "file" && target.preview === "code";
   const canUseDesktopWorkspaceActions = !isRemoteWorkspace && platform.capabilities.revealInFileManager;
   const canUseDesktopFileActions = target.kind === "file" && canUseDesktopWorkspaceActions;
@@ -419,7 +407,7 @@ function ArtifactPanelView({ sessionId, client, workspaceId, workspaceRoot, isRe
         ) : data?.kind === "text" && (editing || isDirectTextEdit) ? (
           <TextEditor value={draft} language={target.preview === "markdown" ? "markdown" : "text"} onChange={setDraft} />
         ) : target.preview === "markdown" && data?.kind === "text" ? (
-          <MarkdownPreview content={data.data} />
+          <MarkdownPreview content={data.data} mermaidSource={isMermaidArtifact} />
         ) : target.preview === "code" && data?.kind === "text" ? (
           <Suspense fallback={<PreviewLoading />}>
             <ArtifactCodeView

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -105,7 +105,7 @@ function extname(value: string) {
 function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPreview {
   if (kind === "url") return "browser";
   const ext = extname(value);
-  if ([".md", ".markdown", ".mdx"].includes(ext)) return "markdown";
+  if ([".md", ".markdown", ".mdx", ".mmd"].includes(ext)) return "markdown";
   if ([".csv", ".tsv", ".xlsx", ".xls", ".ods"].includes(ext)) return "sheet";
   if ([".ppt", ".pptx", ".pptm", ".pot", ".potx", ".odp", ".key", ".sxi"].includes(ext)) return "slides";
   if (ext === ".docx") return "document";

--- a/apps/app/src/react-app/domains/session/artifacts/preview.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/preview.tsx
@@ -33,12 +33,24 @@ export function PlainText({ content, className, ...props }: PlainTextProps) {
 
 interface MarkdownPreviewProps extends React.ComponentProps<"div"> {
   content: string;
+  mermaidSource?: boolean;
 }
 
-export function MarkdownPreview({ content, className, ...props }: MarkdownPreviewProps) {
+function mermaidSourceMarkdown(content: string) {
+  let longestBacktickRun = 2;
+  let currentBacktickRun = 0;
+  for (const character of content) {
+    currentBacktickRun = character === "`" ? currentBacktickRun + 1 : 0;
+    if (currentBacktickRun > longestBacktickRun) longestBacktickRun = currentBacktickRun;
+  }
+  const fence = "`".repeat(longestBacktickRun + 1);
+  return `${fence}mermaid\n${content}\n${fence}`;
+}
+
+export function MarkdownPreview({ content, mermaidSource = false, className, ...props }: MarkdownPreviewProps) {
   return (
-    <div data-openwork-markdown-preview="" className={cn("h-full overflow-auto p-4", className)} {...props}>
-      <MarkdownBlock text={content} />
+    <div data-openwork-markdown-preview="" data-openwork-mermaid-artifact={mermaidSource ? "" : undefined} className={cn("h-full overflow-auto p-4", className)} {...props}>
+      <MarkdownBlock text={mermaidSource ? mermaidSourceMarkdown(content) : content} />
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -68,7 +68,15 @@ The artifact preview keeps **outside-chat Markdown** readable with inline \`surf
 \`\`\`ts
 const surface = "shared markdown primitive";
 console.log(surface);
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  ArtifactStart[Artifact Mermaid Start] --> ArtifactFinish[Artifact Mermaid Finish]
 \`\`\``;
+
+const STANDALONE_MERMAID_ARTIFACT_CONTENT = `flowchart TD
+  StandaloneStart[Standalone Mermaid] --> StandaloneFinish[Rendered artifact]`;
 
 type SidePanelTabProps = {
   tab: PanelTabEntry;
@@ -491,13 +499,16 @@ export function SidePanel({
       description: "Create a deterministic markdown artifact and open it in the preview panel.",
       sideEffect: "mutation",
       disabled: !client || !workspaceId,
-      execute: async () => {
+      execute: async (args) => {
         if (!client || !workspaceId) return { ok: false, error: "Workspace client is not ready." };
 
-        const value = "artifacts/markdown-primitive-proof.md";
+        const standalone = Boolean(args && typeof args === "object" && "standalone" in args && args.standalone);
+        const value = standalone ? "artifacts/standalone-mermaid-proof.mmd" : "artifacts/markdown-primitive-proof.md";
+        const name = standalone ? "standalone-mermaid-proof.mmd" : "markdown-primitive-proof.md";
+        const content = standalone ? STANDALONE_MERMAID_ARTIFACT_CONTENT : MARKDOWN_PRIMITIVE_ARTIFACT_CONTENT;
         await client.writeWorkspaceFile(workspaceId, {
           path: value,
-          content: MARKDOWN_PRIMITIVE_ARTIFACT_CONTENT,
+          content,
           baseUpdatedAt: null,
         });
 
@@ -505,12 +516,12 @@ export function SidePanel({
           id: `file:${value}`,
           kind: "file",
           value,
-          name: "markdown-primitive-proof.md",
+          name,
           preview: "markdown",
           confidence: 100,
           reason: "eval",
           exists: true,
-          size: MARKDOWN_PRIMITIVE_ARTIFACT_CONTENT.length,
+          size: content.length,
         };
 
         const store = usePanelTabStore.getState();

--- a/apps/app/src/react-app/domains/session/surface/markdown.tsx
+++ b/apps/app/src/react-app/domains/session/surface/markdown.tsx
@@ -8,6 +8,7 @@ import {
   renderMarkdownHtml,
 } from "@/components/markdown/markdown-primitive";
 import { useSelectionStableValue } from "@/components/markdown/selection-stability";
+import { useMermaidEnhancer } from "@/components/markdown/mermaid";
 
 function MarkdownBlockInner(props: {
   text: string;
@@ -40,6 +41,7 @@ function MarkdownBlockInner(props: {
   const candidateHtml = !props.streaming && highlightedHtml?.text === props.text ? highlightedHtml.html : syncHtml;
   const html = useSelectionStableValue(rootRef, candidateHtml);
   const stableInnerHtml = useMemo(() => ({ __html: html }), [html]);
+  useMermaidEnhancer(rootRef, html, !props.streaming);
 
   useEffect(() => {
     const root = rootRef.current;

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -9,6 +9,7 @@ import { toast } from "@/components/ui/sonner";
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
+import { setThemeMode } from "@/app/theme";
 import { t } from "@/i18n";
 import type { ComposerSettingsSection } from "@/react-app/domains/settings/library";
 import { type CloudImportedPlugin } from "@/app/cloud/import-state";
@@ -99,6 +100,7 @@ import type {
   ChatToolReconnectResult,
 } from "@/components/tools/error-attribution";
 import { useChatMcpReconnectStore } from "@/components/tools/mcp-reconnect-state";
+import { MERMAID_LIMITS } from "@/components/markdown/mermaid";
 import {
   isChatMcpReconnectScopeCurrent,
   waitForFreshMcpAuthorization,
@@ -133,6 +135,11 @@ This shared renderer keeps **bold proof text**, inline \`renderMarkdownHtml\`, a
 \`\`\`ts
 const pipeline = "shared markdown primitive";
 console.log(pipeline);
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  InlineStart[Inline Mermaid Start] --> InlineFinish[Inline Mermaid Finish]
 \`\`\`
 
 Search token: markdown-primitive-highlight.`;
@@ -170,6 +177,25 @@ type SessionError = {
 function createMarkdownPrimitiveEvalMessages(sessionId: string) {
   const userMessageId = `${sessionId}:eval-markdown-user`;
   const assistantMessageId = `${sessionId}:eval-markdown-assistant`;
+  const guardedDiagram = [
+    "flowchart TD",
+    ...Array.from({ length: MERMAID_LIMITS.maxNodes + 1 }, (_, index) => `Guard${index}[Guard node ${index}]`),
+  ].join("\n");
+  const proofText = `${MARKDOWN_PRIMITIVE_EVAL_TEXT}
+
+\`\`\`mermaid
+flowchart LR
+  Remote[No remote resources] --> Safe[Sanitized SVG]
+  click Remote "https://example.com/redirect"
+\`\`\`
+
+\`\`\`mermaid
+not-a-mermaid-diagram
+\`\`\`
+
+\`\`\`mermaid
+${guardedDiagram}
+\`\`\``;
   const messages: UIMessage[] = [
     {
       id: userMessageId,
@@ -180,7 +206,7 @@ function createMarkdownPrimitiveEvalMessages(sessionId: string) {
     {
       id: assistantMessageId,
       role: "assistant",
-      parts: [{ type: "text", text: MARKDOWN_PRIMITIVE_EVAL_TEXT }],
+      parts: [{ type: "text", text: proofText }],
       metadata: { opencode: { created: Date.now() + 1 } },
     },
   ];
@@ -1118,6 +1144,24 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId]);
   useControlAction(props.isControlTarget ? seedMarkdownPrimitiveControlAction : null);
+  const setMermaidEvalThemeControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.mermaid.set_theme",
+      label: "Set the Mermaid eval theme",
+      description: "Dev-only eval hook that changes the app theme through the production theme API.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: (args) => {
+        const mode = args && typeof args === "object" && "mode" in args ? args.mode : null;
+        if (mode !== "light" && mode !== "dark") throw new Error("Mermaid eval theme must be light or dark.");
+        setThemeMode(mode);
+        return { ok: true, mode };
+      },
+    };
+  }, [props.sessionId]);
+  useControlAction(props.isControlTarget ? setMermaidEvalThemeControlAction : null);
   const seedMarkdownMathControlAction = useMemo<OpenworkControlAction | null>(() => {
     if (!import.meta.env.DEV) return null;
 

--- a/apps/app/tests/markdown-mermaid.test.ts
+++ b/apps/app/tests/markdown-mermaid.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  renderHighlightedMarkdownHtml,
+  renderMarkdownHtml,
+  type MarkdownPresentation,
+} from "../src/components/markdown/markdown-primitive";
+import { getArtifactType, isMarkdownPreviewSupported } from "../src/lib/artifacts";
+import {
+  guardMermaidSource,
+  isSafeMermaidSvgReference,
+  MERMAID_LIMITS,
+  mermaidConfigForTheme,
+  normalizeCssEscapes,
+  renderMermaidSource,
+  type MermaidRuntime,
+} from "../src/components/markdown/mermaid";
+
+const SOURCE = "flowchart LR\n  Start[Start] --> Finish[Finish]";
+const MARKDOWN = `\`\`\`mermaid\n${SOURCE}\n\`\`\``;
+
+describe("Mermaid Markdown placeholders", () => {
+  test("parses Mermaid fences into inert source fallbacks for chat and artifact surfaces", async () => {
+    const presentations: MarkdownPresentation[] = ["chat", "surface"];
+    for (const presentation of presentations) {
+      const fallback = renderMarkdownHtml(MARKDOWN, presentation);
+      const highlighted = await renderHighlightedMarkdownHtml(MARKDOWN, presentation);
+
+      for (const html of [fallback, highlighted]) {
+        expect(html).toContain("data-openwork-mermaid");
+        expect(html).toContain("data-openwork-mermaid-source");
+        expect(html).toContain("data-openwork-mermaid-view=\"rendered\"");
+        expect(html).toContain("data-openwork-mermaid-download");
+        expect(html).toContain("Start[Start] --&gt; Finish[Finish]");
+        expect(html).not.toContain("<svg");
+      }
+    }
+  });
+
+  test("leaves non-Mermaid fences on the existing code path", () => {
+    const html = renderMarkdownHtml("```ts\nconst diagram = false;\n```");
+    expect(html).toContain("data-openwork-code-block");
+    expect(html).not.toContain("data-openwork-mermaid");
+  });
+
+  test("classifies standalone Mermaid source as a Markdown artifact", () => {
+    expect(getArtifactType("diagrams/architecture.mmd")).toBe("markdown");
+    expect(isMarkdownPreviewSupported("mmd")).toBe(true);
+  });
+});
+
+describe("Mermaid rendering boundaries", () => {
+  test("guards source bytes, nodes, edges, and semicolon-separated statements before loading Mermaid", async () => {
+    expect(guardMermaidSource("x".repeat(MERMAID_LIMITS.maxSourceBytes + 1))).toMatchObject({ ok: false, reason: "size" });
+    const complex = [
+      "flowchart TD",
+      ...Array.from({ length: MERMAID_LIMITS.maxNodes + 1 }, (_, index) => `N${index}[Node ${index}]`),
+    ].join("\n");
+    expect(guardMermaidSource(complex)).toMatchObject({ ok: false, reason: "complexity" });
+    const statementHeavy = [
+      "flowchart TD",
+      ...Array.from({ length: MERMAID_LIMITS.maxStatements }, (_, index) => `statement${index}`),
+    ].join(";");
+    expect(guardMermaidSource(statementHeavy)).toMatchObject({ ok: false, reason: "complexity" });
+
+    let loads = 0;
+    const guarded = await renderMermaidSource(complex, "light", {
+      loadRuntime: async () => {
+        loads += 1;
+        throw new Error("must not load");
+      },
+    });
+    expect(guarded).toEqual({ status: "source", reason: "complexity" });
+    expect(await renderMermaidSource(statementHeavy, "light", {
+      loadRuntime: async () => {
+        loads += 1;
+        throw new Error("must not load");
+      },
+    })).toEqual({ status: "source", reason: "complexity" });
+    expect(loads).toBe(0);
+  });
+
+  test("rejects directives and resource syntax before loading Mermaid", async () => {
+    const unsafeSources = [
+      "%%{init: {'theme': 'dark'}}%%\nflowchart LR\nA --> B",
+      "%%{config: {'htmlLabels': true}}%%\nflowchart LR\nA --> B",
+      "---\nconfig:\n  theme: dark\n---\nflowchart LR\nA --> B",
+      "flowchart LR; A --> B; click A callback",
+      "flowchart LR\nA[https://example.com/image.svg]",
+      "flowchart LR\nA[data:image/svg+xml;base64,AAAA]",
+      "flowchart LR\nA[blob:payload]",
+      "flowchart LR\nA[file:///tmp/payload]",
+      "flowchart LR\nA[javascript:alert(1)]",
+      "flowchart LR\nA[ftp://example.com/payload]",
+      "flowchart LR\nA[//example.com/payload]",
+      String.raw`flowchart LR; A[u\72l(https://example.com/payload)]`,
+      String.raw`flowchart LR; A[u\72l(#local-resource)]`,
+      String.raw`flowchart LR; A[\68 ttps://example.com/payload]`,
+      String.raw`flowchart LR; cl\69 ck A callback`,
+      String.raw`%%{\69 nit: {'theme': 'dark'}}%%; flowchart LR; A --> B`,
+      "flowchart LR; A[@import 'theme.css']",
+      "flowchart LR; A[src=local.svg]",
+      "flowchart LR; A[h/**/ttps://example.com/payload]",
+    ];
+    let loads = 0;
+
+    for (const source of unsafeSources) {
+      expect(guardMermaidSource(source)).toMatchObject({ ok: false, reason: "unsafe" });
+      expect(await renderMermaidSource(source, "light", {
+        loadRuntime: async () => {
+          loads += 1;
+          throw new Error("must not load");
+        },
+      })).toEqual({ status: "source", reason: "unsafe" });
+    }
+    expect(loads).toBe(0);
+  });
+
+  test("keeps source for malformed, unavailable, and timed-out renders", async () => {
+    const malformedRuntime: MermaidRuntime = {
+      initialize: () => undefined,
+      render: async () => { throw new Error("bad syntax"); },
+    };
+    await expect(renderMermaidSource("not-a-diagram", "light", {
+      loadRuntime: async () => malformedRuntime,
+    })).resolves.toEqual({ status: "source", reason: "invalid" });
+
+    await expect(renderMermaidSource(SOURCE, "light", {
+      loadRuntime: async () => { throw new Error("chunk unavailable"); },
+    })).resolves.toEqual({ status: "source", reason: "unavailable" });
+
+    const stalledRuntime: MermaidRuntime = {
+      initialize: () => undefined,
+      render: () => new Promise<{ svg: string }>(() => undefined),
+    };
+    await expect(renderMermaidSource(SOURCE, "light", {
+      loadRuntime: async () => stalledRuntime,
+      timeoutMs: 1,
+    })).resolves.toEqual({ status: "source", reason: "timeout" });
+  });
+
+  test("uses strict theme-specific config with HTML labels disabled", () => {
+    const light = mermaidConfigForTheme("light");
+    const dark = mermaidConfigForTheme("dark");
+
+    expect(light).toMatchObject({ securityLevel: "strict", htmlLabels: false, startOnLoad: false, theme: "default" });
+    expect(light.flowchart).toMatchObject({ htmlLabels: false });
+    expect(light.secure).toContain("securityLevel");
+    expect(light.secure).toContain("htmlLabels");
+    expect(dark.theme).toBe("dark");
+  });
+
+  test("allows local SVG fragments but rejects remote-resource and redirect vectors", () => {
+    expect(normalizeCssEscapes(String.raw`u\72l(\68 ttps://example.com)`)).toBe("url(https://example.com)");
+    expect(isSafeMermaidSvgReference("url(#arrowhead)")).toBe(true);
+    expect(isSafeMermaidSvgReference("#local-gradient")).toBe(true);
+    expect(isSafeMermaidSvgReference("url(https://example.com/tracker.svg)")).toBe(false);
+    expect(isSafeMermaidSvgReference("@import url('//example.com/diagram.css')")).toBe(false);
+    expect(isSafeMermaidSvgReference("javascript:location='https://example.com'")).toBe(false);
+    expect(isSafeMermaidSvgReference("data:image/svg+xml;base64,AAAA")).toBe(false);
+    expect(isSafeMermaidSvgReference(String.raw`background:u\72l(\68 ttps://example.com/tracker.svg)`)).toBe(false);
+    expect(isSafeMermaidSvgReference("background:u/**/rl(https://example.com/tracker.svg)")).toBe(false);
+  });
+});

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -21,6 +21,7 @@ async function createWorkspaceRoot() {
   roots.push(root);
   await mkdir(join(root, "reports"), { recursive: true });
   await writeFile(join(root, "reports", "artifact-eval.md"), "# Artifact Eval\n\nHello markdown.\n", "utf8");
+  await writeFile(join(root, "reports", "architecture.mmd"), "flowchart LR\n  A --> B\n", "utf8");
   await writeFile(join(root, "reports", "artifact-eval.csv"), "name,revenue\nAda,10\nGrace,20\n", "utf8");
   await writeFile(join(root, "reports", "index.html"), "<!doctype html><h1>Artifact site</h1>", "utf8");
   await writeFile(join(root, "reports", "artifact-eval.ts"), "export const artifact = true;\n", "utf8");
@@ -70,6 +71,7 @@ describe("artifact file routes", () => {
         targets: [
           { kind: "file", value: join(root, "reports", "artifact-eval.md"), confidence: 95 },
           { kind: "file", value: "Workspace/32423/reports/artifact-eval.md", confidence: 80 },
+          { kind: "file", value: "reports/architecture.mmd", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.csv", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.xlsx", confidence: 80 },
           { kind: "file", value: "reports/artifact-eval.pptx", confidence: 80 },
@@ -85,6 +87,7 @@ describe("artifact file routes", () => {
     expect(resolveResponse.status).toBe(200);
     const resolved = await resolveResponse.json() as { items: Array<any> };
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.md")).toMatchObject({ exists: true, preview: "markdown", confidence: 95 });
+    expect(resolved.items.find((item) => item.value === "reports/architecture.mmd")).toMatchObject({ exists: true, preview: "markdown", contentType: "text/plain; charset=utf-8" });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.csv")).toMatchObject({ exists: true, preview: "sheet" });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.xlsx")).toMatchObject({ exists: true, preview: "sheet" });
     expect(resolved.items.find((item) => item.value === "reports/artifact-eval.pptx")).toMatchObject({ exists: true, preview: "slides", contentType: "application/vnd.openxmlformats-officedocument.presentationml.presentation" });
@@ -97,6 +100,9 @@ describe("artifact file routes", () => {
 
     const csvRead = await fetch(`${base}/workspace/ws_1/files/content?path=${encodeURIComponent("reports/artifact-eval.csv")}`, { headers: auth(token) });
     expect(await csvRead.json()).toMatchObject({ content: "name,revenue\nAda,10\nGrace,20\n" });
+
+    const mermaidRead = await fetch(`${base}/workspace/ws_1/files/content?path=${encodeURIComponent("reports/architecture.mmd")}`, { headers: auth(token) });
+    expect(await mermaidRead.json()).toMatchObject({ content: "flowchart LR\n  A --> B\n" });
 
     const mdWrite = await fetch(`${base}/workspace/ws_1/files/content`, {
       method: "POST",

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -112,6 +112,7 @@ export function isSupportedWorkspaceTextFilePath(relativePath: string): boolean 
     ".md",
     ".mdx",
     ".markdown",
+    ".mmd",
     ".csv",
     ".tsv",
     ".json",
@@ -230,7 +231,7 @@ type ArtifactTargetInput = {
 
 function artifactPreviewForPath(path: string): string {
   const lowered = path.toLowerCase();
-  if (/\.(md|markdown|mdx)$/.test(lowered)) return "markdown";
+  if (/\.(md|markdown|mdx|mmd)$/.test(lowered)) return "markdown";
   if (/\.(csv|tsv|xlsx|xls|ods)$/.test(lowered)) return "sheet";
   if (/\.(ppt|pptx|pptm|pot|potx|odp|key|sxi)$/.test(lowered)) return "slides";
   if (lowered.endsWith(".docx")) return "document";

--- a/evals/specs/mermaid-rendering.e2e.test.ts
+++ b/evals/specs/mermaid-rendering.e2e.test.ts
@@ -1,0 +1,140 @@
+import { expect } from "vitest";
+import { clickButton, control, createAndSelectWorkspace, evalIn, seedSessions, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "Mermaid renders safely in completed chat and Markdown artifacts"
+  : "Mermaid rendering skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+test.skipIf(!enabled)(title, async () => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  await using app = await desktop({
+    name: "mermaid-rendering",
+    mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+    env: { OPENWORK_ELECTRON_START_URL: "", PORT: "0" },
+  });
+  await createAndSelectWorkspace(app, { path: `/tmp/openwork-mermaid-rendering-${Date.now()}` });
+  await seedSessions(app, ["Mermaid rendering proof"]);
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "eval.markdown_primitive.seed_chat" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "Mermaid chat fixture available",
+  });
+
+  await control(app, "eval.mermaid.set_theme", { mode: "light" });
+  await waitFor(app, `document.documentElement.dataset.theme === "light"`, { timeoutMs: 10_000, label: "light theme applied" });
+  await control(app, "eval.markdown_primitive.seed_chat");
+  await waitFor(app, `(() => {
+    const diagrams = Array.from(document.querySelectorAll("[data-openwork-mermaid]"));
+    return diagrams.length === 4 && diagrams.every((diagram) => diagram.getAttribute("aria-busy") === "false");
+  })()`, { timeoutMs: 30_000, label: "all chat Mermaid diagrams settled" });
+
+  const chatContract = await evalIn(app, `(() => {
+    const diagrams = Array.from(document.querySelectorAll("[data-openwork-mermaid]"));
+    const find = (text) => diagrams.find((diagram) => diagram.querySelector("[data-openwork-mermaid-source]")?.textContent?.includes(text));
+    const valid = find("Inline Mermaid Start");
+    const remote = find("No remote resources");
+    const malformed = find("not-a-mermaid-diagram");
+    const guarded = find("Guard node 250");
+    const sourceVisible = (diagram) => diagram?.querySelector("[data-openwork-mermaid-source]")?.hidden === false;
+    return {
+      validRendered: valid?.dataset.openworkMermaidState === "rendered" && Boolean(valid.querySelector("svg")),
+      controls: Boolean(valid?.querySelector("[data-openwork-mermaid-view='source']") && valid.querySelector("[data-openwork-mermaid-view='rendered']") && valid.querySelector("[data-openwork-mermaid-download]:not([hidden])")),
+      unsafeFallback: remote?.dataset.openworkMermaidReason === "unsafe" && sourceVisible(remote) && !remote.querySelector("svg"),
+      malformedFallback: malformed?.dataset.openworkMermaidReason === "invalid" && sourceVisible(malformed) && !malformed.querySelector("svg"),
+      guardFallback: guarded?.dataset.openworkMermaidReason === "complexity" && sourceVisible(guarded) && !guarded.querySelector("svg"),
+      lightTheme: valid?.dataset.openworkMermaidTheme === "light",
+      states: diagrams.map((diagram) => ({
+        source: diagram.querySelector("[data-openwork-mermaid-source]")?.textContent?.slice(0, 40),
+        state: diagram.getAttribute("data-openwork-mermaid-state"),
+        reason: diagram.getAttribute("data-openwork-mermaid-reason"),
+        theme: diagram.getAttribute("data-openwork-mermaid-theme"),
+      })),
+    };
+  })()`);
+  expect(chatContract, JSON.stringify(chatContract)).toMatchObject({
+    validRendered: true,
+    controls: true,
+    unsafeFallback: true,
+    malformedFallback: true,
+    guardFallback: true,
+    lightTheme: true,
+  });
+
+  const toggleContract = await evalIn(app, `(() => {
+    const diagram = Array.from(document.querySelectorAll("[data-openwork-mermaid]")).find((item) => item.textContent?.includes("Inline Mermaid Start"));
+    diagram?.querySelector("[data-openwork-mermaid-view='source']")?.click();
+    const source = diagram?.dataset.openworkMermaidState === "source" && diagram.querySelector("[data-openwork-mermaid-source]")?.hidden === false;
+    diagram?.querySelector("[data-openwork-mermaid-view='rendered']")?.click();
+    return source && diagram?.dataset.openworkMermaidState === "rendered";
+  })()`);
+  expect(toggleContract).toBe(true);
+
+  const downloadContract = await evalIn(app, `(async () => {
+    const diagram = Array.from(document.querySelectorAll("[data-openwork-mermaid]")).find((item) => item.textContent?.includes("Inline Mermaid Start"));
+    const button = diagram?.querySelector("[data-openwork-mermaid-download]");
+    if (!button) return false;
+    return await new Promise((resolve) => {
+      const listener = (event) => {
+        if (!(event.target instanceof HTMLAnchorElement) || !event.target.download.endsWith(".svg")) return;
+        event.preventDefault();
+        clearTimeout(timer);
+        document.removeEventListener("click", listener, true);
+        resolve(event.target.href.startsWith("blob:"));
+      };
+      const timer = setTimeout(() => {
+        document.removeEventListener("click", listener, true);
+        resolve(false);
+      }, 2_000);
+      document.addEventListener("click", listener, true);
+      button.click();
+    });
+  })()`, { awaitPromise: true });
+  expect(downloadContract).toBe(true);
+
+  await control(app, "eval.mermaid.set_theme", { mode: "dark" });
+  expect(await evalIn(app, `(() => {
+    const diagram = Array.from(document.querySelectorAll("[data-openwork-mermaid]")).find((item) => item.textContent?.includes("Inline Mermaid Start"));
+    diagram?.querySelector("[data-openwork-mermaid-view='source']")?.click();
+    return diagram?.dataset.openworkMermaidState === "source";
+  })()`)).toBe(true);
+  await waitFor(app, `(() => {
+    const diagram = Array.from(document.querySelectorAll("[data-openwork-mermaid]")).find((item) => item.textContent?.includes("Inline Mermaid Start"));
+    return diagram?.getAttribute("data-openwork-mermaid-theme") === "dark" && diagram?.getAttribute("data-openwork-mermaid-state") === "source";
+  })()`, {
+    timeoutMs: 30_000,
+    label: "dark theme rerender preserved the selected source view",
+  });
+  expect(await evalIn(app, `document.documentElement.dataset.theme === "dark" && Boolean(document.querySelector("[data-openwork-mermaid-theme='dark'] svg")) && document.querySelector("[data-openwork-mermaid-theme='dark'] [data-openwork-mermaid-source]")?.hidden === false`)).toBe(true);
+
+  await control(app, "browser.open_url", { url: "about:blank" }).catch(() => undefined);
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "eval.markdown_primitive.seed_artifact" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "Mermaid artifact fixture available",
+  });
+  await control(app, "eval.markdown_primitive.seed_artifact");
+  await clickButton(app, "markdown-primitive-proof.md");
+  await waitFor(app, `Boolean(document.querySelector("[data-openwork-markdown-preview] [data-openwork-mermaid-state='rendered'] svg"))`, {
+    timeoutMs: 30_000,
+    label: "fenced Mermaid rendered in Markdown artifact preview",
+  });
+  expect(await evalIn(app, `document.querySelector("[data-openwork-markdown-preview] [data-openwork-mermaid-source]")?.textContent?.includes("Artifact Mermaid Start")`)).toBe(true);
+
+  await control(app, "eval.markdown_primitive.seed_artifact", { standalone: true });
+  await clickButton(app, "standalone-mermaid-proof.mmd");
+  await waitFor(app, `Boolean(document.querySelector("[data-openwork-mermaid-artifact] [data-openwork-mermaid-state='rendered'] svg"))`, {
+    timeoutMs: 30_000,
+    label: "standalone mmd artifact rendered",
+  });
+  expect(await evalIn(app, `document.body.innerText.includes("standalone-mermaid-proof.mmd") && Array.from(document.querySelectorAll("button")).some((button) => button.textContent?.trim() === "Edit")`)).toBe(true);
+  expect(await evalIn(app, `(() => {
+    const button = document.querySelector("button[aria-label='Artifact actions']");
+    button?.click();
+    return Boolean(button);
+  })()`)).toBe(true);
+  const rawDownloadSelector = `[role="menuitem"]`;
+  await waitFor(app, `Array.from(document.querySelectorAll(${JSON.stringify(rawDownloadSelector)})).some((item) => item.textContent?.trim() === "Download")`, { timeoutMs: 10_000, label: "raw Mermaid artifact download action" });
+  expect(await evalIn(app, `Array.from(document.querySelectorAll(${JSON.stringify(rawDownloadSelector)})).some((item) => item.textContent?.trim() === "Download")`)).toBe(true);
+
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,9 @@ importers:
       marked-katex-extension:
         specifier: ^5.1.10
         version: 5.1.10(katex@0.18.1)(marked@17.0.1)
-      marked-shiki:
-        specifier: ^1.2.1
-        version: 1.2.1(marked@17.0.1)(shiki@4.0.2)
+      mermaid:
+        specifier: ^11.17.1
+        version: 11.17.1
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1383,6 +1383,9 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@apm-js-collab/code-transformer-bundler-plugins@0.5.0':
     resolution: {integrity: sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==}
     engines: {node: '>=18.0.0'}
@@ -1872,6 +1875,12 @@ packages:
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
 
@@ -2230,6 +2239,12 @@ packages:
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2750,6 +2765,9 @@ packages:
 
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
+
+  '@mermaid-js/parser@1.2.1':
+    resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
 
   '@modelcontextprotocol/client@2.0.0':
     resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
@@ -4857,6 +4875,99 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.2.0':
+    resolution: {integrity: sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -4868,6 +4979,9 @@ packages:
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -4945,6 +5059,9 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -5545,6 +5662,10 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -5611,6 +5732,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -5645,9 +5772,168 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  dayjs@1.11.23:
+    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
   debounce-fn@6.0.0:
     resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
@@ -5711,6 +5997,9 @@ packages:
 
   defu@6.1.5:
     resolution: {integrity: sha512-pwdBJxJuJXmqrLO6s0VBmfbRz+G7FUzkjldAsdi9Yrv86mPyzq0ll1o8+8gB4Gsr6GJHbK1Lh3ngllgTInDCjA==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -6019,6 +6308,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -6159,6 +6451,9 @@ packages:
   fast-xml-parser@5.8.0:
     resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
     hasBin: true
+
+  fastdom@1.0.12:
+    resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -6395,6 +6690,9 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -6503,6 +6801,10 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -6525,6 +6827,9 @@ packages:
     resolution: {integrity: sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==}
     engines: {node: '>=18'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -6535,6 +6840,13 @@ packages:
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@6.0.0:
     resolution: {integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==}
@@ -6745,12 +7057,19 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   katex@0.18.1:
     resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
     hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -6766,6 +7085,12 @@ packages:
   kysely@0.28.17:
     resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -6881,6 +7206,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -6960,15 +7288,14 @@ packages:
       katex: '>=0.16 <0.18'
       marked: '>=4 <19'
 
-  marked-shiki@1.2.1:
-    resolution: {integrity: sha512-yHxYQhPY5oYaIRnROn98foKhuClark7M373/VpLxiy5TrDu9Jd/LsMwo8w+U91Up4oDb9IXFrP0N1MFRz8W/DQ==}
-    peerDependencies:
-      marked: '>=7.0.0'
-      shiki: '>=1.0.0'
-
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   marked@17.0.1:
@@ -7044,6 +7371,9 @@ packages:
   meriyah@6.1.4:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
+
+  mermaid@11.17.1:
+    resolution: {integrity: sha512-G1BP6qU4BRwEGk2SdsxgDk1cSuApimT32Nkb52YRSv+856FrmB8qo28BaNk9Ee8Fvuon3OxpXDJ4L6cD5AykXg==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -7523,6 +7853,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -7551,6 +7884,9 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -7632,6 +7968,12 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postal-mime@2.7.4:
     resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
@@ -8011,6 +8353,9 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -8024,6 +8369,9 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -8034,6 +8382,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -8253,6 +8604,9 @@ packages:
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
+  strictdom@1.0.1:
+    resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -8327,6 +8681,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -8485,6 +8842,10 @@ packages:
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -9023,6 +9384,11 @@ snapshots:
       - zod
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.1.2
 
   '@apm-js-collab/code-transformer-bundler-plugins@0.5.0':
     dependencies:
@@ -9869,6 +10235,10 @@ snapshots:
 
   '@better-fetch/fetch@1.3.1': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
   '@codemirror/autocomplete@6.20.3':
     dependencies:
       '@codemirror/language': 6.12.1
@@ -10307,6 +10677,14 @@ snapshots:
       hono: 4.12.34
 
   '@iarna/toml@2.2.5': {}
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@img/colour@1.1.0': {}
 
@@ -10795,6 +11173,10 @@ snapshots:
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@marijn/find-cluster-break@1.0.3': {}
+
+  '@mermaid-js/parser@1.2.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@modelcontextprotocol/client@2.0.0(patch_hash=702e2000a3f78e99cfa6971ac4c90466d482174e49340634c0f5b1f346285c12)':
     dependencies:
@@ -12799,6 +13181,123 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.2.0':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.2.0
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -12810,6 +13309,8 @@ snapshots:
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 20.12.12
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -12894,6 +13395,11 @@ snapshots:
       '@types/node': 20.12.12
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vercel/oidc@3.1.0': {}
 
@@ -13529,6 +14035,8 @@ snapshots:
 
   commander@5.1.0: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   commander@9.5.0:
@@ -13579,6 +14087,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -13610,7 +14126,193 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.1
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.1
+
+  cytoscape@3.34.1: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
+
+  dayjs@1.11.23: {}
 
   debounce-fn@6.0.0:
     dependencies:
@@ -13660,6 +14362,10 @@ snapshots:
     optional: true
 
   defu@6.1.5: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -13966,6 +14672,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  es-toolkit@1.51.0: {}
+
   es6-error@4.1.1:
     optional: true
 
@@ -14167,6 +14875,10 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
       xml-naming: 0.1.0
+
+  fastdom@1.0.12:
+    dependencies:
+      strictdom: 1.0.1
 
   fastest-levenshtein@1.0.16: {}
 
@@ -14428,6 +15140,8 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -14555,6 +15269,10 @@ snapshots:
 
   human-signals@8.0.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -14576,6 +15294,8 @@ snapshots:
       es-module-lexer: 2.3.0
       module-details-from-path: 1.0.4
 
+  import-meta-resolve@4.2.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -14584,6 +15304,10 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@7.0.0: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ioredis@6.0.0:
     dependencies:
@@ -14742,6 +15466,10 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   katex@0.18.1:
     dependencies:
       commander: 8.3.0
@@ -14750,6 +15478,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  khroma@2.1.0: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -14757,6 +15487,10 @@ snapshots:
   kubernetes-types@1.30.0: {}
 
   kysely@0.28.17: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lazy-val@1.0.5: {}
 
@@ -14835,6 +15569,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.escaperegexp@4.1.2: {}
@@ -14902,12 +15638,9 @@ snapshots:
       katex: 0.18.1
       marked: 17.0.1
 
-  marked-shiki@1.2.1(marked@17.0.1)(shiki@4.0.2):
-    dependencies:
-      marked: 17.0.1
-      shiki: 4.0.2
-
   marked@15.0.12: {}
+
+  marked@16.4.2: {}
 
   marked@17.0.1: {}
 
@@ -15048,6 +15781,31 @@ snapshots:
   merge2@1.4.1: {}
 
   meriyah@6.1.4: {}
+
+  mermaid@11.17.1:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.1)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.23
+      dompurify: 3.4.13
+      es-toolkit: 1.51.0
+      fastdom: 1.0.12
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 11.1.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -15608,6 +16366,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-manager-detector@1.8.0: {}
+
   pako@1.0.11: {}
 
   parent-module@1.0.1:
@@ -15633,6 +16393,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -15695,6 +16457,13 @@ snapshots:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postal-mime@2.7.4: {}
 
@@ -16094,6 +16863,8 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -16158,6 +16929,13 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -16173,6 +16951,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
 
@@ -16517,6 +17297,8 @@ snapshots:
 
   strict-event-emitter@0.5.1: {}
 
+  strictdom@1.0.1: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -16585,6 +17367,8 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
+
+  stylis@4.4.0: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -16759,6 +17543,8 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  ts-dedent@2.3.0: {}
 
   ts-interface-checker@0.1.13: {}
 


### PR DESCRIPTION
## Summary
- render fenced Mermaid diagrams through one lazy shared enhancer in assistant chat and Markdown artifact previews
- preserve source/rendered controls and SVG download, with strict config, sanitized SVG, remote-resource rejection, and bounded source/complexity/time safeguards
- preview standalone `.mmd` files as diagrams while retaining edit and raw download actions

## Verification
- `corepack pnpm@10.27.0 --filter @openwork/app typecheck`
- `corepack pnpm@10.27.0 --filter @openwork/app exec bun test tests/markdown-mermaid.test.ts tests/markdown-code-block.test.ts tests/markdown-selection-stability.test.ts tests/markdown-math.test.ts scripts/open-target.test.ts` — 54 passed
- `corepack pnpm@10.27.0 --filter openwork-server exec bun test src/artifact-files.e2e.test.ts` — 2 passed
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/mermaid-rendering.e2e.test.ts` — 1 passed (local Electron lane)
- `corepack pnpm@10.27.0 --filter @openwork/app build`

Daytona was attempted first, but the reusable `openwork-eval-vnc` snapshot was in an error state, so verification used the supported local fallback lane.

## Notes
- Mermaid remains code-split from the ordinary chat bundle.
- The timeout bounds asynchronous completion; preflight source and complexity limits bound work before Mermaid runs.