### PR TITLE
docs(changelog): add v0.18.36-v0.18.39 release notes

### DIFF
--- a/changelog/release-tracker-2026-08-24.md
+++ b/changelog/release-tracker-2026-08-24.md
@@ -1,0 +1,61 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.36
+
+#### Commit
+`0f0c7d4e`
+
+#### Released at
+`2026-08-24T00:34:54Z`
+
+#### Title
+Hosted MCP Apps and cloud sign-in become more reliable
+
+#### One-line summary
+Routes hosted MCP Apps through the credential-bound Den gateway and hardens cloud sign-in, live sessions, updates, and MCP recovery.
+
+#### Main changes
+- Hosted MCP Apps now render through the credential-bound Den gateway, and Connect refreshes its MCP App catalog when cached inventory is incomplete.
+- Fixed Den callback routing, API-origin derivation, and cookie forwarding so hosted sign-in remains on the correct domain.
+- Workspace switches preserve live agent runs under load, while stale tool activity and scrolling no longer disrupt the active transcript.
+- Desktop update channel selection stays stable, Automation control-plane traffic is bounded, and standalone MCP requests stop retrying indefinitely.
+- Clarified the difference between local setup, managed OpenWork Cloud, OpenCode models, and OpenWork-managed models.
+
+#### Lines of code changed since previous release
+125650 lines changed since `v0.18.35` (13432 insertions, 112218 deletions).
+
+#### Release importance
+Major release: makes hosted MCP Apps, cloud authentication, live sessions, and background recovery more dependable.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+2
+
+#### Major improvement details
+- Rendered hosted MCP Apps through the credential-bound Den gateway.
+- Clarified local, managed Cloud, OpenCode, and OpenWork model setup.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+4
+
+#### Major bug fix details
+- Repaired Den callback routing, API-origin derivation, and cookie forwarding.
+- Preserved live agent runs across workspace switches.
+- Kept desktop update channel selection stable.
+- Bounded Automation and standalone MCP retry traffic.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.

--- a/changelog/release-tracker-2026-08-26.md
+++ b/changelog/release-tracker-2026-08-26.md
@@ -1,0 +1,62 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.37
+
+#### Commit
+`b0cbe846`
+
+#### Released at
+`2026-08-26T13:25:06Z`
+
+#### Title
+Managed dashboards arrive and everyday navigation gets faster
+
+#### One-line summary
+Adds organization-managed MCP App dashboards and improves artifact browsing, navigation, streaming performance, and Azure provider setup.
+
+#### Main changes
+- Organization-managed MCP App dashboards now render on desktop, with a personal grid and an add-from-Connect picker that refreshes automatically.
+- Code Mode and MCP Apps are enabled by default, and Dashboard visibility follows each deployment's availability controls.
+- Added an artifact code browser, branded connector tool calls, delegated-task shimmer, and smoother keyboard, Library, model, and chat controls.
+- Improved streaming and render performance, stabilized sidebar ordering and Settings state, and kept composer focus through refreshes.
+- Fixed Azure managed-provider credential selection and clarified Azure Foundry resource names for bring-your-own-key setup.
+
+#### Lines of code changed since previous release
+57774 lines changed since `v0.18.36` (49106 insertions, 8668 deletions).
+
+#### Release importance
+Major release: brings organization-managed dashboards to desktop and makes daily navigation and streaming substantially smoother.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+4
+
+#### Major improvement details
+- Added organization-managed MCP App dashboards on desktop.
+- Enabled Code Mode and MCP Apps by default.
+- Added an artifact code browser and branded connector activity.
+- Improved keyboard, Library, model, chat, and streaming workflows.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+3
+
+#### Major bug fix details
+- Stabilized sidebar ordering and Settings runtime state.
+- Preserved composer focus through refreshes.
+- Fixed Azure managed-provider credential selection.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.

