### PR TITLE
fix(app): make the queued-message drain admission-aware so it cannot wedge

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/queued-drain-machine.ts
+++ b/apps/app/src/react-app/domains/session/surface/queued-drain-machine.ts
@@ -1,0 +1,275 @@
+/**
+ * Admission-aware drain state machine for queued composer follow-ups.
+ *
+ * The previous drain used a single boolean "awaiting busy" edge-wait: it was
+ * armed before every queued send and cleared only by an observed busy edge or
+ * a failed send. When a send was admitted but the busy event never surfaced
+ * (dropped SSE event, upstream dispatch failure after admission, or a stream
+ * reconnect during admission), the boolean stayed armed forever and every
+ * later queued item was wedged behind it.
+ *
+ * This machine replaces the edge-wait with explicit per-item admission state
+ * keyed by the queued item id (which the drain also uses as the engine
+ * message admission key). Every queued item resolves to exactly one of:
+ *
+ * - `admitted_running`               — admission + a busy observation
+ * - `admitted_awaiting_observation`  — admitted, run not yet observed
+ * - `completed`                      — an authoritative idle level observed
+ *                                      at/after admission released the item
+ * - `needs_input`                    — the pre-send gate blocked; the user
+ *                                      must retry explicitly
+ * - `rejected`                       — the send was cancelled (context
+ *                                      changed / unmounted); item re-queued
+ * - `retryable_unknown`              — the send threw; item re-queued
+ * - `terminal_failure`               — the same item exhausted its send
+ *                                      attempts; drain halts until user retry
+ *
+ * A missing busy event is never the only signal that allows progress: an
+ * item stuck in `awaiting_observation` is released by a *level-reconciled*
+ * idle observation (an authoritative status read whose observation time is
+ * at/after the admission time), never by a stale idle that predates the
+ * admission.
+ *
+ * State lives in a module-level per-session store (not component refs) so an
+ * in-flight admission survives navigating away from and back to the session.
+ */
+
+/** How long an admitted send may go unobserved before the drain probes an
+ * authoritative status level instead of waiting for the busy edge. */
+export const QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS = 10_000;
+
+/** Spacing between authoritative probes when the first probe cannot decide
+ * (for example the status endpoint is briefly unreachable). */
+export const QUEUE_ADMISSION_PROBE_RETRY_MS = 5_000;
+
+/** Send attempts allowed per queued item before the drain halts as a
+ * terminal failure and waits for an explicit user retry. */
+export const QUEUE_SEND_ATTEMPT_LIMIT = 3;
+
+export type QueuedDrainPhase =
+  | { kind: "ready" }
+  | { kind: "sending"; itemId: string; busySeen: boolean }
+  | { kind: "awaiting_observation"; itemId: string; admittedAt: number }
+  | { kind: "running"; itemId: string }
+  | { kind: "halted"; itemId: string; reason: "needs_input" | "terminal_failure" };
+
+export type QueuedItemResolution =
+  | "admitted_running"
+  | "admitted_awaiting_observation"
+  | "completed"
+  | "needs_input"
+  | "rejected"
+  | "retryable_unknown"
+  | "terminal_failure";
+
+export type QueuedDrainState = {
+  phase: QueuedDrainPhase;
+  attemptsByItemId: Record<string, number>;
+  lastResolution: { itemId: string; resolution: QueuedItemResolution } | null;
+};
+
+export type QueuedDrainEvent =
+  | { type: "send_started"; itemId: string }
+  | { type: "send_result"; itemId: string; outcome: "sent" | "accepted" | "blocked" | "cancelled"; at: number }
+  | { type: "send_error"; itemId: string }
+  | { type: "busy_observed" }
+  /** An authoritative status level read (SSE-followed idle after a busy
+   * observation, or an explicit snapshot/status probe). `observedAt` is when
+   * the observation was initiated so stale idles are ordered against the
+   * admission time and dropped. */
+  | { type: "idle_reconciled"; observedAt: number }
+  | { type: "user_retry" }
+  | { type: "queue_cleared" };
+
+export const INITIAL_QUEUED_DRAIN_STATE: QueuedDrainState = {
+  phase: { kind: "ready" },
+  attemptsByItemId: {},
+  lastResolution: null,
+};
+
+function resolved(
+  state: QueuedDrainState,
+  phase: QueuedDrainPhase,
+  itemId: string,
+  resolution: QueuedItemResolution,
+  attemptsByItemId?: Record<string, number>,
+): QueuedDrainState {
+  return {
+    phase,
+    attemptsByItemId: attemptsByItemId ?? state.attemptsByItemId,
+    lastResolution: { itemId, resolution },
+  };
+}
+
+export function reduceQueuedDrain(state: QueuedDrainState, event: QueuedDrainEvent): QueuedDrainState {
+  const { phase } = state;
+  switch (event.type) {
+    case "send_started": {
+      if (phase.kind !== "ready") return state;
+      const attempts = (state.attemptsByItemId[event.itemId] ?? 0) + 1;
+      return {
+        phase: { kind: "sending", itemId: event.itemId, busySeen: false },
+        attemptsByItemId: { ...state.attemptsByItemId, [event.itemId]: attempts },
+        lastResolution: state.lastResolution,
+      };
+    }
+    case "send_result": {
+      if (phase.kind !== "sending" || phase.itemId !== event.itemId) return state;
+      if (event.outcome === "sent" || event.outcome === "accepted") {
+        // Admitted. The engine may have rendered its busy status before the
+        // send promise resolved; a busy seen during the send belongs to this
+        // admission.
+        if (phase.busySeen) {
+          return resolved(state, { kind: "running", itemId: event.itemId }, event.itemId, "admitted_running");
+        }
+        return resolved(
+          state,
+          { kind: "awaiting_observation", itemId: event.itemId, admittedAt: event.at },
+          event.itemId,
+          "admitted_awaiting_observation",
+        );
+      }
+      if (event.outcome === "blocked") {
+        return resolved(
+          state,
+          { kind: "halted", itemId: event.itemId, reason: "needs_input" },
+          event.itemId,
+          "needs_input",
+        );
+      }
+      // cancelled: the submission context changed; the caller re-queues the
+      // item and the drain may try again when conditions settle.
+      return resolved(state, { kind: "ready" }, event.itemId, "rejected");
+    }
+    case "send_error": {
+      if (phase.kind !== "sending" || phase.itemId !== event.itemId) return state;
+      const attempts = state.attemptsByItemId[event.itemId] ?? 1;
+      if (attempts >= QUEUE_SEND_ATTEMPT_LIMIT) {
+        return resolved(
+          state,
+          { kind: "halted", itemId: event.itemId, reason: "terminal_failure" },
+          event.itemId,
+          "terminal_failure",
+        );
+      }
+      return resolved(state, { kind: "ready" }, event.itemId, "retryable_unknown");
+    }
+    case "busy_observed": {
+      if (phase.kind === "sending") {
+        return { ...state, phase: { ...phase, busySeen: true } };
+      }
+      if (phase.kind === "awaiting_observation") {
+        return resolved(state, { kind: "running", itemId: phase.itemId }, phase.itemId, "admitted_running");
+      }
+      return state;
+    }
+    case "idle_reconciled": {
+      if (phase.kind === "running") {
+        // Busy was observed for this admission, so a later idle level is a
+        // genuinely new level: the run finished.
+        return resolved(state, { kind: "ready" }, phase.itemId, "completed", dropAttempt(state, phase.itemId));
+      }
+      if (phase.kind === "awaiting_observation") {
+        // Negative invariant: a stale idle observed before the admission
+        // must never release the item — that idle predates our send.
+        if (event.observedAt < phase.admittedAt) return state;
+        // Authoritative idle at/after admission: either the run started and
+        // finished between observations (missed busy edge) or upstream
+        // dispatch failed after admission. Either way the admitted item can
+        // no longer block the queue.
+        return resolved(state, { kind: "ready" }, phase.itemId, "completed", dropAttempt(state, phase.itemId));
+      }
+      return state;
+    }
+    case "user_retry": {
+      if (phase.kind !== "halted") return state;
+      return {
+        phase: { kind: "ready" },
+        attemptsByItemId: dropAttempt(state, phase.itemId),
+        lastResolution: state.lastResolution,
+      };
+    }
+    case "queue_cleared": {
+      // Stop means stop: an aborted queue must not leave a halted or
+      // awaiting admission behind to wedge the next queueing round. A
+      // running admission resolves through the normal idle level.
+      if (phase.kind === "running" || phase.kind === "sending") return state;
+      return { ...INITIAL_QUEUED_DRAIN_STATE, lastResolution: state.lastResolution };
+    }
+  }
+}
+
+function dropAttempt(state: QueuedDrainState, itemId: string): Record<string, number> {
+  if (!(itemId in state.attemptsByItemId)) return state.attemptsByItemId;
+  const next = { ...state.attemptsByItemId };
+  delete next[itemId];
+  return next;
+}
+
+/** True when the drain may admit the next queued item. */
+export function canAdmitNextQueuedItem(state: QueuedDrainState): boolean {
+  return state.phase.kind === "ready";
+}
+
+/** When (epoch ms) the awaiting admission should be probed against an
+ * authoritative status level; null when no probe is due. */
+export function nextObservationProbeAt(state: QueuedDrainState, lastProbeAt: number | null): number | null {
+  if (state.phase.kind !== "awaiting_observation") return null;
+  const due = state.phase.admittedAt + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS;
+  if (lastProbeAt === null) return due;
+  return Math.max(due, lastProbeAt + QUEUE_ADMISSION_PROBE_RETRY_MS);
+}
+
+// --- Per-session store -----------------------------------------------------
+//
+// Component refs die on unmount, but an admission does not: navigating away
+// from a session and back while its first queued item is running must not
+// forget the in-flight admission (a fresh boolean would either wedge or,
+// worse, drain the next item into a stale idle render). Sessions are pruned
+// from the map as soon as they return to the initial state.
+
+const drainStateBySession = new Map<string, QueuedDrainState>();
+const drainListenersBySession = new Map<string, Set<() => void>>();
+
+export function getQueuedDrainState(sessionId: string): QueuedDrainState {
+  return drainStateBySession.get(sessionId) ?? INITIAL_QUEUED_DRAIN_STATE;
+}
+
+export function dispatchQueuedDrain(sessionId: string, event: QueuedDrainEvent): QueuedDrainState {
+  const current = getQueuedDrainState(sessionId);
+  const next = reduceQueuedDrain(current, event);
+  if (next === current) return current;
+  if (next.phase.kind === "ready" && Object.keys(next.attemptsByItemId).length === 0 && next.lastResolution === null) {
+    drainStateBySession.delete(sessionId);
+  } else {
+    drainStateBySession.set(sessionId, next);
+  }
+  const listeners = drainListenersBySession.get(sessionId);
+  if (listeners) for (const listener of listeners) listener();
+  return next;
+}
+
+/** Atomically claim the send slot for one queued item. Returns false when
+ * another surface (for example a split view of the same session) already
+ * holds a non-ready phase, so a queued item can never be sent twice. */
+export function claimQueuedSend(sessionId: string, itemId: string): boolean {
+  if (!canAdmitNextQueuedItem(getQueuedDrainState(sessionId))) return false;
+  const next = dispatchQueuedDrain(sessionId, { type: "send_started", itemId });
+  return next.phase.kind === "sending" && next.phase.itemId === itemId;
+}
+
+export function subscribeQueuedDrain(sessionId: string, listener: () => void): () => void {
+  const listeners = drainListenersBySession.get(sessionId) ?? new Set();
+  drainListenersBySession.set(sessionId, listeners);
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) drainListenersBySession.delete(sessionId);
+  };
+}
+
+/** Test-only: forget every session's drain state. */
+export function resetQueuedDrainForTests() {
+  drainStateBySession.clear();
+  drainListenersBySession.clear();
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
@@ -50,6 +50,14 @@ import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
 import { connectSkillPrompt, parseConnectSkillToken } from "./composer/connect-skill-token";
 import { createPastedTextChip, resolvePastedTextPlaceholders } from "./composer/pasted-text";
+import {
+  canAdmitNextQueuedItem,
+  claimQueuedSend,
+  dispatchQueuedDrain,
+  getQueuedDrainState,
+  nextObservationProbeAt,
+  subscribeQueuedDrain,
+} from "./queued-drain-machine";
 import { DevProfiler } from "@/react-app/shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
 import { useShellConfig } from "@/react-app/shell/shell-config";
@@ -922,7 +930,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const cloudQueueBlockedRef = useRef(false);
   // Shared with promote-to-send so a manual send-now cannot race the idle drain.
   const drainingQueueRef = useRef(false);
-  const awaitingQueueBusyRef = useRef(false);
+  // Admission-aware drain state. It lives in a module-level per-session store
+  // (not a ref) so an in-flight admission survives navigating away and back.
+  const subscribeDrainState = useCallback(
+    (listener: () => void) => subscribeQueuedDrain(props.sessionId, listener),
+    [props.sessionId],
+  );
+  const readDrainState = useCallback(() => getQueuedDrainState(props.sessionId), [props.sessionId]);
+  const queuedDrainState = useSyncExternalStore(subscribeDrainState, readDrainState);
+  const lastObservationProbeAtRef = useRef<number | null>(null);
+  const [observationProbeVersion, setObservationProbeVersion] = useState(0);
   const composerShellRef = useRef<HTMLDivElement>(null);
   const hydratedKeyRef = useRef<string | null>(null);
   const autoOpenedTargetRef = useRef<string | null>(null);
@@ -957,7 +974,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   const currentSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
   const transcriptState = useSharedQueryState<UIMessage[]>(transcriptQueryKey, EMPTY_TRANSCRIPT);
-  const statusState = useSharedQueryState(statusQueryKey, currentSnapshot?.status ?? IDLE_STATUS);
+  const statusQuery = useQuery<SessionStatus, Error, SessionStatus, readonly unknown[]>({
+    queryKey: statusQueryKey,
+    queryFn: async () => currentSnapshot?.status ?? IDLE_STATUS,
+    enabled: false,
+  });
+  const statusState = statusQuery.data ?? currentSnapshot?.status ?? IDLE_STATUS;
+  // The shared status entry is written only by the session-status stream and
+  // its reconnect-time level reconciliation, so its presence marks the value
+  // as a real observed level instead of a render fallback. Queue-drain
+  // completion must never trust a fallback idle (a remount briefly renders
+  // idle before any status has been observed).
+  const statusIsObservedLevel = statusQuery.data !== undefined;
 
   useEffect(() => {
     if (!currentSnapshot) return;
@@ -1563,8 +1591,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return;
     }
     cloudQueueBlockedRef.current = false;
+    dispatchQueuedDrain(props.sessionId, { type: "user_retry" });
     setCloudQueueRetryVersion((version) => version + 1);
-  }, [attachments.length, draft, handleSend]);
+  }, [attachments.length, draft, handleSend, props.sessionId]);
 
   // Queue: hold the draft locally and clear the composer. The drain effect
   // sends it once the session reports idle.
