### PR TITLE
fix(app): restart a dead workspace event stream when the sync token generation changes

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import { create } from "zustand";
 import type { FilePart, Part, PermissionRequest, PermissionV2Request, QuestionRequest, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { getReactQueryClient } from "../../../infra/query-client";
@@ -44,7 +45,9 @@ import {
   type DeltaFlushLane,
   type PendingDelta,
 } from "./session-transcript-deltas";
+import { startSyncStreamLifecycle, type SyncStreamPhase } from "./sync-stream-lifecycle";
 
+export { type SyncStreamPhase } from "./sync-stream-lifecycle";
 export {
   applyPendingDeltasToTranscript,
   coalescePendingDeltas,
@@ -68,6 +71,10 @@ type ListenerRegistry<Listener> = Map<Listener, number>;
 type SyncEntry = {
   input: SyncOptions;
   openworkToken: string;
+  // Reattachment can rotate the token after the stream already failed. This
+  // hook advances the stream lifecycle's connection generation so a stream
+  // parked in auth backoff restarts immediately with the new credential.
+  notifyStreamGenerationChanged: (() => void) | null;
   refs: number;
   dispose: () => void;
   disposeTimer: ReturnType<typeof setTimeout> | null;
@@ -199,6 +206,37 @@ function syncKey(input: SyncOptions) {
   return `${input.workspaceId}:${input.baseUrl}`;
 }
 
+type WorkspaceSyncStreamStore = {
+  phasesByKey: Record<string, SyncStreamPhase>;
+  publishPhase: (key: string, phase: SyncStreamPhase) => void;
+  removePhase: (key: string) => void;
+};
+
+/**
+ * Live health of each workspace event stream so surfaces can tell a live
+ * stream from one that is reconnecting, blocked on authentication, or stale.
+ * The lifecycle only publishes actual transitions, so subscribers do not see
+ * duplicate notifications.
+ */
+export const useWorkspaceSyncStreamStore = create<WorkspaceSyncStreamStore>((set) => ({
+  phasesByKey: {},
+  publishPhase: (key, phase) => set((state) => ({
+    phasesByKey: { ...state.phasesByKey, [key]: phase },
+  })),
+  removePhase: (key) => set((state) => {
+    if (!(key in state.phasesByKey)) return state;
+    const next = { ...state.phasesByKey };
+    delete next[key];
+    return { phasesByKey: next };
+  }),
+}));
+
+export function getWorkspaceSessionSyncStreamPhase(
+  input: Pick<SyncOptions, "workspaceId" | "baseUrl">,
+): SyncStreamPhase | null {
+  return useWorkspaceSyncStreamStore.getState().phasesByKey[`${input.workspaceId}:${input.baseUrl}`] ?? null;
+}
+
 function getErrorStatus(error: unknown) {
   if (!error || typeof error !== "object") return null;
   const record = error as {
@@ -210,9 +248,14 @@ function getErrorStatus(error: unknown) {
   return typeof status === "number" ? status : null;
 }
 
-function shouldRetrySyncSubscribe(error: unknown) {
+// 401/403/404 can mean a permanently invalid token, but the same statuses
+// occur transiently while the local server restarts or the runtime generation
+// rotates. They select the slower bounded auth backoff lane instead of
+// terminating the stream: the task may still be running on the server, and a
+// dead stream would silently stop delivering its events.
+function isAuthBlockedSubscribeError(error: unknown) {
   const status = getErrorStatus(error);
-  return status !== 401 && status !== 403 && status !== 404;
+  return status === 401 || status === 403 || status === 404;
 }
 
 function isTrackedSession(entry: SyncEntry, sessionId: string) {
@@ -1070,69 +1113,33 @@ function commitDeltas(entry: SyncEntry, workspaceId: string, items: PendingDelta
 }
 
 function startSync(input: SyncOptions, entry: SyncEntry) {
-  const controller = new AbortController();
-  let disposed = false;
-  let retryTimer: ReturnType<typeof setTimeout> | null = null;
-  let watchdogTimer: ReturnType<typeof setInterval> | null = null;
-  let activeConnectionController: AbortController | null = null;
-  let lastEventAt = Date.now();
-  let retryDelayMs = 1_000;
-  const staleStreamMs = 30_000;
-
-  const scheduleRetry = () => {
-    if (disposed || controller.signal.aborted || retryTimer) return;
-    activeConnectionController = null;
-    retryTimer = setTimeout(() => {
-      retryTimer = null;
-      void connect();
-    }, retryDelayMs);
-    retryDelayMs = Math.min(retryDelayMs * 2, 10_000);
-  };
-
-  const connect = async () => {
-    const connectionController = new AbortController();
-    activeConnectionController = connectionController;
-    try {
-      const stream = await syncSubscriptionFactory(input.baseUrl, entry.openworkToken, connectionController.signal);
-      retryDelayMs = 1_000;
-      lastEventAt = Date.now();
-      void reconcileSessionRunStatuses(entry, input, connectionController.signal);
-      for await (const raw of stream) {
-        if (controller.signal.aborted || connectionController.signal.aborted) return;
-        lastEventAt = Date.now();
-        const event = normalizeEvent(raw);
-        if (!event) continue;
-        applyEvent(entry, input.workspaceId, event);
-      }
-      if (!controller.signal.aborted && activeConnectionController === connectionController) scheduleRetry();
-    } catch (error) {
-      if (
-        !controller.signal.aborted &&
-        (connectionController.signal.aborted || shouldRetrySyncSubscribe(error))
-      ) {
-        scheduleRetry();
-      }
-    } finally {
-      if (activeConnectionController === connectionController) activeConnectionController = null;
-    }
-  };
-
-  void connect();
-  watchdogTimer = setInterval(() => {
-    if (disposed || controller.signal.aborted || retryTimer) return;
-    const active = activeConnectionController;
-    if (!active || active.signal.aborted) return;
-    if (Date.now() - lastEventAt < staleStreamMs) return;
-    active.abort();
-    scheduleRetry();
-  }, 10_000);
+  const streamKey = syncKey(input);
+  const lifecycle = startSyncStreamLifecycle({
+    // Read the token at connect time so every retry — including a
+    // generation-triggered restart — uses the latest credential.
+    subscribe: (signal) => syncSubscriptionFactory(input.baseUrl, entry.openworkToken, signal),
+    onEvent: (raw) => {
+      const event = normalizeEvent(raw);
+      if (!event) return;
+      applyEvent(entry, input.workspaceId, event);
+    },
+    // Level-reconcile run statuses on every (re)connect before trusting any
+    // cached idle: the server may have started or finished work while the
+    // stream was down.
+    onConnected: (signal) => {
+      void reconcileSessionRunStatuses(entry, input, signal);
+    },
+    onPhaseChange: (phase) => {
+      useWorkspaceSyncStreamStore.getState().publishPhase(streamKey, phase);
+    },
+    isAuthError: isAuthBlockedSubscribeError,
+  });
+  entry.notifyStreamGenerationChanged = lifecycle.notifyGenerationChanged;
 
   return () => {
-    disposed = true;
-    if (retryTimer) clearTimeout(retryTimer);
-    if (watchdogTimer) clearInterval(watchdogTimer);
-    activeConnectionController?.abort();
-    controller.abort();
+    entry.notifyStreamGenerationChanged = null;
+    lifecycle.dispose();
+    useWorkspaceSyncStreamStore.getState().removePhase(streamKey);
   };
 }
 
@@ -1194,7 +1201,13 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   const existing = syncs.get(key);
   if (existing) {
     existing.input = input;
-    existing.openworkToken = input.openworkToken;
+    if (existing.openworkToken !== input.openworkToken) {
+      // Reattachment with a rotated token (or a restarted runtime's fresh
+      // credential) is a new connection generation: restart a stream parked
+      // in auth backoff instead of leaving the task streaming nowhere.
+      existing.openworkToken = input.openworkToken;
+      existing.notifyStreamGenerationChanged?.();
+    }
     if (existing.disposeTimer) {
       clearTimeout(existing.disposeTimer);
       existing.disposeTimer = null;
@@ -1211,6 +1224,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   const created: SyncEntry = {
     input,
     openworkToken: input.openworkToken,
+    notifyStreamGenerationChanged: null,
     refs: 1,
     dispose: () => {},
     disposeTimer: null,
@@ -1405,6 +1419,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
   syncs.set(key, {
     input,
     openworkToken: input.openworkToken,
+    notifyStreamGenerationChanged: null,
     refs: 1,
     dispose: () => {},
     disposeTimer: null,

--- a/apps/app/src/react-app/domains/session/sync/sync-stream-lifecycle.ts
+++ b/apps/app/src/react-app/domains/session/sync/sync-stream-lifecycle.ts
@@ -1,0 +1,167 @@
+/**
+ * Generation-aware reconnect lifecycle for the workspace event stream.
+ *
+ * The stream must never park in a terminal dead state: 401/403/404 from the
+ * subscribe call can mean a permanently invalid token, but the same statuses
+ * occur transiently while the local server restarts or the runtime generation
+ * rotates. Auth-shaped failures therefore keep retrying on a slower bounded
+ * exponential schedule, and `notifyGenerationChanged` (a rotated token or a
+ * new runtime generation) restarts a parked stream immediately with fresh
+ * backoff instead of waiting out stale failure evidence.
+ *
+ * This module is dependency-free on purpose so specs can drive it directly.
+ */
+
+export type SyncStreamPhase =
+  | "connecting"
+  | "live"
+  | "reconnecting"
+  | "auth-blocked"
+  | "stale";
+
+type SyncStreamLifecycleOptions = {
+  subscribe: (signal: AbortSignal) => Promise<AsyncIterable<unknown>>;
+  onEvent: (event: unknown) => void;
+  /**
+   * Runs on every successful (re)connect, before events flow. Owners
+   * level-reconcile active run statuses here so a cached idle recorded while
+   * the stream was down cannot mask work that continued on the server.
+   */
+  onConnected?: (signal: AbortSignal) => void;
+  onPhaseChange?: (phase: SyncStreamPhase) => void;
+  isAuthError?: (error: unknown) => boolean;
+  retryInitialDelayMs?: number;
+  retryMaxDelayMs?: number;
+  authRetryInitialDelayMs?: number;
+  authRetryMaxDelayMs?: number;
+  staleStreamMs?: number;
+  watchdogIntervalMs?: number;
+};
+
+export type SyncStreamLifecycle = {
+  /**
+   * The credential or runtime generation behind `subscribe` changed. Resets
+   * both backoff schedules and, when no healthy connection exists, reconnects
+   * immediately. A healthy stream keeps flowing: if the server cuts it over
+   * the rotation, the ordinary retry path reconnects with the new generation.
+   */
+  notifyGenerationChanged: () => void;
+  getPhase: () => SyncStreamPhase;
+  dispose: () => void;
+};
+
+export function startSyncStreamLifecycle(options: SyncStreamLifecycleOptions): SyncStreamLifecycle {
+  const retryInitialDelayMs = options.retryInitialDelayMs ?? 1_000;
+  const retryMaxDelayMs = options.retryMaxDelayMs ?? 10_000;
+  const authRetryInitialDelayMs = options.authRetryInitialDelayMs ?? 5_000;
+  const authRetryMaxDelayMs = options.authRetryMaxDelayMs ?? 60_000;
+  const staleStreamMs = options.staleStreamMs ?? 30_000;
+  const watchdogIntervalMs = options.watchdogIntervalMs ?? 10_000;
+  const isAuthError = options.isAuthError ?? (() => false);
+
+  const controller = new AbortController();
+  let disposed = false;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeConnectionController: AbortController | null = null;
+  let lastEventAt = Date.now();
+  let retryDelayMs = retryInitialDelayMs;
+  let authRetryDelayMs = authRetryInitialDelayMs;
+  let generation = 0;
+  let phase: SyncStreamPhase = "connecting";
+
+  const setPhase = (next: SyncStreamPhase) => {
+    if (phase === next) return;
+    phase = next;
+    options.onPhaseChange?.(next);
+  };
+
+  const scheduleRetry = (reason: "reconnecting" | "auth-blocked" | "stale") => {
+    if (disposed || controller.signal.aborted || retryTimer) return;
+    activeConnectionController = null;
+    setPhase(reason);
+    const delayMs = reason === "auth-blocked" ? authRetryDelayMs : retryDelayMs;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void connect();
+    }, delayMs);
+    if (reason === "auth-blocked") {
+      authRetryDelayMs = Math.min(authRetryDelayMs * 2, authRetryMaxDelayMs);
+    } else {
+      retryDelayMs = Math.min(retryDelayMs * 2, retryMaxDelayMs);
+    }
+  };
+
+  const connect = async () => {
+    const connectionController = new AbortController();
+    activeConnectionController = connectionController;
+    const connectGeneration = generation;
+    setPhase("connecting");
+    try {
+      const stream = await options.subscribe(connectionController.signal);
+      retryDelayMs = retryInitialDelayMs;
+      authRetryDelayMs = authRetryInitialDelayMs;
+      lastEventAt = Date.now();
+      setPhase("live");
+      options.onConnected?.(connectionController.signal);
+      for await (const raw of stream) {
+        if (controller.signal.aborted || connectionController.signal.aborted) return;
+        lastEventAt = Date.now();
+        options.onEvent(raw);
+      }
+      if (!controller.signal.aborted && activeConnectionController === connectionController) {
+        scheduleRetry("reconnecting");
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      if (connectionController.signal.aborted || !isAuthError(error)) {
+        scheduleRetry("reconnecting");
+      } else if (generation !== connectGeneration) {
+        // The generation rotated while this attempt was in flight, so its
+        // auth failure is stale evidence about the previous generation.
+        scheduleRetry("reconnecting");
+      } else {
+        scheduleRetry("auth-blocked");
+      }
+    } finally {
+      if (activeConnectionController === connectionController) activeConnectionController = null;
+    }
+  };
+
+  const notifyGenerationChanged = () => {
+    if (disposed || controller.signal.aborted) return;
+    generation += 1;
+    // New generation: previous failures no longer predict the next attempt.
+    retryDelayMs = retryInitialDelayMs;
+    authRetryDelayMs = authRetryInitialDelayMs;
+    const active = activeConnectionController;
+    if (active && !active.signal.aborted) return;
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    void connect();
+  };
+
+  options.onPhaseChange?.(phase);
+  void connect();
+  const watchdogTimer = setInterval(() => {
+    if (disposed || controller.signal.aborted || retryTimer) return;
+    const active = activeConnectionController;
+    if (!active || active.signal.aborted) return;
+    if (Date.now() - lastEventAt < staleStreamMs) return;
+    active.abort();
+    scheduleRetry("stale");
+  }, watchdogIntervalMs);
+
+  return {
+    notifyGenerationChanged,
+    getPhase: () => phase,
+    dispose: () => {
+      disposed = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      clearInterval(watchdogTimer);
+      activeConnectionController?.abort();
+      controller.abort();
+    },
+  };
+}

--- a/apps/app/tests/session-sync-token-rotation.test.ts
+++ b/apps/app/tests/session-sync-token-rotation.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+
+import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
+import {
+  __disposeWorkspaceSessionSyncForTest,
+  __setWorkspaceSessionSyncStatusFetcherForTest,
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest,
+  ensureWorkspaceSessionSync,
+  getWorkspaceSessionSyncStreamPhase,
+  statusKey,
+  trackWorkspaceSessionSync,
+  transcriptKey,
+  useWorkspaceSyncStreamStore,
+} from "../src/react-app/domains/session/sync/session-sync";
+import { getReactQueryClient } from "../src/react-app/infra/query-client";
+
+type SyncInput = {
+  workspaceId: string;
+  baseUrl: string;
+  openworkToken: string;
+};
+
+type LiveSubscription = {
+  token: string;
+  push: (event: unknown) => void;
+  signal: AbortSignal;
+};
+
+const workspaceId = "workspace-token-rotation";
+const sessionId = "session-token-rotation";
+const baseUrl = "https://token-rotation.example/opencode";
+const staleToken = "stale-token";
+const freshToken = "fresh-token";
+
+const syncInputs: SyncInput[] = [];
+const liveSubscriptions: LiveSubscription[] = [];
+let authRejections = 0;
+
+function createSyncInput(openworkToken: string): SyncInput {
+  const input = { workspaceId, baseUrl, openworkToken };
+  syncInputs.push(input);
+  return input;
+}
+
+async function subscriptionFactory(_baseUrl: string, token: string, signal: AbortSignal) {
+  if (token === staleToken) {
+    authRejections += 1;
+    throw Object.assign(new Error("unauthorized"), { status: 401 });
+  }
+  const queue: unknown[] = [];
+  let notify: (() => void) | null = null;
+  let ended = false;
+  const wake = () => {
+    const pending = notify;
+    notify = null;
+    pending?.();
+  };
+  const push = (event: unknown) => {
+    queue.push(event);
+    wake();
+  };
+  signal.addEventListener("abort", () => {
+    ended = true;
+    wake();
+  }, { once: true });
+  async function* stream() {
+    while (!ended) {
+      while (queue.length > 0) yield queue.shift();
+      if (ended) break;
+      await new Promise<void>((resolve) => {
+        notify = resolve;
+      });
+    }
+  }
+  liveSubscriptions.push({ token, push, signal });
+  return stream();
+}
+
+async function eventually(check: () => boolean, label: string) {
+  const deadline = Date.now() + 2_000;
+  while (!check() && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+  if (!check()) throw new Error(`Timed out waiting for: ${label}`);
+}
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+}
+
+afterEach(() => {
+  for (const input of syncInputs) __disposeWorkspaceSessionSyncForTest(input);
+  syncInputs.length = 0;
+  liveSubscriptions.length = 0;
+  authRejections = 0;
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
+  __setWorkspaceSessionSyncStatusFetcherForTest(null);
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+  useWorkspaceSyncStreamStore.setState({ phasesByKey: {} });
+  getReactQueryClient().clear();
+});
+
+describe("session sync token rotation", () => {
+  test("a rotated token restarts an auth-blocked stream without a remount and the task resumes", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(subscriptionFactory);
+    // The server still reports the long task busy: reconciliation on the
+    // reconnect must override any idle recorded while the stream was down.
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({
+      [sessionId]: { type: "busy" } satisfies SessionStatus,
+    }));
+
+    const staleInput = createSyncInput(staleToken);
+    const releaseWorkspace = ensureWorkspaceSessionSync(staleInput);
+    const releaseSession = trackWorkspaceSessionSync(staleInput, sessionId);
+
+    // The stale token breaks the stream: it parks visibly in the
+    // authentication-blocked state instead of dying silently.
+    await eventually(() => authRejections >= 1, "stale token rejected");
+    await flushMicrotasks();
+    expect(getWorkspaceSessionSyncStreamPhase(staleInput)).toBe("auth-blocked");
+    expect(liveSubscriptions).toHaveLength(0);
+
+    // While the stream is down the client cached an idle status.
+    getReactQueryClient().setQueryData(statusKey(workspaceId, sessionId), { type: "idle" });
+
+    // Reattachment rotates the token on the same sync entry — no remount,
+    // no release of the original owner.
+    const freshInput = createSyncInput(freshToken);
+    const releaseRotated = ensureWorkspaceSessionSync(freshInput);
+
+    await eventually(() => liveSubscriptions.length === 1, "fresh token subscribed");
+    expect(liveSubscriptions[0]?.token).toBe(freshToken);
+    await eventually(
+      () => getWorkspaceSessionSyncStreamPhase(freshInput) === "live",
+      "stream live after rotation",
+    );
+
+    // Level reconciliation corrected the cached idle to the server's busy
+    // truth before the stream is trusted again.
+    await eventually(
+      () => {
+        const cached = getReactQueryClient().getQueryData<SessionStatus>(statusKey(workspaceId, sessionId));
+        return cached?.type === "busy";
+      },
+      "cached idle reconciled to busy",
+    );
+    expect(
+      useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive,
+    ).toBe(true);
+
+    // The same task's output resumes over the restarted stream…
+    liveSubscriptions[0]?.push({
+      type: "message.updated",
+      properties: { info: { id: "assistant-resumed", sessionID: sessionId, role: "assistant" } },
+    });
+    await eventually(
+      () => {
+        const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId));
+        return Boolean(transcript?.some((message) => message.id === "assistant-resumed"));
+      },
+      "resumed assistant message reached the transcript",
+    );
+
+    // …and completes.
+    liveSubscriptions[0]?.push({ type: "session.idle", properties: { sessionID: sessionId } });
+    await eventually(
+      () => {
+        const cached = getReactQueryClient().getQueryData<SessionStatus>(statusKey(workspaceId, sessionId));
+        return cached?.type === "idle";
+      },
+      "task completed after resume",
+    );
+
+    // Negative half: rotation reused the existing entry — exactly one live
+    // subscription exists and the stale token never connected.
+    expect(liveSubscriptions).toHaveLength(1);
+    expect(liveSubscriptions.every((subscription) => subscription.token === freshToken)).toBe(true);
+
+    releaseRotated();
+    releaseSession();
+    releaseWorkspace();
+  });
+
+  test("an unchanged token on reattachment does not churn a healthy stream", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(subscriptionFactory);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+
+    const first = createSyncInput(freshToken);
+    const releaseFirst = ensureWorkspaceSessionSync(first);
+    await eventually(() => liveSubscriptions.length === 1, "initial subscription");
+
+    const second = createSyncInput(freshToken);
+    const releaseSecond = ensureWorkspaceSessionSync(second);
+    await flushMicrotasks();
+
+    expect(liveSubscriptions).toHaveLength(1);
+    expect(liveSubscriptions[0]?.signal.aborted).toBe(false);
+    expect(getWorkspaceSessionSyncStreamPhase(first)).toBe("live");
+
+    releaseSecond();
+    releaseFirst();
+  });
+});

--- a/evals/specs/session-sync-stream-generation-restart.test.ts
+++ b/evals/specs/session-sync-stream-generation-restart.test.ts
@@ -1,0 +1,192 @@
+import { expect, vi } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  startSyncStreamLifecycle,
+  type SyncStreamPhase,
+} from "../../apps/app/src/react-app/domains/session/sync/sync-stream-lifecycle";
+
+/**
+ * The workspace event stream must never park in a terminal dead state while
+ * a task keeps running on the server. Auth-shaped subscribe failures (401,
+ * 403, 404) can be transient — a restarting local server or a rotating
+ * runtime generation — so they retry on a slower bounded backoff, and a
+ * token/runtime generation change restarts the stream immediately.
+ */
+
+function authError(status: number) {
+  return Object.assign(new Error(`subscribe rejected with ${status}`), { status });
+}
+
+function isAuthError(error: unknown) {
+  if (!error || typeof error !== "object" || !("status" in error)) return false;
+  const status = (error as { status: unknown }).status;
+  return status === 401 || status === 403 || status === 404;
+}
+
+function streamOf(items: unknown[], options: { thenHang: boolean }, signal: AbortSignal): AsyncIterable<unknown> {
+  return (async function* () {
+    for (const item of items) yield item;
+    if (options.thenHang) {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    }
+  })();
+}
+
+test("a stream killed by a stale token restarts on generation change and resumes the same task's events", async () => {
+  vi.useFakeTimers();
+  try {
+    let token = "generation-1";
+    const received: string[] = [];
+    const phases: SyncStreamPhase[] = [];
+    const timeline: string[] = [];
+    let subscribeAttempts = 0;
+
+    const lifecycle = startSyncStreamLifecycle({
+      subscribe: async (signal) => {
+        subscribeAttempts += 1;
+        timeline.push(`subscribe:${subscribeAttempts}:${token}`);
+        if (subscribeAttempts === 1) {
+          // The long task starts streaming, then the server drops the
+          // connection (for example a local server restart).
+          return streamOf(["task-started", "output-1"], { thenHang: false }, signal);
+        }
+        if (token !== "generation-2") throw authError(401);
+        return streamOf(["output-2", "task-completed"], { thenHang: true }, signal);
+      },
+      onEvent: (event) => {
+        received.push(String(event));
+        timeline.push(`event:${String(event)}`);
+      },
+      onConnected: () => {
+        timeline.push("reconcile");
+      },
+      onPhaseChange: (phase) => phases.push(phase),
+      isAuthError,
+    });
+
+    // First connection delivers the first half of the task, then ends.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(received).toEqual(["task-started", "output-1"]);
+    expect(lifecycle.getPhase()).toBe("reconnecting");
+
+    // Reconnects with the stale token are refused with 401 and park the
+    // stream in the auth-blocked lane — visibly, not silently.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscribeAttempts).toBe(2);
+    expect(lifecycle.getPhase()).toBe("auth-blocked");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(subscribeAttempts).toBe(3);
+    expect(lifecycle.getPhase()).toBe("auth-blocked");
+
+    // Negative half: while blocked, no events flow and nothing tight-loops.
+    expect(received).toEqual(["task-started", "output-1"]);
+
+    // The token rotates (reattachment) — the restart is immediate, with no
+    // timer to wait out and no remount of the lifecycle.
+    token = "generation-2";
+    lifecycle.notifyGenerationChanged();
+    expect(subscribeAttempts).toBe(4);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The same task's output resumes and completes on the same lifecycle.
+    expect(received).toEqual(["task-started", "output-1", "output-2", "task-completed"]);
+    expect(lifecycle.getPhase()).toBe("live");
+
+    // Level reconciliation runs on the reconnect before any resumed events,
+    // so cached idle state is corrected before the stream is trusted again.
+    const reconnectSubscribe = timeline.indexOf("subscribe:4:generation-2");
+    const reconnectReconcile = timeline.indexOf("reconcile", reconnectSubscribe);
+    const resumedEvent = timeline.indexOf("event:output-2");
+    expect(reconnectReconcile).toBeGreaterThan(reconnectSubscribe);
+    expect(resumedEvent).toBeGreaterThan(reconnectReconcile);
+
+    // The UI-facing phase history names every state it passed through.
+    expect(phases).toEqual([
+      "connecting",
+      "live",
+      "reconnecting",
+      "connecting",
+      "auth-blocked",
+      "connecting",
+      "auth-blocked",
+      "connecting",
+      "live",
+    ]);
+
+    lifecycle.dispose();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("a permanently invalid token backs off exponentially within bounds instead of tight-looping or dying", async () => {
+  vi.useFakeTimers();
+  try {
+    const attemptAt: number[] = [];
+    const lifecycle = startSyncStreamLifecycle({
+      subscribe: async () => {
+        attemptAt.push(Date.now());
+        throw authError(403);
+      },
+      onEvent: () => {},
+      isAuthError,
+    });
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    // Never terminal: the stream keeps probing so a later server-side fix
+    // (or generation change) can be picked up.
+    expect(lifecycle.getPhase()).toBe("auth-blocked");
+    expect(attemptAt.length).toBeGreaterThanOrEqual(5);
+
+    // Negative proof: no infinite tight reconnect loop. Ten minutes of a
+    // permanently invalid token yields a bounded number of attempts with a
+    // growing, capped spacing.
+    expect(attemptAt.length).toBeLessThanOrEqual(15);
+    const gaps = attemptAt.slice(1).map((at, index) => at - attemptAt[index]);
+    for (const gap of gaps) {
+      expect(gap).toBeGreaterThanOrEqual(5_000);
+      expect(gap).toBeLessThanOrEqual(60_000);
+    }
+    // The schedule is exponential until the cap, then holds the cap.
+    expect(gaps.slice(0, 4)).toEqual([5_000, 10_000, 20_000, 40_000]);
+    expect(gaps.at(-1)).toBe(60_000);
+
+    lifecycle.dispose();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("a silent live stream is exposed as stale and reconnected by the watchdog", async () => {
+  vi.useFakeTimers();
+  try {
+    let attempts = 0;
+    const phases: SyncStreamPhase[] = [];
+    const lifecycle = startSyncStreamLifecycle({
+      subscribe: async (signal) => {
+        attempts += 1;
+        return streamOf([], { thenHang: true }, signal);
+      },
+      onEvent: () => {},
+      onPhaseChange: (phase) => phases.push(phase),
+      isAuthError,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.getPhase()).toBe("live");
+
+    // No events for longer than the stale threshold: the watchdog exposes
+    // the stall as "stale" and replaces the connection.
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(phases).toContain("stale");
+    expect(attempts).toBeGreaterThanOrEqual(2);
+    expect(lifecycle.getPhase()).toBe("live");
+
+    lifecycle.dispose();
+  } finally {
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Problem

`shouldRetrySyncSubscribe` treated 401/403/404 subscribe failures as terminal: the reconnect loop stopped scheduling retries entirely. That is reasonable for a permanently invalid token, but the same statuses occur transiently while the local server restarts or the runtime generation rotates. Later reattachment updated `entry.openworkToken`, but a stream that had already terminated was never restarted — the watchdog only acts while an active connection controller exists. The task kept running on the server while Desktop received no further events until a full reload.

## Change

- Extracted the reconnect loop from `session-sync.ts` into a dependency-free, generation-aware lifecycle (`sync-stream-lifecycle.ts`). There is no terminal dead state anymore:
  - Auth-shaped failures (401/403/404) retry on a slower **bounded exponential backoff** (5s doubling to a 60s cap) instead of dying — and instead of tight-looping on the fast network-error schedule.
  - Reattachment with a rotated token advances the connection **generation**: a stream parked in auth backoff restarts immediately with fresh backoff and the new credential. An auth failure from an attempt that raced the rotation is treated as stale evidence and retried promptly.
  - A healthy stream is left alone on rotation; if the server cuts it, the ordinary retry path reconnects with the new generation.
- On every successful (re)connect, run statuses are **level-reconciled** (existing `reconcileSessionRunStatuses`) before the stream is trusted again, so a cached idle recorded while the stream was down cannot mask work that continued on the server.
- The stream phase is **exposed** to surfaces through `useWorkspaceSyncStreamStore` / `getWorkspaceSessionSyncStreamPhase`: `connecting`, `live`, `reconnecting`, `auth-blocked`, `stale`.

## Proof (local lane)

`evals/specs/session-sync-stream-generation-restart.test.ts` (`@openwork/testkit`, PR lane):

- **Resume after rotation**: a long task streams, the connection drops, stale-token reconnects park the stream in `auth-blocked`; rotating the token restarts the stream immediately (no timer wait, no remount), reconciliation runs before the first resumed event, and the same task's events resume and complete. Phase history asserts every state transition.
- **Negative proof**: a permanently invalid token over 10 simulated minutes yields a bounded number of attempts (≤15), every gap ≥5s and ≤60s, exponential (5s, 10s, 20s, 40s) up to the 60s cap — no infinite tight reconnect loop, and the stream still probes (never terminal).
- **Watchdog**: a silent live stream is exposed as `stale` and reconnected.

`apps/app/tests/session-sync-token-rotation.test.ts` (wiring through the real `session-sync` module): a stale token parks the real sync entry in `auth-blocked`; `ensureWorkspaceSessionSync` reattachment with a rotated token restarts the stream on the same entry (no remount), the fresh-token subscription reconciles a cached idle back to the server's busy truth, a resumed assistant message reaches the transcript cache, and `session.idle` completes the task. Negative half: exactly one live subscription, never with the stale token; an unchanged token does not churn a healthy stream.

```
pnpm --dir evals exec vitest run --project pr specs/session-sync-stream-generation-restart.test.ts
  → 3 passed (3), 0 failed, 0 skipped
cd apps/app && bun test --isolate tests/session-sync-token-rotation.test.ts \
  tests/session-sync-run-status.test.ts tests/session-sync-lifecycle.test.ts \
  tests/session-sync-permissions.test.ts tests/session-sync-tool-parts.test.ts
  → 51 pass, 0 fail
pnpm --dir apps/app typecheck → clean
```

Full `bun test --isolate tests/` shows 5 failures that reproduce identically on a clean `origin/dev` (4e9b6eac6) control run in the same environment (1047 pass/5 fail clean vs 1049 pass/5 fail with this change — the +2 are this PR's new tests): `connect-capability-inventory` ×2, `cloud workspace boot takeover`, `session-route cloud provider sync wiring`, `extensions-sidebar-header` — pre-existing, unrelated.

Verdict: **Passed** (local lane; Daytona not used for this renderer-unit-provable change).