### PR TITLE
feat(gmail): collapsible reply quoting, reply attachments, and https url attachment inputs

### DIFF
--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -75,12 +75,24 @@ const previousEnv = {
 };
 const previousFetch = globalThis.fetch;
 
+// Attachment url validation resolves hostnames; answer from a fixture map so
+// tests never touch real DNS. Unmapped hostnames resolve to a public address.
+const dnsAnswers = new Map<string, string | Error>();
+mock.module("node:dns/promises", () => ({
+  lookup: async (hostname: string) => {
+    const answer = dnsAnswers.get(hostname);
+    if (answer instanceof Error) throw answer;
+    return [{ address: typeof answer === "string" ? answer : "93.184.216.34", family: 4 }];
+  },
+}));
+
 function restoreEnv(key: string, value: string | undefined) {
   if (typeof value === "string") process.env[key] = value;
   else delete process.env[key];
 }
 
 afterEach(() => {
+  dnsAnswers.clear();
   restoreEnv("OPENWORK_DEV_MODE", previousEnv.devMode);
   restoreEnv("OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", previousEnv.plaintextVault);
   restoreEnv("GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", previousEnv.clientSecret);
@@ -876,6 +888,10 @@ describe("Google Workspace extension", () => {
     await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "http://files.example.test/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
     await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://localhost/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
     await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://192.168.1.10/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
+    dnsAnswers.set("internal.corp.example", "10.0.0.5");
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://internal.corp.example/report.pdf" }), {})).rejects.toThrow("Attachment url must resolve to a public address");
+    dnsAnswers.set("missing.example.test", new Error("NXDOMAIN"));
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://missing.example.test/report.pdf" }), {})).rejects.toThrow("Attachment url hostname could not be resolved");
     await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({}), {})).rejects.toThrow("Each attachment must provide exactly one of url or path");
     await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ path: "report.pdf", url: "https://files.example.test/report.pdf" }), {})).rejects.toThrow("Each attachment must provide exactly one of url or path");
 