--- a/changelog/release-tracker-2026-08-27.md
+++ b/changelog/release-tracker-2026-08-27.md
@@ -1,0 +1,125 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.38
+
+#### Commit
+`5a7ea5af`
+
+#### Released at
+`2026-08-27T13:24:26Z`
+
+#### Title
+Split-view workflows and live sessions get more dependable
+
+#### One-line summary
+Adds cross-workspace split view and interrupted-run recovery while keeping live sessions and long-running streams responsive.
+
+#### Main changes
+- Added cross-workspace split view and transcript actions for resuming interrupted runs.
+- Live session status now survives navigation, workspace switches, and reattachment while long-running streams remain responsive.
+- Refined tool-call activity, thought grouping, artifact controls, and Library choices so active work is easier to follow and manage.
+- Cloud extension status now reflects real connectivity, remote-session capabilities reach cloud targets, and worker recovery avoids competing owners.
+- Added a pull-only Docker evaluation stack and strengthened enterprise licensing documentation and stewardship metadata.
+
+#### Lines of code changed since previous release
+12814 lines changed since `v0.18.37` (11415 insertions, 1399 deletions).
+
+#### Release importance
+Major release: adds cross-workspace split view and makes live session recovery and active work presentation more dependable.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+4
+
+#### Major improvement details
+- Added cross-workspace split view.
+- Added transcript actions for resuming interrupted runs.
+- Refined tool-call activity, thought grouping, artifact controls, and Library choices.
+- Added cloud-target remote-session capabilities and a pull-only Docker evaluation stack.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+4
+
+#### Major bug fix details
+- Preserved live session status across navigation and workspace switches.
+- Kept reattached observers live.
+- Improved long-running stream responsiveness.
+- Made Cloud extension status and worker recovery reflect real ownership and connectivity.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+## v0.18.39
+
+#### Commit
+`63625a4b`
+
+#### Released at
+`2026-08-27T23:29:36Z`
+
+#### Title
+Richer session artifacts and more resilient agent runs
+
+#### One-line summary
+Moves session files into the artifact rail, adds richer Markdown controls, and strengthens run recovery across desktop, web, and cloud.
+
+#### Main changes
+- Session files now live in the artifact rail instead of interrupting the chat transcript, with safer badge layout and responsive behavior on narrow screens.
+- Markdown can render Mermaid diagrams safely, and code blocks offer a word-wrap control for long lines.
+- Agent runs recover more reliably from idle admissions, queued follow-ups, event-stream restarts, Settings visits, and large workspace session histories.
+- OpenWork Cloud adds per-member managed-model credentials, paid browser access, desktop delivery for remote-session commands, and more reliable worker recovery.
+- Electron file transfers now work correctly across the remote bridge, and LiteLLM examples include synchronized model metadata.
+
+#### Lines of code changed since previous release
+55851 lines changed since `v0.18.38` (53651 insertions, 2200 deletions).
+
+#### Release importance
+Major release: improves session artifact workflows and makes local, remote, and cloud agent runs substantially more resilient.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+5
+
+#### Major improvement details
+- Moved session files into the artifact rail.
+- Added safe Mermaid rendering and code-block word wrapping.
+- Added per-member managed-model credentials.
+- Added paid OpenWork browser access and desktop remote-session delivery.
+- Synchronized LiteLLM example model metadata.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+5
+
+#### Major bug fix details
+- Recovered agent runs from idle admissions and queued follow-up wedges.
+- Restarted dead event streams after synchronization changes.
+- Prevented Settings visits from interrupting healthy runs.
+- Bounded large workspace session hydration and improved worker recovery.
+- Corrected Electron remote binary transfers and narrow-screen layouts.
+
+#### Deprecated features
+True
+
+#### Number of deprecated features
+1
+
+#### Deprecated details
+- Removed the legacy cloud worker proxy path.

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,50 @@
 ---
 title: "Changelog"
 ---
