### PR TITLE
ci: run OpenWork Tests on stacked PRs, not only dev-based ones

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,9 +1,12 @@
 name: OpenWork Tests
 
 on:
+  # No base-branch filter: stacked PRs (base = another feature branch) must run
+  # the same lane as dev-based PRs. With `branches: [dev]` here, every
+  # intermediate PR in a stack skipped this workflow entirely — including the
+  # `openwork-tests-required` context that branch rulesets require — so stacked
+  # changes only met the unit/e2e lane when the final PR was retargeted to dev.
   pull_request:
-    branches:
-      - dev
   push:
     branches:
       - dev


### PR DESCRIPTION
## Problem

`ci-tests.yml` triggers on `pull_request` with `branches: [dev]` — a **base-branch** filter. Any PR whose base is another feature branch (i.e. every intermediate PR in a stack) skips the entire OpenWork Tests lane:

- app / server / desktop unit tests
- eval spec lane (`test:pr`)
- the packaged-build server bundle check (whose own comment notes unbuildable imports "reached dev twice before this ran here")
- app e2e tests
- **`openwork-tests-required`** — the single context branch rulesets require, so stack-internal merges bypass the required check entirely until the final retarget to dev

Concretely: in the recent 9-PR thin-server stack (#4188–#4196), only #4188 (base `dev`) ran this lane in CI. #4189–#4196 were merged-able green with zero unit coverage in CI; the gap was only covered by manual local runs.

## Fix

Drop the base filter on `pull_request` so the lane runs on every PR regardless of base. `push` stays dev-only, so no double-running on feature-branch pushes without a PR.

Cost: the 2-leg matrix now runs on stacked PRs too — that is the point.

## Validation

Workflow-config-only change (inert until merged; per AGENTS.md this may skip runtime proof). YAML validated with `yaml.safe_load`. The trigger semantics are GitHub's documented `pull_request.branches` base-ref filtering.