### PR TITLE
fix(server): reclaim idle per-directory engine instances

### DIFF
--- a/apps/server/src/engine-instance-eviction.e2e.test.ts
+++ b/apps/server/src/engine-instance-eviction.e2e.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { engineInstanceReaperForConfig } from "./engine-instance-reaper.js";
+import { clearEnginePoolForConfig, computeEngineConfigFingerprint, type EngineSpawnTemplate } from "./engine-pool.js";
+import type { ManagedOpencodeServer } from "./managed-opencode.js";
+import { createEnginePoolForConfig, registerTrustedOpencodeProcess, startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+/**
+ * The continuous engine keeps one managed engine process alive across
+ * workspace switches, so every visited workspace retains a live per-directory
+ * instance forever. This tape proves the reaper's full loop against a real
+ * server: an idle background workspace's instance is disposed after the TTL,
+ * the active workspace and a busy background run are immune, and the next
+ * traffic for the evicted workspace re-attaches its runtime-DB MCPs.
+ */
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+type EngineRequest = { method: string; pathname: string; search: string; body: unknown };
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+const savedEnv = new Map<string, string | undefined>();
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  for (const [name, value] of savedEnv) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  savedEnv.clear();
+});
+
+function setEnv(name: string, value: string): void {
+  if (!savedEnv.has(name)) savedEnv.set(name, process.env[name]);
+  process.env[name] = value;
+}
+
+async function createWorkspaceRoot(label: string) {
+  const root = await mkdtemp(join(tmpdir(), `openwork-instance-eviction-${label}-`));
+  await mkdir(join(root, ".opencode"), { recursive: true });
+  roots.push(root);
+  return root;
+}
+
+function startMockEngine() {
+  const requests: EngineRequest[] = [];
+  const busySessionsByDirectory = new Map<string, string[]>();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = request.method === "POST" ? await request.json().catch(() => null) : null;
+      requests.push({ method: request.method, pathname: url.pathname, search: url.search, body });
+
+      if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      if (url.pathname === "/session/status") {
+        const directory = url.searchParams.get("directory") ?? request.headers.get("x-opencode-directory") ?? "";
+        const sessions = busySessionsByDirectory.get(directory) ?? [];
+        return Response.json(Object.fromEntries(sessions.map((id) => [id, { type: "busy" }])));
+      }
+      if (url.pathname === "/mcp" && request.method === "POST") {
+        const name = (body as { name?: string } | null)?.name;
+        return Response.json(name ? { [name]: { status: "connected" } } : {});
+      }
+      if (url.pathname === "/mcp" && request.method === "GET") return Response.json({});
+      if (url.pathname.match(/^\/mcp\/[^/]+\/disconnect$/)) return Response.json({});
+      if (url.pathname === "/session") return Response.json([]);
+      if (url.pathname === "/event") {
+        // Held open like a real engine event stream; ends when the proxy
+        // aborts it after its client disconnects.
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: {}\n\n"));
+          },
+        });
+        return new Response(body, { headers: { "content-type": "text/event-stream" } });
+      }
+      return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
+    },
+  }) as Served & { port: number };
+  stops.push(() => server.stop(true));
+  return {
+    requests,
+    url: `http://127.0.0.1:${server.port}`,
+    setBusySessions: (directory: string, sessions: string[]) => {
+      busySessionsByDirectory.set(directory, sessions);
+    },
+  };
+}
+
+function syntheticManagedHandle(url: string): ManagedOpencodeServer {
+  return {
+    url,
+    username: "instance-eviction-user",
+    password: "instance-eviction-pass",
+    pid: null,
+    execution: { command: "opencode", args: [], cwd: "/", env: [] },
+    isAlive: () => true,
+    close: async () => undefined,
+  };
+}
+
+async function startPooledOpenworkServer(input: { activeRoot: string; idleRoot: string; engineUrl: string }) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      {
+        id: "ws_active",
+        name: "Active",
+        path: input.activeRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: input.engineUrl,
+      },
+      {
+        id: "ws_idle",
+        name: "Idle",
+        path: input.idleRoot,
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: input.engineUrl,
+      },
+    ],
+    authorizedRoots: [input.activeRoot, input.idleRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  registerTrustedOpencodeProcess(config, {
+    baseUrl: input.engineUrl,
+    identity: "test-managed-instance-eviction",
+    isAlive: () => true,
+  });
+  const runtimeConfigPath = join(input.activeRoot, ".opencode", "runtime-config.json");
+  await writeFile(runtimeConfigPath, "{}\n", "utf8");
+  const template: EngineSpawnTemplate = {
+    cwd: input.activeRoot,
+    runtimeConfigPath,
+    env: {},
+    reservedPorts: () => [],
+  };
+  const pool = createEnginePoolForConfig({
+    config,
+    template,
+    handle: syntheticManagedHandle(input.engineUrl),
+    fingerprint: await computeEngineConfigFingerprint(template),
+    registryId: null,
+    trustedIdentity: null,
+  });
+  stops.push(async () => {
+    clearEnginePoolForConfig(config);
+    await pool.disposeAll();
+  });
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token, config };
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function waitForRequest(
+  requests: EngineRequest[],
+  match: (entry: EngineRequest) => boolean,
+  label: string,
+  timeoutMs = 3_000,
+): Promise<EngineRequest> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const found = requests.find(match);
+    if (found) return found;
+    await Bun.sleep(20);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+const disposesFor = (requests: EngineRequest[], root: string) =>
+  requests.filter((entry) =>
+    entry.pathname === "/instance/dispose" && entry.search.includes(`directory=${encodeURIComponent(root)}`),
+  );
+
+describe("engine instance eviction", () => {
+  test("an idle background instance is evicted after the TTL and re-attached on return; active and busy instances stay", async () => {
+    setEnv("OPENWORK_ENGINE_INSTANCE_IDLE_TTL_MS", "250");
+    setEnv("OPENWORK_MCP_SYNC_RETRY_DELAY_MS", "10");
+    const activeRoot = await createWorkspaceRoot("active");
+    const idleRoot = await createWorkspaceRoot("idle");
+    setEnv("OPENWORK_RUNTIME_DB", join(activeRoot, "runtime.sqlite"));
+    const engine = startMockEngine();
+    const openwork = await startPooledOpenworkServer({ activeRoot, idleRoot, engineUrl: engine.url });
+    const reaper = engineInstanceReaperForConfig(openwork.config);
+    expect(reaper).not.toBeNull();
+    if (!reaper) throw new Error("engine instance reaper was not registered");
+
+    // A runtime-DB MCP on the background workspace: the dynamic push is the
+    // state a fresh instance cannot recover from disk.
+    const added = await fetch(`${openwork.base}/workspace/ws_idle/mcp`, {
+      method: "POST",
+      headers: auth(openwork.token),
+      body: JSON.stringify({
+        name: "posthog",
+        config: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true, oauth: {} },
+      }),
+    });
+    expect(added.status).toBe(200);
+    await waitForRequest(
+      engine.requests,
+      (entry) => entry.method === "POST" && entry.pathname === "/mcp",
+      "the initial runtime MCP push",
+    );
+
+    // Both workspaces see traffic, so both instances are tracked.
+    for (const workspaceId of ["ws_active", "ws_idle"]) {
+      const proxied = await fetch(`${openwork.base}/workspace/${workspaceId}/opencode/session`, {
+        headers: auth(openwork.token),
+      });
+      expect(proxied.status).toBe(200);
+    }
+    expect(reaper.snapshot().map((entry) => entry.directory).sort()).toEqual([activeRoot, idleRoot].sort());
+
+    // Not yet stale: nothing is evicted.
+    expect(await reaper.sweep()).toBe(0);
+    expect(disposesFor(engine.requests, idleRoot)).toHaveLength(0);
+
+    // A live background run holds the instance past the TTL.
+    engine.setBusySessions(idleRoot, ["ses_live_run"]);
+    await Bun.sleep(300);
+    expect(await reaper.sweep()).toBe(0);
+    expect(disposesFor(engine.requests, idleRoot)).toHaveLength(0);
+
+    // Idle past the TTL: only the background instance is disposed.
+    engine.setBusySessions(idleRoot, []);
+    await Bun.sleep(300);
+    expect(await reaper.sweep()).toBe(1);
+    expect(disposesFor(engine.requests, idleRoot)).toHaveLength(1);
+    expect(disposesFor(engine.requests, activeRoot)).toHaveLength(0);
+    expect(reaper.snapshot().map((entry) => entry.directory)).toEqual([activeRoot]);
+
+    // Returning to the evicted workspace re-attaches its runtime-DB MCPs.
+    engine.requests.length = 0;
+    const returned = await fetch(`${openwork.base}/workspace/ws_idle/opencode/session`, {
+      headers: auth(openwork.token),
+    });
+    expect(returned.status).toBe(200);
+    const restore = await waitForRequest(
+      engine.requests,
+      (entry) =>
+        entry.method === "POST"
+        && entry.pathname === "/mcp"
+        && entry.search.includes(`directory=${encodeURIComponent(idleRoot)}`)
+        && (entry.body as { name?: string } | null)?.name === "posthog",
+      "the post-eviction runtime MCP re-push",
+    );
+    expect(restore).toBeDefined();
+
+    // The active workspace was never disposed, and repeated sweeps stay quiet
+    // for the freshly returned instance.
+    expect(disposesFor(engine.requests, activeRoot)).toHaveLength(0);
+    expect(await reaper.sweep()).toBe(0);
+  }, 30_000);
+
+  test("an open engine event stream keeps a stale background instance alive until the client disconnects", async () => {
+    setEnv("OPENWORK_ENGINE_INSTANCE_IDLE_TTL_MS", "250");
+    const activeRoot = await createWorkspaceRoot("active");
+    const idleRoot = await createWorkspaceRoot("watched");
+    setEnv("OPENWORK_RUNTIME_DB", join(activeRoot, "runtime.sqlite"));
+    const engine = startMockEngine();
+    const openwork = await startPooledOpenworkServer({ activeRoot, idleRoot, engineUrl: engine.url });
+    const reaper = engineInstanceReaperForConfig(openwork.config);
+    if (!reaper) throw new Error("engine instance reaper was not registered");
+
+    // A live proxied event stream is exactly what an open tab holds.
+    const streamAbort = new AbortController();
+    const streamResponse = await fetch(`${openwork.base}/workspace/ws_idle/opencode/event`, {
+      headers: auth(openwork.token),
+      signal: streamAbort.signal,
+    });
+    expect(streamResponse.ok).toBe(true);
+    expect(streamResponse.headers.get("content-type") ?? "").toContain("text/event-stream");
+    expect(reaper.snapshot().find((entry) => entry.directory === idleRoot)?.streamHolds).toBe(1);
+
+    // Stale past the TTL, but watched: the instance stays.
+    await Bun.sleep(300);
+    expect(await reaper.sweep()).toBe(0);
+    expect(disposesFor(engine.requests, idleRoot)).toHaveLength(0);
+
+    // The watching client goes away; the idle clock restarts and the next
+    // stale sweep evicts.
+    streamAbort.abort();
+    await streamResponse.body?.cancel().catch(() => undefined);
+    const releasedAt = Date.now();
+    while (Date.now() - releasedAt < 3_000) {
+      const holds = reaper.snapshot().find((entry) => entry.directory === idleRoot)?.streamHolds ?? 0;
+      if (holds === 0) break;
+      await Bun.sleep(20);
+    }
+    expect(reaper.snapshot().find((entry) => entry.directory === idleRoot)?.streamHolds).toBe(0);
+    await Bun.sleep(300);
+    expect(await reaper.sweep()).toBe(1);
+    expect(disposesFor(engine.requests, idleRoot)).toHaveLength(1);
+    expect(disposesFor(engine.requests, activeRoot)).toHaveLength(0);
+  }, 30_000);
+});

