### PR TITLE
Never abort an actively streaming session at the engine drain deadline

### DIFF
--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -67,6 +67,15 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "    return value[directory ?? ''] ?? [];",
     "  } catch { return []; }",
     "};",
+    "const eventSessions = (port) => {",
+    "  try {",
+    "    const state = JSON.parse(readFileSync(statePath, 'utf8'));",
+    "    const events = state.__events;",
+    "    if (!events || typeof events !== 'object') return null;",
+    "    const value = events[String(port)];",
+    "    return Array.isArray(value) ? value : null;",
+    "  } catch { return null; }",
+    "};",
     "const server = Bun.serve({",
     "  hostname: '127.0.0.1',",
     "  port: requestedPort,",
@@ -84,13 +93,27 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "      return Response.json([{ id: url.searchParams.get('request') ?? `req_${server.port}`, sessionID }]);",
     "    }",
     "    if (url.pathname === '/event') {",
-    "      const sessionID = busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
-    "      const payload = { type: 'session.updated', properties: { sessionID } };",
-    "      if (url.searchParams.has('hold')) {",
-    "        const body = new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(payload)}\\n\\n`)); } });",
+    "      const frame = (id) => `data: ${JSON.stringify({ type: 'session.updated', properties: { sessionID: id } })}\\n\\n`;",
+    "      if (eventSessions(server.port) !== null) {",
+    "        // Test-controlled live bus: emit an event per configured session",
+    "        // every 50ms on a held stream, re-reading state between beats.",
+    "        let timer = null;",
+    "        const body = new ReadableStream({",
+    "          start(controller) {",
+    "            timer = setInterval(() => {",
+    "              for (const id of eventSessions(server.port) ?? []) controller.enqueue(new TextEncoder().encode(frame(id)));",
+    "            }, 50);",
+    "          },",
+    "          cancel() { if (timer) clearInterval(timer); },",
+    "        });",
     "        return new Response(body, { headers: { 'content-type': 'text/event-stream' } });",
     "      }",
-    "      return new Response(`data: ${JSON.stringify(payload)}\\n\\n`, { headers: { 'content-type': 'text/event-stream' } });",
+    "      const sessionID = busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
+    "      if (url.searchParams.has('hold')) {",
+    "        const body = new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(frame(sessionID))); } });",
+    "        return new Response(body, { headers: { 'content-type': 'text/event-stream' } });",
+    "      }",
+    "      return new Response(frame(sessionID), { headers: { 'content-type': 'text/event-stream' } });",
     "    }",
     "    if (url.pathname.endsWith('/reply')) {",
     "      const owner = Number(url.searchParams.get('owner') ?? 0);",
@@ -129,6 +152,7 @@ type Fixture = {
   hooks: EnginePoolHooks;
   setBusy: (port: number, sessionIds: string[]) => Promise<void>;
   setBusyForDirectory: (port: number, directory: string, sessionIds: string[]) => Promise<void>;
+  setEventSessions: (port: number, sessionIds: string[] | null) => Promise<void>;
   logLines: () => Promise<string[]>;
   setRuntimeConfig: (content: string) => Promise<void>;
   spawnPrimary: () => Promise<ManagedOpencodeServer>;
@@ -227,6 +251,22 @@ async function createFixture(options?: { bin?: "ready" | "unready" }): Promise<F
     await writeFile(statePath, JSON.stringify(state));
   };
 
