### PR TITLE
refactor(desktop): use opencode SDK in automation runner

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -1,3 +1,5 @@
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
+
 const EMPTY_USAGE = { inputTokens: null, outputTokens: null, costMicros: null }
 const RUNNER_WORK_POLL_MS = 60_000
 
@@ -66,6 +68,40 @@ async function requestJson(fetchImpl, baseUrl, token, requestPath, options = {})
   return payload
 }
 
+function opencodeFetch(fetchImpl) {
+  return async (input, init = {}) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const body = ["GET", "HEAD"].includes(request.method) ? undefined : await request.text()
+    return fetchImpl(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: body || undefined,
+      signal: request.signal,
+    })
+  }
+}
+
+function unwrapOpencodeResult(result, operation) {
+  if (result?.data != null) return result.data
+  if (result?.error === undefined && result?.response?.ok) return null
+  const error = new Error(
+    result?.error === undefined
+      ? `OpenCode returned an empty response for ${operation}`
+      : serializedError(result.error),
+  )
+  const status = result?.response?.status ?? result?.error?.cause?.status
+  if (status !== undefined) Object.defineProperty(error, "status", { value: status })
+  throw error
+}
+
+function createWorkspaceOpencodeClient(local, workspaceId, fetchImpl) {
+  return createOpencodeClient({
+    baseUrl: `${local.baseUrl.replace(/\/+$/, "")}/workspace/${encodeURIComponent(workspaceId)}/opencode`,
+    headers: { Authorization: `Bearer ${local.token}` },
+    fetch: opencodeFetch(fetchImpl),
+  })
+}
+
 function assistantResult(snapshot) {
   const assistants = Array.isArray(snapshot?.messages)
     ? snapshot.messages.filter((message) => message?.info?.role === "assistant")
@@ -126,31 +162,56 @@ export async function executeDesktopAutomation(assignment, options) {
   const workspace = workspaces.find((item) => item?.id === listed?.activeId) ?? workspaces[0]
   if (!workspace?.id) throw new Error("No local workspace is available")
   const workspaceId = String(workspace.id)
-  const created = await localRequest(`/workspace/${encodeURIComponent(workspaceId)}/sessions`, {
-    method: "POST",
-    body: {
-      title: `Automation: ${assignment.automationName}`.slice(0, 120),
-      prompt: assignment.instructions,
-      providerId: assignment.model.providerId,
-      modelId: assignment.model.modelId,
-      ...(assignment.model.variant ? { variant: assignment.model.variant } : {}),
-    },
-  })
-  const sessionId = typeof created?.item?.id === "string" ? created.item.id : null
+  const opencode = createWorkspaceOpencodeClient(local, workspaceId, options.fetchImpl ?? fetch)
+  const created = unwrapOpencodeResult(
+    await opencode.session.create(
+      { title: `Automation: ${assignment.automationName}`.slice(0, 120) },
+      { signal: options.signal },
+    ),
+    "session creation",
+  )
+  const sessionId = typeof created?.id === "string" ? created.id : null
   if (!sessionId) throw new Error("The desktop runtime returned no thread")
-  const abort = () => void localRequest(
-    `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/abort`,
-    { method: "POST", body: {} },
-  ).catch(() => undefined)
+  if (assignment.instructions) {
+    unwrapOpencodeResult(
+      await opencode.session.promptAsync({
+        sessionID: sessionId,
+        model: {
+          providerID: assignment.model.providerId,
+          modelID: assignment.model.modelId,
+        },
+        ...(assignment.model.variant ? { variant: assignment.model.variant } : {}),
+        parts: [{ type: "text", text: assignment.instructions }],
+      }, { signal: options.signal }),
+      "session prompt",
+    )
+  }
+  // The assignment signal is already aborted when this listener runs. Do not
+  // pass it to the cleanup request or fetch can reject before reaching OpenCode.
+  const abort = () => void opencode.session.abort({ sessionID: sessionId })
+    .then((result) => unwrapOpencodeResult(result, "session abort"))
+    .catch(() => undefined)
   options.signal.addEventListener("abort", abort, { once: true })
   try {
     const startedAt = Date.now()
     while (true) {
       if (Date.now() - startedAt > assignment.timeoutMs) throw new Error("Desktop Automation execution timed out")
-      const response = await localRequest(
-        `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/snapshot?limit=200`,
-      )
-      const snapshot = response?.item
+      const [session, messages, todos, statuses] = await Promise.all([
+        opencode.session.get({ sessionID: sessionId }, { signal: options.signal })
+          .then((result) => unwrapOpencodeResult(result, "session read")),
+        opencode.session.messages({ sessionID: sessionId, limit: 200 }, { signal: options.signal })
+          .then((result) => unwrapOpencodeResult(result, "session messages")),
+        opencode.session.todo({ sessionID: sessionId }, { signal: options.signal })
+          .then((result) => unwrapOpencodeResult(result, "session todos")),
+        opencode.session.status(undefined, { signal: options.signal })
+          .then((result) => unwrapOpencodeResult(result, "session status")),
+      ])
+      const snapshot = {
+        session,
+        messages,
+        todos,
+        status: statuses?.[sessionId] ?? { type: "idle" },
+      }
       const output = assistantResult(snapshot)
       const snapshotError = assistantFailure(snapshot)
       if (snapshotError) {
@@ -201,23 +262,33 @@ export async function executeDesktopRemoteSession(assignment, options) {
   const workspace = workspaces.find((item) => item?.id === listed?.activeId) ?? workspaces[0]
   if (!workspace?.id) throw new Error("No local workspace is available")
   const workspaceId = String(workspace.id)
+  const opencode = createWorkspaceOpencodeClient(local, workspaceId, options.fetchImpl ?? fetch)
   let sessionId = null
   try {
-    const created = await localRequest(`/workspace/${encodeURIComponent(workspaceId)}/sessions`, {
-      method: "POST",
-      body: {
-        title: assignment.title,
-        ...(typeof assignment.prompt === "string" ? { prompt: assignment.prompt } : {}),
-        ...(assignment.model ? {
-          providerId: assignment.model.providerId,
-          modelId: assignment.model.modelId,
-          ...(assignment.model.variant ? { variant: assignment.model.variant } : {}),
-        } : {}),
-      },
-    })
-    sessionId = typeof created?.item?.id === "string" ? created.item.id : null
+    const created = unwrapOpencodeResult(
+      await opencode.session.create({ title: assignment.title }, { signal: options.signal }),
+      "session creation",
+    )
+    sessionId = typeof created?.id === "string" ? created.id : null
     if (!sessionId) throw new Error("The desktop runtime returned no thread")
-    return { sessionId, workspaceId, started: Boolean(created.started) }
+    const started = Boolean(assignment.prompt)
+    if (started) {
+      unwrapOpencodeResult(
+        await opencode.session.promptAsync({
+          sessionID: sessionId,
+          ...(assignment.model ? {
+            model: {
+              providerID: assignment.model.providerId,
+              modelID: assignment.model.modelId,
+            },
+            ...(assignment.model.variant ? { variant: assignment.model.variant } : {}),
+          } : {}),
+          parts: [{ type: "text", text: assignment.prompt }],
+        }, { signal: options.signal }),
+        "session prompt",
+      )
+    }
+    return { sessionId, workspaceId, started }
   } catch (error) {
     const contextualError = error instanceof Error ? error : new Error(serializedError(error))
     if (sessionId && Reflect.get(contextualError, "sessionId") === undefined) {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -154,10 +154,35 @@ function remoteSessionAssignment(overrides = {}) {
   }
 }
 
+function opencodeSessionPaths(workspaceId, sessionId) {
+  const base = `/workspace/${encodeURIComponent(workspaceId)}/opencode/session`
+  return {
+    create: base,
+    prompt: `${base}/${encodeURIComponent(sessionId)}/prompt_async`,
+    get: `${base}/${encodeURIComponent(sessionId)}`,
+    messages: `${base}/${encodeURIComponent(sessionId)}/message`,
+    todo: `${base}/${encodeURIComponent(sessionId)}/todo`,
+    status: `${base}/status`,
+    abort: `${base}/${encodeURIComponent(sessionId)}/abort`,
+  }
+}
+
+function respondToSnapshotRequest(parsed, paths, snapshot) {
+  if (parsed.pathname === paths.get) return Response.json(snapshot.session ?? { id: paths.get.split("/").at(-1) })
+  if (parsed.pathname === paths.messages) return Response.json(snapshot.messages ?? [])
+  if (parsed.pathname === paths.todo) return Response.json(snapshot.todos ?? [])
+  if (parsed.pathname === paths.status) {
+    const sessionId = paths.get.split("/").at(-1)
+    return Response.json(snapshot.statuses ?? { [sessionId]: snapshot.status ?? { type: "idle" } })
+  }
+  return null
+}
+
 async function observeAssignmentCredentialRejection(status, deniedRoute) {
   const denRequests = []
   let workRequests = 0
   let snapshotStarted = false
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   let resolveRejected
   const rejected = new Promise((resolve) => { resolveRejected = resolve })
   const runner = createDesktopAutomationRunner({
@@ -168,10 +193,11 @@ async function observeAssignmentCredentialRejection(status, deniedRoute) {
         if (parsed.pathname === "/workspaces") {
           return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-          return Response.json({ item: { id: "session-1" } }, { status: 201 })
+        if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+          return Response.json({ id: "session-1" }, { status: 201 })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions/session-1/snapshot") {
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+        if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
           snapshotStarted = true
           if (deniedRoute === "heartbeat") {
             return new Promise((resolve, reject) => {
@@ -180,13 +206,13 @@ async function observeAssignmentCredentialRejection(status, deniedRoute) {
               else options.signal?.addEventListener("abort", abort, { once: true })
             })
           }
-          return Response.json({ item: {
+          return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{
               info: { role: "assistant", tokens: { input: 1, output: 1 } },
               parts: [{ type: "text", text: "Finished" }],
             }],
-          } })
+          })
         }
         throw new Error(`Unexpected local request ${parsed.pathname}`)
       }
@@ -514,21 +540,23 @@ test("routine credential rotation waits for the active assignment to complete", 
   let snapshotStarted = false
   let finishSnapshot = false
   let localAborts = 0
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url, options = {}) => {
       const parsed = new URL(url)
       if (parsed.origin === "http://127.0.0.1:3000") {
         if (parsed.pathname === "/workspaces") return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
-        if (parsed.pathname === "/workspace/workspace-1/sessions") return Response.json({ item: { id: "session-1" } })
-        if (parsed.pathname.endsWith("/abort")) { localAborts += 1; return Response.json({ ok: true }) }
-        if (parsed.pathname.endsWith("/snapshot")) {
+        if (parsed.pathname === sessionPaths.create) return Response.json({ id: "session-1" })
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+        if (parsed.pathname === sessionPaths.abort) { localAborts += 1; return Response.json(true) }
+        if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
           snapshotStarted = true
           while (!finishSnapshot) await new Promise((resolve) => setImmediate(resolve))
-          return Response.json({ item: {
+          return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Finished" }] }],
-          } })
+          })
         }
       }
       const path = parsed.pathname
@@ -571,18 +599,20 @@ test("routine credential rotation waits for an in-flight claim", async () => {
   /** @type {(response: Response) => void} */
   let resolveClaim = () => {}
   const claimResponse = new Promise((resolve) => { resolveClaim = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
     fetchImpl: async (url, options = {}) => {
       const parsed = new URL(url)
       if (parsed.origin === "http://127.0.0.1:3000") {
         if (parsed.pathname === "/workspaces") return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
-        if (parsed.pathname === "/workspace/workspace-1/sessions") return Response.json({ item: { id: "session-1" } })
-        if (parsed.pathname.endsWith("/snapshot")) {
-          return Response.json({ item: {
+        if (parsed.pathname === sessionPaths.create) return Response.json({ id: "session-1" })
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+        if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+          return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Finished" }] }],
-          } })
+          })
         }
       }
       const path = parsed.pathname
@@ -716,6 +746,7 @@ test("waking during an active run keeps its lease and starts no second claim loo
   let resolveCompleted
   const completed = new Promise((resolve) => { resolveCompleted = resolve })
   let offered = false
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
     fetchImpl: async (url, options = {}) => {
@@ -725,18 +756,19 @@ test("waking during an active run keeps its lease and starts no second claim loo
         if (parsed.pathname === "/workspaces") {
           return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-          return Response.json({ item: { id: "session-1" }, started: true }, { status: 201 })
+        if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+          return Response.json({ id: "session-1" }, { status: 201 })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions/session-1/snapshot") {
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+        if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
           await snapshotGate
-          return Response.json({ item: {
+          return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{
               info: { role: "assistant", tokens: { input: 1, output: 1 } },
               parts: [{ type: "text", text: "done" }],
             }],
-          } })
+          })
         }
         throw new Error(`Unexpected local request ${parsed.pathname}`)
       }
@@ -763,6 +795,8 @@ test("waking during an active run keeps its lease and starts no second claim loo
   await flushTasks()
   assert.equal(paths.filter((path) => path === "/v1/automation-runner/work").length, 1)
   assert.equal(paths.filter((path) => path.endsWith("/claim")).length, 1)
+  assert.ok([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status]
+    .every((path) => paths.includes(path)), "snapshot endpoints did not start in parallel")
 
   // The wake joins the reconcile cycle that is already executing run-1 rather
   // than polling over it, so the desktop cannot double-claim its own work.
@@ -796,6 +830,7 @@ test("a remote-session work item creates a local session and completes with its 
   let createStarted = false
   let resolveCompleted
   const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
     fetchImpl: async (url, options = {}) => {
@@ -807,11 +842,12 @@ test("a remote-session work item creates a local session and completes with its 
         if (parsed.pathname === "/workspaces") {
           return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
+        if (parsed.pathname === sessionPaths.create && options.method === "POST") {
           createStarted = true
           await createGate
-          return Response.json({ item: { id: "session-1" }, started: true }, { status: 201 })
+          return Response.json({ id: "session-1" }, { status: 201 })
         }
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
         throw new Error(`Unexpected local request ${parsed.pathname}`)
       }
       denRequests.push({ path: parsed.pathname, authorization, body })
@@ -851,14 +887,18 @@ test("a remote-session work item creates a local session and completes with its 
   assert.deepEqual(localRequests, [
     { path: "/workspaces", method: "GET", body: null, authorization: "Bearer local-client-token" },
     {
-      path: "/workspace/workspace-1/sessions",
+      path: "/workspace/workspace-1/opencode/session",
+      method: "POST",
+      body: { title: "Desktop handoff" },
+      authorization: "Bearer local-client-token",
+    },
+    {
+      path: "/workspace/workspace-1/opencode/session/session-1/prompt_async",
       method: "POST",
       body: {
-        title: "Desktop handoff",
-        prompt: "Inspect the repo",
-        providerId: "provider",
-        modelId: "model",
+        model: { providerID: "provider", modelID: "model" },
         variant: "high",
+        parts: [{ type: "text", text: "Inspect the repo" }],
       },
       authorization: "Bearer local-client-token",
     },
@@ -878,25 +918,50 @@ test("a remote-session work item creates a local session and completes with its 
 
 test("remote-session creation omits nullable prompt and model fields", async () => {
   const requests = []
+  const sessionPaths = opencodeSessionPaths("workspace/first", "session-not-started")
   const result = await executeDesktopRemoteSession(remoteSessionAssignment({ prompt: null, model: null }), {
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
     fetchImpl: async (url, options = {}) => {
       const parsed = new URL(url)
       requests.push({ path: parsed.pathname, body: options.body ? JSON.parse(options.body) : null })
-      if (parsed.pathname === "/workspaces") return Response.json({ items: [{ id: "workspace-first" }] })
-      if (parsed.pathname === "/workspace/workspace-first/sessions") {
-        return Response.json({ item: { id: "session-not-started" } }, { status: 201 })
+      if (parsed.pathname === "/workspaces") return Response.json({ items: [{ id: "workspace/first" }] })
+      if (parsed.pathname === sessionPaths.create) {
+        return Response.json({ id: "session-not-started" }, { status: 201 })
       }
       throw new Error(`Unexpected request ${parsed.pathname}`)
     },
     signal: new AbortController().signal,
   })
 
-  assert.deepEqual(result, { sessionId: "session-not-started", workspaceId: "workspace-first", started: false })
+  assert.deepEqual(result, { sessionId: "session-not-started", workspaceId: "workspace/first", started: false })
   assert.deepEqual(requests, [
     { path: "/workspaces", body: null },
-    { path: "/workspace/workspace-first/sessions", body: { title: "Desktop handoff" } },
+    { path: "/workspace/workspace%2Ffirst/opencode/session", body: { title: "Desktop handoff" } },
   ])
+})
+
+test("native OpenCode failures preserve upstream status, message, and workspace context", async () => {
+  const sessionPaths = opencodeSessionPaths("workspace-1", "unused")
+  await assert.rejects(
+    executeDesktopRemoteSession(remoteSessionAssignment({ prompt: null, model: null }), {
+      getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
+      fetchImpl: async (url) => {
+        const parsed = new URL(url)
+        if (parsed.pathname === "/workspaces") {
+          return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+        }
+        if (parsed.pathname === sessionPaths.create) {
+          return Response.json({ message: "OpenCode is temporarily unavailable" }, { status: 503 })
+        }
+        throw new Error(`Unexpected request ${parsed.pathname}`)
+      },
+      signal: new AbortController().signal,
+    }),
+    (error) => error instanceof Error
+      && error.message === "OpenCode is temporarily unavailable"
+      && Reflect.get(error, "status") === 503
+      && Reflect.get(error, "workspaceId") === "workspace-1",
+  )
 })
 
 test("a local remote-session failure completes as failed without leaking the response body", async () => {
@@ -905,6 +970,7 @@ test("a local remote-session failure completes as failed without leaking the res
   let offered = false
   let resolveCompleted
   const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "unused")
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
     fetchImpl: async (url, options = {}) => {
@@ -913,7 +979,7 @@ test("a local remote-session failure completes as failed without leaking the res
         if (parsed.pathname === "/workspaces") {
           return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions") {
+        if (parsed.pathname === sessionPaths.create) {
           return Response.json({ message: "x".repeat(2_500), token: sensitiveToken }, { status: 500 })
         }
       }
@@ -993,25 +1059,27 @@ test("a work poll left hanging by a suspended machine times out and retries", as
 test("desktop Automation execution creates a normal visible local OpenWork thread", async () => {
   const requests = []
   let snapshots = 0
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const fetchImpl = async (url, options = {}) => {
     const parsed = new URL(url)
     const body = options.body ? JSON.parse(options.body) : null
-    requests.push({ path: parsed.pathname, method: options.method ?? "GET", body })
+    requests.push({ path: parsed.pathname, search: parsed.search, method: options.method ?? "GET", body, options })
     if (parsed.pathname === "/workspaces") {
       return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-      return Response.json({ item: { id: "session-1" }, started: true }, { status: 201 })
+    if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+      return Response.json({ id: "session-1" }, { status: 201 })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions/session-1/snapshot") {
-      snapshots += 1
-      return Response.json({ item: {
-        status: { type: snapshots === 1 ? "busy" : "idle" },
-        messages: snapshots === 1 ? [] : [{
+    if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+    if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+      if (parsed.pathname === sessionPaths.get) snapshots += 1
+      return respondToSnapshotRequest(parsed, sessionPaths, {
+        status: { type: snapshots <= 1 ? "busy" : "idle" },
+        messages: snapshots <= 1 ? [] : [{
           info: { role: "assistant", tokens: { input: 12, output: 7 } },
           parts: [{ type: "text", text: "Desktop runner result" }],
         }],
-      } })
+      })
     }
     throw new Error(`Unexpected request ${parsed.pathname}`)
   }
@@ -1022,7 +1090,7 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
     automationId: "automation-1",
     automationName: "Daily brief",
     instructions: "Prepare the brief",
-    model: { providerId: "opencode", modelId: "big-pickle" },
+    model: { providerId: "opencode", modelId: "big-pickle", variant: "high" },
     timeoutMs: 30_000,
     leaseExpiresAt: Date.now() + 60_000,
     attempt: 1,
@@ -1036,32 +1104,51 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
   assert.equal(result.workspaceId, "workspace-1")
   assert.equal(result.resultSummary, "Desktop runner result")
   assert.deepEqual(result.usage, { inputTokens: 12, outputTokens: 7, costMicros: null })
-  const create = requests.find((request) => request.path === "/workspace/workspace-1/sessions")
-  assert.deepEqual(create?.body, {
-    title: "Automation: Daily brief",
-    prompt: "Prepare the brief",
-    providerId: "opencode",
-    modelId: "big-pickle",
-  })
+  const localRequests = requests.filter((request) => request.path !== "/workspaces")
+  assert.deepEqual(localRequests.slice(0, 2).map(({ path, method, body }) => ({ path, method, body })), [
+    {
+      path: sessionPaths.create,
+      method: "POST",
+      body: { title: "Automation: Daily brief" },
+    },
+    {
+      path: sessionPaths.prompt,
+      method: "POST",
+      body: {
+        model: { providerID: "opencode", modelID: "big-pickle" },
+        variant: "high",
+        parts: [{ type: "text", text: "Prepare the brief" }],
+      },
+    },
+  ])
+  for (const path of [sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status]) {
+    assert.equal(requests.filter((request) => request.path === path).length, 2)
+  }
+  assert.ok(requests.filter((request) => request.path === sessionPaths.messages)
+    .every((request) => request.search === "?limit=200"))
+  assert.ok(requests.every((request) => request.options.signal instanceof AbortSignal))
+  assert.ok(localRequests.every((request) => new Headers(request.options.headers).get("Authorization") === "Bearer local-client-token"))
 })
 
 test("desktop Automation execution accepts a completed tool-only assistant turn", async () => {
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-tool-only")
   const fetchImpl = async (url, options = {}) => {
     const parsed = new URL(url)
     if (parsed.pathname === "/workspaces") {
       return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-      return Response.json({ item: { id: "session-tool-only" }, started: true }, { status: 201 })
+    if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+      return Response.json({ id: "session-tool-only" }, { status: 201 })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions/session-tool-only/snapshot") {
-      return Response.json({ item: {
-        status: { type: "idle" },
+    if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+    if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+      return respondToSnapshotRequest(parsed, sessionPaths, {
+        statuses: {},
         messages: [{
           info: { role: "assistant", tokens: { input: 9, output: 3 } },
           parts: [{ type: "tool", tool: "example", state: { status: "completed", output: "done" } }],
         }],
-      } })
+      })
     }
     throw new Error(`Unexpected request ${parsed.pathname}`)
   }
@@ -1085,6 +1172,7 @@ test("failed desktop assignments retain their created local thread in the Den co
   const completions = []
   let resolveCompleted
   const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-failed")
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
     fetchImpl: async (url, options = {}) => {
@@ -1093,11 +1181,12 @@ test("failed desktop assignments retain their created local thread in the Den co
         if (parsed.pathname === "/workspaces") {
           return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-          return Response.json({ item: { id: "session-failed" }, started: true }, { status: 201 })
+        if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+          return Response.json({ id: "session-failed" }, { status: 201 })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions/session-failed/snapshot") {
-          return Response.json({ item: {
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+        if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+          return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{
               info: {
@@ -1109,7 +1198,7 @@ test("failed desktop assignments retain their created local thread in the Den co
               },
               parts: [],
             }],
-          } })
+          })
         }
         throw new Error(`Unexpected local request ${parsed.pathname}`)
       }
@@ -1150,18 +1239,27 @@ test("cancellation during execution preserves the local thread and reaches a ter
   const completions = []
   let resolveCompleted
   const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-cancelled")
+  const localRequests = []
   const runner = createDesktopAutomationRunner({
     getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local-client-token" }),
     fetchImpl: async (url, options = {}) => {
       const parsed = new URL(url)
       if (parsed.origin === "http://127.0.0.1:3000") {
+        localRequests.push({
+          path: parsed.pathname,
+          method: options.method ?? "GET",
+          authorization: new Headers(options.headers).get("Authorization"),
+          signal: options.signal,
+        })
         if (parsed.pathname === "/workspaces") {
           return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-          return Response.json({ item: { id: "session-cancelled" }, started: true }, { status: 201 })
+        if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+          return Response.json({ id: "session-cancelled" }, { status: 201 })
         }
-        if (parsed.pathname === "/workspace/workspace-1/sessions/session-cancelled/snapshot") {
+        if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+        if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
           snapshotStarted = true
           return new Promise((resolve, reject) => {
             const abort = () => reject(options.signal?.reason ?? new Error("cancelled"))
@@ -1169,7 +1267,7 @@ test("cancellation during execution preserves the local thread and reaches a ter
             else options.signal?.addEventListener("abort", abort, { once: true })
           })
         }
-        if (parsed.pathname.endsWith("/abort")) return Response.json({ ok: true })
+        if (parsed.pathname === sessionPaths.abort) return Response.json(true)
         throw new Error(`Unexpected local request ${parsed.pathname}`)
       }
       if (parsed.pathname === "/v1/automation-runner/work") {
@@ -1205,19 +1303,25 @@ test("cancellation during execution preserves the local thread and reaches a ter
   assert.equal(completionBody.sessionId, "session-cancelled")
   assert.equal(completionBody.workspaceId, "workspace-1")
   assert.equal(completionBody.error.code, "cancelled")
+  const abortRequest = localRequests.find((request) => request.path === sessionPaths.abort)
+  assert.equal(abortRequest?.method, "POST")
+  assert.equal(abortRequest?.authorization, "Bearer local-client-token")
+  assert.equal(abortRequest?.signal?.aborted, false)
 })
 
 test("an explicit assistant provider failure terminates immediately with its local thread", async () => {
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-provider-failure")
   const fetchImpl = async (url, options = {}) => {
     const parsed = new URL(url)
     if (parsed.pathname === "/workspaces") {
       return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-      return Response.json({ item: { id: "session-provider-failure" }, started: true }, { status: 201 })
+    if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+      return Response.json({ id: "session-provider-failure" }, { status: 201 })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions/session-provider-failure/snapshot") {
-      return Response.json({ item: {
+    if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+    if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+      return respondToSnapshotRequest(parsed, sessionPaths, {
         status: { type: "idle" },
         messages: [{
           info: {
@@ -1229,7 +1333,7 @@ test("an explicit assistant provider failure terminates immediately with its loc
           },
           parts: [],
         }],
-      } })
+      })
     }
     throw new Error(`Unexpected request ${parsed.pathname}`)
   }
@@ -1264,16 +1368,18 @@ test("a temporarily unavailable workspace fails clearly before session creation"
 })
 
 test("desktop Automation execution surfaces a missing pinned model", async () => {
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const fetchImpl = async (url, options = {}) => {
     const parsed = new URL(url)
     if (parsed.pathname === "/workspaces") {
       return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions" && options.method === "POST") {
-      return Response.json({ item: { id: "session-1" }, started: true }, { status: 201 })
+    if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+      return Response.json({ id: "session-1" }, { status: 201 })
     }
-    if (parsed.pathname === "/workspace/workspace-1/sessions/session-1/snapshot") {
-      return Response.json({ item: {
+    if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+    if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+      return respondToSnapshotRequest(parsed, sessionPaths, {
         status: { type: "idle" },
         messages: [{
           info: {
@@ -1285,7 +1391,7 @@ test("desktop Automation execution surfaces a missing pinned model", async () =>
           },
           parts: [],
         }],
-      } })
+      })
     }
     throw new Error(`Unexpected request ${parsed.pathname}`)
   }

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -45,8 +45,8 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("remote-session creation omits nullable prompt and model fields");
   expect(unit.stdout).toContain("a local remote-session failure completes as failed without leaking the response body");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 33\b/);
-  expect(unit.stdout).toMatch(/# pass 33\b/);
+  expect(unit.stdout).toMatch(/# tests 34\b/);
+  expect(unit.stdout).toMatch(/# pass 34\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);


### PR DESCRIPTION
## Stack

Stacked on #4189, which is stacked on #4188. Review only commit `26f2a4f3` / the diff against `thin/proxy-scope-hardening`.

## Why

The desktop Automation/remote-session runner still used OpenWork’s duplicate session create/abort/snapshot endpoints. This migrates that trusted consumer to the official `@opencode-ai/sdk/v2/client` through the workspace-mounted, scope-hardened proxy from #4189.

## What changed

- Keep OpenWork HTTP only for `/workspaces` discovery and Den runner APIs.
- Build a workspace-bound SDK client at `/workspace/:id/opencode`.
- Preserve local OpenWork bearer authentication in the SDK transport.
- Create sessions with native `session.create`.
- Submit initial work with native `session.promptAsync`, preserving provider/model/variant/text semantics.
- Poll a snapshot in parallel from native `session.get`, `session.messages(limit: 200)`, `session.todo`, and `session.status`.
- Preserve idle status fallback, assistant output/usage aggregation, provider failure handling, timeout behavior, and Den completion context.
- Abort with native `session.abort`. The cleanup call intentionally does not reuse the already-aborted assignment signal, so it can actually reach OpenCode.
- Preserve useful native upstream status/message on failures.
- No fallback to the old wrapper endpoints.

Server session wrappers remain for other consumers and are removed only after the rest of the stack migrates.

## Verification

### Branch-specific
- `node --test apps/desktop/electron/automation-runner.test.mjs` — **34 pass / 0 fail**
- `./node_modules/.bin/tsc -p apps/desktop/tsconfig.electron.json --noEmit` — pass
- `pnpm --filter @openwork/desktop check:electron` — pass (52 renderer methods covered)
- `pnpm --filter @openwork/desktop typecheck:electron` — pass
- `vitest ... specs/automation-runner-reconnect-backoff.test.ts` — **1 pass / 0 fail**
- `git diff --check` — pass

### Broader local matrix
- Full desktop suite executes **276 tests**; runner’s 34 tests all pass. Its sole assertion failure is the unrelated local runtime CA fixture; two subsequent chain-repair tests are cancelled by that parent failure. Files untouched by this PR.
- Full PR eval project: 91 pass / 3 fail / 2 skipped before the witness-count fix. The only branch-related failure was its expected runner count (33→34); after updating, that spec passes in isolation. The other two failures are unrelated local build-state issues: concurrent Den DB asset copy `EEXIST`, and Node 22 loading an unbuilt workspace `.ts` export.
- Hosted CI is the authoritative clean-environment lane and must be fully green before merge.

## Contract coverage added/updated

- native create → prompt ordering and exact payloads
- encoded workspace ids
- nullable prompt/model omission
- four snapshot endpoints launched in parallel
- message `limit=200`
- status fallback when status map omits the session
- bearer auth and AbortSignal propagation
- cleanup abort uses a live signal
- upstream status/message + workspace context preservation
- cancellation, lease rotation, wake/double-claim protection, tool-only completion, provider failure, and pinned model loss
