### PR TITLE
feat(examples): sync LiteLLM model metadata

### DIFF
--- a/evals/packages/env/src/litellm.ts
+++ b/evals/packages/env/src/litellm.ts
@@ -32,6 +32,8 @@ const DAYTONA_LOG = "/tmp/openwork-litellm.log";
 const DAYTONA_WITNESS_LOG = "/tmp/openwork-litellm-witness.log";
 const BASE64_CHUNK_LENGTH = 8 * 1_024;
 const MAX_DAYTONA_COMMAND_LENGTH = 12 * 1_024;
+const DEFAULT_MAX_INPUT_TOKENS = 128_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
 
 const DAYTONA_DOCKERFILE = `FROM ${IMAGE}
 USER root
@@ -478,7 +480,14 @@ function startWitness(
   });
 }
 
-function liteLlmConfig(modelId: string, apiBase: string, masterKey: string, upstreamKey: string): string {
+function liteLlmConfig(
+  modelId: string,
+  apiBase: string,
+  masterKey: string,
+  upstreamKey: string,
+  maxInputTokens: number,
+  maxOutputTokens: number,
+): string {
   return JSON.stringify({
     model_list: [{
       model_name: modelId,
@@ -487,9 +496,23 @@ function liteLlmConfig(modelId: string, apiBase: string, masterKey: string, upst
         api_base: apiBase,
         api_key: upstreamKey,
       },
+      model_info: {
+        max_input_tokens: maxInputTokens,
+        max_output_tokens: maxOutputTokens,
+        supports_function_calling: true,
+        supports_vision: true,
+        supports_reasoning: false,
+        supports_response_schema: true,
+        supported_openai_params: ["temperature", "tools", "response_format"],
+      },
     }],
     general_settings: { master_key: masterKey },
   }, null, 2);
+}
+
+function positiveTokenLimit(value: number, label: string): number {
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${label} must be a finite positive number.`);
+  return value;
 }
 
 async function mappedPort(container: string): Promise<number> {
@@ -600,7 +623,13 @@ async function waitForPostgres(container: string): Promise<void> {
 }
 
 async function startLocalLiteLlm(
-  input: { modelId: string; reply: string; database?: boolean },
+  input: {
+    modelId: string;
+    reply: string;
+    database?: boolean;
+    maxInputTokens: number;
+    maxOutputTokens: number;
+  },
   secrets: LiteLlmSecrets,
 ): Promise<LiteLlmHandle> {
   try {
@@ -633,6 +662,8 @@ async function startLocalLiteLlm(
         `http://host.docker.internal:${startedWitness.port}/v1`,
         secrets.masterKey,
         secrets.upstreamKey,
+        input.maxInputTokens,
+        input.maxOutputTokens,
       ),
       { mode: 0o600 },
     );
@@ -853,7 +884,14 @@ echo detached`;
 }
 
 async function startDaytonaLiteLlm(
-  input: { modelId: string; reply: string; daytonaExec?: DaytonaExec; fetchImpl?: typeof fetch },
+  input: {
+    modelId: string;
+    reply: string;
+    maxInputTokens: number;
+    maxOutputTokens: number;
+    daytonaExec?: DaytonaExec;
+    fetchImpl?: typeof fetch;
+  },
   secrets: LiteLlmSecrets,
 ): Promise<LiteLlmHandle> {
   const exec = input.daytonaExec ?? defaultDaytonaExec;
@@ -890,6 +928,8 @@ async function startDaytonaLiteLlm(
       `http://127.0.0.1:${DAYTONA_WITNESS_PORT}/v1`,
       secrets.masterKey,
       secrets.upstreamKey,
+      input.maxInputTokens,
+      input.maxOutputTokens,
     );
     const uploads = [
       ...uploadCommands(config, DAYTONA_CONFIG),
@@ -947,6 +987,8 @@ export async function liteLlm(input: {
   modelId: string;
   reply: string;
   database?: boolean;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
   daytonaExec?: DaytonaExec;
   fetchImpl?: typeof fetch;
 }): Promise<LiteLlmHandle> {
@@ -958,7 +1000,12 @@ export async function liteLlm(input: {
   if (input.database && input.place.kind === "daytona") {
     throw new SkipError("LiteLLM database mode currently requires docker placement");
   }
+  const normalizedInput = {
+    ...input,
+    maxInputTokens: positiveTokenLimit(input.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS, "maxInputTokens"),
+    maxOutputTokens: positiveTokenLimit(input.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS, "maxOutputTokens"),
+  };
   return input.place.kind === "daytona"
-    ? startDaytonaLiteLlm(input, secrets)
-    : startLocalLiteLlm(input, secrets);
+    ? startDaytonaLiteLlm(normalizedInput, secrets)
+    : startLocalLiteLlm(normalizedInput, secrets);
 }

--- a/evals/packages/env/test/litellm.test.ts
+++ b/evals/packages/env/test/litellm.test.ts
@@ -57,6 +57,7 @@ function makeFake(options: FakeOptions = {}): {
   masterKey(): string;
   upstreamKey(): string;
   controlKey(): string;
+  modelInfo(): Record<string, unknown>;
 } {
   const calls: ExecCall[] = [];
   const uploads = new Map<string, string>();
@@ -64,6 +65,7 @@ function makeFake(options: FakeOptions = {}): {
   let masterKey = "";
   let upstreamKey = "";
   let controlKey = "";
+  let modelInfo: Record<string, unknown> = {};
   let deleteAttempts = 0;
   const exec: DaytonaExec = async (args, opts) => {
     calls.push({ args: [...args], opts });
@@ -101,6 +103,7 @@ function makeFake(options: FakeOptions = {}): {
         const params = models[0] && isRecord(models[0].litellm_params) ? models[0].litellm_params : {};
         masterKey = typeof general.master_key === "string" ? general.master_key : "";
         upstreamKey = typeof params.api_key === "string" ? params.api_key : "";
+        modelInfo = models[0] && isRecord(models[0].model_info) ? models[0].model_info : {};
       }
     }
     if (script.includes("tail -80")) {
@@ -131,6 +134,7 @@ function makeFake(options: FakeOptions = {}): {
     masterKey: () => masterKey,
     upstreamKey: () => upstreamKey,
     controlKey: () => controlKey,
+    modelInfo: () => modelInfo,
   };
 }
 
@@ -172,6 +176,8 @@ test("Daytona LiteLLM pins its image, verifies bounded uploads, exposes both por
     place: daytonaPlace,
     modelId: MODEL_ID,
     reply: "deterministic reply",
+    maxInputTokens: 96_000,
+    maxOutputTokens: 12_345,
     daytonaExec: fake.exec,
     fetchImpl: fake.fetchImpl,
   });
@@ -220,6 +226,15 @@ test("Daytona LiteLLM pins its image, verifies bounded uploads, exposes both por
     [{ port: "4000", expires: "7200" }, { port: "4001", expires: "7200" }],
   );
   assert.equal(gateway.baseUrl, "https://port-4000.example.test/v1");
+  assert.deepEqual(fake.modelInfo(), {
+    max_input_tokens: 96_000,
+    max_output_tokens: 12_345,
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_reasoning: false,
+    supports_response_schema: true,
+    supported_openai_params: ["temperature", "tools", "response_format"],
+  });
   assert.equal(await gateway.checkpoint(), 3);
   assert.deepEqual((await gateway.upstreamRequests({ after: 1 })).map((request) => request.sequence), [2, 3]);
   assert.equal((await gateway.waitForUpstreamRequest({

--- a/evals/specs/litellm-per-member-credentials.e2e.test.ts
+++ b/evals/specs/litellm-per-member-credentials.e2e.test.ts
@@ -36,8 +36,25 @@ interface ProvisionerConfig {
 }
 
 interface ProvisionerModule {
-  reconcileMemberKeys(input: ProvisionerConfig): Promise<unknown[]>;
+  syncProviderModelMetadata(input: ProvisionerConfig): Promise<ModelMetadataResult>;
+  reconcileMemberKeys(input: ProvisionerConfig): Promise<ReconcileResult>;
   offboardMember(input: ProvisionerConfig & { orgMembershipId: string }): Promise<unknown>;
+}
+
+interface ModelMetadataResult {
+  action: "unchanged" | "updated";
+  models: Array<{ id: string; maxInputTokens: number; maxOutputTokens: number }>;
+}
+
+interface ReconcileResult {
+  modelMetadata: ModelMetadataResult;
+  memberCredentials: unknown[];
+}
+
+interface LiveModelMetadata {
+  maxInputTokens: number;
+  maxOutputTokens: number;
+  capabilities: Record<string, boolean>;
 }
 
 interface ChatResult {
@@ -51,6 +68,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isProvisionerModule(value: unknown): value is ProvisionerModule {
   return isRecord(value)
+    && typeof value.syncProviderModelMetadata === "function"
     && typeof value.reconcileMemberKeys === "function"
     && typeof value.offboardMember === "function";
 }
@@ -108,7 +126,12 @@ async function createProvider(admin: DenSession, orgId: string, baseUrl: string)
         npm: "@ai-sdk/openai-compatible",
         env: [PROVIDER_ENV],
         api: baseUrl,
-        models: [{ id: MODEL_ID, name: MODEL_NAME }],
+        models: [{
+          id: MODEL_ID,
+          name: MODEL_NAME,
+          family: "preserved-witness-family",
+          limit: { context: 32_000, input: 32_000, output: 32_000 },
+        }],
       },
       credentialMode: "per_member",
       allMembers: true,
@@ -156,6 +179,58 @@ function memberCredentials(value: unknown): Record<string, unknown>[] {
     throw new Error("Member credential response had an invalid shape.");
   }
   return value.memberCredentials.filter(isRecord);
+}
+
+async function manageableProvider(admin: DenSession, orgId: string, providerId: string): Promise<Record<string, unknown>> {
+  const result = await denFetch(admin, "/v1/llm-providers?scope=manageable", {
+    headers: orgHeaders(admin, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const providers = isRecord(result.body) && Array.isArray(result.body.llmProviders)
+    ? result.body.llmProviders.filter(isRecord)
+    : [];
+  const provider = providers.find((entry) => entry.id === providerId);
+  if (!result.response.ok || !provider) {
+    throw new Error(`Finding manageable provider ${providerId} failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return provider;
+}
+
+function providerModelConfig(provider: Record<string, unknown>, modelId: string): Record<string, unknown> {
+  const models = Array.isArray(provider.models) ? provider.models.filter(isRecord) : [];
+  const model = models.find((entry) => entry.id === modelId);
+  if (!model || !isRecord(model.config)) throw new Error(`Manageable provider did not include model config ${modelId}.`);
+  return model.config;
+}
+
+async function liveModelMetadata(baseUrl: string, apiKey: string): Promise<LiveModelMetadata> {
+  const adminBaseUrl = baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "");
+  const response = await fetch(`${adminBaseUrl}/model_group/info`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body: unknown = await response.json();
+  const entries = isRecord(body) && Array.isArray(body.data) ? body.data.filter(isRecord) : [];
+  const metadata = entries.find((entry) => entry.model_group === MODEL_ID);
+  if (!response.ok
+    || !metadata
+    || typeof metadata.max_input_tokens !== "number"
+    || typeof metadata.max_output_tokens !== "number") {
+    throw new Error(`LiteLLM model-group metadata was unavailable for ${MODEL_ID}: HTTP ${response.status}.`);
+  }
+  const capabilities: Record<string, boolean> = {};
+  if (typeof metadata.supports_function_calling === "boolean") capabilities.tool_call = metadata.supports_function_calling;
+  if (typeof metadata.supports_reasoning === "boolean") capabilities.reasoning = metadata.supports_reasoning;
+  if (typeof metadata.supports_vision === "boolean") capabilities.attachment = metadata.supports_vision;
+  if (typeof metadata.supports_response_schema === "boolean") capabilities.structured_output = metadata.supports_response_schema;
+  if (Array.isArray(metadata.supported_openai_params)) {
+    capabilities.temperature = metadata.supported_openai_params.includes("temperature");
+  }
+  return {
+    maxInputTokens: metadata.max_input_tokens,
+    maxOutputTokens: metadata.max_output_tokens,
+    capabilities,
+  };
 }
 
 async function chat(baseUrl: string, apiKey: string): Promise<ChatResult> {
@@ -244,8 +319,59 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
     liteLlmMasterKey: gateway.apiKey,
     models: [MODEL_ID],
   };
+  const gatewayMetadata = await liveModelMetadata(gateway.baseUrl, gateway.apiKey);
+  expect(gatewayMetadata).toEqual({
+    maxInputTokens: 128_000,
+    maxOutputTokens: 16_384,
+    capabilities: {
+      tool_call: true,
+      reasoning: false,
+      attachment: true,
+      temperature: true,
+    },
+  });
   const reconcileSummary = await imported.reconcileMemberKeys(provisionerConfig);
-  expect(reconcileSummary.length).toBeGreaterThanOrEqual(2);
+  expect(reconcileSummary.modelMetadata).toEqual({
+    action: "updated",
+    models: [{ id: MODEL_ID, maxInputTokens: 128_000, maxOutputTokens: 16_384 }],
+  });
+  expect(reconcileSummary.memberCredentials.length).toBeGreaterThanOrEqual(2);
+
+  const syncedProvider = await manageableProvider(den.admin, orgId, providerId);
+  const syncedModel = providerModelConfig(syncedProvider, MODEL_ID);
+  expect(syncedModel).toMatchObject({
+    family: "preserved-witness-family",
+    limit: { context: 128_000, input: 128_000, output: 16_384 },
+    ...gatewayMetadata.capabilities,
+  });
+  expect(syncedProvider.access).toMatchObject({ allMembers: true });
+  const syncedLimit = isRecord(syncedModel.limit) ? syncedModel.limit : null;
+  const metadataCameFromGateway = syncedLimit?.context === gatewayMetadata.maxInputTokens
+    && syncedLimit.input === gatewayMetadata.maxInputTokens
+    && syncedLimit.output === gatewayMetadata.maxOutputTokens
+    && Object.entries(gatewayMetadata.capabilities).every(([key, value]) => syncedModel[key] === value)
+    && syncedModel.family === "preserved-witness-family";
+  expect(metadataCameFromGateway).toBe(true);
+  evidence.recordAssertionEvidence(
+    "The provisioner synchronizes model limits and capabilities from the live LiteLLM gateway without dropping existing model fields or access",
+    "LiteLLM /model_group/info reported 128000 input and 16384 output tokens plus capability facts; Den replaced the intentionally wrong 32000 limits with those exact values, preserved the witness family, and retained all-member access.",
+    metadataCameFromGateway
+      && isRecord(syncedProvider.access)
+      && syncedProvider.access.allMembers === true,
+  );
+
+  const secondReconcile = await imported.reconcileMemberKeys(provisionerConfig);
+  expect(secondReconcile.modelMetadata).toEqual({
+    action: "unchanged",
+    models: [{ id: MODEL_ID, maxInputTokens: 128_000, maxOutputTokens: 16_384 }],
+  });
+  expect(secondReconcile.memberCredentials).toEqual([]);
+  evidence.recordAssertionEvidence(
+    "Repeated reconciliation does not rewrite model metadata that is already synchronized",
+    "The second real provisioner run returned modelMetadata.action=unchanged and provisioned no additional member credentials.",
+    secondReconcile.modelMetadata.action === "unchanged"
+      && secondReconcile.memberCredentials.length === 0,
+  );
 
   const [aliceConnect, bobConnect] = await Promise.all([
     connect(alice, orgId, providerId),

--- a/examples/litellm-per-member-keys/README.md
+++ b/examples/litellm-per-member-keys/README.md
@@ -20,7 +20,11 @@ Run reconciliation after granting provider access:
 node provision.mjs reconcile
 ```
 
-The script lists Den member credential states, mints a LiteLLM virtual key for each `missing` member, and writes the key to Den with LiteLLM's `token_id` as `externalCredentialId`. Summaries never contain member keys.
+Before provisioning keys, the script reads the existing custom, `per_member` provider from Den and reconciles its configured model metadata from LiteLLM `GET /model_group/info` using master-key authentication. It preserves the provider config, model names and unknown model fields, and current member/team access while updating token limits. When LiteLLM supplies the corresponding facts, it also maps function calling, reasoning, vision, response schemas, and temperature support to Den's `tool_call`, `reasoning`, `attachment`, `structured_output`, and `temperature` model fields. It only PATCHes Den when those values changed.
+
+Every model in `LITELLM_MODELS` must have an exact `model_group` match with finite, positive `max_input_tokens` and `max_output_tokens`. Reconciliation fails closed before creating member keys if LiteLLM omits a requested model or either limit. The example never guesses token limits or falls back to a generic value.
+
+After metadata is synchronized, the script lists Den member credential states, mints a LiteLLM virtual key for each `missing` member, and writes the key to Den with LiteLLM's `token_id` as `externalCredentialId`. Summaries report the metadata action and safe model limits but never contain member keys.
 
 Offboard a member by organization membership ID:
 

--- a/examples/litellm-per-member-keys/provision.mjs
+++ b/examples/litellm-per-member-keys/provision.mjs
@@ -14,10 +14,44 @@ import { pathToFileURL } from "node:url";
  */
 
 /**
- * @typedef {object} ReconcileSummary
+ * @typedef {object} MemberCredentialSummary
  * @property {string} orgMembershipId
  * @property {"provisioned"} action
  * @property {string} externalCredentialId
+ */
+
+/**
+ * @typedef {object} ModelMetadataSummary
+ * @property {string} id
+ * @property {number} maxInputTokens
+ * @property {number} maxOutputTokens
+ */
+
+/**
+ * @typedef {object} ModelMetadataResult
+ * @property {"unchanged" | "updated"} action
+ * @property {ModelMetadataSummary[]} models
+ */
+
+/**
+ * @typedef {object} ReconcileResult
+ * @property {ModelMetadataResult} modelMetadata
+ * @property {MemberCredentialSummary[]} memberCredentials
+ */
+
+/**
+ * @typedef {object} CurrentProviderModel
+ * @property {string} id
+ * @property {string} name
+ * @property {Record<string, unknown>} config
+ */
+
+/**
+ * @typedef {object} LiteLlmModelMetadata
+ * @property {string} id
+ * @property {number} maxInputTokens
+ * @property {number} maxOutputTokens
+ * @property {Record<string, unknown>} facts
  */
 
 /**
@@ -38,6 +72,17 @@ function requireString(value, label) {
     throw new Error(`${label} must be a non-empty string.`);
   }
   return value.trim();
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ */
+function requirePositiveNumber(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a finite positive number.`);
+  }
+  return value;
 }
 
 /** @param {unknown} value */
@@ -107,6 +152,231 @@ function denHeaders(input) {
 }
 
 /**
+ * @param {ProvisionerConfig} input
+ */
+function configuredModels(input) {
+  const models = [...new Set(input.models.map((model) => requireString(model, "model")))];
+  if (models.length === 0) throw new Error("models must contain at least one model id.");
+  return models;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} providerId
+ */
+function manageableProvider(value, providerId) {
+  if (!isRecord(value) || !Array.isArray(value.llmProviders)) {
+    throw new Error("Den manageable provider response had an invalid shape.");
+  }
+  const provider = value.llmProviders.filter(isRecord).find((entry) => entry.id === providerId);
+  if (!provider) throw new Error(`Den provider ${providerId} was not found in the manageable provider list.`);
+  if (provider.source !== "custom") throw new Error(`Den provider ${providerId} must have source custom.`);
+  if (provider.credentialMode !== "per_member") throw new Error(`Den provider ${providerId} must have credentialMode per_member.`);
+  return provider;
+}
+
+/**
+ * @param {Record<string, unknown>} provider
+ * @returns {CurrentProviderModel[]}
+ */
+function currentProviderModels(provider) {
+  if (!Array.isArray(provider.models)) throw new Error("Den manageable provider did not include models.");
+  return provider.models.map((value) => {
+    if (!isRecord(value) || !isRecord(value.config)) {
+      throw new Error("Den manageable provider included an invalid model config.");
+    }
+    return {
+      id: requireString(value.id, "Den model id"),
+      name: requireString(value.name, `Den model ${String(value.id)} name`),
+      config: value.config,
+    };
+  });
+}
+
+/**
+ * @param {Record<string, unknown>} provider
+ */
+function currentProviderAccess(provider) {
+  if (!isRecord(provider.access)
+    || typeof provider.access.allMembers !== "boolean"
+    || !Array.isArray(provider.access.members)
+    || !Array.isArray(provider.access.teams)) {
+    throw new Error("Den manageable provider did not include a valid access summary.");
+  }
+  const memberIds = provider.access.members.map((entry) => {
+    if (!isRecord(entry)) throw new Error("Den manageable provider included an invalid member access grant.");
+    return requireString(entry.orgMembershipId, "Den member access orgMembershipId");
+  });
+  const teamIds = provider.access.teams.map((entry) => {
+    if (!isRecord(entry)) throw new Error("Den manageable provider included an invalid team access grant.");
+    return requireString(entry.teamId, "Den team access teamId");
+  });
+  return {
+    allMembers: provider.access.allMembers,
+    memberIds: [...new Set(memberIds)].sort(),
+    teamIds: [...new Set(teamIds)].sort(),
+  };
+}
+
+/**
+ * @param {unknown} value
+ * @param {string[]} models
+ * @returns {LiteLlmModelMetadata[]}
+ */
+function liteLlmModelMetadata(value, models) {
+  if (!isRecord(value) || !Array.isArray(value.data)) {
+    throw new Error("LiteLLM /model_group/info response had an invalid shape.");
+  }
+  const entries = value.data.filter(isRecord);
+  return models.map((id) => {
+    const matches = entries.filter((entry) => entry.model_group === id);
+    if (matches.length === 0) {
+      throw new Error(`LiteLLM /model_group/info did not include requested model_group ${id}.`);
+    }
+    if (matches.length > 1) {
+      throw new Error(`LiteLLM /model_group/info included duplicate metadata for model_group ${id}.`);
+    }
+    const facts = matches[0];
+    if (!facts) throw new Error(`LiteLLM /model_group/info did not include requested model_group ${id}.`);
+    return {
+      id,
+      maxInputTokens: requirePositiveNumber(
+        facts.max_input_tokens,
+        `LiteLLM model_group ${id} max_input_tokens`,
+      ),
+      maxOutputTokens: requirePositiveNumber(
+        facts.max_output_tokens,
+        `LiteLLM model_group ${id} max_output_tokens`,
+      ),
+      facts,
+    };
+  });
+}
+
+/**
+ * @param {CurrentProviderModel} model
+ * @param {LiteLlmModelMetadata | undefined} metadata
+ */
+function synchronizedModelConfig(model, metadata) {
+  if (!metadata) return { ...model.config, id: model.id, name: model.name };
+  const currentLimit = isRecord(model.config.limit) ? model.config.limit : {};
+  /** @type {Record<string, unknown>} */
+  const config = {
+    ...model.config,
+    id: model.id,
+    name: model.name,
+    limit: {
+      ...currentLimit,
+      context: metadata.maxInputTokens,
+      input: metadata.maxInputTokens,
+      output: metadata.maxOutputTokens,
+    },
+  };
+  if (typeof metadata.facts.supports_function_calling === "boolean") {
+    config.tool_call = metadata.facts.supports_function_calling;
+  }
+  if (typeof metadata.facts.supports_reasoning === "boolean") {
+    config.reasoning = metadata.facts.supports_reasoning;
+  }
+  if (typeof metadata.facts.supports_vision === "boolean") {
+    config.attachment = metadata.facts.supports_vision;
+  }
+  if (typeof metadata.facts.supports_response_schema === "boolean") {
+    config.structured_output = metadata.facts.supports_response_schema;
+  }
+  if (Array.isArray(metadata.facts.supported_openai_params)) {
+    config.temperature = metadata.facts.supported_openai_params.includes("temperature");
+  }
+  return config;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]),
+  );
+}
+
+/**
+ * Synchronize the configured Den model limits and capability facts from the
+ * live LiteLLM model-group metadata endpoint.
+ *
+ * @param {ProvisionerConfig} input
+ * @returns {Promise<ModelMetadataResult>}
+ */
+export async function syncProviderModelMetadata(input) {
+  const denApiUrl = cleanBaseUrl(input.denApiUrl);
+  const liteLlmBaseUrl = liteLlmAdminBaseUrl(input.liteLlmBaseUrl);
+  const rawProviderId = requireString(input.providerId, "providerId");
+  const providerId = encodeURIComponent(rawProviderId);
+  const models = configuredModels(input);
+  const secrets = [input.denToken, input.liteLlmMasterKey];
+  const providerList = await requestJson(
+    `${denApiUrl}/v1/llm-providers?scope=manageable`,
+    { headers: denHeaders(input) },
+    secrets,
+  );
+  const provider = manageableProvider(providerList, rawProviderId);
+  const providerName = requireString(provider.name, "Den provider name");
+  if (!isRecord(provider.providerConfig)) {
+    throw new Error(`Den provider ${rawProviderId} did not include providerConfig.`);
+  }
+  const currentModels = currentProviderModels(provider);
+  for (const model of models) {
+    if (!currentModels.some((current) => current.id === model)) {
+      throw new Error(`Den provider ${rawProviderId} does not configure requested model ${model}.`);
+    }
+  }
+  const metadataResponse = await requestJson(
+    `${liteLlmBaseUrl}/model_group/info`,
+    { headers: { authorization: `Bearer ${input.liteLlmMasterKey}` } },
+    secrets,
+  );
+  const metadata = liteLlmModelMetadata(metadataResponse, models);
+  const metadataById = new Map(metadata.map((entry) => [entry.id, entry]));
+  const access = currentProviderAccess(provider);
+  const currentCustomConfig = {
+    ...provider.providerConfig,
+    models: currentModels.map((model) => synchronizedModelConfig(model, undefined)),
+  };
+  const desiredCustomConfig = {
+    ...provider.providerConfig,
+    models: currentModels.map((model) => synchronizedModelConfig(model, metadataById.get(model.id))),
+  };
+  const current = {
+    name: providerName,
+    source: "custom",
+    customConfig: currentCustomConfig,
+    credentialMode: "per_member",
+    ...access,
+  };
+  const desired = { ...current, customConfig: desiredCustomConfig };
+  const summaries = metadata.map((entry) => ({
+    id: entry.id,
+    maxInputTokens: entry.maxInputTokens,
+    maxOutputTokens: entry.maxOutputTokens,
+  }));
+  if (JSON.stringify(canonicalJson(current)) === JSON.stringify(canonicalJson(desired))) {
+    return { action: "unchanged", models: summaries };
+  }
+  await requestJson(
+    `${denApiUrl}/v1/llm-providers/${providerId}`,
+    {
+      method: "PATCH",
+      headers: denHeaders(input),
+      body: JSON.stringify(desired),
+    },
+    secrets,
+  );
+  return { action: "updated", models: summaries };
+}
+
+/**
  * @param {unknown} value
  * @returns {Record<string, unknown>[]}
  */
@@ -137,21 +407,21 @@ function externalCredentialId(value) {
  * Mint a LiteLLM virtual key for every granted Den member whose binding is missing.
  *
  * @param {ProvisionerConfig} input
- * @returns {Promise<ReconcileSummary[]>}
+ * @returns {Promise<ReconcileResult>}
  */
 export async function reconcileMemberKeys(input) {
+  const modelMetadata = await syncProviderModelMetadata(input);
   const denApiUrl = cleanBaseUrl(input.denApiUrl);
   const liteLlmBaseUrl = liteLlmAdminBaseUrl(input.liteLlmBaseUrl);
   const providerId = encodeURIComponent(requireString(input.providerId, "providerId"));
-  const models = input.models.map((model) => requireString(model, "model"));
-  if (models.length === 0) throw new Error("models must contain at least one model id.");
+  const models = configuredModels(input);
   const secrets = [input.denToken, input.liteLlmMasterKey];
   const listed = await requestJson(
     `${denApiUrl}/v1/llm-providers/${providerId}/member-credentials`,
     { headers: denHeaders(input) },
     secrets,
   );
-  /** @type {ReconcileSummary[]} */
+  /** @type {MemberCredentialSummary[]} */
   const summary = [];
 
   for (const entry of memberCredentials(listed)) {
@@ -192,7 +462,7 @@ export async function reconcileMemberKeys(input) {
     summary.push({ orgMembershipId, action: "provisioned", externalCredentialId: credentialId });
   }
 
-  return summary;
+  return { modelMetadata, memberCredentials: summary };
 }
 
 /**

--- a/packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx
+++ b/packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx
@@ -5,7 +5,7 @@ description: "Bind a separate write-only provider credential to each organizatio
 
 Per-member credential bindings let an organization grant one managed LLM provider to many people without sharing one upstream key. Use this when an external gateway, such as LiteLLM, issues a distinct virtual key for each member.
 
-This page describes an API integration pattern. LiteLLM provisioning is not built into Den; run your own provisioner against Den's credential-binding routes and the LiteLLM API.
+This page describes an API integration pattern. LiteLLM provisioning and metadata discovery are not built into Den; run your own provisioner against Den's generic provider and credential-binding routes plus the LiteLLM API.
 
 ## Choose a credential mode
 
@@ -77,7 +77,11 @@ The runnable example at [`examples/litellm-per-member-keys`](https://github.com/
 node provision.mjs reconcile
 ```
 
-The reconcile loop is:
+The example first reads the exact provider from `GET /v1/llm-providers?scope=manageable`, verifies that it is a custom `per_member` provider, then queries LiteLLM `GET /model_group/info` with the master key. Every configured model must have an exact `model_group` match and finite, positive `max_input_tokens` and `max_output_tokens`. The provisioner uses those facts to update each Den model's context, input, and output limits. When present, it maps LiteLLM's function-calling, reasoning, vision, response-schema, and temperature facts to `tool_call`, `reasoning`, `attachment`, `structured_output`, and `temperature`. The replacement preserves the complete provider config, existing model fields, credential mode, and all member/team access.
+
+This step fails closed before key creation if metadata or limits are missing. It never guesses a token limit or falls back to a generic value. The full-replacement Den PATCH omits `apiKey` and `apiKeys`, so Den preserves the write-only stored credential, and the example skips the PATCH entirely when the provider is already synchronized.
+
+It then reconciles missing member credentials:
 
 ```js
 const { memberCredentials } = await den.get(
@@ -107,6 +111,8 @@ for (const binding of memberCredentials) {
 ```
 
 LiteLLM v1.97 returns a `token_id` that can address the virtual key without retaining its plaintext value. The example stores that identifier in `externalCredentialId`; Den's admin list can return it safely to the provisioner later.
+
+The `/model_group/info` call and field mapping are deliberately implemented in this LiteLLM-specific example. Den core remains vendor-neutral: its provider PATCH and per-member credential APIs accept the resulting generic model configuration without hardcoding LiteLLM behavior.
 
 ### Offboard in the safe order
 


### PR DESCRIPTION
## Summary
- synchronize custom-provider model limits and capabilities from LiteLLM `/model_group/info` before per-member key provisioning
- preserve provider configuration, model fields, access grants, and stored credentials while avoiding unchanged PATCHes
- extend the LiteLLM witness, E2E proof, and documentation

## Verification
- `PATH=/opt/homebrew/bin:$PATH pnpm --dir evals exec node --test packages/env/test/litellm.test.ts` (6 passed)
- provisioner syntax/JSDoc check and focused LiteLLM environment TypeScript check
- `PATH=/opt/homebrew/bin:$PATH OPENWORK_EVAL_E2E_TESTS=1 ./node_modules/.bin/vitest run --config vitest.config.ts --project e2e specs/litellm-per-member-credentials.e2e.test.ts` (1 passed; 6/6 evidence assertions)
- `git diff --check`