### PR TITLE
fix(den-api): normalize remote session bodies

### DIFF
--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -250,6 +250,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
+function normalizeToolBody(body: unknown): unknown {
+  if (typeof body !== "string") return body
+  const trimmed = body.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return body
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return body
+  }
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -455,7 +466,7 @@ export async function executeRemoteSessionCapability(
     })
   }
 
-  const parsedBody = BODY_SCHEMAS[input.action].safeParse(input.body ?? {})
+  const parsedBody = BODY_SCHEMAS[input.action].safeParse(normalizeToolBody(input.body) ?? {})
   if (!parsedBody.success) {
     return errorResult({
       error: "invalid_capability_arguments",

--- a/evals/specs/remote-session-capability.test.ts
+++ b/evals/specs/remote-session-capability.test.ts
@@ -322,3 +322,21 @@ test("remote-session capabilities drive a real openwork-server wire with scoped 
     true,
   );
 });
+
+test("remote-session capability accepts a JSON-stringified body", async ({ evidence }) => {
+  const created = await executeRemoteSessionCapability(
+    input("create", JSON.stringify({ title: "Stringified handoff" })),
+    deps,
+  );
+
+  expect(created.isError).toBeUndefined();
+  expect(payload(created).sessionId).toMatch(/^ses_witness_/);
+  expect(witness.requests.findLast(
+    (request) => request.method === "POST" && request.path === `/workspace/${WORKSPACE_ID}/opencode/session`,
+  )?.body).toMatchObject({ title: "Stringified handoff" });
+  evidence.recordAssertionEvidence(
+    "JSON-stringified capability body is normalized",
+    "remote-session:create accepted a JSON-stringified body and passed its title to the native session route.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- normalize JSON-stringified bodies before remote-session capability validation
- add a regression witness for `remote-session:create`

## Verification
- `./node_modules/.bin/vitest run --config vitest.config.ts --project pr specs/remote-session-capability.test.ts`
- 2 tests passed, 0 failed, 0 skipped
- Local PR lane; Daytona was not used.