@@ -1629,6 +1658,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     // lands and the session reports idle (#2014).
     queuedItems.forEach((item) => item.draft.attachments.forEach(revokeAttachmentPreview));
     clearQueuedDrafts(props.sessionId);
+    dispatchQueuedDrain(props.sessionId, { type: "queue_cleared" });
     // The prompt was sent through a directory-scoped client (session-route
     // passes the workspace root), so the abort must target the same scope —
     // without it the server resolves the default project, finds no live run,
@@ -1657,61 +1687,114 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, props.workspaceId]);
 
   // Drain one queued follow-up each time the session goes idle, so prompts
-  // run as separate turns instead of one merged message. The busy-wait is
-  // grounded in the engine's own run status (liveStatus), not chatStreaming:
-  // the client-side `sending` pulse would release the wait before the engine
+  // run as separate turns instead of one merged message. Progress is grounded
+  // in the engine's own run status (liveStatus), not chatStreaming: the
+  // client-side `sending` pulse would release the wait before the engine
   // actually went busy and the next idle render could steer the following
-  // item into the still-starting turn.
+  // item into the still-starting turn. Feed status levels into the
+  // admission-aware machine: a busy level attaches the current admission to a
+  // running run, and an idle level completes an admission that was already
+  // observed running. An admission that never shows busy is released only by
+  // the authoritative probe below — never by a stale idle render.
   useEffect(() => {
     if (liveStatus.type !== "idle") {
-      awaitingQueueBusyRef.current = false;
+      dispatchQueuedDrain(props.sessionId, { type: "busy_observed" });
+      return;
     }
-  }, [liveStatus.type]);
+    if (!statusIsObservedLevel) return;
+    if (getQueuedDrainState(props.sessionId).phase.kind === "running") {
+      dispatchQueuedDrain(props.sessionId, { type: "idle_reconciled", observedAt: Date.now() });
+    }
+  }, [liveStatus.type, props.sessionId, statusIsObservedLevel]);
+
+  // Admission observation probe: when an admitted send has produced no busy
+  // observation within its window (dropped event, upstream dispatch failure
+  // after admission, or an event-stream reconnect), reconcile against an
+  // authoritative snapshot fetch instead of waiting on the missing edge
+  // forever. The probe's start time orders the observed level against the
+  // admission time inside the machine, so a stale idle can never release it.
+  useEffect(() => {
+    const probeAt = nextObservationProbeAt(queuedDrainState, lastObservationProbeAtRef.current);
+    if (probeAt === null) return;
+    const timer = window.setTimeout(() => {
+      const startedAt = Date.now();
+      lastObservationProbeAtRef.current = startedAt;
+      void (async () => {
+        try {
+          const result = await snapshotQuery.refetch();
+          const probed = result.data?.session.id === props.sessionId ? result.data.status : null;
+          if (!probed) return;
+          if (probed.type === "idle") {
+            dispatchQueuedDrain(props.sessionId, { type: "idle_reconciled", observedAt: startedAt });
+          } else {
+            dispatchQueuedDrain(props.sessionId, { type: "busy_observed" });
+          }
+        } catch {
+          // Probe failed (for example the local server was briefly
+          // unreachable); the version bump below re-arms a spaced retry.
+        } finally {
+          setObservationProbeVersion((version) => version + 1);
+        }
+      })();
+    }, Math.max(0, probeAt - Date.now()));
+    return () => window.clearTimeout(timer);
+  }, [observationProbeVersion, props.sessionId, queuedDrainState, snapshotQuery.refetch]);
 
   useEffect(() => {
     if (drainingQueueRef.current || sendingQueued) return;
     if (cloudQueueBlockedRef.current) return;
-    if (awaitingQueueBusyRef.current) return;
     if (queuedItems.length === 0) return;
     if (chatStreaming || liveStatus.type !== "idle") return;
+    if (!canAdmitNextQueuedItem(queuedDrainState)) return;
     const nextItem = queuedItems[0];
     if (!nextItem) return;
     const nextDraft = withoutRevertTarget(nextItem.draft);
     if (!nextDraft) return;
+    // Claim the send slot atomically BEFORE the send can resolve: the
+    // engine's busy status can render before the send promise's continuation
+    // runs, and claiming late would erase that observation. The claim is
+    // per-session (not per-surface), so a split view of this session cannot
+    // deliver the same queued item twice.
+    if (!claimQueuedSend(props.sessionId, nextItem.id)) return;
     drainingQueueRef.current = true;
     removeQueuedDraftFromStore(props.sessionId, nextItem.id);
-    // Arm the busy-wait BEFORE the send can resolve: the engine's busy status
-    // can render before the send promise's continuation runs, and arming late
-    // would erase that observation — the next idle would then never drain the
-    // following item. Failure paths below disarm so retries stay possible.
-    awaitingQueueBusyRef.current = true;
     void (async () => {
       try {
         const result = await sendDraft(nextDraft);
+        dispatchQueuedDrain(props.sessionId, {
+          type: "send_result",
+          itemId: nextItem.id,
+          outcome: result.outcome,
+          at: Date.now(),
+        });
         if (result.outcome === "blocked") {
           cloudQueueBlockedRef.current = true;
-          awaitingQueueBusyRef.current = false;
           prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
         } else if (result.outcome === "cancelled") {
-          awaitingQueueBusyRef.current = false;
           prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
         } else {
           nextDraft.attachments.forEach(revokeAttachmentPreview);
         }
       } catch {
-        awaitingQueueBusyRef.current = false;
+        dispatchQueuedDrain(props.sessionId, { type: "send_error", itemId: nextItem.id });
         prependQueuedDrafts(props.sessionId, [{ id: nextItem.id, draft: nextDraft }]);
       } finally {
         drainingQueueRef.current = false;
       }
     })();
-  }, [chatStreaming, cloudQueueRetryVersion, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedItems, removeQueuedDraftFromStore, sendDraft, sendingQueued]);
+  }, [chatStreaming, cloudQueueRetryVersion, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrainState, queuedItems, removeQueuedDraftFromStore, sendDraft, sendingQueued]);
 
   useEffect(() => {
     if (props.cloudMcpSubmissionState.status !== "failed") {
       cloudQueueBlockedRef.current = false;
+      // A cleared submission gate releases a drain halted on needs_input; a
+      // terminal_failure halt stays until the user explicitly retries.
+      const drain = getQueuedDrainState(props.sessionId);
+      if (drain.phase.kind === "halted" && drain.phase.reason === "needs_input") {
+        dispatchQueuedDrain(props.sessionId, { type: "user_retry" });
+      }
     }
-  }, [props.cloudMcpSubmissionState.status]);
+  }, [props.cloudMcpSubmissionState.status, props.sessionId]);
 
   useEffect(() => {
     const nextDraft = buildDraft(draft, attachments);

--- a/evals/specs/queued-drain-admission-wedge.test.ts
+++ b/evals/specs/queued-drain-admission-wedge.test.ts
@@ -1,0 +1,225 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import {
+  canAdmitNextQueuedItem,
+  claimQueuedSend,
+  dispatchQueuedDrain,
+  getQueuedDrainState,
+  INITIAL_QUEUED_DRAIN_STATE,
+  nextObservationProbeAt,
+  QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS,
+  QUEUE_ADMISSION_PROBE_RETRY_MS,
+  QUEUE_SEND_ATTEMPT_LIMIT,
+  reduceQueuedDrain,
+  resetQueuedDrainForTests,
+  subscribeQueuedDrain,
+  type QueuedDrainState,
+} from "../../apps/app/src/react-app/domains/session/surface/queued-drain-machine";
+
+// The queued-message drain protocol lives entirely in the admission-aware
+// machine these tests drive; session-surface.tsx is a thin adapter that maps
+// engine status levels and send outcomes onto these events. Each scenario
+// asserts both the progress claim and its negative half: what must NOT allow
+// the next queued item to be sent.
+
+const t0 = 1_000_000;
+
+function admit(state: QueuedDrainState, itemId: string, at: number): QueuedDrainState {
+  const sending = reduceQueuedDrain(state, { type: "send_started", itemId });
+  expect(sending.phase).toEqual({ kind: "sending", itemId, busySeen: false });
+  return reduceQueuedDrain(sending, { type: "send_result", itemId, outcome: "sent", at });
+}
+
+test("a dropped busy event after a successful admission cannot wedge the drain", () => {
+  // Admission succeeds, but the engine's busy event never arrives (dropped
+  // SSE event). The old boolean edge-wait stayed armed forever here.
+  let state = admit(INITIAL_QUEUED_DRAIN_STATE, "item-1", t0);
+  expect(state.phase).toEqual({ kind: "awaiting_observation", itemId: "item-1", admittedAt: t0 });
+  expect(state.lastResolution).toEqual({ itemId: "item-1", resolution: "admitted_awaiting_observation" });
+
+  // Negative half: while the admission is unobserved, nothing may drain — a
+  // stale idle level observed BEFORE the admission must be dropped.
+  expect(canAdmitNextQueuedItem(state)).toBe(false);
+  const staleIdle = reduceQueuedDrain(state, { type: "idle_reconciled", observedAt: t0 - 1 });
+  expect(staleIdle).toBe(state);
+  expect(canAdmitNextQueuedItem(staleIdle)).toBe(false);
+
+  // The machine schedules an authoritative observation probe instead of
+  // waiting on the missing edge forever.
+  expect(nextObservationProbeAt(state, null)).toBe(t0 + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS);
+
+  // The probe observes an authoritative idle level at/after the admission:
+  // the run started and finished between observations. The item completes
+  // and the next queued item may be admitted.
+  const probedAt = t0 + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS;
+  state = reduceQueuedDrain(state, { type: "idle_reconciled", observedAt: probedAt });
+  expect(state.lastResolution).toEqual({ itemId: "item-1", resolution: "completed" });
+  expect(canAdmitNextQueuedItem(state)).toBe(true);
+});
+
+test("a message accepted by admission whose upstream dispatch fails still releases the queue", () => {
+  // The admission call returned accepted, but dispatch never produced a run:
+  // no busy level ever exists. Progress must not depend on the busy event.
+  let state = admit(INITIAL_QUEUED_DRAIN_STATE, "item-1", t0);
+
+  // No busy is ever observed. The first probe is inconclusive (endpoint
+  // briefly unreachable) — retries stay bounded and spaced.
+  const firstProbeAt = t0 + QUEUE_ADMISSION_OBSERVATION_TIMEOUT_MS;
+  expect(nextObservationProbeAt(state, firstProbeAt)).toBe(firstProbeAt + QUEUE_ADMISSION_PROBE_RETRY_MS);
+
+  // The retry probe reads the authoritative level: still idle, at a time
+  // after the admission. The admitted-but-never-ran item cannot block the
+  // queue: it resolves and the next item drains.
+  state = reduceQueuedDrain(state, {
+    type: "idle_reconciled",
+    observedAt: firstProbeAt + QUEUE_ADMISSION_PROBE_RETRY_MS,
+  });
+  expect(state.lastResolution).toEqual({ itemId: "item-1", resolution: "completed" });
+  expect(canAdmitNextQueuedItem(state)).toBe(true);
+
+  // Contrast: a send whose transport THREW was never admitted — it stays
+  // retryable and halts as a terminal failure once attempts are exhausted,
+  // instead of retrying forever or silently dropping the item.
+  let failing = INITIAL_QUEUED_DRAIN_STATE;
+  for (let attempt = 1; attempt <= QUEUE_SEND_ATTEMPT_LIMIT; attempt += 1) {
+    failing = reduceQueuedDrain(failing, { type: "send_started", itemId: "item-2" });
+    failing = reduceQueuedDrain(failing, { type: "send_error", itemId: "item-2" });
+    if (attempt < QUEUE_SEND_ATTEMPT_LIMIT) {
+      expect(failing.lastResolution).toEqual({ itemId: "item-2", resolution: "retryable_unknown" });
+      expect(canAdmitNextQueuedItem(failing)).toBe(true);
+    }
+  }
+  expect(failing.phase).toEqual({ kind: "halted", itemId: "item-2", reason: "terminal_failure" });
+  expect(failing.lastResolution).toEqual({ itemId: "item-2", resolution: "terminal_failure" });
+  // Negative half: a terminal failure never self-heals into a send.
+  expect(canAdmitNextQueuedItem(failing)).toBe(false);
+  // An explicit user retry — and only that — releases it.
+  failing = reduceQueuedDrain(failing, { type: "user_retry" });
+  expect(canAdmitNextQueuedItem(failing)).toBe(true);
+});
+
+test("an event-stream disconnect and reconnect during admission is healed by level reconciliation", () => {
+  // Busy can render before the send promise resolves; an admission must
+  // attach that observation instead of losing it (fast engine, slow HTTP).
+  let racing = reduceQueuedDrain(INITIAL_QUEUED_DRAIN_STATE, { type: "send_started", itemId: "item-1" });
+  racing = reduceQueuedDrain(racing, { type: "busy_observed" });
+  racing = reduceQueuedDrain(racing, { type: "send_result", itemId: "item-1", outcome: "sent", at: t0 });
+  expect(racing.phase).toEqual({ kind: "running", itemId: "item-1" });
+  expect(racing.lastResolution).toEqual({ itemId: "item-1", resolution: "admitted_running" });
+
+  // Disconnect during admission: the stream dies right after the send is
+  // admitted, so no live busy event ever arrives.
+  let state = admit(INITIAL_QUEUED_DRAIN_STATE, "item-1", t0);
+  expect(canAdmitNextQueuedItem(state)).toBe(false);
+
+  // Reconnect path A: the reconnect-time status reconciliation reports the
+  // session busy — the admission attaches to the running run, and only a
+  // LATER observed idle completes it.
+  const reconnectBusy = reduceQueuedDrain(state, { type: "busy_observed" });
+  expect(reconnectBusy.phase).toEqual({ kind: "running", itemId: "item-1" });
+  const finished = reduceQueuedDrain(reconnectBusy, { type: "idle_reconciled", observedAt: t0 + 20_000 });
+  expect(finished.lastResolution).toEqual({ itemId: "item-1", resolution: "completed" });
+  expect(canAdmitNextQueuedItem(finished)).toBe(true);
+
+  // Reconnect path B: the run already finished while disconnected; the
+  // reconciliation reports idle observed after the admission. That level —
+  // not a busy edge — releases the item.
+  const reconnectIdle = reduceQueuedDrain(state, { type: "idle_reconciled", observedAt: t0 + 20_000 });
+  expect(reconnectIdle.lastResolution).toEqual({ itemId: "item-1", resolution: "completed" });
+  expect(canAdmitNextQueuedItem(reconnectIdle)).toBe(true);
+
+  // Negative half: an idle captured before the admission (a snapshot fetched
+  // pre-send that resolves late) must not release the admission.
+  const staleIdle = reduceQueuedDrain(state, { type: "idle_reconciled", observedAt: t0 - 5 });
+  expect(staleIdle).toBe(state);
+  expect(canAdmitNextQueuedItem(staleIdle)).toBe(false);
+});
+
+test("three queued items are admitted exactly once each and in order", () => {
+  resetQueuedDrainForTests();
+  const sessionId = "ses_fifo";
+  const items = ["item-1", "item-2", "item-3"];
+  const admitted: string[] = [];
+
+  for (const [index, itemId] of items.entries()) {
+    // The drain claims the send slot atomically before sending.
+    expect(claimQueuedSend(sessionId, itemId)).toBe(true);
+    admitted.push(itemId);
+
+    // Negative half (exactly once): while this item is in flight — through
+    // sending, admission, and the run itself — no other surface (for
+    // example a split view of the same session) can claim another send.
+    const rival = items[index + 1] ?? "item-extra";
+    expect(claimQueuedSend(sessionId, rival)).toBe(false);
+    dispatchQueuedDrain(sessionId, { type: "send_result", itemId, outcome: "sent", at: t0 + index * 100 });
+    expect(claimQueuedSend(sessionId, rival)).toBe(false);
+    dispatchQueuedDrain(sessionId, { type: "busy_observed" });
+    expect(claimQueuedSend(sessionId, rival)).toBe(false);
+
+    // The run finishes: an observed idle level completes the item.
+    dispatchQueuedDrain(sessionId, { type: "idle_reconciled", observedAt: t0 + index * 100 + 50 });
+  }
+
+  expect(admitted).toEqual(items);
+  expect(canAdmitNextQueuedItem(getQueuedDrainState(sessionId))).toBe(true);
+  resetQueuedDrainForTests();
+});
+
+test("an active admission survives navigating away and back", () => {
+  resetQueuedDrainForTests();
+  const sessionId = "ses_navigation";
+
+  // The surface mounts, drains the first item, and observes its run start.
+  const unsubscribe = subscribeQueuedDrain(sessionId, () => {});
+  expect(claimQueuedSend(sessionId, "item-1")).toBe(true);
+  dispatchQueuedDrain(sessionId, { type: "send_result", itemId: "item-1", outcome: "sent", at: t0 });
+  dispatchQueuedDrain(sessionId, { type: "busy_observed" });
+
+  // Navigate away: the surface unmounts and its subscription is dropped.
+  // Component-local refs would die here; the admission must not.
+  unsubscribe();
+
+  // Navigate back: a fresh surface reads the same in-flight admission.
+  const remounted = getQueuedDrainState(sessionId);
+  expect(remounted.phase).toEqual({ kind: "running", itemId: "item-1" });
+
+  // Negative half: the remount briefly renders a fallback idle before any
+  // status level is observed. The adapter never emits idle_reconciled for a
+  // fallback, and the machine keeps the queue closed until a real level
+  // arrives — the next item is not sent into the still-active run.
+  expect(canAdmitNextQueuedItem(remounted)).toBe(false);
+  expect(claimQueuedSend(sessionId, "item-2")).toBe(false);
+
+  // The run completes and a real observed idle level arrives: the queue
+  // reopens and the next item drains in order.
+  dispatchQueuedDrain(sessionId, { type: "idle_reconciled", observedAt: t0 + 30_000 });
+  expect(claimQueuedSend(sessionId, "item-2")).toBe(true);
+  resetQueuedDrainForTests();
+});
+
+test("blocked and cancelled sends classify as needs_input and rejected without wedging", () => {
+  // Blocked by the pre-send gate: the user must act; drain halts loudly.
+  let blocked = reduceQueuedDrain(INITIAL_QUEUED_DRAIN_STATE, { type: "send_started", itemId: "item-1" });
+  blocked = reduceQueuedDrain(blocked, { type: "send_result", itemId: "item-1", outcome: "blocked", at: t0 });
+  expect(blocked.phase).toEqual({ kind: "halted", itemId: "item-1", reason: "needs_input" });
+  expect(blocked.lastResolution).toEqual({ itemId: "item-1", resolution: "needs_input" });
+  expect(canAdmitNextQueuedItem(blocked)).toBe(false);
+  const retried = reduceQueuedDrain(blocked, { type: "user_retry" });
+  expect(canAdmitNextQueuedItem(retried)).toBe(true);
+
+  // Cancelled (submission context changed): the item is rejected and
+  // re-queued by the caller; the drain itself stays open.
+  let cancelled = reduceQueuedDrain(INITIAL_QUEUED_DRAIN_STATE, { type: "send_started", itemId: "item-1" });
+  cancelled = reduceQueuedDrain(cancelled, { type: "send_result", itemId: "item-1", outcome: "cancelled", at: t0 });
+  expect(cancelled.lastResolution).toEqual({ itemId: "item-1", resolution: "rejected" });
+  expect(canAdmitNextQueuedItem(cancelled)).toBe(true);
+
+  // Stopping the queue clears a halted drain so the next queueing round
+  // starts clean, but never erases a live admission.
+  const cleared = reduceQueuedDrain(blocked, { type: "queue_cleared" });
+  expect(cleared.phase).toEqual({ kind: "ready" });
+  const live = admit(INITIAL_QUEUED_DRAIN_STATE, "item-9", t0);
+  const running = reduceQueuedDrain(live, { type: "busy_observed" });
+  expect(reduceQueuedDrain(running, { type: "queue_cleared" })).toBe(running);
+});


### PR DESCRIPTION
## Problem

The queued-message drain in `session-surface.tsx` armed a single boolean (`awaitingQueueBusyRef`) before every queued send and cleared it only when a busy edge was observed or the send threw/was blocked. When the admission call returned accepted but dispatch never produced a visible busy event — a dropped SSE event, an upstream dispatch failure after admission, or an event-stream reconnect during admission — the flag stayed armed forever and every later queued item was wedged behind it. Deterministic P0.

## Fix

Replace the boolean edge-wait with an admission-aware queue state machine (`queued-drain-machine.ts`) keyed by the queued item id, building on the acknowledgment-safe command admission contract from #4129 and the existing level-triggered status reconciliation in `session-sync.ts`. Every queued item now resolves to exactly one of: **admitted and running**, **admitted awaiting observation**, **completed**, **needs input**, **rejected**, **retryable unknown**, or **terminal failure**.

- A missing busy event is never the only signal that allows progress: an unobserved admission is released by a bounded authoritative snapshot probe (10s window, 5s spaced retries) whose observation time is ordered against the admission time.
- The negative invariant is structural: an idle observed before the admission — including the render-fallback idle a remount briefly shows — can never release an admission. Completion of a running admission requires a real observed status level (the shared status entry written by the stream or its reconnect reconciliation), not the `IDLE_STATUS` fallback.
- Drain state lives in a module-level per-session store instead of component refs, so an in-flight admission survives navigating away from and back to the session.
- The send slot is claimed atomically per session, so each queued item is delivered exactly once and in order even with a split view of the same session.
- Blocked sends halt as needs-input until the gate clears or the user retries; a send that throws is retryable with a bounded attempt cap before halting as a terminal failure that only an explicit user retry releases.

## Proof

`evals/specs/queued-drain-admission-wedge.test.ts` (PR lane, `@openwork/testkit`) — 6 tests, all passing at this head:

- dropped first busy event after a successful admission cannot wedge the drain (+ stale-idle negative)
- admission accepted but upstream dispatch fails still releases the queue through level reconciliation (+ bounded probe retry spacing, attempt cap, terminal halt)
- event-stream disconnect/reconnect during admission heals through reconnect-time level reconciliation (busy-during-send race, busy path, idle path, stale-idle negative)
- three queued items admitted exactly once each and in order (+ rival-claim negative at every phase)
- an active admission survives navigating away and back (+ fallback-idle-at-remount negative)
- blocked/cancelled classify as needs_input/rejected without wedging; queue-clear never erases a live admission

Commands and results:

- `pnpm --filter ./apps/app typecheck` — passed
- `pnpm --dir evals exec vitest run specs/queued-drain-admission-wedge.test.ts` — passed (6/6)
- `pnpm evals:pr` — 64 files passed, 2 skipped; `world-attach.test.ts` failed under parallel load but passes standalone (Den boot resource contention, unrelated surface)
- `pnpm evals:e2e composer-queued-follow-ups-sequential --local` — **failed identically at the unmodified merge base** (`dev@4e9b6eac6`): setup times out waiting for the mock model to appear in the picker, before any queue interaction. Pre-existing local-lane setup failure, not introduced or fixable by this diff; runtime E2E verification defers to CI.

Deferred proof: the local E2E lane for the existing FIFO spec is red at baseline as described above; no Daytona verdict was produced for this change.