+<Update label="August 27th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
+
+  ## [v0.18.39](https://github.com/different-ai/openwork/compare/v0.18.38...v0.18.39): Richer session artifacts and more resilient agent runs
+
+  - Session files now live in the artifact rail instead of interrupting the chat transcript, with safer badge layout and responsive behavior on narrow screens.
+  - Markdown can render Mermaid diagrams safely, and code blocks offer a word-wrap control for long lines.
+  - Agent runs recover more reliably from idle admissions, queued follow-ups, event-stream restarts, Settings visits, and large workspace session histories.
+  - OpenWork Cloud adds per-member managed-model credentials, paid browser access, desktop delivery for remote-session commands, and more reliable worker recovery.
+  - Electron file transfers now work correctly across the remote bridge, and LiteLLM examples include synchronized model metadata.
+
+  ## [v0.18.38](https://github.com/different-ai/openwork/compare/v0.18.37...v0.18.38): Split-view workflows and live sessions get more dependable
+
+  - Added cross-workspace split view and transcript actions for resuming interrupted runs.
+  - Live session status now survives navigation, workspace switches, and reattachment while long-running streams remain responsive.
+  - Refined tool-call activity, thought grouping, artifact controls, and Library choices so active work is easier to follow and manage.
+  - Cloud extension status now reflects real connectivity, remote-session capabilities reach cloud targets, and worker recovery avoids competing owners.
+  - Added a pull-only Docker evaluation stack and strengthened enterprise licensing documentation and stewardship metadata.
+
+</Update>
+
+<Update label="August 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
+
+  ## [v0.18.37](https://github.com/different-ai/openwork/compare/v0.18.36...v0.18.37): Managed dashboards arrive and everyday navigation gets faster
+
+  - Organization-managed MCP App dashboards now render on desktop, with a personal grid and an add-from-Connect picker that refreshes automatically.
+  - Code Mode and MCP Apps are enabled by default, and Dashboard visibility follows each deployment's availability controls.
+  - Added an artifact code browser, branded connector tool calls, delegated-task shimmer, and smoother keyboard, Library, model, and chat controls.
+  - Improved streaming and render performance, stabilized sidebar ordering and Settings state, and kept composer focus through refreshes.
+  - Fixed Azure managed-provider credential selection and clarified Azure Foundry resource names for bring-your-own-key setup.
+
+</Update>
+
+<Update label="August 24th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
+
+  ## [v0.18.36](https://github.com/different-ai/openwork/compare/v0.18.35...v0.18.36): Hosted MCP Apps and cloud sign-in become more reliable
+
+  - Hosted MCP Apps now render through the credential-bound Den gateway, and Connect refreshes its MCP App catalog when cached inventory is incomplete.
+  - Fixed Den callback routing, API-origin derivation, and cookie forwarding so hosted sign-in remains on the correct domain.
+  - Workspace switches preserve live agent runs under load, while stale tool activity and scrolling no longer disrupt the active transcript.
+  - Desktop update channel selection stays stable, Automation control-plane traffic is bounded, and standalone MCP requests stop retrying indefinitely.
+  - Clarified the difference between local setup, managed OpenWork Cloud, OpenCode models, and OpenWork-managed models.
+
+</Update>
+
 <Update label="August 20th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.18.35](https://github.com/different-ai/openwork/compare/v0.18.34...v0.18.35): Desktop respects Automation deployment controls


### PR DESCRIPTION
## Summary
- backfill docs changelog entries for v0.18.36 through v0.18.38
- document the newly published v0.18.39 patch release
- add complete release tracker records with verified commits, timestamps, and diff statistics

## Validation
- `git diff --check`
- `node scripts/check-changelog-output.mjs v0.18.36 v0.18.35`
- `node scripts/check-changelog-output.mjs v0.18.37 v0.18.36`
- `node scripts/check-changelog-output.mjs v0.18.38 v0.18.37`
- `node scripts/check-changelog-output.mjs v0.18.39 v0.18.38`
- `node scripts/release/review.mjs --strict`

Docs-only change; runtime proof is not required.