### PR TITLE
feat(den): grant complimentary OpenWork Web access

### DIFF
--- a/ee/apps/den-api/src/audit-events.ts
+++ b/ee/apps/den-api/src/audit-events.ts
@@ -22,6 +22,8 @@ export const ORGANIZATION_AUDIT_ACTIONS = {
   scimGroupMappingUpdated: "organization.scim.group_mapping_updated",
   ssoConnectionRegistered: "organization.sso.connection_registered",
   ssoConnectionDeleted: "organization.sso.connection_deleted",
+  openWorkWebComplimentaryAccessGranted: "organization.openwork_web.complimentary_access_granted",
+  openWorkWebComplimentaryAccessRevoked: "organization.openwork_web.complimentary_access_revoked",
 }
 
 type OrganizationAuditAction = typeof ORGANIZATION_AUDIT_ACTIONS[keyof typeof ORGANIZATION_AUDIT_ACTIONS]
@@ -44,7 +46,7 @@ export function buildOrganizationAuditEvent(input: {
   }
 }
 
-type OrganizationAuditEvent = ReturnType<typeof buildOrganizationAuditEvent>
+export type OrganizationAuditEvent = ReturnType<typeof buildOrganizationAuditEvent>
 
 export function isOrganizationAuditAlertAction(action: OrganizationAuditAction) {
   switch (action) {
@@ -63,6 +65,8 @@ export function isOrganizationAuditAlertAction(action: OrganizationAuditAction) 
     case ORGANIZATION_AUDIT_ACTIONS.scimGroupMappingUpdated:
     case ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered:
     case ORGANIZATION_AUDIT_ACTIONS.ssoConnectionDeleted:
+    case ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessGranted:
+    case ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessRevoked:
       return true
     case ORGANIZATION_AUDIT_ACTIONS.scimReconciliationRun:
       return false
@@ -79,10 +83,7 @@ export function buildOrganizationAuditAlertLogLine(event: OrganizationAuditEvent
   })}`
 }
 
-export async function recordOrganizationAuditEvent(input: Parameters<typeof buildOrganizationAuditEvent>[0]) {
-  const { db } = await import("./db.js")
-  const event = buildOrganizationAuditEvent(input)
-  await db.insert(AuditEventTable).values(event)
+export function logOrganizationAuditEvent(event: OrganizationAuditEvent) {
   if (isOrganizationAuditAlertAction(event.action)) {
     logger.warn(`${AUDIT_ALERT_OPERATIONAL_MARKER} organization audit alert`, {
       operational_marker: AUDIT_ALERT_OPERATIONAL_MARKER,
@@ -93,4 +94,11 @@ export async function recordOrganizationAuditEvent(input: Parameters<typeof buil
       payload: event.payload,
     })
   }
+}
+
+export async function recordOrganizationAuditEvent(input: Parameters<typeof buildOrganizationAuditEvent>[0]) {
+  const { db } = await import("./db.js")
+  const event = buildOrganizationAuditEvent(input)
+  await db.insert(AuditEventTable).values(event)
+  logOrganizationAuditEvent(event)
 }

--- a/ee/apps/den-api/src/openwork-web-access.ts
+++ b/ee/apps/den-api/src/openwork-web-access.ts
@@ -1,0 +1,75 @@
+export type OpenWorkWebAccessSource = "subscription" | "complimentary" | null
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseMetadata(value: Record<string, unknown> | string | null | undefined): Record<string, unknown> {
+  if (!value) {
+    return {}
+  }
+  if (typeof value !== "string") {
+    return value
+  }
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function hasOpenWorkWebComplimentaryAccess(metadata: Record<string, unknown> | string | null | undefined) {
+  const complimentaryAccess = parseMetadata(metadata).complimentaryAccess
+  return isRecord(complimentaryAccess) && complimentaryAccess.openworkWeb === true
+}
+
+export function setOpenWorkWebComplimentaryAccess(metadata: Record<string, unknown>, enabled: boolean) {
+  const nextMetadata = { ...metadata }
+  const current = isRecord(metadata.complimentaryAccess) ? metadata.complimentaryAccess : {}
+  const complimentaryAccess = { ...current }
+
+  if (enabled) {
+    complimentaryAccess.openworkWeb = true
+  } else {
+    delete complimentaryAccess.openworkWeb
+  }
+
+  if (Object.keys(complimentaryAccess).length > 0) {
+    nextMetadata.complimentaryAccess = complimentaryAccess
+  } else {
+    delete nextMetadata.complimentaryAccess
+  }
+
+  return nextMetadata
+}
+
+export function resolveOpenWorkWebAccess(input: {
+  deploymentAvailable: boolean
+  hasEligibleSubscription: boolean
+  complimentaryAccess: boolean
+}): {
+  hasAccess: boolean
+  accessSource: OpenWorkWebAccessSource
+  complimentaryAccess: boolean
+} {
+  if (!input.deploymentAvailable) {
+    return {
+      hasAccess: false,
+      accessSource: null,
+      complimentaryAccess: input.complimentaryAccess,
+    }
+  }
+
+  const accessSource: OpenWorkWebAccessSource = input.hasEligibleSubscription
+    ? "subscription"
+    : input.complimentaryAccess
+      ? "complimentary"
+      : null
+
+  return {
+    hasAccess: accessSource !== null,
+    accessSource,
+    complimentaryAccess: input.complimentaryAccess,
+  }
+}

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -25,6 +25,7 @@ import {
   TelemetryEventTable,
   WorkerTable,
   AdminAllowlistTable,
+  AuditEventTable,
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, isDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
@@ -43,7 +44,10 @@ import { normalizeOrganizationCapabilities, readOrganizationCapabilityOverrides 
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
 import { env } from "../../env.js"
 import type { AuthContextVariables } from "../../session.js"
-import { calculateOrganizationSeatBillingCounts, getOrganizationSeatBillingCounts, refreshOrgSubscriptionFromStripe, syncSeatSubscriptionQuantityAfterMemberChange } from "../../stripe-billing.js"
+import { buildOrganizationAuditEvent, logOrganizationAuditEvent, ORGANIZATION_AUDIT_ACTIONS } from "../../audit-events.js"
+import { hasOpenWorkWebComplimentaryAccess, resolveOpenWorkWebAccess, setOpenWorkWebComplimentaryAccess } from "../../openwork-web-access.js"
+import { isOpenWorkWebAvailable } from "../../openwork-web-availability.js"
+import { calculateOrganizationSeatBillingCounts, getOrganizationSeatBillingCounts, isEligibleOpenWorkWebSubscriptionStatus, isOngoingOpenWorkWebSubscriptionStatus, organizationHasOngoingOpenWorkWebSubscription, refreshOrgSubscriptionFromStripe, syncSeatSubscriptionQuantityAfterMemberChange } from "../../stripe-billing.js"
 import { buildAdminPageInfo, normalizeAdminPageRequest, sanitizeAdminSearchForLike, type AdminPageRequest } from "./scale-performance.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -83,6 +87,11 @@ const updateOrganizationPlanSchema = z.object({
 
 const updateOrganizationFreeSeatsSchema = z.object({
   totalFreeSeats: z.number().int().min(DEFAULT_ORGANIZATION_FREE_SEAT_COUNT).max(100000),
+})
+
+const updateOrganizationOpenWorkWebAccessSchema = z.object({
+  enabled: z.boolean(),
+  reason: z.string().trim().min(3).max(500),
 })
 
 const updateOrganizationCapabilitiesSchema = z.object({
@@ -282,6 +291,31 @@ function readAdminVisibleOrganizationCapabilities(metadata: Record<string, unkno
   }
 }
 
+function readAdminOpenWorkWebAccess(
+  metadata: Record<string, unknown> | string | null | undefined,
+  subscription: AdminOpenWorkWebSubscription | null,
+) {
+  const complimentaryAccess = hasOpenWorkWebComplimentaryAccess(metadata)
+  const hasEligibleSubscription = Boolean(
+    subscription
+    && isEligibleOpenWorkWebSubscriptionStatus(subscription.status)
+    && env.stripe.openworkWebPriceId
+    && subscription.stripe_price_id === env.stripe.openworkWebPriceId
+    && subscription.payment_failed !== true,
+  )
+  const access = resolveOpenWorkWebAccess({
+    deploymentAvailable: isOpenWorkWebAvailable(),
+    hasEligibleSubscription,
+    complimentaryAccess,
+  })
+  return {
+    ...access,
+    hasEligibleSubscription,
+    hasOngoingSubscription: Boolean(subscription && isOngoingOpenWorkWebSubscriptionStatus(subscription.status)),
+    subscriptionStatus: subscription?.status ?? null,
+  }
+}
+
 function readUnmanagedCapabilityMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
   const raw = isRecord(metadata.capabilities) ? metadata.capabilities : {}
   const capabilities: Record<string, unknown> = {}
@@ -415,7 +449,15 @@ type AdminOrganizationRow = {
   seatsFreeAdditional: number
   billableSeatCount: number
   capabilities: ReturnType<typeof normalizeOrganizationCapabilities>
+  openworkWebAccess: AdminOpenWorkWebAccess
 }
+
+type AdminOpenWorkWebSubscription = Pick<
+  typeof OrgSubscriptionTable.$inferSelect,
+  "status" | "stripe_price_id" | "payment_failed"
+>
+
+type AdminOpenWorkWebAccess = ReturnType<typeof readAdminOpenWorkWebAccess>
 
 type AdminSummary = {
   totalUsers: number
@@ -884,15 +926,30 @@ async function shapeAdminOrganizationRows(rows: Array<Pick<typeof OrganizationTa
   }
 
   const organizationIds = rows.map((row) => row.id)
-  const memberRows = await db
-    .select({ organizationId: MemberTable.organizationId, memberCount: sql<number>`count(*)` })
-    .from(MemberTable)
-    .where(and(inArray(MemberTable.organizationId, organizationIds), isNull(MemberTable.removedAt)))
-    .groupBy(MemberTable.organizationId)
+  const [memberRows, webSubscriptionRows] = await Promise.all([
+    db
+      .select({ organizationId: MemberTable.organizationId, memberCount: sql<number>`count(*)` })
+      .from(MemberTable)
+      .where(and(inArray(MemberTable.organizationId, organizationIds), isNull(MemberTable.removedAt)))
+      .groupBy(MemberTable.organizationId),
+    db
+      .select({
+        organizationId: OrgSubscriptionTable.organization_id,
+        status: OrgSubscriptionTable.status,
+        stripe_price_id: OrgSubscriptionTable.stripe_price_id,
+        payment_failed: OrgSubscriptionTable.payment_failed,
+      })
+      .from(OrgSubscriptionTable)
+      .where(and(
+        inArray(OrgSubscriptionTable.organization_id, organizationIds),
+        eq(OrgSubscriptionTable.type, "web"),
+      )),
+  ])
   const memberCountByOrg = new Map<string, number>()
   for (const row of memberRows) {
     memberCountByOrg.set(row.organizationId, toNumber(row.memberCount))
   }
+  const webSubscriptionByOrg = new Map(webSubscriptionRows.map((row) => [row.organizationId, row]))
 
   return rows.map((entry) => {
     const metadata = normalizeOrganizationMetadata(entry.metadata).metadata
@@ -911,6 +968,7 @@ async function shapeAdminOrganizationRows(rows: Array<Pick<typeof OrganizationTa
       seatsFreeAdditional: seatCounts.additionalFree,
       billableSeatCount: seatCounts.chargeable,
       capabilities: readAdminVisibleOrganizationCapabilities(metadata),
+      openworkWebAccess: readAdminOpenWorkWebAccess(metadata, webSubscriptionByOrg.get(entry.id) ?? null),
     }
   })
 }
@@ -1606,6 +1664,102 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           freeSeatCount: seatCounts.free,
           seatsFreeAdditional: seatCounts.additionalFree,
           billableSeatCount: seatCounts.chargeable,
+        },
+      })
+    },
+  )
+
+  app.put(
+    "/v1/admin/organizations/:organizationId/openwork-web-access",
+    adminRoute(),
+    async (c) => {
+      const body = updateOrganizationOpenWorkWebAccessSchema.safeParse(await c.req.json().catch(() => null))
+      if (!body.success) {
+        return c.json({ error: "invalid_request", message: body.error.issues[0]?.message ?? "Invalid OpenWork Web access request." }, 400)
+      }
+
+      const organizationId = c.req.param("organizationId")
+      if (!isOrganizationId(organizationId)) {
+        return c.json({ error: "invalid_request", message: "Invalid organization id." }, 400)
+      }
+
+      if (body.data.enabled && await organizationHasOngoingOpenWorkWebSubscription(organizationId)) {
+        return c.json({
+          error: "openwork_web_subscription_exists",
+          message: "Cancel or finish the existing paid OpenWork Web subscription before granting complimentary access.",
+        }, 409)
+      }
+
+      const actorUserId = c.get("user").id
+      const result = await db.transaction(async (tx) => {
+        const organizations = await tx
+          .select({ id: OrganizationTable.id, metadata: OrganizationTable.metadata })
+          .from(OrganizationTable)
+          .where(eq(OrganizationTable.id, organizationId))
+          .limit(1)
+          .for("update")
+        const organization = organizations[0]
+        if (!organization) {
+          return "not_found"
+        }
+
+        const webSubscriptions = await tx
+          .select({
+            status: OrgSubscriptionTable.status,
+            stripe_price_id: OrgSubscriptionTable.stripe_price_id,
+            payment_failed: OrgSubscriptionTable.payment_failed,
+          })
+          .from(OrgSubscriptionTable)
+          .where(and(
+            eq(OrgSubscriptionTable.organization_id, organizationId),
+            eq(OrgSubscriptionTable.type, "web"),
+          ))
+          .limit(1)
+          .for("update")
+        const webSubscription = webSubscriptions[0] ?? null
+        if (body.data.enabled && webSubscription && isOngoingOpenWorkWebSubscriptionStatus(webSubscription.status)) {
+          return "subscription_exists"
+        }
+
+        const normalizedMetadata = normalizeOrganizationMetadata(organization.metadata).metadata
+        const metadata = setOpenWorkWebComplimentaryAccess(normalizedMetadata, body.data.enabled)
+        const auditEvent = buildOrganizationAuditEvent({
+          organizationId,
+          actorUserId,
+          action: body.data.enabled
+            ? ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessGranted
+            : ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessRevoked,
+          payload: {
+            reason: body.data.reason,
+            complimentaryAccess: body.data.enabled,
+          },
+        })
+
+        await tx
+          .update(OrganizationTable)
+          .set({ metadata })
+          .where(eq(OrganizationTable.id, organizationId))
+        await tx.insert(AuditEventTable).values(auditEvent)
+
+        return { metadata, webSubscription, auditEvent }
+      })
+
+      if (result === "not_found") {
+        return c.json({ error: "not_found", message: "Organization not found." }, 404)
+      }
+      if (result === "subscription_exists") {
+        return c.json({
+          error: "openwork_web_subscription_exists",
+          message: "Cancel or finish the existing paid OpenWork Web subscription before granting complimentary access.",
+        }, 409)
+      }
+
+      logOrganizationAuditEvent(result.auditEvent)
+      return c.json({
+        ok: true,
+        organization: {
+          id: organizationId,
+          openworkWebAccess: readAdminOpenWorkWebAccess(result.metadata, result.webSubscription),
         },
       })
     },

--- a/ee/apps/den-api/src/routes/org/billing.ts
+++ b/ee/apps/den-api/src/routes/org/billing.ts
@@ -217,6 +217,15 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
       if (subscriptionType === "web" && !isOpenWorkWebAvailable()) {
         return c.json(openWorkWebUnavailableResponse(), 404)
       }
+      if (subscriptionType === "web") {
+        const webBilling = await getOpenWorkWebBillingSummary(payload.organization.id)
+        if (webBilling.complimentaryAccess) {
+          return c.json({
+            error: "openwork_web_complimentary_access_exists",
+            message: "OpenWork Web is already included for this organization without a Stripe subscription.",
+          }, 409)
+        }
+      }
       const createCheckoutSession = subscriptionType === "seat"
         ? createSeatCheckoutSession
         : subscriptionType === "web"

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -14,6 +14,7 @@ import type { DenOrgMode } from "./env.js"
 import { setInferenceEnabled } from "./inference.js"
 import { appLogger } from "./observability/logger.js"
 import { isOpenWorkWebAvailable } from "./openwork-web-availability.js"
+import { hasOpenWorkWebComplimentaryAccess, resolveOpenWorkWebAccess } from "./openwork-web-access.js"
 
 type OrgId = typeof OrganizationTable.$inferSelect.id
 type MemberId = typeof MemberTable.$inferSelect.id
@@ -175,6 +176,15 @@ async function joinedMemberCount(organizationId: OrgId) {
       isNull(MemberTable.removedAt),
     ))
   return normalizeSeatCount(Number(row?.count ?? 0))
+}
+
+async function organizationOpenWorkWebComplimentaryAccess(organizationId: OrgId) {
+  const rows = await db
+    .select({ metadata: OrganizationTable.metadata })
+    .from(OrganizationTable)
+    .where(eq(OrganizationTable.id, organizationId))
+    .limit(1)
+  return hasOpenWorkWebComplimentaryAccess(rows[0]?.metadata)
 }
 
 export function isOpenWorkWebBillableMember(input: { joinedAt: Date | null; removedAt: Date | null }) {
@@ -419,6 +429,14 @@ function isOngoingConfiguredOpenWorkWebSubscriptionRow(row: Awaited<ReturnType<t
 
 export async function organizationHasEligibleOpenWorkWebSubscription(organizationId: OrgId) {
   return isEligibleOpenWorkWebSubscriptionRow(await findWebSubscriptionByOrg(organizationId))
+}
+
+export async function organizationHasOngoingOpenWorkWebSubscription(organizationId: OrgId) {
+  let row = await findWebSubscriptionByOrg(organizationId)
+  if (row?.stripe_subscription_id) {
+    row = await refreshOrgSubscriptionFromStripe(row.stripe_subscription_id)
+  }
+  return Boolean(row && isOngoingOpenWorkWebSubscriptionStatus(row.status))
 }
 
 export async function getOrganizationSeatAddEligibility(organizationId: OrgId) {
@@ -907,8 +925,18 @@ function serializeOpenWorkWebSubscription(row: Awaited<ReturnType<typeof findWeb
 }
 
 async function loadOpenWorkWebBillingSummary(organizationId: OrgId) {
-  const row = await findWebSubscriptionByOrg(organizationId)
-  const billing = calculateOpenWorkWebBilling({ joinedMemberCount: await joinedMemberCount(organizationId) })
+  const [row, memberCount, complimentaryAccess] = await Promise.all([
+    findWebSubscriptionByOrg(organizationId),
+    joinedMemberCount(organizationId),
+    organizationOpenWorkWebComplimentaryAccess(organizationId),
+  ])
+  const billing = calculateOpenWorkWebBilling({ joinedMemberCount: memberCount })
+  const hasEligibleSubscription = isEligibleOpenWorkWebSubscriptionRow(row)
+  const access = resolveOpenWorkWebAccess({
+    deploymentAvailable: isOpenWorkWebAvailable(),
+    hasEligibleSubscription,
+    complimentaryAccess,
+  })
   return {
     row,
     summary: {
@@ -921,7 +949,8 @@ async function loadOpenWorkWebBillingSummary(organizationId: OrgId) {
       quantityDescription: "Every joined, non-removed organization member; pending invitations are excluded.",
       quantity: billing.quantity,
       expectedMonthlyTotal: billing.expectedMonthlyTotal,
-      hasEligibleSubscription: isEligibleOpenWorkWebSubscriptionRow(row),
+      hasEligibleSubscription,
+      ...access,
       subscription: serializeOpenWorkWebSubscription(row),
     },
   }

--- a/ee/apps/den-api/test/admin-organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-organization-capabilities.test.ts
@@ -10,7 +10,7 @@ const adminEmail = `admin-capabilities+${adminUserId}@test.local`
 const organizationSlug = `admin-capabilities-${organizationId}`
 
 function seedRequiredEnv() {
-  process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test"
   process.env.DEN_DB_ENCRYPTION_KEY = "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = "y".repeat(32)
   process.env.BETTER_AUTH_URL = "http://127.0.0.1:8790"
@@ -62,6 +62,8 @@ async function cleanup() {
     return
   }
 
+  await db.delete(schema.AuditEventTable).where(drizzle.eq(schema.AuditEventTable.org_id, organizationId))
+  await db.delete(schema.OrgSubscriptionTable).where(drizzle.eq(schema.OrgSubscriptionTable.organization_id, organizationId))
   await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
   await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, adminUserId))
   await db.delete(schema.AdminAllowlistTable).where(drizzle.eq(schema.AdminAllowlistTable.id, adminAllowlistId))
@@ -95,6 +97,14 @@ async function putCapabilities(capabilities: { installLinks?: boolean | null; mc
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ capabilities }),
+  })
+}
+
+async function putOpenWorkWebAccess(enabled: boolean, reason: string) {
+  return routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/openwork-web-access`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled, reason }),
   })
 }
 
