### PR TITLE
fix(app): treat an accepted admission that goes idle with no assistant result as a recoverable failure state

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1200,6 +1200,7 @@ export default {
   "session.diagnostics_exported": "Diagnostics exported",
   "session.diagnostics_failed": "Could not prepare diagnostics",
   "session.resume_interrupted": "Resume",
+  "session.admission_outcome_unknown": "The task was accepted, but no result arrived",
   "session.stop_failed": "Could not stop the run — the engine reported no active run was aborted. Try again.",
   "session.revert_failed": "Could not revert the conversation. Try again once the current run finishes.",
   "session.branch_failed": "Could not branch this conversation. Try again.",

--- a/apps/app/src/react-app/domains/session/surface/session-admission-outcome.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-admission-outcome.ts
@@ -1,0 +1,102 @@
+import type { UIMessage } from "ai";
+
+/**
+ * Terminal invariant for accepted admissions.
+ *
+ * Every user message the session accepts must end in one of:
+ * - assistant output followed by idle,
+ * - a pending question or permission wait,
+ * - an explicit error the error card owns,
+ * - or a bounded "accepted but execution outcome unknown" recovery state.
+ *
+ * Plain idle with no assistant result must never silently clear the task:
+ * the appended user message alone previously satisfied the transcript-length
+ * check in the idle-clear effect, so the wait state vanished after ~1.2s
+ * without any assistant message, error, or recovery action.
+ */
+
+/** Bounded debounce before an idle run with no assistant result is declared unresolved. */
+export const ADMISSION_OUTCOME_GRACE_MS = 1500;
+
+export function messageHasVisibleAssistantOutput(message: UIMessage): boolean {
+  if (message.role !== "assistant") return false;
+  return message.parts.some((part) => {
+    if ("text" in part && typeof part.text === "string") return part.text.trim().length > 0;
+    return part.type === "dynamic-tool" || part.type === "file";
+  });
+}
+
+export function findLastUserMessageIndex(messages: readonly UIMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") return index;
+  }
+  return -1;
+}
+
+export type AdmissionOutcomeInput = {
+  messages: readonly UIMessage[];
+  /** Engine-reported run status ("idle" | "busy" | "retry"). */
+  statusType: string;
+  /** Client-side submission pulse: a send is still being admitted. */
+  sending: boolean;
+  hasActiveQuestion: boolean;
+  hasActivePermission: boolean;
+  /** An explicit session error is already displayed and owns recovery. */
+  hasSessionError: boolean;
+};
+
+export type AdmissionOutcome = "settled" | "pending" | "unresolved";
+
+/**
+ * Decide the terminal state of the most recent accepted admission.
+ *
+ * "unresolved" means the last admitted user message has no visible assistant
+ * result after it while the session reports idle with no other terminal
+ * surface (question, permission, error). The UI must then show a recovery
+ * card after {@link ADMISSION_OUTCOME_GRACE_MS} instead of plain idle.
+ *
+ * Because this derives purely from the transcript and live status, the
+ * recovery state is recomputed identically after a reload.
+ */
+export function resolveAdmissionOutcome(input: AdmissionOutcomeInput): AdmissionOutcome {
+  const lastUserIndex = findLastUserMessageIndex(input.messages);
+  if (lastUserIndex === -1) return "settled";
+  const answered = input.messages
+    .slice(lastUserIndex + 1)
+    .some(messageHasVisibleAssistantOutput);
+  if (answered) return "settled";
+  if (input.hasSessionError) return "settled";
+  if (input.sending || input.statusType !== "idle") return "pending";
+  if (input.hasActiveQuestion || input.hasActivePermission) return "pending";
+  return "unresolved";
+}
+
+export type SingleFlight = {
+  readonly inFlight: boolean;
+  /** Runs the task unless one is already in flight; returns whether it ran. */
+  run(task: () => Promise<void>): Promise<boolean>;
+};
+
+/**
+ * Exactly-once in-flight guard for recovery actions: while one invocation is
+ * running, further invocations are dropped (not queued), so rapid repeated
+ * clicks on Resume admit a single recovery prompt.
+ */
+export function createSingleFlight(): SingleFlight {
+  let inFlight = false;
+  return {
+    get inFlight() {
+      return inFlight;
+    },
+    async run(task: () => Promise<void>): Promise<boolean> {
+      if (inFlight) return false;
+      inFlight = true;
+      try {
+        await task();
+        return true;
+      } finally {
+        inFlight = false;
+      }
+    },
+  };
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRe
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
-import { Check, Minimize2 } from "lucide-react";
+import { Check, CirclePause, Minimize2 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
@@ -65,6 +65,13 @@ import { useShellConfig } from "@/react-app/shell/shell-config";
 import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog";
 import { SessionDebugPanel } from "./debug-panel";
 import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
+import {
+  ADMISSION_OUTCOME_GRACE_MS,
+  createSingleFlight,
+  messageHasVisibleAssistantOutput,
+  resolveAdmissionOutcome,
+} from "./session-admission-outcome";
+import { interruptedTaskRecoveryPrompt } from "@/react-app/domains/session/sync/session-error";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
@@ -592,14 +599,6 @@ function useSharedQueryState<T>(queryKey: readonly unknown[], fallback: T) {
   return query.data ?? fallback;
 }
 
-function messageHasVisibleAssistantOutput(message: UIMessage) {
-  if (message.role !== "assistant") return false;
-  return message.parts.some((part) => {
-    if ("text" in part && typeof part.text === "string") return part.text.trim().length > 0;
-    return part.type === "dynamic-tool" || part.type === "file";
-  });
-}
-
 function AssistantWaitingCard({ label = t("session.assistant_thinking") }: { label?: string }) {
   return (
     <div className="flex justify-start" role="status" aria-live="polite">
@@ -617,6 +616,34 @@ function AssistantWaitingCard({ label = t("session.assistant_thinking") }: { lab
           />
         </div>
         <span>{label}</span>
+      </div>
+    </div>
+  );
+}
+
+// Terminal recovery surface for an accepted admission that reached idle with
+// no assistant result. Styled after the interrupted-run status line: a quiet
+// pause, not a failure, with Resume as the single emphasized action.
+function AdmissionOutcomeUnknownCard(props: { resuming: boolean; onResume: () => void }) {
+  return (
+    <div
+      data-testid="admission-outcome-unknown"
+      role="status"
+      className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
+    >
+      <div className="flex min-w-0 items-center gap-2 py-1 text-sm text-dls-secondary">
+        <CirclePause aria-hidden="true" className="size-4 shrink-0" />
+        <span className="min-w-0">{t("session.admission_outcome_unknown")}</span>
+        <span aria-hidden="true" className="text-dls-secondary/60">·</span>
+        <button
+          type="button"
+          data-testid="admission-outcome-resume"
+          disabled={props.resuming}
+          onClick={props.onResume}
+          className="shrink-0 cursor-pointer font-medium text-dls-text underline-offset-2 transition-colors hover:underline disabled:cursor-default disabled:opacity-60"
+        >
+          {t("session.resume_interrupted")}
+        </button>
       </div>
     </div>
   );
@@ -932,6 +959,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [restoringRevertedMessages, setRestoringRevertedMessages] = useState(false);
   const [showDelayedLoading, setShowDelayedLoading] = useState(false);
   const [awaitingAssistantBaseline, setAwaitingAssistantBaseline] = useState<number | null>(null);
+  // Terminal invariant: an accepted admission that reached idle with no
+  // assistant result surfaces a bounded recovery card instead of plain idle.
+  const [admissionOutcomeUnresolved, setAdmissionOutcomeUnresolved] = useState(false);
   const [rendered, setRendered] = useState<{ sessionId: string; snapshot: OpenworkSessionSnapshot } | null>(null);
   const [toolSkills, setToolSkills] = useState<SkillCard[]>([]);
   const [toolMcpServers, setToolMcpServers] = useState<McpServerEntry[]>([]);
@@ -1025,6 +1055,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setRestoringRevertedMessages(false);
     setShowDelayedLoading(false);
     setAwaitingAssistantBaseline(null);
+    setAdmissionOutcomeUnresolved(false);
     // Composer draft state lives in the shared store keyed by session id, so
     // switching sessions preserves each session's own in-progress composer.
     autoOpenedTargetRef.current = null;
@@ -1454,17 +1485,34 @@ export function SessionSurface(props: SessionSurfaceProps) {
     return () => window.clearTimeout(id);
   }, [pendingSessionLoad]);
 
+  // Terminal invariant for accepted admissions: idle with no assistant result
+  // must never silently clear the task. The transcript-length check alone is
+  // not an outcome — the newly appended user message satisfies it even when no
+  // assistant message exists. Deriving the outcome from the transcript (last
+  // user message answered by visible assistant output) also makes the recovery
+  // state survive a reload: rehydrating the same transcript recomputes it.
+  const admissionOutcome = useMemo(() => resolveAdmissionOutcome({
+    messages: renderedMessages,
+    statusType: liveStatus.type,
+    sending,
+    hasActiveQuestion: Boolean(props.activeQuestion),
+    hasActivePermission: Boolean(props.activePermission),
+    hasSessionError: error !== null,
+  }), [error, liveStatus.type, props.activePermission, props.activeQuestion, renderedMessages, sending]);
+
   useEffect(() => {
-    if (awaitingAssistantBaseline === null) return;
-    if (assistantOutputAfterAwaitStart) {
+    if (admissionOutcome !== "unresolved") {
+      setAdmissionOutcomeUnresolved(false);
       return;
     }
-    if (sending || liveStatus.type !== "idle" || renderedMessages.length <= awaitingAssistantBaseline) return;
     const id = window.setTimeout(() => {
+      // Swap the wait state for the recovery card in one step so the
+      // admission never terminates as plain idle without a result.
       setAwaitingAssistantBaseline(null);
-    }, 1200);
+      setAdmissionOutcomeUnresolved(true);
+    }, ADMISSION_OUTCOME_GRACE_MS);
     return () => window.clearTimeout(id);
-  }, [assistantOutputAfterAwaitStart, awaitingAssistantBaseline, liveStatus.type, renderedMessages.length, sending]);
+  }, [admissionOutcome]);
 
   const model = deriveSessionRenderModel({
     intendedSessionId: props.sessionId,
@@ -2205,21 +2253,34 @@ export function SessionSurface(props: SessionSurfaceProps) {
     void typeComposerText(prompt);
   }, [typeComposerText]);
 
-  // Explicit user click on the interrupted-run error card. Re-submits the
-  // classified recovery prompt through the normal send path so the agent
-  // continues the interrupted task in this session instead of restarting it.
+  // Explicit user click on the interrupted-run error card or the
+  // outcome-unknown recovery card. Re-submits the classified recovery prompt
+  // through the normal send path so the agent continues the interrupted task
+  // in this session instead of restarting it. The single-flight guard drops
+  // (never queues) repeat clicks while one resume is in flight, so rapid
+  // clicking admits exactly one recovery prompt.
+  const resumeGuardRef = useRef(createSingleFlight());
+  const [resuming, setResuming] = useState(false);
   const handleResumeInterrupted = useCallback(async (recoveryPrompt: string) => {
-    try {
-      await sendDraft({
-        mode: "prompt",
-        parts: [{ type: "text", text: recoveryPrompt }],
-        attachments: [],
-        text: recoveryPrompt,
-      });
-    } catch {
-      // sendDraft already surfaced the failure on the session error state.
-    }
+    await resumeGuardRef.current.run(async () => {
+      setResuming(true);
+      try {
+        await sendDraft({
+          mode: "prompt",
+          parts: [{ type: "text", text: recoveryPrompt }],
+          attachments: [],
+          text: recoveryPrompt,
+        });
+      } catch {
+        // sendDraft already surfaced the failure on the session error state.
+      } finally {
+        setResuming(false);
+      }
+    });
   }, [sendDraft]);
+  const handleResumeUnknownOutcome = useCallback(() => {
+    void handleResumeInterrupted(interruptedTaskRecoveryPrompt);
+  }, [handleResumeInterrupted]);
 
   useEffect(() => {
     const resetReconnectState = () => {
@@ -2575,6 +2636,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
                 </OpenTargetProvider>
               </DevProfiler>
             )}
+            {admissionOutcomeUnresolved && renderedMessages.length > 0 ? (
+              <AdmissionOutcomeUnknownCard
+                resuming={resuming}
+                onResume={handleResumeUnknownOutcome}
+              />
+            ) : null}
           </div>
         </div>
         <SessionScrollOverlay

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -13,7 +13,7 @@ export type OpencodeSessionErrorPresentation = {
   recoveryPrompt: string | null;
 };
 
-const interruptedTaskRecoveryPrompt = [
+export const interruptedTaskRecoveryPrompt = [
   "Continue the interrupted task from the current state.",
   "First inspect the conversation and workspace to verify which actions already completed.",
   "Preserve completed work, do not repeat side effects, and finish only what remains.",

--- a/evals/specs/session-admission-no-result-recovery.e2e.test.ts
+++ b/evals/specs/session-admission-no-result-recovery.e2e.test.ts
@@ -1,0 +1,259 @@
+import { createServer } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, selectModel, waitFor, waitForText } from "@openwork/behaviors";
+import { screenshot, validate } from "@openwork/test-evidence";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const providerId = "admission-no-result-mock";
+const modelId = "admission-no-result-model";
+const prompt = "Run the admission no result reproduction task";
+const resumedReply = "admission recovery proof reply";
+// First sentence of the interrupted-task recovery prompt sent by Resume.
+const recoveryPromptMarker = "Continue the interrupted task from the current state.";
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "accepted admission that goes idle with no assistant result shows a reload-safe recovery card whose Resume admits exactly one prompt"
+  : "session admission no-result recovery skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+const cardExpression = (present: boolean) => `(() => {
+  const card = document.querySelector('[data-testid="admission-outcome-unknown"]');
+  return ${present ? "Boolean(card)" : "!card"};
+})()`;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+test.skipIf(!e2eTestsEnabled)(title, { timeout: 600_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  // The completion for the reproduction prompt returns an SSE stream with no
+  // visible assistant content (whitespace only), reproducing "accepted, then
+  // idle, but no assistant result". Every other completion — title
+  // generation and the post-Resume turn (whose conversation contains the
+  // recovery prompt) — answers normally so Resume can finish the task.
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { body += chunk; });
+      request.on("end", () => {
+        const empty = body.includes(prompt) && !body.includes(recoveryPromptMarker);
+        const chunks = [
+          { id: "chatcmpl-admission-no-result", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+          { id: "chatcmpl-admission-no-result", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: empty ? " " : resumedReply }, finish_reason: null }] },
+          { id: "chatcmpl-admission-no-result", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+        ];
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  // Blank ambient provider keys so the run cannot fall back to a real model:
+  // this reproduction depends on the mock provider producing no visible
+  // assistant result.
+  await using app = await desktop({
+    name: "admission-no-result",
+    env: {
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      OPENROUTER_API_KEY: "",
+      GOOGLE_GENERATIVE_AI_API_KEY: "",
+      OPENWORK_API_KEY: "",
+      OPENWORK_INFERENCE_BASE_URL: "",
+    },
+  });
+  const workspace = await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-admission-no-result-${Date.now()}`,
+  });
+
+  const configured = await evalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const request = async (path, init) => {
+      const response = await fetch("http://127.0.0.1:" + port + path, {
+        ...init,
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      });
+      if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
+      return "ok";
+    };
+    const workspaceId = ${JSON.stringify(workspace.workspaceId)};
+    const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+      method: "PATCH",
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            [${JSON.stringify(providerId)}]: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Admission no result mock",
+              options: { baseURL: ${JSON.stringify(baseUrl)}, apiKey: "sk-admission-no-result" },
+              models: {
+                [${JSON.stringify(modelId)}]: { name: "Admission no result model" },
+              },
+            },
+          },
+        },
+      }),
+    });
+    if (patched !== "ok") return patched;
+    const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
+    if (reloaded !== "ok") return reloaded;
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.removeItem("openwork.sessionModels." + workspaceId);
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  expect(configured).toBe("ok");
+
+  await control(app, "session.create_task");
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.set_text" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer text action enabled",
+  });
+  // Pin the session to the mock model through the picker: ambient free models
+  // can otherwise win the default-model resolution and answer for real.
+  const pinned = await selectModel(app, "Admission no result model");
+  expect(pinned.selected, `mock model not selected: ${JSON.stringify(pinned)}`).toBe(true);
+  await control(app, "composer.set_text", { text: prompt });
+  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "composer.send" && !action.disabled)`, {
+    timeoutMs: 30_000,
+    label: "composer send action enabled",
+  });
+  const admittedAt = Date.now();
+  await control(app, "composer.send");
+
+  // Admission accepted: the user message was created and is rendered.
+  await waitForText(app, prompt, { timeoutMs: 60_000 });
+  evidence.recordAssertionEvidence(
+    "The session, admission, and user message were created",
+    "After composer.send the prompt text was rendered as a user message in the new session's transcript.",
+    true,
+  );
+
+  // The run goes idle with no assistant result (whitespace-only completion).
+  // The terminal invariant must produce an actionable recovery card instead
+  // of silently clearing the wait state.
+  await waitFor(app, cardExpression(true), {
+    timeoutMs: 60_000,
+    label: "admission outcome recovery card appeared after idle with no assistant result",
+  });
+  const cardShownAfterMs = Date.now() - admittedAt;
+  const assistantReplyVisible = await evalIn(app, `document.body.innerText.includes(${JSON.stringify(resumedReply)})`);
+  expect(assistantReplyVisible, "no assistant reply must be visible before resume").toBe(false);
+  evidence.recordAssertionEvidence(
+    "Idle without an assistant result surfaces an actionable recovery card",
+    `The session reached idle with no visible assistant output and the accepted-but-outcome-unknown recovery card appeared ${Math.round(cardShownAfterMs / 100) / 10}s after admission, instead of silently clearing the wait state.`,
+    true,
+  );
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      `The user's message '${prompt}' is visible in the conversation with no assistant reply below it`,
+      "A status line saying the task was accepted but no result arrived is visible with a Resume action",
+      "No crash or blank screen is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  // Reload before resuming: the recovery information must survive because it
+  // derives from the server-persisted transcript, not component memory.
+  const previousTimeOrigin = await evalIn(app, "performance.timeOrigin");
+  expect(typeof previousTimeOrigin).toBe("number");
+  await evalIn(app, "location.reload(); true").catch(() => undefined);
+  await waitFor(app, `performance.timeOrigin !== ${JSON.stringify(previousTimeOrigin)}`, {
+    timeoutMs: 30_000,
+    label: "renderer reloaded",
+  });
+  await waitForText(app, prompt, { timeoutMs: 60_000 });
+  await waitFor(app, cardExpression(true), {
+    timeoutMs: 60_000,
+    label: "recovery card re-derived after reload",
+  });
+  evidence.recordAssertionEvidence(
+    "The recovery state survives a reload before resuming",
+    "After location.reload() the rehydrated transcript re-derived the same accepted-but-outcome-unknown recovery card for the unanswered user message.",
+    true,
+  );
+
+  // Rapid double click on Resume: the single-flight guard must admit exactly
+  // one recovery prompt.
+  const clicked = await evalIn(app, `(() => {
+    const button = document.querySelector('[data-testid="admission-outcome-resume"]');
+    if (!button) return "missing resume button";
+    button.click();
+    button.click();
+    return "ok";
+  })()`);
+  expect(clicked).toBe("ok");
+
+  await waitForText(app, resumedReply, { timeoutMs: 120_000 });
+  await waitFor(app, cardExpression(false), {
+    timeoutMs: 30_000,
+    label: "recovery card cleared after assistant output arrived",
+  });
+  await sleep(2_000);
+  const recoveryPromptCount = await evalIn(app, `(() => {
+    const text = document.body.innerText;
+    let count = 0;
+    let index = text.indexOf(${JSON.stringify(recoveryPromptMarker)});
+    while (index !== -1) {
+      count += 1;
+      index = text.indexOf(${JSON.stringify(recoveryPromptMarker)}, index + 1);
+    }
+    return count;
+  })()`);
+  expect(recoveryPromptCount, "exactly one recovery prompt admitted for two rapid clicks").toBe(1);
+  evidence.recordAssertionEvidence(
+    "Two rapid Resume clicks admit exactly one recovery prompt",
+    `After a rapid double click the transcript contains exactly one recovery prompt (count=${String(recoveryPromptCount)}), the assistant produced '${resumedReply}', and the recovery card cleared once assistant output arrived.`,
+    true,
+  );
+
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      `The assistant reply '${resumedReply}' is visible in the conversation`,
+      "Exactly one resume/recovery user message is visible between the original prompt and the assistant reply",
+      "No status line about a missing result is visible anymore",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+});

