### PR TITLE
feat(evals): add LiteLLM per-member world

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -174,7 +174,7 @@ deep-patched with `.with()`. The topology has:
   ports, and `den.seed` selects the supported demo seed.
 - `apps`: optional named desktop apps with their target org/member, workspace,
   model, sessions, and optional local server delay.
-- `witnesses`: optional named witnesses; v1 accepts MCP mocks only.
+- `witnesses`: optional named MCP or database-backed LiteLLM witnesses. Organizations can bind LiteLLM witnesses through `llmProviders` declarations.
 
 The shipped definitions are `soloWorkspace`, `supportOrg`, `acmeDemo`,
 `acmeDocs`, and `desktopProductionLive`; their CLI names are `solo`,
@@ -207,6 +207,7 @@ pnpm world forget <name>
 
 # Path definitions use the filename as their name and can default to detached.
 pnpm world up ./worlds/dev-headless.ts
+pnpm world up ./worlds/litellm-per-member.ts
 pnpm world up ./worlds/headless-prod-live.ts --allow-shared-state
 
 # Explicit macOS-only live sharing with the installed production stores.

--- a/evals/packages/env/src/topology.ts
+++ b/evals/packages/env/src/topology.ts
@@ -30,6 +30,7 @@ export interface WorldOrg {
     };
   }[];
   connections?: { name: string; witness: string }[];