+  /**
+   * Configure which sessions the fake engine's event bus reports as active.
+   * An array (even empty) switches that engine to a held live stream; null
+   * restores the legacy single-shot event body.
+   */
+  const setEventSessions = async (port: number, sessionIds: string[] | null): Promise<void> => {
+    const state = JSON.parse(await readFile(statePath, "utf8").catch(() => "{}")) as Record<string, string[] | Record<string, string[]>>;
+    const current = state.__events;
+    const events = current !== undefined && !Array.isArray(current) ? current : {};
+    if (sessionIds === null) delete events[String(port)];
+    else events[String(port)] = sessionIds;
+    if (Object.keys(events).length === 0) delete state.__events;
+    else state.__events = events;
+    await writeFile(statePath, JSON.stringify(state));
+  };
+
   const spawnPrimary = async (): Promise<ManagedOpencodeServer> => {
     const handle = await createManagedOpencodeServer({ bin, cwd: root, env: template.env });
     cleanups.push(() => handle.close().catch(() => undefined));
@@ -244,6 +284,7 @@ async function createFixture(options?: { bin?: "ready" | "unready" }): Promise<F
     hooks,
     setBusy,
     setBusyForDirectory,
+    setEventSessions,
     logLines: async () => (await readFile(logPath, "utf8").catch(() => "")).split("\n").filter(Boolean),
     setRuntimeConfig: (content: string) => writeFile(runtimeConfigPath, content),
     spawnPrimary,
@@ -693,14 +734,16 @@ describe("engine pool", () => {
     expect(closed).toBe(true);
   });
 
-  test("aborts the remaining sessions once the drain grace period expires", async () => {
+  test("aborts the remaining sessions once the drain inactivity grace period expires", async () => {
     setEnv("OPENWORK_ENGINE_DRAIN_TIMEOUT_MS", "300");
     setEnv("OPENWORK_ENGINE_ABORT_SETTLE_MS", "100");
     const fixture = await createFixture();
     const { pool, primary } = await createPool(fixture);
     const oldPort = portOf(primary.url);
-    // This session never finishes, so only the grace timeout can end the drain.
+    // This session reports busy forever but never emits an event, so only the
+    // inactivity grace timeout can end the drain.
     await fixture.setBusy(oldPort, ["ses_stuck"]);
+    await fixture.setEventSessions(oldPort, []);
     await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
 
     expect((await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace })).action)
@@ -711,6 +754,35 @@ describe("engine pool", () => {
     const lines = await fixture.logLines();
     expect(lines).toContain(`${oldPort} POST /session/ses_stuck/abort`);
     expect(lines).toContain(`${oldPort} SIGTERM`);
+  });
+
+  test("never aborts an actively streaming session at the drain deadline, then retires the engine once it idles", async () => {
+    setEnv("OPENWORK_ENGINE_DRAIN_TIMEOUT_MS", "300");
+    setEnv("OPENWORK_ENGINE_ABORT_SETTLE_MS", "100");
+    const fixture = await createFixture();
+    const { pool, primary } = await createPool(fixture);
+    const oldPort = portOf(primary.url);
+    // The run keeps streaming: the engine event bus names it continuously.
+    await fixture.setBusy(oldPort, ["ses_streaming"]);
+    await fixture.setEventSessions(oldPort, ["ses_streaming"]);
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+
+    expect((await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace })).action)
+      .toBe("rolled_over");
+
+    // Wait out four full grace periods: an actively working session must
+    // never be aborted, so the draining engine stays alive the whole time.
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(primary.isAlive()).toBe(true);
+    expect((await fixture.logLines()).some((line) => line.includes("/abort"))).toBe(false);
+
+    // The run finishes: the engine idles and the drained generation closes
+    // without ever aborting anything.
+    await fixture.setEventSessions(oldPort, []);
+    await fixture.setBusy(oldPort, []);
+    expect(await waitUntil(() => !primary.isAlive(), 5_000)).toBe(true);
+    expect((await fixture.logLines()).some((line) => line.includes("/abort"))).toBe(false);
+    expect(await fixture.logLines()).toContain(`${oldPort} SIGTERM`);
   });
 
   test("never runs more than one primary and one draining engine", async () => {

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -89,6 +89,7 @@ type Generation = {
   trustedIdentity: string | null;
   drainTimer: ReturnType<typeof setInterval> | null;
   drainDeadline: number | null;
+  drainActivityWatch: AbortController | null;
 };
 
 export type EnginePoolSnapshot = {
@@ -137,9 +138,18 @@ function nonNegativeIntFromEnv(name: string, fallback: number): number {
   return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
 }
 
-/** How long a draining engine may keep running before its sessions are aborted. */
+/**
+ * How long a draining engine may go without any owned-session activity before
+ * its sessions are aborted. Activity on the engine event stream pushes the
+ * deadline out, so this bounds inactivity, not total drain time.
+ */
 function drainTimeoutMs(): number {
   return positiveIntFromEnv("OPENWORK_ENGINE_DRAIN_TIMEOUT_MS", 15 * 60_000);
+}
+
+/** Delay before the drain activity watch reconnects to a lost engine event stream. */
+function drainActivityReconnectMs(): number {
+  return positiveIntFromEnv("OPENWORK_ENGINE_DRAIN_ACTIVITY_RECONNECT_MS", 1_000);
 }
 
 /** Floor between automatic spawns, so a burst of triggers cannot thrash. 0 disables it. */
@@ -279,6 +289,21 @@ function eventIdentifiers(payload: unknown): { sessionIds: Set<string>; requestI
   return { sessionIds, requestIds };
 }
 
+/** Decode one SSE frame's `data:` payload; null when the frame carries none. */
+function sseFramePayload(frame: string): unknown {
+  const data = frame
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trim())
+    .join("\n");
+  if (!data) return null;
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Everything a spawned engine reads at build time. Comparing this is what
  * lets a repeated no-op reload skip spawning a replacement.
@@ -347,6 +372,7 @@ export class EnginePool {
       trustedIdentity: input.trustedIdentity,
       drainTimer: null,
       drainDeadline: null,
+      drainActivityWatch: null,
     });
     this.lastSpawnAt = Date.now();
   }
@@ -636,6 +662,7 @@ export class EnginePool {
       trustedIdentity: null,
       drainTimer: null,
       drainDeadline: null,
+      drainActivityWatch: null,
     };
     this.generations.push(generation);
 
@@ -746,11 +773,16 @@ export class EnginePool {
   }
 
   /**
-   * Watch a draining engine and close it once its runs finish. Past the grace
-   * window the remaining sessions are aborted rather than kept alive forever.
+   * Watch a draining engine and close it once its runs finish. The grace
+   * window bounds inactivity, not total drain time: engine events for an
+   * owned session push the deadline out, so a run that is actively making
+   * progress is never aborted mid-flight, while a non-idle session that stops
+   * reporting anything for the whole window is aborted rather than kept alive
+   * forever.
    */
   private startDrainMonitor(generation: Generation, workspace: WorkspaceInfo): void {
     generation.drainDeadline = Date.now() + drainTimeoutMs();
+    this.watchDrainActivity(generation);
     const tick = async (): Promise<void> => {
       if (generation.status !== "draining") return;
       const remaining = await this.nonIdleSessionIds(generation);
@@ -760,7 +792,7 @@ export class EnginePool {
         return;
       }
       if (generation.drainDeadline !== null && Date.now() >= generation.drainDeadline) {
-        this.hooks.logger?.log("warn", "Engine drain exceeded its grace period; aborting the remaining sessions.", {
+        this.hooks.logger?.log("warn", "Engine drain saw no session activity for the grace period; aborting the remaining sessions.", {
           "engine.drain.sessions": remaining.join(","),
           "engine.drain.session_count": remaining.length,
         });
@@ -778,6 +810,93 @@ export class EnginePool {
     void tick().catch(() => undefined);
   }
 
+  /**
+   * Hold an event-stream subscription per instance directory on the draining
+   * engine so owned-session activity keeps extending the drain deadline. The
+   * client event fan-in only exists while a client is attached; the pool owns
+   * this watch so a background run with no observer still counts as active.
+   */
+  private watchDrainActivity(generation: Generation): void {
+    const controller = new AbortController();
+    generation.drainActivityWatch = controller;
+    for (const directory of this.engineProbeDirectories()) {
+      void this.runDrainActivityWatch(generation, directory, controller.signal).catch(() => undefined);
+    }
+  }
+
+  private async runDrainActivityWatch(
+    generation: Generation,
+    directory: string | null,
+    signal: AbortSignal,
+  ): Promise<void> {
+    while (!signal.aborted && generation.status === "draining") {
+      try {
+        const url = new URL("/event", generation.handle.url);
+        if (directory !== null) url.searchParams.set("directory", directory);
+        const response = await loopbackFetch(url.toString(), {
+          headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
+          signal,
+        });
+        if (response.ok && response.body) {
+          await this.consumeDrainActivityEvents(generation, response.body, signal);
+        }
+      } catch {
+        // Losing the stream only pauses activity credit. The poll loop still
+        // owns the abort decision, and an unreachable engine reports no
+        // sessions to drain in the first place.
+      }
+      if (signal.aborted || generation.status !== "draining") return;
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, drainActivityReconnectMs());
+        timer.unref?.();
+      });
+    }
+  }
+
+  private async consumeDrainActivityEvents(
+    generation: Generation,
+    body: ReadableStream<Uint8Array>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    try {
+      while (!signal.aborted && generation.status === "draining") {
+        const chunk = await reader.read();
+        if (chunk.done) return;
+        buffered += decoder.decode(chunk.value, { stream: true });
+        while (true) {
+          const delimiter = buffered.match(/\r?\n\r?\n/);
+          if (!delimiter || delimiter.index === undefined) break;
+          const frame = buffered.slice(0, delimiter.index);
+          buffered = buffered.slice(delimiter.index + delimiter[0].length);
+          this.noteDrainActivity(generation, sseFramePayload(frame));
+        }
+      }
+    } finally {
+      await reader.cancel().catch(() => undefined);
+    }
+  }
+
+  /** An engine event naming an owned session is proof of progress: push the deadline out. */
+  private noteDrainActivity(generation: Generation, payload: unknown): void {
+    if (payload === null || generation.status !== "draining" || generation.drainDeadline === null) return;
+    const owned = this.activeSessionsByGeneration.get(generation.id);
+    if (!owned || owned.size === 0) return;
+    const { sessionIds } = eventIdentifiers(payload);
+    let hasOwnedSession = false;
+    for (const sessionId of sessionIds) {
+      if (owned.has(sessionId)) {
+        hasOwnedSession = true;
+        break;
+      }
+    }
+    if (!hasOwnedSession) return;
+    const extended = Date.now() + drainTimeoutMs();
+    if (extended > generation.drainDeadline) generation.drainDeadline = extended;
+  }
+
   private async retire(generation: Generation, cause: "idle" | "forced" | "shutdown"): Promise<void> {
     if (generation.status === "dead") return;
     generation.status = "dead";
@@ -785,6 +904,8 @@ export class EnginePool {
       clearInterval(generation.drainTimer);
       generation.drainTimer = null;
     }
+    generation.drainActivityWatch?.abort();
+    generation.drainActivityWatch = null;
     generation.drainDeadline = null;
     this.activeSessionsByGeneration.delete(generation.id);
     for (const [sessionId, generationId] of this.sessionOwnership) {
@@ -917,6 +1038,7 @@ export class EnginePool {
         trustedIdentity: null,
         drainTimer: null,
         drainDeadline: null,
+        drainActivityWatch: null,
       };
       this.generations.push(generation);
       if (handle.pid) {
@@ -1122,7 +1244,7 @@ export class EnginePool {
     this.hooks.logger?.log("info", "Aborting OpenCode session from engine pool.", {
       "abort.source": "engine_pool.drain_timeout",
       "abort.initiator": "system",
-      "abort.reason": "draining engine exceeded grace period",
+      "abort.reason": "draining engine saw no session activity for the grace period",
       "session.id": sessionId,
       "engine.generation_id": generation.id,
     });

--- a/evals/specs/engine-drain-activity-survival.test.ts
+++ b/evals/specs/engine-drain-activity-survival.test.ts
@@ -1,0 +1,260 @@
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { briefTest, claim, testBrief } from "@openwork/testkit";
+import { EnginePool } from "../../apps/server/src/engine-pool";
+import type { ManagedOpencodeServer } from "../../apps/server/src/managed-opencode";
+import type { ServerConfig, WorkspaceInfo } from "../../apps/server/src/types";
+
+/**
+ * The engine rollover pool keeps a superseded engine generation alive only
+ * while it drains, and historically force-aborted every remaining session at
+ * a fixed deadline — killing runs that were still actively streaming. The
+ * drain grace period must bound inactivity, not total drain time: an engine
+ * event naming an owned session pushes the deadline out, while a non-idle
+ * session that reports nothing for the whole window is still reaped.
+ * apps/server/src/engine-pool.test.ts drives the same loop through spawned
+ * fake engine processes; this spec proves the policy app-lessly.
+ */
+
+const ENV = {
+  OPENWORK_ENGINE_DRAIN_TIMEOUT_MS: "300",
+  OPENWORK_ENGINE_DRAIN_POLL_MS: "100",
+  OPENWORK_ENGINE_ABORT_SETTLE_MS: "50",
+  OPENWORK_ENGINE_MIN_SPAWN_INTERVAL_MS: "0",
+};
+
+type FakeEngine = {
+  handle: ManagedOpencodeServer;
+  aborted: string[];
+  setBusy: (sessionIds: string[]) => void;
+  emit: (sessionId: string) => void;
+  isClosed: () => boolean;
+  stop: () => Promise<void>;
+};
+
+async function startFakeEngine(): Promise<FakeEngine> {
+  const busy = new Set<string>();
+  const aborted: string[] = [];
+  const eventClients = new Set<ServerResponse>();
+  let closed = false;
+
+  const server: Server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/session/status") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(Object.fromEntries([...busy].map((id) => [id, { type: "busy" }]))));
+      return;
+    }
+    if (url.pathname === "/event") {
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      eventClients.add(response);
+      request.on("close", () => eventClients.delete(response));
+      return;
+    }
+    const abortMatch = url.pathname.match(/^\/session\/([^/]+)\/abort$/);
+    if (abortMatch && request.method === "POST") {
+      aborted.push(decodeURIComponent(abortMatch[1] ?? ""));
+      response.setHeader("content-type", "application/json");
+      response.end("{}");
+      return;
+    }
+    response.setHeader("content-type", "application/json");
+    response.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("fake engine failed to bind a port");
+  const url = `http://127.0.0.1:${address.port}`;
+
+  const stop = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    for (const client of eventClients) client.end();
+    eventClients.clear();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  };
+
+  return {
+    handle: {
+      url,
+      username: "engine",
+      password: "engine-password",
+      pid: null,
+      execution: { command: "fake-engine", args: [], cwd: "/", env: [] },
+      isAlive: () => !closed,
+      close: stop,
+    },
+    aborted,
+    setBusy: (sessionIds) => {
+      busy.clear();
+      for (const id of sessionIds) busy.add(id);
+    },
+    emit: (sessionId) => {
+      const frame = `data: ${JSON.stringify({ type: "session.updated", properties: { sessionID: sessionId } })}\n\n`;
+      for (const client of eventClients) client.write(frame);
+    },
+    isClosed: () => closed,
+    stop,
+  };
+}
+
+type Scenario = {
+  pool: EnginePool;
+  old: FakeEngine;
+  next: FakeEngine;
+  workspace: WorkspaceInfo;
+  rollover: () => Promise<{ action: string }>;
+  dispose: () => Promise<void>;
+};
+
+async function startScenario(root: string, name: string): Promise<Scenario> {
+  const old = await startFakeEngine();
+  const next = await startFakeEngine();
+  const runtimeConfigPath = join(root, `${name}-runtime-config.json`);
+  await writeFile(runtimeConfigPath, JSON.stringify({ scenario: name }));
+
+  const workspace: WorkspaceInfo = {
+    id: `ws_${name}`,
+    name: `Drain ${name}`,
+    path: join(root, name),
+    preset: "starter",
+    workspaceType: "local",
+    baseUrl: old.handle.url,
+  };
+  const config = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    configPath: join(root, `${name}-server.json`),
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [workspace],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+    opencodeBaseUrl: old.handle.url,
+  } as ServerConfig;
+
+  const pool = new EnginePool({
+    config,
+    template: {
+      cwd: root,
+      runtimeConfigPath,
+      env: {},
+      reservedPorts: () => [],
+    },
+    hooks: {
+      reloadInPlace: async () => undefined,
+      engineBusy: async () => true,
+      postRefreshSync: async () => undefined,
+      writeRuntimeConfigFile: async () => ({ path: runtimeConfigPath }),
+      registerTrusted: () => undefined,
+      clearTrusted: () => undefined,
+      spawn: async () => next.handle,
+      waitForHealthy: async () => undefined,
+    },
+  });
+  pool.adoptPrimary({
+    handle: old.handle,
+    fingerprint: "superseded-config",
+    registryId: null,
+    trustedIdentity: null,
+  });
+
+  return {
+    pool,
+    old,
+    next,
+    workspace,
+    rollover: () => pool.requestRollover({ reason: `${name}_config_changed`, workspace }),
+    dispose: async () => {
+      await pool.disposeAll().catch(() => undefined);
+      await old.stop();
+      await next.stop();
+    },
+  };
+}
+
+function sleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(25);
+  }
+  return predicate();
+}
+
+briefTest(testBrief({
+  behavior: "A draining engine generation never aborts a session that is actively making progress; the drain grace period bounds inactivity instead of total drain time.",
+  claims: {
+    activeRunSurvival: claim("a session that keeps emitting engine events survives a drain lasting several full grace periods", {
+      never: "abort an actively streaming session because a rollover started a drain clock",
+    }),
+    cleanRetire: claim("once the surviving session finishes, the drained engine closes without any abort", {
+      never: "leak the drained engine process or abort a run that already completed",
+    }),
+    inactivityBound: claim("a non-idle session that emits nothing for the whole grace period is aborted and its generation force-retired", {
+      never: "keep a wedged generation alive indefinitely once activity stops",
+    }),
+  },
+}), async ({ prove }) => {
+  const savedEnv = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(ENV)) {
+    savedEnv.set(name, process.env[name]);
+    process.env[name] = value;
+  }
+  const root = await mkdtemp(join(tmpdir(), "openwork-drain-activity-"));
+  const scenarios: Scenario[] = [];
+  try {
+    // activeRunSurvival + cleanRetire — one continuously streaming session.
+    const streaming = await startScenario(root, "streaming");
+    scenarios.push(streaming);
+    streaming.old.setBusy(["ses_streaming"]);
+    const streamingRollover = await streaming.rollover();
+    const heartbeat = setInterval(() => streaming.old.emit("ses_streaming"), 50);
+    await sleep(1_200);
+    const survivedFourGracePeriods = !streaming.old.isClosed() && streaming.old.aborted.length === 0;
+    prove.activeRunSurvival(
+      streamingRollover.action === "rolled_over" && survivedFourGracePeriods,
+      `Rollover ${streamingRollover.action}; after 1200ms of streaming against a 300ms grace period the draining engine was ${streaming.old.isClosed() ? "closed" : "alive"} with ${streaming.old.aborted.length} aborts.`,
+    );
+
+    clearInterval(heartbeat);
+    streaming.old.setBusy([]);
+    const retiredCleanly = await waitUntil(() => streaming.old.isClosed(), 5_000);
+    prove.cleanRetire(
+      retiredCleanly && streaming.old.aborted.length === 0,
+      `After the session idled, the drained engine closed=${retiredCleanly} with ${streaming.old.aborted.length} aborts.`,
+    );
+
+    // inactivityBound — busy status forever, but zero events.
+    const wedged = await startScenario(root, "wedged");
+    scenarios.push(wedged);
+    wedged.old.setBusy(["ses_wedged"]);
+    const wedgedRollover = await wedged.rollover();
+    const reaped = await waitUntil(() => wedged.old.isClosed() && wedged.old.aborted.includes("ses_wedged"), 5_000);
+    prove.inactivityBound(
+      wedgedRollover.action === "rolled_over" && reaped,
+      `Rollover ${wedgedRollover.action}; the silent busy session was aborted (${wedged.old.aborted.join(",") || "none"}) and its engine closed=${wedged.old.isClosed()}.`,
+    );
+  } finally {
+    for (const scenario of scenarios) await scenario.dispose();
+    await rm(root, { recursive: true, force: true });
+    for (const [name, value] of savedEnv) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

A rollover flips new work to a fresh engine and keeps the old generation alive only to drain, but the drain deadline was fixed at drain start: `OPENWORK_ENGINE_DRAIN_TIMEOUT_MS` (default 15 minutes) after any reload, every remaining session on the old engine was force-aborted — including one actively mid-stream. Since #4120 made the rollover pool the default for managed engines, any task running longer than one grace period past any reload dies with a "Task interrupted" card timed exactly at that boundary. A field trace shows a generation flip at `17:11:21.7`, the session still streaming at `17:20`, and the pool's `cancel` landing at `17:26:21.879` — deadline + 150 ms.

This change makes the grace window bound **inactivity** instead of total drain time:

- The pool holds its own event-stream watch on the draining engine (one subscription per instance directory, mirroring the existing status-probe set). Any engine event naming an owned session pushes `drainDeadline` out to `now + grace`.
- An actively working run therefore drains to completion no matter how long it takes, while a non-idle session that reports nothing for the whole window is still aborted and its generation force-retired, so a wedged engine cannot live forever.
- The watch is pool-owned rather than piggybacking on the client event fan-in, so a background run with no attached observer still counts as active. It reconnects with a bounded delay (`OPENWORK_ENGINE_DRAIN_ACTIVITY_RECONNECT_MS`, default 1 s) and is aborted on retire.
- Stream loss only pauses activity credit: the poll loop still owns the abort decision, and an unreachable engine reports no sessions to drain.

## Verification

All at this head:

- `pnpm evals:pr specs/engine-drain-activity-survival.test.ts` — 1 passed / 0 failed / 0 skipped. The spec proves: a continuously streaming session survives a drain lasting four full grace periods with zero aborts (`activeRunSurvival`), the drained engine closes cleanly once the session idles (`cleanRetire`), and a silent busy session is still aborted and force-retired (`inactivityBound`).
- `bun --conditions=development test src/engine-pool.test.ts src/engine-reload-defer.test.ts src/engine-instance-eviction.e2e.test.ts src/workspace-activate.e2e.test.ts` (apps/server) — 34 pass / 0 fail, including a new fake-engine-driven survival test and the existing forced-drain test tightened to explicit zero-event inactivity.
- `pnpm --filter openwork-server typecheck` — exit 0.

Lane: local app-less PR lane (no Daytona credentials configured in this environment).

## Notes

- Anyone needing the old absolute-cap behavior can still bound total drain time operationally by disabling activity credit (the deadline only extends on observed owned-session events).
- The interrupted-run Resume card (#4124) remains the recovery path for aborts that still occur (wedged sessions, engine crashes).
