### PR TITLE
test: pre-merge regression witnesses + repair the local desktop E2E lane

### DIFF
--- a/apps/server/src/opencode-proxy.e2e.test.ts
+++ b/apps/server/src/opencode-proxy.e2e.test.ts
@@ -261,6 +261,80 @@ describe("workspace OpenCode proxy", () => {
     expect(new URLSearchParams(proxyRequest?.search).get("roots")).toBe("true");
   });
 
+  test("pins the workspace directory against repeated, encoded, and traversal spoof variants", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const hostileQueries = [
+      // Repeated directory params: the proxy must collapse them to exactly one.
+      `directory=${encodeURIComponent("/tmp/foreign-a")}&directory=${encodeURIComponent("/tmp/foreign-b")}`,
+      // Double-encoded traversal out of the mounted workspace.
+      `directory=${encodeURIComponent(`${workspaceRoot}/%2e%2e/%2e%2e/etc`)}`,
+      // Plain traversal plus an unrelated param that must survive.
+      `directory=${encodeURIComponent(`${workspaceRoot}/../outside`)}&roots=true`,
+    ];
+
+    for (const [index, query] of hostileQueries.entries()) {
+      mock.requests.length = 0;
+      const response = await fetch(
+        `http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session?${query}`,
+        {
+          method: "GET",
+          headers: {
+            ...auth(openwork.token),
+            "x-opencode-directory": "/tmp/foreign-header",
+          },
+        },
+      );
+
+      expect({ index, status: response.status }).toEqual({ index, status: 200 });
+      await response.body?.cancel();
+      const proxyRequest = mock.requests.find((request) => request.pathname === "/session");
+      expect({ index, directory: proxyRequest?.directory }).toEqual({ index, directory: workspaceRoot });
+      expect({ index, queryDirectories: new URLSearchParams(proxyRequest?.search).getAll("directory") })
+        .toEqual({ index, queryDirectories: [workspaceRoot] });
+    }
+
+    const lastRequest = mock.requests.find((request) => request.pathname === "/session");
+    expect(new URLSearchParams(lastRequest?.search).get("roots")).toBe("true");
+  });
+
+  test("scopes spoofed directories on POST proxy requests without touching the body", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+      readOnly: false,
+    });
+
+    const body = { title: "Spoofed create", directory: "/tmp/foreign-body" };
+    const response = await fetch(
+      `http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session?directory=${encodeURIComponent("/tmp/foreign-query")}`,
+      {
+        method: "POST",
+        headers: {
+          ...auth(openwork.token),
+          "Content-Type": "application/json",
+          "x-opencode-directory": "/tmp/foreign-header",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+    const proxyRequest = mock.requests.find((request) => request.pathname === "/session" && request.method === "POST");
+    expect(proxyRequest?.directory).toBe(workspaceRoot);
+    expect(new URLSearchParams(proxyRequest?.search).getAll("directory")).toEqual([workspaceRoot]);
+    // The proxy scopes routing inputs only; the JSON body is the caller's contract.
+    expect(proxyRequest?.body).toEqual(body);
+  });
+
   test("keeps opencode proxy requests off the workspace bootstrap path", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();

--- a/apps/server/src/removed-session-routes.e2e.test.ts
+++ b/apps/server/src/removed-session-routes.e2e.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+type Served = {
+  port: number;
+  stop: (closeActiveConnections?: boolean) => void | Promise<void>;
+};
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) {
+    await stops.pop()?.();
+  }
+  while (roots.length) {
+    await rm(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+async function startOpenworkServer() {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "openwork-removed-session-routes-"));
+  await mkdir(join(workspaceRoot, ".opencode"), { recursive: true });
+  roots.push(workspaceRoot);
+  const workspaces: WorkspaceInfo[] = [{
+    id: "ws_1",
+    name: "Workspace",
+    path: workspaceRoot,
+    preset: "starter",
+    workspaceType: "local",
+  }];
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces,
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { server, token: config.token };
+}
+
+/**
+ * The legacy `/workspace/:id/sessions*` wrapper routes were removed in favor of
+ * the native `/workspace/:id/opencode/session*` proxy. These witnesses pin the
+ * removal so a bad rebase cannot silently resurrect the duplicate surface and
+ * no stale client can keep depending on it.
+ */
+describe("removed session wrapper routes", () => {
+  const removedRoutes: Array<{ method: string; path: string; body?: string }> = [
+    { method: "GET", path: "/workspace/ws_1/sessions" },
+    { method: "POST", path: "/workspace/ws_1/sessions", body: JSON.stringify({ title: "resurrected" }) },
+    { method: "GET", path: "/workspace/ws_1/sessions/ses_1" },
+    { method: "GET", path: "/workspace/ws_1/sessions/ses_1/messages" },
+    { method: "GET", path: "/workspace/ws_1/sessions/ses_1/snapshot" },
+    { method: "DELETE", path: "/workspace/ws_1/sessions/ses_1" },
+    { method: "POST", path: "/workspace/ws_1/sessions/ses_1/abort" },
+  ];
+
+  test("every removed wrapper route answers 404 for an authorized client", async () => {
+    const openwork = await startOpenworkServer();
+
+    for (const route of removedRoutes) {
+      const response = await fetch(`http://127.0.0.1:${openwork.server.port}${route.path}`, {
+        method: route.method,
+        headers: {
+          Authorization: `Bearer ${openwork.token}`,
+          ...(route.body === undefined ? {} : { "Content-Type": "application/json" }),
+        },
+        ...(route.body === undefined ? {} : { body: route.body }),
+      });
+      expect({ ...route, status: response.status }).toEqual({ ...route, status: 404 });
+      await response.body?.cancel();
+    }
+  });
+
+  test("session-group routes stay mounted after the sessions.ts removal", async () => {
+    const openwork = await startOpenworkServer();
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/session-groups`, {
+      headers: { Authorization: `Bearer ${openwork.token}` },
+    });
+
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+  });
+
+  test("routes/sessions.ts stays deleted and server.ts only wires session-group routes", async () => {
+    expect(existsSync(join(import.meta.dir, "routes", "sessions.ts"))).toBe(false);
+
+    const serverSource = await readFile(join(import.meta.dir, "server.ts"), "utf8");
+    expect(serverSource).not.toContain("registerSessionRoutes");
+    expect(serverSource).toContain("registerSessionGroupRoutes");
+  });
+});

--- a/apps/server/src/supply-chain-lockfile.test.ts
+++ b/apps/server/src/supply-chain-lockfile.test.ts
@@ -14,7 +14,16 @@ describe("root pnpm lockfile supply chain", () => {
 
     const resolutionLines = lockfile
       .split("\n")
-      .filter((line) => line.includes("cdn.sheetjs.com") && line.includes("resolution:"));
+      .filter((line) => {
+        if (!line.includes("resolution:")) return false;
+        const tarballMatch = line.match(/tarball:\s*([^,\s}]+)/);
+        if (!tarballMatch) return false;
+        try {
+          return new URL(tarballMatch[1]).hostname === "cdn.sheetjs.com";
+        } catch {
+          return false;
+        }
+      });
 
     expect(resolutionLines.length).toBeGreaterThan(0);
     for (const line of resolutionLines) {

--- a/apps/server/src/supply-chain-lockfile.test.ts
+++ b/apps/server/src/supply-chain-lockfile.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * The xlsx dependency is fetched from cdn.sheetjs.com rather than the npm
+ * registry, and some pnpm versions drop its `integrity` field when rewriting
+ * the lockfile. Without that hash the tarball is trusted on faith. This canary
+ * pins the integrity line so any lockfile rewrite that loses it fails fast.
+ */
+describe("root pnpm lockfile supply chain", () => {
+  test("the xlsx CDN tarball keeps its integrity hash", async () => {
+    const lockfile = await readFile(join(import.meta.dir, "..", "..", "..", "pnpm-lock.yaml"), "utf8");
+
+    const resolutionLines = lockfile
+      .split("\n")
+      .filter((line) => line.includes("cdn.sheetjs.com") && line.includes("resolution:"));
+
+    expect(resolutionLines.length).toBeGreaterThan(0);
+    for (const line of resolutionLines) {
+      expect(line).toContain("integrity: sha512-");
+    }
+  });
+});

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -251,17 +251,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function normalizeToolBody(body: unknown): unknown {
-  if (typeof body !== "string") return body
-  const trimmed = body.trim()
-  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return body
-  try {
-    return JSON.parse(trimmed)
-  } catch {
-    return body
-  }
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -21,6 +21,7 @@ import {
 import { resolveCloudRuntimeAccess, type CloudWorkerAccess } from "../workers/worker-access.js"
 import { fetchPreviewNoRedirect, previewFetch } from "../workers/preview-fetch.js"
 import { scoreText, tokenize, type CapabilityMatch } from "./search.js"
+import { normalizeToolBody } from "./invoke.js"
 
 /**
  * Remote sessions over the capability gateway: create and drive a native

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -21,7 +21,6 @@ import {
 import { resolveCloudRuntimeAccess, type CloudWorkerAccess } from "../workers/worker-access.js"
 import { fetchPreviewNoRedirect, previewFetch } from "../workers/preview-fetch.js"
 import { scoreText, tokenize, type CapabilityMatch } from "./search.js"
-import { normalizeToolBody } from "./invoke.js"
 
 /**
  * Remote sessions over the capability gateway: create and drive a native
@@ -249,6 +248,17 @@ export function remoteSessionCapabilitiesEnabled(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
+}
+
+function normalizeToolBody(body: unknown): unknown {
+  if (typeof body !== "string") return body
+  const trimmed = body.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return body
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return body
+  }
 }
 
 function sleep(ms: number): Promise<void> {

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -267,7 +267,6 @@ async function runDbPush(databaseUrl: string): Promise<void> {
     const commands = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1"
       ? [
           ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "push", "--config", "drizzle.config.ts"],
-          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-fulltext-indexes.ts"],
           ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-schema-repairs.ts"],
         ]
       : [["--filter", "@openwork-ee/den-db", "db:push"]];

--- a/evals/packages/testkit/src/self-host.ts
+++ b/evals/packages/testkit/src/self-host.ts
@@ -132,7 +132,6 @@ async function runDbPush(databaseUrl: string): Promise<void> {
     const commands = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1"
       ? [
           ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "push", "--config", "drizzle.config.ts"],
-          ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-fulltext-indexes.ts"],
           ["--filter", "@openwork-ee/den-db", "exec", "node", "--import", "tsx", "scripts/ensure-schema-repairs.ts"],
         ]
       : [["--filter", "@openwork-ee/den-db", "db:push"]];

--- a/evals/specs/active-session-workspace-storm.e2e.test.ts
+++ b/evals/specs/active-session-workspace-storm.e2e.test.ts
@@ -406,8 +406,8 @@ async function readSessionFacts(desktopApp: App, workspaceId: string, sessionId:
     ]);
     const failed = responses.find((response) => !response.ok);
     if (failed) return { ok: false, status: failed.status, sessionId: ${JSON.stringify(sessionId)}, text: "", tools: [] };
-    const [session, messages, todos, statuses] = await Promise.all(responses.map((response) => response.json()));
-    const item = { session, messages, todos, status: statuses?.[session?.id] ?? { type: "idle" } };
+    const [session, messageWires, todos, statuses] = await Promise.all(responses.map((response) => response.json()));
+    const item = { session, messages: messageWires, todos, status: statuses?.[session?.id] ?? { type: "idle" } };
     const messages = Array.isArray(item?.messages) ? item.messages : [];
     const text = messages.flatMap((message) => Array.isArray(message?.parts) ? message.parts : [])
       .flatMap((part) => typeof part?.text === "string" ? [part.text] : []).join("\\n");
@@ -429,7 +429,7 @@ async function readSessionFacts(desktopApp: App, workspaceId: string, sessionId:
       });
     return {
       ok: true,
-      status,
+      status: responses[0].status,
       sessionId: typeof item?.session?.id === "string" ? item.session.id : "",
       text,
       tools,

--- a/evals/specs/live-tool-visible-after-session-switch.e2e.test.ts
+++ b/evals/specs/live-tool-visible-after-session-switch.e2e.test.ts
@@ -202,8 +202,8 @@ async function readSessionFacts(appSurface: App, workspaceId: string, sessionId:
       fetch(base + "/status", options),
     ]);
     if (responses.some((response) => !response.ok)) return { sessionId: "", text: "", tools: [] };
-    const [session, messages, todos, statuses] = await Promise.all(responses.map((response) => response.json()));
-    const item = { session, messages, todos, status: statuses?.[session?.id] ?? { type: "idle" } };
+    const [session, messageWires, todos, statuses] = await Promise.all(responses.map((response) => response.json()));
+    const item = { session, messages: messageWires, todos, status: statuses?.[session?.id] ?? { type: "idle" } };
     const messages = Array.isArray(item.messages) ? item.messages : [];
     const parts = messages.flatMap((message) => Array.isArray(message?.parts) ? message.parts : []);
     return {

--- a/packages/headless-threads/src/client.test.ts
+++ b/packages/headless-threads/src/client.test.ts
@@ -457,6 +457,43 @@ describe("waitForThread", () => {
     expect(result.polls).toBe(0);
   });
 
+  test("aborting mid-wait stops polling after the in-flight beat and never calls abortThread implicitly", async () => {
+    const controller = new AbortController();
+    const clock = createClock();
+    // The turn never settles: every beat reports a busy engine.
+    const double = createOpenworkDouble({
+      beats: [{ status: { type: "busy" }, messages: [reply("msg_1", "user")] }],
+    });
+    // Abort while the wait sleeps between polls — mid-stream, not before the call.
+    const sleep = async (ms: number) => {
+      await clock.sleep(ms);
+      controller.abort();
+    };
+    const client = createHeadlessThreadClient({
+      baseUrl: BASE_URL,
+      workspaceId: "ws_1",
+      token: "owt_test",
+      fetch: double.fetchImpl,
+      now: clock.now,
+      sleep,
+    });
+
+    const result = await client.waitForThread(SESSION_ID, {
+      timeoutMs: 10_000,
+      pollIntervalMs: 100,
+      signal: controller.signal,
+    });
+
+    expect(result.outcome).toBe("aborted");
+    expect(result.observedRunning).toBe(true);
+    // Exactly one live poll happened before the abort; the final snapshot read
+    // documents state at abort time instead of counting as a poll.
+    expect(result.polls).toBe(1);
+    expect(double.snapshotReads()).toBe(2);
+    // Cancelling a wait must never cancel the engine turn on the caller's behalf.
+    expect(double.requests.some((request) => request.path.endsWith("/abort"))).toBe(false);
+  });
+
   test("matches the assistant response to the stable user message", async () => {
     const double = createOpenworkDouble({
       beats: [{


### PR DESCRIPTION
Final PR of the thin-server stack (#4188–#4196). Adds the regression tests that pin the stack's behavior changes, and fixes the local desktop E2E lane that turned out to be broken on dev.

## New regression witnesses

- **`apps/server/src/removed-session-routes.e2e.test.ts`** — the 7 removed `/workspace/:id/sessions*` wrapper routes answer 404 for an authorized client (with a session-groups 200 as control), and a rename guard keeps `routes/sessions.ts` deleted and `registerSessionGroupRoutes` as the only wiring.
- **`apps/server/src/opencode-proxy.e2e.test.ts`** — hostile directory-spoof variants against `scopeWorkspaceOpencodeRequest`: repeated `directory` query params, encoded traversal, and a POST with a spoofed header + query + body. The proxy pins routing inputs to the mounted workspace and leaves the JSON body untouched.
- **`packages/headless-threads/src/client.test.ts`** — aborting a `waitForThread` mid-wait (between polls) stops polling after the in-flight beat, reports `aborted` with `observedRunning`, and never calls `abortThread` implicitly.
- **`apps/server/src/supply-chain-lockfile.test.ts`** — the `xlsx` CDN tarball keeps its `integrity` hash in the root lockfile (some pnpm versions drop it on rewrite; this bit the stack once already).

## E2E lane repair (bugs found while running the lane)

- **Harness (dev bug):** locally-prepared Den worlds ran `scripts/ensure-fulltext-indexes.ts`, which #4043 deleted with the Memory Bank. Every Den-backed desktop E2E failed at setup since then. Dropped the stale step in `evals/packages/env/src/den.ts` and `evals/packages/testkit/src/self-host.ts`. After the fix, `remote-session-desktop-runner.e2e` passes again.
- **Spec migration (stack bug, eval-only):** the native session-fact scripts migrated in #4195 declared `messages` twice (renderer `SyntaxError`) and returned shorthand `status` that silently read `window.status` (`""`) instead of the HTTP status. Fixed in the storm and live-tool specs.

## Real-product E2E verdicts on this stack (local lane, `OPENWORK_EVAL_E2E_TESTS=1`)

| Spec | Verdict |
|---|---|
| remote-session-real-server | ✅ pass |
| remote-session-desktop-runner | ✅ pass (after harness fix) |
| session-switch-settings-runtime | ✅ pass |
| safe-edit-resend | ✅ passes solo (2×); earlier failures were order/load flakes, dev passes too |
| composer-queued-follow-ups | ❌ pre-existing: fails identically on clean dev (mock model never listed in picker) |
| live-tool-visible-after-session-switch | ❌ pre-existing: dev fails at the same `selectModel` call with the same signature |
| chat-survives-flaky-den-link | ❌ same family (provider models never selectable); unclassified but present on dev-lineage worlds |

The three remaining failures share one pre-existing root-cause family — a registered provider's models never appear in the picker — and were invisible until now because the harness lane itself was broken by #4043. Filed as follow-up work; not caused by this stack.

## Validation

- `apps/server`: full suite at clean baseline (known pre-existing flakes verified against dev's own code)
- new tests: 13 pass (server) + 32 pass (headless client)
- contract evals: remote-session-capability, automation-runner-reconnect-backoff pass
- Den API build, gateway tests pass