### PR TITLE
refactor(runtime): add an optional thin session client port

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -1,4 +1,4 @@
-import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
+import { createHeadlessThreadClient } from "@openwork/headless-threads"
 
 const EMPTY_USAGE = { inputTokens: null, outputTokens: null, costMicros: null }
 const RUNNER_WORK_POLL_MS = 60_000
@@ -68,43 +68,19 @@ async function requestJson(fetchImpl, baseUrl, token, requestPath, options = {})
   return payload
 }
 
-function opencodeFetch(fetchImpl) {
-  return async (input, init = {}) => {
-    const request = input instanceof Request ? input : new Request(input, init)
-    const body = ["GET", "HEAD"].includes(request.method) ? undefined : await request.text()
-    return fetchImpl(request.url, {
-      method: request.method,
-      headers: request.headers,
-      body: body || undefined,
-      signal: request.signal,
-    })
-  }
-}
-
-function unwrapOpencodeResult(result, operation) {
-  if (result?.data != null) return result.data
-  if (result?.error === undefined && result?.response?.ok) return null
-  const error = new Error(
-    result?.error === undefined
-      ? `OpenCode returned an empty response for ${operation}`
-      : serializedError(result.error),
-  )
-  const status = result?.response?.status ?? result?.error?.cause?.status
-  if (status !== undefined) Object.defineProperty(error, "status", { value: status })
-  throw error
-}
-
-function createWorkspaceOpencodeClient(local, workspaceId, fetchImpl) {
-  return createOpencodeClient({
-    baseUrl: `${local.baseUrl.replace(/\/+$/, "")}/workspace/${encodeURIComponent(workspaceId)}/opencode`,
-    headers: { Authorization: `Bearer ${local.token}` },
-    fetch: opencodeFetch(fetchImpl),
+function createWorkspaceSessionClient(local, workspaceId, fetchImpl) {
+  return createHeadlessThreadClient({
+    baseUrl: local.baseUrl,
+    workspaceId,
+    token: local.token,
+    fetch: fetchImpl,
+    requestTimeoutMs: 0,
   })
 }
 
 function assistantResult(snapshot) {
   const assistants = Array.isArray(snapshot?.messages)
-    ? snapshot.messages.filter((message) => message?.info?.role === "assistant")
+    ? snapshot.messages.filter((message) => message?.role === "assistant")
     : []
   let resultSummary = null
   let inputTokens = 0
@@ -113,14 +89,14 @@ function assistantResult(snapshot) {
   let sawOutput = false
   let sawCompletedTool = false
   for (const message of assistants) {
-    const tokens = message?.info?.tokens
-    if (Number.isFinite(tokens?.input)) { inputTokens += Number(tokens.input); sawInput = true }
-    if (Number.isFinite(tokens?.output)) { outputTokens += Number(tokens.output); sawOutput = true }
+    const usage = message?.usage
+    if (Number.isFinite(usage?.inputTokens)) { inputTokens += Number(usage.inputTokens); sawInput = true }
+    if (Number.isFinite(usage?.outputTokens)) { outputTokens += Number(usage.outputTokens); sawOutput = true }
     for (const part of Array.isArray(message?.parts) ? message.parts : []) {
       if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
         resultSummary = part.text.trim().slice(0, 20_000)
       }
-      if (part?.type === "tool" && (part?.toolStatus === "completed" || part?.state?.status === "completed")) {
+      if (part?.type === "tool" && part?.toolStatus === "completed") {
         sawCompletedTool = true
       }
     }
@@ -140,8 +116,8 @@ function assistantFailure(snapshot) {
   const messages = Array.isArray(snapshot?.messages) ? snapshot.messages : []
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
-    if (message?.info?.role !== "assistant" || !message.info.error) continue
-    return classifyAutomationExecutionError(message.info.error)
+    if (message?.role !== "assistant" || !message.error) continue
+    return classifyAutomationExecutionError(message.error)
   }
   return null
 }
@@ -162,56 +138,23 @@ export async function executeDesktopAutomation(assignment, options) {
   const workspace = workspaces.find((item) => item?.id === listed?.activeId) ?? workspaces[0]
   if (!workspace?.id) throw new Error("No local workspace is available")
   const workspaceId = String(workspace.id)
-  const opencode = createWorkspaceOpencodeClient(local, workspaceId, options.fetchImpl ?? fetch)
-  const created = unwrapOpencodeResult(
-    await opencode.session.create(
-      { title: `Automation: ${assignment.automationName}`.slice(0, 120) },
-      { signal: options.signal },
-    ),
-    "session creation",
-  )
-  const sessionId = typeof created?.id === "string" ? created.id : null
-  if (!sessionId) throw new Error("The desktop runtime returned no thread")
-  if (assignment.instructions) {
-    unwrapOpencodeResult(
-      await opencode.session.promptAsync({
-        sessionID: sessionId,
-        model: {
-          providerID: assignment.model.providerId,
-          modelID: assignment.model.modelId,
-        },
-        ...(assignment.model.variant ? { variant: assignment.model.variant } : {}),
-        parts: [{ type: "text", text: assignment.instructions }],
-      }, { signal: options.signal }),
-      "session prompt",
-    )
-  }
+  const client = createWorkspaceSessionClient(local, workspaceId, options.fetchImpl ?? fetch)
+  const created = await client.createThread({
+    title: `Automation: ${assignment.automationName}`.slice(0, 120),
+    ...(assignment.instructions ? { prompt: assignment.instructions } : {}),
+    model: assignment.model,
+    signal: options.signal,
+  })
+  const sessionId = created.id
   // The assignment signal is already aborted when this listener runs. Do not
   // pass it to the cleanup request or fetch can reject before reaching OpenCode.
-  const abort = () => void opencode.session.abort({ sessionID: sessionId })
-    .then((result) => unwrapOpencodeResult(result, "session abort"))
-    .catch(() => undefined)
+  const abort = () => void client.abortThread(sessionId).catch(() => undefined)
   options.signal.addEventListener("abort", abort, { once: true })
   try {
     const startedAt = Date.now()
     while (true) {
       if (Date.now() - startedAt > assignment.timeoutMs) throw new Error("Desktop Automation execution timed out")
-      const [session, messages, todos, statuses] = await Promise.all([
-        opencode.session.get({ sessionID: sessionId }, { signal: options.signal })
-          .then((result) => unwrapOpencodeResult(result, "session read")),
-        opencode.session.messages({ sessionID: sessionId, limit: 200 }, { signal: options.signal })
-          .then((result) => unwrapOpencodeResult(result, "session messages")),
-        opencode.session.todo({ sessionID: sessionId }, { signal: options.signal })
-          .then((result) => unwrapOpencodeResult(result, "session todos")),
-        opencode.session.status(undefined, { signal: options.signal })
-          .then((result) => unwrapOpencodeResult(result, "session status")),
-      ])
-      const snapshot = {
-        session,
-        messages,
-        todos,
-        status: statuses?.[sessionId] ?? { type: "idle" },
-      }
+      const snapshot = await client.getThreadSnapshot(sessionId, { signal: options.signal, limit: 200 })
       const output = assistantResult(snapshot)
       const snapshotError = assistantFailure(snapshot)
       if (snapshotError) {
@@ -262,32 +205,17 @@ export async function executeDesktopRemoteSession(assignment, options) {
   const workspace = workspaces.find((item) => item?.id === listed?.activeId) ?? workspaces[0]
   if (!workspace?.id) throw new Error("No local workspace is available")
   const workspaceId = String(workspace.id)
-  const opencode = createWorkspaceOpencodeClient(local, workspaceId, options.fetchImpl ?? fetch)
+  const client = createWorkspaceSessionClient(local, workspaceId, options.fetchImpl ?? fetch)
   let sessionId = null
   try {
-    const created = unwrapOpencodeResult(
-      await opencode.session.create({ title: assignment.title }, { signal: options.signal }),
-      "session creation",
-    )
-    sessionId = typeof created?.id === "string" ? created.id : null
-    if (!sessionId) throw new Error("The desktop runtime returned no thread")
-    const started = Boolean(assignment.prompt)
-    if (started) {
-      unwrapOpencodeResult(
-        await opencode.session.promptAsync({
-          sessionID: sessionId,
-          ...(assignment.model ? {
-            model: {
-              providerID: assignment.model.providerId,
-              modelID: assignment.model.modelId,
-            },
-            ...(assignment.model.variant ? { variant: assignment.model.variant } : {}),
-          } : {}),
-          parts: [{ type: "text", text: assignment.prompt }],
-        }, { signal: options.signal }),
-        "session prompt",
-      )
-    }
+    const created = await client.createThread({
+      title: assignment.title,
+      ...(assignment.prompt ? { prompt: assignment.prompt } : {}),
+      ...(assignment.model ? { model: assignment.model } : {}),
+      signal: options.signal,
+    })
+    sessionId = created.id
+    const started = created.started
     return { sessionId, workspaceId, started }
   } catch (error) {
     const contextualError = error instanceof Error ? error : new Error(serializedError(error))

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -209,8 +209,8 @@ async function observeAssignmentCredentialRejection(status, deniedRoute) {
           return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{
-              info: { role: "assistant", tokens: { input: 1, output: 1 } },
-              parts: [{ type: "text", text: "Finished" }],
+              info: { id: "msg-finished", role: "assistant", tokens: { input: 1, output: 1 } },
+              parts: [{ id: "part-finished", type: "text", text: "Finished" }],
             }],
           })
         }
@@ -555,7 +555,7 @@ test("routine credential rotation waits for the active assignment to complete", 
           while (!finishSnapshot) await new Promise((resolve) => setImmediate(resolve))
           return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
-            messages: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Finished" }] }],
+            messages: [{ info: { id: "msg-finished", role: "assistant" }, parts: [{ id: "part-finished", type: "text", text: "Finished" }] }],
           })
         }
       }
@@ -611,7 +611,7 @@ test("routine credential rotation waits for an in-flight claim", async () => {
         if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
           return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
-            messages: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Finished" }] }],
+            messages: [{ info: { id: "msg-finished", role: "assistant" }, parts: [{ id: "part-finished", type: "text", text: "Finished" }] }],
           })
         }
       }
@@ -765,8 +765,8 @@ test("waking during an active run keeps its lease and starts no second claim loo
           return respondToSnapshotRequest(parsed, sessionPaths, {
             status: { type: "idle" },
             messages: [{
-              info: { role: "assistant", tokens: { input: 1, output: 1 } },
-              parts: [{ type: "text", text: "done" }],
+              info: { id: "msg-done", role: "assistant", tokens: { input: 1, output: 1 } },
+              parts: [{ id: "part-done", type: "text", text: "done" }],
             }],
           })
         }
@@ -1076,8 +1076,8 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
       return respondToSnapshotRequest(parsed, sessionPaths, {
         status: { type: snapshots <= 1 ? "busy" : "idle" },
         messages: snapshots <= 1 ? [] : [{
-          info: { role: "assistant", tokens: { input: 12, output: 7 } },
-          parts: [{ type: "text", text: "Desktop runner result" }],
+          info: { id: "msg-result", role: "assistant", tokens: { input: 12, output: 7 } },
+          parts: [{ id: "part-result", type: "text", text: "Desktop runner result" }],
         }],
       })
     }
@@ -1124,8 +1124,10 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
   for (const path of [sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status]) {
     assert.equal(requests.filter((request) => request.path === path).length, 2)
   }
-  assert.ok(requests.filter((request) => request.path === sessionPaths.messages)
-    .every((request) => request.search === "?limit=200"))
+  assert.deepEqual(
+    requests.filter((request) => request.path === sessionPaths.messages).map((request) => request.search),
+    ["?limit=200", "?limit=200"],
+  )
   assert.ok(requests.every((request) => request.options.signal instanceof AbortSignal))
   assert.ok(localRequests.every((request) => new Headers(request.options.headers).get("Authorization") === "Bearer local-client-token"))
 })
