### PR TITLE
refactor(app): list sessions through opencode SDK

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -35,14 +35,6 @@ type CommandParameters = {
   reasoning_effort?: string;
 };
 
-type SessionListParameters = {
-  directory?: string;
-  roots?: boolean;
-  start?: number;
-  search?: string;
-  limit?: number;
-};
-
 type SessionLookupParameters = {
   sessionID: string;
   directory?: string;
@@ -381,31 +373,11 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
   // TODO(2026-04-12): remove the old-server compatibility path here once all
   // OpenWork servers expose the workspace-scoped session read APIs.
   const sessionOverrides = session as any as {
-    list: (parameters?: SessionListParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Session[]>>;
     get: (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Session>>;
     messages: (parameters: SessionMessagesParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Array<{ info: Message; parts: Part[] }>>>;
     todo: (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Todo[]>>;
     promptAsync: (parameters: PromptAsyncParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<{}>>;
     command: (parameters: CommandParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<{}>>;
-  };
-
-  const listOriginal = sessionOverrides.list.bind(session);
-  sessionOverrides.list = (parameters?: SessionListParameters, options?: { throwOnError?: boolean }) => {
-    if (!openworkMount || !openworkSessionClient) {
-      return listOriginal(parameters, options);
-    }
-    const query = new URLSearchParams();
-    if (typeof parameters?.roots === "boolean") query.set("roots", String(parameters.roots));
-    if (typeof parameters?.start === "number") query.set("start", String(parameters.start));
-    if (parameters?.search?.trim()) query.set("search", parameters.search.trim());
-    if (typeof parameters?.limit === "number") query.set("limit", String(parameters.limit));
-    const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions${query.size ? `?${query.toString()}` : ""}`;
-    return wrapOpenworkReadWithFallback(
-      url,
-      async () => (await openworkSessionClient.listSessions(openworkMount.workspaceId, parameters)).items,
-      () => listOriginal(parameters, options),
-      options,
-    );
   };
 
   const getOriginal = sessionOverrides.get.bind(session);

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1587,22 +1587,6 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
         { token, hostToken, method: "DELETE", timeoutMs: timeouts.deleteSession },
       ),
-    listSessions: (
-      workspaceId: string,
-      options?: { roots?: boolean; start?: number; search?: string; limit?: number },
-    ) => {
-      const query = new URLSearchParams();
-      if (typeof options?.roots === "boolean") query.set("roots", String(options.roots));
-      if (typeof options?.start === "number") query.set("start", String(options.start));
-      if (options?.search?.trim()) query.set("search", options.search.trim());
-      if (typeof options?.limit === "number") query.set("limit", String(options.limit));
-      const suffix = query.size ? `?${query.toString()}` : "";
-      return requestJson<{ items: Session[] }>(
-        baseUrl,
-        `/workspace/${encodeURIComponent(workspaceId)}/sessions${suffix}`,
-        { token, hostToken, timeoutMs: timeouts.sessionRead },
-      );
-    },
     getSessionGroups: (workspaceId: string) =>
       requestJson<{ state: OpenworkSessionGroupState; updatedAt: number | null }>(
         baseUrl,

--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -156,7 +156,7 @@ export async function mapRouteWorkspaceLoads<T, R>(
  * the routed workspace left every other workspace's sidebar showing the
  * "No tasks yet." empty state on launch even when it had sessions, because
  * nothing else ever fetched their session lists. Session-list loads are
- * read-only `listSessions` calls, so this does not interact with the
+ * read-only native `session.list` calls, so this does not interact with the
  * workspace-activation serialization from the switching-coherence fix.
  */
 export function planRouteWorkspaceLoads(

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -5,7 +5,9 @@
 
 import type { Session } from "@opencode-ai/sdk/v2/client";
 
+import { createClient, unwrap } from "@/app/lib/opencode";
 import type { OpenworkWorkspaceInfo } from "@/app/lib/openwork-server";
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import type { WorkspaceInfo } from "@/app/lib/desktop-types";
 import type { WorkspaceSessionGroup } from "@/app/types";
 import {
@@ -20,8 +22,7 @@ export type RouteWorkspace = OpenworkWorkspaceInfo & {
 };
 
 /**
- * Sessions as the routes handle them: SDK sessions from
- * openwork-server's listSessions, optionally enriched with run-status
+ * Sessions as the routes handle them: native SDK sessions, optionally enriched with run-status
  * fields that the sidebar probes defensively via getSessionStatus.
  */
 export type RouteSession = Session & {
@@ -30,6 +31,40 @@ export type RouteSession = Session & {
   runStatus?: unknown;
   slug?: string | null;
 };
+
+type RouteSessionListResult =
+  | { data: RouteSession[]; error?: undefined; request: Request; response: Response }
+  | { data?: undefined; error: unknown; request: Request; response: Response };
+type RouteSessionListTransport = (input: {
+  endpoint: ResolvedWorkspaceEndpoint;
+  limit: number;
+}) => Promise<RouteSessionListResult>;
+
+const nativeRouteSessionList: RouteSessionListTransport = async ({ endpoint, limit }) => {
+  const client = createClient(endpoint.opencodeBaseUrl, undefined, {
+    mode: "openwork",
+    token: endpoint.token,
+  });
+  return client.session.list({ limit });
+};
+
+export async function listRouteSessions(
+  endpoint: ResolvedWorkspaceEndpoint,
+  transport: RouteSessionListTransport = nativeRouteSessionList,
+): Promise<RouteSession[]> {
+  const result = await transport({ endpoint, limit: 200 });
+  try {
+    return unwrap(result);
+  } catch (error) {
+    if (error instanceof Error) {
+      Object.assign(error, { status: result.response.status });
+      if (result.error && typeof result.error === "object" && "code" in result.error && typeof result.error.code === "string") {
+        Object.assign(error, { code: result.error.code });
+      }
+    }
+    throw error;
+  }
+}
 
 export function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
   return {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -49,6 +49,7 @@ import {
   downloadWorkspaceJson,
   getSessionStatus,
   isActiveSessionStatus,
+  listRouteSessions,
   mapDesktopWorkspace,
   mergeRouteWorkspaces,
   orderRouteWorkspaces,
@@ -1510,15 +1511,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           }
           try {
             const response = await readRouteSessionsWithRetry({
-              load: () => endpoint.client.listSessions(endpoint.workspaceId, { limit: 200 }),
+              load: () => listRouteSessions(endpoint),
               retryDelaysMs: [250, 750, 1_500],
             });
             const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
             const items = workspaceRoot && !endpoint.isRemote
-              ? (response.items ?? []).filter((session) =>
+              ? response.filter((session) =>
                   normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
                 )
-              : (response.items ?? []);
+              : response;
             return {
               workspaceId: workspace.id,
               sessions: items,

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -58,6 +58,7 @@ import {
 import {
   classifyRouteSessionReadError,
   describeRouteError,
+  listRouteSessions,
   mapDesktopWorkspace,
   refreshRouteWorkspaceListState,
   stabilizeRouteWorkspaceOrder,
@@ -342,8 +343,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           }));
         }
         try {
-          const response = await endpoint.client.listSessions(endpoint.workspaceId, { limit: 200 });
-          const fetchedItems = response.items ?? [];
+          const fetchedItems = await listRouteSessions(endpoint);
           const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
           const items = workspaceRoot && !isRemoteOpenworkWorkspace
             ? fetchedItems.filter((session) =>

--- a/apps/app/tests/route-session-list.test.ts
+++ b/apps/app/tests/route-session-list.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
+import { listRouteSessions, readRouteSessionsWithRetry } from "../src/react-app/shell/route-workspaces";
+
+describe("workspace route native session lists", () => {
+  test("loads a bare session array through the local native transport input", async () => {
+    const endpoint = resolveWorkspaceEndpoint({
+      id: "local workspace",
+      workspaceType: "local",
+    }, {
+      baseUrl: "https://local.example.test",
+      token: "local-token",
+    });
+    if (!endpoint) throw new Error("Expected a local endpoint");
+
+    const inputs: unknown[] = [];
+
+    await expect(listRouteSessions(endpoint, async (input) => {
+      inputs.push(input);
+      return {
+        data: [{ id: "ses_local", directory: "/tmp/local" }],
+        request: new Request(`${endpoint.opencodeBaseUrl}/session?limit=200`),
+        response: Response.json([{ id: "ses_local", directory: "/tmp/local" }]),
+      };
+    })).resolves.toEqual([
+      { id: "ses_local", directory: "/tmp/local" },
+    ]);
+    expect(inputs).toEqual([{ endpoint, limit: 200 }]);
+    expect(endpoint.opencodeBaseUrl).toBe("https://local.example.test/workspace/local%20workspace/opencode");
+    expect(endpoint.token).toBe("local-token");
+  });
+
+  test("retries a remote native list failure on the remote endpoint and token", async () => {
+    const endpoint = resolveWorkspaceEndpoint({
+      id: "rem_ui-id",
+      workspaceType: "remote",
+      baseUrl: "https://remote.example.test/worker",
+      openworkToken: "remote-token",
+      openworkWorkspaceId: "server/id",
+    }, {
+      baseUrl: "https://local.example.test",
+      token: "local-token",
+    });
+    if (!endpoint) throw new Error("Expected a remote endpoint");
+
+    const inputs: unknown[] = [];
+    const waits: number[] = [];
+
+    await expect(readRouteSessionsWithRetry({
+      load: () => listRouteSessions(endpoint, async (input) => {
+        inputs.push(input);
+        const response = inputs.length === 1
+          ? Response.json({ code: "opencode_engine_unreachable", message: "engine starting" }, { status: 503 })
+          : Response.json([{ id: "ses_remote", directory: "/workspace/remote" }]);
+        return inputs.length === 1
+          ? {
+              error: { code: "opencode_engine_unreachable", message: "engine starting" },
+              request: new Request(`${endpoint.opencodeBaseUrl}/session?limit=200`),
+              response,
+            }
+          : {
+              data: [{ id: "ses_remote", directory: "/workspace/remote" }],
+              request: new Request(`${endpoint.opencodeBaseUrl}/session?limit=200`),
+              response,
+            };
+      }),
+      retryDelaysMs: [250],
+      wait: async (delayMs) => { waits.push(delayMs); },
+    })).resolves.toEqual([{ id: "ses_remote", directory: "/workspace/remote" }]);
+    expect(waits).toEqual([250]);
+    expect(inputs).toEqual([
+      { endpoint, limit: 200 },
+      { endpoint, limit: 200 },
+    ]);
+    expect(endpoint.opencodeBaseUrl).toBe("https://remote.example.test/worker/workspace/server%2Fid/opencode");
+    expect(endpoint.token).toBe("remote-token");
+  });
+});

--- a/apps/app/tests/workspace-endpoint.test.ts
+++ b/apps/app/tests/workspace-endpoint.test.ts
@@ -19,6 +19,8 @@ describe("workspace endpoint resolution", () => {
     expect(endpoint?.baseUrl).toBe("http://127.0.0.1:4096");
     expect(endpoint?.isRemote).toBe(false);
     expect(endpoint?.mountedBaseUrl).toBe("http://127.0.0.1:4096/workspace/ws_local");
+    expect(endpoint?.opencodeBaseUrl).toBe("http://127.0.0.1:4096/workspace/ws_local/opencode");
+    expect(endpoint?.token).toBe("local-token");
   });
 
   test("remote workspaces use the owning worker URL and server-side workspace id", () => {
@@ -40,6 +42,8 @@ describe("workspace endpoint resolution", () => {
     expect(endpoint?.baseUrl).toBe("https://worker.example.test");
     expect(endpoint?.isRemote).toBe(true);
     expect(endpoint?.mountedBaseUrl).toBe("https://worker.example.test/workspace/server-workspace-b");
+    expect(endpoint?.opencodeBaseUrl).toBe("https://worker.example.test/workspace/server-workspace-b/opencode");
+    expect(endpoint?.token).toBe("remote-token");
   });
 
   test("remote workspace ids fall back to stripping rem_ when no explicit server id exists", () => {


### PR DESCRIPTION
## Stack

Stacked on #4191 → #4190 → #4189 → #4188. Review only commit `ec4d8bf7` / the diff against `thin/headless-threads-opencode-sdk`.

## Why

The app still replaced the SDK’s native `session.list` with an OpenWork wrapper endpoint and separately called `OpenworkServerClient.listSessions` in both route loaders. This removes that duplication while leaving get/messages/todo/snapshot/delete/abort for the next isolated PR.

## What changed

- Removed the custom `session.list` override and old-server fallback from `app/lib/opencode.ts`.
- Removed `OpenworkServerClient.listSessions`; no production callers remain.
- Added one `listRouteSessions` helper that:
  - uses `endpoint.opencodeBaseUrl` from the existing workspace endpoint source of truth
  - authenticates with the resolved local/remote OpenWork token
  - calls native SDK `session.list({limit: 200})`
  - preserves HTTP status/error code metadata used by retry and remote diagnostics
- Migrated both loaders:
  - background sidebar workspace loads
  - Settings route multi-workspace loads
- Preserved retries, local directory defense-in-depth filtering, pending-session merge, remote connection diagnostics, and connection-state messaging.
- Tests inject only the transport operation, avoiding Bun’s global SDK module mock leaking across the full suite; production defaults to the native SDK transport.
- Server session routes remain for unmigrated consumers.

## Verification

- Focused route/workspace suite — **21 pass / 0 fail**
- Workspace session load-budget eval — **1 pass / 0 fail**
- `pnpm --filter @openwork/app typecheck` — pass
- `pnpm --filter @openwork/app build` — pass (6704 modules)
- Full app suite — **1066 pass / 5 fail**. The five failures are the existing unrelated global-mock/browser fixtures (Connect inventory, cloud overlay `matchMedia`, provider-auth mock, extensions header `matchMedia`). Before making tests transport-injected, the new list tests added two failures; after the fix, no list tests fail in the full suite. Hosted CI must be green.
- `git diff --check` — pass

## Coverage

- local mounted opencode URL + local token
- remote owning-worker URL, server-side workspace ID, and remote token
- bare native session-array shape
- retry after native 503 with status/code preservation
- endpoint URL/token resolution for local and remote workspaces
- fixed `limit=200` load budget