@@ -245,4 +255,83 @@ test("admin capability routes show effective defaults while preserving raw overr
   const getEnabledOverride = await routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`)
   expect(getEnabledOverride.status).toBe(200)
   await expect(getEnabledOverride.json()).resolves.toMatchObject({ capabilities: { mcpConnections: true } })
+})
+
+test("platform admins grant and revoke audited complimentary Web access", async () => {
+  if (routeTestUnavailable) {
+    console.warn(`admin complimentary Web route DB coverage skipped: ${routeTestUnavailable}`)
+    return
+  }
+
+  const invalid = await putOpenWorkWebAccess(true, "x")
+  expect(invalid.status).toBe(400)
+
+  const grant = await putOpenWorkWebAccess(true, "Internal administration organization")
+  expect(grant.status).toBe(200)
+  await expect(grant.json()).resolves.toMatchObject({
+    organization: {
+      id: organizationId,
+      openworkWebAccess: {
+        hasAccess: false,
+        accessSource: null,
+        complimentaryAccess: true,
+        hasOngoingSubscription: false,
+      },
+    },
+  })
+  expect(await readOrganizationMetadata()).toMatchObject({
+    mcpConnectionsEnabled: false,
+    capabilities: { installLinks: true, mcpConnections: true },
+    complimentaryAccess: { openworkWeb: true },
+  })
+
+  const listed = await routeApp().request(`http://den.local/v1/admin/organizations?search=${organizationId}`)
+  expect(listed.status).toBe(200)
+  await expect(listed.json()).resolves.toMatchObject({
+    organizations: [{
+      id: organizationId,
+      openworkWebAccess: { complimentaryAccess: true, hasOngoingSubscription: false },
+    }],
+  })
+
+  const { db, schema, drizzle } = testDatabase()
+  const auditRows = await db
+    .select({ action: schema.AuditEventTable.action, payload: schema.AuditEventTable.payload })
+    .from(schema.AuditEventTable)
+    .where(drizzle.eq(schema.AuditEventTable.org_id, organizationId))
+  expect(auditRows).toHaveLength(1)
+  expect(auditRows[0]).toMatchObject({
+    action: "organization.openwork_web.complimentary_access_granted",
+    payload: { reason: "Internal administration organization", complimentaryAccess: true },
+  })
+
+  const revoke = await putOpenWorkWebAccess(false, "Return organization to standard billing")
+  expect(revoke.status).toBe(200)
+  expect(await readOrganizationMetadata()).not.toHaveProperty("complimentaryAccess.openworkWeb")
+
+  const revokedAuditRows = await db
+    .select({ action: schema.AuditEventTable.action })
+    .from(schema.AuditEventTable)
+    .where(drizzle.eq(schema.AuditEventTable.org_id, organizationId))
+  expect(revokedAuditRows.map((row) => row.action).sort()).toEqual([
+    "organization.openwork_web.complimentary_access_granted",
+    "organization.openwork_web.complimentary_access_revoked",
+  ])
+
+  await db.insert(schema.OrgSubscriptionTable).values({
+    id: createDenTypeId("orgSubscription"),
+    organization_id: organizationId,
+    created_by_org_membership_id: null,
+    type: "web",
+    status: "active",
+    stripe_customer_id: "cus_admin_web_access_test",
+    stripe_subscription_id: "sub_admin_web_access_test",
+    stripe_price_id: "price_admin_web_access_test",
+    stripe_subscription_item_id: "si_admin_web_access_test",
+    quantity: 1,
+  })
+  const paidConflict = await putOpenWorkWebAccess(true, "Would overlap paid billing")
+  expect(paidConflict.status).toBe(409)
+  await expect(paidConflict.json()).resolves.toMatchObject({ error: "openwork_web_subscription_exists" })
+  expect(await readOrganizationMetadata()).not.toHaveProperty("complimentaryAccess.openworkWeb")
 })