@@ -1145,8 +1147,8 @@ test("desktop Automation execution accepts a completed tool-only assistant turn"
       return respondToSnapshotRequest(parsed, sessionPaths, {
         statuses: {},
         messages: [{
-          info: { role: "assistant", tokens: { input: 9, output: 3 } },
-          parts: [{ type: "tool", tool: "example", state: { status: "completed", output: "done" } }],
+          info: { id: "msg-tool", role: "assistant", tokens: { input: 9, output: 3 } },
+          parts: [{ id: "part-tool", type: "tool", tool: "example", state: { status: "completed", output: "done" } }],
         }],
       })
     }
@@ -1190,6 +1192,7 @@ test("failed desktop assignments retain their created local thread in the Den co
             status: { type: "idle" },
             messages: [{
               info: {
+                id: "msg-failed",
                 role: "assistant",
                 error: {
                   name: "ProviderModelNotFoundError",
@@ -1325,6 +1328,7 @@ test("an explicit assistant provider failure terminates immediately with its loc
         status: { type: "idle" },
         messages: [{
           info: {
+            id: "msg-provider-failure",
             role: "assistant",
             error: {
               name: "APIError",
@@ -1383,6 +1387,7 @@ test("desktop Automation execution surfaces a missing pinned model", async () =>
         status: { type: "idle" },
         messages: [{
           info: {
+            id: "msg-missing-model",
             role: "assistant",
             error: {
               name: "ProviderModelNotFoundError",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.18.15",
     "@openwork/enterprise-mcp-client": "workspace:*",
+    "@openwork/headless-threads": "workspace:*",
     "@openwork/paths": "workspace:*",
     "@sentry/electron": "^7.16.0",
     "ajv": "^8.17.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
+    "pretest": "pnpm --filter @openwork/headless-threads build",
     "test": "node --test electron/after-pack-paths.test.mjs electron/agent-context-diagnostics-fetch.test.mjs electron/automation-runner.test.mjs electron/binary-transfer.test.mjs electron/blank-slate-profile.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-darwin.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/desktop-distribution.test.mjs electron/dev-profile.test.mjs electron/electron-builder-config.test.mjs electron/linux-desktop-integration.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/runtime-chain-repair.test.mjs electron/sentry.test.mjs electron/server-dependency-mirror.test.mjs electron/secure-vault-key.test.mjs electron/stdio-errors.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-archive.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -51,6 +51,10 @@ run(nodeCmd, [resolve(__dirname, "prepare-runtime-node-modules.mjs"), "--outdir"
 writeSentryBuildConfig();
 // Build the server TS → JS so Electron can import it in-process
 run(pnpmCmd, ["--filter", "openwork-server", "build"], repoRoot);
+// automation-runner.mjs imports @openwork/headless-threads through its
+// published "default" export (dist/index.js); build it so plain-node
+// consumers resolve it in packaged layouts.
+run(pnpmCmd, ["--filter", "@openwork/headless-threads", "build"], repoRoot);
 // OPENWORK_ELECTRON_BUILD tells Vite to emit relative asset paths so
 // index.html resolves /assets/* correctly when loaded via file:// from
 // inside the packaged .app bundle.

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -1,4 +1,4 @@
-import { createHeadlessThreadClient, toTranscript, type HeadlessThreadClient, type HeadlessThreadModel } from "@openwork/headless-threads"
+import { createHeadlessThreadClient, toTranscript, type AgentSessionClient, type HeadlessThreadModel } from "@openwork/headless-threads"
 import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { MemberTable, OrganizationTable } from "@openwork-ee/den-db/schema/org"
 import { createDenTypeId, normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
@@ -201,7 +201,7 @@ export type RemoteSessionRuntimeResult =
       retryable: boolean
     }
 
-export type RemoteSessionThreadClient = Pick<HeadlessThreadClient, "createThread" | "sendTurn" | "getThreadSnapshot">
+export type RemoteSessionThreadClient = Pick<AgentSessionClient, "createThread" | "sendTurn" | "getThreadSnapshot">
 
 export type RemoteSessionExecuteDeps = {
   resolveRuntime: (scope: { organizationId: DenTypeId<"organization">; userId: string }) => Promise<RemoteSessionRuntimeResult>

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -18,6 +18,15 @@ function requestBudget(delays: number[], windowMs: number): number {
 }
 
 test("desktop Automation runner retires rejected credentials without changing transient backoff", async ({ evidence }) => {
+  // automation-runner.mjs resolves @openwork/headless-threads through its
+  // published "default" export (dist/index.js) when run under plain node,
+  // so the package must be built before the unit test can load.
+  const build = spawnSync("pnpm", ["--filter", "@openwork/headless-threads", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  expect(build.status, build.stderr || build.stdout).toBe(0);
+
   const unit = spawnSync(process.execPath, [
     "--test",
     "--test-reporter=tap",

--- a/packages/headless-threads/README.md
+++ b/packages/headless-threads/README.md
@@ -65,6 +65,12 @@ shows this conversation in the sidebar.
 
 ## Contract
 
+`AgentSessionClient` is the intentionally small replaceable runtime port:
+create a thread, send a turn, read a snapshot, and abort. `HeadlessThreadClient`
+extends it with polling and transcript helpers. OpenCode is currently the only
+implementation; UI inventory and cross-workspace plugin routing stay on the
+native protocol instead of expanding this port speculatively.
+
 | Function | Does |
 | --- | --- |
 | `createThread` | Creates a thread, optionally with its first turn and a model. |

--- a/packages/headless-threads/src/client.test.ts
+++ b/packages/headless-threads/src/client.test.ts
@@ -546,6 +546,56 @@ describe("failures", () => {
     expect(error.status).toBeNull();
   });
 
+  test("defaults individual request timeouts to 15 seconds", async () => {
+    const originalTimeout = AbortSignal.timeout;
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, "timeout");
+    if (!timeoutDescriptor) throw new Error("AbortSignal.timeout is unavailable");
+    const requested: number[] = [];
+    Object.defineProperty(AbortSignal, "timeout", {
+      configurable: true,
+      value: (milliseconds: number) => {
+        requested.push(milliseconds);
+        return originalTimeout(milliseconds);
+      },
+    });
+    try {
+      await createClient(createOpenworkDouble()).createThread({ title: "Default timeout" });
+      expect(requested).toEqual([15_000]);
+    } finally {
+      Object.defineProperty(AbortSignal, "timeout", timeoutDescriptor);
+    }
+  });
+
+  test("disables request timeouts when configured with zero", async () => {
+    const originalTimeout = AbortSignal.timeout;
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, "timeout");
+    if (!timeoutDescriptor) throw new Error("AbortSignal.timeout is unavailable");
+    const requested: number[] = [];
+    Object.defineProperty(AbortSignal, "timeout", {
+      configurable: true,
+      value: (milliseconds: number) => {
+        requested.push(milliseconds);
+        return originalTimeout(milliseconds);
+      },
+    });
+    const double = createOpenworkDouble();
+    const client = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      fetch: double.fetchImpl,
+      requestTimeoutMs: 0,
+    });
+
+    try {
+      await client.createThread({ title: "No timeout" });
+      expect(requested).toEqual([]);
+      expect(double.requests[0]?.signal?.aborted).toBe(false);
+    } finally {
+      Object.defineProperty(AbortSignal, "timeout", timeoutDescriptor);
+    }
+  });
+
   test("merges the client-wide and per-call signals into SDK requests", async () => {
     const globalController = new AbortController();
     const callController = new AbortController();

--- a/packages/headless-threads/src/client.ts
+++ b/packages/headless-threads/src/client.ts
@@ -100,10 +100,10 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
     return prompt;
   }
 
-  function requestSignal(signal?: AbortSignal): AbortSignal {
+  function requestSignal(signal?: AbortSignal): AbortSignal | undefined {
     const signals = [options.signal, signal].filter((item): item is AbortSignal => item !== undefined);
-    signals.push(AbortSignal.timeout(requestTimeoutMs));
-    return AbortSignal.any(signals);
+    if (requestTimeoutMs !== 0) signals.push(AbortSignal.timeout(requestTimeoutMs));
+    return signals.length === 0 ? undefined : signals.length === 1 ? signals[0] : AbortSignal.any(signals);
   }
 
   const sdkFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -177,7 +177,7 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
     );
   }
 
-  async function getThreadSnapshot(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessThreadSnapshot> {
+  async function getThreadSnapshot(threadId: string, input?: { signal?: AbortSignal; limit?: number }): Promise<HeadlessThreadSnapshot> {
     const encodedThreadId = encodeURIComponent(threadId);
     const sessionPath = `${opencodePath}/session/${encodedThreadId}`;
     const messagesPath = `${sessionPath}/message`;
@@ -185,7 +185,7 @@ export function createHeadlessThreadClient(options: HeadlessThreadClientOptions)
     const statusPath = `${opencodePath}/session/status`;
     const [sessionResult, messagesResult, todosResult, statusResult] = await Promise.all([
       opencode.session.get({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
-      opencode.session.messages({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
+      opencode.session.messages({ sessionID: threadId, limit: input?.limit }, { signal: requestSignal(input?.signal) }),
       opencode.session.todo({ sessionID: threadId }, { signal: requestSignal(input?.signal) }),
       opencode.session.status(undefined, { signal: requestSignal(input?.signal) }),
     ]);

--- a/packages/headless-threads/src/index.ts
+++ b/packages/headless-threads/src/index.ts
@@ -3,6 +3,7 @@ export { HeadlessThreadError } from "./errors.js";
 export { hasAssistantReplySince, toTranscript, toTranscriptMessage } from "./transcript.js";
 export { isRunning } from "./wire.js";
 export type {
+  AgentSessionClient,
   CreateThreadInput,
   HeadlessAbortResult,
   HeadlessFetch,

--- a/packages/headless-threads/src/types.ts
+++ b/packages/headless-threads/src/types.ts
@@ -173,13 +173,16 @@ export interface HeadlessThreadTranscript {
   terminalError: HeadlessThreadMessageError | null;
 }
 
-export interface HeadlessThreadClient {
+export interface AgentSessionClient {
   createThread(input: CreateThreadInput): Promise<HeadlessThread>;
   sendTurn(threadId: string, input: HeadlessThreadTurnInput): Promise<HeadlessTurnAcceptance>;
+  getThreadSnapshot(threadId: string, input?: { signal?: AbortSignal; limit?: number }): Promise<HeadlessThreadSnapshot>;
+  abortThread(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessAbortResult>;
+}
+
+export interface HeadlessThreadClient extends AgentSessionClient {
   waitForThread(threadId: string, input: HeadlessThreadWaitInput): Promise<HeadlessThreadWaitResult>;
   waitUntilIdle(threadId: string, input: HeadlessThreadWaitInput): Promise<HeadlessThreadWaitResult>;
-  getThreadSnapshot(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessThreadSnapshot>;
-  abortThread(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessAbortResult>;
   exportTranscript(threadId: string, input?: { signal?: AbortSignal }): Promise<HeadlessThreadTranscript>;
 }
 
@@ -205,7 +208,7 @@ export interface HeadlessThreadClientOptions {
   defaultModel?: HeadlessThreadModel;
   /** Default `waitForThread` poll interval. Defaults to 500ms. */
   pollIntervalMs?: number;
-  /** Bounds every individual HTTP request. Defaults to 15 seconds. */
+  /** Bounds every individual HTTP request. Defaults to 15 seconds; use 0 to disable. */
   requestTimeoutMs?: number;
   /** Cancels every operation issued by this client. */
   signal?: AbortSignal;

--- a/packages/headless-threads/src/wire.ts
+++ b/packages/headless-threads/src/wire.ts
@@ -153,7 +153,7 @@ export function toThreadMessage(message: MessageWire): HeadlessThreadMessage {
     parentId: message.info.parentID ?? null,
     createdAt: message.info.time?.created ?? null,
     error: toMessageError(message.info.error),
-    usage: message.info.role === "assistant" ? {
+    usage: message.info.role === "assistant" && message.info.tokens ? {
       inputTokens: message.info.tokens?.input ?? 0,
       outputTokens: message.info.tokens?.output ?? 0,
       reasoningTokens: message.info.tokens?.reasoning ?? 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
       '@openwork/enterprise-mcp-client':
         specifier: workspace:*
         version: link:../../packages/enterprise-mcp-client
+      '@openwork/headless-threads':
+        specifier: workspace:*
+        version: link:../../packages/headless-threads
       '@openwork/paths':
         specifier: workspace:*
         version: link:../../packages/paths


### PR DESCRIPTION
## Optional stack layer

Stacked on #4195 → #4194 → #4193 → #4192 → #4191 → #4190 → #4189 → #4188. This PR is intentionally optional; review commit `cf87c760` / diff against `thin/remove-session-wrapper-routes`.

## T3 Code comparison

T3 Code does have a shared 135-line ProviderAdapter for five active runtimes. It is justified there because Codex, Claude, Cursor, Grok, and OpenCode all implement the same lifecycle/event contract. T3 also pays for a much larger canonical event protocol and ~31k LOC of protocol adapters.

OpenWork has one active engine. A broad provider adapter now would recreate OpenCode’s SDK and event model speculatively. This PR takes only the useful part: a tiny semantic session port already backed by `@openwork/headless-threads`.

## What changed

- Added `AgentSessionClient` (four methods):
  - createThread
  - sendTurn
  - getThreadSnapshot
  - abortThread
- `HeadlessThreadClient` extends it with waits and transcript export.
- Desktop Automation runner now depends on this semantic port rather than directly implementing SDK transport/snapshot normalization.
- Den remote-session typing uses the same port.
- UI inventory/session rendering and plugin cross-workspace routing intentionally remain raw/native; adapting them would hide routing or recreate the full SDK shape.
- Added `requestTimeoutMs: 0` for clients, like Desktop, whose assignment deadline owns timing. Defaults remain 15 seconds.
- Snapshot input supports a message limit so Desktop’s existing 200-message cap is preserved.
- Signal composition uses SDK request signals directly—no ordering queue—so concurrent snapshot calls are safe. Cleanup abort runs without the already-aborted assignment signal.
- Normalized assistant messages without token metadata keep usage unknown rather than fabricating zero usage.
- Desktop retains its direct SDK dependency because it packages the embedded server runtime; the dependency-mirror invariant remains green.

## Size

**127 additions / 130 deletions (net −3 LOC).** The interface itself is 7 method lines, not a new framework/package/event bus.

## Verification

- Headless package — **38 pass / 0 fail**
- Desktop runner — **34 pass / 0 fail**
- Remote-session + runner contract evals — **2 pass / 0 fail**
- Headless typecheck/build — pass
- Desktop Electron typecheck + bridge check — pass (52 methods)
- Desktop server dependency mirror — **2 pass / 0 fail**
- Den API production build — pass
- Frozen lockfile install + supply-chain verification — pass; lock change is exactly the Desktop workspace dependency (3 lines)
- Full Desktop suite — 272 pass, 1 known local TLS fixture failure, 2 child cancellations; branch-specific runner and dependency tests are green. Hosted CI must be fully green.
- `git diff --check` — pass

## Deliberately not abstracted

- provider/model configuration
- MCP/Connect
- permission/approval protocol
- event streaming
- full Session/Message/Part UI models
- cross-workspace plugin routing

Those stay raw until a second real engine proves the abstraction needed.