--- a/apps/server/src/engine-instance-reaper.test.ts
+++ b/apps/server/src/engine-instance-reaper.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  EngineInstanceReaper,
+  type EngineInstanceReaperHooks,
+  type TrackedEngineInstance,
+} from "./engine-instance-reaper.js";
+
+const ENGINE_URL = "http://127.0.0.1:4101";
+const TTL_ENV = "OPENWORK_ENGINE_INSTANCE_IDLE_TTL_MS";
+
+const savedEnv = new Map<string, string | undefined>();
+
+afterEach(() => {
+  for (const [name, value] of savedEnv) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  savedEnv.clear();
+});
+
+function setEnv(name: string, value: string): void {
+  if (!savedEnv.has(name)) savedEnv.set(name, process.env[name]);
+  process.env[name] = value;
+}
+
+type Harness = {
+  reaper: EngineInstanceReaper;
+  disposed: TrackedEngineInstance[];
+  clock: { now: number };
+  setBusy: (directory: string, busy: boolean) => void;
+  failProbes: (fail: boolean) => void;
+  failDisposes: (fail: boolean) => void;
+  setActiveDirectory: (directory: string | null) => void;
+  setEngineBaseUrl: (url: string | null) => void;
+  onBusyProbe: (probe: ((entry: TrackedEngineInstance) => void) | null) => void;
+};
+
+function createHarness(overrides?: Partial<EngineInstanceReaperHooks>): Harness {
+  const clock = { now: 1_000_000 };
+  const busyByDirectory = new Map<string, boolean>();
+  const disposed: TrackedEngineInstance[] = [];
+  let probesFail = false;
+  let disposesFail = false;
+  let activeDirectory: string | null = null;
+  let engineBaseUrl: string | null = ENGINE_URL;
+  let busyProbeObserver: ((entry: TrackedEngineInstance) => void) | null = null;
+  const reaper = new EngineInstanceReaper({
+    engineBaseUrl: () => engineBaseUrl,
+    activeDirectory: () => activeDirectory,
+    directoryBusy: async (entry) => {
+      busyProbeObserver?.(entry);
+      if (probesFail) throw new Error("status probe unavailable");
+      return busyByDirectory.get(entry.directory) === true;
+    },
+    dispose: async (entry) => {
+      if (disposesFail) throw new Error("dispose unavailable");
+      disposed.push({ ...entry });
+    },
+    now: () => clock.now,
+    ...overrides,
+  });
+  return {
+    reaper,
+    disposed,
+    clock,
+    setBusy: (directory, busy) => void busyByDirectory.set(directory, busy),
+    failProbes: (fail) => void (probesFail = fail),
+    failDisposes: (fail) => void (disposesFail = fail),
+    setActiveDirectory: (directory) => void (activeDirectory = directory),
+    setEngineBaseUrl: (url) => void (engineBaseUrl = url),
+    onBusyProbe: (probe) => void (busyProbeObserver = probe),
+  };
+}
+
+function use(directory: string, workspaceId = `ws-${directory}`) {
+  return { directory, workspaceId, engineBaseUrl: ENGINE_URL };
+}
+
+describe("engine instance reaper", () => {
+  test("evicts an idle non-active instance after the TTL and marks its workspace exactly once", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.setActiveDirectory("/work/active");
+    harness.reaper.noteUsed(use("/work/active"));
+    harness.reaper.noteUsed(use("/work/background"));
+
+    harness.clock.now += 999;
+    expect(await harness.reaper.sweep()).toBe(0);
+
+    harness.clock.now += 2;
+    expect(await harness.reaper.sweep()).toBe(1);
+    expect(harness.disposed.map((entry) => entry.directory)).toEqual(["/work/background"]);
+    expect(harness.reaper.snapshot().map((entry) => entry.directory)).toEqual(["/work/active"]);
+
+    // The next traffic for the evicted workspace re-attaches state exactly once.
+    expect(harness.reaper.noteUsed(use("/work/background"))).toBe(true);
+    expect(harness.reaper.noteUsed(use("/work/background"))).toBe(false);
+  });
+
+  test("never evicts the active workspace instance and keeps it warm instead", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.setActiveDirectory("/work/active");
+    harness.reaper.noteUsed(use("/work/active"));
+
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+    // The sweep refreshed the active instance, so a later activity check
+    // still sees it as recently used.
+    expect(harness.reaper.snapshot()[0]?.lastUsedAt).toBe(harness.clock.now);
+  });
+
+  test("an open event stream holds the instance; releasing the hold restarts the idle clock", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    const release = harness.reaper.holdStream(use("/work/watched"));
+
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+
+    release();
+    release(); // Idempotent: double release never underflows the hold count.
+    harness.clock.now += 999;
+    expect(await harness.reaper.sweep()).toBe(0);
+    harness.clock.now += 2;
+    expect(await harness.reaper.sweep()).toBe(1);
+    expect(harness.disposed.map((entry) => entry.directory)).toEqual(["/work/watched"]);
+  });
+
+  test("a stream hold never consumes the pending post-eviction mark", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/background"));
+    harness.clock.now += 1_001;
+    expect(await harness.reaper.sweep()).toBe(1);
+
+    const release = harness.reaper.holdStream(use("/work/background"));
+    expect(harness.reaper.noteUsed(use("/work/background"))).toBe(true);
+    release();
+  });
+
+  test("a busy instance is kept and its idle clock restarts", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/running"));
+    harness.setBusy("/work/running", true);
+
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+
+    harness.setBusy("/work/running", false);
+    harness.clock.now += 999;
+    expect(await harness.reaper.sweep()).toBe(0);
+    harness.clock.now += 2;
+    expect(await harness.reaper.sweep()).toBe(1);
+  });
+
+  test("an unreadable activity probe never evicts", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/unknown"));
+    harness.failProbes(true);
+
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+
+    harness.failProbes(false);
+    expect(await harness.reaper.sweep()).toBe(1);
+  });
+
+  test("traffic landing during the activity probe wins over the eviction", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/racing"));
+    harness.onBusyProbe(() => {
+      harness.reaper.noteUsed(use("/work/racing"));
+    });
+
+    harness.clock.now += 1_001;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+  });
+
+  test("a failed dispose keeps the instance for a later retry", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/background"));
+    harness.failDisposes(true);
+
+    harness.clock.now += 1_001;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.reaper.snapshot()).toHaveLength(1);
+    expect(harness.reaper.noteUsed(use("/work/background"))).toBe(false);
+
+    harness.failDisposes(false);
+    harness.clock.now += 1_001;
+    expect(await harness.reaper.sweep()).toBe(1);
+  });
+
+  test("instances from a retired engine generation are dropped without a dispose", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/old"));
+    harness.setEngineBaseUrl("http://127.0.0.1:4999");
+
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+    expect(harness.reaper.snapshot()).toHaveLength(0);
+  });
+
+  test("no managed engine means nothing is swept", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/background"));
+    harness.setEngineBaseUrl(null);
+
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+    expect(harness.reaper.snapshot()).toHaveLength(1);
+  });
+
+  test("a zero TTL disables eviction entirely", async () => {
+    setEnv(TTL_ENV, "0");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/background"));
+
+    harness.clock.now += 100_000_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+    expect(harness.disposed).toHaveLength(0);
+  });
+
+  test("close clears state and stops tracking", async () => {
+    setEnv(TTL_ENV, "1000");
+    const harness = createHarness();
+    harness.reaper.noteUsed(use("/work/background"));
+    harness.reaper.close();
+    expect(harness.reaper.snapshot()).toHaveLength(0);
+    expect(harness.reaper.noteUsed(use("/work/background"))).toBe(false);
+    harness.clock.now += 100_000;
+    expect(await harness.reaper.sweep()).toBe(0);
+  });
+});