--- a/ee/apps/den-api/test/audit-events.test.ts
+++ b/ee/apps/den-api/test/audit-events.test.ts
@@ -203,7 +203,27 @@ test("organization audit alerting covers sensitive access changes", () => {
   expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.roleUpdated)).toBe(true)
   expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.scimTokenRotated)).toBe(true)
   expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.ssoConnectionRegistered)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessGranted)).toBe(true)
+  expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessRevoked)).toBe(true)
   expect(isOrganizationAuditAlertAction(ORGANIZATION_AUDIT_ACTIONS.scimReconciliationRun)).toBe(false)
+})
+
+test("organization audit events record complimentary Web access changes without storing access metadata", () => {
+  const event = buildOrganizationAuditEvent({
+    organizationId: createDenTypeId("organization"),
+    actorUserId: createDenTypeId("user"),
+    action: ORGANIZATION_AUDIT_ACTIONS.openWorkWebComplimentaryAccessGranted,
+    payload: {
+      reason: "Internal administration organization",
+      complimentaryAccess: true,
+    },
+  })
+
+  expect(event.action).toBe("organization.openwork_web.complimentary_access_granted")
+  expect(event.payload).toEqual({
+    reason: "Internal administration organization",
+    complimentaryAccess: true,
+  })
 })
 
 test("organization audit alert log line is structured and secret-free", () => {

--- a/ee/apps/den-api/test/openwork-web-access.test.ts
+++ b/ee/apps/den-api/test/openwork-web-access.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import {
+  hasOpenWorkWebComplimentaryAccess,
+  resolveOpenWorkWebAccess,
+  setOpenWorkWebComplimentaryAccess,
+} from "../src/openwork-web-access.js"
+
+test("complimentary Web access is an explicit metadata grant that preserves unrelated settings", () => {
+  const original = {
+    brandAppName: "OpenWork Internal",
+    capabilities: { cloud: true },
+    complimentaryAccess: { futureProduct: true },
+  }
+  const granted = setOpenWorkWebComplimentaryAccess(original, true)
+
+  expect(hasOpenWorkWebComplimentaryAccess(granted)).toBe(true)
+  expect(granted).toMatchObject({
+    brandAppName: "OpenWork Internal",
+    capabilities: { cloud: true },
+    complimentaryAccess: { futureProduct: true, openworkWeb: true },
+  })
+  expect(original.complimentaryAccess).toEqual({ futureProduct: true })
+
+  const revoked = setOpenWorkWebComplimentaryAccess(granted, false)
+  expect(hasOpenWorkWebComplimentaryAccess(revoked)).toBe(false)
+  expect(revoked).toMatchObject({
+    brandAppName: "OpenWork Internal",
+    capabilities: { cloud: true },
+    complimentaryAccess: { futureProduct: true },
+  })
+})
+
+test("revoking the only complimentary grant removes the empty metadata group", () => {
+  expect(setOpenWorkWebComplimentaryAccess({ complimentaryAccess: { openworkWeb: true } }, false)).toEqual({})
+})
+
+test("complimentary Web access fails closed behind the deployment switch", () => {
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: false,
+    hasEligibleSubscription: false,
+    complimentaryAccess: true,
+  })).toEqual({
+    hasAccess: false,
+    accessSource: null,
+    complimentaryAccess: true,
+  })
+
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: true,
+    hasEligibleSubscription: false,
+    complimentaryAccess: true,
+  })).toEqual({
+    hasAccess: true,
+    accessSource: "complimentary",
+    complimentaryAccess: true,
+  })
+})
+
+test("an eligible paid subscription remains the authoritative source when both grants are present", () => {
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: true,
+    hasEligibleSubscription: true,
+    complimentaryAccess: true,
+  })).toEqual({
+    hasAccess: true,
+    accessSource: "subscription",
+    complimentaryAccess: true,
+  })
+})

--- a/ee/apps/den-api/test/stripe-billing.test.ts
+++ b/ee/apps/den-api/test/stripe-billing.test.ts
@@ -320,7 +320,7 @@ test("member-readable Web billing summary omits Stripe identifiers and portal ac
     cancel_at_period_end: false,
     canceled_at: null,
     ended_at: null,
-  }], [{ count: 2 }])
+  }], [{ count: 2 }], [{ metadata: {} }])
 
   const summary = await getOpenWorkWebBillingSummary("org_test")
 