+  llmProviders?: WorldLlmProvider[];
   desktopPolicies?: {
     name: string;
     priority?: number;
@@ -37,6 +38,15 @@ export interface WorldOrg {
     members?: string[];
     teams?: { name: string; members: string[] }[];
   }[];
+}
+
+export interface WorldLlmProvider {
+  kind: "litellm-per-member";
+  name: string;
+  providerId: string;
+  env: string;
+  witness: string;
+  modelName?: string;
 }
 
 export interface WorldApp {
@@ -48,12 +58,22 @@ export interface WorldApp {
   sessions?: readonly string[];
 }
 
-export interface WorldWitness {
+export interface WorldMcpWitness {
   kind: "mcp";
   allowUnauthenticatedMcp?: boolean;
   profileId?: EnterpriseMcpProfileId;
   fault?: string;
 }
+
+export interface WorldLiteLlmWitness {
+  kind: "litellm";
+  modelId: string;
+  reply: string;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+}
+
+export type WorldWitness = WorldMcpWitness | WorldLiteLlmWitness;
 
 export interface WorldTopology {
   den: {
@@ -106,6 +126,15 @@ const worldConnectionSchema = z.strictObject({
   witness: z.string(),
 });
 
+const worldLlmProviderSchema = z.strictObject({
+  kind: z.literal("litellm-per-member"),
+  name: z.string().trim().min(1).max(255),
+  providerId: z.string().trim().min(1).max(255),
+  env: z.string().trim().min(1).max(255),
+  witness: z.string().trim().min(1),
+  modelName: z.string().trim().min(1).max(255).optional(),
+});
+
 const worldDesktopPolicySchema = z.strictObject({
   name: z.string(),
   priority: z.number().optional(),
@@ -126,6 +155,7 @@ const worldOrgSchema = z.strictObject({
   capabilities: z.record(z.string(), z.boolean()).optional(),
   plugins: z.array(worldPluginSchema).optional(),
   connections: z.array(worldConnectionSchema).optional(),
+  llmProviders: z.array(worldLlmProviderSchema).optional(),
   desktopPolicies: z.array(worldDesktopPolicySchema).optional(),
 });
 
@@ -172,7 +202,7 @@ const enterpriseMcpProfileIdSchema = z.enum([
   "slack-user-mcp",
 ]);
 
-const worldWitnessSchema = z.strictObject({
+const worldMcpWitnessSchema = z.strictObject({
   kind: z.literal("mcp"),
   allowUnauthenticatedMcp: z.boolean().optional(),
   profileId: enterpriseMcpProfileIdSchema.optional(),
@@ -186,6 +216,16 @@ const worldWitnessSchema = z.strictObject({
     });
   }
 });
+
+const positiveTokenLimitSchema = z.number().finite().positive();
+const worldLiteLlmWitnessSchema = z.strictObject({
+  kind: z.literal("litellm"),
+  modelId: z.string().trim().min(1).max(255),
+  reply: z.string().min(1),
+  maxInputTokens: positiveTokenLimitSchema.optional(),
+  maxOutputTokens: positiveTokenLimitSchema.optional(),
+});
+const worldWitnessSchema = z.discriminatedUnion("kind", [worldMcpWitnessSchema, worldLiteLlmWitnessSchema]);
 
 const worldPortsSchema = z.strictObject({
   api: z.number().int().min(1024).max(65_535),
@@ -292,9 +332,10 @@ function validateReferences(topology: WorldTopology): void {
       seededOrg.capabilities !== undefined
       || seededOrg.plugins !== undefined
       || seededOrg.connections !== undefined
+      || seededOrg.llmProviders !== undefined
       || seededOrg.desktopPolicies !== undefined
     ) {
-      throw new Error('den.seed "demo-org" cannot define capabilities, plugins, connections, or desktopPolicies: v1 limitation: the demo seed owns these content nouns.');
+      throw new Error('den.seed "demo-org" cannot define capabilities, plugins, connections, llmProviders, or desktopPolicies: v1 limitation: the demo seed owns these content nouns.');
     }
   }
 
@@ -303,19 +344,30 @@ function validateReferences(topology: WorldTopology): void {
       org.capabilities !== undefined
       || org.plugins !== undefined
       || org.connections !== undefined
+      || org.llmProviders !== undefined
       || org.desktopPolicies !== undefined
     ) {
       throw new Error(
-        `World org ${JSON.stringify(orgName)} cannot define capabilities, plugins, connections, or desktopPolicies: v1 limitation: these content nouns may only be defined on primary org ${JSON.stringify(primaryOrg)}.`,
+        `World org ${JSON.stringify(orgName)} cannot define capabilities, plugins, connections, llmProviders, or desktopPolicies: v1 limitation: these content nouns may only be defined on primary org ${JSON.stringify(primaryOrg)}.`,
       );
     }
   }
 
   for (const [orgName, org] of Object.entries(topology.den.orgs)) {
     for (const connection of org.connections ?? []) {
-      if (!Object.hasOwn(topology.witnesses ?? {}, connection.witness)) {
+      const witness = topology.witnesses?.[connection.witness];
+      if (!witness || witness.kind !== "mcp") {
         throw new Error(
-          `World org ${JSON.stringify(orgName)} connection ${JSON.stringify(connection.name)} references witness ${JSON.stringify(connection.witness)}, which does not exist in topology.witnesses.`,
+          `World org ${JSON.stringify(orgName)} connection ${JSON.stringify(connection.name)} must reference an MCP witness; received ${JSON.stringify(connection.witness)}.`,
+        );
+      }
+    }
+
+    for (const provider of org.llmProviders ?? []) {
+      const witness = topology.witnesses?.[provider.witness];
+      if (!witness || witness.kind !== "litellm") {
+        throw new Error(
+          `World org ${JSON.stringify(orgName)} LLM provider ${JSON.stringify(provider.name)} must reference a LiteLLM witness; received ${JSON.stringify(provider.witness)}.`,
         );
       }
     }

--- a/evals/packages/env/src/topology.ts
+++ b/evals/packages/env/src/topology.ts
@@ -356,18 +356,28 @@ function validateReferences(topology: WorldTopology): void {
   for (const [orgName, org] of Object.entries(topology.den.orgs)) {
     for (const connection of org.connections ?? []) {
       const witness = topology.witnesses?.[connection.witness];
-      if (!witness || witness.kind !== "mcp") {
+      if (!witness) {
         throw new Error(
-          `World org ${JSON.stringify(orgName)} connection ${JSON.stringify(connection.name)} must reference an MCP witness; received ${JSON.stringify(connection.witness)}.`,
+          `World org ${JSON.stringify(orgName)} connection ${JSON.stringify(connection.name)} references witness ${JSON.stringify(connection.witness)}, which does not exist in topology.witnesses.`,
+        );
+      }
+      if (witness.kind !== "mcp") {
+        throw new Error(
+          `World org ${JSON.stringify(orgName)} connection ${JSON.stringify(connection.name)} must reference an MCP witness; ${JSON.stringify(connection.witness)} has kind ${JSON.stringify(witness.kind)}.`,
         );
       }
     }
 
     for (const provider of org.llmProviders ?? []) {
       const witness = topology.witnesses?.[provider.witness];
-      if (!witness || witness.kind !== "litellm") {
+      if (!witness) {
         throw new Error(
-          `World org ${JSON.stringify(orgName)} LLM provider ${JSON.stringify(provider.name)} must reference a LiteLLM witness; received ${JSON.stringify(provider.witness)}.`,
+          `World org ${JSON.stringify(orgName)} LLM provider ${JSON.stringify(provider.name)} references witness ${JSON.stringify(provider.witness)}, which does not exist in topology.witnesses.`,
+        );
+      }
+      if (witness.kind !== "litellm") {
+        throw new Error(
+          `World org ${JSON.stringify(orgName)} LLM provider ${JSON.stringify(provider.name)} must reference a LiteLLM witness; ${JSON.stringify(provider.witness)} has kind ${JSON.stringify(witness.kind)}.`,
         );
       }
     }

--- a/evals/packages/env/src/world-adapter.ts
+++ b/evals/packages/env/src/world-adapter.ts
@@ -11,6 +11,7 @@ import type {
   WorldStartRequest,
 } from "@openwork/world";
 import type { WorldTopology } from "./topology.ts";
+import type { WorldLlmProviderRuntime } from "./world.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const SNAPSHOT_DIRECTORY = join(REPO_ROOT, "evals", "results", ".worlds");
@@ -19,10 +20,16 @@ function displayLines(
   topology: WorldTopology,
   den: { ref: { apiUrl: string; webUrl: string } },
   apps: Record<string, { handle: { cdpUrl: string } }>,
+  llmProviders: Record<string, WorldLlmProviderRuntime> = {},
 ): string[] {
   const lines: string[] = [];
   if (!usesLiveSharedProductionState(topology)) {
     lines.push(`den web  ${den.ref.webUrl}`, `den api  ${den.ref.apiUrl}`);
+  }
+  for (const [name, provider] of Object.entries(llmProviders)) {
+    lines.push(
+      `litellm ${name}  ${provider.baseUrl}  model ${provider.modelId}  limits ${provider.maxInputTokens}/${provider.maxOutputTokens}  Den ${provider.providerRecordId}`,
+    );
   }
   for (const [name, app] of Object.entries(apps)) {
     const signedInTo = topology.apps?.[name]?.signedInTo;
@@ -54,7 +61,7 @@ async function start(request: WorldStartRequest): Promise<StartedWorldRuntime> {
   });
   return {
     name: world.name,
-    lines: displayLines(topology, world.den, world.apps),
+    lines: displayLines(topology, world.den, world.apps, world.llmProviders),
     ...(usesLiveSharedProductionState(topology) ? { sharedState: true } : {}),
     snapshotPath: world.snapshotPath,
     async detach() {

--- a/evals/packages/env/src/world.ts
+++ b/evals/packages/env/src/world.ts
@@ -23,6 +23,8 @@ import type { App } from "./desktop-app.ts";
 import { defaultReuseAdmin, personDefaults, server } from "./den.ts";
 import type { Den } from "./den.ts";
 import { DEMO_PASSWORD, ensureKindDenReady, exposeEndpointHandles, kubeProfileConfig } from "./kind-stack.ts";
+import { liteLlm } from "./litellm.ts";
+import type { LiteLlmHandle } from "./litellm.ts";
 import { mcpMock } from "./mock.ts";
 import { resolvePlace, validateDatabaseName } from "./place.ts";
 import type { Place } from "./place.ts";
@@ -50,8 +52,20 @@ export interface World extends AsyncDisposable {
   topology: WorldTopology;
   den: Den;
   apps: Record<string, App>;
+  llmProviders: Record<string, WorldLlmProviderRuntime>;
   app(name: string): App;
   snapshotPath: string;
+}
+
+export interface WorldLlmProviderRuntime {
+  providerId: string;
+  providerRecordId: string;
+  witness: string;
+  baseUrl: string;
+  modelId: string;
+  maxInputTokens: number;
+  maxOutputTokens: number;
+  metadataAction: "updated" | "unchanged";
 }
 
 export interface WorldSnapshotResolved {
@@ -298,7 +312,7 @@ function validateUntrustedSnapshot(snapshot: WorldSnapshot): void {
     }
   }
   for (const [name, witness] of Object.entries(snapshot.topology.witnesses ?? {})) {
-    if (witness.fault !== undefined && !SNAPSHOT_FAULT.test(witness.fault)) {
+    if (witness.kind === "mcp" && witness.fault !== undefined && !SNAPSHOT_FAULT.test(witness.fault)) {
       rejectSnapshotField(`topology.witnesses.${name}.fault`, witness.fault, "expected a lowercase fault id containing only letters, numbers, or hyphens");
     }
   }
@@ -382,6 +396,128 @@ function snapshotTopology(topology: WorldTopology): WorldTopology {
 
 function auth(token: string): Record<string, string> {
   return { authorization: `Bearer ${token}` };
+}
+
+interface ExampleProvisionerModule {
+  reconcileMemberKeys(input: {
+    denApiUrl: string;
+    denToken: string;
+    orgId: string;
+    providerId: string;
+    liteLlmBaseUrl: string;
+    liteLlmMasterKey: string;
+    models: string[];
+  }): Promise<unknown>;
+}
+
+function isExampleProvisionerModule(value: unknown): value is ExampleProvisionerModule {
+  return isRecord(value) && typeof value.reconcileMemberKeys === "function";
+}
+
+async function exampleProvisioner(): Promise<ExampleProvisionerModule> {
+  const url = new URL("../../../../examples/litellm-per-member-keys/provision.mjs", import.meta.url).href;
+  const imported: unknown = await import(url);
+  if (!isExampleProvisionerModule(imported)) {
+    throw new Error("The LiteLLM per-member example did not export reconcileMemberKeys.");
+  }
+  return imported;
+}
+
+function metadataResult(value: unknown, modelId: string): {
+  action: "updated" | "unchanged";
+  maxInputTokens: number;
+  maxOutputTokens: number;
+} {
+  const metadata = isRecord(value) && isRecord(value.modelMetadata) ? value.modelMetadata : null;
+  const models = metadata && Array.isArray(metadata.models) ? metadata.models.filter(isRecord) : [];
+  const model = models.find((entry) => entry.id === modelId);
+  if (!metadata
+    || (metadata.action !== "updated" && metadata.action !== "unchanged")
+    || !model
+    || typeof model.maxInputTokens !== "number"
+    || typeof model.maxOutputTokens !== "number") {
+    throw new Error(`LiteLLM example reconciliation returned invalid metadata for model ${JSON.stringify(modelId)}.`);
+  }
+  return {
+    action: metadata.action,
+    maxInputTokens: model.maxInputTokens,
+    maxOutputTokens: model.maxOutputTokens,
+  };
+}
+
+async function provisionWorldLlmProviders(
+  den: Den,
+  organizationId: string,
+  org: WorldOrg,
+  topology: WorldTopology,
+  gateways: Record<string, LiteLlmHandle>,
+): Promise<Record<string, WorldLlmProviderRuntime>> {
+  const providers = org.llmProviders ?? [];
+  if (providers.length === 0) return {};
+  const provisioner = await exampleProvisioner();
+  const realized: Record<string, WorldLlmProviderRuntime> = {};
+  for (const provider of providers) {
+    const witness = topology.witnesses?.[provider.witness];
+    const gateway = gateways[provider.witness];
+    if (!witness || witness.kind !== "litellm" || !gateway) {
+      throw new Error(`LiteLLM witness ${JSON.stringify(provider.witness)} was not booted for provider ${JSON.stringify(provider.name)}.`);
+    }
+    const route = "/v1/llm-providers";
+    const created = await denFetch(den.admin, route, {
+      method: "POST",
+      headers: {
+        ...auth(den.admin.token),
+        "content-type": "application/json",
+        "x-openwork-org-id": organizationId,
+      },
+      body: JSON.stringify({
+        name: provider.name,
+        source: "custom",
+        customConfig: {
+          id: provider.providerId,
+          name: provider.name,
+          npm: "@ai-sdk/openai-compatible",
+          env: [provider.env],
+          api: gateway.baseUrl,
+          models: [{ id: witness.modelId, name: provider.modelName ?? witness.modelId }],
+        },
+        credentialMode: "per_member",
+        allMembers: true,
+        memberIds: [],
+        teamIds: [],
+      }),
+    });
+    const createdProvider = isRecord(created.body) && isRecord(created.body.llmProvider)
+      ? created.body.llmProvider
+      : null;
+    const providerRecordId = createdProvider && typeof createdProvider.id === "string"
+      ? createdProvider.id
+      : "";
+    if (created.response.status !== 201 || !providerRecordId) {
+      throw new Error(`POST ${route} failed for provider ${JSON.stringify(provider.name)}: HTTP ${created.response.status} ${created.text.slice(0, 500)}`);
+    }
+    const reconciled = await provisioner.reconcileMemberKeys({
+      denApiUrl: den.ref.apiUrl,
+      denToken: den.admin.token,
+      orgId: organizationId,
+      providerId: providerRecordId,
+      liteLlmBaseUrl: gateway.baseUrl,
+      liteLlmMasterKey: gateway.apiKey,
+      models: [witness.modelId],
+    });
+    const metadata = metadataResult(reconciled, witness.modelId);
+    realized[provider.providerId] = {
+      providerId: provider.providerId,
+      providerRecordId,
+      witness: provider.witness,
+      baseUrl: gateway.baseUrl,
+      modelId: witness.modelId,
+      maxInputTokens: metadata.maxInputTokens,
+      maxOutputTokens: metadata.maxOutputTokens,
+      metadataAction: metadata.action,
+    };
+  }
+  return realized;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -507,7 +643,9 @@ async function realizePrimaryOrganizationContent(
   den: Den,
   organizationId: string,
   org: WorldOrg,
-): Promise<void> {
+  topology: WorldTopology,
+  gateways: Record<string, LiteLlmHandle>,
+): Promise<Record<string, WorldLlmProviderRuntime>> {
   if (org.capabilities !== undefined) {
     const route = `/v1/admin/organizations/${organizationId}/capabilities`;
     const updated = await denFetch(den.admin, route, {
@@ -555,6 +693,7 @@ async function realizePrimaryOrganizationContent(
   for (const policy of org.desktopPolicies ?? []) {
     await createDesktopPolicy(den, organizationId, policy);
   }
+  return provisionWorldLlmProviders(den, organizationId, org, topology, gateways);
 }
 
 async function addPrimaryAdminToOrganization(
@@ -645,14 +784,16 @@ function extraOrganizationMembers(
 
 function witnessMocks(topology: WorldTopology) {
   return Object.fromEntries(
-    Object.entries(topology.witnesses ?? {}).map(([name, witness]) => [
-      name,
-      mcpMock({
-        allowUnauthenticatedMcp: witness.allowUnauthenticatedMcp,
-        profileId: witness.profileId,
-        fault: witness.fault,
-      }),
-    ]),
+    Object.entries(topology.witnesses ?? {}).flatMap(([name, witness]) => witness.kind === "mcp"
+      ? [[
+          name,
+          mcpMock({
+            allowUnauthenticatedMcp: witness.allowUnauthenticatedMcp,
+            profileId: witness.profileId,
+            fault: witness.fault,
+          }),
+        ]]
+      : []),
   );
 }
 
@@ -984,6 +1125,21 @@ export async function startWorld(
   const scope = await Effect.runPromise(Scope.make("sequential"));
 
   const acquisition = Effect.gen(function*() {
+    const gateways: Record<string, LiteLlmHandle> = {};
+    for (const [witnessName, witness] of Object.entries(topology.witnesses ?? {})) {
+      if (witness.kind !== "litellm") continue;
+      gateways[witnessName] = yield* Effect.acquireRelease(
+        Effect.promise(() => liteLlm({
+          place,
+          modelId: witness.modelId,
+          reply: witness.reply,
+          database: true,
+          maxInputTokens: witness.maxInputTokens,
+          maxOutputTokens: witness.maxOutputTokens,
+        })),
+        (gateway) => Effect.promise(() => gateway[Symbol.asyncDispose]()),
+      );
+    }
     const den = yield* Effect.acquireRelease(
       Effect.promise(() => sharedProductionState
         ? Promise.resolve(disabledDen())
@@ -1016,6 +1172,7 @@ export async function startWorld(
           })),
       (booted) => Effect.promise(() => booted[Symbol.asyncDispose]()),
     );
+    const llmProviders: Record<string, WorldLlmProviderRuntime> = {};
     if (
       primaryOrgName !== undefined
       && primaryOrg !== undefined
@@ -1039,7 +1196,16 @@ export async function startWorld(
       }
 
       // Local/Daytona DBs are ephemeral; attached-Den reuse can leak rows not covered by organization deletion.
-      yield* Effect.promise(() => realizePrimaryOrganizationContent(den, primaryOrganizationId, primaryOrg));
+      Object.assign(
+        llmProviders,
+        yield* Effect.promise(() => realizePrimaryOrganizationContent(
+          den,
+          primaryOrganizationId,
+          primaryOrg,
+          topology,
+          gateways,
+        )),
+      );
     }
 
     const apps: Record<string, App> = {};
@@ -1104,7 +1270,7 @@ export async function startWorld(
       });
       await chmod(snapshotPath, 0o600);
     });
-    return { den, apps, snapshotPath };
+    return { den, apps, llmProviders, snapshotPath };
   });
 
   try {
@@ -1115,6 +1281,7 @@ export async function startWorld(
       topology,
       den: acquired.den,
       apps: acquired.apps,
+      llmProviders: acquired.llmProviders,
       app(appName) {
         const found = acquired.apps[appName];
         if (!found) {

--- a/evals/packages/env/test/topology.test.ts
+++ b/evals/packages/env/test/topology.test.ts
@@ -182,7 +182,8 @@ test("demo seed requires one content-free organization", () => {
     () => defineWorld({
       den: { orgs: { acme: { plugins: [] } }, seed: "demo-org" },
     }),
-    /cannot define capabilities, plugins, connections, or desktopPolicies: v1 limitation/,
+    // Anchor on the stable reason, not the growing noun enumeration.
+    /v1 limitation: the demo seed owns these content nouns/,
   );
 });
 
@@ -256,6 +257,50 @@ test("defineWorld rejects connections whose witness is not declared", () => {
       },
     }),
     /connection "Notion" references witness "notion", which does not exist in topology\.witnesses/,
+  );
+  assert.throws(
+    () => defineWorld({
+      den: {
+        orgs: {
+          acme: { connections: [{ name: "Notion", witness: "notion" }] },
+        },
+      },
+      witnesses: {
+        notion: { kind: "litellm", modelId: "witness-model", reply: "ok" },
+      },
+    }),
+    /connection "Notion" must reference an MCP witness; "notion" has kind "litellm"/,
+  );
+});
+
+test("defineWorld constrains LLM providers to declared LiteLLM witnesses", () => {
+  const provider = {
+    kind: "litellm-per-member" as const,
+    name: "Per-Member Gateway",
+    providerId: "openwork-litellm",
+    env: "LITELLM_PER_MEMBER_API_KEY",
+    witness: "litellm",
+  };
+  const world = defineWorld({
+    den: { orgs: { acme: { llmProviders: [provider] } } },
+    witnesses: {
+      litellm: { kind: "litellm", modelId: "witness-model", reply: "ok" },
+    },
+  });
+  assert.deepEqual(world.topology.den.orgs.acme?.llmProviders, [provider]);
+
+  assert.throws(
+    () => defineWorld({
+      den: { orgs: { acme: { llmProviders: [provider] } } },
+    }),
+    /LLM provider "Per-Member Gateway" references witness "litellm", which does not exist in topology\.witnesses/,
+  );
+  assert.throws(
+    () => defineWorld({
+      den: { orgs: { acme: { llmProviders: [provider] } } },
+      witnesses: { litellm: { kind: "mcp" } },
+    }),
+    /LLM provider "Per-Member Gateway" must reference a LiteLLM witness; "litellm" has kind "mcp"/,
   );
 });
 

--- a/evals/specs/litellm-per-member-world.e2e.test.ts
+++ b/evals/specs/litellm-per-member-world.e2e.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { needs, startWorld, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+import {
+  LITELLM_WORLD_MODEL,
+  LITELLM_WORLD_PROVIDER,
+  liteLlmPerMember,
+} from "../../worlds/litellm-per-member.ts";
+
+const REPLY = "The database-backed per-member LiteLLM world is working.";
+const requirements: TestNeeds = { optIn: ["OPENWORK_EVAL_E2E_TESTS"], commands: ["docker"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `LiteLLM per-member world skipped — needs: ${missingRequirements.join(", ")}`
+  : "one world boots Desktop, Den, and a reconciled per-member LiteLLM provider";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  await using world = await startWorld(liteLlmPerMember, {
+    place,
+    name: `litellm-per-member-world-${Date.now().toString(36)}`,
+  });
+
+  const providerRuntime = world.llmProviders[LITELLM_WORLD_PROVIDER];
+  if (!providerRuntime) throw new Error("The world did not realize its LiteLLM provider.");
+  expect(providerRuntime).toMatchObject({
+    providerId: LITELLM_WORLD_PROVIDER,
+    modelId: LITELLM_WORLD_MODEL,
+    maxInputTokens: 128_000,
+    maxOutputTokens: 16_384,
+    metadataAction: "updated",
+  });
+  expect(providerRuntime.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
+
+  const listed = await denFetch(world.den.admin, "/v1/llm-providers?scope=manageable", {
+    headers: { authorization: `Bearer ${world.den.admin.token}` },
+  });
+  const providers = isRecord(listed.body) && Array.isArray(listed.body.llmProviders)
+    ? listed.body.llmProviders.filter(isRecord)
+    : [];
+  const provider = providers.find((entry) => entry.id === providerRuntime.providerRecordId);
+  const models = provider && Array.isArray(provider.models) ? provider.models.filter(isRecord) : [];
+  const model = models.find((entry) => entry.id === LITELLM_WORLD_MODEL);
+  expect(listed.response.status).toBe(200);
+  expect(model).toMatchObject({
+    config: { limit: { context: 128_000, input: 128_000, output: 16_384 } },
+  });
+
+  const connected = await denFetch(
+    world.den.admin,
+    `/v1/llm-providers/${encodeURIComponent(providerRuntime.providerRecordId)}/connect`,
+    { headers: { authorization: `Bearer ${world.den.admin.token}` } },
+  );
+  const connectedProvider = isRecord(connected.body) && isRecord(connected.body.llmProvider)
+    ? connected.body.llmProvider
+    : null;
+  const memberKey = connectedProvider && typeof connectedProvider.apiKey === "string"
+    ? connectedProvider.apiKey
+    : "";
+  expect(connected.response.status).toBe(200);
+  expect(connectedProvider).toMatchObject({ memberCredential: { state: "active" } });
+  expect(memberKey).toMatch(/^sk-/);
+
+  const response = await fetch(`${providerRuntime.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${memberKey}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      model: LITELLM_WORLD_MODEL,
+      messages: [{ role: "user", content: "Verify the one-command world." }],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const completion: unknown = await response.json();
+  const choices = isRecord(completion) && Array.isArray(completion.choices)
+    ? completion.choices.filter(isRecord)
+    : [];
+  const message = choices[0] && isRecord(choices[0].message) ? choices[0].message : null;
+  expect(response.status).toBe(200);
+  expect(message?.content).toBe(REPLY);
+  expect(world.app("desktop").handle.cdpUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+  evidence.recordAssertionEvidence(
+    "One world starts a signed-in Desktop with a database-backed, metadata-synchronized per-member LiteLLM provider",
+    `The world booted Desktop CDP, created Den provider ${providerRuntime.providerRecordId}, synchronized 128000/16384 limits, provisioned the admin member key, and returned the deterministic LiteLLM reply.`,
+    response.status === 200
+      && message?.content === REPLY
+      && providerRuntime.metadataAction === "updated"
+      && memberKey.startsWith("sk-"),
+  );
+});

--- a/evals/specs/shared-world-engine.test.ts
+++ b/evals/specs/shared-world-engine.test.ts
@@ -1,74 +1,98 @@
 import assert from "node:assert/strict";
+import { readdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { desktopProductionLive, test } from "@openwork/testkit";
 import { discoverWorlds, loadWorldFile, main } from "@openwork/world";
-import type { WorldRuntimeAdapter } from "@openwork/world";
+import type { LoadedWorld, WorldRuntimeAdapter } from "@openwork/world";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const WORLDS_DIRECTORY = join(REPO_ROOT, "worlds");
 
 test("shared world files are discovered, path-loadable, consent-gated, and detached by default", async ({ evidence }) => {
+  // Discovery must mirror the worlds/ directory itself. The listing is derived
+  // here, not hardcoded, so adding a world file never edits this spec; only a
+  // discovery defect (dropped, invented, renamed, or reordered entries) fails.
+  const worldFileNames = (await readdir(WORLDS_DIRECTORY))
+    .filter((entry) => entry.endsWith(".ts") && !entry.endsWith(".test.ts"))
+    .sort();
+  assert.ok(worldFileNames.length > 0, "expected at least one root world file in worlds/");
   const discovered = await discoverWorlds(WORLDS_DIRECTORY);
-  assert.deepEqual(discovered.map((world) => world.name), [
-    "azure-byok",
-    "cloud-model-infra-worker",
-    "cloud-model-infra",
-    "cross-workspace-split-view",
-    "den-split-origin-kind",
-    "desktop-prod-live",
-    "dev-headless",
-    "headless-prod-live",
-    "remote-session",
-  ]);
+  assert.deepEqual(
+    discovered.map((world) => ({ name: world.name, path: world.path })),
+    worldFileNames.map((entry) => ({ name: basename(entry, ".ts"), path: join(WORLDS_DIRECTORY, entry) })),
+  );
 
-  const azureByok = await loadWorldFile(join(WORLDS_DIRECTORY, "azure-byok.ts"));
-  const cloudModelInfra = await loadWorldFile(join(WORLDS_DIRECTORY, "cloud-model-infra.ts"));
-  const cloudModelInfraWorker = await loadWorldFile(join(WORLDS_DIRECTORY, "cloud-model-infra-worker.ts"));
-  const crossWorkspaceSplitView = await loadWorldFile(join(WORLDS_DIRECTORY, "cross-workspace-split-view.ts"));
-  const denSplitOriginKind = await loadWorldFile(join(WORLDS_DIRECTORY, "den-split-origin-kind.ts"));
-  const devHeadless = await loadWorldFile(join(WORLDS_DIRECTORY, "dev-headless.ts"));
-  const headlessProduction = await loadWorldFile(join(WORLDS_DIRECTORY, "headless-prod-live.ts"));
-  const desktopProduction = await loadWorldFile(join(WORLDS_DIRECTORY, "desktop-prod-live.ts"));
-  assert.equal(azureByok.defaultName, "azure-byok");
-  assert.equal(azureByok.definition.adapter, "eval");
-  assert.equal(azureByok.definition.detached, true);
-  assert.equal(azureByok.definition.requiresSharedState, false);
-  assert.equal(cloudModelInfra.defaultName, "cloud-model-infra");
-  assert.equal(cloudModelInfra.definition.adapter, "eval");
-  assert.equal(cloudModelInfra.definition.detached, true);
-  assert.equal(cloudModelInfra.definition.requiresSharedState, false);
-  assert.equal(cloudModelInfraWorker.defaultName, "cloud-model-infra-worker");
-  assert.equal(cloudModelInfraWorker.definition.adapter, "headless-web");
-  assert.equal(cloudModelInfraWorker.definition.detached, true);
-  assert.equal(cloudModelInfraWorker.definition.requiresSharedState, false);
-  assert.deepEqual(cloudModelInfraWorker.definition.topology, {
-    surface: { kind: "headless-web", state: "isolated", workspace: "/tmp/openwork-cloud-model-infra-worker" },
-  });
-  assert.equal(crossWorkspaceSplitView.defaultName, "cross-workspace-split-view");
-  assert.equal(crossWorkspaceSplitView.definition.adapter, "eval");
-  assert.equal(crossWorkspaceSplitView.definition.detached, true);
-  assert.equal(crossWorkspaceSplitView.definition.requiresSharedState, false);
-  assert.equal(denSplitOriginKind.defaultName, "den-split-origin-kind");
-  assert.equal(denSplitOriginKind.definition.adapter, "eval");
-  assert.equal(denSplitOriginKind.definition.detached, true);
-  assert.equal(denSplitOriginKind.definition.requiresSharedState, false);
-  assert.equal(devHeadless.defaultName, "dev-headless");
+  // Every discovered world must load from its path and satisfy the launch
+  // contract. A new world file is covered here automatically.
+  const loadedWorlds = new Map<string, LoadedWorld>();
+  for (const world of discovered) {
+    const loaded = await loadWorldFile(world.path);
+    loadedWorlds.set(world.name, loaded);
+    assert.equal(loaded.defaultName, world.name);
+    assert.equal(typeof loaded.definition.adapter, "string");
+    assert.ok(loaded.definition.adapter.length > 0, `world ${world.name} must name its runtime adapter`);
+    assert.equal(typeof loaded.definition.detached, "boolean", `world ${world.name} must declare detached`);
+    assert.equal(
+      typeof loaded.definition.requiresSharedState,
+      "boolean",
+      `world ${world.name} must declare requiresSharedState`,
+    );
+    assert.ok("topology" in loaded.definition, `world ${world.name} must carry a topology`);
+  }
+  const loadedWorld = (name: string): LoadedWorld => {
+    const loaded = loadedWorlds.get(name);
+    assert.ok(loaded, `expected a root world file named ${name}`);
+    return loaded;
+  };
+
+  // Pinned product decisions for specific worlds. These couple to the named
+  // world's own contract, so unrelated additions cannot break them.
+  const devHeadless = loadedWorld("dev-headless");
   assert.equal(devHeadless.definition.detached, true);
   assert.deepEqual(devHeadless.definition.topology, {
     surface: { kind: "headless-web", state: "isolated" },
   });
-  assert.equal(headlessProduction.definition.requiresSharedState, true);
+  const desktopProduction = loadedWorld("desktop-prod-live");
   assert.equal(desktopProduction.definition.adapter, "eval");
   assert.deepEqual(desktopProduction.definition.topology, desktopProductionLive.topology);
-  const remoteSession = await loadWorldFile(join(WORLDS_DIRECTORY, "remote-session.ts"));
-  assert.equal(remoteSession.defaultName, "remote-session");
+  const remoteSession = loadedWorld("remote-session");
   assert.equal(remoteSession.definition.adapter, "headless-web");
-  assert.equal(remoteSession.definition.detached, true);
-  assert.equal(remoteSession.definition.requiresSharedState, false);
   assert.deepEqual(remoteSession.definition.topology, {
     surface: { kind: "headless-web", state: "isolated", workspace: "/tmp/openwork-remote-session-world" },
   });
+  const cloudModelInfraWorker = loadedWorld("cloud-model-infra-worker");
+  assert.equal(cloudModelInfraWorker.definition.adapter, "headless-web");
+  assert.deepEqual(cloudModelInfraWorker.definition.topology, {
+    surface: { kind: "headless-web", state: "isolated", workspace: "/tmp/openwork-cloud-model-infra-worker" },
+  });
+  assert.equal(loadedWorld("headless-prod-live").definition.requiresSharedState, true);
+
+  // Every world that touches live shared state must refuse to launch without
+  // explicit consent, before any runtime adapter is started.
+  const sharedStateWorlds = discovered.filter((world) => loadedWorld(world.name).definition.requiresSharedState);
+  assert.ok(sharedStateWorlds.length > 0, "expected at least one shared-state world to exercise the consent gate");
+  const refusalAdapters: WorldRuntimeAdapter[] = [...new Set(
+    discovered.map((world) => loadedWorld(world.name).definition.adapter),
+  )].map((id) => ({
+    id,
+    snapshotDirectory: join(REPO_ROOT, "tmp", "spec-worlds"),
+    async start() { throw new Error("the consent gate must refuse before any adapter starts"); },
+    async rebuild() { throw new Error("unused"); },
+    async resume() { throw new Error("unused"); },
+    summarize() { throw new Error("unused"); },
+  }));
+  for (const world of sharedStateWorlds) {
+    const refusedLines: string[] = [];
+    const refused = await main(["up", world.path], {
+      cwd: REPO_ROOT,
+      worldsDirectory: WORLDS_DIRECTORY,
+      adapters: refusalAdapters,
+      print: (line) => refusedLines.push(line),
+    });
+    assert.equal(refused, 1, `world ${world.name} must refuse to launch without --allow-shared-state`);
+    assert.match(refusedLines[0] ?? "", /without explicit --allow-shared-state/);
+  }
 
   let receivedName: string | undefined;
   let receivedAllowSharedState = false;
@@ -93,17 +117,6 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
     async resume() { throw new Error("unused"); },
     summarize() { throw new Error("unused"); },
   };
-  const refusedLines: string[] = [];
-  const refused = await main(["up", "./worlds/headless-prod-live.ts"], {
-    cwd: REPO_ROOT,
-    worldsDirectory: WORLDS_DIRECTORY,
-    adapters: [adapter],
-    print: (line) => refusedLines.push(line),
-  });
-  assert.equal(refused, 1);
-  assert.equal(starts, 0);
-  assert.match(refusedLines[0] ?? "", /without explicit --allow-shared-state/);
-
   const launched = await main([
     "up",
     "./worlds/headless-prod-live.ts",
@@ -115,13 +128,14 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
     print: () => {},
   });
   assert.equal(launched, 0);
+  assert.equal(starts, 1);
   assert.equal(receivedName, "headless-prod-live");
   assert.equal(receivedAllowSharedState, true);
   assert.equal(detached, true);
 
   evidence.recordAssertionEvidence(
     "Root world files are auto-discovered and path-loadable",
-    "Discovery returned all five approved files, and loading retained each adapter/topology contract.",
+    `Discovery mirrored the worlds/ directory listing (${discovered.length} files) and every file loaded with a valid launch contract, so new worlds are covered without editing this spec.`,
     true,
   );
   evidence.recordAssertionEvidence(
@@ -131,7 +145,7 @@ test("shared world files are discovered, path-loadable, consent-gated, and detac
   );
   evidence.recordAssertionEvidence(
     "Shared production state still requires explicit consent",
-    "The adapter was not invoked before --allow-shared-state and received the consent bit after opt-in.",
+    `All ${sharedStateWorlds.length} shared-state world(s) refused to launch before adapter start, and headless-prod-live received the consent bit after opt-in.`,
     true,
   );
 });

--- a/examples/litellm-per-member-keys/README.md
+++ b/examples/litellm-per-member-keys/README.md
@@ -26,6 +26,16 @@ Every model in `LITELLM_MODELS` must have an exact `model_group` match with fini
 
 After metadata is synchronized, the script lists Den member credential states, mints a LiteLLM virtual key for each `missing` member, and writes the key to Den with LiteLLM's `token_id` as `externalCredentialId`. Summaries report the metadata action and safe model limits but never contain member keys.
 
+## Run the complete local world
+
+From the repository root, launch a signed-in Desktop, an isolated Den organization, and a database-backed LiteLLM gateway with the provider and member keys already reconciled:
+
+```bash
+pnpm world up ./worlds/litellm-per-member.ts
+```
+
+The command prints the Den URLs, LiteLLM URL, synchronized model limits, Den provider record ID, and Desktop CDP URL. Keep it running while testing and press Ctrl-C to tear down the world. Docker, local MySQL, and local Redis are required. The gateway uses a deterministic local OpenAI-compatible witness and does not read or require `OPENAI_API_KEY`.
+
 Offboard a member by organization membership ID:
 
 ```bash

--- a/worlds/litellm-per-member.ts
+++ b/worlds/litellm-per-member.ts
@@ -1,0 +1,55 @@
+import { createWorldDefinition } from "../packages/world/src/index.ts";
+import { parseWorldTopology } from "../evals/packages/env/src/topology.ts";
+
+export const LITELLM_WORLD_ORG = "LiteLLM Per-Member World";
+export const LITELLM_WORLD_PROVIDER = "openwork-litellm-per-member";
+export const LITELLM_WORLD_MODEL = "openwork-litellm-per-member-model";
+
+/**
+ * Local Desktop + Den + database-backed LiteLLM world for manually exercising
+ * the complete per-member example. The LiteLLM gateway talks to a deterministic
+ * local OpenAI-compatible witness; it never reads or requires OPENAI_API_KEY.
+ *
+ * Launch: `pnpm world up ./worlds/litellm-per-member.ts`
+ */
+export const liteLlmPerMember = createWorldDefinition({
+  den: {
+    orgs: {
+      [LITELLM_WORLD_ORG]: {
+        admin: { name: "LiteLLM Admin", email: "litellm-admin@openwork.test" },
+        members: {
+          alice: { name: "Alice LiteLLM", email: "alice-litellm@openwork.test" },
+        },
+        llmProviders: [{
+          kind: "litellm-per-member",
+          name: "Per-Member LiteLLM Gateway",
+          providerId: LITELLM_WORLD_PROVIDER,
+          env: "LITELLM_PER_MEMBER_API_KEY",
+          witness: "litellm",
+          modelName: "Per-Member LiteLLM Witness",
+        }],
+      },
+    },
+  },
+  apps: {
+    desktop: {
+      signedInTo: { org: LITELLM_WORLD_ORG, as: "admin" },
+      workspacePath: "/tmp/openwork-litellm-per-member-world",
+      model: `${LITELLM_WORLD_PROVIDER}/${LITELLM_WORLD_MODEL}`,
+    },
+  },
+  witnesses: {
+    litellm: {
+      kind: "litellm",
+      modelId: LITELLM_WORLD_MODEL,
+      reply: "The database-backed per-member LiteLLM world is working.",
+      maxInputTokens: 128_000,
+      maxOutputTokens: 16_384,
+    },
+  },
+}, {
+  adapter: "eval",
+  detached: false,
+}, parseWorldTopology);
+
+export default liteLlmPerMember;


### PR DESCRIPTION
## Summary
- add a declarative database-backed LiteLLM witness and per-member LLM provider to eval worlds
- add `worlds/litellm-per-member.ts`, which boots Den, reconciles metadata and member keys through the real example provisioner, then opens a signed-in Desktop
- print safe LiteLLM/model/provider details from `pnpm world up` and document the workflow

No real OpenAI key is used; the world routes LiteLLM to the deterministic local OpenAI-compatible witness.

## Verification
- `PATH=/opt/homebrew/bin:$PATH pnpm --dir evals exec node --test packages/env/test/litellm.test.ts packages/env/test/world-attach.test.ts` (11 passed)
- `PATH=/opt/homebrew/bin:$PATH ./node_modules/.bin/vitest run --config vitest.config.ts --project pr specs/world-snapshot.test.ts` (1 passed)
- `PATH=/opt/homebrew/bin:$PATH OPENWORK_EVAL_E2E_TESTS=1 ./node_modules/.bin/vitest run --config vitest.config.ts --project e2e specs/litellm-per-member-world.e2e.test.ts` (1 passed; Desktop + Den + LiteLLM + metadata + member key + chat)
- `PATH=/opt/homebrew/bin:$PATH pnpm world list` (definition discovered)
- `git diff --check`

Focused TypeScript invocation also reaches an existing `evals/packages/env/src/den.ts:417` mysql2 value-type error; no new changed-file diagnostic was reported.