### PR TITLE
refactor(plugin): use native opencode session routes

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -97,7 +97,10 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
   const workspaceTwo = { id: "ws_2", name: "Archive", displayName: "Archive", path: "/tmp/archive", workspaceType: "remote" };
   const sessionAlpha = { id: "ses_alpha", title: "Alpha planning", time: { created: 100, updated: 300 } };
   const sessionBeta = { id: "ses_beta", title: "Neon backlog", time: { created: 50, updated: 200 } };
-  const sessionArchive = { id: "ses_archive", title: "Archive decisions", time: { created: 10, updated: 100 } };
+  const sessionArchive = { id: "ses_archive", title: "Archive decisions", directory: "/tmp/archive", time: { created: 10, updated: 100 } };
+  // Lives outside every workspace root: reads must refuse to expose it even
+  // though the native engine route happily returns it (cross-workspace leak).
+  const sessionForeign = { id: "ses_foreign", title: "Other tenant secrets", directory: "/tmp/elsewhere", time: { created: 20, updated: 120 } };
 
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -180,6 +183,16 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
       if (url.pathname === "/workspace/ws_1/opencode/session/ses_alpha") return Response.json(sessionAlpha);
       if (url.pathname === "/workspace/ws_1/opencode/session/ses_beta") return Response.json(sessionBeta);
       if (url.pathname === "/workspace/ws_2/opencode/session/ses_archive") return Response.json(sessionArchive);
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_foreign") return Response.json(sessionForeign);
+      if (url.pathname === "/workspace/ws_2/opencode/session/ses_foreign") return Response.json(sessionForeign);
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_foreign/message" || url.pathname === "/workspace/ws_2/opencode/session/ses_foreign/message") {
+        return Response.json([
+          {
+            info: { id: "msg_foreign", role: "assistant", time: { created: 121 } },
+            parts: [{ type: "text", text: "Cross-tenant transcript that must never leak." }],
+          },
+        ]);
+      }
 
       if (url.pathname === "/workspace/ws_1/opencode/session/ses_alpha/message") {
         return Response.json([
@@ -383,6 +396,20 @@ describe("OpenWorkExtensionsPreview session tools", () => {
 
     expect(parsed.result.sessionId).toBe("ses_archive");
     expect(parsed.result.messages.at(-1)?.text).toContain("archive importer");
+  });
+
+  test("refuses to expose a session that lives outside the requested workspace", async () => {
+    startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+
+    const output = await plugin.tool.openwork_query.execute({
+      id: "session.read",
+      args: { sessionId: "ses_foreign", count: 2 },
+    });
+
+    expect(output).not.toContain("Other tenant secrets");
+    expect(output).not.toContain("Cross-tenant transcript");
+    expect(output).toContain("was not found");
   });
 
   test("searches past chat transcript text and prefers the user's matching message", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -89,11 +89,12 @@ async function transformedSystem(plugin: Awaited<ReturnType<typeof OpenWorkExten
   return output.system.join("\n");
 }
 
-function startFakeOpenWorkServer() {
+function startFakeOpenWorkServer(options: { failPromptText?: string; failSessionListWorkspaceId?: string } = {}) {
   const requests: Array<{ pathname: string; search: string; authorization: string | null; method: string; body?: unknown }> = [];
+  let createdCount = 0;
 
   const workspaceOne = { id: "ws_1", name: "Main", path: "/tmp/main" };
-  const workspaceTwo = { id: "ws_2", name: "Archive", displayName: "Archive", path: "/tmp/archive" };
+  const workspaceTwo = { id: "ws_2", name: "Archive", displayName: "Archive", path: "/tmp/archive", workspaceType: "remote" };
   const sessionAlpha = { id: "ses_alpha", title: "Alpha planning", time: { created: 100, updated: 300 } };
   const sessionBeta = { id: "ses_beta", title: "Neon backlog", time: { created: 50, updated: 200 } };
   const sessionArchive = { id: "ses_archive", title: "Archive decisions", time: { created: 10, updated: 100 } };
@@ -154,58 +155,68 @@ function startFakeOpenWorkServer() {
         return Response.json({ items: [workspaceOne, workspaceTwo], workspaces: [workspaceOne, workspaceTwo] });
       }
 
-      if (url.pathname === "/workspace/ws_1/sessions") {
-        return Response.json({ items: [sessionAlpha, sessionBeta] });
+      if (url.pathname === "/workspace/ws_1/opencode/session") {
+        if (options.failSessionListWorkspaceId === "ws_1") {
+          return Response.json({ message: "Remote worker unavailable" }, { status: 503 });
+        }
+        return Response.json([sessionAlpha, sessionBeta]);
       }
-      if (url.pathname === "/workspace/ws_2/sessions") {
+      if (url.pathname === "/workspace/ws_2/opencode/session") {
         if (request.method === "POST") {
-          const body = z.object({ title: z.string(), prompt: z.string() }).parse(record.body);
+          const body = z.object({ title: z.string() }).strict().parse(record.body);
+          createdCount += 1;
           return Response.json({
-            item: {
-              id: `ses_created_${requests.filter((entry) => entry.pathname === url.pathname && entry.method === "POST").length}`,
-              title: body.title,
-              time: { created: 400, updated: 400 },
-            },
-            started: true,
+            id: `ses_created_${createdCount}`,
+            title: body.title,
+            time: { created: 400, updated: 400 },
           }, { status: 201 });
         }
-        return Response.json({ items: [sessionArchive] });
+        if (options.failSessionListWorkspaceId === "ws_2") {
+          return Response.json({ message: "Remote worker unavailable" }, { status: 503 });
+        }
+        return Response.json([sessionArchive]);
       }
 
-      if (url.pathname === "/workspace/ws_1/sessions/ses_alpha") return Response.json({ item: sessionAlpha });
-      if (url.pathname === "/workspace/ws_1/sessions/ses_beta") return Response.json({ item: sessionBeta });
-      if (url.pathname === "/workspace/ws_2/sessions/ses_archive") return Response.json({ item: sessionArchive });
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_alpha") return Response.json(sessionAlpha);
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_beta") return Response.json(sessionBeta);
+      if (url.pathname === "/workspace/ws_2/opencode/session/ses_archive") return Response.json(sessionArchive);
 
-      if (url.pathname === "/workspace/ws_1/sessions/ses_alpha/messages") {
-        return Response.json({
-          items: [
-            {
-              info: { id: "msg_assistant", role: "assistant", time: { created: 301 } },
-              parts: [{ type: "text", text: "The launch checklist can wait." }],
-            },
-            {
-              info: { id: "msg_user", role: "user", time: { created: 302 } },
-              parts: [{ type: "text", text: "Please remember the raven launch checklist." }],
-            },
-          ],
-        });
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_alpha/message") {
+        return Response.json([
+          {
+            info: { id: "msg_assistant", role: "assistant", time: { created: 301 } },
+            parts: [{ type: "text", text: "The launch checklist can wait." }],
+          },
+          {
+            info: { id: "msg_user", role: "user", time: { created: 302 } },
+            parts: [{ type: "text", text: "Please remember the raven launch checklist." }],
+          },
+        ]);
       }
-      if (url.pathname === "/workspace/ws_1/sessions/ses_beta/messages") {
-        return Response.json({ items: [] });
+      if (url.pathname === "/workspace/ws_1/opencode/session/ses_beta/message") {
+        return Response.json([]);
       }
-      if (url.pathname === "/workspace/ws_2/sessions/ses_archive/messages") {
-        return Response.json({
-          items: [
-            {
-              info: { id: "msg_old", role: "assistant", time: { created: 101 } },
-              parts: [{ type: "text", text: "Ignored implementation note", ignored: true }],
-            },
-            {
-              info: { id: "msg_latest", role: "assistant", time: { created: 102 } },
-              parts: [{ type: "text", text: "We decided to ship the archive importer first." }],
-            },
-          ],
-        });
+      if (url.pathname === "/workspace/ws_2/opencode/session/ses_archive/message") {
+        return Response.json([
+          {
+            info: { id: "msg_old", role: "assistant", time: { created: 101 } },
+            parts: [{ type: "text", text: "Ignored implementation note", ignored: true }],
+          },
+          {
+            info: { id: "msg_latest", role: "assistant", time: { created: 102 } },
+            parts: [{ type: "text", text: "We decided to ship the archive importer first." }],
+          },
+        ]);
+      }
+
+      if (/^\/workspace\/ws_2\/opencode\/session\/ses_created_\d+\/prompt_async$/.test(url.pathname)) {
+        const body = z.object({
+          parts: z.array(z.object({ type: z.literal("text"), text: z.string() }).strict()).length(1),
+        }).strict().parse(record.body);
+        if (body.parts[0]?.text === options.failPromptText) {
+          return Response.json({ message: "Prompt failed" }, { status: 503 });
+        }
+        return new Response(null, { status: 204 });
       }
 
       return Response.json({ message: "Not found" }, { status: 404 });
@@ -396,7 +407,27 @@ describe("OpenWorkExtensionsPreview session tools", () => {
       role: "user",
     });
     expect(parsed.result.results[0]?.snippet.match.toLowerCase()).toBe("raven launch");
-    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_1/sessions/ses_alpha/messages" && request.search === "?limit=400")).toBe(true);
+    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_1/opencode/session" && request.search === "?roots=true&limit=10")).toBe(true);
+    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_1/opencode/session/ses_alpha/message" && request.search === "?limit=400")).toBe(true);
+  });
+
+  test("keeps search results when one workspace native mount is unavailable", async () => {
+    const fake = startFakeOpenWorkServer({ failSessionListWorkspaceId: "ws_2" });
+    const plugin = await OpenWorkExtensionsPreview();
+
+    const output = await plugin.tool.openwork_query.execute({
+      id: "session.search",
+      args: { query: "raven launch", scanLimit: 10 },
+    });
+    const parsed = affordanceResultSchema("session.search", searchResultSchema.extend({
+      workspaceErrors: z.array(z.object({ workspaceId: z.string(), error: z.string() }).passthrough()),
+    })).parse(JSON.parse(output));
+
+    expect(parsed.result.results[0]?.sessionId).toBe("ses_alpha");
+    expect(parsed.result.workspaceErrors).toEqual([
+      expect.objectContaining({ workspaceId: "ws_2", error: "Remote worker unavailable" }),
+    ]);
+    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_2/opencode/session")).toBe(true);
   });
 
   test("merges factory directory into transform steering when hook input omits it", async () => {
@@ -462,8 +493,8 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(output.system[0]).not.toContain("Do not use OpenWork documentation tools");
   });
 
-  test("reads a transcript by session id without opening the UI", async () => {
-    startFakeOpenWorkServer();
+  test("routes transcript reads through a remote workspace native mount", async () => {
+    const fake = startFakeOpenWorkServer();
     const plugin = await OpenWorkExtensionsPreview();
 
     const output = await plugin.tool.openwork_query.execute({
@@ -485,6 +516,9 @@ describe("OpenWorkExtensionsPreview session tools", () => {
         text: "We decided to ship the archive importer first.",
       },
     ]);
+    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_2/opencode/session/ses_archive")).toBe(true);
+    expect(fake.requests.some((request) => request.pathname === "/workspace/ws_2/opencode/session/ses_archive/message" && request.search === "?limit=2")).toBe(true);
+    expect(fake.requests.some((request) => request.pathname.includes("/sessions"))).toBe(false);
   });
 
   test("creates and starts multiple sessions through the OpenWork backend", async () => {
@@ -518,14 +552,41 @@ describe("OpenWorkExtensionsPreview session tools", () => {
       "/workspace/ws_2/session/ses_created_3",
     ]);
 
-    const createRequests = fake.requests.filter((request) => request.pathname === "/workspace/ws_2/sessions" && request.method === "POST");
+    const createRequests = fake.requests.filter((request) => request.pathname === "/workspace/ws_2/opencode/session" && request.method === "POST");
+    const promptRequests = fake.requests.filter((request) => request.pathname.endsWith("/prompt_async") && request.method === "POST");
     expect(createRequests).toHaveLength(3);
-    expect(createRequests.every((request) => request.authorization === "Bearer test-token")).toBe(true);
+    expect(promptRequests).toHaveLength(3);
+    expect([...createRequests, ...promptRequests].every((request) => request.authorization === "Bearer test-token")).toBe(true);
     expect(createRequests.map((request) => request.body)).toEqual(expect.arrayContaining([
-      { title: "Look into dolphins", prompt: "Research dolphins." },
-      { title: "Look into bananas", prompt: "Research bananas." },
-      { title: "Look into apple pies", prompt: "Research apple pies." },
+      { title: "Look into dolphins" },
+      { title: "Look into bananas" },
+      { title: "Look into apple pies" },
     ]));
+    expect(promptRequests.map((request) => request.body)).toEqual(expect.arrayContaining([
+      { parts: [{ type: "text", text: "Research dolphins." }] },
+      { parts: [{ type: "text", text: "Research bananas." }] },
+      { parts: [{ type: "text", text: "Research apple pies." }] },
+    ]));
+  });
+
+  test("reports a created session as failed when its native prompt does not start", async () => {
+    const fake = startFakeOpenWorkServer({ failPromptText: "Fail this prompt." });
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
+
+    const output = await plugin.tool.openwork_execute.execute({
+      id: "session.create",
+      args: { sessions: [{ title: "Prompt failure", prompt: "Fail this prompt." }] },
+    }, { sessionID: "ses_origin" });
+    const parsed = z.object({
+      ok: z.literal(false),
+      id: z.literal("session.create"),
+      error: z.string(),
+      code: z.literal("failed"),
+    }).parse(JSON.parse(output));
+
+    expect(parsed.error).toBe("session.create failed");
+    expect(fake.requests.filter((request) => request.pathname === "/workspace/ws_2/opencode/session" && request.method === "POST")).toHaveLength(1);
+    expect(fake.requests.filter((request) => request.pathname.endsWith("/prompt_async") && request.method === "POST")).toHaveLength(1);
   });
 
   test("creates more than twenty sessions in one tool call", async () => {
@@ -545,7 +606,8 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(parsed.result.ok).toBe(true);
     expect(parsed.result.created).toHaveLength(21);
     expect(parsed.result.failures).toEqual([]);
-    expect(fake.requests.filter((request) => request.pathname === "/workspace/ws_2/sessions" && request.method === "POST")).toHaveLength(21);
+    expect(fake.requests.filter((request) => request.pathname === "/workspace/ws_2/opencode/session" && request.method === "POST")).toHaveLength(21);
+    expect(fake.requests.filter((request) => request.pathname.endsWith("/prompt_async") && request.method === "POST")).toHaveLength(21);
   });
 });
 

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir, platform } from "node:os";
 import { z } from "zod";
@@ -98,6 +98,7 @@ const sessionTimeSchema = z.object({
 const sessionInfoSchema = z.object({
   id: z.string(),
   title: z.string().nullish(),
+  directory: z.string().optional(),
   time: sessionTimeSchema.optional(),
 }).passthrough();
 
@@ -621,10 +622,30 @@ async function listWorkspaceSessions(workspace: OpenWorkWorkspace, limit: number
   );
 }
 
+// The removed wrapper route validated that a session actually belongs to the
+// requested workspace before exposing it (requireWorkspaceSession). The native
+// engine route only scopes the upstream request, so a caller supplying a
+// foreign session ID would otherwise read cross-workspace transcript data.
+async function assertSessionInWorkspace(workspace: OpenWorkWorkspace, session: SessionInfo): Promise<void> {
+  const workspacePath = workspace.path?.trim();
+  const sessionDirectory = session.directory?.trim();
+  if (!workspacePath || !sessionDirectory) return;
+  const [root, dir] = await Promise.all([
+    realpath(workspacePath).catch(() => workspacePath),
+    realpath(sessionDirectory).catch(() => sessionDirectory),
+  ]);
+  const normalizedRoot = normalizeDirPath(root);
+  const normalizedDir = normalizeDirPath(dir);
+  if (normalizedDir === normalizedRoot || normalizedDir.startsWith(`${normalizedRoot}/`)) return;
+  throw new Error(`Session ${session.id} not found in workspace ${workspaceLabel(workspace)}`);
+}
+
 async function readWorkspaceSession(workspace: OpenWorkWorkspace, sessionId: string): Promise<SessionInfo> {
-  return sessionInfoSchema.parse(
+  const session = sessionInfoSchema.parse(
     await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/opencode/session/${encodeURIComponent(sessionId)}`),
   );
+  await assertSessionInWorkspace(workspace, session);
+  return session;
 }
 
 async function readSessionMessages(workspace: OpenWorkWorkspace, sessionId: string, limit: number): Promise<SessionMessage[]> {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -101,19 +101,6 @@ const sessionInfoSchema = z.object({
   time: sessionTimeSchema.optional(),
 }).passthrough();
 
-const sessionListEnvelopeSchema = z.object({
-  items: z.array(sessionInfoSchema),
-}).passthrough();
-
-const sessionEnvelopeSchema = z.object({
-  item: sessionInfoSchema,
-}).passthrough();
-
-const createdSessionEnvelopeSchema = z.object({
-  item: sessionInfoSchema,
-  started: z.boolean(),
-}).passthrough();
-
 const sessionPartSchema = z.object({
   type: z.string().optional(),
   text: z.string().optional(),
@@ -128,10 +115,6 @@ const sessionMessageSchema = z.object({
     time: sessionTimeSchema.optional(),
   }).passthrough(),
   parts: z.array(sessionPartSchema),
-}).passthrough();
-
-const sessionMessagesEnvelopeSchema = z.object({
-  items: z.array(sessionMessageSchema),
 }).passthrough();
 
 const OPENWORK_AGENT_SURFACE_INSTRUCTION =
@@ -633,22 +616,22 @@ function filterWorkspaces(workspaces: OpenWorkWorkspace[], workspaceId?: string)
 
 async function listWorkspaceSessions(workspace: OpenWorkWorkspace, limit: number): Promise<SessionInfo[]> {
   const query = new URLSearchParams({ roots: "true", limit: String(limit) });
-  return sessionListEnvelopeSchema.parse(
-    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/sessions?${query.toString()}`),
-  ).items;
+  return z.array(sessionInfoSchema).parse(
+    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/opencode/session?${query.toString()}`),
+  );
 }
 
 async function readWorkspaceSession(workspace: OpenWorkWorkspace, sessionId: string): Promise<SessionInfo> {
-  return sessionEnvelopeSchema.parse(
-    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/sessions/${encodeURIComponent(sessionId)}`),
-  ).item;
+  return sessionInfoSchema.parse(
+    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/opencode/session/${encodeURIComponent(sessionId)}`),
+  );
 }
 
 async function readSessionMessages(workspace: OpenWorkWorkspace, sessionId: string, limit: number): Promise<SessionMessage[]> {
   const query = new URLSearchParams({ limit: String(limit) });
-  return sessionMessagesEnvelopeSchema.parse(
-    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/sessions/${encodeURIComponent(sessionId)}/messages?${query.toString()}`),
-  ).items;
+  return z.array(sessionMessageSchema).parse(
+    await serverGet(`/workspace/${encodeURIComponent(workspace.id)}/opencode/session/${encodeURIComponent(sessionId)}/message?${query.toString()}`),
+  );
 }
 
 async function forEachWithConcurrency<T>(items: T[], concurrency: number, run: (item: T) => Promise<void>): Promise<void> {
@@ -838,16 +821,20 @@ async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext
   const workspace = await resolveContextWorkspace(args.workspaceId, context);
   const results = await Promise.all(args.sessions.map(async (session): Promise<CreatedOpenWorkSessionResult | FailedOpenWorkSessionResult> => {
     try {
-      const payload = createdSessionEnvelopeSchema.parse(await postJson(
-        `/workspace/${encodeURIComponent(workspace.id)}/sessions`,
-        session,
+      const payload = sessionInfoSchema.parse(await postJson(
+        `/workspace/${encodeURIComponent(workspace.id)}/opencode/session`,
+        { title: session.title },
       ));
+      await postJson(
+        `/workspace/${encodeURIComponent(workspace.id)}/opencode/session/${encodeURIComponent(payload.id)}/prompt_async`,
+        { parts: [{ type: "text", text: session.prompt }] },
+      );
       return {
         ok: true,
-        sessionId: payload.item.id,
-        title: payload.item.title?.trim() || session.title,
-        started: payload.started,
-        route: `/workspace/${encodeURIComponent(workspace.id)}/session/${encodeURIComponent(payload.item.id)}`,
+        sessionId: payload.id,
+        title: payload.title?.trim() || session.title,
+        started: true,
+        route: `/workspace/${encodeURIComponent(workspace.id)}/session/${encodeURIComponent(payload.id)}`,
       };
     } catch (error) {
       return {

--- a/apps/server/src/opencode-proxy-gate.test.ts
+++ b/apps/server/src/opencode-proxy-gate.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, test } from "bun:test";
 import {
   assertOpencodeProxyAllowed,
   normalizeOpencodeDirectory,
+  proxyOpencodeRequest,
   scopeWorkspaceOpencodeRequest,
 } from "./server.js";
 import { ApiError } from "./errors.js";
-import type { Actor, TokenScope } from "./types.js";
+import type { Actor, ServerConfig, TokenScope, WorkspaceInfo } from "./types.js";
 
 const actor = (scope: TokenScope | undefined): Actor => ({ type: "remote", scope });
 
@@ -98,5 +99,65 @@ describe("normalizeOpencodeDirectory", () => {
   test("leaves paths unchanged on non-Windows platforms", () => {
     expect(normalizeOpencodeDirectory("\\\\?\\C:\\Users\\agent\\repo", "darwin"))
       .toBe("\\\\?\\C:\\Users\\agent\\repo");
+  });
+});
+
+describe("proxyOpencodeRequest read-only guard", () => {
+  const workspace: WorkspaceInfo = {
+    id: "ws_ro",
+    name: "Read-only workspace",
+    path: "/tmp/openwork-proxy-gate-ro",
+    preset: "starter",
+    workspaceType: "local",
+  };
+
+  const readOnlyConfig: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [workspace],
+    authorizedRoots: [workspace.path],
+    readOnly: true,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+
+  const proxy = (method: string) => {
+    const proxyPath = "/session";
+    const url = new URL(`http://openwork.invalid/opencode${proxyPath}`);
+    return proxyOpencodeRequest({
+      config: readOnlyConfig,
+      workspace,
+      proxyPath,
+      url,
+      request: new Request(url, { method }),
+    });
+  };
+
+  test("rejects native proxy writes on a read-only server (parity with the removed ensureWritable wrapper routes)", async () => {
+    for (const method of ["POST", "DELETE", "PATCH", "PUT"]) {
+      const error = await proxy(method).then(
+        () => null,
+        (thrown: unknown) => thrown,
+      );
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error instanceof ApiError ? error.code : null).toBe("read_only");
+    }
+  });
+
+  test("still lets reads through the read-only gate", async () => {
+    // No engine is configured, so a read that passes the read-only gate fails
+    // later with opencode_unconfigured — proving the gate did not block it.
+    const error = await proxy("GET").then(
+      () => null,
+      (thrown: unknown) => thrown,
+    );
+    expect(error instanceof ApiError ? error.code : null).toBe("opencode_unconfigured");
   });
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1296,6 +1296,12 @@ export async function proxyOpencodeRequest(input: {
   const workspace = input.workspace;
   const proxyPath = input.proxyPath ?? input.url.pathname;
   const method = input.request.method.toUpperCase();
+  // The wrapper routes enforced the server read-only mode via ensureWritable;
+  // native proxy writes must honor the same guard so a read-only server never
+  // forwards mutations to the engine.
+  if (method !== "GET" && method !== "HEAD") {
+    ensureWritable(input.config);
+  }
   const pool = workspace?.workspaceType === "remote" ? null : enginePoolForConfig(input.config);
   const route = pool?.routeRequest(method, proxyPath) ?? null;
   const baseUrl = route?.target.baseUrl ??


### PR DESCRIPTION
## Stack

Stacked on #4193 → #4192 → #4191 → #4190 → #4189 → #4188. Review commit `f3b242b8` / diff against `thin/app-native-session-reads`.

## Why

The OpenWork engine plugin’s session affordances still called duplicate OpenWork session wrapper routes. They must migrate before those routes can be deleted. A factory-client-only migration would break cross-workspace search/read for remote workers, so this uses each workspace’s authenticated native mounted `/opencode` route.

## What changed

- `session.search`:
  - native raw `GET /workspace/:id/opencode/session?roots=true&limit=N`
  - native raw `GET .../session/:id/message?limit=N`
- `session.read`:
  - native raw session + message routes
- `session.create`:
  - native `POST .../opencode/session` with title
  - then native `POST .../:id/prompt_async` with text part
  - reports started only after prompt succeeds
- Removed obsolete wrapper envelope schemas; retained permissive raw payload validation.
- Preserved multi-workspace concurrency, remote worker routing, partial workspace errors, ordering, scan/message/result limits, snippets, auth, result contracts, and OpenWork navigation routes.
- Server wrapper routes remain for direct coded eval consumers until the final deletion PR.

## Verification

- Plugin suite — **19 pass / 0 fail**
- `pnpm --filter openwork-server typecheck` — pass
- `pnpm --filter openwork-server build` — pass; bundled extension plugin succeeds
- `git diff --check` — pass

## Coverage

- native raw list/get/messages paths and payloads
- query limits
- remote workspace native mount routing
- partial search success when one remote workspace is unavailable
- transcript reads without UI navigation
- create+prompt exact payloads and bearer auth
- 21-session batch creation
- prompt failure reported as failed rather than started
- no remaining `/sessions` wrapper paths inside plugin production code