@@ -330,6 +330,9 @@ test("member-readable Web billing summary omits Stripe identifiers and portal ac
     quantity: 2,
     expectedMonthlyTotal: 10000,
     hasEligibleSubscription: true,
+    hasAccess: true,
+    accessSource: "subscription",
+    complimentaryAccess: false,
     subscription: {
       status: "active",
       paymentStatus: "paid",
@@ -345,12 +348,37 @@ test("member-readable Web billing summary omits Stripe identifiers and portal ac
 
 test("the Web flag controls availability while Stripe readiness controls purchasing", async () => {
   env.stripe.secretKey = ""
-  selectResults.push([], [{ count: 2 }])
+  selectResults.push([], [{ count: 2 }], [{ metadata: {} }])
 
   const summary = await getOpenWorkWebBillingSummary("org_test")
 
   expect(openWorkWebDeploymentAvailable(env.openworkWebEnabled)).toBe(true)
   expect(summary.configured).toBe(false)
+  expect(summary.hasAccess).toBe(false)
+})
+
+test("complimentary Web access works without Stripe configuration but remains behind the deployment flag", async () => {
+  env.stripe.secretKey = ""
+  selectResults.push([], [{ count: 2 }], [{ metadata: { complimentaryAccess: { openworkWeb: true } } }])
+
+  const enabledSummary = await getOpenWorkWebBillingSummary("org_test")
+
+  expect(enabledSummary).toMatchObject({
+    configured: false,
+    hasEligibleSubscription: false,
+    hasAccess: true,
+    accessSource: "complimentary",
+    complimentaryAccess: true,
+  })
+
+  env.openworkWebEnabled = false
+  selectResults.push([], [{ count: 2 }], [{ metadata: { complimentaryAccess: { openworkWeb: true } } }])
+  const disabledSummary = await getOpenWorkWebBillingSummary("org_test")
+  expect(disabledSummary).toMatchObject({
+    hasAccess: false,
+    accessSource: null,
+    complimentaryAccess: true,
+  })
 })
 
 test("an active Web subscription with a failed payment remains locked", async () => {
@@ -365,11 +393,12 @@ test("an active Web subscription with a failed payment remains locked", async ()
     payment_failed: true,
     canceled_at: null,
     ended_at: null,
-  }], [{ count: 2 }])
+  }], [{ count: 2 }], [{ metadata: {} }])
 
   const summary = await getOpenWorkWebBillingSummary("org_test")
 
   expect(summary.hasEligibleSubscription).toBe(false)
