### PR TITLE
fix(app): stop the Library page from refetching opencode-config on every settings re-render

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -759,6 +759,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   refreshMcpServersRef.current = connectionsStore.refreshMcpServers;
   notifyMcpReloadingRef.current = connectionsStore.notifyMcpReloading;
   pollMcpServersAfterReloadRef.current = connectionsStore.pollMcpServersAfterReload;
+  // Stable identity: McpView reloads opencode.json whenever this prop changes,
+  // so an inline lambda would refetch the config on every settings re-render
+  // (store snapshots tick every few seconds while idle on the Library page).
+  const readMcpConfigFile = useCallback(
+    (scope: "project" | "global") => connectionsStore.readMcpConfigFile(scope),
+    [connectionsStore],
+  );
   const providerAuthStore = useMemo(
     () =>
       createProviderAuthStore({
@@ -2495,7 +2502,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                     ? (name, enabled) => connectionsStore.setMcpEnabled(name, enabled)
                     : undefined
                 }
-                readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
+                readConfigFile={readMcpConfigFile}
                 installedSkills={[
                   ...extensionItems.installedSkills,
                   ...connectCapabilities.skills.filter(

--- a/evals/specs/library-config-read-budget.e2e.test.ts
+++ b/evals/specs/library-config-read-budget.e2e.test.ts
@@ -1,0 +1,97 @@
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const requirements: TestNeeds = { optIn: ["OPENWORK_EVAL_E2E_TESTS"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `library config read budget skipped — needs: ${missingRequirements.join(", ")}`
+  : "an idle Library page keeps opencode-config reads bounded";
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+const IDLE_WINDOW_MS = 20_000;
+// One legitimate re-read is tolerated (workspace identity settling after
+// navigation). The regression this guards against produced a project+global
+// pair on every settings re-render: 8+ requests in the same window.
+const IDLE_READ_BUDGET = 2;
+
+test(title, { timeout: 300_000 }, async () => {
+  needs(requirements);
+
+  await using app = await desktop({ name: "library-config-read-budget" });
+  await createAndSelectWorkspace(app, { path: repoRoot });
+
+  // Count opencode-config reads from the renderer before Library mounts so
+  // the initial load is observable (the positive half of the claim). The read
+  // reaches the config through either seam depending on server availability:
+  // an openwork-server fetch (/opencode-config) or the Electron desktop
+  // bridge (readOpencodeConfig IPC). Count both.
+  const installed = await evalIn(app, `(() => {
+    if (window.__opencodeConfigReads !== undefined) return true;
+    window.__opencodeConfigReads = 0;
+    const originalFetch = window.fetch;
+    window.fetch = function (...args) {
+      const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
+      if (typeof target === "string" && target.includes("/opencode-config")) {
+        window.__opencodeConfigReads += 1;
+      }
+      return originalFetch.apply(this, args);
+    };
+    const bridge = window.__OPENWORK_ELECTRON__;
+    if (bridge && typeof bridge.invokeDesktop === "function") {
+      const originalInvoke = bridge.invokeDesktop.bind(bridge);
+      bridge.invokeDesktop = function (command, ...rest) {
+        if (command === "readOpencodeConfig") {
+          window.__opencodeConfigReads += 1;
+        }
+        return originalInvoke(command, ...rest);
+      };
+    }
+    return true;
+  })()`);
+  expect(installed).toBe(true);
+
+  await evalIn(app, `(() => {
+    window.location.hash = "#/settings/extensions";
+    return true;
+  })()`);
+  await waitFor(
+    app,
+    `window.location.hash.includes("/settings/extensions")
+      && [...document.querySelectorAll("h1, h2")].some((heading) => heading.textContent?.trim() === "Library")`,
+    { timeoutMs: 60_000, label: "Library page" },
+  );
+
+  // Positive half: the Library page still reads opencode.json at least once.
+  await waitFor(app, `window.__opencodeConfigReads >= 1`, {
+    timeoutMs: 30_000,
+    label: "initial opencode-config read",
+  });
+
+  // Let the initial mount (project + global scopes, workspace settling) finish.
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  const settled = await evalIn(app, `window.__opencodeConfigReads`);
+  expect(typeof settled).toBe("number");
+
+  // Negative half: while idle on Library, background store ticks (health
+  // polls, MCP status refreshes) must not retrigger config reads.
+  await new Promise((resolve) => setTimeout(resolve, IDLE_WINDOW_MS));
+  const afterIdle = await evalIn(app, `window.__opencodeConfigReads`);
+  expect(typeof afterIdle).toBe("number");
+
+  const idleReads = Number(afterIdle) - Number(settled);
+  expect(
+    idleReads,
+    `opencode-config was read ${idleReads} times during a ${IDLE_WINDOW_MS / 1000}s idle window (budget ${IDLE_READ_BUDGET}); the Library page is refetching config on unrelated re-renders`,
+  ).toBeLessThanOrEqual(IDLE_READ_BUDGET);
+
+  // The page must still be alive and on Library after the idle window.
+  const stillOnLibrary = await evalIn(
+    app,
+    `window.location.hash.includes("/settings/extensions")`,
+  );
+  expect(stillOnLibrary).toBe(true);
+});


### PR DESCRIPTION
## Problem

`McpView` reloads `opencode.json` whenever its `readConfigFile` prop changes identity. `settings-route.tsx` passed an inline lambda, so every settings re-render — which store snapshots trigger every few seconds while idle (health-poll timestamps like `openworkServerCheckedAt`, MCP status refresh `mcpLastUpdatedAt`) — refired the config-load effect and issued a project+global read pair.

Measured live against an installed-production workspace (headless-prod-live world, CDP-instrumented `window.fetch`): **37 `GET /workspace/:id/opencode-config` requests in a 30s idle window** on the Library page (~1.2 req/s of pure refetch churn).

The unstable prop dates to #1470 (April); recent settings-route store churn made it fire more often.

## Fix

Memoize the prop on the stable connections store (`useCallback`), so the config effect only refires when the workspace actually changes. One line at the call site plus the memoized callback.

## Proof

New spec `evals/specs/library-config-read-budget.e2e.test.ts`:
- Positive half: the Library page still performs the initial opencode-config read (counted at both seams — openwork-server fetch and Electron `readOpencodeConfig` IPC).
- Negative half: during a 20s idle window on Library, reads stay within a budget of 2.

Discrimination check: with the fix stashed (unfixed tree), the same spec fails with **7 reads in 20s idle**; with the fix it passes.

Lane: Daytona (`OPENWORK_EVAL_DAYTONA=1`), evidence to be published on the PR head.