### PR TITLE
refactor(app): use opencode SDK for session reads

### DIFF
--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -1,0 +1,102 @@
+import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+
+import { createClient, unwrap, type FieldsResult } from "./opencode";
+import type { OpenworkSessionSnapshot } from "./openwork-server";
+import type { ResolvedWorkspaceEndpoint } from "./workspace-endpoint";
+
+type NativeSessionEndpoint = Pick<ResolvedWorkspaceEndpoint, "opencodeBaseUrl" | "token">;
+type RequestOptions = { signal?: AbortSignal };
+
+export type NativeSessionOperations = {
+  get: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<Session>>;
+  messages: (sessionId: string, limit: number | undefined, options?: RequestOptions) => Promise<FieldsResult<Array<{ info: Message; parts: Part[] }>>>;
+  todo: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<Todo[]>>;
+  status: (options?: RequestOptions) => Promise<FieldsResult<Record<string, SessionStatus>>>;
+  delete: (sessionId: string, options?: RequestOptions) => Promise<FieldsResult<boolean>>;
+};
+
+export type NativeSessionDependencies = {
+  createOperations?: (endpoint: NativeSessionEndpoint) => NativeSessionOperations;
+};
+
+function createNativeOperations(endpoint: NativeSessionEndpoint): NativeSessionOperations {
+  const client = createClient(endpoint.opencodeBaseUrl, undefined, { mode: "openwork", token: endpoint.token });
+  return {
+    get: (sessionId, options) => client.session.get({ sessionID: sessionId }, options),
+    messages: (sessionId, limit, options) => client.session.messages({ sessionID: sessionId, limit }, options),
+    todo: (sessionId, options) => client.session.todo({ sessionID: sessionId }, options),
+    status: (options) => client.session.status(undefined, options),
+    delete: (sessionId, options) => client.session.delete({ sessionID: sessionId }, options),
+  };
+}
+
+function sessionOperations(endpoint: NativeSessionEndpoint, dependencies?: NativeSessionDependencies) {
+  return (dependencies?.createOperations ?? createNativeOperations)(endpoint);
+}
+
+function unwrapSessionResult<T>(result: FieldsResult<T>, notFoundCode?: string): NonNullable<T> {
+  try {
+    return unwrap(result);
+  } catch (error) {
+    if (error instanceof Error) {
+      Object.assign(error, { status: result.response.status });
+      const code = result.error && typeof result.error === "object" && "code" in result.error && typeof result.error.code === "string"
+        ? result.error.code
+        : result.response.status === 404
+          ? notFoundCode
+          : undefined;
+      if (code) Object.assign(error, { code });
+    }
+    throw error;
+  }
+}
+
+export async function getNativeSession(
+  endpoint: NativeSessionEndpoint,
+  sessionId: string,
+  options?: RequestOptions,
+  dependencies?: NativeSessionDependencies,
+) {
+  const result = await sessionOperations(endpoint, dependencies).get(sessionId, options);
+  return unwrapSessionResult(result, "session_not_found");
+}
+
+export async function getNativeSessionMessages(
+  endpoint: NativeSessionEndpoint,
+  sessionId: string,
+  options?: RequestOptions & { limit?: number },
+  dependencies?: NativeSessionDependencies,
+) {
+  const result = await sessionOperations(endpoint, dependencies).messages(sessionId, options?.limit, options);
+  return unwrapSessionResult(result, "session_not_found");
+}
+
+export async function composeNativeSessionSnapshot(
+  endpoint: NativeSessionEndpoint,
+  sessionId: string,
+  options?: RequestOptions & { limit?: number },
+  dependencies?: NativeSessionDependencies,
+): Promise<OpenworkSessionSnapshot> {
+  const operations = sessionOperations(endpoint, dependencies);
+  const [sessionResult, messagesResult, todoResult, statusResult] = await Promise.all([
+    operations.get(sessionId, options),
+    operations.messages(sessionId, options?.limit, options),
+    operations.todo(sessionId, options),
+    operations.status(options),
+  ]);
+  const session = unwrapSessionResult(sessionResult, "session_not_found");
+  const messages = unwrapSessionResult(messagesResult, "session_not_found");
+  const todos = unwrapSessionResult(todoResult, "session_not_found");
+  const statuses = unwrapSessionResult(statusResult);
+  return { session, messages, todos, status: statuses[sessionId] ?? { type: "idle" } };
+}
+
+export async function deleteNativeSession(
+  endpoint: NativeSessionEndpoint,
+  sessionId: string,
+  options?: RequestOptions,
+  dependencies?: NativeSessionDependencies,
+) {
+  const result = await sessionOperations(endpoint, dependencies).delete(sessionId, options);
+  return unwrapSessionResult(result, "session_not_found");
+}

