### PR TITLE
refactor(headless): use opencode SDK for threads

### DIFF
--- a/evals/specs/remote-session-capability.test.ts
+++ b/evals/specs/remote-session-capability.test.ts
@@ -27,9 +27,8 @@ let executeRemoteSessionCapability: RemoteSessionModule["executeRemoteSessionCap
 let searchRemoteSessionCapabilities: RemoteSessionModule["searchRemoteSessionCapabilities"];
 
 /**
- * A witness openwork-server: the exact session routes the headless-threads
- * client speaks (`POST /workspace/:id/sessions`, `GET .../sessions/:id/messages`,
- * `GET .../sessions/:id/snapshot`, `POST .../opencode/session/:id/prompt_async`),
+ * A witness openwork-server: the exact native OpenCode routes the
+ * headless-threads client speaks through `/workspace/:id/opencode`,
  * recording every request so assertions observe the real wire traffic the
  * `remote-session:*` capabilities produce — not a stubbed client.
  */
@@ -91,12 +90,10 @@ function snapshotWire(session: WitnessSession) {
     },
   ]);
   return {
-    item: {
-      session: { id: session.id, title: session.title, directory: null, time: { created: 1 } },
-      messages,
-      todos: [],
-      status: { type: "idle" },
-    },
+    session: { id: session.id, title: session.title, directory: null, time: { created: 1 } },
+    messages,
+    todos: [],
+    status: { type: "idle" },
   };
 }
 
@@ -112,41 +109,46 @@ async function handle(request: IncomingMessage, response: ServerResponse) {
     body,
   });
 
