### PR TITLE
fix(sso): validate SAML responses against the SP-advertised ACS origin

### DIFF
--- a/ee/apps/den-api/src/sso-saml-response-middleware.ts
+++ b/ee/apps/den-api/src/sso-saml-response-middleware.ts
@@ -3,6 +3,7 @@ import { SsoProviderTable } from "@openwork-ee/den-db/schema"
 import type { MiddlewareHandler } from "hono"
 import { z } from "zod"
 import { db } from "./db.js"
+import { getSsoAcsUrl } from "./sso.js"
 import { validateSamlResponsePolicy } from "./sso-saml-response-policy.js"
 
 const samlProviderConfigSchema = z.object({
@@ -44,11 +45,15 @@ export const samlResponsePolicyMiddleware: MiddlewareHandler = async (c, next) =
     return c.json({ error: "invalid_saml_configuration" }, 400)
   }
 
+  // Better Auth advertises the baseURL-derived ACS in SP metadata and in the
+  // AuthnRequest, so the IdP posts there. Providers registered while the
+  // stored callbackUrl pointed at the API origin must keep working, so accept
+  // either URL as the delivery target.
+  const expectedAcsUrls = [...new Set([config.callbackUrl, getSsoAcsUrl(providerId)])]
   const result = validateSamlResponsePolicy({
     samlResponse,
     expectedAudience: config.audience,
-    expectedRecipient: config.callbackUrl,
-    expectedDestination: config.callbackUrl,
+    expectedAcsUrls,
   })
   if (!result.ok) {
     return c.json({ error: result.code, message: result.message }, 400)

--- a/ee/apps/den-api/src/sso-saml-response-policy.ts
+++ b/ee/apps/den-api/src/sso-saml-response-policy.ts
@@ -11,8 +11,7 @@ const parser = new XMLParser({
 export type SamlResponsePolicyInput = {
   samlResponse: string
   expectedAudience: string
-  expectedRecipient: string
-  expectedDestination: string
+  expectedAcsUrls: string[]
 }
 
 type SamlResponsePolicyFailure = { ok: false; code: string; message: string }
@@ -31,7 +30,7 @@ export function validateSamlResponsePolicy(input: SamlResponsePolicyInput): Saml
   }
 
   const destination = stringAttribute(response, "Destination")
-  if (!sameUrl(destination, input.expectedDestination)) {
+  if (!matchesAnyUrl(destination, input.expectedAcsUrls)) {
     return invalid("invalid_destination", "SAML response Destination does not match the configured ACS URL.")
   }
 
@@ -56,7 +55,7 @@ export function validateSamlResponsePolicy(input: SamlResponsePolicyInput): Saml
     return invalid("missing_recipient", "SAML assertion is missing SubjectConfirmationData Recipient.")
   }
 
-  if (!recipients.every((recipient) => sameUrl(recipient, input.expectedRecipient))) {
+  if (!recipients.every((recipient) => matchesAnyUrl(recipient, input.expectedAcsUrls))) {
     return invalid("invalid_recipient", "SAML assertion Recipient does not match the configured ACS URL.")
   }
 
@@ -128,10 +127,12 @@ function textValue(value: unknown) {
   return typeof text === "string" && text.length > 0 ? text : null
 }
 
-function sameUrl(value: string | null, expected: string) {
+function matchesAnyUrl(value: string | null, expected: string[]) {
   const normalizedValue = normalizeUrl(value)
-  const normalizedExpected = normalizeUrl(expected)
-  return normalizedValue !== null && normalizedExpected !== null && normalizedValue === normalizedExpected
+  if (normalizedValue === null) {
+    return false
+  }
+  return expected.some((candidate) => normalizeUrl(candidate) === normalizedValue)
 }
 
 function normalizeUrl(value: string | null) {

--- a/ee/apps/den-api/src/sso.ts
+++ b/ee/apps/den-api/src/sso.ts
@@ -64,12 +64,16 @@ function authCallbackBaseUrl() {
   return env.apiPublicUrl ?? env.betterAuthUrl
 }
 
+// Better Auth builds the SAML SP metadata and AuthnRequest ACS location from
+// its own baseURL (the web origin), not from samlConfig.callbackUrl. The URLs
+// we display and store must match what the SP actually advertises to the IdP,
+// otherwise the IdP posts to the web origin and response validation rejects it.
 export function getSsoAcsUrl(providerId: string) {
-  return `${authCallbackBaseUrl()}/api/auth/sso/saml2/sp/acs/${encodeURIComponent(providerId)}`
+  return `${env.betterAuthUrl}/api/auth/sso/saml2/sp/acs/${encodeURIComponent(providerId)}`
 }
 
 export function getSsoMetadataUrl(providerId: string) {
-  return `${authCallbackBaseUrl()}/api/auth/sso/saml2/sp/metadata?providerId=${encodeURIComponent(providerId)}`
+  return `${env.betterAuthUrl}/api/auth/sso/saml2/sp/metadata?providerId=${encodeURIComponent(providerId)}`
 }
 
 export function getSsoOidcRedirectUrl(providerId: string) {

--- a/ee/apps/den-api/test/sso-saml-response-policy.test.ts
+++ b/ee/apps/den-api/test/sso-saml-response-policy.test.ts
@@ -9,8 +9,7 @@ describe("SAML response policy", () => {
     expect(validateSamlResponsePolicy({
       samlResponse: samlResponse(),
       expectedAudience,
-      expectedRecipient: expectedAcsUrl,
-      expectedDestination: expectedAcsUrl,
+      expectedAcsUrls: [expectedAcsUrl],
     })).toEqual({ ok: true })
   })
 
@@ -18,8 +17,7 @@ describe("SAML response policy", () => {
     const result = validateSamlResponsePolicy({
       samlResponse: samlResponse({ assertionId: null }),
       expectedAudience,
-      expectedRecipient: expectedAcsUrl,
-      expectedDestination: expectedAcsUrl,
+      expectedAcsUrls: [expectedAcsUrl],
     })
 
     expect(result).toMatchObject({ ok: false, code: "missing_assertion_id" })
@@ -29,8 +27,7 @@ describe("SAML response policy", () => {
     const result = validateSamlResponsePolicy({
       samlResponse: samlResponse({ audience: "https://other-sp.example.com/saml/metadata" }),
       expectedAudience,
-      expectedRecipient: expectedAcsUrl,
-      expectedDestination: expectedAcsUrl,
+      expectedAcsUrls: [expectedAcsUrl],
     })
 
     expect(result).toMatchObject({ ok: false, code: "invalid_audience" })
@@ -40,8 +37,28 @@ describe("SAML response policy", () => {
     const result = validateSamlResponsePolicy({
       samlResponse: samlResponse({ destination: "https://evil.example.com/acs" }),
       expectedAudience,
-      expectedRecipient: expectedAcsUrl,
-      expectedDestination: expectedAcsUrl,
+      expectedAcsUrls: [expectedAcsUrl],
+    })
+
+    expect(result).toMatchObject({ ok: false, code: "invalid_destination" })
+  })
+
+  test("accepts delivery to the advertised web-origin ACS when the stored callback is on the API origin", () => {
+    const webOriginAcsUrl = "https://app.openwork.example.com/api/auth/sso/saml2/sp/acs/openwork-sso-org_123"
+    const apiOriginAcsUrl = "https://api.openwork.example.com/api/auth/sso/saml2/sp/acs/openwork-sso-org_123"
+
+    expect(validateSamlResponsePolicy({
+      samlResponse: samlResponse({ destination: webOriginAcsUrl, recipient: webOriginAcsUrl }),
+      expectedAudience,
+      expectedAcsUrls: [apiOriginAcsUrl, webOriginAcsUrl],
+    })).toEqual({ ok: true })
+  })
+
+  test("rejects destinations outside the expected ACS URL set", () => {
+    const result = validateSamlResponsePolicy({
+      samlResponse: samlResponse({ destination: "https://evil.example.com/acs" }),
+      expectedAudience,
+      expectedAcsUrls: [expectedAcsUrl, "https://api.openwork.example.com/api/auth/sso/saml2/sp/acs/openwork-sso-org_123"],
     })
 
     expect(result).toMatchObject({ ok: false, code: "invalid_destination" })
@@ -51,8 +68,7 @@ describe("SAML response policy", () => {
     const result = validateSamlResponsePolicy({
       samlResponse: samlResponse({ recipient: "https://evil.example.com/acs" }),
       expectedAudience,
-      expectedRecipient: expectedAcsUrl,
-      expectedDestination: expectedAcsUrl,
+      expectedAcsUrls: [expectedAcsUrl],
     })
 
     expect(result).toMatchObject({ ok: false, code: "invalid_recipient" })

--- a/evals/specs/sso-saml-acs-delivery.test.ts
+++ b/evals/specs/sso-saml-acs-delivery.test.ts
@@ -1,0 +1,155 @@
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { localMysqlIsRunning, server, test } from "@openwork/testkit";
+
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !localPlacement
+  ? "SAML ACS delivery skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+  : !mysqlOpen
+    ? "SAML ACS delivery skipped — needs MySQL on 127.0.0.1:3306"
+    : "a Google-style SAML response posted to the SP-advertised ACS URL is not rejected as invalid_destination";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(admin: DenSession, organizationName: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", { headers: auth(admin) });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === organizationName);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+// A minimal, unsigned Google Workspace-shaped SAML response. It only needs to
+// carry the fields the delivery policy inspects (Destination, Recipient,
+// Audience, assertion ID); Better Auth's own signature validation rejects it
+// afterwards, which is expected and asserted as a non-policy failure.
+function googleSamlResponse(input: { destination: string; recipient: string; audience: string }): string {
+  const xml = `
+    <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="response-${Date.now()}" Version="2.0" IssueInstant="2026-08-28T00:00:00Z" Destination="${input.destination}">
+      <saml:Issuer>https://accounts.google.com/o/saml2?idpid=mock</saml:Issuer>
+      <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+      </samlp:Status>
+      <saml:Assertion ID="assertion-${Date.now()}" Version="2.0" IssueInstant="2026-08-28T00:00:00Z">
+        <saml:Issuer>https://accounts.google.com/o/saml2?idpid=mock</saml:Issuer>
+        <saml:Subject>
+          <saml:NameID>enterprise-user@customer.test</saml:NameID>
+          <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml:SubjectConfirmationData Recipient="${input.recipient}" NotOnOrAfter="2027-01-01T00:00:00Z" />
+          </saml:SubjectConfirmation>
+        </saml:Subject>
+        <saml:Conditions NotBefore="2026-01-01T00:00:00Z" NotOnOrAfter="2027-01-01T00:00:00Z">
+          <saml:AudienceRestriction>
+            <saml:Audience>${input.audience}</saml:Audience>
+          </saml:AudienceRestriction>
+        </saml:Conditions>
+      </saml:Assertion>
+    </samlp:Response>
+  `;
+  return Buffer.from(xml, "utf8").toString("base64");
+}
+
+async function postToAcs(den: DenSession, acsPath: string, samlResponse: string) {
+  return denFetch(den, acsPath, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ SAMLResponse: samlResponse, RelayState: "openwork-eval" }).toString(),
+  });
+}
+
+test.skipIf(!localPlacement || !mysqlOpen)(title, { timeout: 300_000 }, async ({ evidence, place }) => {
+  const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const organizationName = `SAML ACS delivery ${runId}`;
+
+  await using den = await server({ place, org: { name: organizationName, members: {} } });
+  const owner = den.admin;
+  const orgId = await organizationId(owner, organizationName);
+
+  const ownerSignIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: owner.email, password: owner.password }),
+  });
+  const ownerCookie = ownerSignIn.response.headers.get("set-cookie")?.split(";")[0]?.trim() ?? "";
+  expect(ownerCookie).toBeTruthy();
+
+  const orgHeaders = { ...auth(owner), cookie: ownerCookie, "x-openwork-org-id": orgId };
+  const audience = den.ref.apiUrl;
+  const registration = await denFetch(den.ref, "/v1/sso/saml", {
+    method: "POST",
+    headers: orgHeaders,
+    body: JSON.stringify({
+      issuer: "http://127.0.0.1/google-saml",
+      domain: `saml-acs-${runId}.test`,
+      entryPoint: "https://accounts.google.com/o/saml2/idp?idpid=mock",
+      cert: "mock-google-signing-certificate",
+      audience,
+    }),
+  });
+  expect(registration.response.status, registration.text).toBe(201);
+  const connection = isRecord(registration.body) && isRecord(registration.body.connection)
+    ? registration.body.connection
+    : null;
+  const settingsAcsUrl = connection && typeof connection.acsUrl === "string" ? connection.acsUrl : "";
+  const providerId = connection && typeof connection.providerId === "string" ? connection.providerId : "";
+  expect(settingsAcsUrl).toBeTruthy();
+  expect(providerId).toBeTruthy();
+
+  // The mock IdP's view: the real SP metadata Better Auth generates. Google
+  // Workspace posts the SAML response to the ACS location advertised here.
+  const metadata = await denFetch(den.ref, "/v1/sso/metadata", { headers: orgHeaders });
+  expect(metadata.response.status, metadata.text).toBe(200);
+  const advertisedAcsUrl = metadata.text.match(/AssertionConsumerService[^>]*Location="([^"]+)"/)?.[1]
+    ?? metadata.text.match(/Location="([^"]+\/sp\/acs\/[^"]+)"/)?.[1]
+    ?? "";
+  expect(advertisedAcsUrl, `SP metadata did not advertise an ACS location: ${metadata.text.slice(0, 800)}`).toBeTruthy();
+
+  // The regression: Settings displayed an API-origin ACS while the SP
+  // advertised the web-origin ACS, so no IdP configuration could satisfy both.
+  expect(new URL(settingsAcsUrl).href).toBe(new URL(advertisedAcsUrl).href);
+
+  const acsPath = `/api/auth/sso/saml2/sp/acs/${encodeURIComponent(providerId)}`;
+
+  // Delivery to the SP-advertised ACS (what mock Google actually does) must
+  // clear the delivery policy. The unsigned assertion still fails Better
+  // Auth's signature checks afterwards — but never as a destination mismatch.
+  const advertisedDelivery = await postToAcs(den.ref, acsPath, googleSamlResponse({
+    destination: advertisedAcsUrl,
+    recipient: advertisedAcsUrl,
+    audience,
+  }));
+  expect(advertisedDelivery.text).not.toContain("invalid_destination");
+  expect(advertisedDelivery.text).not.toContain("invalid_recipient");
+
+  // The policy must still fail closed on the same endpoint for responses
+  // addressed to a foreign ACS.
+  const foreignDelivery = await postToAcs(den.ref, acsPath, googleSamlResponse({
+    destination: "https://attacker.example/acs",
+    recipient: "https://attacker.example/acs",
+    audience,
+  }));
+  expect(foreignDelivery.response.status, foreignDelivery.text).toBe(400);
+  expect(foreignDelivery.text).toContain("invalid_destination");
+
+  evidence.recordAssertionEvidence(
+    "The SAML response delivery policy accepts the SP-advertised ACS URL and rejects foreign destinations",
+    `Settings ACS ${settingsAcsUrl} matched the SP metadata ACS ${advertisedAcsUrl}; a mock Google response addressed there returned HTTP ${advertisedDelivery.response.status} without invalid_destination, while a response addressed to attacker.example returned HTTP ${foreignDelivery.response.status} with invalid_destination.`,
+    new URL(settingsAcsUrl).href === new URL(advertisedAcsUrl).href
+      && !advertisedDelivery.text.includes("invalid_destination")
+      && !advertisedDelivery.text.includes("invalid_recipient")
+      && foreignDelivery.response.status === 400
+      && foreignDelivery.text.includes("invalid_destination"),
+  );
+});


### PR DESCRIPTION
## Problem

Since #4063, the SAML ACS/metadata URLs shown in Settings (and stored as `samlConfig.callbackUrl`) moved to the API origin (`env.apiPublicUrl`). But Better Auth builds the SP metadata and the AuthnRequest ACS location from its own `baseURL` (the web origin) and ignores `samlConfig.callbackUrl` for that purpose.

Result: the SP tells the IdP to POST the response to the **web origin**, while `samlResponsePolicyMiddleware` validates `Destination`/`Recipient` against the stored **API-origin** URL. Every SAML login fails with `invalid_destination`, and no IdP-side configuration can satisfy both hosts (configuring the IdP with the API-origin ACS instead makes the IdP reject our web-origin AuthnRequest). Reported by an enterprise customer setting up Google Workspace SAML.

## Fix

- `getSsoAcsUrl` / `getSsoMetadataUrl` return the web-origin (`env.betterAuthUrl`) URLs again, matching what the SP actually advertises to the IdP. The OIDC redirect URL keeps the #4063 behavior (API origin).
- `samlResponsePolicyMiddleware` validates `Destination`/`Recipient` against a set: the stored `callbackUrl` **and** the canonical SP-advertised ACS URL. Providers registered while the regression was live (stored API-origin callback) work immediately without re-registration.
- `validateSamlResponsePolicy` takes `expectedAcsUrls: string[]`; unknown destinations/recipients are still rejected.

## Verification (local lane)

```
cd ee/apps/den-api
bun test test/sso-saml-response-policy.test.ts   # 7 pass, 0 fail
bun test test/sso-provider-rotation.test.ts test/sso-saml-policy.test.ts \
  test/sso-readiness.test.ts test/route-guard-policy.test.ts \
  test/sso-resolve-route.test.ts test/sso-resolve-helpers.test.ts \
  test/sso-saml-response-policy.test.ts          # 17 pass / 5 fail
pnpm exec tsc -p tsconfig.json --noEmit          # clean
```

The 5 failures require a live database and fail identically on clean `origin/dev` (baseline 15 pass / 5 fail); this diff adds 2 passing regression tests, including one reproducing the mixed-host delivery scenario. Not validated against a live Google Workspace IdP — repro there: configure a Google SAML app with Entity ID + ACS on the web origin, sign in, and confirm no `invalid_destination`.