--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -1,10 +1,9 @@
-import { createOpencodeClient, type Message, type Part, type Session, type Todo } from "@opencode-ai/sdk/v2/client";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
 import { desktopFetch } from "./desktop";
-import { createOpenworkServerClient, OpenworkServerError } from "./openwork-server";
 import { isDesktopRuntime } from "./runtime-env";
 
-type FieldsResult<T> =
+export type FieldsResult<T> =
   | ({ data: T; error?: undefined } & { request: Request; response: Response })
   | ({ data?: undefined; error: unknown } & { request: Request; response: Response });
 
@@ -33,17 +32,6 @@ type CommandParameters = {
   variant?: string;
   parts?: unknown[];
   reasoning_effort?: string;
-};
-
-type SessionLookupParameters = {
-  sessionID: string;
-  directory?: string;
-};
-
-type SessionMessagesParameters = {
-  sessionID: string;
-  directory?: string;
-  limit?: number;
 };
 
 export type OpencodeAuth = {
@@ -143,67 +131,6 @@ function resolveOpenworkWorkspaceMount(baseUrl: string): { baseUrl: string; work
     };
   } catch {
     return null;
-  }
-}
-
-function createSyntheticResult<T>(
-  url: string,
-  method: string,
-  input:
-    | { ok: true; data: T; status?: number }
-    | { ok: false; error: unknown; status?: number },
-): FieldsResult<T> {
-  const request = new Request(url, { method });
-  const response = new Response(input.ok ? JSON.stringify(input.data) : null, {
-    status: input.status ?? (input.ok ? 200 : 500),
-    headers: { "Content-Type": "application/json" },
-  });
-  if (input.ok) {
-    return { data: input.data, request, response };
-  }
-  return { error: input.error, request, response };
-}
-
-async function wrapOpenworkRead<T>(
-  url: string,
-  read: () => Promise<T>,
-  options?: { throwOnError?: boolean },
-): Promise<FieldsResult<T>> {
-  try {
-    return createSyntheticResult(url, "GET", { ok: true, data: await read() });
-  } catch (error) {
-    if (options?.throwOnError) throw error;
-    return createSyntheticResult(url, "GET", {
-      ok: false,
-      error,
-      status: error instanceof OpenworkServerError ? error.status : 500,
-    });
-  }
-}
-
-function shouldFallbackToLegacySessionRead(error: unknown): boolean {
-  if (!(error instanceof OpenworkServerError)) return false;
-  return error.status === 404 || error.status === 405 || error.status === 501;
-}
-
-async function wrapOpenworkReadWithFallback<T>(
-  url: string,
-  read: () => Promise<T>,
-  fallback: () => Promise<FieldsResult<T>>,
-  options?: { throwOnError?: boolean },
-): Promise<FieldsResult<T>> {
-  try {
-    return createSyntheticResult(url, "GET", { ok: true, data: await read() });
-  } catch (error) {
-    if (!shouldFallbackToLegacySessionRead(error)) {
-      if (options?.throwOnError) throw error;
-      return createSyntheticResult(url, "GET", {
-        ok: false,
-        error,
-        status: error instanceof OpenworkServerError ? error.status : 500,
-      });
-    }
-    return fallback();
   }
 }
 