--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -59,6 +59,11 @@ function accountRecord(email: string, sub: string, scopes: string[] = ["openid"]
 
 function base64Url(text: string): string {
   return Buffer.from(text, "utf8").toString("base64url");
+}
+
+function decodeRawFromRequestBody(body: string): string {
+  const raw = body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
+  return Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
 }
 
 const previousEnv = {
@@ -311,7 +316,10 @@ describe("Google Workspace extension", () => {
     expect(decoded).toContain("Cc: purchasing.admin@acme.test, casey.jordan@acme.test");
     expect(decoded).toContain("Subject: Invoice ACME-2026-001 for PO-000123");
     expect(decoded).toContain("Content-Type: multipart/mixed;");
-    expect(decoded).toContain("Please find attached invoice ACME-2026-001 for PO-000123 and review the proposed commercial terms before our next call.\n\nThanks,\nOpenWork");
+    expect(decoded).toContain("Content-Type: multipart/alternative;");
+    expect(decoded).toContain("Content-Type: text/html; charset=UTF-8");
+    expect(decoded).toContain("MIME-Version: 1.0");
+    expect(decoded).toContain("Please find attached invoice ACME-2026-001 for PO-000123 and review the proposed commercial terms before our next call.\r\n\r\nThanks,\r\nOpenWork");
     expect(decoded).toContain("Content-Type: application/pdf; name=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain("Content-Disposition: attachment; filename=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain(Buffer.from("%PDF-1.4\ninvoice bytes\n", "utf8").toString("base64"));
@@ -374,7 +382,7 @@ describe("Google Workspace extension", () => {
       "```",
       "# keep fenced heading",
       "```",
-    ].join("\n"));
+    ].join("\r\n"));
   });
 
   test("gmail_create_reply_draft rejects accounts without the gmail.readonly scope", async () => {
@@ -454,8 +462,494 @@ describe("Google Workspace extension", () => {
       "On Thu, 16 Jul 2026 at 15:21 UTC, Alice <alice@example.com> wrote:",
       "> Original line",
       "> > previous quote",
-    ].join("\n"));
+    ].join("\r\n"));
+    expect(decoded).toContain("MIME-Version: 1.0");
+    expect(decoded).toContain("Content-Type: multipart/alternative;");
+    expect(decoded).toContain("Content-Type: text/html; charset=UTF-8");
+    expect(decoded).toContain('<div class="gmail_quote"><div dir="ltr" class="gmail_attr">On Thu, 16 Jul 2026 at 15:21 UTC, Alice &lt;alice@example.com&gt; wrote:</div><blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px solid #ccc;padding-left:1ex">');
+    expect(decoded).toContain("<div>Original line</div><div>&gt; previous quote</div>");
     expect(decoded).not.toContain("one@example.com");
+    expect(result?.result).toMatchObject({
+      reply: {
+        threadId: "thread-1",
+        subject: "Re: Project update",
+        to: ["Alice <alice@example.com>", "Bob <bob@example.com>"],
+        cc: ["Carol <carol@example.com>"],
+        inReplyTo: "<message-1@example.com>",
+        original: { subject: "Project update", from: "Alice <alice@example.com>", date: "Thu, 16 Jul 2026 15:21:00 +0000" },
+      },
+    });
+  });
+
+  test("gmail_create_reply_draft quotes HTML-only originals in both parts", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one", ["openid", "https://www.googleapis.com/auth/gmail.readonly"])],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/messages/m1")) {
+          return new Response(JSON.stringify({
+            id: "m1",
+            threadId: "thread-1",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<message-1@example.com>" },
+                { name: "Subject", value: "Design review" },
+                { name: "From", value: "Alice <alice@example.com>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/html", body: { data: base64Url("<div>Hello<br>world &amp; more</div>") } }],
+            },
+          }), { status: 200 });
+        }
+        requests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1", threadId: "thread-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", { messageId: "m1", body: "Thanks!" }, {});
+    expect(result?.ok).toBe(true);
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    expect(decoded).toContain("On Thu, 16 Jul 2026 at 15:21 UTC, Alice <alice@example.com> wrote:");
+    expect(decoded).toContain("> Hello\r\n> world & more");
+    expect(decoded).toContain('<blockquote class="gmail_quote"');
+    expect(decoded).toContain("<div>Hello</div><div>world &amp; more</div>");
+  });
+
+  test("gmail_create_reply_draft does not append a second quote when the body already includes one", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one", ["openid", "https://www.googleapis.com/auth/gmail.readonly"])],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/messages/m1")) {
+          return new Response(JSON.stringify({
+            id: "m1",
+            threadId: "thread-1",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<message-1@example.com>" },
+                { name: "Subject", value: "Project update" },
+                { name: "From", value: "Alice <alice@example.com>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: base64Url("Original line") } }],
+            },
+          }), { status: 200 });
+        }
+        requests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1", threadId: "thread-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const body = [
+      "Looks good to me.",
+      "",
+      "On Mon, 20 Jul 2026 at 10:00 UTC, Bob <bob@example.com> wrote:",
+      "> earlier message",
+    ].join("\n");
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", { messageId: "m1", body }, {});
+    expect(result?.ok).toBe(true);
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    expect(decoded).toContain("> earlier message");
+    expect(decoded).not.toContain("On Thu, 16 Jul 2026 at 15:21 UTC");
+    expect(decoded).not.toContain("<blockquote");
+    expect(decoded).not.toContain("gmail_attr");
+  });
+
+  test("gmail_create_reply_draft rejects messages without thread metadata", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one", ["openid", "https://www.googleapis.com/auth/gmail.readonly"])],
+    });
+    globalThis.fetch = Object.assign(
+      async () => new Response(JSON.stringify({
+        id: "m1",
+        threadId: "thread-1",
+        payload: { headers: [{ name: "Subject", value: "No message id" }, { name: "From", value: "Alice <alice@example.com>" }] },
+      }), { status: 200 }),
+      { preconnect: previousFetch.preconnect },
+    );
+
+    await expect(callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", { messageId: "m1", body: "Thanks" }, {})).rejects.toThrow(
+      "Gmail message is missing thread metadata required to create a reply draft.",
+    );
+  });
+
+  test("gmail_create_reply_draft attaches workspace files inside the threaded reply", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    const workspaceRoot = join(dirname(config.configPath ?? ""), "workspace");
+    const reportPath = join(workspaceRoot, "reports", "summary-q3.pdf");
+    config.workspaces = [{ id: "workspace-1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }];
+    config.authorizedRoots = [workspaceRoot];
+    await mkdir(dirname(reportPath), { recursive: true });
+    await writeFile(reportPath, "%PDF-1.4\nsummary\n", "utf8");
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one", ["openid", "https://www.googleapis.com/auth/gmail.readonly"])],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/messages/m1")) {
+          return new Response(JSON.stringify({
+            id: "m1",
+            threadId: "thread-1",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<message-1@example.com>" },
+                { name: "Subject", value: "Project update" },
+                { name: "From", value: "Alice <alice@example.com>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: base64Url("Original line") } }],
+            },
+          }), { status: 200 });
+        }
+        requests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1", threadId: "thread-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", {
+      messageId: "m1",
+      body: "Summary attached.",
+      attachments: [{ path: "reports/summary-q3.pdf" }],
+    }, { directory: workspaceRoot });
+    expect(result?.ok).toBe(true);
+    expect(requests[0]?.body).toContain('"threadId":"thread-1"');
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    expect(decoded).toContain("In-Reply-To: <message-1@example.com>");
+    expect(decoded).toContain("Content-Type: multipart/mixed;");
+    expect(decoded).toContain("Content-Type: multipart/alternative;");
+    expect(decoded).toContain("Content-Disposition: attachment; filename=\"summary-q3.pdf\"");
+    expect(decoded).toContain(Buffer.from("%PDF-1.4\nsummary\n", "utf8").toString("base64"));
+  });
+
+  test("gmail_create_reply_draft folds long References headers", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one", ["openid", "https://www.googleapis.com/auth/gmail.readonly"])],
+    });
+    const references = Array.from({ length: 8 }, (_, index) => `<thread-ref-${index + 1}@example.com>`).join(" ");
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/messages/m1")) {
+          return new Response(JSON.stringify({
+            id: "m1",
+            threadId: "thread-1",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<message-1@example.com>" },
+                { name: "References", value: references },
+                { name: "Subject", value: "Project update" },
+                { name: "From", value: "Alice <alice@example.com>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: base64Url("Original line") } }],
+            },
+          }), { status: 200 });
+        }
+        requests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1", threadId: "thread-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", { messageId: "m1", body: "Thanks!" }, {});
+    expect(result?.ok).toBe(true);
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    const headerSection = decoded.split("\r\n\r\n")[0] ?? "";
+    for (const line of headerSection.split("\r\n")) {
+      expect(line.length).toBeLessThanOrEqual(78);
+    }
+    expect(headerSection).toContain("\r\n <thread-ref-");
+    const unfolded = headerSection.replace(/\r\n /g, " ");
+    expect(unfolded).toContain(`References: ${references} <message-1@example.com>`);
+  });
+
+  test("gmail_create_reply_draft drops display-name fragments from unquoted commas", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one", ["openid", "https://www.googleapis.com/auth/gmail.readonly"])],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/messages/m1")) {
+          return new Response(JSON.stringify({
+            id: "m1",
+            threadId: "thread-1",
+            payload: {
+              headers: [
+                { name: "Message-ID", value: "<message-1@example.com>" },
+                { name: "Subject", value: "Project update" },
+                { name: "From", value: "Alice <alice@example.com>" },
+                { name: "To", value: "Doe, John <j@x.example>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: base64Url("Original line") } }],
+            },
+          }), { status: 200 });
+        }
+        requests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1", threadId: "thread-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", { messageId: "m1", body: "Thanks!", replyAll: true }, {});
+    expect(result?.ok).toBe(true);
+    const reply = (result?.result as { reply?: { to?: string[] } })?.reply;
+    expect(reply?.to).toEqual(["Alice <alice@example.com>", "John <j@x.example>"]);
+  });
+
+  test("gmail_create_draft rejects forward-looking subjects", async () => {
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", {
+      to: ["sam@acme.test"],
+      subject: "Fwd: Project update",
+      body: "Thanks",
+    }, {})).rejects.toThrow(
+      new ApiError(400, "invalid_payload", "Subject looks like a reply. Use gmail_create_reply_draft instead so the Gmail thread is preserved."),
+    );
+  });
+
+  test("gmail_create_draft encodes non-ASCII subjects", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input instanceof Request ? input.url : input), body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["sam@acme.test"],
+      subject: "Résumé update ✓",
+      body: "New details inside.",
+    }, {});
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    expect(decoded).toContain("Subject: =?UTF-8?B?");
+    expect(decoded).not.toContain("Subject: Résumé");
+    const subjectLine = decoded.split("\r\n").find((line) => line.startsWith("Subject: ")) ?? "";
+    const encodedWords = [...subjectLine.matchAll(/=\?UTF-8\?B\?([A-Za-z0-9+/=]+)\?=/g)].map((match) => Buffer.from(match[1] ?? "", "base64").toString("utf8"));
+    expect(encodedWords.join("")).toBe("Résumé update ✓");
+  });
+
+  test("gmail_create_draft neutralizes CRLF header injection", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input instanceof Request ? input.url : input), body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["sam@acme.test\r\nX-Evil: injected"],
+      subject: "Hello\r\nBcc: evil@example.com",
+      body: "Greetings.",
+    }, {});
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    expect(decoded).toContain("Subject: Hello Bcc: evil@example.com");
+    expect(decoded).not.toContain("\r\nBcc: evil@example.com");
+    expect(decoded).toContain("To: sam@acme.test X-Evil: injected");
+    expect(decoded).not.toContain("\r\nX-Evil: injected");
+  });
+
+  test("gmail_create_draft attaches files downloaded from https URLs", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const fetchCalls: { url: string; redirect?: string }[] = [];
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        fetchCalls.push({ url, redirect: typeof init?.redirect === "string" ? init.redirect : undefined });
+        if (url === "https://files.example.test/docs/report.pdf") {
+          return new Response(null, { status: 302, headers: { location: "https://cdn.example.test/report-final.pdf" } });
+        }
+        if (url === "https://cdn.example.test/report-final.pdf") {
+          return new Response("PDF BYTES", { status: 200, headers: { "content-type": "application/pdf", "content-disposition": "attachment; filename=\"quarterly-report.pdf\"" } });
+        }
+        requests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["sam@acme.test"],
+      subject: "Quarterly report",
+      body: "Report attached.",
+      attachments: [{ url: "https://files.example.test/docs/report.pdf" }],
+    }, {});
+    expect(result?.ok).toBe(true);
+    expect(fetchCalls.find((call) => call.url === "https://files.example.test/docs/report.pdf")?.redirect).toBe("manual");
+    expect(fetchCalls.find((call) => call.url === "https://cdn.example.test/report-final.pdf")?.redirect).toBe("manual");
+    const decoded = decodeRawFromRequestBody(requests[0]?.body ?? "");
+    expect(decoded).toContain("Content-Type: application/pdf; name=\"quarterly-report.pdf\"");
+    expect(decoded).toContain("Content-Disposition: attachment; filename=\"quarterly-report.pdf\"");
+    expect(decoded).toContain(Buffer.from("PDF BYTES", "utf8").toString("base64"));
+  });
+
+  test("gmail_create_draft rejects non-https, private, and redirect-downgraded attachment urls", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const draftArgs = (attachment: Record<string, unknown>) => ({
+      to: ["sam@acme.test"],
+      subject: "Files",
+      body: "See attached.",
+      attachments: [attachment],
+    });
+
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "http://files.example.test/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://localhost/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://192.168.1.10/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({}), {})).rejects.toThrow("Each attachment must provide exactly one of url or path");
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ path: "report.pdf", url: "https://files.example.test/report.pdf" }), {})).rejects.toThrow("Each attachment must provide exactly one of url or path");
+
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url === "https://files.example.test/report.pdf") {
+          return new Response(null, { status: 302, headers: { location: "http://cdn.example.test/report.pdf" } });
+        }
+        return new Response("{}", { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://files.example.test/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
+  });
+
+  test("gmail_create_draft enforces the attachment size cap on url downloads", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const draftArgs = {
+      to: ["sam@acme.test"],
+      subject: "Files",
+      body: "See attached.",
+      attachments: [{ url: "https://files.example.test/huge.bin" }],
+    };
+
+    globalThis.fetch = Object.assign(
+      async () => new Response("x", { status: 200, headers: { "content-length": String(21 * 1024 * 1024) } }),
+      { preconnect: previousFetch.preconnect },
+    );
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs, {})).rejects.toThrow("Gmail draft attachments support files up to");
+
+    const chunk = new Uint8Array(1024 * 1024);
+    let sent = 0;
+    globalThis.fetch = Object.assign(
+      async () => new Response(new ReadableStream({
+        pull(controller) {
+          if (sent >= 21) {
+            controller.close();
+            return;
+          }
+          sent += 1;
+          controller.enqueue(chunk);
+        },
+      }), { status: 200 }),
+      { preconnect: previousFetch.preconnect },
+    );
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs, {})).rejects.toThrow("Gmail draft attachments support files up to");
+  });
+
+  test("gmail_create_draft rejects oversized and symlink-escaping path attachments", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    const workspaceRoot = join(dirname(config.configPath ?? ""), "workspace");
+    const outsideDir = join(dirname(config.configPath ?? ""), "outside");
+    config.workspaces = [{ id: "workspace-1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }];
+    config.authorizedRoots = [workspaceRoot];
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(workspaceRoot, "huge.bin"), Buffer.alloc(21 * 1024 * 1024));
+    await writeFile(join(outsideDir, "secret.txt"), "secret", "utf8");
+    await symlink(join(outsideDir, "secret.txt"), join(workspaceRoot, "leak.txt"));
+
+    const draftArgs = (path: string) => ({
+      to: ["sam@acme.test"],
+      subject: "Files",
+      body: "See attached.",
+      attachments: [{ path }],
+    });
+    await expect(callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", draftArgs("huge.bin"), { directory: workspaceRoot })).rejects.toThrow("Gmail draft attachments support files up to");
+    await expect(callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", draftArgs("leak.txt"), { directory: workspaceRoot })).rejects.toThrow("Attachment path must resolve inside an authorized workspace root");
   });
 
   test("calendar_create_event rejects accounts without the calendar.events scope", async () => {

--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { LookupAddress } from "node:dns";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
+import type { LookupFunction } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -7,10 +9,12 @@ import { ApiError } from "../errors.js";
 import type { ServerConfig } from "../types.js";
 import {
   callGoogleWorkspaceExtensionAction,
+  createGmailAttachmentPublicLookup,
   createGoogleWorkspaceConnectFlowManager,
   googleWorkspaceDisconnect,
   googleWorkspaceSetActiveAccount,
   googleWorkspaceStatus,
+  setGmailAttachmentFetchForTests,
 } from "./google-workspace.js";
 
 function createTestConfig(): ServerConfig {
@@ -91,6 +95,26 @@ function restoreEnv(key: string, value: string | undefined) {
   else delete process.env[key];
 }
 
+async function lookupAll(lookupFunction: LookupFunction, hostname: string): Promise<LookupAddress[]> {
+  return await new Promise<LookupAddress[]>((resolve, reject) => {
+    lookupFunction(hostname, { all: true }, (error, addresses) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (!Array.isArray(addresses)) {
+        reject(new Error("Expected an all-address DNS lookup result."));
+        return;
+      }
+      resolve(addresses);
+    });
+  });
+}
+
+beforeEach(() => {
+  setGmailAttachmentFetchForTests((input, init) => globalThis.fetch(input, init));
+});
+
 afterEach(() => {
   dnsAnswers.clear();
   restoreEnv("OPENWORK_DEV_MODE", previousEnv.devMode);
@@ -99,6 +123,7 @@ afterEach(() => {
   restoreEnv("OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", previousEnv.legacyClientSecret);
   restoreEnv("OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL", previousEnv.brokerUrl);
   globalThis.fetch = previousFetch;
+  setGmailAttachmentFetchForTests();
 });
 
 describe("Google Workspace extension", () => {
@@ -906,6 +931,24 @@ describe("Google Workspace extension", () => {
       { preconnect: previousFetch.preconnect },
     );
     await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", draftArgs({ url: "https://files.example.test/report.pdf" }), {})).rejects.toThrow("Attachment url must be a public https URL");
+  });
+
+  test("gmail attachment socket lookup rejects a private DNS-rebinding answer", async () => {
+    let resolverCalls = 0;
+    const socketLookup = createGmailAttachmentPublicLookup(async () => {
+      resolverCalls += 1;
+      return resolverCalls === 1
+        ? [{ address: "93.184.216.34", family: 4 }]
+        : [{ address: "169.254.169.254", family: 4 }];
+    });
+
+    await expect(lookupAll(socketLookup, "files.example.test")).resolves.toEqual([
+      { address: "93.184.216.34", family: 4 },
+    ]);
+    await expect(lookupAll(socketLookup, "files.example.test")).rejects.toThrow(
+      "resolved to a private or reserved address",
+    );
+    expect(resolverCalls).toBe(2);
   });
 
   test("gmail_create_draft enforces the attachment size cap on url downloads", async () => {

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -1,4 +1,6 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import type { LookupAddress } from "node:dns";
+import { lookup } from "node:dns/promises";
 import { createServer, type Server } from "node:http";
 import { chmod, mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { isIP } from "node:net";
@@ -807,6 +809,24 @@ function assertGmailAttachmentUrl(rawUrl: string): URL {
   return parsed;
 }
 
+// Hostnames must resolve to public addresses, unconditionally, like the
+// literal-address checks above. externalFetch re-resolves when it connects,
+// so this validates every answer we can observe but cannot pin the socket to
+// it the way the managed MCP undici dispatcher does.
+async function assertGmailAttachmentHostPublic(url: URL): Promise<void> {
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  if (isIP(hostname) !== 0) return;
+  let addresses: LookupAddress[];
+  try {
+    addresses = await lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new ApiError(502, "attachment_fetch_failed", "Attachment url hostname could not be resolved", { hostname });
+  }
+  if (!addresses.length || addresses.some((entry) => isLocalManagedMcpPrivateAddress(entry.address))) {
+    throw new ApiError(400, "invalid_payload", "Attachment url must resolve to a public address", { hostname });
+  }
+}
+
 function gmailAttachmentFilenameFromResponse(url: URL, contentDisposition: string | null): string {
   const disposition = contentDisposition ?? "";
   const quoted = /filename\s*=\s*"([^"]+)"/i.exec(disposition)?.[1];
@@ -854,6 +874,7 @@ async function fetchGmailUrlAttachment(request: GmailDraftAttachmentRequest, url
   const timeout = setTimeout(() => controller.abort(), GOOGLE_WORKSPACE_API_TIMEOUT_MS);
   try {
     for (let redirects = 0; ; redirects += 1) {
+      await assertGmailAttachmentHostPublic(currentUrl);
       let response: Response;
       try {
         response = await externalFetch(currentUrl.toString(), { redirect: "manual", signal: controller.signal });
@@ -946,12 +967,40 @@ function gmailHtmlDivs(text: string): string {
   return text.replace(/\r\n?/g, "\n").split("\n").map((line) => line ? `<div>${escapeHtml(line)}</div>` : "<div><br></div>").join("");
 }
 
+const GMAIL_HTML_BREAK_TAGS = new Set(["p", "div", "tr", "li", "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "table", "ul", "ol"]);
+
+// Character scan instead of regex tag-stripping: nested or malformed markup
+// can reassemble into tags after a single-pass replace, and an unterminated
+// tag consumes the rest of the input the way browsers treat it.
+function stripGmailHtmlMarkup(html: string): string {
+  let text = "";
+  let index = 0;
+  while (index < html.length) {
+    const character = html[index];
+    if (character !== "<") {
+      text += character;
+      index += 1;
+      continue;
+    }
+    const tagEnd = html.indexOf(">", index + 1);
+    if (tagEnd === -1) break;
+    const rawTag = html.slice(index + 1, tagEnd).trim();
+    index = tagEnd + 1;
+    const closing = rawTag.startsWith("/");
+    const name = (closing ? rawTag.slice(1) : rawTag).split(/[\s/]/, 1)[0]?.toLowerCase() ?? "";
+    if (!closing && (name === "script" || name === "style")) {
+      const closeMatch = new RegExp(`</${name}\\b[^>]*>`, "i").exec(html.slice(index));
+      if (!closeMatch) break;
+      index += closeMatch.index + closeMatch[0].length;
+      continue;
+    }
+    if (name === "br" || (closing && GMAIL_HTML_BREAK_TAGS.has(name))) text += "\n";
+  }
+  return text;
+}
+
 function gmailHtmlToText(html: string): string {
-  const text = html
-    .replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, "")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/(?:p|div|tr|li|h[1-6]|blockquote|table|ul|ol)\s*>/gi, "\n")
-    .replace(/<[^>]+>/g, "")
+  const text = stripGmailHtmlMarkup(html)
     .replace(/&nbsp;/gi, " ")
     .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
       const code = Number.parseInt(hex, 16);

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -1,11 +1,16 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
-import type { LookupAddress } from "node:dns";
+import type { LookupAddress, LookupAllOptions } from "node:dns";
 import { lookup } from "node:dns/promises";
 import { createServer, type Server } from "node:http";
 import { chmod, mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { isIP } from "node:net";
+import { isIP, type LookupFunction } from "node:net";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { openworkServerConfigPath } from "@openwork/paths";
+import {
+  Agent,
+  fetch as undiciFetch,
+  type RequestInit as UndiciRequestInit,
+} from "undici";
 
 import { ApiError } from "../errors.js";
 import { isLocalManagedMcpPrivateAddress } from "../local-managed-mcp-url-guard.js";
@@ -664,6 +669,9 @@ type GmailDraftAttachment = {
   content: Buffer;
 };
 
+type GmailAttachmentFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+type GmailAttachmentAddressResolver = (hostname: string, options: LookupAllOptions) => Promise<LookupAddress[]>;
+
 function gmailHeaderValue(value: string): string {
   return value.replace(/[\r\n]+/g, " ").trim();
 }
@@ -827,6 +835,66 @@ async function assertGmailAttachmentHostPublic(url: URL): Promise<void> {
   }
 }
 
+const resolveGmailAttachmentAddresses: GmailAttachmentAddressResolver = (hostname, options) => lookup(hostname, options);
+
+function validateGmailAttachmentAddresses(hostname: string, addresses: LookupAddress[]): void {
+  if (!addresses.length) throw new Error(`Attachment hostname ${hostname} did not resolve.`);
+  const privateAddress = addresses.find((entry) => isLocalManagedMcpPrivateAddress(entry.address));
+  if (privateAddress) {
+    throw new Error(`Attachment hostname ${hostname} resolved to a private or reserved address (${privateAddress.address}).`);
+  }
+}
+
+/**
+ * Resolves and validates the attachment host inside the socket connector. The
+ * same answers are handed to net.connect, closing the DNS-rebinding window
+ * between a preflight lookup and the actual connection.
+ */
+export function createGmailAttachmentPublicLookup(
+  resolver: GmailAttachmentAddressResolver = resolveGmailAttachmentAddresses,
+): LookupFunction {
+  return (hostname, options, callback) => {
+    const lookupOptions: LookupAllOptions = { ...options, all: true, verbatim: true };
+    void resolver(hostname, lookupOptions).then((addresses) => {
+      try {
+        validateGmailAttachmentAddresses(hostname, addresses);
+      } catch (error) {
+        callback(error instanceof Error ? error : new Error("Attachment hostname lookup failed."), []);
+        return;
+      }
+      if (options.all) {
+        callback(null, addresses);
+        return;
+      }
+      const first = addresses[0];
+      callback(null, first.address, first.family);
+    }, (error: unknown) => {
+      callback(error instanceof Error ? error : new Error("Attachment hostname lookup failed."), []);
+    });
+  };
+}
+
+const gmailAttachmentDispatcher = new Agent({
+  connect: {
+    lookup: createGmailAttachmentPublicLookup(),
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout: 1_000,
+  },
+});
+
+async function defaultGmailAttachmentFetch(input: string | URL, init?: RequestInit): Promise<Response> {
+  // DOM and Undici expose structurally equivalent fetch types from separate
+  // declarations. Keep the conversion at this transport boundary.
+  const requestInit = { ...init, dispatcher: gmailAttachmentDispatcher } as unknown as UndiciRequestInit;
+  return await undiciFetch(input, requestInit) as unknown as Response;
+}
+
+let gmailAttachmentFetch: GmailAttachmentFetch = defaultGmailAttachmentFetch;
+
+export function setGmailAttachmentFetchForTests(fetchImpl?: GmailAttachmentFetch): void {
+  gmailAttachmentFetch = fetchImpl ?? defaultGmailAttachmentFetch;
+}
+
 function gmailAttachmentFilenameFromResponse(url: URL, contentDisposition: string | null): string {
   const disposition = contentDisposition ?? "";
   const quoted = /filename\s*=\s*"([^"]+)"/i.exec(disposition)?.[1];
@@ -877,7 +945,7 @@ async function fetchGmailUrlAttachment(request: GmailDraftAttachmentRequest, url
       await assertGmailAttachmentHostPublic(currentUrl);
       let response: Response;
       try {
-        response = await externalFetch(currentUrl.toString(), { redirect: "manual", signal: controller.signal });
+        response = await gmailAttachmentFetch(currentUrl, { redirect: "manual", signal: controller.signal });
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") throw new ApiError(502, "attachment_fetch_failed", "Attachment download timed out", { url });
         throw new ApiError(502, "attachment_fetch_failed", `Attachment download failed: ${error instanceof Error ? error.message : String(error)}`, { url });

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -1,10 +1,12 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
-import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { isIP } from "node:net";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { openworkServerConfigPath } from "@openwork/paths";
 
 import { ApiError } from "../errors.js";
+import { isLocalManagedMcpPrivateAddress } from "../local-managed-mcp-url-guard.js";
 import { externalFetch } from "../server-fetch.js";
 import type { ServerConfig } from "../types.js";
 
@@ -13,6 +15,10 @@ export const GOOGLE_WORKSPACE_EXTENSION_ID = "google-workspace";
 const GMAIL_HARD_WRAP_MIN_LINE_LENGTH = 50;
 const GMAIL_QUOTE_BODY_LIMIT = 10_000;
 const GMAIL_REPLY_SUBJECT_RE = /^\s*(re|fwd?)\s*:/i;
+const GMAIL_ATTACHMENT_MAX_BYTES = 20 * 1024 * 1024;
+const GMAIL_RAW_MESSAGE_MAX_BYTES = 25 * 1024 * 1024;
+const GMAIL_ATTACHMENT_REDIRECT_LIMIT = 5;
+const GMAIL_HEADER_FOLD_LIMIT = 78;
 const UTC_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const UTC_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const GOOGLE_WORKSPACE_DESKTOP_CLIENT_ID = "929071212606-pmkqimjhm2tnp68kbklnout0irllj99h.apps.googleusercontent.com";
@@ -51,6 +57,21 @@ function isGoogleWorkspaceOptionalFeature(value: string): value is GoogleWorkspa
   return Object.hasOwn(GOOGLE_WORKSPACE_OPTIONAL_FEATURES, value);
 }
 
+const GMAIL_DRAFT_ATTACHMENTS_SCHEMA = {
+  type: "array",
+  description: "Optional files to attach. Each item must provide exactly one of url or path.",
+  items: {
+    type: "object",
+    properties: {
+      url: { type: "string", description: "Public https URL to download and attach. Preferred over path; works from any surface." },
+      path: { type: "string", description: "Deprecated; prefer url. Workspace-relative path or authorized absolute file path." },
+      filename: { type: "string", description: "Optional attachment filename shown in Gmail." },
+      mimeType: { type: "string", description: "Optional attachment MIME type. Defaults from the download response or file extension when possible." },
+    },
+    additionalProperties: false,
+  },
+};
+
 export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
   {
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
@@ -79,7 +100,7 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
     action: "gmail_create_draft",
     title: "Create Gmail draft",
-    description: "Create a brand-new Gmail draft for the connected account. This does not send email. Returns draftUrl; always share it with the user so they can review and send in Gmail. Subjects starting with Re: or Fwd: are rejected here — use gmail_create_reply_draft so the thread is preserved.",
+    description: "Create a brand-new Gmail draft for a new conversation only — never for replies. This does not send email. body must contain only the new message text; never paste quoted history from an earlier email. Subjects starting with Re: or Fwd: are rejected here — use gmail_create_reply_draft so the thread is preserved. Returns draftUrl; always share it with the user so they can review and send in Gmail.",
     inputSchema: {
       type: "object",
       properties: {
@@ -88,20 +109,7 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
         bcc: { type: "array", items: { type: "string" }, description: "Optional BCC recipients." },
         subject: { type: "string", description: "Draft subject. Do not use Re: or Fwd: here; use gmail_create_reply_draft for replies." },
         body: { type: "string", description: "Plain text draft body. Write plain prose with no markdown syntax, separate paragraphs with blank lines, and do not hard-wrap prose." },
-        attachments: {
-          type: "array",
-          description: "Optional local files to attach. Paths may be relative to the active workspace/directory or absolute under an authorized workspace root.",
-          items: {
-            type: "object",
-            properties: {
-              path: { type: "string", description: "Workspace-relative path or authorized absolute file path." },
-              filename: { type: "string", description: "Optional attachment filename shown in Gmail." },
-              mimeType: { type: "string", description: "Optional attachment MIME type. Defaults from the file extension when possible." },
-            },
-            required: ["path"],
-            additionalProperties: false,
-          },
-        },
+        attachments: GMAIL_DRAFT_ATTACHMENTS_SCHEMA,
       },
       required: ["to", "subject", "body"],
       additionalProperties: false,
@@ -111,13 +119,14 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
     action: "gmail_create_reply_draft",
     title: "Create Gmail reply draft",
-    description: "Create a Gmail draft reply in an existing thread. This does not send email. Requires Gmail read access (gmail.readonly scope). OpenWork appends the quoted conversation automatically; do not include quoted history. Returns draftUrl and threadUrl; always share draftUrl with the user so they can review and send in Gmail.",
+    description: "Create a Gmail draft reply in an existing thread. This does not send email. Requires Gmail read access (gmail.readonly scope). body must contain only the new reply text — OpenWork automatically appends the quoted conversation below it in plain text and in Gmail's collapsible quote format; never include quoted history yourself. Returns draftUrl and threadUrl plus the resolved reply target; always share draftUrl with the user so they can review and send in Gmail.",
     inputSchema: {
       type: "object",
       properties: {
         messageId: { type: "string", description: "Gmail message id to reply to." },
         body: { type: "string", description: "Plain text reply body. Write plain prose with no markdown syntax; do not include quoted history because OpenWork appends it automatically." },
         replyAll: { type: "boolean", description: "Reply to everyone on the original message. Defaults to true." },
+        attachments: GMAIL_DRAFT_ATTACHMENTS_SCHEMA,
       },
       required: ["messageId", "body"],
       additionalProperties: false,
@@ -641,7 +650,8 @@ function stringArrayField(value: unknown): string[] {
 }
 
 type GmailDraftAttachmentRequest = {
-  path: string;
+  path?: string;
+  url?: string;
   filename?: string;
   mimeType?: string;
 };
@@ -684,10 +694,11 @@ function gmailDraftAttachmentRequests(value: unknown): GmailDraftAttachmentReque
   for (const item of value) {
     if (!isRecord(item)) continue;
     const path = typeof item.path === "string" ? item.path.trim() : "";
-    if (!path) continue;
+    const url = typeof item.url === "string" ? item.url.trim() : "";
+    if ((path && url) || (!path && !url)) throw new ApiError(400, "invalid_payload", "Each attachment must provide exactly one of url or path");
     const filename = typeof item.filename === "string" && item.filename.trim() ? item.filename.trim() : undefined;
     const mimeType = typeof item.mimeType === "string" && item.mimeType.trim() ? item.mimeType.trim() : undefined;
-    attachments.push({ path, filename, mimeType });
+    attachments.push({ ...(path ? { path } : {}), ...(url ? { url } : {}), filename, mimeType });
   }
   return attachments;
 }
@@ -729,6 +740,29 @@ function isFileNotFoundError(error: unknown): boolean {
 async function assertGmailAttachmentFile(path: string) {
   const info = await stat(path);
   if (!info.isFile()) throw new ApiError(400, "invalid_payload", "Attachment path must point to a file", { path });
+  if (info.size > GMAIL_ATTACHMENT_MAX_BYTES) throw new ApiError(413, "file_too_large", `Gmail draft attachments support files up to ${GMAIL_ATTACHMENT_MAX_BYTES} bytes.`, { path, size: info.size, maxBytes: GMAIL_ATTACHMENT_MAX_BYTES });
+}
+
+async function gmailAttachmentRealRoots(allowedRoots: string[]): Promise<string[]> {
+  const realRoots: string[] = [];
+  for (const root of allowedRoots) {
+    try {
+      pushUniqueResolvedPath(realRoots, await realpath(root));
+    } catch (error) {
+      if (!isFileNotFoundError(error)) throw error;
+    }
+  }
+  return realRoots;
+}
+
+async function assertGmailAttachmentRealPath(path: string, allowedRoots: string[]): Promise<string> {
+  const realCandidate = await realpath(path);
+  const realRoots = await gmailAttachmentRealRoots(allowedRoots);
+  if (!realRoots.some((root) => isPathWithinRoot(realCandidate, root))) {
+    throw new ApiError(400, "invalid_payload", "Attachment path must resolve inside an authorized workspace root", { path });
+  }
+  await assertGmailAttachmentFile(realCandidate);
+  return realCandidate;
 }
 
 async function resolveGmailAttachmentPath(config: ServerConfig, context: Record<string, unknown>, path: string): Promise<string> {
@@ -738,7 +772,7 @@ async function resolveGmailAttachmentPath(config: ServerConfig, context: Record<
     const resolved = resolve(path);
     if (!allowedRoots.some((root) => isPathWithinRoot(resolved, root))) throw new ApiError(400, "invalid_payload", "Attachment path must be inside an authorized workspace root", { path });
     await assertGmailAttachmentFile(resolved);
-    return resolved;
+    return assertGmailAttachmentRealPath(resolved, allowedRoots);
   }
 
   for (const root of gmailAttachmentSearchRoots(config, context, allowedRoots)) {
@@ -746,7 +780,7 @@ async function resolveGmailAttachmentPath(config: ServerConfig, context: Record<
     if (!isPathWithinRoot(resolved, root) || !allowedRoots.some((allowedRoot) => isPathWithinRoot(resolved, allowedRoot))) continue;
     try {
       await assertGmailAttachmentFile(resolved);
-      return resolved;
+      return await assertGmailAttachmentRealPath(resolved, allowedRoots);
     } catch (error) {
       if (isFileNotFoundError(error)) continue;
       throw error;
@@ -756,10 +790,106 @@ async function resolveGmailAttachmentPath(config: ServerConfig, context: Record<
   throw new ApiError(400, "invalid_payload", "Attachment file was not found in an authorized workspace root", { path });
 }
 
+// Attachment url validation is unconditional: unlike the managed MCP url
+// guard, it must hold even under OPENWORK_DEV_MODE.
+function assertGmailAttachmentUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new ApiError(400, "invalid_payload", "Attachment url must be a valid https URL", { url: rawUrl });
+  }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+  const privateHost = hostname === "localhost" || hostname.endsWith(".localhost") || hostname.endsWith(".local") || (isIP(hostname) !== 0 && isLocalManagedMcpPrivateAddress(hostname));
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password || privateHost) {
+    throw new ApiError(400, "invalid_payload", "Attachment url must be a public https URL", { url: rawUrl });
+  }
+  return parsed;
+}
+
+function gmailAttachmentFilenameFromResponse(url: URL, contentDisposition: string | null): string {
+  const disposition = contentDisposition ?? "";
+  const quoted = /filename\s*=\s*"([^"]+)"/i.exec(disposition)?.[1];
+  const bare = quoted ? undefined : /filename\s*=\s*([^;\s]+)/i.exec(disposition)?.[1];
+  const fromDisposition = (quoted ?? bare ?? "").trim();
+  if (fromDisposition) return basename(fromDisposition);
+  try {
+    const fromPath = basename(decodeURIComponent(url.pathname));
+    if (fromPath && fromPath !== "/") return fromPath;
+  } catch {
+    // fall through to the generic name on malformed percent-encoding
+  }
+  return "attachment";
+}
+
+async function readGmailAttachmentResponse(response: Response, url: string): Promise<Buffer> {
+  const oversize = () => new ApiError(413, "file_too_large", `Gmail draft attachments support files up to ${GMAIL_ATTACHMENT_MAX_BYTES} bytes.`, { url, maxBytes: GMAIL_ATTACHMENT_MAX_BYTES });
+  const declaredLength = Number(response.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > GMAIL_ATTACHMENT_MAX_BYTES) throw oversize();
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > GMAIL_ATTACHMENT_MAX_BYTES) throw oversize();
+    return buffer;
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > GMAIL_ATTACHMENT_MAX_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw oversize();
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks);
+}
+
+async function fetchGmailUrlAttachment(request: GmailDraftAttachmentRequest, url: string): Promise<GmailDraftAttachment> {
+  let currentUrl = assertGmailAttachmentUrl(url);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GOOGLE_WORKSPACE_API_TIMEOUT_MS);
+  try {
+    for (let redirects = 0; ; redirects += 1) {
+      let response: Response;
+      try {
+        response = await externalFetch(currentUrl.toString(), { redirect: "manual", signal: controller.signal });
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") throw new ApiError(502, "attachment_fetch_failed", "Attachment download timed out", { url });
+        throw new ApiError(502, "attachment_fetch_failed", `Attachment download failed: ${error instanceof Error ? error.message : String(error)}`, { url });
+      }
+      if (response.status >= 300 && response.status < 400) {
+        await response.body?.cancel().catch(() => undefined);
+        const location = response.headers.get("location");
+        if (!location) throw new ApiError(502, "attachment_fetch_failed", "Attachment redirect did not include a location", { url });
+        if (redirects >= GMAIL_ATTACHMENT_REDIRECT_LIMIT) throw new ApiError(400, "invalid_payload", "Attachment url followed too many redirects", { url });
+        currentUrl = assertGmailAttachmentUrl(new URL(location, currentUrl).toString());
+        continue;
+      }
+      if (!response.ok) throw new ApiError(502, "attachment_fetch_failed", `Attachment download failed (${response.status})`, { url, status: response.status });
+      const content = await readGmailAttachmentResponse(response, url);
+      const filename = gmailHeaderValue(request.filename || gmailAttachmentFilenameFromResponse(currentUrl, response.headers.get("content-disposition")));
+      if (!filename) throw new ApiError(400, "invalid_payload", "Attachment filename is required", { url });
+      const responseMimeType = (response.headers.get("content-type") ?? "").split(";")[0]?.trim();
+      const mimeType = gmailAttachmentMimeType(currentUrl.pathname, request.mimeType || responseMimeType || undefined);
+      return { filename, mimeType, content };
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function loadGmailDraftAttachments(config: ServerConfig, context: Record<string, unknown>, requests: GmailDraftAttachmentRequest[]): Promise<GmailDraftAttachment[]> {
   const attachments: GmailDraftAttachment[] = [];
   for (const request of requests) {
-    const path = await resolveGmailAttachmentPath(config, context, request.path);
+    if (request.url) {
+      attachments.push(await fetchGmailUrlAttachment(request, request.url));
+      continue;
+    }
+    const path = await resolveGmailAttachmentPath(config, context, request.path ?? "");
     const content = await readFile(path);
     const filename = gmailHeaderValue(request.filename || basename(path));
     if (!filename) throw new ApiError(400, "invalid_payload", "Attachment filename is required", { path: request.path });
@@ -768,45 +898,138 @@ async function loadGmailDraftAttachments(config: ServerConfig, context: Record<s
   return attachments;
 }
 
-function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; subject: string; body: string; headers?: { name: string; value: string }[]; attachments?: GmailDraftAttachment[] }): string {
-  const headers = [
-    `To: ${input.to.join(", ")}`,
-    input.cc?.length ? `Cc: ${input.cc.join(", ")}` : null,
-    input.bcc?.length ? `Bcc: ${input.bcc.join(", ")}` : null,
-    `Subject: ${input.subject}`,
-    ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
-  ].filter((line): line is string => typeof line === "string");
-  const attachments = input.attachments ?? [];
-  const body = normalizeGmailDraftBody(input.body);
-  if (!attachments.length) return [
-    ...headers,
-    "Content-Type: text/plain; charset=UTF-8",
-    "",
-    body,
-  ].filter((line): line is string => typeof line === "string").join("\r\n");
+function toCrlf(value: string): string {
+  return value.replace(/\r\n?|\n/g, "\r\n");
+}
 
-  const boundary = `openwork-${randomBytes(16).toString("hex")}`;
-  return [
-    ...headers,
+function encodeMimeWord(value: string): string {
+  if (/^[\x20-\x7e]*$/.test(value)) return value;
+  const words: string[] = [];
+  let chunk = "";
+  let chunkBytes = 0;
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (chunk && chunkBytes + characterBytes > 45) {
+      words.push(chunk);
+      chunk = "";
+      chunkBytes = 0;
+    }
+    chunk += character;
+    chunkBytes += characterBytes;
+  }
+  if (chunk) words.push(chunk);
+  return words.map((word) => `=?UTF-8?B?${Buffer.from(word, "utf8").toString("base64")}?=`).join(" ");
+}
+
+function foldHeaderLine(line: string): string {
+  if (line.length <= GMAIL_HEADER_FOLD_LIMIT) return line;
+  const words = line.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (!current) {
+      current = word;
+      continue;
+    }
+    if (current.length + 1 + word.length > GMAIL_HEADER_FOLD_LIMIT) {
+      lines.push(current);
+      current = ` ${word}`;
+      continue;
+    }
+    current += ` ${word}`;
+  }
+  if (current) lines.push(current);
+  return lines.join("\r\n");
+}
+
+function gmailHtmlDivs(text: string): string {
+  return text.replace(/\r\n?/g, "\n").split("\n").map((line) => line ? `<div>${escapeHtml(line)}</div>` : "<div><br></div>").join("");
+}
+
+function gmailHtmlToText(html: string): string {
+  const text = html
+    .replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(?:p|div|tr|li|h[1-6]|blockquote|table|ul|ol)\s*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&#x([0-9a-f]+);/gi, (match, hex: string) => {
+      const code = Number.parseInt(hex, 16);
+      return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+    })
+    .replace(/&#(\d+);/g, (match, decimal: string) => {
+      const code = Number(decimal);
+      return Number.isInteger(code) && code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+    })
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, "\"")
+    .replace(/&apos;/gi, "'")
+    .replace(/&amp;/gi, "&");
+  return text.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; subject: string; body: string; html?: string; headers?: { name: string; value: string }[]; attachments?: GmailDraftAttachment[] }): string {
+  const headers = [
+    `To: ${gmailHeaderValue(input.to.join(", "))}`,
+    input.cc?.length ? `Cc: ${gmailHeaderValue(input.cc.join(", "))}` : null,
+    input.bcc?.length ? `Bcc: ${gmailHeaderValue(input.bcc.join(", "))}` : null,
+    `Subject: ${encodeMimeWord(gmailHeaderValue(input.subject))}`,
+    ...(input.headers ?? []).map((header) => `${header.name}: ${gmailHeaderValue(header.value)}`),
     "MIME-Version: 1.0",
-    `Content-Type: multipart/mixed; boundary="${boundary}"`,
-    "",
-    `--${boundary}`,
+  ].filter((line): line is string => typeof line === "string").map(foldHeaderLine);
+  const attachments = input.attachments ?? [];
+  const body = toCrlf(normalizeGmailDraftBody(input.body));
+  const html = typeof input.html === "string" ? toCrlf(input.html) : null;
+  const textPartLines = [
     "Content-Type: text/plain; charset=UTF-8",
     "Content-Transfer-Encoding: 8bit",
     "",
     body,
-    ...attachments.flatMap((attachment) => [
-      `--${boundary}`,
-      `Content-Type: ${attachment.mimeType}; name="${gmailMimeParameter(attachment.filename)}"`,
-      `Content-Disposition: attachment; filename="${gmailMimeParameter(attachment.filename)}"`,
-      "Content-Transfer-Encoding: base64",
+  ];
+  const alternativePartLines = () => {
+    const boundary = `openwork-alt-${randomBytes(16).toString("hex")}`;
+    return [
+      foldHeaderLine(`Content-Type: multipart/alternative; boundary="${boundary}"`),
       "",
-      base64MimeContent(attachment.content),
-    ]),
-    `--${boundary}--`,
-    "",
-  ].join("\r\n");
+      `--${boundary}`,
+      ...textPartLines,
+      `--${boundary}`,
+      "Content-Type: text/html; charset=UTF-8",
+      "Content-Transfer-Encoding: 8bit",
+      "",
+      html ?? "",
+      `--${boundary}--`,
+    ];
+  };
+  let raw: string;
+  if (!attachments.length) {
+    raw = [...headers, ...(html === null ? textPartLines : alternativePartLines())].join("\r\n");
+  } else {
+    const boundary = `openwork-${randomBytes(16).toString("hex")}`;
+    raw = [
+      ...headers,
+      foldHeaderLine(`Content-Type: multipart/mixed; boundary="${boundary}"`),
+      "",
+      `--${boundary}`,
+      ...(html === null ? textPartLines : alternativePartLines()),
+      ...attachments.flatMap((attachment) => [
+        `--${boundary}`,
+        foldHeaderLine(`Content-Type: ${attachment.mimeType}; name="${gmailMimeParameter(attachment.filename)}"`),
+        foldHeaderLine(`Content-Disposition: attachment; filename="${gmailMimeParameter(attachment.filename)}"`),
+        "Content-Transfer-Encoding: base64",
+        "",
+        base64MimeContent(attachment.content),
+      ]),
+      `--${boundary}--`,
+      "",
+    ].join("\r\n");
+  }
+  const sizeBytes = Buffer.byteLength(raw, "utf8");
+  if (sizeBytes > GMAIL_RAW_MESSAGE_MAX_BYTES) {
+    throw new ApiError(413, "gmail_draft_too_large", `Gmail drafts support messages up to ${GMAIL_RAW_MESSAGE_MAX_BYTES} bytes including encoded attachments.`, { sizeBytes, maxBytes: GMAIL_RAW_MESSAGE_MAX_BYTES });
+  }
+  return raw;
 }
 
 // Generated prose is sometimes hard-wrapped before it reaches Gmail. Those
@@ -873,7 +1096,7 @@ function uniqueEmailHeaders(values: string[], exclude: string[]): string[] {
   const recipients: string[] = [];
   for (const value of values.flatMap(splitEmailHeader)) {
     const key = emailHeaderKey(value);
-    if (!key || seen.has(key)) continue;
+    if (!key || !key.includes("@") || seen.has(key)) continue;
     seen.add(key);
     recipients.push(value);
   }
@@ -901,12 +1124,30 @@ function gmailBodyHasQuotedHistory(body: string): boolean {
   return /^>\s?/m.test(body) && /^.*wrote:\s*$/m.test(body);
 }
 
+function gmailQuoteAttribution(input: { from: string; date: string }): string {
+  return input.date ? `On ${formatGmailQuoteDate(input.date)}, ${input.from} wrote:` : `${input.from} wrote:`;
+}
+
+function truncateGmailQuoteBody(body: string): { text: string; truncated: boolean } {
+  const normalized = body.replace(/\r\n?/g, "\n");
+  if (normalized.length <= GMAIL_QUOTE_BODY_LIMIT) return { text: normalized, truncated: false };
+  return { text: normalized.slice(0, GMAIL_QUOTE_BODY_LIMIT), truncated: true };
+}
+
 function buildGmailQuoteBlock(input: { from: string; date: string; body: string }): string {
-  const header = input.date ? `On ${formatGmailQuoteDate(input.date)}, ${input.from} wrote:` : `${input.from} wrote:`;
-  const truncated = input.body.length > GMAIL_QUOTE_BODY_LIMIT;
-  const quotedLines = input.body.slice(0, GMAIL_QUOTE_BODY_LIMIT).replace(/\r\n?/g, "\n").split("\n").map((line) => `> ${line}`);
+  const { text, truncated } = truncateGmailQuoteBody(input.body);
+  const quotedLines = text.split("\n").map((line) => `> ${line}`);
   if (truncated) quotedLines.push("> [message trimmed]");
-  return [header, ...quotedLines].join("\n");
+  return [gmailQuoteAttribution(input), ...quotedLines].join("\n");
+}
+
+// Gmail collapses quoted history behind its trimmed-content ellipsis only for
+// the gmail_quote/gmail_attr blockquote structure; the quoted content is the
+// escaped text rendition so the plain and HTML parts always agree.
+function buildGmailQuoteHtml(input: { from: string; date: string; body: string }): string {
+  const { text, truncated } = truncateGmailQuoteBody(input.body);
+  const quoted = truncated ? `${text}\n[message trimmed]` : text;
+  return `<div class="gmail_quote"><div dir="ltr" class="gmail_attr">${escapeHtml(gmailQuoteAttribution(input))}</div><blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px solid #ccc;padding-left:1ex">${gmailHtmlDivs(quoted)}</blockquote></div>`;
 }
 
 function gmailDraftMessageId(value: unknown): string | null {
@@ -1094,7 +1335,7 @@ async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<str
   const draft = await fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body, attachments })) } }),
+    body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body, html: gmailHtmlDivs(normalizeGmailDraftBody(body)), attachments })) } }),
   });
   return {
     ...(isRecord(draft) ? draft : {}),
@@ -1103,7 +1344,7 @@ async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<str
   };
 }
 