--- a/apps/server/src/engine-instance-reaper.ts
+++ b/apps/server/src/engine-instance-reaper.ts
@@ -1,0 +1,235 @@
+/**
+ * Idle eviction for per-directory OpenCode engine instances.
+ *
+ * The managed engine is one long-lived process that boots a per-directory
+ * instance on demand and never retires one on its own. Since the continuous
+ * engine keeps that process alive across workspace switches, every workspace
+ * ever visited retains a live instance — config, plugins, watchers, session
+ * caches — for the lifetime of the app. This reaper reclaims those instances.
+ *
+ * Policy: an instance is evicted only when every hold is absent —
+ * - it is not the active workspace's instance,
+ * - no engine event stream from that workspace is open (no visible UI),
+ * - it reports no non-idle session (a live background run always stays), and
+ * - it has seen no traffic for the idle TTL.
+ *
+ * Sessions live in the engine's shared SQLite, so an evicted instance loses
+ * only process state. The next request re-materializes it from disk config;
+ * the server owns pushing back the runtime-DB MCPs a fresh instance cannot
+ * read from disk, which is why eviction marks the workspace and `noteUsed`
+ * reports that mark exactly once to whoever sends the next traffic.
+ *
+ * Only managed engines are swept: an attached engine may serve other clients,
+ * so its instances are not ours to trim. The hooks own every side effect; this
+ * module holds the policy and its bookkeeping.
+ */
+import type { ServerConfig } from "./types.js";
+
+export type EngineInstanceReaperLogger = {
+  log: (level: "info" | "warn" | "error", message: string, attributes?: Record<string, unknown>) => void;
+};
+
+export type EngineInstanceUse = {
+  directory: string;
+  workspaceId: string;
+  engineBaseUrl: string;
+};
+
+export type TrackedEngineInstance = EngineInstanceUse & {
+  lastUsedAt: number;
+  streamHolds: number;
+};
+
+export type EngineInstanceReaperHooks = {
+  /** Primary managed engine URL. Null means no managed engine: nothing is swept. */
+  engineBaseUrl: () => string | null;
+  /** Directory of the active local workspace. Its instance always stays warm. */
+  activeDirectory: () => string | null;
+  /** True when the instance still reports a non-idle session. A thrown error means unknown, which never evicts. */
+  directoryBusy: (instance: TrackedEngineInstance) => Promise<boolean>;
+  /** Dispose the instance and invalidate whatever per-workspace evidence a fresh instance cannot honor. */
+  dispose: (instance: TrackedEngineInstance) => Promise<void>;
+  now?: () => number;
+  logger?: EngineInstanceReaperLogger;
+};
+
+/** How long an instance may sit unused before it is eligible for eviction. 0 disables eviction. */
+export function engineInstanceIdleTtlMs(): number {
+  const raw = process.env.OPENWORK_ENGINE_INSTANCE_IDLE_TTL_MS?.trim();
+  if (!raw) return 15 * 60_000;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : 15 * 60_000;
+}
+
+function sweepIntervalMs(): number {
+  const value = Number(process.env.OPENWORK_ENGINE_INSTANCE_SWEEP_MS);
+  return Number.isFinite(value) && value > 0 ? value : 60_000;
+}
+
+export class EngineInstanceReaper {
+  private readonly hooks: EngineInstanceReaperHooks;
+  private readonly instances = new Map<string, TrackedEngineInstance>();
+  private readonly evictedWorkspaceIds = new Set<string>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private sweeping = false;
+  private closed = false;
+
+  constructor(hooks: EngineInstanceReaperHooks) {
+    this.hooks = hooks;
+  }
+
+  /**
+   * Record traffic for a directory instance. Returns true exactly once after
+   * that workspace's instance was evicted, so the caller can re-attach the
+   * state a fresh instance cannot recover from disk.
+   */
+  noteUsed(use: EngineInstanceUse): boolean {
+    if (this.closed) return false;
+    const existing = this.instances.get(use.directory);
+    if (existing && existing.engineBaseUrl === use.engineBaseUrl) {
+      existing.workspaceId = use.workspaceId;
+      existing.lastUsedAt = this.now();
+    } else {
+      // A different engine URL means a new engine process; streams held on the
+      // previous generation were aborted with it.
+      this.instances.set(use.directory, { ...use, lastUsedAt: this.now(), streamHolds: 0 });
+    }
+    return this.evictedWorkspaceIds.delete(use.workspaceId);
+  }
+
+  /**
+   * Hold the instance while an engine event stream from its workspace stays
+   * open, so a workspace that is visible anywhere in the UI is never evicted.
+   * Unlike `noteUsed` this never consumes the one-shot post-eviction mark;
+   * callers report that mark through their own `noteUsed` call.
+   */
+  holdStream(use: EngineInstanceUse): () => void {
+    if (this.closed) return () => undefined;
+    const existing = this.instances.get(use.directory);
+    let entry: TrackedEngineInstance;
+    if (existing && existing.engineBaseUrl === use.engineBaseUrl) {
+      existing.workspaceId = use.workspaceId;
+      existing.lastUsedAt = this.now();
+      entry = existing;
+    } else {
+      entry = { ...use, lastUsedAt: this.now(), streamHolds: 0 };
+      this.instances.set(use.directory, entry);
+    }
+    entry.streamHolds += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const current = this.instances.get(use.directory);
+      if (!current || current.engineBaseUrl !== use.engineBaseUrl) return;
+      current.streamHolds = Math.max(0, current.streamHolds - 1);
+      current.lastUsedAt = this.now();
+    };
+  }
+
+  snapshot(): TrackedEngineInstance[] {
+    return [...this.instances.values()].map((entry) => ({ ...entry }));
+  }
+
+  start(): void {
+    if (this.closed || this.sweepTimer) return;
+    const timer = setInterval(() => void this.sweep().catch(() => undefined), sweepIntervalMs());
+    timer.unref?.();
+    this.sweepTimer = timer;
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.instances.clear();
+    this.evictedWorkspaceIds.clear();
+  }
+
+  /** Run one eviction pass. Returns how many instances were evicted. */
+  async sweep(): Promise<number> {
+    if (this.closed || this.sweeping) return 0;
+    const ttl = engineInstanceIdleTtlMs();
+    if (ttl <= 0) return 0;
+    const engineBaseUrl = this.hooks.engineBaseUrl();
+    if (!engineBaseUrl) return 0;
+    this.sweeping = true;
+    try {
+      const activeDirectory = this.hooks.activeDirectory();
+      let evicted = 0;
+      for (const entry of [...this.instances.values()]) {
+        if (this.closed) break;
+        if (entry.engineBaseUrl !== engineBaseUrl) {
+          // The engine process this instance lived in is gone; there is
+          // nothing left to dispose.
+          this.instances.delete(entry.directory);
+          continue;
+        }
+        if (entry.directory === activeDirectory) {
+          entry.lastUsedAt = this.now();
+          continue;
+        }
+        if (entry.streamHolds > 0) continue;
+        if (this.now() - entry.lastUsedAt < ttl) continue;
+        let busy: boolean;
+        try {
+          busy = await this.hooks.directoryBusy(entry);
+        } catch (error) {
+          this.hooks.logger?.log("warn", "Engine instance activity probe failed; the instance stays.", {
+            "engine.instance.directory": entry.directory,
+            "engine.instance.workspace_id": entry.workspaceId,
+            "error.message": error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+        if (busy) {
+          entry.lastUsedAt = this.now();
+          continue;
+        }
+        // Traffic may have landed while the probe ran; a fresh touch wins.
+        if (this.now() - entry.lastUsedAt < ttl) continue;
+        try {
+          await this.hooks.dispose(entry);
+        } catch (error) {
+          this.hooks.logger?.log("warn", "Idle engine instance dispose failed; it will be retried.", {
+            "engine.instance.directory": entry.directory,
+            "engine.instance.workspace_id": entry.workspaceId,
+            "error.message": error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+        this.instances.delete(entry.directory);
+        this.evictedWorkspaceIds.add(entry.workspaceId);
+        evicted += 1;
+        this.hooks.logger?.log("info", "Evicted an idle engine instance.", {
+          "engine.instance.directory": entry.directory,
+          "engine.instance.workspace_id": entry.workspaceId,
+          "engine.instance.idle_ms": this.now() - entry.lastUsedAt,
+        });
+      }
+      return evicted;
+    } finally {
+      this.sweeping = false;
+    }
+  }
+
+  private now(): number {
+    return this.hooks.now?.() ?? Date.now();
+  }
+}
+
+const reaperByConfig = new WeakMap<ServerConfig, EngineInstanceReaper>();
+
+export function setEngineInstanceReaperForConfig(config: ServerConfig, reaper: EngineInstanceReaper): void {
+  reaperByConfig.set(config, reaper);
+}
+
+export function engineInstanceReaperForConfig(config: ServerConfig): EngineInstanceReaper | null {
+  return reaperByConfig.get(config) ?? null;
+}
+
+export function clearEngineInstanceReaperForConfig(config: ServerConfig): void {
+  reaperByConfig.delete(config);
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -16,6 +16,13 @@ import {
   type EngineSpawnTemplate,
 } from "./engine-pool.js";
 import { withEngineDirectoryFence } from "./engine-directory-fence.js";
+import {
+  clearEngineInstanceReaperForConfig,
+  EngineInstanceReaper,
+  engineInstanceReaperForConfig,
+  setEngineInstanceReaperForConfig,
+  type TrackedEngineInstance,
+} from "./engine-instance-reaper.js";
 import { shouldDeferInPlaceEngineReload } from "./engine-reload-defer.js";
 import { LatestTrailingWorkQueue } from "./latest-trailing-work-queue.js";
 import { buildEngineAuthProbeHeader } from "./engine-registry.js";
@@ -1022,6 +1029,20 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
   };
   const engineMcpServerState = beginEngineMcpServerState(config);
+  const engineInstanceReaper = new EngineInstanceReaper({
+    // Only the managed engine is swept: the pool exists exactly when this
+    // server owns the engine process. An attached engine may serve other
+    // clients, so its per-directory instances are not ours to trim.
+    engineBaseUrl: () => enginePoolForConfig(config)?.primaryUrl() ?? null,
+    activeDirectory: () => {
+      const active = config.workspaces[0];
+      return active ? resolveOpencodeDirectory(active) : null;
+    },
+    directoryBusy: (instance) => engineInstanceHasActiveSessions(config, instance),
+    dispose: (instance) => disposeIdleEngineInstance(config, engineMcpServerState, instance),
+    logger,
+  });
+  setEngineInstanceReaperForConfig(config, engineInstanceReaper);
   const cloudProviderSync = new CloudProviderSync({
     config,
     env,
@@ -1246,6 +1267,8 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   } catch (error) {
     captureServerException(error, { method: "START", route: "startServer" });
     cloudProviderSync.stop();
+    engineInstanceReaper.close();
+    clearEngineInstanceReaperForConfig(config);
     invalidateEngineMcpServerState(config, engineMcpServerState);
     watcherHandle.close();
     reloadBaselineRefreshers.delete(config);
@@ -1270,10 +1293,14 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   resetManagedProviderAuthCache();
   void syncManagedProviderAuth({ config, env, logger: toManagedProviderAuthLogger(logger) }).catch(() => undefined);
 
+  engineInstanceReaper.start();
+
   return {
     ...server,
     stop: async () => {
       cloudProviderSync.stop();
+      engineInstanceReaper.close();
+      clearEngineInstanceReaperForConfig(config);
       invalidateEngineMcpServerState(config, engineMcpServerState);
       watcherHandle.close();
       reloadBaselineRefreshers.delete(config);
@@ -1344,6 +1371,7 @@ export function createWorkspaceOpencodeClient(
     });
   }
   const directory = resolveOpencodeDirectory(workspace);
+  touchEngineWorkspaceInstance(config, workspace, baseUrl);
   const baseFetch = directory ? createOpencodeDirectoryFetch(directory) : globalThis.fetch;
   const clientFetch = options?.boundedDiagnosticsReads
     ? createAgentDiagnosticsEngineFetch(baseFetch)
@@ -1414,6 +1442,8 @@ export async function proxyOpencodeRequest(input: {
     headers.set("Authorization", auth);
   }
 
+  if (workspace) touchEngineWorkspaceInstance(input.config, workspace, baseUrl);
+
   // Buffer the request body so it can be forwarded reliably across Node.js
   // stream boundaries (Readable.toWeb streams from the HTTP adapter aren't
   // always accepted directly by Node's global fetch as a body).
@@ -1421,14 +1451,37 @@ export async function proxyOpencodeRequest(input: {
     ? undefined
     : await input.request.arrayBuffer().then((buf) => (buf.byteLength > 0 ? buf : undefined));
   if (pool && method === "GET" && isEngineEventPath(proxyPath)) {
-    return proxyEngineEventStreams({
-      pool,
-      connections: pool.connections(),
-      proxyPath,
-      search: input.url.search,
-      headers,
-      clientSignal: input.request.signal,
-    });
+    // An open engine event stream means this workspace is visible somewhere in
+    // the UI; hold its instance so the idle reaper leaves it alone until the
+    // stream's client goes away.
+    const releaseStreamHold = workspace && workspace.workspaceType !== "remote" && directory
+      ? engineInstanceReaperForConfig(input.config)?.holdStream({
+          directory,
+          workspaceId: workspace.id,
+          engineBaseUrl: baseUrl,
+        }) ?? null
+      : null;
+    if (releaseStreamHold) {
+      if (input.request.signal.aborted) releaseStreamHold();
+      else input.request.signal.addEventListener("abort", releaseStreamHold, { once: true });
+    }
+    try {
+      const response = await proxyEngineEventStreams({
+        pool,
+        connections: pool.connections(),
+        proxyPath,
+        search: input.url.search,
+        headers,
+        clientSignal: input.request.signal,
+      });
+      // A non-stream response completes immediately; holding it would leak
+      // across every client retry.
+      if (releaseStreamHold && (!response.ok || !response.body)) releaseStreamHold();
+      return response;
+    } catch (error) {
+      releaseStreamHold?.();
+      throw error;
+    }
   }
   if (pool && method === "GET" && engineAggregateKind(proxyPath)) {
     return proxyEngineAggregateRead({
@@ -4172,6 +4225,82 @@ async function engineHasActiveSessions(config: ServerConfig, workspace: Workspac
   }
 }
 
+function primaryManagedEngineConnection(config: ServerConfig): EnginePoolConnection | null {
+  return enginePoolForConfig(config)?.connections().find((entry) => entry.role === "primary") ?? null;
+}
+
+/**
+ * Whether a tracked engine instance still reports a non-idle session. Probed
+ * directly against the managed engine (never through the workspace client) so
+ * the reaper's own probe cannot refresh the instance's last-used time.
+ * Throws on an unreadable status: unknown activity must never evict.
+ */
+async function engineInstanceHasActiveSessions(
+  config: ServerConfig,
+  instance: TrackedEngineInstance,
+): Promise<boolean> {
+  const primary = primaryManagedEngineConnection(config);
+  if (!primary || primary.baseUrl !== instance.engineBaseUrl) return false;
+  const url = new URL("/session/status", primary.baseUrl);
+  url.searchParams.set("directory", instance.directory);
+  const response = await loopbackFetch(url.toString(), {
+    headers: { Authorization: buildEngineAuthProbeHeader(primary.username, primary.password) },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`OpenCode session status probe failed with status ${response.status}`);
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)) return false;
+  return Object.values(payload).some((status) => isRecord(status) && status.type !== "idle");
+}
+
+/**
+ * Dispose one idle per-directory engine instance without the reload path's
+ * post-refresh sync: re-materializing the instance here would defeat the
+ * eviction. The workspace's MCP registration evidence is invalidated first so
+ * nothing claims the fresh instance already holds the runtime-DB MCPs; the
+ * reaper marks the workspace and the next traffic re-attaches that state.
+ */
+async function disposeIdleEngineInstance(
+  config: ServerConfig,
+  serverState: EngineMcpServerState,
+  instance: TrackedEngineInstance,
+): Promise<void> {
+  const primary = primaryManagedEngineConnection(config);
+  if (!primary || primary.baseUrl !== instance.engineBaseUrl) {
+    throw new Error("The managed engine connection is unavailable for the instance dispose");
+  }
+  const activeState = activeEngineMcpServerState(config, serverState);
+  if (activeState) invalidateEngineMcpWorkspace(activeState, instance.workspaceId);
+  const response = await loopbackFetch(buildOpencodeReloadUrl(primary.baseUrl, instance.directory), {
+    method: "POST",
+    headers: { Authorization: buildEngineAuthProbeHeader(primary.username, primary.password) },
+    signal: AbortSignal.timeout(opencodeDisposeTimeoutMs()),
+  });
+  if (!response.ok) throw new Error(`OpenCode instance dispose failed with status ${response.status}`);
+}
+
+/**
+ * Record engine traffic for a local workspace's directory instance. When this
+ * is the first traffic after that instance was evicted, re-attach the state a
+ * fresh instance cannot recover from disk (the runtime-DB MCP push), detached
+ * from the request that triggered it.
+ */
+function touchEngineWorkspaceInstance(config: ServerConfig, workspace: WorkspaceInfo, engineBaseUrl: string): void {
+  if (workspace.workspaceType === "remote") return;
+  const reaper = engineInstanceReaperForConfig(config);
+  if (!reaper) return;
+  const directory = resolveOpencodeDirectory(workspace);
+  if (!directory) return;
+  const evicted = reaper.noteUsed({ directory, workspaceId: workspace.id, engineBaseUrl });
+  if (!evicted) return;
+  void postEngineRefreshSync(config, workspace, activeEngineMcpServerState(config)).catch((error) => {
+    createServerLogger(config).log("error", "Post-eviction engine MCP re-sync failed.", {
+      "workspace.id": workspace.id,
+      "error.message": error instanceof Error ? error.message : String(error),
+    });
+  });
+}
+
 /**
  * Bring the engine onto current config.
  *
@@ -4254,6 +4383,13 @@ async function reloadOpencodeEngineInPlace(
       status: response.status,
       body,
     });
+  }
+
+  // The reload rebuilt this directory's instance and the post-refresh sync
+  // below re-attaches its runtime state, so any pending post-eviction mark is
+  // satisfied here rather than by the next request.
+  if (directory && workspace.workspaceType !== "remote") {
+    engineInstanceReaperForConfig(config)?.noteUsed({ directory, workspaceId: workspace.id, engineBaseUrl: baseUrl });
   }
 
   const postRefreshSync = postEngineRefreshSync(config, workspace, activeState);

--- a/evals/specs/engine-idle-instance-eviction.test.ts
+++ b/evals/specs/engine-idle-instance-eviction.test.ts
@@ -1,0 +1,201 @@
+import { briefTest, claim, testBrief } from "@openwork/testkit";
+import {
+  EngineInstanceReaper,
+  type TrackedEngineInstance,
+} from "../../apps/server/src/engine-instance-reaper";
+
+/**
+ * The continuous engine keeps one managed OpenCode process alive across
+ * workspace switches, so every visited workspace retains a live per-directory
+ * instance — config, plugins, watchers, session caches — for the lifetime of
+ * the app. The engine instance reaper is the reclamation policy: evict an
+ * instance only when nothing holds it. This spec proves that policy and its
+ * negative halves; apps/server/src/engine-instance-eviction.e2e.test.ts drives
+ * the same loop through a running OpenWork server and mock engine.
+ */
+
+const ENGINE_URL = "http://127.0.0.1:4101";
+const TTL_ENV = "OPENWORK_ENGINE_INSTANCE_IDLE_TTL_MS";
+
+type Harness = {
+  reaper: EngineInstanceReaper;
+  disposed: TrackedEngineInstance[];
+  clock: { now: number };
+  setBusy: (directory: string, busy: boolean) => void;
+  failProbes: (fail: boolean) => void;
+  setActiveDirectory: (directory: string | null) => void;
+  setEngineBaseUrl: (url: string | null) => void;
+};
+
+function createHarness(): Harness {
+  const clock = { now: 1_000_000 };
+  const busyByDirectory = new Map<string, boolean>();
+  const disposed: TrackedEngineInstance[] = [];
+  let probesFail = false;
+  let activeDirectory: string | null = null;
+  let engineBaseUrl: string | null = ENGINE_URL;
+  const reaper = new EngineInstanceReaper({
+    engineBaseUrl: () => engineBaseUrl,
+    activeDirectory: () => activeDirectory,
+    directoryBusy: async (entry) => {
+      if (probesFail) throw new Error("status probe unavailable");
+      return busyByDirectory.get(entry.directory) === true;
+    },
+    dispose: async (entry) => {
+      disposed.push({ ...entry });
+    },
+    now: () => clock.now,
+  });
+  return {
+    reaper,
+    disposed,
+    clock,
+    setBusy: (directory, busy) => void busyByDirectory.set(directory, busy),
+    failProbes: (fail) => void (probesFail = fail),
+    setActiveDirectory: (directory) => void (activeDirectory = directory),
+    setEngineBaseUrl: (url) => void (engineBaseUrl = url),
+  };
+}
+
+function use(directory: string) {
+  return { directory, workspaceId: `ws-${directory}`, engineBaseUrl: ENGINE_URL };
+}
+
+async function withTtl<T>(ttlMs: number, run: () => Promise<T>): Promise<T> {
+  const previous = process.env[TTL_ENV];
+  process.env[TTL_ENV] = String(ttlMs);
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env[TTL_ENV];
+    else process.env[TTL_ENV] = previous;
+  }
+}
+
+briefTest(testBrief({
+  behavior: "Idle per-directory engine instances are reclaimed without touching anything a user still depends on.",
+  claims: {
+    idleEviction: claim("an idle, inactive, unwatched instance is evicted once the idle TTL elapses", {
+      never: "dispose an instance before its TTL has fully elapsed",
+    }),
+    activeImmunity: claim("the active workspace's instance survives any amount of idle time", {
+      never: "dispose the instance of the workspace the user is in",
+    }),
+    liveRunHold: claim("an instance reporting a non-idle session stays and its idle clock restarts", {
+      never: "dispose an instance with a live background run",
+    }),
+    watchedHold: claim("an instance held by an open engine event stream stays until the hold is released", {
+      never: "dispose an instance while any tab still watches its workspace",
+    }),
+    reattachOnce: claim("after an eviction, the next traffic for that workspace reports the re-attach mark exactly once", {
+      never: "report the mark twice or drop it before the workspace returns",
+    }),
+    safeDefaults: claim("unknown activity, retired engine generations, unmanaged engines, and a zero TTL never dispose", {
+      never: "evict when the engine's state cannot be read or is not ours to manage",
+    }),
+  },
+}), async ({ prove }) => {
+  await withTtl(1_000, async () => {
+    // idleEviction — both halves of the TTL boundary.
+    const idle = createHarness();
+    idle.reaper.noteUsed(use("/work/background"));
+    idle.clock.now += 999;
+    const beforeTtl = await idle.reaper.sweep();
+    const disposedBeforeTtl = idle.disposed.length;
+    idle.clock.now += 2;
+    const afterTtl = await idle.reaper.sweep();
+    prove.idleEviction(
+      beforeTtl === 0 && disposedBeforeTtl === 0 && afterTtl === 1 && idle.disposed[0]?.directory === "/work/background",
+      `At TTL-1ms the sweep evicted ${beforeTtl} instances and disposed ${disposedBeforeTtl}; at TTL+1ms it evicted ${afterTtl} and disposed /work/background.`,
+    );
+
+    // activeImmunity — the active workspace outlives any idle window.
+    const active = createHarness();
+    active.setActiveDirectory("/work/active");
+    active.reaper.noteUsed(use("/work/active"));
+    active.clock.now += 100_000;
+    const activeSweep = await active.reaper.sweep();
+    prove.activeImmunity(
+      activeSweep === 0 && active.disposed.length === 0 && active.reaper.snapshot()[0]?.directory === "/work/active",
+      `After 100x the TTL the active instance was still tracked and ${active.disposed.length} disposes ran.`,
+    );
+
+    // liveRunHold — busy sessions hold, and going idle restarts the clock.
+    const running = createHarness();
+    running.reaper.noteUsed(use("/work/running"));
+    running.setBusy("/work/running", true);
+    running.clock.now += 100_000;
+    const busySweep = await running.reaper.sweep();
+    running.setBusy("/work/running", false);
+    running.clock.now += 999;
+    const freshIdleSweep = await running.reaper.sweep();
+    running.clock.now += 2;
+    const staleIdleSweep = await running.reaper.sweep();
+    prove.liveRunHold(
+      busySweep === 0 && freshIdleSweep === 0 && staleIdleSweep === 1,
+      `Busy at 100x TTL: ${busySweep} evictions. Idle again: ${freshIdleSweep} before the restarted TTL, ${staleIdleSweep} after it.`,
+    );
+
+    // watchedHold — a stream hold pins the instance; release restarts the clock.
+    const watched = createHarness();
+    const release = watched.reaper.holdStream(use("/work/watched"));
+    watched.clock.now += 100_000;
+    const heldSweep = await watched.reaper.sweep();
+    release();
+    watched.clock.now += 999;
+    const justReleasedSweep = await watched.reaper.sweep();
+    watched.clock.now += 2;
+    const releasedStaleSweep = await watched.reaper.sweep();
+    prove.watchedHold(
+      heldSweep === 0 && justReleasedSweep === 0 && releasedStaleSweep === 1,
+      `Held at 100x TTL: ${heldSweep} evictions; after release: ${justReleasedSweep} inside the restarted TTL, ${releasedStaleSweep} past it.`,
+    );
+
+    // reattachOnce — the mark survives a stream hold and reports exactly once.
+    const returning = createHarness();
+    returning.reaper.noteUsed(use("/work/background"));
+    returning.clock.now += 1_001;
+    await returning.reaper.sweep();
+    const holdAfterEviction = returning.reaper.holdStream(use("/work/background"));
+    const firstUse = returning.reaper.noteUsed(use("/work/background"));
+    const secondUse = returning.reaper.noteUsed(use("/work/background"));
+    holdAfterEviction();
+    prove.reattachOnce(
+      firstUse === true && secondUse === false,
+      `After eviction and an intervening stream hold, noteUsed reported the mark once (${firstUse}) and then never again (${secondUse}).`,
+    );
+
+    // safeDefaults — unknown, retired, and unmanaged states never dispose.
+    const unknown = createHarness();
+    unknown.reaper.noteUsed(use("/work/unknown"));
+    unknown.failProbes(true);
+    unknown.clock.now += 100_000;
+    const unknownSweep = await unknown.reaper.sweep();
+
+    const retired = createHarness();
+    retired.reaper.noteUsed(use("/work/old"));
+    retired.setEngineBaseUrl("http://127.0.0.1:4999");
+    retired.clock.now += 100_000;
+    const retiredSweep = await retired.reaper.sweep();
+    const retiredDropped = retired.reaper.snapshot().length === 0;
+
+    const unmanaged = createHarness();
+    unmanaged.reaper.noteUsed(use("/work/attached"));
+    unmanaged.setEngineBaseUrl(null);
+    unmanaged.clock.now += 100_000;
+    const unmanagedSweep = await unmanaged.reaper.sweep();
+
+    const disabled = createHarness();
+    disabled.reaper.noteUsed(use("/work/disabled"));
+    disabled.clock.now += 100_000_000;
+    const disabledSweep = await withTtl(0, () => disabled.reaper.sweep());
+
+    prove.safeDefaults(
+      unknownSweep === 0 && unknown.disposed.length === 0
+        && retiredSweep === 0 && retired.disposed.length === 0 && retiredDropped
+        && unmanagedSweep === 0 && unmanaged.disposed.length === 0
+        && disabledSweep === 0 && disabled.disposed.length === 0,
+      `Unreadable probe: ${unknownSweep} evictions. Retired generation: ${retiredSweep} evictions with the stale entry dropped (${retiredDropped}). No managed engine: ${unmanagedSweep}. TTL 0: ${disabledSweep}. No disposes ran in any of them.`,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The continuous engine (#4120) keeps one managed OpenCode process alive across workspace switches. The engine is multi-instance: it boots a per-directory instance on demand, and nothing ever retires one — workspace activation reloads only the **incoming** workspace's instance, and no idle eviction, cap, or TTL exists anywhere. Every workspace visited in a desktop session therefore retains a live instance (config, plugins, watchers, session caches) for the lifetime of the app, and engine memory only ever grows. On a 3-workspace install the engine sidecar reached ~1 GB RSS within minutes.

## Fix

A per-config **engine instance reaper** (`apps/server/src/engine-instance-reaper.ts`) tracks every local workspace directory that managed-engine traffic touches, and a periodic sweep disposes an instance (`POST /instance/dispose?directory=`) only when every hold is absent:

- it is **not the active workspace** (the front of the registry stays warm),
- **no engine event stream** from that workspace is open — an open tab holds its workspace's instance via the existing event proxy, released on client disconnect,
- it reports **no non-idle session** — a live background run always stays (probed directly against the engine so the reaper's own probe cannot refresh the idle clock; an unreadable status never evicts),
- it has seen **no traffic for the idle TTL**.

Sessions live in the engine's shared SQLite, so eviction loses only process state. The next traffic re-materializes the instance from disk config, and the reaper's one-shot mark makes the server re-attach the runtime-DB MCP push a fresh instance cannot read from disk (`postEngineRefreshSync`, detached from the triggering request).

Scope guards:
- Only **managed** engines are swept (the pool exists exactly when this server owns the engine process); attached engines may serve other clients and are never trimmed.
- Instances recorded against a retired engine generation are dropped without a dispose — the process that held them is already gone.
- A failed dispose keeps the instance and retries on a later sweep; traffic landing during the activity probe wins over the eviction.

Tunables: `OPENWORK_ENGINE_INSTANCE_IDLE_TTL_MS` (default 15 minutes, `0` disables), `OPENWORK_ENGINE_INSTANCE_SWEEP_MS` (default 60 s).

## Proof (local lane)

- `pnpm evals:pr specs/engine-idle-instance-eviction.test.ts` — **passed**. Brief claims with negative halves: eviction only after the TTL boundary, active-workspace immunity, live-run hold with a restarted idle clock, event-stream hold until release, exactly-once re-attach mark, and safe defaults (unknown activity, retired generation, unmanaged engine, TTL 0 never dispose).
- `apps/server: bun test src/engine-instance-eviction.e2e.test.ts` — **passed (2)**. Drives the full loop through a running OpenWork server, a real `EnginePool`, and a mock engine: only the stale background workspace's instance is disposed; a busy background run and a live proxied `/event` stream hold it; returning traffic triggers the runtime MCP re-push for the evicted directory (`POST /mcp` with the workspace's directory observed at the engine).
- `apps/server: bun test src/engine-instance-reaper.test.ts` — **passed (12)** policy unit tests.
- Adjacent suites (`engine-pool`, `workspace-activate`, `mcp.engine-sync`, `engine-reload-defer`): **67/67 pass** at the rebased head; `pnpm --filter openwork-server typecheck` clean.
- Full `apps/server` suite: 805 pass / 8 skip, plus 1 fail (`workspace-init` chmod-dependent) and 1 error (`workspace-kv-store.node` — `node:sqlite` unresolvable under local bun 1.3.4) — both reproduce on a clean `dev` checkout with this diff stashed, i.e. pre-existing environment issues unrelated to this change.