### PR TITLE
docs: point LiteLLM example link to dev

### DIFF
--- a/packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx
+++ b/packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx
@@ -71,7 +71,7 @@ A blocked binding is admin-owned. A member cannot overwrite or delete it: member
 
 ## LiteLLM example
 
-The runnable example at [`examples/litellm-per-member-keys`](https://github.com/different-ai/openwork/tree/main/examples/litellm-per-member-keys) uses LiteLLM virtual keys. Configure the Den and LiteLLM URLs, admin tokens, provider ID, and model IDs listed in its README, then run:
+The runnable example at [`examples/litellm-per-member-keys`](https://github.com/different-ai/openwork/tree/dev/examples/litellm-per-member-keys) uses LiteLLM virtual keys. Configure the Den and LiteLLM URLs, admin tokens, provider ID, and model IDs listed in its README, then run:
 
 ```bash
 node provision.mjs reconcile


### PR DESCRIPTION
## Summary
- point the per-member LiteLLM example link at the `dev` branch instead of `main`

## Verification
- `git diff --check`
- confirmed the document contains the `tree/dev/examples/litellm-per-member-keys` URL

Docs-only change; runtime proof is not applicable.