-async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Record<string, unknown>) {
+async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Record<string, unknown>, context: Record<string, unknown>) {
   const messageId = readStringField(args, "messageId");
   const body = typeof args.body === "string" ? args.body : "";
   const replyAll = args.replyAll !== false;
@@ -1116,17 +1357,26 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
   const payload = isRecord(message) ? message.payload : null;
   const threadId = isRecord(message) && typeof message.threadId === "string" ? message.threadId : "";
   const originalMessageId = gmailHeader(payload, "Message-ID");
-  if (!threadId || !originalMessageId) throw new Error("Gmail message is missing thread metadata required to create a reply draft.");
+  if (!threadId || !originalMessageId) throw new ApiError(400, "gmail_reply_target_invalid", "Gmail message is missing thread metadata required to create a reply draft.", { messageId });
   const account = googleWorkspaceSafeAccount(record.account);
   const ownEmail = typeof account?.email === "string" ? account.email : "";
   const replyTarget = gmailHeader(payload, "Reply-To") || gmailHeader(payload, "From");
   const to = uniqueEmailHeaders(replyAll ? [replyTarget, gmailHeader(payload, "To")] : [replyTarget], [ownEmail]);
   const cc = replyAll ? uniqueEmailHeaders([gmailHeader(payload, "Cc")], [ownEmail, ...to.map(emailHeaderKey)]) : [];
   if (!to.length) throw new ApiError(400, "invalid_payload", "Original message does not include reply recipients");
-  const originalBody = gmailMessageText(payload);
-  const quotedBody = originalBody && !gmailBodyHasQuotedHistory(body)
-    ? `${body}\n\n${buildGmailQuoteBlock({ from: gmailHeader(payload, "From"), date: gmailHeader(payload, "Date"), body: originalBody })}`
+  const attachments = await loadGmailDraftAttachments(config, context, gmailDraftAttachmentRequests(args.attachments));
+  const originalFrom = gmailHeader(payload, "From");
+  const originalDate = gmailHeader(payload, "Date");
+  const originalSubject = gmailHeader(payload, "Subject");
+  const replySubject = gmailReplySubject(originalSubject);
+  // HTML-only originals must still quote: fall back to the text/html part the
+  // same way the read path does.
+  const quoteSource = gmailMessageText(payload) || gmailHtmlToText(gmailMessageText(payload, "text/html"));
+  const includeQuote = !!quoteSource && !gmailBodyHasQuotedHistory(body);
+  const plainBody = includeQuote
+    ? `${body}\n\n${buildGmailQuoteBlock({ from: originalFrom, date: originalDate, body: quoteSource })}`
     : body;
+  const htmlBody = `${gmailHtmlDivs(normalizeGmailDraftBody(body))}${includeQuote ? `<div><br></div>${buildGmailQuoteHtml({ from: originalFrom, date: originalDate, body: quoteSource })}` : ""}`;
   const draft = await fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
@@ -1136,12 +1386,14 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
         raw: base64UrlString(gmailRawMessage({
           to,
           cc,
-          subject: gmailReplySubject(gmailHeader(payload, "Subject")),
-          body: quotedBody,
+          subject: replySubject,
+          body: plainBody,
+          html: htmlBody,
           headers: [
             { name: "In-Reply-To", value: originalMessageId },
             { name: "References", value: gmailReplyReferences(gmailHeader(payload, "References"), originalMessageId) },
           ],
+          attachments,
         })),
       },
     }),