-  const prefix = `/workspace/${WORKSPACE_ID}`;
-  if (method === "POST" && path === `${prefix}/sessions`) {
+  const prefix = `/workspace/${WORKSPACE_ID}/opencode/session`;
+  if (method === "POST" && path === prefix) {
     const title = typeof body === "object" && body !== null && typeof (body as Record<string, unknown>).title === "string"
       ? String((body as Record<string, unknown>).title)
       : "Untitled";
-    const prompt = typeof body === "object" && body !== null && typeof (body as Record<string, unknown>).prompt === "string"
-      ? String((body as Record<string, unknown>).prompt)
-      : undefined;
     const session: WitnessSession = {
       id: `ses_witness_${witness.nextSessionId++}`,
       title,
-      prompts: prompt === undefined ? [] : [prompt],
+      prompts: [],
     };
     witness.sessions.set(session.id, session);
-    return json(response, 200, {
-      item: { id: session.id, title: session.title, directory: null, time: { created: 1 } },
-      started: prompt !== undefined,
-    });
+    return json(response, 200, snapshotWire(session).session);
   }
 
-  const messagesMatch = path.match(new RegExp(`^${prefix}/sessions/([^/]+)/messages$`));
+  const messagesMatch = path.match(new RegExp(`^${prefix}/([^/]+)/message$`));
   if (method === "GET" && messagesMatch) {
     const session = witness.sessions.get(decodeURIComponent(messagesMatch[1] ?? ""));
     if (!session) return json(response, 404, { code: "not_found", message: "session not found" });
-    return json(response, 200, { items: snapshotWire(session).item.messages });
+    return json(response, 200, snapshotWire(session).messages);
   }
 
-  const snapshotMatch = path.match(new RegExp(`^${prefix}/sessions/([^/]+)/snapshot$`));
-  if (method === "GET" && snapshotMatch) {
-    const session = witness.sessions.get(decodeURIComponent(snapshotMatch[1] ?? ""));
+  if (method === "GET" && path === `${prefix}/status`) {
+    return json(response, 200, {});
+  }
+
+  const sessionMatch = path.match(new RegExp(`^${prefix}/([^/]+)$`));
+  if (method === "GET" && sessionMatch) {
+    const session = witness.sessions.get(decodeURIComponent(sessionMatch[1] ?? ""));
     if (!session) return json(response, 404, { code: "not_found", message: "session not found" });
-    return json(response, 200, snapshotWire(session));
+    return json(response, 200, snapshotWire(session).session);
   }
 
-  const promptMatch = path.match(new RegExp(`^${prefix}/opencode/session/([^/]+)/prompt_async$`));
+  const todoMatch = path.match(new RegExp(`^${prefix}/([^/]+)/todo$`));
+  if (method === "GET" && todoMatch) {
+    const session = witness.sessions.get(decodeURIComponent(todoMatch[1] ?? ""));
+    if (!session) return json(response, 404, { code: "not_found", message: "session not found" });
+    return json(response, 200, snapshotWire(session).todos);
+  }
+
+  const promptMatch = path.match(new RegExp(`^${prefix}/([^/]+)/prompt_async$`));
   if (method === "POST" && promptMatch) {
     const session = witness.sessions.get(decodeURIComponent(promptMatch[1] ?? ""));
     if (!session) return json(response, 404, { code: "not_found", message: "session not found" });
@@ -227,14 +229,14 @@ test("remote-session capabilities drive a real openwork-server wire with scoped 
   expect(createdBody.started).toBe(true);
 
   const createRequest = witness.requests.find(
-    (request) => request.method === "POST" && request.path === `/workspace/${WORKSPACE_ID}/sessions`,
+    (request) => request.method === "POST" && request.path === `/workspace/${WORKSPACE_ID}/opencode/session`,
   );
   expect(createRequest).toBeDefined();
   expect(createRequest?.authorization).toBe(`Bearer ${CLIENT_TOKEN}`);
   expect(createRequest?.hostToken).toBe(HOST_TOKEN);
   evidence.recordAssertionEvidence(
-    "Create reaches the worker session route with worker credentials",
-    "remote-session:create produced POST /workspace/:id/sessions on the witness with the collaborator bearer token and host token header, returning the native session id.",
+    "Create reaches the worker's native OpenCode route with worker credentials",
+    "remote-session:create produced POST /workspace/:id/opencode/session on the witness with the collaborator bearer token and host token header, returning the native session id.",
     true,
   );
 
@@ -244,7 +246,7 @@ test("remote-session capabilities drive a real openwork-server wire with scoped 
   );
   expect(sent.isError).toBeUndefined();
   expect(payload(sent).state).toBe("accepted");
-  const promptRequest = witness.requests.find(
+  const promptRequest = witness.requests.findLast(
     (request) => request.method === "POST" && request.path.includes("/prompt_async"),
   );
   expect(promptRequest).toBeDefined();

--- a/packages/headless-threads/README.md
+++ b/packages/headless-threads/README.md
@@ -8,8 +8,8 @@ final state the desktop UI shows. A thread this package creates can be opened
 in the app afterwards, because there is no separate headless thread type.
 
 This is a client, not a runtime. It adds no chat engine, no session store, no
-model gateway, and no new server route — it is a typed shape over session
-surfaces the OpenWork server already serves.
+model gateway, and no new server route — it is a typed workflow over the
+official OpenCode SDK through OpenWork's workspace-scoped proxy.
 
 ## Why
 

--- a/packages/headless-threads/package.json
+++ b/packages/headless-threads/package.json
@@ -22,6 +22,7 @@
     "test": "bun test src"
   },
   "dependencies": {
+    "@opencode-ai/sdk": "^1.18.15",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/headless-threads/src/client.test.ts
+++ b/packages/headless-threads/src/client.test.ts
@@ -5,7 +5,14 @@ import { createHeadlessThreadClient } from "./client.js";
 import { HeadlessThreadError } from "./errors.js";
 import type { HeadlessFetch, HeadlessThreadStatus } from "./types.js";
 
-type RecordedRequest = { method: string; path: string; body: unknown };
+type RecordedRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+  headers: Headers;
+  redirect: RequestRedirect | undefined;
+  signal: AbortSignal | undefined;
+};
 type MessageWire = { info: { id: string; role: string; parentID?: string; time?: { created: number }; error?: unknown; tokens?: unknown; cost?: number }; parts: unknown[] };
 /** One poll's worth of thread state, consumed in order by snapshot reads. */
 type Beat = { status: HeadlessThreadStatus; messages: MessageWire[] };
@@ -41,16 +48,16 @@ function reply(id: string, role: string, text?: string, parentID?: string): Mess
 }
 
 /**
- * A stand-in for the OpenWork server's session routes. `beats` scripts what
+ * A stand-in for the OpenWork server's native OpenCode proxy. `beats` scripts what
  * successive snapshot reads observe, so a wait can be tested without a clock
  * or an engine.
  */
-function createOpenworkDouble(input?: { beats?: Beat[]; messages?: MessageWire[] }) {
+function createOpenworkDouble(input?: { beats?: Beat[]; messages?: MessageWire[]; abortResult?: boolean }) {
   const requests: RecordedRequest[] = [];
-  const requestHeaders: Headers[] = [];
   const beats = input?.beats ?? [];
   const messages = input?.messages ?? [];
   let beatIndex = 0;
+  let activeBeat: Beat | undefined;
 
   const session = { id: SESSION_ID, title: "Refund policy", directory: "/workspace", time: { created: 1 } };
 
@@ -58,38 +65,43 @@ function createOpenworkDouble(input?: { beats?: Beat[]; messages?: MessageWire[]
     const parsed = new URL(url);
     const method = init?.method ?? "GET";
     const body: unknown = init?.body === undefined ? undefined : JSON.parse(init.body);
-    requests.push({ method, path: `${parsed.pathname}${parsed.search}`, body });
-    requestHeaders.push(new Headers(init?.headers));
+    requests.push({
+      method,
+      path: `${parsed.pathname}${parsed.search}`,
+      body,
+      headers: new Headers(init?.headers),
+      redirect: init?.redirect,
+      signal: init?.signal,
+    });
 
-    if (method === "POST" && parsed.pathname === "/workspace/ws_1/sessions") {
-      const started = typeof body === "object" && body !== null && "prompt" in body;
-      return Response.json({ item: session, started }, { status: 201 });
+    if (method === "POST" && parsed.pathname === "/workspace/ws_1/opencode/session") {
+      return Response.json(session);
     }
-    if (method === "GET" && parsed.pathname === `/workspace/ws_1/sessions/${SESSION_ID}/messages`) {
-      return Response.json({ items: messages });
-    }
-    if (method === "GET" && parsed.pathname === `/workspace/ws_1/sessions/${SESSION_ID}/snapshot`) {
-      const beat = beats[Math.min(beatIndex, beats.length - 1)];
+    if (method === "GET" && parsed.pathname === `/workspace/ws_1/opencode/session/${SESSION_ID}`) {
+      activeBeat = beats[Math.min(beatIndex, beats.length - 1)];
       beatIndex += 1;
-      return Response.json({
-        item: {
-          session,
-          messages: beat === undefined ? messages : beat.messages,
-          todos: [],
-          status: beat === undefined ? { type: "idle" } : beat.status,
-        },
-      });
+      return Response.json(session);
+    }
+    if (method === "GET" && parsed.pathname === `/workspace/ws_1/opencode/session/${SESSION_ID}/message`) {
+      return Response.json(activeBeat?.messages ?? messages);
+    }
+    if (method === "GET" && parsed.pathname === `/workspace/ws_1/opencode/session/${SESSION_ID}/todo`) {
+      return Response.json([]);
+    }
+    if (method === "GET" && parsed.pathname === "/workspace/ws_1/opencode/session/status") {
+      const status = activeBeat?.status;
+      return Response.json(status === undefined || status.type === "idle" ? {} : { [SESSION_ID]: status });
     }
     if (method === "POST" && parsed.pathname === `/workspace/ws_1/opencode/session/${SESSION_ID}/prompt_async`) {
       return new Response(null, { status: 204 });
     }
-    if (method === "POST" && parsed.pathname === `/workspace/ws_1/sessions/${SESSION_ID}/abort`) {
-      return Response.json({ ok: true });
+    if (method === "POST" && parsed.pathname === `/workspace/ws_1/opencode/session/${SESSION_ID}/abort`) {
+      return Response.json(input?.abortResult ?? true);
     }
     return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
   };
 
-  return { fetchImpl, requests, requestHeaders, snapshotReads: () => beatIndex };
+  return { fetchImpl, requests, snapshotReads: () => beatIndex };
 }
 
 /** A clock that only moves when the client sleeps, so waits are instant. */
@@ -116,7 +128,7 @@ function createClient(double: ReturnType<typeof createOpenworkDouble>, clock = c
 }
 
 describe("createThread", () => {
-  test("sends the title, prompt, and model in OpenWork's casing", async () => {
+  test("creates first, then submits the initial prompt in OpenCode's casing", async () => {
     const double = createOpenworkDouble();
     const thread = await createClient(double).createThread({
       title: "Refund policy",
@@ -124,16 +136,15 @@ describe("createThread", () => {
       model: { providerId: "anthropic", modelId: "claude-sonnet-5", variant: "thinking" },
     });
 
-    expect(double.requests[0]).toEqual({
-      method: "POST",
-      path: "/workspace/ws_1/sessions",
-      body: {
-        title: "Refund policy",
-        prompt: "A customer wants a refund after 40 days.",
-        providerId: "anthropic",
-        modelId: "claude-sonnet-5",
-        variant: "thinking",
-      },
+    expect(double.requests.map(({ method, path }) => ({ method, path }))).toEqual([
+      { method: "POST", path: "/workspace/ws_1/opencode/session" },
+      { method: "POST", path: "/workspace/ws_1/opencode/session/ses_1/prompt_async" },
+    ]);
+    expect(double.requests[0]?.body).toEqual({ title: "Refund policy" });
+    expect(double.requests[1]?.body).toEqual({
+      parts: [{ type: "text", text: "A customer wants a refund after 40 days." }],
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      variant: "thinking",
     });
     expect(thread).toEqual({
       id: SESSION_ID,
@@ -156,7 +167,7 @@ describe("createThread", () => {
 
     await client.createThread({ title: "Refund policy" });
 
-    expect(double.requests[0]?.path).toBe("/workspace/ws_1/sessions");
+    expect(double.requests[0]?.path).toBe("/workspace/ws_1/opencode/session");
   });
 
   test("authenticates server-to-server Cloud requests with both worker tokens", async () => {
@@ -171,8 +182,18 @@ describe("createThread", () => {
 
     await client.createThread({ title: "Cloud Automation" });
 
-    expect(double.requestHeaders[0]?.get("authorization")).toBe("Bearer client-token");
-    expect(double.requestHeaders[0]?.get("x-openwork-host-token")).toBe("host-token");
+    expect(double.requests[0]?.headers.get("authorization")).toBe("Bearer client-token");
+    expect(double.requests[0]?.headers.get("x-openwork-host-token")).toBe("host-token");
+    expect(double.requests[0]?.redirect).toBe("error");
+  });
+
+  test("omits the optional host token", async () => {
+    const double = createOpenworkDouble();
+
+    await createClient(double).createThread({ title: "Local" });
+
+    expect(double.requests[0]?.headers.get("authorization")).toBe("Bearer owt_test");
+    expect(double.requests[0]?.headers.has("x-openwork-host-token")).toBe(false);
   });
 
   test("omits the prompt and model when none were given", async () => {
@@ -180,7 +201,43 @@ describe("createThread", () => {
     const thread = await createClient(double).createThread({ title: "Empty" });
 
     expect(double.requests[0]?.body).toEqual({ title: "Empty" });
+    expect(double.requests).toHaveLength(1);
     expect(thread.started).toBe(false);
+  });
+
+  test("treats an explicitly empty initial prompt as not started", async () => {
+    const double = createOpenworkDouble();
+
+    const thread = await createClient(double).createThread({ title: "Empty prompt", prompt: "" });
+
+    expect(double.requests).toHaveLength(1);
+    expect(thread.started).toBe(false);
+  });
+
+  test("preserves wrapper validation and normalization for initial title and prompt", async () => {
+    const double = createOpenworkDouble();
+    const client = createClient(double);
+
+    await client.createThread({ title: "  Refund policy  ", prompt: "  Review it  " });
+    expect(double.requests[0]?.body).toEqual({ title: "Refund policy" });
+    expect(double.requests[1]?.body).toEqual({ parts: [{ type: "text", text: "Review it" }] });
+
+    await expect(client.createThread({ title: "  " })).rejects.toMatchObject({
+      code: "invalid_payload",
+      status: 400,
+    });
+    await expect(client.createThread({ title: "Valid", prompt: "  " })).rejects.toMatchObject({
+      code: "invalid_payload",
+      status: 400,
+    });
+    await expect(client.createThread({ title: "x".repeat(121) })).rejects.toMatchObject({
+      code: "invalid_payload",
+      status: 400,
+    });
+    await expect(client.createThread({ title: "Valid", prompt: "x".repeat(100_001) })).rejects.toMatchObject({
+      code: "invalid_payload",
+      status: 400,
+    });
   });
 });
 
@@ -200,7 +257,7 @@ describe("sendTurn", () => {
       alreadyPresent: false,
     });
     expect(double.requests.map((request) => request.path)).toEqual([
-      "/workspace/ws_1/sessions/ses_1/messages",
+      "/workspace/ws_1/opencode/session/ses_1/message",
       "/workspace/ws_1/opencode/session/ses_1/prompt_async",
     ]);
     expect(double.requests[1]?.body).toEqual({
@@ -238,7 +295,7 @@ describe("sendTurn", () => {
     expect(acceptance.alreadyPresent).toBe(true);
     expect(acceptance.messageId).toBe("msg_run_1");
     expect(double.requests).toHaveLength(1);
-    expect(double.requests[0]?.path).toBe("/workspace/ws_1/sessions/ses_1/messages");
+    expect(double.requests[0]?.path).toBe("/workspace/ws_1/opencode/session/ses_1/message");
   });
 
   test("passes a new stable message id to OpenCode", async () => {
@@ -250,6 +307,76 @@ describe("sendTurn", () => {
       parts: [{ type: "text", text: "Run it." }],
       messageID: "msg_run_2",
     });
+  });
+
+  test("URL-encodes workspace and session IDs on native proxy calls", async () => {
+    const paths: string[] = [];
+    const fetchImpl: HeadlessFetch = async (url) => {
+      const path = new URL(url).pathname;
+      paths.push(path);
+      if (path.endsWith("/message")) return Response.json([]);
+      return new Response(null, { status: 204 });
+    };
+    const client = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws /?",
+      token: "owt_test",
+      fetch: fetchImpl,
+    });
+
+    await client.sendTurn("ses /?", { prompt: "hello" });
+
+    expect(paths).toEqual([
+      "/workspace/ws%20%2F%3F/opencode/session/ses%20%2F%3F/message",
+      "/workspace/ws%20%2F%3F/opencode/session/ses%20%2F%3F/prompt_async",
+    ]);
+  });
+});
+
+describe("getThreadSnapshot", () => {
+  test("reads session, messages, todos, and status in parallel", async () => {
+    const requests: string[] = [];
+    let markStarted: () => void = () => {};
+    let releaseRequests: () => void = () => {};
+    const allStarted = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      releaseRequests = resolve;
+    });
+    const fetchImpl: HeadlessFetch = async (url) => {
+      const path = new URL(url).pathname;
+      requests.push(path);
+      if (requests.length === 4) markStarted();
+      await released;
+      if (path.endsWith("/message")) return Response.json([]);
+      if (path.endsWith("/todo")) return Response.json([{ content: "Check", status: "pending", priority: "high" }]);
+      if (path.endsWith("/status")) return Response.json({ [SESSION_ID]: { type: "busy" } });
+      return Response.json({ id: SESSION_ID, title: "Refund policy", directory: "/workspace", time: { created: 1 } });
+    };
+    const client = createHeadlessThreadClient({ baseUrl: BASE_URL, workspaceId: "ws_1", token: "owt_test", fetch: fetchImpl });
+
+    const pending = client.getThreadSnapshot(SESSION_ID);
+    await allStarted;
+    expect(requests).toEqual([
+      "/workspace/ws_1/opencode/session/ses_1",
+      "/workspace/ws_1/opencode/session/ses_1/message",
+      "/workspace/ws_1/opencode/session/ses_1/todo",
+      "/workspace/ws_1/opencode/session/status",
+    ]);
+    releaseRequests();
+
+    await expect(pending).resolves.toMatchObject({
+      threadId: SESSION_ID,
+      status: { type: "busy" },
+      todos: [{ content: "Check", status: "pending", priority: "high" }],
+    });
+  });
+
+  test("falls back to idle when the native status map omits the session", async () => {
+    const snapshot = await createClient(createOpenworkDouble()).getThreadSnapshot(SESSION_ID);
+
+    expect(snapshot.status).toEqual({ type: "idle" });
   });
 });
 
@@ -376,7 +503,9 @@ describe("failures", () => {
     expect(error.code).toBe("not_found");
     expect(error.status).toBe(404);
     expect(error.method).toBe("GET");
-    expect(error.path).toBe("/workspace/ws_1/sessions/ses_missing/snapshot");
+    expect(error.path).toBe("/workspace/ws_1/opencode/session/ses_missing");
+    expect(error.message).toBe("Not found");
+    expect(error.body).toEqual({ code: "not_found", message: "Not found" });
   });
 
   test("rejects a payload that does not match the session read model", async () => {
@@ -407,7 +536,48 @@ describe("failures", () => {
       requestTimeoutMs: 5,
     });
 
-    await expect(client.getThreadSnapshot(SESSION_ID)).rejects.toBeDefined();
+    const error = await client.getThreadSnapshot(SESSION_ID).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HeadlessThreadError);
+    if (!(error instanceof HeadlessThreadError)) throw new Error("expected a HeadlessThreadError");
+    expect(error.code).toBe("request_failed");
+    expect(error.method).toBe("GET");
+    expect(error.path).toBe("/workspace/ws_1/opencode/session/ses_1");
+    expect(error.status).toBeNull();
+  });
+
+  test("merges the client-wide and per-call signals into SDK requests", async () => {
+    const globalController = new AbortController();
+    const callController = new AbortController();
+    const first = createOpenworkDouble();
+    const firstClient = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      signal: globalController.signal,
+      fetch: first.fetchImpl,
+    });
+    await firstClient.createThread({ title: "Global signal", signal: callController.signal });
+    const firstSignal = first.requests[0]?.signal;
+    expect(firstSignal?.aborted).toBe(false);
+    globalController.abort();
+    expect(firstSignal?.aborted).toBe(true);
+
+    const secondGlobal = new AbortController();
+    const secondCall = new AbortController();
+    const second = createOpenworkDouble();
+    const secondClient = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      signal: secondGlobal.signal,
+      fetch: second.fetchImpl,
+    });
+    await secondClient.createThread({ title: "Call signal", signal: secondCall.signal });
+    const secondSignal = second.requests[0]?.signal;
+    expect(secondSignal?.aborted).toBe(false);
+    secondCall.abort();
+    expect(secondSignal?.aborted).toBe(true);
   });
 
   test("a custom Cloud fetch cannot follow a 307 with the thread body or tokens", async () => {
@@ -449,6 +619,16 @@ describe("abortThread", () => {
       threadId: SESSION_ID,
       accepted: true,
     });
+  });
+
+  test("preserves a native false abort result", async () => {
+    const double = createOpenworkDouble({ abortResult: false });
+
+    await expect(createClient(double).abortThread(SESSION_ID)).resolves.toEqual({
+      threadId: SESSION_ID,
+      accepted: false,
+    });
+    expect(double.requests[0]?.path).toBe("/workspace/ws_1/opencode/session/ses_1/abort");
   });
 
   test("waits until the aborted thread is observably idle", async () => {

--- a/packages/headless-threads/src/client.ts
+++ b/packages/headless-threads/src/client.ts
@@ -128,7 +128,7 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
       ...(options.hostToken === undefined ? {} : { "X-OpenWork-Host-Token": options.hostToken }),
     },
     redirect: "error",
-    fetch: Object.assign(sdkFetch, { preconnect: globalThis.fetch.preconnect }),
+    fetch: Object.assign(sdkFetch, { preconnect: () => {} }),
   });
 
   type SdkResult<T> = {

--- a/packages/headless-threads/src/client.ts
+++ b/packages/headless-threads/src/client.ts
@@ -1,20 +1,13 @@
 /**
  * A function-driven client for native OpenWork threads.
  *
- * Every call goes to an OpenWork server surface that already exists:
+ * Every call uses the OpenCode SDK through OpenWork's workspace-scoped mount:
  *
- * - `POST   /workspace/:id/sessions`                        create a thread
- * - `GET    /workspace/:id/sessions/:threadId/messages`     read messages
- * - `GET    /workspace/:id/sessions/:threadId/snapshot`     read status + messages + todos
- * - `POST   /workspace/:id/sessions/:threadId/abort`        stop a run
- * - `POST   /workspace/:id/opencode/session/:threadId/prompt_async`  submit a turn
- *
- * The last one is the workspace OpenCode mount the desktop app itself prompts
- * through. Routing turns through it — rather than adding a parallel prompt
- * route — is what keeps a headless thread indistinguishable from a thread the
- * user typed into. Callers depend on the functions below, not on those paths,
- * so the transport can move without breaking them.
+ * - `POST /workspace/:id/opencode/session` creates a thread
+ * - native session reads provide messages, todos, and status
+ * - native prompt and abort calls control a turn
  */
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { z } from "zod";
 
 import { HeadlessThreadError } from "./errors.js";
@@ -33,11 +26,13 @@ import type {
   HeadlessTurnAcceptance,
 } from "./types.js";
 import {
-  abortResponseSchema,
-  createThreadResponseSchema,
+  abortResultSchema,
   isRunning,
-  threadMessagesResponseSchema,
-  threadSnapshotResponseSchema,
+  sessionSchema,
+  threadMessagesSchema,
+  threadSnapshotSchema,
+  threadStatusesSchema,
+  threadTodosSchema,
   toSnapshot,
   toThread,
 } from "./wire.js";
@@ -72,9 +67,37 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const workspacePath = `/workspace/${encodeURIComponent(workspaceId)}`;
+  const opencodePath = `${workspacePath}/opencode`;
 
-  function threadPath(threadId: string, suffix: string): string {
-    return `${workspacePath}/sessions/${encodeURIComponent(threadId)}${suffix}`;
+  function invalidCreatePayload(message: string): never {
+    const path = `${opencodePath}/session`;
+    throw new HeadlessThreadError({
+      code: "invalid_payload",
+      message,
+      method: "POST",
+      path,
+      status: 400,
+      body: { code: "invalid_payload", message },
+    });
+  }
+
+  function createTitle(value: unknown): string {
+    if (typeof value !== "string" || !value.trim()) {
+      return invalidCreatePayload("title must be a non-empty string");
+    }
+    const title = value.trim();
+    if (title.length > 120) return invalidCreatePayload("title must be 120 characters or fewer");
+    return title;
+  }
+
+  function initialPrompt(value: unknown): string | undefined {
+    if (value === undefined || value === null || value === "") return undefined;
+    if (typeof value !== "string" || !value.trim()) {
+      return invalidCreatePayload("prompt must be a non-empty string");
+    }
+    const prompt = value.trim();
+    if (prompt.length > 100_000) return invalidCreatePayload("prompt must be 100000 characters or fewer");
+    return prompt;
   }
 
   function requestSignal(signal?: AbortSignal): AbortSignal {
@@ -83,68 +106,122 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
     return AbortSignal.any(signals);
   }
 
-  async function send(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<{ status: number; payload: unknown }> {
-    const response = await fetchImpl(`${baseUrl}${path}`, {
-      method,
-      headers: {
-        Authorization: `Bearer ${options.token}`,
-        ...(options.hostToken === undefined ? {} : { "X-OpenWork-Host-Token": options.hostToken }),
-        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
-      },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-      redirect: "error",
-      signal: requestSignal(signal),
+  const sdkFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key] = value;
     });
-    const text = await response.text().catch(() => "");
-    const payload = text === "" ? undefined : safeJsonParse(text);
-    if (response.ok) return { status: response.status, payload };
+    const body = request.method === "GET" || request.method === "HEAD" ? undefined : await request.text();
+    return fetchImpl(request.url, {
+      method: request.method,
+      headers,
+      ...(body === "" ? {} : { body }),
+      redirect: "error",
+      signal: request.signal,
+    });
+  };
+  const opencode = createOpencodeClient({
+    baseUrl: `${baseUrl}${opencodePath}`,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      ...(options.hostToken === undefined ? {} : { "X-OpenWork-Host-Token": options.hostToken }),
+    },
+    redirect: "error",
+    fetch: Object.assign(sdkFetch, { preconnect: globalThis.fetch.preconnect }),
+  });
 
-    const detail = errorBodySchema.safeParse(payload);
+  type SdkResult<T> = {
+    data?: T;
+    error?: unknown;
+    response?: Response;
+  };
+
+  function sdkSuccess<T>(result: SdkResult<T>, method: string, path: string): T | undefined {
+    if (result.error === undefined) return result.data;
+    const detail = errorBodySchema.safeParse(result.error);
     throw new HeadlessThreadError({
       code: detail.success && detail.data.code !== undefined ? detail.data.code : "request_failed",
       message: detail.success && detail.data.message !== undefined
         ? detail.data.message
-        : `OpenWork returned ${response.status} for ${method} ${path}`,
+        : result.response
+          ? `OpenWork returned ${result.response.status} for ${method} ${path}`
+          : `OpenWork request failed for ${method} ${path}`,
       method,
       path,
-      status: response.status,
-      body: payload,
+      ...(result.response === undefined ? {} : { status: result.response.status }),
+      body: result.error,
     });
   }
 
-  async function requestJson<T>(schema: z.ZodType<T>, method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
-    const response = await send(method, path, body, signal);
-    const parsed = schema.safeParse(response.payload);
+  function sdkJson<T>(schema: z.ZodType<T>, result: SdkResult<unknown>, method: string, path: string): T {
+    const parsed = schema.safeParse(sdkSuccess(result, method, path));
     if (parsed.success) return parsed.data;
     throw new HeadlessThreadError({
       code: "invalid_response",
       message: `OpenWork returned an unexpected payload for ${method} ${path}`,
       method,
       path,
-      status: response.status,
+      ...(result.response === undefined ? {} : { status: result.response.status }),
       body: parsed.error.issues,
     });
   }
 
   async function readMessages(threadId: string, signal?: AbortSignal) {
-    const body = await requestJson(threadMessagesResponseSchema, "GET", threadPath(threadId, "/messages"), undefined, signal);
-    return body.items;
+    const path = `${opencodePath}/session/${encodeURIComponent(threadId)}/message`;
+    return sdkJson(
+      threadMessagesSchema,
+      await opencode.session.messages({ sessionID: threadId }, { signal: requestSignal(signal) }),
+      "GET",
+      path,
+    );
   }
 
   async function getThreadSnapshot(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessThreadSnapshot> {
-    const body = await requestJson(threadSnapshotResponseSchema, "GET", threadPath(threadId, "/snapshot"), undefined, input?.signal);
-    return toSnapshot(body.item);
+    const encodedThreadId = encodeURIComponent(threadId);
+    const sessionPath = `${opencodePath}/session/${encodedThreadId}`;
+    const messagesPath = `${sessionPath}/message`;
+    const todosPath = `${sessionPath}/todo`;
+    const statusPath = `${opencodePath}/session/status`;
+    const [sessionResult, messagesResult, todosResult, statusResult] = await Promise.all([
+      opencode.session.get({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
+      opencode.session.messages({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
+      opencode.session.todo({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
+      opencode.session.status(undefined, { signal: requestSignal(input?.signal) }),
+    ]);
+    const session = sdkJson(sessionSchema, sessionResult, "GET", sessionPath);
+    const messages = sdkJson(threadMessagesSchema, messagesResult, "GET", messagesPath);
+    const todos = sdkJson(threadTodosSchema, todosResult, "GET", todosPath);
+    const statuses = sdkJson(threadStatusesSchema, statusResult, "GET", statusPath);
+    return toSnapshot(threadSnapshotSchema.parse({
+      session,
+      messages,
+      todos,
+      status: statuses[threadId] ?? { type: "idle" },
+    }));
   }
 
   async function createThread(input: CreateThreadInput): Promise<HeadlessThread> {
     const model = input.model ?? options.defaultModel;
-    const body = await requestJson(createThreadResponseSchema, "POST", `${workspacePath}/sessions`, {
-      title: input.title,
-      ...(input.prompt === undefined ? {} : { prompt: input.prompt }),
-      ...(model === undefined ? {} : { providerId: model.providerId, modelId: model.modelId }),
-      ...(model?.variant === undefined ? {} : { variant: model.variant }),
-    }, input.signal);
-    return toThread(body.item, workspaceId, body.started);
+    const createPath = `${opencodePath}/session`;
+    const prompt = initialPrompt(input.prompt);
+    const session = sdkJson(
+      sessionSchema,
+      await opencode.session.create({ title: createTitle(input.title) }, { signal: requestSignal(input.signal) }),
+      "POST",
+      createPath,
+    );
+    if (prompt !== undefined) {
+      const promptPath = `${opencodePath}/session/${encodeURIComponent(session.id)}/prompt_async`;
+      const result = await opencode.session.promptAsync({
+        sessionID: session.id,
+        parts: [{ type: "text", text: prompt }],
+        ...(model === undefined ? {} : { model: { providerID: model.providerId, modelID: model.modelId } }),
+        ...(model?.variant === undefined ? {} : { variant: model.variant }),
+      }, { signal: requestSignal(input.signal) });
+      sdkSuccess(result, "POST", promptPath);
+    }
+    return toThread(session, workspaceId, prompt !== undefined);
   }
 
   async function sendTurn(threadId: string, input: HeadlessThreadTurnInput): Promise<HeadlessTurnAcceptance> {
@@ -154,12 +231,15 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
     if (input.messageId && messages.some((message) => message.info.id === input.messageId && message.info.role === "user")) {
       return { threadId, acceptedAt: now(), messageCountBefore, messageId: input.messageId, alreadyPresent: true };
     }
-    await send("POST", `${workspacePath}/opencode/session/${encodeURIComponent(threadId)}/prompt_async`, {
+    const path = `${opencodePath}/session/${encodeURIComponent(threadId)}/prompt_async`;
+    const result = await opencode.session.promptAsync({
+      sessionID: threadId,
       parts: [{ type: "text", text: input.prompt }],
       ...(input.messageId === undefined ? {} : { messageID: input.messageId }),
       ...(model === undefined ? {} : { model: { providerID: model.providerId, modelID: model.modelId } }),
       ...(model?.variant === undefined ? {} : { variant: model.variant }),
-    }, input.signal);
+    }, { signal: requestSignal(input.signal) });
+    sdkSuccess(result, "POST", path);
     return { threadId, acceptedAt: now(), messageCountBefore, messageId: input.messageId ?? null, alreadyPresent: false };
   }
 
@@ -231,8 +311,14 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
   }
 
   async function abortThread(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessAbortResult> {
-    const body = await requestJson(abortResponseSchema, "POST", threadPath(threadId, "/abort"), {}, input?.signal);
-    return { threadId, accepted: body.ok };
+    const path = `${opencodePath}/session/${encodeURIComponent(threadId)}/abort`;
+    const accepted = sdkJson(
+      abortResultSchema,
+      await opencode.session.abort({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
+      "POST",
+      path,
+    );
+    return { threadId, accepted };
   }
 
   async function exportTranscript(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessThreadTranscript> {
@@ -240,12 +326,4 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
   }
 
   return { createThread, sendTurn, waitForThread, waitUntilIdle, getThreadSnapshot, abortThread, exportTranscript };
-}
-
-function safeJsonParse(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
 }

--- a/packages/headless-threads/src/wire.ts
+++ b/packages/headless-threads/src/wire.ts
@@ -1,6 +1,6 @@
 /**
- * The wire boundary: schemas for what the OpenWork server already returns on
- * its session routes, plus the mapping into the headless thread types.
+ * The wire boundary: schemas for native OpenCode session payloads, plus the
+ * mapping into the headless thread types.
  *
  * Every schema is permissive about fields it does not name, so an engine or
  * server that grows a field does not break a benchmark run mid-campaign.
@@ -29,7 +29,7 @@ export const threadStatusSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("retry"), attempt: z.number(), message: z.string(), next: z.number() }),
 ]);
 
-const sessionSchema = z
+export const sessionSchema = z
   .object({
     id: z.string(),
     title: z.string().nullish(),
@@ -84,26 +84,16 @@ const todoSchema = z
   })
   .passthrough();
 
-export const createThreadResponseSchema = z.object({
-  item: sessionSchema,
-  started: z.boolean(),
-});
+export const threadMessagesSchema = z.array(messageSchema);
+export const threadTodosSchema = z.array(todoSchema);
+export const threadStatusesSchema = z.record(z.string(), threadStatusSchema);
+export const abortResultSchema = z.boolean();
 
-export const threadSnapshotResponseSchema = z.object({
-  item: z.object({
-    session: sessionSchema,
-    messages: z.array(messageSchema),
-    todos: z.array(todoSchema),
-    status: threadStatusSchema,
-  }),
-});
-
-export const threadMessagesResponseSchema = z.object({
-  items: z.array(messageSchema),
-});
-
-export const abortResponseSchema = z.object({
-  ok: z.boolean(),
+export const threadSnapshotSchema = z.object({
+  session: sessionSchema,
+  messages: threadMessagesSchema,
+  todos: threadTodosSchema,
+  status: threadStatusSchema,
 });
 
 type SessionWire = z.infer<typeof sessionSchema>;
@@ -190,7 +180,7 @@ export function toThread(session: SessionWire, workspaceId: string, started: boo
   };
 }
 
-export function toSnapshot(item: z.infer<typeof threadSnapshotResponseSchema>["item"]): HeadlessThreadSnapshot {
+export function toSnapshot(item: z.infer<typeof threadSnapshotSchema>): HeadlessThreadSnapshot {
   return {
     threadId: item.session.id,
     title: optionalString(item.session.title),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,6 +1223,9 @@ importers:
 
   packages/headless-threads:
     dependencies:
+      '@opencode-ai/sdk':
+        specifier: ^1.18.15
+        version: 1.18.18
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Stack

Stacked on #4190 → #4189 → #4188. Review only commit `0f7589f2` / the diff against `thin/automation-runner-opencode-sdk`.

## Why

`@openwork/headless-threads` is the stable programmatic thread API used by Den Automations and MCP remote-session capabilities. It still called OpenWork’s duplicate session create/messages/snapshot/abort endpoints. This migrates its transport to the official OpenCode SDK through the workspace-scoped proxy while preserving the package’s public API and transcript/wait semantics.

## What changed

- Added `@opencode-ai/sdk` as a direct package dependency (3-line importer-only lockfile change; trusted `xlsx` integrity preserved and frozen install verified).
- Native SDK operations:
  - `session.create`, then optional `session.promptAsync`
  - `session.messages` for admission/idempotency checks
  - parallel `session.get` + `messages` + `todo` + `status` snapshots
  - `session.promptAsync` for turns
  - `session.abort` with native boolean acceptance
- Preserved:
  - client + host bearer headers
  - redirect rejection
  - injected fetch
  - global/per-call/timeout signal merging
  - stable `HeadlessThreadError` fields
  - pre-turn message count and stable message-ID idempotency
  - idle-before-busy wait correctness
  - transcript and public result types
  - old wrapper validation/normalization for title and initial prompt (trim, empty prompt not started, whitespace rejection, 120/100000 limits)
- Removed only obsolete wrapper envelope schemas; raw OpenCode payload validation remains permissive and explicit.
- Updated the remote-session capability’s real HTTP witness to native mounted proxy paths and raw SDK shapes.
- Server wrapper routes remain until all app/plugin consumers migrate.

## Verification

- `pnpm --filter @openwork/headless-threads test` — **36 pass / 0 fail**
- `pnpm --filter @openwork/headless-threads typecheck` — pass
- `pnpm --filter @openwork/headless-threads build` — pass
- `bun ... apps/server/src/headless-threads.e2e.test.ts` — **2 pass / 0 fail**
- Remote-session capability real-wire eval — **1 pass / 0 fail**
- `pnpm install --frozen-lockfile --prefer-offline` — pass; supply-chain policy verified 1718 entries
- Clean full server suite — **757 pass / 8 skip / 1 fail / 1 error**. The sole local failure/error is the baseline bun 1.3.5 inability to resolve `node:sqlite` in `workspace-kv-store.node.test.ts`; file untouched, and hosted parent CI is green on Linux/macOS.
- `git diff --check` — pass

## Coverage added

- create→prompt ordering and native payload casing
- explicitly empty, whitespace-only, oversized, and trimmed title/prompt compatibility
- both worker credentials and optional host token
- redirect protection
- URL-encoded workspace/session IDs
- parallel four-part snapshots and idle fallback
- global + per-call AbortSignal merging and timeout mapping
- stable native error status/message/body/path
- native false abort result
- duplicate stable message ID admission
- remote-session capability create/send/read/scoping over the native wire
