### PR TITLE
fix(den-web): keep runtime config available during URL migration

### DIFF
--- a/ee/apps/den-web/app/api/runtime-config/route.ts
+++ b/ee/apps/den-web/app/api/runtime-config/route.ts
@@ -13,8 +13,20 @@ function readOrgMode() {
   return readPublicRuntimeEnv("DEN_ORG_MODE") === "multi_org" ? "multi_org" : "single_org";
 }
 
-function readDenApiUrl() {
-  return readBaseUrlEnv(process.env, "DEN_API_PUBLIC_URL") ?? denUrls(process.env).api;
+function readDenApiUrl(request?: Request) {
+  const configuredPublicUrl = readBaseUrlEnv(process.env, "DEN_API_PUBLIC_URL");
+  if (configuredPublicUrl) {
+    return configuredPublicUrl;
+  }
+
+  try {
+    return denUrls(process.env).api;
+  } catch {
+    if (!request) {
+      return "";
+    }
+    return denUrls({ DEN_BASE_URL: new URL(request.url).origin }).api;
+  }
 }
 
 function readBooleanEnv(name: string, defaultValue: boolean) {
@@ -68,13 +80,13 @@ async function readSingleOrgSsoConfigured(orgMode: string) {
   }
 }
 
-export async function GET() {
+export async function GET(request?: Request) {
   const orgMode = readOrgMode();
   const singleOrgSsoConfigured = await readSingleOrgSsoConfigured(orgMode);
 
   return NextResponse.json(
     {
-      denApiUrl: readDenApiUrl(),
+      denApiUrl: readDenApiUrl(request),
       openworkAppConnectUrl: readPublicRuntimeEnv("DEN_WEB_OPENWORK_APP_CONNECT_URL"),
       openworkWebUrl: readPublicRuntimeEnv("DEN_WEB_OPENWORK_WEB_URL") || DEFAULT_OPENWORK_WEB_URL,
       openworkAuthCallbackUrl: readPublicRuntimeEnv("DEN_WEB_OPENWORK_AUTH_CALLBACK_URL"),

--- a/ee/apps/den-web/app/api/runtime-config/route.ts
+++ b/ee/apps/den-web/app/api/runtime-config/route.ts
@@ -22,10 +22,11 @@ function readDenApiUrl(request?: Request) {
   try {
     return denUrls(process.env).api;
   } catch {
-    if (!request) {
-      return "";
-    }
-    return denUrls({ DEN_BASE_URL: new URL(request.url).origin }).api;
+    // Only the canonical hosted origin has a known public API during migration.
+    // Never let an untrusted request host choose an authenticated API destination.
+    return request && new URL(request.url).origin === "https://app.openworklabs.com"
+      ? "https://api.openworklabs.com"
+      : "";
   }
 }
 

--- a/ee/apps/den-web/tests/web-page.test.ts
+++ b/ee/apps/den-web/tests/web-page.test.ts
@@ -18,6 +18,7 @@ const originalEnv = {
   DEN_API_BASE: process.env.DEN_API_BASE,
   DEN_API_PUBLIC_URL: process.env.DEN_API_PUBLIC_URL,
   DEN_BASE_URL: process.env.DEN_BASE_URL,
+  DEN_ORG_MODE: process.env.DEN_ORG_MODE,
   DEN_WEB_OPENWORK_WEB_URL: process.env.DEN_WEB_OPENWORK_WEB_URL,
 };
 
@@ -43,6 +44,7 @@ afterEach(() => {
   restoreEnvValue("DEN_API_BASE");
   restoreEnvValue("DEN_API_PUBLIC_URL");
   restoreEnvValue("DEN_BASE_URL");
+  restoreEnvValue("DEN_ORG_MODE");
   restoreEnvValue("DEN_WEB_OPENWORK_WEB_URL");
 });
 
@@ -217,30 +219,54 @@ describe("Web dashboard page", () => {
   });
 
   test("runtime config exposes the public Den API URL without leaking the internal API base", async () => {
+    process.env.DEN_ORG_MODE = "multi_org";
     process.env.DEN_BASE_URL = "https://den.example.test";
     process.env.DEN_API_PUBLIC_URL = "https://public-api.example.test";
     process.env.DEN_API_BASE = "http://openwork-ee-den-api:8788";
 
-    const publicPayload: unknown = await (await GET()).json();
+    const request = new Request("https://untrusted.example.test/api/runtime-config");
+    const publicPayload: unknown = await (await GET(request)).json();
     expect(readStringProperty(publicPayload, "denApiUrl")).toBe("https://public-api.example.test");
     expect(JSON.stringify(publicPayload)).not.toContain("openwork-ee-den-api");
 
     delete process.env.DEN_API_PUBLIC_URL;
-    const derivedPayload: unknown = await (await GET()).json();
+    const derivedPayload: unknown = await (await GET(request)).json();
     expect(readStringProperty(derivedPayload, "denApiUrl")).toBe("https://api.den.example.test");
     expect(JSON.stringify(derivedPayload)).not.toContain("openwork-ee-den-api");
   });
 
-  test("runtime config derives the public API URL from the request during deployment migration", async () => {
+  test("runtime config only uses the canonical hosted mapping during deployment migration", async () => {
     delete process.env.DEN_API_PUBLIC_URL;
-    delete process.env.DEN_BASE_URL;
     process.env.DEN_API_BASE = "http://openwork-ee-den-api:8788";
+    process.env.DEN_ORG_MODE = "multi_org";
 
-    const response = await GET(new Request("https://app.openworklabs.com/api/runtime-config"));
-    const payload: unknown = await response.json();
+    for (const baseUrl of [undefined, "", "https://invalid.example.test/path"]) {
+      if (baseUrl === undefined) delete process.env.DEN_BASE_URL;
+      else process.env.DEN_BASE_URL = baseUrl;
 
-    expect(response.status).toBe(200);
-    expect(readStringProperty(payload, "denApiUrl")).toBe("https://api.app.openworklabs.com");
-    expect(JSON.stringify(payload)).not.toContain("openwork-ee-den-api");
+      for (const origin of [
+        "https://app.openworklabs.com",
+        "https://untrusted.example.test",
+        "https://app.openworklabs.com.untrusted.example.test",
+        "https://app.openworklabs.com@untrusted.example.test",
+        "https://app.openworklabs.com:444",
+        "http://app.openworklabs.com",
+        "http://localhost:3005",
+        undefined,
+      ]) {
+        const request = origin ? new Request(`${origin}/api/runtime-config`, {
+          headers: { "x-forwarded-host": "app.openworklabs.com", "x-forwarded-proto": "https" },
+        }) : undefined;
+        const response = await GET(request);
+        const payload: unknown = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(readStringProperty(payload, "denApiUrl")).toBe(
+          origin === "https://app.openworklabs.com" ? "https://api.openworklabs.com" : "",
+        );
+        expect(JSON.stringify(payload)).not.toContain("openwork-ee-den-api");
+        expect(JSON.stringify(payload)).not.toContain("untrusted.example.test");
+      }
+    }
   });
 });

--- a/ee/apps/den-web/tests/web-page.test.ts
+++ b/ee/apps/den-web/tests/web-page.test.ts
@@ -230,4 +230,17 @@ describe("Web dashboard page", () => {
     expect(readStringProperty(derivedPayload, "denApiUrl")).toBe("https://api.den.example.test");
     expect(JSON.stringify(derivedPayload)).not.toContain("openwork-ee-den-api");
   });
+
+  test("runtime config derives the public API URL from the request during deployment migration", async () => {
+    delete process.env.DEN_API_PUBLIC_URL;
+    delete process.env.DEN_BASE_URL;
+    process.env.DEN_API_BASE = "http://openwork-ee-den-api:8788";
+
+    const response = await GET(new Request("https://app.openworklabs.com/api/runtime-config"));
+    const payload: unknown = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(readStringProperty(payload, "denApiUrl")).toBe("https://api.app.openworklabs.com");
+    expect(JSON.stringify(payload)).not.toContain("openwork-ee-den-api");
+  });
 });

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -46,6 +46,21 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
   };
 
   await step("a person arrives at signup and creates their actual account", async () => {
+    for (const host of [new URL(world.den.ref.webUrl).host, "untrusted.example.test"]) {
+      const { response, body: config } = await probe.api(
+        { ...world.den.admin, apiUrl: world.den.ref.webUrl },
+        "/api/runtime-config",
+        {
+          headers: { host, "x-forwarded-host": host, "x-forwarded-proto": "https" },
+          signal: AbortSignal.timeout(30_000),
+        },
+      );
+      expect(response.status).toBe(200);
+      if (!isRecord(config)) throw new Error("Expected runtime configuration");
+      expect(config.denApiUrl).toBe(world.den.ref.apiUrl);
+      expect(JSON.stringify(config)).not.toContain("untrusted.example.test");
+    }
+    evidence.recordAssertionEvidence("Signup runtime configuration keeps its configured API despite untrusted host headers", "Both normal and host-poisoned requests returned the isolated Den API, never an attacker-selected destination.", true);
     await user.see({ text: "Good work starts here." }, { timeoutMs: 90_000 });
     await user.see({ role: "textbox", label: "Email" });
     await user.notSee({ role: "textbox", label: "Team name" });


### PR DESCRIPTION
## Summary

- keep `/api/runtime-config` available during public URL configuration migration
- preserve `DEN_API_PUBLIC_URL` precedence and derivation from explicitly configured `DEN_BASE_URL`
- when public configuration is unavailable, map only the exact HTTPS origin `https://app.openworklabs.com` to `https://api.openworklabs.com`; return an empty override for other request origins
- never derive an API hostname from an untrusted request origin or expose internal `DEN_API_BASE` in browser runtime configuration

## Historical Incident

This addresses the previously observed signup bootstrap failure: at the time, Den API health was green at `758c37a`, while Den Web `/api/runtime-config` returned an empty HTTP 500 when `DEN_API_PUBLIC_URL` was empty and `DEN_BASE_URL` was missing or invalid. This is historical context, not a claim of a current production incident; production state was not rechecked here.

## Verification

Head: `48d514b4713026110fbed33cd5cab7535e72c48c`, rebased onto `dev` at `f6f93bdb39dded5ff134b87521778bb96ad25c43`. All branch commit signatures verify.

- Passed: `pnpm --filter @openwork-ee/den-web exec tsc --noEmit --pretty false --incremental false` (exit 0).
- Passed: `pnpm --dir ee/apps/den-web exec bun test --conditions development tests/web-page.test.ts tests/den-api-origin.test.ts` (exit 0; 18 passed, 0 failed, 0 skipped). These are unit checks, not journey proof. Coverage includes explicit configuration precedence, missing/empty/invalid base configuration, canonical hosted mapping, untrusted/lookalike hosts, alternate protocol/port, missing request, and internal-hostname non-disclosure.
- Passed: `git diff --check origin/dev...HEAD` (exit 0).
- Failed: `node evals/scripts/spec-boundary-ratchet.mjs` and `node evals/scripts/spec-channel-ratchet.mjs` (both exit 1). Identical failures reproduced with those exact commands in a clean control at `f6f93bdb39dded5ff134b87521778bb96ad25c43`; no ratchet baseline changes included.
- Skipped: `pnpm evals:e2e signup-workspace-intent`. Placement preflight on this head returned `placement: daytona (daytona CLI authenticated)`. This journey requires a dedicated sandbox for its environment overrides; new paid allocation was not authorized. The journey command was not started, so there are no runtime counts or exit code.

## Proof Status

**Incomplete.** The existing signup journey now asserts that normal and host-poisoned runtime-config requests retain the configured API destination, but it has not been executed on this head. The missing-configuration hosted fallback currently has unit coverage only. Exact-head cold-boot journey evidence and its publication are deferred until the required test infrastructure is authorized. No merge or deployment is requested.

## Review Follow-up

Security clearance approved on `48d514b4713026110fbed33cd5cab7535e72c48c` with no security findings. Review finding `48C-4CN` remains unresolved: the signup assertion exercises explicit configuration, not the missing-configuration fallback. Isolated Den Web startup coverage for that branch and exact-head journey execution/publication remain deferred. Clearance is not a passing proof verdict or merge approval.