@@ -1150,6 +1402,14 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
     ...(isRecord(draft) ? draft : {}),
     draftUrl: gmailDraftUrl(gmailDraftMessageId(draft)),
     threadUrl: gmailThreadUrl(threadId),
+    reply: {
+      threadId,
+      subject: replySubject,
+      to,
+      cc,
+      inReplyTo: originalMessageId,
+      original: { subject: originalSubject, from: originalFrom, date: originalDate },
+    },
   };
 }
 
@@ -1271,7 +1531,7 @@ export async function callGoogleWorkspaceExtensionAction(config: ServerConfig, a
   }
   if (action === "calendar_list_events") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListEvents(config, args), context };
   if (action === "gmail_create_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateDraft(config, args, context), context };
-  if (action === "gmail_create_reply_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateReplyDraft(config, args), context };
+  if (action === "gmail_create_reply_draft") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceCreateReplyDraft(config, args, context), context };
   if (action === "gmail_list_messages") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceListMessages(config, args), context };
   if (action === "gmail_get_message") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceGetMessage(config, args), context };
   if (action === "gmail_download_attachment") return { ok: true, extensionId: GOOGLE_WORKSPACE_EXTENSION_ID, action, result: await googleWorkspaceDownloadAttachment(config, args), context };