+  expect(summary.hasAccess).toBe(false)
   expect(summary.subscription?.status).toBe("active")
   expect(summary.subscription?.paymentStatus).toBe("payment_failed")
 })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -357,12 +357,14 @@ export function BillingDashboardScreen() {
 
   const webSubscription = webBilling?.subscription ?? null;
   const webSubscribed = Boolean(webSubscription);
-  const webEligible = webBilling?.hasEligibleSubscription === true;
+  const webEligible = webBilling?.hasAccess === true;
+  const webAccessSource = webBilling?.accessSource ?? null;
+  const webComplimentary = webAccessSource === "complimentary";
   const webPrice = webBilling ? formatMoneyMinor(webBilling.unitAmount, webBilling.currency) : null;
   const webChargeMinor = webBilling?.expectedMonthlyTotal ?? 0;
   const webChargeLabel = webBilling ? formatMoneyMinor(webChargeMinor, webBilling.currency) : null;
   const webStatus = webSubscription?.status ?? null;
-  const webCountsTowardTotal = webSubscribed && webStatus !== "canceled" && webStatus !== "expired" && webStatus !== "incomplete_expired";
+  const webCountsTowardTotal = !webComplimentary && webSubscribed && webStatus !== "canceled" && webStatus !== "expired" && webStatus !== "incomplete_expired";
   const webPaymentStatus = webSubscription?.paymentStatus ?? null;
   const webPaymentFailed = webPaymentStatus === "past_due" || webPaymentStatus === "unpaid" || webPaymentStatus === "payment_failed";
   const webRenewsOn = formatBillingDate(webSubscription?.currentPeriodEnd ?? null);
@@ -383,7 +385,9 @@ export function BillingDashboardScreen() {
         icon={CreditCard}
         title="Billing"
         description={webFeatureEnabled
-          ? "OpenWork Web, team seats, and built-in AI model access are separate purchases. Your expected monthly total reflects the subscriptions shown below."
+          ? webComplimentary
+            ? "OpenWork Web is included for this organization at no charge. Team seats and built-in AI model access remain separate purchases."
+            : "OpenWork Web, team seats, and built-in AI model access are separate purchases. Your expected monthly total reflects the subscriptions shown below."
           : "Team seats and built-in AI model access are separate purchases. Your expected monthly total reflects the subscriptions shown below."}
         colors={["#F5F3FF", "#312E81", "#635BFF", "#C4B5FD"]}
       >
@@ -448,7 +452,9 @@ export function BillingDashboardScreen() {
           className="p-6 pb-4"
           title="Your subscriptions"
           description={webFeatureEnabled
-            ? "Each plan is billed separately. OpenWork Web is $50 per joined organization member each month."
+            ? webComplimentary
+              ? "OpenWork Web is included without a Stripe subscription or per-member charge."
+              : "Each plan is billed separately. OpenWork Web is $50 per joined organization member each month."
             : "Each plan is billed separately."}
           action={
             <DenButton variant="secondary" size="sm" icon={RefreshCw} loading={stripeBusy} onClick={() => void refreshStripeBilling(false)}>
@@ -491,16 +497,20 @@ export function BillingDashboardScreen() {
               description={
                 !webBilling
                   ? "Billing details are unavailable · browser access remains locked"
+                  : webComplimentary
+                    ? `${getOpenWorkWebQuantityDescription(webBilling.quantity)} covered · complimentary access`
                   : !webConfigured
                     ? "This deployment does not sell OpenWork Web access"
                     : webSubscribed
                       ? `${getOpenWorkWebQuantityDescription(webBilling.quantity)} × ${webPrice} · ${formatSubscriptionStatus(webStatus ?? "unknown")}`
                       : `${getOpenWorkWebQuantityDescription(webBilling.quantity)} · not subscribed`
               }
-              value={webCountsTowardTotal ? webChargeLabel ?? "" : formatMoneyMinor(0, webBilling?.currency ?? "usd")}
-              valueCaption={`per ${webBilling?.interval ?? "month"}`}
+              value={webComplimentary ? formatMoneyMinor(0, webBilling?.currency ?? "usd") : webCountsTowardTotal ? webChargeLabel ?? "" : formatMoneyMinor(0, webBilling?.currency ?? "usd")}
+              valueCaption={webComplimentary ? "no charge" : `per ${webBilling?.interval ?? "month"}`}
               badge={
-                !webBilling || !webConfigured
+                webComplimentary
+                  ? <DenBadge tone="success" icon={Check}>Complimentary</DenBadge>
+                  : !webBilling || !webConfigured
                   ? <DenBadge tone="neutral">Not billed</DenBadge>
                   : webPaymentFailed
                     ? <DenBadge tone="warning">Payment failed</DenBadge>
@@ -551,9 +561,13 @@ export function BillingDashboardScreen() {
         <DenCard className="mb-6" data-testid="billing-openwork-web-card">
           <DenSectionHeader
             title="OpenWork Web"
-            description="Browser access for your organization — $50 per joined member each month."
+            description={webComplimentary
+              ? "Browser access is included for every joined organization member at no charge."
+              : "Browser access for your organization — $50 per joined member each month."}
             action={
-              !webBilling || !webConfigured
+              webComplimentary
+                ? <DenBadge tone="success" icon={Check}>Complimentary</DenBadge>
+                : !webBilling || !webConfigured
                 ? <DenBadge tone="neutral">Not billed</DenBadge>
                 : webPaymentFailed
                   ? <DenBadge tone="warning">Payment failed</DenBadge>
@@ -576,9 +590,11 @@ export function BillingDashboardScreen() {
             <>
               <DenNotice
                 className="mt-5"
-                tone={!webConfigured ? "neutral" : webPaymentFailed ? "error" : webEligible ? "info" : "warning"}
+                tone={webComplimentary ? "info" : !webConfigured ? "neutral" : webPaymentFailed ? "error" : webEligible ? "info" : "warning"}
                 message={
-                  !webConfigured
+                  webComplimentary
+                    ? "OpenWork Web is included for this organization without a Stripe subscription or per-member charge."
+                    : !webConfigured
                     ? "OpenWork Web billing is not configured for this deployment."
                     : webPaymentFailed
                       ? webPaymentStatus === "payment_failed"
@@ -595,34 +611,40 @@ export function BillingDashboardScreen() {
               />
 
               <p className="mt-5 text-[14px] leading-6 text-gray-600" data-testid="billing-openwork-web-quantity-definition">
-                {OPENWORK_WEB_QUANTITY_EXPLANATION}
+                {webComplimentary
+                  ? "Every joined organization member is covered, including the owner. Pending invitations are not counted until they join."
+                  : OPENWORK_WEB_QUANTITY_EXPLANATION}
               </p>
               <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 p-4" data-testid="billing-openwork-web-price-breakdown">
                 <p className="text-[22px] font-semibold tracking-[-0.03em] text-gray-950">
-                  {getOpenWorkWebQuantityDescription(webBilling.quantity)} × {webPrice}
+                  {webComplimentary
+                    ? `${getOpenWorkWebQuantityDescription(webBilling.quantity)} covered`
+                    : `${getOpenWorkWebQuantityDescription(webBilling.quantity)} × ${webPrice}`}
                 </p>
                 <p className="mt-1 text-[14px] text-gray-600">
-                  {webChargeLabel} per {webBilling.interval}
+                  {webComplimentary ? "$0.00 monthly charge" : `${webChargeLabel} per ${webBilling.interval}`}
                 </p>
               </div>
 
               <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                 <BillingStat label="Plan" value="OpenWork Web" />
-                <BillingStat label="Unit price" value={`${webPrice ?? "—"} / member / month`} />
-                <BillingStat label="Members billed" value={String(webBilling.quantity)} />
-                <BillingStat label="Expected monthly total" value={webChargeLabel ?? "—"} />
+                <BillingStat label={webComplimentary ? "Access" : "Unit price"} value={webComplimentary ? "Complimentary" : `${webPrice ?? "—"} / member / month`} />
+                <BillingStat label={webComplimentary ? "Members covered" : "Members billed"} value={String(webBilling.quantity)} />
+                <BillingStat label="Expected monthly total" value={webComplimentary ? "$0.00" : webChargeLabel ?? "—"} />
               </div>
 
-              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3" data-testid="billing-openwork-web-lifecycle">
-                <BillingStat label="Subscription status" value={webStatus ? formatSubscriptionStatus(webStatus) : "Not subscribed"} />
-                <BillingStat label="Payment status" value={webPaymentStatus ? formatSubscriptionStatus(webPaymentStatus) : "Not available"} />
-                <BillingStat
-                  label={webCancelling ? "Access ends" : "Next renewal"}
-                  value={webRenewsOn ?? "Not available"}
-                />
-              </div>
+              {!webComplimentary ? (
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3" data-testid="billing-openwork-web-lifecycle">
+                  <BillingStat label="Subscription status" value={webStatus ? formatSubscriptionStatus(webStatus) : "Not subscribed"} />
+                  <BillingStat label="Payment status" value={webPaymentStatus ? formatSubscriptionStatus(webPaymentStatus) : "Not available"} />
+                  <BillingStat
+                    label={webCancelling ? "Access ends" : "Next renewal"}
+                    value={webRenewsOn ?? "Not available"}
+                  />
+                </div>
+              ) : null}
 
-              {!webQuantityCurrent ? (
+              {!webComplimentary && !webQuantityCurrent ? (
                 <DenNotice
                   className="mt-5"
                   tone="info"
@@ -632,10 +654,12 @@ export function BillingDashboardScreen() {
 
               <DenActionList className="mt-5">
                 <DenActionRow
-                  description="Add or remove members to change what your organization is billed. Pending invitations are never billed."
+                  description={webComplimentary
+                    ? "Every joined member is covered without a per-member charge. Manage membership without changing this grant."
+                    : "Add or remove members to change what your organization is billed. Pending invitations are never billed."}
                   action={<DenButton variant="secondary" onClick={goToMembers}>Manage members</DenButton>}
                 />
-                {webSubscribed ? (
+                {webComplimentary ? null : webSubscribed ? (
                   <DenActionRow
                     description={
                       webCancelling

--- a/ee/apps/den-web/app/(den)/dashboard/_lib/stripe-web-billing.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_lib/stripe-web-billing.ts
@@ -4,6 +4,8 @@ export const OPENWORK_WEB_UNIT_AMOUNT = 5000;
 export const OPENWORK_WEB_CURRENCY = "usd";
 export const OPENWORK_WEB_INTERVAL = "month";
 
+export type OpenWorkWebAccessSource = "subscription" | "complimentary" | null;
+
 export type StripeWebSubscription = {
   status: string;
   quantity: number;
@@ -23,6 +25,9 @@ export type StripeWebBilling = {
   quantity: number;
   expectedMonthlyTotal: number;
   hasEligibleSubscription: boolean;
+  hasAccess: boolean;
+  accessSource: OpenWorkWebAccessSource;
+  complimentaryAccess: boolean;
   subscription: StripeWebSubscription | null;
 };
 
@@ -63,6 +68,11 @@ export function parseStripeWebBilling(payload: unknown): StripeWebBilling | null
 
   const value = payload.billing.stripe.web;
   const subscription = parseSubscription(value.subscription);
+  const accessSource: OpenWorkWebAccessSource | undefined = value.accessSource === "subscription" || value.accessSource === "complimentary"
+    ? value.accessSource
+    : value.accessSource === null
+      ? null
+      : undefined;
   if (
     typeof value.configured !== "boolean" ||
     (value.priceId !== undefined && value.priceId !== null && typeof value.priceId !== "string") ||
@@ -76,6 +86,13 @@ export function parseStripeWebBilling(payload: unknown): StripeWebBilling | null
     typeof value.expectedMonthlyTotal !== "number" ||
     value.expectedMonthlyTotal !== value.quantity * OPENWORK_WEB_UNIT_AMOUNT ||
     typeof value.hasEligibleSubscription !== "boolean" ||
+    typeof value.hasAccess !== "boolean" ||
+    accessSource === undefined ||
+    typeof value.complimentaryAccess !== "boolean" ||
+    value.hasAccess !== (accessSource !== null) ||
+    (accessSource === "subscription" && value.hasEligibleSubscription !== true) ||
+    (value.hasAccess && value.hasEligibleSubscription && accessSource !== "subscription") ||
+    (accessSource === "complimentary" && value.complimentaryAccess !== true) ||
     subscription === undefined
   ) {
     return null;
@@ -91,6 +108,9 @@ export function parseStripeWebBilling(payload: unknown): StripeWebBilling | null
     quantity: value.quantity,
     expectedMonthlyTotal: value.expectedMonthlyTotal,
     hasEligibleSubscription: value.hasEligibleSubscription,
+    hasAccess: value.hasAccess,
+    accessSource,
+    complimentaryAccess: value.complimentaryAccess,
     subscription,
   };
 }

--- a/ee/apps/den-web/app/(den)/dashboard/web/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/web/page.tsx
@@ -32,13 +32,13 @@ export function hasOngoingWebSubscription(billing: StripeWebBilling): boolean {
   );
 }
 
-export function isExistingWebSubscriptionResponse(response: Response, payload: unknown): boolean {
+export function isExistingWebAccessResponse(response: Response, payload: unknown): boolean {
   return response.status === 409
     && Boolean(
       payload
       && typeof payload === "object"
       && "error" in payload
-      && payload.error === "stripe_subscription_exists",
+      && (payload.error === "stripe_subscription_exists" || payload.error === "openwork_web_complimentary_access_exists"),
     );
 }
 
@@ -68,7 +68,7 @@ export function getWebPageAccessState({
   if (billingError) return "error";
   if (billingOrgId !== activeOrgId || !billing) return "loading";
   if (confirming) return "confirming";
-  return billing.hasEligibleSubscription ? "eligible" : "unsubscribed";
+  return billing.hasAccess ? "eligible" : "unsubscribed";
 }
 
 function CheckingWorkspaceAccess({ message = "Checking workspace access" }: { message?: string }) {
@@ -249,7 +249,7 @@ export default function WebPage() {
         attempts += 1;
         const nextBilling = await requestWebBilling(expectedOrgId, true);
         if (stopped || !mountedRef.current || currentOrgIdRef.current !== expectedOrgId) return;
-        if (nextBilling?.hasEligibleSubscription) {
+        if (nextBilling?.hasAccess) {
           setReturnChecking(false);
           setErrorRecord(null);
           clearStripeReturnParameters();
@@ -287,7 +287,7 @@ export default function WebPage() {
       setErrorRecord({ orgId, message: "OpenWork Web billing is not configured for this deployment." });
       return;
     }
-    if (billing.hasEligibleSubscription || hasOngoingWebSubscription(billing)) return;
+    if (billing.hasAccess || hasOngoingWebSubscription(billing)) return;
 
     checkoutStartingRef.current = true;
     setCheckoutBusy(true);
@@ -303,7 +303,7 @@ export default function WebPage() {
           },
           12000,
         );
-        if (isExistingWebSubscriptionResponse(response, payload)) {
+        if (isExistingWebAccessResponse(response, payload)) {
           await requestWebBilling(orgId, false);
           return;
         }
@@ -358,7 +358,7 @@ export default function WebPage() {
       description="Use OpenWork in your browser with an organization subscription."
       colors={["#EFF6FF", "#0F172A", "#2563EB", "#BAE6FD"]}
     >
-      <div data-testid="openwork-web-access" data-access-state={accessState}>
+      <div data-testid="openwork-web-access" data-access-state={accessState} data-access-source={billing?.accessSource ?? "none"}>
         {accessState === "error" ? (
           <DenCard size="spacious" data-testid="openwork-web-error">
             <p className="text-[18px] font-medium text-gray-950">OpenWork Web remains locked</p>
@@ -427,10 +427,14 @@ export default function WebPage() {
 
         {accessState === "eligible" && billing ? (
           <DenCard size="spacious" data-testid="openwork-web-eligible">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-emerald-700">Subscription active</p>
+            <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-emerald-700">
+              {billing.accessSource === "complimentary" ? "Complimentary access" : "Subscription active"}
+            </p>
             <h2 className="mt-2 text-[22px] font-semibold tracking-[-0.03em] text-gray-950">OpenWork Web is ready</h2>
             <p className="mt-3 text-[14px] leading-6 text-gray-600">
-              OpenWork Web is active for {getOpenWorkWebQuantityDescription(billing.quantity)} in this organization.
+              {billing.accessSource === "complimentary"
+                ? `OpenWork Web is included for all ${getOpenWorkWebQuantityDescription(billing.quantity)} in this organization, with no Stripe subscription or per-member charge.`
+                : `OpenWork Web is active for ${getOpenWorkWebQuantityDescription(billing.quantity)} in this organization.`}
             </p>
             <div className="mt-5 flex flex-wrap gap-3">
               <WebOpenButton openworkWebUrl={runtimeConfig.openworkWebUrl} />

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -134,6 +134,15 @@ type AdminOrganizationCapabilities = {
   cloud: boolean;
 };
 
+type AdminOpenWorkWebAccess = {
+  hasAccess: boolean;
+  accessSource: "subscription" | "complimentary" | null;
+  complimentaryAccess: boolean;
+  hasEligibleSubscription: boolean;
+  hasOngoingSubscription: boolean;
+  subscriptionStatus: string | null;
+};
+
 type AdminOrganization = {
   id: string;
   name: string;
@@ -150,6 +159,7 @@ type AdminOrganization = {
   seatsFreeAdditional: number;
   billableSeatCount: number;
   capabilities: AdminOrganizationCapabilities;
+  openworkWebAccess: AdminOpenWorkWebAccess;
 };
 
 type AdminPageInfo = {
@@ -236,6 +246,31 @@ function parseBillingStatus(value: unknown): AdminBillingStatus | null {
     currentPeriodEnd: toStringValue(value.currentPeriodEnd),
     source,
     note: toStringValue(value.note)
+  };
+}
+
+function parseAdminOpenWorkWebAccess(value: unknown): AdminOpenWorkWebAccess {
+  if (!isRecord(value)) {
+    return {
+      hasAccess: false,
+      accessSource: null,
+      complimentaryAccess: false,
+      hasEligibleSubscription: false,
+      hasOngoingSubscription: false,
+      subscriptionStatus: null
+    };
+  }
+
+  const accessSource = value.accessSource === "subscription" || value.accessSource === "complimentary"
+    ? value.accessSource
+    : null;
+  return {
+    hasAccess: value.hasAccess === true,
+    accessSource,
+    complimentaryAccess: value.complimentaryAccess === true,
+    hasEligibleSubscription: value.hasEligibleSubscription === true,
+    hasOngoingSubscription: value.hasOngoingSubscription === true,
+    subscriptionStatus: toStringValue(value.subscriptionStatus)
   };
 }
 
@@ -419,7 +454,8 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
             installLinks: capabilities.installLinks === true,
             mcpConnections: capabilities.mcpConnections === true,
             cloud: capabilities.cloud === true
-          }
+          },
+          openworkWebAccess: parseAdminOpenWorkWebAccess(value.openworkWebAccess)
         };
       })
       .filter((value): value is AdminOrganization => value !== null)
@@ -788,7 +824,15 @@ function buildFixtureOrganization(index: number): AdminOrganization {
     freeSeatCount: target ? 25 : DEFAULT_FREE_SEAT_COUNT,
     seatsFreeAdditional: target ? 20 : 0,
     billableSeatCount: target ? 103 : 0,
-    capabilities: { installLinks: target, mcpConnections: target, cloud: false }
+    capabilities: { installLinks: target, mcpConnections: target, cloud: false },
+    openworkWebAccess: {
+      hasAccess: target,
+      accessSource: target ? "complimentary" : null,
+      complimentaryAccess: target,
+      hasEligibleSubscription: false,
+      hasOngoingSubscription: false,
+      subscriptionStatus: null
+    }
   };
 }
 
@@ -1359,6 +1403,25 @@ function PlanPill({ tier }: { tier: AdminOrganization["plan"]["tier"] }) {
   );
 }
 
+function OpenWorkWebAccessPill({ access }: { access: AdminOpenWorkWebAccess }) {
+  const label = access.hasOngoingSubscription
+    ? "Paid subscription"
+    : access.complimentaryAccess
+      ? "Complimentary"
+      : "No access";
+  const palette = access.hasOngoingSubscription
+    ? "border-violet-200 bg-violet-50 text-violet-700"
+    : access.complimentaryAccess
+      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      : "border-slate-200 bg-slate-100 text-slate-600";
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em] ${palette}`}>
+      {label}
+    </span>
+  );
+}
+
 function DenAdminLoadingShell() {
   return (
     <section className="mx-auto w-full max-w-6xl rounded-3xl border border-slate-200 bg-white shadow-sm" aria-busy="true">
@@ -1430,6 +1493,9 @@ export function DenAdminPanel() {
   const [savingFreeSeatsOrgId, setSavingFreeSeatsOrgId] = useState<string | null>(null);
   const [savingCapabilityOrgId, setSavingCapabilityOrgId] = useState<string | null>(null);
   const [capabilityError, setCapabilityError] = useState<{ orgId: string; message: string } | null>(null);
+  const [openworkWebAccessDialog, setOpenWorkWebAccessDialog] = useState<{ org: AdminOrganization; enabled: boolean; reason: string } | null>(null);
+  const [savingOpenWorkWebAccessOrgId, setSavingOpenWorkWebAccessOrgId] = useState<string | null>(null);
+  const [openworkWebAccessError, setOpenWorkWebAccessError] = useState<{ orgId: string; message: string } | null>(null);
   const [deleteUserDialog, setDeleteUserDialog] = useState<AdminUser | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
   const [adminEmail, setAdminEmail] = useState("");
@@ -2094,6 +2160,60 @@ export function DenAdminPanel() {
     }
   }, [setOrganizationCapabilityLocally]);
 
+  const saveOpenWorkWebAccess = useCallback(async () => {
+    if (!openworkWebAccessDialog) {
+      return;
+    }
+
+    const reason = openworkWebAccessDialog.reason.trim();
+    if (reason.length < 3) {
+      setOpenWorkWebAccessError({ orgId: openworkWebAccessDialog.org.id, message: "Add a short reason for the audit log." });
+      return;
+    }
+
+    const { org, enabled } = openworkWebAccessDialog;
+    setSavingOpenWorkWebAccessOrgId(org.id);
+    setOpenWorkWebAccessError(null);
+    setError(null);
+
+    try {
+      const { response, payload: nextPayload } = await putJson(`/v1/admin/organizations/${org.id}/openwork-web-access`, {
+        enabled,
+        reason
+      });
+      if (!response.ok) {
+        const message = getErrorMessage(nextPayload, `Could not update OpenWork Web access for ${org.name}.`);
+        setOpenWorkWebAccessError({ orgId: org.id, message });
+        setError(message);
+        return;
+      }
+
+      const updatedOrganization = isRecord(nextPayload) && isRecord(nextPayload.organization) ? nextPayload.organization : null;
+      if (!updatedOrganization) {
+        throw new Error("The OpenWork Web access response was incomplete.");
+      }
+      const openworkWebAccess = parseAdminOpenWorkWebAccess(updatedOrganization.openworkWebAccess);
+      setPayload((current) => {
+        if (!current) {
+          return current;
+        }
+        return {
+          ...current,
+          organizations: current.organizations.map((entry) => entry.id === org.id
+            ? { ...entry, openworkWebAccess }
+            : entry)
+        };
+      });
+      setOpenWorkWebAccessDialog(null);
+    } catch (nextError) {
+      const message = nextError instanceof Error ? nextError.message : "Unknown network error";
+      setOpenWorkWebAccessError({ orgId: org.id, message });
+      setError(message);
+    } finally {
+      setSavingOpenWorkWebAccessOrgId(null);
+    }
+  }, [openworkWebAccessDialog]);
+
   const deleteUser = useCallback(async () => {
     if (!deleteUserDialog) {
       return;
@@ -2649,6 +2769,53 @@ export function DenAdminPanel() {
                     <p className="mt-1 text-xs text-slate-400">Off by default. Turn on organization-scoped Cloud workers and remote Cloud capabilities.</p>
                   </div>
 
+                  <div className="mt-4 border-t border-slate-200 pt-4" data-testid="admin-openwork-web-access">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">OpenWork Web billing access</p>
+                          <OpenWorkWebAccessPill access={org.openworkWebAccess} />
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-slate-600">
+                          {org.openworkWebAccess.hasOngoingSubscription
+                            ? `A ${org.openworkWebAccess.subscriptionStatus ?? "current"} Stripe subscription controls access and billing.`
+                            : org.openworkWebAccess.complimentaryAccess
+                              ? org.openworkWebAccess.hasAccess
+                                ? "All joined members can use OpenWork Web without a Stripe subscription or per-member charge."
+                                : "The complimentary grant is stored, but this deployment has not enabled OpenWork Web."
+                              : "No complimentary grant or ongoing paid OpenWork Web subscription."}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        data-testid="admin-openwork-web-access-action"
+                        onClick={() => setOpenWorkWebAccessDialog({
+                          org,
+                          enabled: !org.openworkWebAccess.complimentaryAccess,
+                          reason: ""
+                        })}
+                        disabled={savingOpenWorkWebAccessOrgId === org.id || (!org.openworkWebAccess.complimentaryAccess && org.openworkWebAccess.hasOngoingSubscription)}
+                        className="inline-flex shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {savingOpenWorkWebAccessOrgId === org.id
+                          ? "Saving..."
+                          : org.openworkWebAccess.complimentaryAccess
+                            ? "Revoke complimentary access"
+                            : "Grant complimentary access"}
+                      </button>
+                    </div>
+                    {!org.openworkWebAccess.complimentaryAccess && org.openworkWebAccess.hasOngoingSubscription ? (
+                      <p className="mt-2 text-xs leading-5 text-amber-700">
+                        Cancel or finish the paid subscription in Stripe before granting complimentary access.
+                      </p>
+                    ) : null}
+                    {openworkWebAccessError?.orgId === org.id ? (
+                      <p data-testid="admin-openwork-web-access-error" className="mt-2 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs leading-5 text-red-700">
+                        {openworkWebAccessError.message}
+                      </p>
+                    ) : null}
+                  </div>
+
                   <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 lg:grid-cols-[12rem_10rem_auto] lg:items-end">
                     <label className="grid gap-2">
                       <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Plan</span>
@@ -2944,6 +3111,73 @@ export function DenAdminPanel() {
 
         <p className="mt-6 text-xs leading-6 text-slate-500">Snapshot generated {formatDateTime(payload.generatedAt)}.</p>
       </div>
+
+      {openworkWebAccessDialog ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="openwork-web-access-dialog-title"
+          onClick={() => setOpenWorkWebAccessDialog(null)}
+        >
+          <div className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-6 shadow-xl" onClick={(event) => event.stopPropagation()}>
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">Organization billing access</p>
+            <h2 id="openwork-web-access-dialog-title" className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-slate-950">
+              {openworkWebAccessDialog.enabled ? "Grant" : "Revoke"} complimentary OpenWork Web?
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              {openworkWebAccessDialog.enabled
+                ? `${openworkWebAccessDialog.org.name} will receive OpenWork Web for every joined member without a Stripe subscription or per-member charge.`
+                : `${openworkWebAccessDialog.org.name} will lose complimentary access immediately unless an independently eligible paid subscription exists.`}
+            </p>
+
+            <label className="mt-5 grid gap-2">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">Reason for audit log</span>
+              <textarea
+                data-testid="admin-openwork-web-access-reason"
+                rows={3}
+                maxLength={500}
+                value={openworkWebAccessDialog.reason}
+                onChange={(event) => setOpenWorkWebAccessDialog({ ...openworkWebAccessDialog, reason: event.target.value })}
+                placeholder="For example: Internal OpenWork administration organization"
+                className="resize-none rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400"
+              />
+            </label>
+
+            {openworkWebAccessError?.orgId === openworkWebAccessDialog.org.id ? (
+              <p className="mt-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-xs leading-5 text-red-700">
+                {openworkWebAccessError.message}
+              </p>
+            ) : null}
+
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setOpenWorkWebAccessDialog(null)}
+                disabled={savingOpenWorkWebAccessOrgId === openworkWebAccessDialog.org.id}
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="admin-openwork-web-access-confirm"
+                onClick={() => {
+                  void saveOpenWorkWebAccess();
+                }}
+                disabled={savingOpenWorkWebAccessOrgId === openworkWebAccessDialog.org.id || openworkWebAccessDialog.reason.trim().length < 3}
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {savingOpenWorkWebAccessOrgId === openworkWebAccessDialog.org.id
+                  ? "Saving..."
+                  : openworkWebAccessDialog.enabled
+                    ? "Grant access"
+                    : "Revoke access"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {freeSeatsDialog ? (
         <div

--- a/ee/apps/den-web/tests/openwork-web-billing.test.ts
+++ b/ee/apps/den-web/tests/openwork-web-billing.test.ts
@@ -19,6 +19,9 @@ function billingPayload() {
           quantity: 4,
           expectedMonthlyTotal: 20000,
           hasEligibleSubscription: true,
+          hasAccess: true,
+          accessSource: "subscription",
+          complimentaryAccess: false,
           subscription: {
             status: "active",
             quantity: 4,
@@ -45,6 +48,9 @@ describe("OpenWork Web billing data", () => {
       quantity: 4,
       expectedMonthlyTotal: 20000,
       hasEligibleSubscription: true,
+      hasAccess: true,
+      accessSource: "subscription",
+      complimentaryAccess: false,
       subscription: {
         status: "active",
         quantity: 4,
@@ -74,14 +80,40 @@ describe("OpenWork Web billing data", () => {
     expect(parseStripeWebBilling(missingPaymentStatus)).toBeNull();
   });
 
+  test("parses complimentary access without pretending a Stripe subscription exists", () => {
+    const paid = billingPayload();
+    const complimentary = {
+      billing: {
+        stripe: {
+          web: {
+            ...paid.billing.stripe.web,
+            hasEligibleSubscription: false,
+            hasAccess: true,
+            accessSource: "complimentary",
+            complimentaryAccess: true,
+            subscription: null,
+          },
+        },
+      },
+    };
+
+    expect(parseStripeWebBilling(complimentary)).toMatchObject({
+      hasEligibleSubscription: false,
+      hasAccess: true,
+      accessSource: "complimentary",
+      complimentaryAccess: true,
+      subscription: null,
+    });
+  });
+
   test("billing presents plan, quantity definition, unit-total math, lifecycle, and management", () => {
     const source = readFileSync(new URL("../app/(den)/dashboard/_components/billing-dashboard-screen.tsx", import.meta.url), "utf8");
 
     expect(OPENWORK_WEB_QUANTITY_EXPLANATION).toContain("Pending invitations are not billed");
     expect(source).toContain('data-testid="billing-openwork-web-card"');
     expect(source).toContain('label="Plan" value="OpenWork Web"');
-    expect(source).toContain('label="Unit price"');
-    expect(source).toContain('label="Members billed"');
+    expect(source).toContain('label={webComplimentary ? "Access" : "Unit price"}');
+    expect(source).toContain('label={webComplimentary ? "Members covered" : "Members billed"}');
     expect(source).toContain('label="Expected monthly total"');
     expect(source).toContain('data-testid="billing-openwork-web-lifecycle"');
     expect(source).toContain('label="Subscription status"');
@@ -96,5 +128,20 @@ describe("OpenWork Web billing data", () => {
     expect(source).not.toContain("orgContext?.capabilities.cloud");
     expect(source).toContain('description={webFeatureEnabled');
     expect(source).toContain("Team seats and built-in AI model access are separate purchases.");
+    expect(source).toContain('webAccessSource === "complimentary"');
+    expect(source).toContain("Members covered");
+    expect(source).toContain("without a Stripe subscription or per-member charge");
+  });
+
+  test("platform admin UI exposes an audited complimentary access action separate from capabilities", () => {
+    const source = readFileSync(new URL("../components/den-admin-panel.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain('data-testid="admin-openwork-web-access"');
+    expect(source).toContain("OpenWork Web billing access");
+    expect(source).toContain("Grant complimentary access");
+    expect(source).toContain("Revoke complimentary access");
+    expect(source).toContain("Reason for audit log");
+    expect(source).toContain("Cancel or finish the paid subscription in Stripe");
+    expect(source).toContain("/openwork-web-access");
   });
 });

--- a/ee/apps/den-web/tests/web-page.test.ts
+++ b/ee/apps/den-web/tests/web-page.test.ts
@@ -7,7 +7,7 @@ import { DEFAULT_OPENWORK_WEB_URL } from "../app/(den)/_lib/runtime-config";
 import {
   getWebPageAccessState,
   hasOngoingWebSubscription,
-  isExistingWebSubscriptionResponse,
+  isExistingWebAccessResponse,
   WebOpenButton,
   WebPurchaseButton,
 } from "../app/(den)/dashboard/web/page";
@@ -57,6 +57,9 @@ describe("Web dashboard page", () => {
     quantity: 3,
     expectedMonthlyTotal: 15000,
     hasEligibleSubscription: false,
+    hasAccess: false,
+    accessSource: null,
+    complimentaryAccess: false,
     subscription: null,
   };
 
@@ -98,7 +101,12 @@ describe("Web dashboard page", () => {
     expect(getWebPageAccessState({ ...accessInput, confirming: true })).toBe("confirming");
     expect(getWebPageAccessState({
       ...accessInput,
-      billing: { ...webBilling, hasEligibleSubscription: true },
+      billing: { ...webBilling, hasEligibleSubscription: true, hasAccess: true, accessSource: "subscription" },
+    })).toBe("eligible");
+
+    expect(getWebPageAccessState({
+      ...accessInput,
+      billing: { ...webBilling, hasAccess: true, accessSource: "complimentary", complimentaryAccess: true },
     })).toBe("eligible");
   });
 
@@ -151,15 +159,19 @@ describe("Web dashboard page", () => {
   });
 
   test("recognizes the server duplicate guard so a checkout race refreshes billing", () => {
-    expect(isExistingWebSubscriptionResponse(
+    expect(isExistingWebAccessResponse(
       new Response(null, { status: 409 }),
       { error: "stripe_subscription_exists" },
     )).toBeTrue();
-    expect(isExistingWebSubscriptionResponse(
+    expect(isExistingWebAccessResponse(
+      new Response(null, { status: 409 }),
+      { error: "openwork_web_complimentary_access_exists" },
+    )).toBeTrue();
+    expect(isExistingWebAccessResponse(
       new Response(null, { status: 409 }),
       { error: "different_error" },
     )).toBeFalse();
-    expect(isExistingWebSubscriptionResponse(
+    expect(isExistingWebAccessResponse(
       new Response(null, { status: 500 }),
       { error: "stripe_subscription_exists" },
     )).toBeFalse();
@@ -175,11 +187,13 @@ describe("Web dashboard page", () => {
     expect(source).toContain("JSON.stringify({ type: OPENWORK_WEB_CHECKOUT_TYPE })");
     expect(source).toContain("JSON.stringify({ sessionId, type: OPENWORK_WEB_CHECKOUT_TYPE })");
     expect(source).toContain("headers: { [ORG_SCOPE_HEADER]: orgId }");
-    expect(source).toContain("nextBilling?.hasEligibleSubscription");
+    expect(source).toContain("nextBilling?.hasAccess");
     expect(source).toContain("OpenWork Web remains locked");
     expect(source).toContain("Ask a workspace owner or admin");
     expect(source).toContain("Access opens as soon as your payment is confirmed.");
     expect(source).toContain("pending invitations are never billed");
+    expect(source).toContain("Complimentary access");
+    expect(source).toContain("no Stripe subscription or per-member charge");
     expect(source).not.toContain("Stripe will show");
     expect(source).toContain("await requestWebBilling(orgId, false)");
     expect(source).not.toContain('runtimeConfig.orgMode === "multi_org"');

--- a/evals/specs/openwork-web-billing.test.ts
+++ b/evals/specs/openwork-web-billing.test.ts
@@ -19,7 +19,7 @@ function seedAppLessDenEnvironment() {
 }
 
 briefTest(testBrief({
-  behavior: "OpenWork Web is a $50-per-joined-member monthly Stripe entitlement that fails closed across billing lifecycle changes.",
+  behavior: "OpenWork Web resolves paid or explicitly granted complimentary organization access behind one fail-closed deployment gate.",
   claims: {
     priceContract: claim("OpenWork Web has a dedicated recurring USD monthly price contract", {
       never: "reuse the generic seat product or silently drift from $50 per user each month",
@@ -32,6 +32,9 @@ briefTest(testBrief({
     }),
     lifecycleContract: claim("only active and trialing OpenWork Web subscriptions are eligible", {
       never: "unlock for payment failure, cancellation, expiry, incomplete checkout, unpaid, or paused states",
+    }),
+    complimentaryContract: claim("platform admins can explicitly grant and revoke audited complimentary Web access", {
+      never: "infer free access from an email, organization role, plan, capability, or a deployment where Web is disabled, or overlap an ongoing paid Web subscription",
     }),
     checkoutContract: claim("Checkout, return sync, and webhooks bind one subscription to the intended organization", {
       never: "open duplicate subscriptions or grant access from an unrelated or unconfirmed Checkout session",
@@ -55,6 +58,11 @@ briefTest(testBrief({
     openWorkWebPaymentStatus,
   } = await import("../../ee/apps/den-api/src/stripe-billing");
   const { openWorkWebDeploymentAvailable } = await import("../../ee/apps/den-api/src/openwork-web-availability");
+  const {
+    hasOpenWorkWebComplimentaryAccess,
+    resolveOpenWorkWebAccess,
+    setOpenWorkWebComplimentaryAccess,
+  } = await import("../../ee/apps/den-api/src/openwork-web-access");
   const [
     environmentSource,
     availabilitySource,
@@ -69,6 +77,10 @@ briefTest(testBrief({
     billingPageSource,
     helmValuesSource,
     helmConfigMapSource,
+    webAccessSource,
+    adminRoutesSource,
+    adminPanelSource,
+    auditEventsSource,
   ] = await Promise.all([
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "env.ts"), "utf8"),
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "openwork-web-availability.ts"), "utf8"),
@@ -83,6 +95,10 @@ briefTest(testBrief({
     readFile(join(repoRoot, "ee", "apps", "den-web", "app", "(den)", "dashboard", "_components", "billing-dashboard-screen.tsx"), "utf8"),
     readFile(join(repoRoot, "packaging", "helm", "openwork-ee", "values.yaml"), "utf8"),
     readFile(join(repoRoot, "packaging", "helm", "openwork-ee", "templates", "configmap.yaml"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-api", "src", "openwork-web-access.ts"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-api", "src", "routes", "admin", "index.ts"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-web", "components", "den-admin-panel.tsx"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-api", "src", "audit-events.ts"), "utf8"),
   ]);
 
   expect(subscriptionSchemaSource).toMatch(/OrgSubscriptionType\s*=\s*\[[^\]]*"web"/s);
@@ -169,6 +185,51 @@ briefTest(testBrief({
     "Eligibility accepted only active and trialing with a matching Web price, rejected all seven non-eligible lifecycle states plus no status, and an active row with persisted payment_failed remains locked.",
   );
 
+  const preservedMetadata = setOpenWorkWebComplimentaryAccess({
+    brandAppName: "OpenWork Internal",
+    capabilities: { cloud: true },
+  }, true);
+  expect(hasOpenWorkWebComplimentaryAccess(preservedMetadata)).toBe(true);
+  expect(preservedMetadata).toMatchObject({
+    brandAppName: "OpenWork Internal",
+    capabilities: { cloud: true },
+    complimentaryAccess: { openworkWeb: true },
+  });
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: false,
+    hasEligibleSubscription: false,
+    complimentaryAccess: true,
+  })).toEqual({ hasAccess: false, accessSource: null, complimentaryAccess: true });
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: true,
+    hasEligibleSubscription: false,
+    complimentaryAccess: true,
+  })).toEqual({ hasAccess: true, accessSource: "complimentary", complimentaryAccess: true });
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: true,
+    hasEligibleSubscription: true,
+    complimentaryAccess: true,
+  })).toEqual({ hasAccess: true, accessSource: "subscription", complimentaryAccess: true });
+  expect(webAccessSource).not.toContain("email");
+  expect(webAccessSource).not.toContain("role");
+  expect(webAccessSource).not.toContain("plan");
+  expect(adminRoutesSource).toContain('"/v1/admin/organizations/:organizationId/openwork-web-access"');
+  expect(adminRoutesSource).toMatch(/openwork-web-access"[\s\S]{0,120}adminRoute\(\)/);
+  expect(adminRoutesSource).toContain("organizationHasOngoingOpenWorkWebSubscription");
+  expect(adminRoutesSource).toContain("isOngoingOpenWorkWebSubscriptionStatus");
+  expect(adminRoutesSource).toContain("buildOrganizationAuditEvent");
+  expect(adminRoutesSource).toContain("reason: body.data.reason");
+  expect(auditEventsSource).toContain("organization.openwork_web.complimentary_access_granted");
+  expect(auditEventsSource).toContain("organization.openwork_web.complimentary_access_revoked");
+  expect(billingRoutesSource).toContain("openwork_web_complimentary_access_exists");
+  expect(adminPanelSource).toContain("OpenWork Web billing access");
+  expect(adminPanelSource).toContain("Grant complimentary access");
+  expect(adminPanelSource).toContain("Reason for audit log");
+  prove.complimentaryContract(
+    true,
+    "The explicit metadata grant preserved unrelated organization settings; the deployment-off matrix remained locked; paid access won if both sources existed; the platform-admin route required an audit reason, rejected ongoing subscriptions twice around the transaction, and Checkout refused a complimentary organization.",
+  );
+
   expect(openWorkWebCheckoutIdempotencyKey({
     organizationId: "org_acme",
     quantity: 3,
@@ -221,6 +282,9 @@ briefTest(testBrief({
           quantity: 3,
           expectedMonthlyTotal: 15_000,
           hasEligibleSubscription: true,
+          hasAccess: true,
+          accessSource: "subscription",
+          complimentaryAccess: false,
           subscription: {
             status: "active",
             quantity: 3,
@@ -238,6 +302,9 @@ briefTest(testBrief({
     quantity: 3,
     expectedMonthlyTotal: 15_000,
     hasEligibleSubscription: true,
+    hasAccess: true,
+    accessSource: "subscription",
+    complimentaryAccess: false,
     subscription: {
       status: "active",
       currentPeriodEnd: "2026-09-01T00:00:00.000Z",
@@ -256,6 +323,9 @@ briefTest(testBrief({
           quantity: 3,
           expectedMonthlyTotal: 15_000,
           hasEligibleSubscription: false,
+          hasAccess: false,
+          accessSource: null,
+          complimentaryAccess: false,
           subscription: {
             status: "active",
             quantity: 3,
@@ -269,10 +339,39 @@ briefTest(testBrief({
     },
   })).toMatchObject({
     hasEligibleSubscription: false,
+    hasAccess: false,
+    accessSource: null,
     subscription: { status: "active", paymentStatus: "payment_failed" },
   });
+  expect(parseStripeWebBilling({
+    billing: {
+      stripe: {
+        web: {
+          configured: false,
+          unitAmount: 5_000,
+          currency: "usd",
+          interval: "month",
+          quantityDefinition: "joined_non_removed_members",
+          quantity: 3,
+          expectedMonthlyTotal: 15_000,
+          hasEligibleSubscription: false,
+          hasAccess: true,
+          accessSource: "complimentary",
+          complimentaryAccess: true,
+          subscription: null,
+        },
+      },
+    },
+  })).toMatchObject({
+    configured: false,
+    hasAccess: true,
+    accessSource: "complimentary",
+    complimentaryAccess: true,
+    subscription: null,
+  });
   expect(webPageSource).toContain("Purchase OpenWork Web — $50 per member/month");
-  expect(webPageSource).toContain("hasEligibleSubscription");
+  expect(webPageSource).toContain("billing.hasAccess");
+  expect(webPageSource).toContain('billing.accessSource === "complimentary"');
   expect(webPageSource).toContain("Confirming your OpenWork Web subscription");
   expect(webPageSource).toContain('data-testid="openwork-web-purchase"');
   expect(webPageSource).toContain('data-testid="openwork-web-eligible"');
@@ -281,22 +380,25 @@ briefTest(testBrief({
   expect(webPageSource).toContain("Manage the existing subscription from Billing");
   expect(webPageSource).toContain("Access opens as soon as your payment is confirmed.");
   expect(webPageSource).not.toContain("Stripe will show");
-  expect(webPageSource).toContain("isExistingWebSubscriptionResponse");
+  expect(webPageSource).toContain("isExistingWebAccessResponse");
   expect(webPageSource).toContain("const webAvailable = runtimeConfigLoaded");
   expect(stripeReturnSource).toContain("?stripe_checkout=web&session_id=");
   expect(stripeReturnSource).toContain('if (returnTarget === "web")');
   expect(billingPageSource).toContain("OpenWork Web");
   expect(billingPageSource).toContain('data-testid="billing-openwork-web-card"');
   expect(billingPageSource).toContain('data-testid="billing-openwork-web-lifecycle"');
-  expect(billingPageSource).toContain('label="Unit price"');
-  expect(billingPageSource).toContain("Members billed");
+  expect(billingPageSource).toContain('label={webComplimentary ? "Access" : "Unit price"}');
+  expect(billingPageSource).toContain('label={webComplimentary ? "Members covered" : "Members billed"}');
   expect(billingPageSource).toContain("Expected monthly total");
   expect(billingPageSource).toContain('label={webCancelling ? "Access ends" : "Next renewal"}');
   expect(billingPageSource).toMatch(/Payment|payment/);
   expect(billingPageSource).toContain('webPaymentStatus === "payment_failed"');
   expect(billingPageSource).toContain("Manage or cancel");
+  expect(billingPageSource).toContain('webAccessSource === "complimentary"');
+  expect(billingPageSource).toContain("Members covered");
+  expect(billingPageSource).toContain("without a Stripe subscription or per-member charge");
   prove.surfaceContract(
     true,
-    "The paywall uses the deployment Web offer, waits for confirmed subscription state, and offers the exact $50/user/month purchase; Billing parses and labels plan, users, unit price, total, payment status, renewal/end date, and Stripe management.",
+    "The paywall uses the deployment Web offer, waits for server-resolved access, renders complimentary access without a purchase action or charge, and otherwise offers the exact $50/user/month purchase; Billing keeps paid lifecycle management while labeling complimentary members as covered rather than billed.",
   );
 });


### PR DESCRIPTION
## Summary

- add an explicit organization-level complimentary OpenWork Web grant managed by platform admins in `/admin`
- resolve paid and complimentary access behind the existing fail-closed `DEN_OPENWORK_WEB_ENABLED` deployment gate
- represent complimentary access clearly in the Web and Billing surfaces without a Stripe subscription or per-member charge

## Billing and security behavior

- require a 3–500 character audit reason for every grant or revocation
- persist the grant in organization metadata while preserving unrelated metadata
- reject grants when an ongoing paid Web subscription exists, including a second check inside the locked transaction
- reject Web Checkout when complimentary access already exists
- prefer an eligible paid subscription as the access source if both records are ever present
- keep self-hosted deployments locked when the deployment flag is absent or false

## Verification

- `pnpm --dir ee/apps/den-api exec tsc --noEmit --pretty false`
- `pnpm --dir ee/apps/den-web exec tsc --noEmit --pretty false --incremental false`
- `pnpm --dir ee/apps/den-api exec bun test test/openwork-web-access.test.ts test/audit-events.test.ts test/stripe-billing.test.ts` — 52 passed
- `pnpm --dir ee/apps/den-web exec bun test tests/openwork-web-billing.test.ts tests/web-page.test.ts` — 13 passed
- isolated MySQL: `pnpm --dir ee/apps/den-api exec bun test test/admin-organization-capabilities.test.ts` — 2 passed
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:pr specs/openwork-web-billing.test.ts` — 1 spec passed with 7 claims

No schema migration, Stripe product change, Helm default change, or deployment action is included.