@@ -366,65 +293,9 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
 
   const session = client.session as typeof client.session;
   const openworkMount = auth?.mode === "openwork" ? resolveOpenworkWorkspaceMount(baseUrl) : null;
-  const openworkSessionClient =
-    openworkMount && auth?.token
-      ? createOpenworkServerClient({ baseUrl: openworkMount.baseUrl, token: auth.token })
-      : null;
-  // TODO(2026-04-12): remove the old-server compatibility path here once all
-  // OpenWork servers expose the workspace-scoped session read APIs.
   const sessionOverrides = session as any as {
-    get: (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Session>>;
-    messages: (parameters: SessionMessagesParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Array<{ info: Message; parts: Part[] }>>>;
-    todo: (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<Todo[]>>;
     promptAsync: (parameters: PromptAsyncParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<{}>>;
     command: (parameters: CommandParameters, options?: { throwOnError?: boolean }) => Promise<FieldsResult<{}>>;
-  };
-
-  const getOriginal = sessionOverrides.get.bind(session);
-  sessionOverrides.get = (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => {
-    if (!openworkMount || !openworkSessionClient) {
-      return getOriginal(parameters, options);
-    }
-    const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions/${encodeURIComponent(parameters.sessionID)}`;
-    return wrapOpenworkReadWithFallback(
-      url,
-      async () => (await openworkSessionClient.getSession(openworkMount.workspaceId, parameters.sessionID)).item,
-      () => getOriginal(parameters, options),
-      options,
-    );
-  };
-
-  const messagesOriginal = sessionOverrides.messages.bind(session);
-  sessionOverrides.messages = (parameters: SessionMessagesParameters, options?: { throwOnError?: boolean }) => {
-    if (!openworkMount || !openworkSessionClient) {
-      return messagesOriginal(parameters, options);
-    }
-    const query = new URLSearchParams();
-    if (typeof parameters.limit === "number") query.set("limit", String(parameters.limit));
-    const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions/${encodeURIComponent(parameters.sessionID)}/messages${query.size ? `?${query.toString()}` : ""}`;
-    return wrapOpenworkReadWithFallback(
-      url,
-      async () =>
-        (await openworkSessionClient.getSessionMessages(openworkMount.workspaceId, parameters.sessionID, {
-          limit: parameters.limit,
-        })).items,
-      () => messagesOriginal(parameters, options),
-      options,
-    );
-  };
-
-  const todoOriginal = sessionOverrides.todo.bind(session);
-  sessionOverrides.todo = (parameters: SessionLookupParameters, options?: { throwOnError?: boolean }) => {
-    if (!openworkMount || !openworkSessionClient) {
-      return todoOriginal(parameters, options);
-    }
-    const url = `${openworkMount.baseUrl}/workspace/${encodeURIComponent(openworkMount.workspaceId)}/sessions/${encodeURIComponent(parameters.sessionID)}/snapshot`;
-    return wrapOpenworkReadWithFallback(
-      url,
-      async () => (await openworkSessionClient.getSessionSnapshot(openworkMount.workspaceId, parameters.sessionID)).item.todos,
-      () => todoOriginal(parameters, options),
-      options,
-    );
   };
 
   const promptAsyncOriginal = sessionOverrides.promptAsync.bind(session);

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1476,7 +1476,6 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     listWorkspaces: 8_000,
     activateWorkspace: 10_000,
     deleteWorkspace: 10_000,
-    deleteSession: 12_000,
     sessionRead: 12_000,
     status: 6_000,
     diagnostics: AGENT_CONTEXT_DIAGNOSTICS_REQUEST_TIMEOUT_MS,
@@ -1581,12 +1580,6 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         `/workspaces/${encodeURIComponent(workspaceId)}`,
         { token, hostToken, method: "DELETE", timeoutMs: timeouts.deleteWorkspace },
       ),
-    deleteSession: (workspaceId: string, sessionId: string) =>
-      requestJson<{ ok: boolean }>(
-        baseUrl,
-        `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
-        { token, hostToken, method: "DELETE", timeoutMs: timeouts.deleteSession },
-      ),
     getSessionGroups: (workspaceId: string) =>
       requestJson<{ state: OpenworkSessionGroupState; updatedAt: number | null }>(
         baseUrl,
@@ -1635,32 +1628,6 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/session-groups/events${query}`,
         { token, hostToken },
-      );
-    },
-    getSession: (workspaceId: string, sessionId: string) =>
-      requestJson<{ item: Session }>(
-        baseUrl,
-        `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
-        { token, hostToken, timeoutMs: timeouts.sessionRead },
-      ),
-    getSessionMessages: (workspaceId: string, sessionId: string, options?: { limit?: number }) => {
-      const query = new URLSearchParams();
-      if (typeof options?.limit === "number") query.set("limit", String(options.limit));
-      const suffix = query.size ? `?${query.toString()}` : "";
-      return requestJson<{ items: OpenworkSessionMessage[] }>(
-        baseUrl,
-        `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/messages${suffix}`,
-        { token, hostToken, timeoutMs: timeouts.sessionRead },
-      );
-    },
-    getSessionSnapshot: (workspaceId: string, sessionId: string, options?: { limit?: number }) => {
-      const query = new URLSearchParams();
-      if (typeof options?.limit === "number") query.set("limit", String(options.limit));
-      const suffix = query.size ? `?${query.toString()}` : "";
-      return requestJson<{ item: OpenworkSessionSnapshot }>(
-        baseUrl,
-        `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/snapshot${suffix}`,
-        { token, hostToken, timeoutMs: timeouts.sessionRead },
       );
     },
     exportWorkspace: (

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1313,8 +1313,9 @@ export function SessionPage(props: SessionPageProps) {
   ) : activeSidePanel === "voice" ? (
     <VoicePanel
       client={props.openworkServerClient}
-      workspaceId={props.runtimeWorkspaceId}
       sessionId={props.selectedSessionId}
+      opencodeBaseUrl={reactSessionBaseUrl}
+      openworkToken={reactSessionToken}
       onClose={closeRightPane}
     />
   ) : activeSidePanel === "panel" ? (

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -3,7 +3,9 @@ import { useCallback, useMemo } from "react";
 
 import type { createClient } from "../../../../app/lib/opencode";
 import type { OpenworkServerClient, OpenworkWorkspaceInfo } from "../../../../app/lib/openwork-server";
+import { deleteNativeSession } from "../../../../app/lib/opencode-session-native";
 import { setSessionArchived } from "../../../../app/lib/opencode-session";
+import type { ResolvedWorkspaceEndpoint } from "../../../../app/lib/workspace-endpoint";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useSessionManagementStore } from "../sidebar/session-management-store";
@@ -19,7 +21,7 @@ type SessionLike = {
 };
 
 type SessionControlWorkspace = OpenworkWorkspaceInfo & {
-  displayNameResolved?: string;
+  displayNameResolved: string;
 };
 
 type UseSessionControlActionsInput = {
@@ -31,6 +33,7 @@ type UseSessionControlActionsInput = {
   canCreateTask: boolean;
   openworkClient: OpenworkServerClient | null;
   opencodeClient: ReturnType<typeof createClient> | null;
+  endpointForWorkspace: (workspace: SessionControlWorkspace | null | undefined) => ResolvedWorkspaceEndpoint | null;
   navigateToSession: (sessionId: string) => void;
   navigateToSessionRoot: () => void;
   createTaskInWorkspace: (workspaceId: string) => Promise<string | null> | string | null;
@@ -69,6 +72,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const {
     canCreateTask,
     createTaskInWorkspace,
+    endpointForWorkspace,
     navigateToSession,
     navigateToSessionRoot,
     openModelPicker,
@@ -210,14 +214,16 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
 
       const targetWorkspace = findSessionWorkspace(workspaces, sessionsByWorkspaceId, sessionId);
       if (!targetWorkspace) return { ok: false, error: "Session was not found in the current session list" };
-      await openworkClient.deleteSession(targetWorkspace.id, sessionId);
+      const endpoint = endpointForWorkspace(targetWorkspace);
+      if (!endpoint) return { ok: false, error: "Workspace runtime is not connected" };
+      await deleteNativeSession(endpoint, sessionId);
       if (selectedSessionId === sessionId) {
         navigateToSessionRoot();
       }
       await refreshRouteState();
       return { ok: true, sessionId, deleted: true };
     },
-  }), [navigateToSessionRoot, openworkClient, refreshRouteState, selectedSessionId, sessionsByWorkspaceId, workspaces]);
+  }), [endpointForWorkspace, navigateToSessionRoot, openworkClient, refreshRouteState, selectedSessionId, sessionsByWorkspaceId, workspaces]);
   useControlAction(deleteSessionControlAction);
 
   const modelPickerControlAction = useMemo<OpenworkControlAction>(() => ({

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -9,6 +9,7 @@ import { toast } from "@/components/ui/sonner";
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
+import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
 import { setThemeMode } from "@/app/theme";
 import { t } from "@/i18n";
 import type { ComposerSettingsSection } from "@/react-app/domains/settings/library";
@@ -1019,9 +1020,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
   );
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const startedAt = Date.now();
-      const item = (await props.client.getSessionSnapshot(props.workspaceId, props.sessionId, { limit: 140 })).item;
+      const item = await composeNativeSessionSnapshot(
+        { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
+        props.sessionId,
+        { limit: 140, signal },
+      );
       markSessionSnapshotFetchStart(item, startedAt);
       return item;
     },

--- a/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
+++ b/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
@@ -5,6 +5,7 @@ import { PaperGrainGradient } from "@openwork/ui/react";
 
 import { desktopFetch } from "@/app/lib/desktop";
 import type { OpenworkServerClient, OpenworkSessionMessage } from "@/app/lib/openwork-server";
+import { getNativeSessionMessages } from "@/app/lib/opencode-session-native";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group";
@@ -37,8 +38,9 @@ type VoiceRuntimeSnapshot = {
 
 type VoicePanelProps = {
   client: OpenworkServerClient | null;
-  workspaceId: string | null;
   sessionId: string | null;
+  opencodeBaseUrl: string;
+  openworkToken: string;
   onClose: () => void;
 };
 
@@ -200,11 +202,11 @@ function buildVoiceSessionContext(messages: OpenworkSessionMessage[]) {
     .slice(0, 6_000);
 }
 
-async function loadVoiceSessionContext(client: OpenworkServerClient, workspaceId: string | null, sessionId: string | null) {
-  if (!workspaceId || !sessionId) return "";
+async function loadVoiceSessionContext(opencodeBaseUrl: string, openworkToken: string, sessionId: string | null) {
+  if (!opencodeBaseUrl || !sessionId) return "";
   try {
-    const response = await client.getSessionMessages(workspaceId, sessionId, { limit: 40 });
-    return buildVoiceSessionContext(response.items);
+    const messages = await getNativeSessionMessages({ opencodeBaseUrl, token: openworkToken }, sessionId, { limit: 40 });
+    return buildVoiceSessionContext(messages);
   } catch {
     return "";
   }
@@ -533,7 +535,7 @@ export function VoicePanel(props: VoicePanelProps) {
 
     disconnectRealtime(true);
     setRuntimeStatus("connecting", "Minting Realtime session...");
-    const sessionContext = await loadVoiceSessionContext(client, props.workspaceId, props.sessionId);
+    const sessionContext = await loadVoiceSessionContext(props.opencodeBaseUrl, props.openworkToken, props.sessionId);
     const realtimeSession = await client.createVoiceRealtimeSession({ sessionContext });
 
     const peer = new RTCPeerConnection();
@@ -594,7 +596,16 @@ export function VoicePanel(props: VoicePanelProps) {
     setRuntimeStatus("listening", audioInput ? undefined : "Connected. Send a typed voice command.");
     addEntry("system", `Realtime connected with ${realtimeSession.model} and ${realtimeSession.tools.length} OpenWork tools.`);
     recordInspectorEvent("voice.connected", { sessionId: props.sessionId, model: realtimeSession.model });
-  }, [addEntry, disconnectRealtime, handleRealtimeMessage, props.client, props.sessionId, props.workspaceId, setRuntimeStatus]);
+  }, [
+    addEntry,
+    disconnectRealtime,
+    handleRealtimeMessage,
+    props.client,
+    props.opencodeBaseUrl,
+    props.openworkToken,
+    props.sessionId,
+    setRuntimeStatus,
+  ]);
 
   const startVoice = useCallback(async () => {
     try {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -23,6 +23,7 @@ import { downloadTextAsFile } from "@/app/lib/download";
 import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
+import { deleteNativeSession, getNativeSessionMessages } from "@/app/lib/opencode-session-native";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
 import {
   buildOpenworkWorkspaceBaseUrl,
@@ -2444,6 +2445,7 @@ export function SessionRoute() {
     canCreateTask,
     openworkClient: client,
     opencodeClient,
+    endpointForWorkspace,
     navigateToSession: navigateToSessionForControl,
     navigateToSessionRoot: navigateToSessionRootForControl,
     createTaskInWorkspace: handleCreateTaskInWorkspace,
@@ -2682,9 +2684,13 @@ export function SessionRoute() {
     // Cap the transcript fetch to keep multi-workspace scans fast; matches in
     // anything older than the most recent 400 messages are traded away for
     // responsiveness.
-    return async (workspaceId: string, sessionId: string) =>
-      (await client.getSessionMessages(workspaceId, sessionId, { limit: 400 })).items;
-  }, [client]);
+    return async (workspaceId: string, sessionId: string) => {
+      const workspace = workspaces.find((item) => item.id === workspaceId);
+      const endpoint = endpointForWorkspace(workspace);
+      if (!endpoint) throw new Error("Workspace runtime is not connected.");
+      return getNativeSessionMessages(endpoint, sessionId, { limit: 400 });
+    };
+  }, [client, endpointForWorkspace, workspaces]);
 
   const sessionSearchPaletteItem = useMemo<PaletteItem>(() => ({
     id: "session-search.open",
@@ -3422,7 +3428,7 @@ export function SessionRoute() {
           ? async (sessionId) => {
               const endpoint = endpointForWorkspace(selectedWorkspace);
               if (!endpoint) return;
-              await endpoint.client.deleteSession(endpoint.workspaceId, sessionId);
+              await deleteNativeSession(endpoint, sessionId);
               if (selectedSessionId === sessionId) {
                 navigateToWorkspaceSession(selectedWorkspaceId);
               }

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -23,6 +23,7 @@ import {
   type WorkspaceList,
 } from "@/app/lib/desktop";
 import { createClient } from "@/app/lib/opencode";
+import { getNativeSession } from "@/app/lib/opencode-session-native";
 import { createOpenworkServerClient, type OpenworkServerClient } from "@/app/lib/openwork-server";
 import { readDenBootstrapConfig } from "@/app/lib/den";
 import { isDesktopRuntime } from "@/app/lib/runtime-env";
@@ -1055,12 +1056,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
         if (cancelled) return;
         try {
-          const response = await selectedWorkspaceEndpoint.client.getSession(
-            selectedWorkspaceEndpoint.workspaceId,
-            selectedSessionId,
-          );
+          const session = await getNativeSession(selectedWorkspaceEndpoint, selectedSessionId);
           if (cancelled) return;
-          if (response.item.id !== selectedSessionId) {
+          if (session.id !== selectedSessionId) {
             setModernRouteSessionResolution({
               key: modernRouteSessionLoadKey,
               status: "error",
@@ -1075,7 +1073,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
               return current;
             }
             hydratedRouteSessionIdsRef.current[selectedWorkspaceId] = selectedSessionId;
-            const nextItems = mergeWorkspaceRouteSession(currentItems, response.item);
+            const nextItems = mergeWorkspaceRouteSession(currentItems, session);
             const next = { ...current, [selectedWorkspaceId]: nextItems };
             sessionsByWorkspaceIdRef.current = next;
             return next;

--- a/apps/app/tests/opencode-session-native.test.ts
+++ b/apps/app/tests/opencode-session-native.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+
+import type { FieldsResult } from "../src/app/lib/opencode";
+import {
+  composeNativeSessionSnapshot,
+  deleteNativeSession,
+  getNativeSession,
+  getNativeSessionMessages,
+  type NativeSessionOperations,
+} from "../src/app/lib/opencode-session-native";
+
+const endpoint = {
+  opencodeBaseUrl: "https://worker.example/workspace/ws-native/opencode",
+  token: "workspace-token",
+};
+
+const session = {
+  id: "ses_native",
+  projectID: "project-native",
+  directory: "/workspace/native",
+  title: "Native session",
+  version: "1",
+  time: { created: 1, updated: 2 },
+} as Session;
+const messages = [{
+  info: { id: "msg_1", sessionID: session.id, role: "user", time: { created: 1 } } as Message,
+  parts: [{ id: "part_1", sessionID: session.id, messageID: "msg_1", type: "text", text: "hello" } as Part],
+}];
+const todos = [{ id: "todo_1", content: "Ship", status: "pending", priority: "high" }] as Todo[];
+
+function result<T>(data: T, status = 200): FieldsResult<T> {
+  return {
+    data,
+    request: new Request(endpoint.opencodeBaseUrl),
+    response: new Response(null, { status }),
+  };
+}
+
+function failedResult(error: unknown, status: number): FieldsResult<never> {
+  return {
+    error,
+    request: new Request(endpoint.opencodeBaseUrl),
+    response: new Response(null, { status }),
+  };
+}
+
+function operations(overrides: Partial<NativeSessionOperations> = {}): NativeSessionOperations {
+  return {
+    get: async () => result(session),
+    messages: async () => result(messages),
+    todo: async () => result(todos),
+    status: async () => result<Record<string, SessionStatus>>({ [session.id]: { type: "busy" } }),
+    delete: async () => result(true),
+    ...overrides,
+  };
+}
+
+describe("native OpenCode session operations", () => {
+  test("uses the resolved mounted endpoint and its workspace token", async () => {
+    let receivedEndpoint: typeof endpoint | null = null;
+    await getNativeSession(endpoint, session.id, undefined, {
+      createOperations: (target) => {
+        receivedEndpoint = target;
+        return operations();
+      },
+    });
+
+    expect(receivedEndpoint).toEqual(endpoint);
+  });
+
+  test("composes get, messages, todo, and status in parallel with limit and signal", async () => {
+    const calls: string[] = [];
+    const controller = new AbortController();
+    const snapshotPromise = composeNativeSessionSnapshot(endpoint, session.id, {
+      limit: 140,
+      signal: controller.signal,
+    }, {
+      createOperations: () => operations({
+        get: async (_sessionId, options) => {
+          calls.push(options?.signal === controller.signal ? "get" : "bad-get");
+          return result(session);
+        },
+        messages: async (_sessionId, limit, options) => {
+          calls.push(limit === 140 && options?.signal === controller.signal ? "messages" : "bad-messages");
+          return result(messages);
+        },
+        todo: async (_sessionId, options) => {
+          calls.push(options?.signal === controller.signal ? "todo" : "bad-todo");
+          return result(todos);
+        },
+        status: async (options) => {
+          calls.push(options?.signal === controller.signal ? "status" : "bad-status");
+          return result<Record<string, SessionStatus>>({});
+        },
+      }),
+    });
+
+    expect(calls).toEqual(["get", "messages", "todo", "status"]);
+    expect(await snapshotPromise).toEqual({ session, messages, todos, status: { type: "idle" } });
+  });
+
+  test("returns raw SDK shapes for get, messages, and delete", async () => {
+    const dependencies = { createOperations: () => operations({ delete: async () => result(false) }) };
+
+    expect(await getNativeSession(endpoint, session.id, undefined, dependencies)).toBe(session);
+    expect(await getNativeSessionMessages(endpoint, session.id, { limit: 40 }, dependencies)).toBe(messages);
+    expect(await deleteNativeSession(endpoint, session.id, undefined, dependencies)).toBe(false);
+  });
+
+  test("preserves native response status and not-found semantics", async () => {
+    const promise = getNativeSession(endpoint, "ses_missing", undefined, {
+      createOperations: () => operations({
+        get: async () => failedResult({ message: "missing" }, 404),
+      }),
+    });
+
+    try {
+      await promise;
+      throw new Error("Expected native session read to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({ status: 404, code: "session_not_found" });
+    }
+  });
+
+  test("fails the snapshot when any native operation fails", async () => {
+    await expect(composeNativeSessionSnapshot(endpoint, session.id, undefined, {
+      createOperations: () => operations({
+        todo: async () => failedResult({ code: "engine_unavailable" }, 503),
+      }),
+    })).rejects.toMatchObject({ status: 503, code: "engine_unavailable" });
+  });
+});


### PR DESCRIPTION
## Stack

Stacked on #4192 → #4191 → #4190 → #4189 → #4188. Review commit `b34673b5` (plus the parent-forward merge) / diff against `thin/app-native-session-list`.

## Why

After #4192 migrated session lists, the app still overrode native SDK get/messages/todo with wrapper reads and directly called OpenworkServerClient get/messages/snapshot/delete methods. This migrates the remaining app session data plane while leaving server routes and engine-plugin/eval consumers for later PRs.

## What changed

- Removed remaining get/messages/todo wrapper overrides and all old-server read-fallback machinery from `app/lib/opencode.ts`. Prompt/command compatibility handling remains intact.
- Removed app-facing OpenworkServerClient session get/messages/snapshot/delete methods after all app production callers migrated.
- Added `opencode-session-native.ts` with:
  - workspace-endpoint-bound get/messages/delete
  - parallel get/messages/todo/status snapshot composition
  - idle fallback
  - message limit + AbortSignal propagation
  - preserved status/error-code metadata
  - injectable operations for deterministic test isolation
- Migrated:
  - selected route-session hydration
  - session search transcript reads
  - sidebar/control deletion
  - session surface snapshot query
  - voice context transcript reads
- Existing native abort helpers stay unchanged.
- Fixed voice callback dependencies for the new endpoint/token inputs and removed the obsolete workspaceId prop.
- Server wrappers remain until plugin/direct-eval migration is complete.

## Verification

- Native-session/list focused suite — **26 pass / 0 fail**
- Post-parent-merge focused suite — **7 pass / 0 fail**
- Workspace session load-budget eval — **1 pass / 0 fail**
- `pnpm --filter @openwork/app typecheck` — pass
- `pnpm --filter @openwork/app build` — pass (6705 modules)
- Full app suite — **1071 pass / 5 fail**. The five are pre-existing order-dependent global-mock/browser fixture failures; each passes isolated:
  - Connect inventory: 6/6
  - cloud workspace overlay: 24/24
  - provider-auth sync: 7/7
  - extensions sidebar: 3/3
  All branch-specific native-session tests pass in the full suite.
- `git diff --check` — pass

## Coverage

- endpoint/token selection through injected operation factory
- parallel snapshot operations with exact limit/signal
- idle fallback
- raw SDK get/messages/delete shapes, including native false delete result
- native 404 mapped to session_not_found
- component snapshot failure propagation
- route hydration/search/delete/voice call-site type coverage
- stale voice endpoint/token callback dependency prevention