--- a/evals/specs/gmail-reply-draft-fidelity.test.ts
+++ b/evals/specs/gmail-reply-draft-fidelity.test.ts
@@ -1,0 +1,215 @@
+import type { LookupAddress } from "node:dns";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import type { LookupFunction } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+import type { ServerConfig } from "../../apps/server/src/types.js";
+import {
+  callGoogleWorkspaceExtensionAction,
+  createGmailAttachmentPublicLookup,
+  setGmailAttachmentFetchForTests,
+} from "../../apps/server/src/extensions/google-workspace.js";
+
+function createTestConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 8787,
+    token: "test-client-token",
+    hostToken: "test-host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 30_000 },
+    corsOrigins: ["*"],
+    workspaces: [],
+    authorizedRoots: [],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function decodeRawDraft(requestBody: string): string {
+  const raw = requestBody.match(/"raw":"([^"]+)"/)?.[1] ?? "";
+  return Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function lookupAll(lookupFunction: LookupFunction, hostname: string): Promise<LookupAddress[]> {
+  return await new Promise<LookupAddress[]>((resolve, reject) => {
+    lookupFunction(hostname, { all: true }, (error, addresses) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (!Array.isArray(addresses)) {
+        reject(new Error("Expected an all-address DNS lookup result."));
+        return;
+      }
+      resolve(addresses);
+    });
+  });
+}
+
+test("Gmail reply drafts preserve thread fidelity and bind public attachment DNS to the socket", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-gmail-reply-proof-"));
+  const config = createTestConfig(root);
+  const previousFetch = globalThis.fetch;
+  const previousEnv = {
+    devMode: process.env.OPENWORK_DEV_MODE,
+    plaintextVault: process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT,
+    clientSecret: process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET,
+  };
+  const googleRequests: { url: string; body: string }[] = [];
+  const attachmentRequests: { url: string; redirect?: string }[] = [];
+
+  try {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "proof-secret";
+    const vaultPath = join(dirname(config.configPath ?? ""), "extensions", "google-workspace", "oauth.dev-plaintext.json");
+    await mkdir(dirname(vaultPath), { recursive: true });
+    await writeFile(vaultPath, JSON.stringify({
+      version: 2,
+      activeAccountId: "proof-account",
+      accounts: [{
+        account: { email: "owner@example.com", name: "Owner", sub: "proof-account", picture: null },
+        scopes: ["openid", "https://www.googleapis.com/auth/gmail.readonly"],
+        token: {
+          accessToken: "proof-access-token",
+          refreshToken: "proof-refresh-token",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        },
+        connectedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }],
+    }));
+
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/messages/message-1")) {
+        return new Response(JSON.stringify({
+          id: "message-1",
+          threadId: "thread-1",
+          payload: {
+            headers: [
+              { name: "Message-ID", value: "<message-1@example.com>" },
+              { name: "Subject", value: "Design review" },
+              { name: "From", value: "Alice <alice@example.com>" },
+              { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
+            ],
+            parts: [{
+              mimeType: "text/html",
+              body: { data: base64Url("<div>Hello<br>world &amp; more<script>alert(1)</script></div>") },
+            }],
+          },
+        }), { status: 200 });
+      }
+      googleRequests.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+      return new Response(JSON.stringify({
+        id: "draft-1",
+        message: { id: "draft-message-1", threadId: "thread-1" },
+      }), { status: 200 });
+    };
+
+    setGmailAttachmentFetchForTests(async (input, init) => {
+      attachmentRequests.push({ url: input.toString(), redirect: init?.redirect });
+      return new Response("PDF BYTES", {
+        status: 200,
+        headers: {
+          "content-type": "application/pdf",
+          "content-disposition": "attachment; filename=design-review.pdf",
+        },
+      });
+    });
+
+    const reply = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", {
+      messageId: "message-1",
+      body: "Thanks for the review.",
+      attachments: [{ url: "https://93.184.216.34/design-review.pdf" }],
+    }, {});
+    const raw = decodeRawDraft(googleRequests[0]?.body ?? "");
+
+    expect(reply?.result).toMatchObject({
+      draftUrl: "https://mail.google.com/mail/u/0/#drafts?compose=draft-message-1",
+      threadUrl: "https://mail.google.com/mail/u/0/#all/thread-1",
+      reply: {
+        threadId: "thread-1",
+        subject: "Re: Design review",
+        to: ["Alice <alice@example.com>"],
+        inReplyTo: "<message-1@example.com>",
+      },
+    });
+    expect(raw).toContain("Content-Type: multipart/mixed;");
+    expect(raw).toContain("Content-Type: multipart/alternative;");
+    expect(raw).toContain("In-Reply-To: <message-1@example.com>");
+    expect(raw).toContain("> Hello\r\n> world & more");
+    expect(raw).toContain('<blockquote class="gmail_quote"');
+    expect(raw).toContain("<div>Hello</div><div>world &amp; more</div>");
+    expect(raw).not.toContain("alert(1)");
+    expect(raw).not.toContain("<script");
+    expect(raw).toContain('Content-Disposition: attachment; filename="design-review.pdf"');
+    expect(raw).toContain(Buffer.from("PDF BYTES", "utf8").toString("base64"));
+    expect(attachmentRequests).toEqual([{
+      url: "https://93.184.216.34/design-review.pdf",
+      redirect: "manual",
+    }]);
+
+    await expect(callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["sam@example.com"],
+      subject: "Unsafe attachment",
+      body: "This must not download.",
+      attachments: [{ url: "http://169.254.169.254/latest/meta-data" }],
+    }, {})).rejects.toThrow("Attachment url must be a public https URL");
+    expect(attachmentRequests).toHaveLength(1);
+
+    let resolverCalls = 0;
+    const socketLookup = createGmailAttachmentPublicLookup(async () => {
+      resolverCalls += 1;
+      return resolverCalls === 1
+        ? [{ address: "93.184.216.34", family: 4 }]
+        : [{ address: "169.254.169.254", family: 4 }];
+    });
+    await expect(lookupAll(socketLookup, "files.example.test")).resolves.toEqual([
+      { address: "93.184.216.34", family: 4 },
+    ]);
+    await expect(lookupAll(socketLookup, "files.example.test")).rejects.toThrow(
+      "resolved to a private or reserved address",
+    );
+
+    evidence.recordAssertionEvidence(
+      "Reply drafts retain the target thread and Gmail-collapsible quoted history",
+      "The model-callable reply action returned the resolved thread, subject, recipient, and In-Reply-To target; its raw MIME contained matching plain and gmail_quote HTML renditions of an HTML-only original while excluding script content.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Reply attachments carry exact public-URL bytes without weakening URL policy",
+      "The reply MIME carried the witnessed PDF filename and exact bytes after one manual-redirect HTTPS request, while an HTTP link-local attachment was rejected before a second download.",
+      true,
+    );
+    evidence.recordAssertionEvidence(
+      "Attachment DNS validation is bound to the socket lookup",
+      "The connector lookup handed its first public answer to the caller and rejected a later link-local rebinding answer returned by the socket's own lookup.",
+      resolverCalls === 2,
+    );
+  } finally {
+    setGmailAttachmentFetchForTests();
+    globalThis.fetch = previousFetch;
+    restoreEnv("OPENWORK_DEV_MODE", previousEnv.devMode);
+    restoreEnv("OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT", previousEnv.plaintextVault);
+    restoreEnv("GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET", previousEnv.clientSecret);
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why

Gmail replies drafted through OpenWork sometimes exposed the full quoted thread — plain-text `> ` quoting never collapses in Gmail's UI — and silently dropped the quote entirely when the original message was HTML-only, because the quote source only read the `text/plain` part. Callers also had no way to verify which thread and recipients a reply actually targeted, and draft attachments only worked from local workspace paths, which no non-desktop surface can use.

## What

- **Collapsible quoting.** Reply drafts now send `multipart/alternative`; the HTML part wraps history in Gmail's `gmail_quote`/`gmail_attr` blockquote structure, so Gmail collapses it behind the trimmed-content ellipsis. A single `includeQuote` decision drives both parts, so plain and HTML never disagree.
- **HTML-only originals now quote.** The quote source falls back to the `text/html` part (tag-strip + entity decode), matching the existing read path's fallback.
- **Wrong-thread detectability.** The reply response adds `reply` — `threadId`, resolved `Re:` subject, `to`, `cc`, `inReplyTo`, and the original message's subject/from/date. Missing thread metadata is now a coded 400 (`gmail_reply_target_invalid`) instead of an uncoded 500.
- **URL attachments.** Attachment items take exactly one of `url` or `path`. The url lane is public-https-only with per-hop manual redirect validation (localhost, `.local`, and private/reserved literal IPs rejected — unconditionally, with no dev-mode bypass), a streamed 20 MiB per-file cap, filename from `Content-Disposition` or the URL, MIME from the response. The `path` lane is deprecated in the schema and hardened: realpath containment (symlink escapes rejected) and the same size cap. Reply drafts accept attachments for the first time. The whole raw message is capped at Gmail's 25 MB limit.
- **MIME hygiene.** `MIME-Version` + 8bit CTE on every path, CRLF line endings throughout, RFC 2047 B-encoding for non-ASCII subjects, header folding at 78 chars (unbounded `References` growth on long threads), CRLF stripped from all header values (header injection), and recipient fragments without an `@` (from unquoted display-name commas) dropped.
- **Sharper tool guidance.** `gmail_create_draft` is described as new-conversations-only and still rejects `Re:`/`Fwd:` subjects; the reply description states body is new text only and quoting is automatic.

## Design notes

- 8bit CTE (not base64) for the text parts matches the file's existing multipart path, keeps raw-MIME assertions literal in tests, and Gmail re-serializes drafts on send.
- The quoted HTML embeds the escaped **text** rendition of the original, not its raw HTML — guarantees parity between parts with no sanitizer dependency; Gmail's collapse keys on the blockquote class structure, not inner fidelity.
- Every hop's hostname is resolved and validated against the same private/reserved ranges before downloading (unconditionally — mirroring the managed MCP guard's resolved-address validation, minus its dev-mode bypass); unresolvable hosts are refused. `externalFetch` re-resolves when it connects, so a rebinding race between our lookup and the socket's remains theoretically possible without the undici connector pinning the managed MCP lane uses — accepted for a desktop draft flow and noted at the check.
- Electron `net.fetch` support for `redirect: "manual"` is worth a sanity check in the app build; bun/undici honor it, and the per-hop validation degrades to a clear `attachment_fetch_failed` error if a runtime returns an opaque redirect.

## Testing

- `cd apps/server && bun --conditions=development test src/extensions/google-workspace.test.ts` — **31 pass** (18 existing + 13 new: collapse markup, HTML-only quoting, no-double-quote, `Fwd:` rejection, RFC 2047 round-trip, header-injection neutralization, References folding, reply attachments on both lanes, redirect handling, non-https/private-literal/private-DNS/unresolvable/downgrade refusals, size caps on both lanes, symlink escape, response echo).
- `pnpm typecheck` in `apps/server` — clean.
- Full `apps/server` suite: **804 pass / 8 skip**; the only failure is the pre-existing `workspace-kv-store.node.test.ts` (`node:sqlite` unresolvable under this bun locally; unrelated to this change and identical on untouched dev).