--- a/evals/specs/session-admission-terminal-invariant.test.ts
+++ b/evals/specs/session-admission-terminal-invariant.test.ts
@@ -1,0 +1,137 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  createSingleFlight,
+  resolveAdmissionOutcome,
+  type AdmissionOutcomeInput,
+} from "../../apps/app/src/react-app/domains/session/surface/session-admission-outcome";
+
+type Messages = AdmissionOutcomeInput["messages"];
+
+function userMessage(id: string, text: string): Messages[number] {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+function assistantMessage(id: string, text: string): Messages[number] {
+  return { id, role: "assistant", parts: [{ type: "text", text }] };
+}
+
+function emptyAssistantMessage(id: string): Messages[number] {
+  return { id, role: "assistant", parts: [{ type: "step-start" }] };
+}
+
+function outcome(messages: Messages, overrides: Partial<AdmissionOutcomeInput> = {}) {
+  return resolveAdmissionOutcome({
+    messages,
+    statusType: "idle",
+    sending: false,
+    hasActiveQuestion: false,
+    hasActivePermission: false,
+    hasSessionError: false,
+    ...overrides,
+  });
+}
+
+test("accepted admission that reaches idle with no assistant result is unresolved, not plain idle", ({ evidence }) => {
+  // The reported failure shape: the session and user message were created
+  // (admission accepted), the engine returned to idle, and no assistant
+  // message exists. The appended user message used to satisfy the
+  // transcript-length check and silently clear the wait state after ~1.2s.
+  const accepted: Messages = [
+    assistantMessage("a0", "previous turn"),
+    userMessage("u1", "do the thing"),
+  ];
+  expect(outcome(accepted)).toBe("unresolved");
+
+  // A brand-new session whose only message is the accepted user message —
+  // exactly the length-check false positive — must also stay unresolved.
+  expect(outcome([userMessage("u1", "first ever message")])).toBe("unresolved");
+
+  evidence.recordAssertionEvidence(
+    "Idle with an unanswered accepted user message is a real failure state",
+    "resolveAdmissionOutcome returned 'unresolved' for an idle transcript whose last user message has no assistant result, including the single-user-message transcript that previously satisfied the length check and cleared silently.",
+    true,
+  );
+});
+
+test("every accepted admission terminates in a supported terminal state", ({ evidence }) => {
+  const unanswered: Messages = [userMessage("u1", "do the thing")];
+
+  // Still executing: busy/retry status or an in-flight submission is pending.
+  expect(outcome(unanswered, { statusType: "busy" })).toBe("pending");
+  expect(outcome(unanswered, { statusType: "retry" })).toBe("pending");
+  expect(outcome(unanswered, { sending: true })).toBe("pending");
+
+  // Needs input: question or permission waits are their own terminal surface.
+  expect(outcome(unanswered, { hasActiveQuestion: true })).toBe("pending");
+  expect(outcome(unanswered, { hasActivePermission: true })).toBe("pending");
+
+  // Explicit error: the session error card owns recovery.
+  expect(outcome(unanswered, { hasSessionError: true })).toBe("settled");
+
+  // Assistant output followed by idle settles the admission.
+  expect(outcome([userMessage("u1", "q"), assistantMessage("a1", "answer")])).toBe("settled");
+
+  // An assistant message with no visible output is not a silent success.
+  expect(outcome([userMessage("u1", "q"), emptyAssistantMessage("a1")])).toBe("unresolved");
+
+  // No admission at all has nothing to recover.
+  expect(outcome([])).toBe("settled");
+  expect(outcome([assistantMessage("a0", "hello")])).toBe("settled");
+
+  evidence.recordAssertionEvidence(
+    "Terminal invariant covers output, needs-input, error, and unknown-outcome states",
+    "resolveAdmissionOutcome classified busy/retry/sending and question/permission waits as pending, visible assistant output and explicit errors as settled, and both the missing and the invisible assistant result as unresolved.",
+    true,
+  );
+});
+
+test("the recovery state is a pure function of transcript and status, so it survives a reload", ({ evidence }) => {
+  const transcript: Messages = [
+    assistantMessage("a0", "previous turn"),
+    userMessage("u1", "do the thing"),
+  ];
+  const before = outcome(transcript);
+  // A reload rehydrates the same server-persisted transcript and idle status;
+  // recomputing from identical inputs must reproduce the recovery state.
+  const rehydrated: Messages = transcript.map((message) => ({ ...message }));
+  const after = outcome(rehydrated);
+  expect(before).toBe("unresolved");
+  expect(after).toBe("unresolved");
+  evidence.recordAssertionEvidence(
+    "Recovery information survives reload by construction",
+    "The unresolved outcome was recomputed identically from a rehydrated copy of the same transcript and idle status, with no reliance on in-memory component state.",
+    true,
+  );
+});
+
+test("resume single-flight guard admits exactly one recovery prompt for rapid repeat clicks", async ({ evidence }) => {
+  const guard = createSingleFlight();
+  let executions = 0;
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+
+  const first = guard.run(async () => {
+    executions += 1;
+    await gate;
+  });
+  // Rapid second and third clicks while the first resume is in flight.
+  const second = guard.run(async () => { executions += 1; });
+  const third = guard.run(async () => { executions += 1; });
+  expect(await second).toBe(false);
+  expect(await third).toBe(false);
+  expect(guard.inFlight).toBe(true);
+  release?.();
+  expect(await first).toBe(true);
+  expect(executions).toBe(1);
+
+  // A later deliberate click, after the first resolved, runs again.
+  expect(await guard.run(async () => { executions += 1; })).toBe(true);
+  expect(executions).toBe(2);
+
+  evidence.recordAssertionEvidence(
+    "Rapid Resume clicks admit exactly one recovery prompt",
+    "While one resume was in flight, two further invocations were dropped without executing; after completion a deliberate new invocation ran, proving in-flight exactly-once semantics rather than a permanent lockout.",
+    true,
+  );
+});


### PR DESCRIPTION
## Problem

An accepted user message can end in plain idle with **no assistant message, no error, and no recovery action**. The idle-clear effect in `session-surface.tsx` treated any transcript growth past `awaitingAssistantBaseline` as an outcome, so the newly appended user message itself satisfied the length check and cleared the wait state after ~1.2s. The task silently vanished (reported as the ~11s "no assistant result" symptom).

The interrupted-run Resume action also had no in-flight guard: rapid clicks could send multiple recovery prompts.

## Fix

Establish a terminal invariant for every accepted admission: it must end in assistant output + idle, a pending question/permission wait, an explicit error, or a bounded **"accepted but execution outcome unknown"** recovery state.

- New pure module `session-admission-outcome.ts` classifies the outcome (`settled` / `pending` / `unresolved`) purely from the transcript and live run status, so the recovery state **survives a reload by construction** — rehydrating the same transcript recomputes it.
- The idle-clear effect is replaced: idle with no visible assistant output after the last admitted user message surfaces a quiet recovery card (styled after the interrupted-run status line) with a Resume action, after a bounded 1.5s grace. An assistant message with no visible output is treated the same way, not as a silent success.
- Resume — both the existing interrupted-run card and the new recovery card — now runs behind a single-flight guard: repeat clicks while one resume is in flight are dropped, so rapid clicking admits exactly one recovery prompt. A later deliberate click still works.

## Proof

- `evals/specs/session-admission-terminal-invariant.test.ts` — outcome classification (idle-without-result is unresolved incl. the single-user-message length-check false positive; busy/retry/sending/question/permission pending; visible output and explicit error settled; empty assistant message unresolved), reload equivalence, and exactly-once resume guard semantics. **4/4 passed.**
- `evals/specs/session-admission-no-result-recovery.e2e.test.ts` — drives the real app against a mock provider whose completion for the reproduction prompt streams no visible content: proves the session/admission/user message were created, the run reaches idle with no assistant result, the recovery card appears, the card is re-derived after `location.reload()` before resuming, and a rapid double click on Resume admits exactly one recovery prompt before the assistant reply lands and the card clears. **Passed** (`pnpm evals:e2e session-admission-no-result-recovery --local`, verdict `passed`).
- `pnpm --dir apps/app typecheck` passed. `pnpm --dir apps/app test` shows the same 5 pre-existing environmental failures as pristine `dev` on the same machine (verified against a clean `origin/dev` worktree); no new failures.

Proof lane: local (Daytona credentials not available in this environment).