### PR TITLE
perf(app): bound renderer module caches

### DIFF
--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -163,6 +163,28 @@ function updateRecord(
   };
 }
 
+// Message roles are only consulted while a run is active to decide whether a
+// streaming part belongs to an assistant message. Without a cap the dict grows
+// by one entry per message for a session's whole lifetime, so keep only the
+// most recently marked messages.
+export const MAX_TRACKED_MESSAGE_ROLES = 200;
+
+function withMessageRole(
+  roles: Record<string, SessionMessageRole>,
+  messageId: string,
+  role: SessionMessageRole,
+): Record<string, SessionMessageRole> {
+  if (roles[messageId] === role) return roles;
+  const next: Record<string, SessionMessageRole> = { ...roles, [messageId]: role };
+  const ids = Object.keys(next);
+  const overflow = ids.length - MAX_TRACKED_MESSAGE_ROLES;
+  if (overflow <= 0) return next;
+  for (const id of ids.slice(0, overflow)) {
+    delete next[id];
+  }
+  return next;
+}
+
 function removeValue(values: string[], value: string) {
   return values.filter((item) => item !== value);
 }
@@ -277,10 +299,7 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
     if (!workspace || !session || !message) return;
     set((state) => updateRecord(state, workspace, session, (record) => ({
       ...record,
-      messageRoles: {
-        ...record.messageRoles,
-        [message]: role,
-      },
+      messageRoles: withMessageRole(record.messageRoles, message, role),
     })));
   },
   markAssistantOutput: (workspaceId, sessionId, messageId, options) => {

--- a/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
+++ b/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
@@ -12,28 +12,15 @@ import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { publishInspectorSlice, recordInspectorEvent } from "@/app/lib/app-inspector";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
-
-type VoiceStatus = "idle" | "connecting" | "listening" | "muted" | "speaking" | "error";
-
-type VoiceTimelineEntry = {
-  id: string;
-  role: "user" | "assistant" | "tool" | "system";
-  text: string;
-  toolName?: string;
-  error?: boolean;
-  at: number;
-};
-
-type VoiceRuntimeSnapshot = {
-  status: VoiceStatus;
-  statusText: string;
-  micMuted: boolean;
-  micDiagnostics: string;
-  realtimeDiagnostics: string;
-  entries: VoiceTimelineEntry[];
-  latestUserTranscript: string;
-  assistantPreview: string;
-};
+import {
+  appendVoiceTimelineEntry,
+  getVoiceRuntimeSnapshot,
+  resetVoiceRuntimeSnapshot,
+  setVoiceRuntimeSnapshot,
+  subscribeVoiceRuntime,
+  type VoiceStatus,
+  type VoiceTimelineEntry,
+} from "./voice-runtime";
 
 type VoicePanelProps = {
   client: OpenworkServerClient | null;
@@ -55,17 +42,6 @@ const TOOL_LABELS: Record<string, string> = {
   openwork_execute_action: "Running UI action",
 };
 
-const initialVoiceRuntimeSnapshot: VoiceRuntimeSnapshot = {
-  status: "idle",
-  statusText: "Ready for voice control.",
-  micMuted: false,
-  micDiagnostics: "Microphone has not started yet.",
-  realtimeDiagnostics: "Realtime is not connected.",
-  entries: [],
-  latestUserTranscript: "",
-  assistantPreview: "",
-};
-
 const voiceRealtime = {
   peer: null as RTCPeerConnection | null,
   channel: null as RTCDataChannel | null,
@@ -76,25 +52,6 @@ const voiceRealtime = {
   pendingResponse: false,
   micMuted: false,
 };
-
-let voiceRuntimeSnapshot: VoiceRuntimeSnapshot = initialVoiceRuntimeSnapshot;
-const voiceRuntimeListeners = new Set<() => void>();
-
-function getVoiceRuntimeSnapshot() {
-  return voiceRuntimeSnapshot;
-}
-
-function subscribeVoiceRuntime(listener: () => void) {
-  voiceRuntimeListeners.add(listener);
-  return () => {
-    voiceRuntimeListeners.delete(listener);
-  };
-}
-
-function setVoiceRuntimeSnapshot(update: (current: VoiceRuntimeSnapshot) => VoiceRuntimeSnapshot) {
-  voiceRuntimeSnapshot = update(voiceRuntimeSnapshot);
-  voiceRuntimeListeners.forEach((listener) => listener());
-}
 
 function useVoiceRuntimeSnapshot() {
   return useSyncExternalStore(subscribeVoiceRuntime, getVoiceRuntimeSnapshot, getVoiceRuntimeSnapshot);
@@ -368,22 +325,7 @@ export function VoicePanel(props: VoicePanelProps) {
   const connected = status === "listening" || status === "speaking" || status === "muted";
 
   const addEntry = useCallback((role: VoiceTimelineEntry["role"], text: string, options: { toolName?: string; error?: boolean } = {}) => {
-    const trimmed = text.trim();
-    if ((role === "user" || role === "assistant") && !trimmed) return;
-    setVoiceRuntimeSnapshot((current) => ({
-      ...current,
-      entries: [
-        ...current.entries,
-        {
-          id: `voice-${Date.now()}-${current.entries.length}`,
-          role,
-          text: trimmed || options.toolName || "Tool call",
-          toolName: options.toolName,
-          error: options.error,
-          at: Date.now(),
-        },
-      ].slice(-120),
-    }));
+    appendVoiceTimelineEntry(role, text, options);
   }, []);
 
   const setRuntimeStatus = useCallback((nextStatus: VoiceStatus, text?: string) => {
@@ -414,15 +356,23 @@ export function VoicePanel(props: VoicePanelProps) {
     voiceRealtime.responseInProgress = false;
     voiceRealtime.pendingResponse = false;
     voiceRealtime.micMuted = false;
-    setVoiceRuntimeSnapshot((current) => ({
-      ...current,
-      micMuted: false,
-      micDiagnostics: "Microphone has not started yet.",
-      realtimeDiagnostics: "Realtime is not connected.",
-      assistantPreview: "",
-    }));
-    setRuntimeStatus("idle");
-    if (!silent) addEntry("system", "Voice session stopped.");
+    if (silent) {
+      // Reconnect path: keep the timeline so the panel stays continuous.
+      setVoiceRuntimeSnapshot((current) => ({
+        ...current,
+        micMuted: false,
+        micDiagnostics: "Microphone has not started yet.",
+        realtimeDiagnostics: "Realtime is not connected.",
+        assistantPreview: "",
+      }));
+      setRuntimeStatus("idle");
+    } else {
+      // Explicit stop: release the module-scope snapshot (timeline text and
+      // transcripts survive panel close otherwise) instead of retaining it
+      // for the rest of the app run.
+      resetVoiceRuntimeSnapshot();
+      addEntry("system", "Voice session stopped.");
+    }
     recordInspectorEvent("voice.disconnected", { sessionId: props.sessionId });
   }, [addEntry, props.sessionId, setRuntimeStatus]);
 

--- a/apps/app/src/react-app/domains/session/voice/voice-runtime.ts
+++ b/apps/app/src/react-app/domains/session/voice/voice-runtime.ts
@@ -1,0 +1,88 @@
+/**
+ * Module-scope Voice Mode runtime state. It intentionally outlives the panel
+ * so a background session keeps streaming into the timeline, but it must stay
+ * bounded: entries are capped and an explicit stop releases the whole
+ * snapshot instead of retaining transcript text for the rest of the app run.
+ */
+
+export type VoiceStatus = "idle" | "connecting" | "listening" | "muted" | "speaking" | "error";
+
+export type VoiceTimelineEntry = {
+  id: string;
+  role: "user" | "assistant" | "tool" | "system";
+  text: string;
+  toolName?: string;
+  error?: boolean;
+  at: number;
+};
+
+export type VoiceRuntimeSnapshot = {
+  status: VoiceStatus;
+  statusText: string;
+  micMuted: boolean;
+  micDiagnostics: string;
+  realtimeDiagnostics: string;
+  entries: VoiceTimelineEntry[];
+  latestUserTranscript: string;
+  assistantPreview: string;
+};
+
+export const VOICE_TIMELINE_LIMIT = 120;
+
+export const initialVoiceRuntimeSnapshot: VoiceRuntimeSnapshot = {
+  status: "idle",
+  statusText: "Ready for voice control.",
+  micMuted: false,
+  micDiagnostics: "Microphone has not started yet.",
+  realtimeDiagnostics: "Realtime is not connected.",
+  entries: [],
+  latestUserTranscript: "",
+  assistantPreview: "",
+};
+
+let voiceRuntimeSnapshot: VoiceRuntimeSnapshot = initialVoiceRuntimeSnapshot;
+const voiceRuntimeListeners = new Set<() => void>();
+
+export function getVoiceRuntimeSnapshot() {
+  return voiceRuntimeSnapshot;
+}
+
+export function subscribeVoiceRuntime(listener: () => void) {
+  voiceRuntimeListeners.add(listener);
+  return () => {
+    voiceRuntimeListeners.delete(listener);
+  };
+}
+
+export function setVoiceRuntimeSnapshot(update: (current: VoiceRuntimeSnapshot) => VoiceRuntimeSnapshot) {
+  voiceRuntimeSnapshot = update(voiceRuntimeSnapshot);
+  voiceRuntimeListeners.forEach((listener) => listener());
+}
+
+/** Release everything the voice runtime retained, including timeline text. */
+export function resetVoiceRuntimeSnapshot() {
+  setVoiceRuntimeSnapshot(() => initialVoiceRuntimeSnapshot);
+}
+
+export function appendVoiceTimelineEntry(
+  role: VoiceTimelineEntry["role"],
+  text: string,
+  options: { toolName?: string; error?: boolean } = {},
+) {
+  const trimmed = text.trim();
+  if ((role === "user" || role === "assistant") && !trimmed) return;
+  setVoiceRuntimeSnapshot((current) => ({
+    ...current,
+    entries: [
+      ...current.entries,
+      {
+        id: `voice-${Date.now()}-${current.entries.length}`,
+        role,
+        text: trimmed || options.toolName || "Tool call",
+        toolName: options.toolName,
+        error: options.error,
+        at: Date.now(),
+      },
+    ].slice(-VOICE_TIMELINE_LIMIT),
+  }));
+}

--- a/apps/app/src/react-app/infra/provider-list-query.ts
+++ b/apps/app/src/react-app/infra/provider-list-query.ts
@@ -21,6 +21,10 @@ export type ConnectedProviderSnapshotChange = {
   next: ConnectedProviderSnapshot;
 };
 
+// Bounded module-scope cache: snapshots are keyed by (baseUrl, directory) and
+// would otherwise accumulate for every workspace ever opened in this app run.
+// Recording refreshes a key's recency; the oldest keys are evicted past the cap.
+const CONNECTED_PROVIDER_SNAPSHOT_LIMIT = 16;
 const connectedProviderSnapshots = new Map<string, ConnectedProviderSnapshot>();
 const connectedProviderSnapshotChanges = new Map<string, ConnectedProviderSnapshotChange>();
 
@@ -111,8 +115,17 @@ function recordConnectedProviderSnapshot(
   const previous = connectedProviderSnapshots.get(key) ?? null;
   const next = getConnectedProviderSnapshot(value);
   const changed = previous !== null && JSON.stringify(previous) !== JSON.stringify(next);
+  // Delete before set so a refreshed key moves to the newest insertion slot.
+  connectedProviderSnapshots.delete(key);
+  connectedProviderSnapshotChanges.delete(key);
   connectedProviderSnapshots.set(key, next);
   connectedProviderSnapshotChanges.set(key, { changed, previous, next });
+  while (connectedProviderSnapshots.size > CONNECTED_PROVIDER_SNAPSHOT_LIMIT) {
+    const oldest = connectedProviderSnapshots.keys().next().value;
+    if (oldest === undefined) break;
+    connectedProviderSnapshots.delete(oldest);
+    connectedProviderSnapshotChanges.delete(oldest);
+  }
   if (changed) {
     dispatchConnectedProviderChanges(previous, next);
   }

--- a/evals/specs/renderer-bounded-caches.test.ts
+++ b/evals/specs/renderer-bounded-caches.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+import type { Client } from "../../apps/app/src/app/types";
+import {
+  fetchProviderList,
+  getConnectedProviderSnapshotChange,
+} from "../../apps/app/src/react-app/infra/provider-list-query";
+import {
+  MAX_TRACKED_MESSAGE_ROLES,
+  useSessionActivityStore,
+} from "../../apps/app/src/react-app/domains/session/status/session-activity-store";
+import {
+  appendVoiceTimelineEntry,
+  getVoiceRuntimeSnapshot,
+  initialVoiceRuntimeSnapshot,
+  resetVoiceRuntimeSnapshot,
+  VOICE_TIMELINE_LIMIT,
+} from "../../apps/app/src/react-app/domains/session/voice/voice-runtime";
+
+test("session activity message-role tracking stays bounded per session", () => {
+  const store = useSessionActivityStore.getState();
+  store.setRunStatus("ws-bounded", "session-a", "busy");
+  for (let index = 0; index < MAX_TRACKED_MESSAGE_ROLES + 50; index += 1) {
+    store.markMessageRole("ws-bounded", "session-a", `message-${index}`, index % 2 === 0 ? "user" : "assistant");
+  }
+
+  const record = useSessionActivityStore.getState().recordsByWorkspaceId["ws-bounded"]?.["session-a"];
+  expect(record).toBeDefined();
+  // The dict is capped at the most recent marks: the oldest overflowed
+  // message ids are dropped, the newest are retained with their roles.
+  expect(Object.keys(record?.messageRoles ?? {})).toHaveLength(MAX_TRACKED_MESSAGE_ROLES);
+  expect(record?.messageRoles["message-0"]).toBeUndefined();
+  expect(record?.messageRoles["message-49"]).toBeUndefined();
+  expect(record?.messageRoles["message-50"]).toBe("user");
+  expect(record?.messageRoles[`message-${MAX_TRACKED_MESSAGE_ROLES + 49}`]).toBe("assistant");
+
+  // Assistant-output gating still works for a retained assistant message.
+  store.markAssistantOutput("ws-bounded", "session-a", `message-${MAX_TRACKED_MESSAGE_ROLES + 49}`);
+  expect(
+    useSessionActivityStore.getState().recordsByWorkspaceId["ws-bounded"]?.["session-a"]?.assistantOutput,
+  ).toBe(true);
+
+  // Negative half: below the cap nothing is evicted.
+  store.setRunStatus("ws-small", "session-b", "busy");
+  for (let index = 0; index < 10; index += 1) {
+    store.markMessageRole("ws-small", "session-b", `small-${index}`, "assistant");
+  }
+  const smallRecord = useSessionActivityStore.getState().recordsByWorkspaceId["ws-small"]?.["session-b"];
+  expect(Object.keys(smallRecord?.messageRoles ?? {})).toHaveLength(10);
+  expect(smallRecord?.messageRoles["small-0"]).toBe("assistant");
+});
+
+test("connected provider snapshot cache evicts the oldest workspace keys", async () => {
+  const emptyProviderList: ProviderListResponse = { all: [], connected: [], default: {} };
+  // Only provider.list is exercised by fetchProviderList; a full Client cannot
+  // be constructed in a unit spec.
+  const client = {
+    provider: { list: async () => ({ data: emptyProviderList }) },
+  } as unknown as Client;
+
+  for (let index = 0; index < 20; index += 1) {
+    await fetchProviderList({ client, baseUrl: "http://localhost:1", directory: `/tmp/workspace-${index}` });
+  }
+
+  // 20 distinct (baseUrl, directory) keys were recorded against a cap of 16:
+  // the oldest keys are gone, the newest are retained.
+  expect(getConnectedProviderSnapshotChange({ baseUrl: "http://localhost:1", directory: "/tmp/workspace-0" })).toBeNull();
+  expect(getConnectedProviderSnapshotChange({ baseUrl: "http://localhost:1", directory: "/tmp/workspace-3" })).toBeNull();
+  expect(getConnectedProviderSnapshotChange({ baseUrl: "http://localhost:1", directory: "/tmp/workspace-4" })).not.toBeNull();
+  expect(getConnectedProviderSnapshotChange({ baseUrl: "http://localhost:1", directory: "/tmp/workspace-19" })).not.toBeNull();
+
+  // Re-recording an existing key refreshes its recency instead of
+  // double-counting it: nothing else is evicted.
+  await fetchProviderList({ client, baseUrl: "http://localhost:1", directory: "/tmp/workspace-4" });
+  expect(getConnectedProviderSnapshotChange({ baseUrl: "http://localhost:1", directory: "/tmp/workspace-4" })).not.toBeNull();
+  expect(getConnectedProviderSnapshotChange({ baseUrl: "http://localhost:1", directory: "/tmp/workspace-5" })).not.toBeNull();
+});
+
+test("voice runtime timeline stays bounded and an explicit stop releases the snapshot", () => {
+  resetVoiceRuntimeSnapshot();
+  for (let index = 0; index < VOICE_TIMELINE_LIMIT + 30; index += 1) {
+    appendVoiceTimelineEntry("assistant", `spoken line ${index}`);
+  }
+
+  const bounded = getVoiceRuntimeSnapshot();
+  expect(bounded.entries).toHaveLength(VOICE_TIMELINE_LIMIT);
+  expect(bounded.entries[0]?.text).toBe("spoken line 30");
+  expect(bounded.entries.at(-1)?.text).toBe(`spoken line ${VOICE_TIMELINE_LIMIT + 29}`);
+
+  // Existing filtering behavior is preserved: blank user/assistant text is
+  // dropped, tool entries fall back to the tool name.
+  appendVoiceTimelineEntry("user", "   ");
+  expect(getVoiceRuntimeSnapshot().entries).toHaveLength(VOICE_TIMELINE_LIMIT);
+  appendVoiceTimelineEntry("tool", "", { toolName: "openwork_snapshot" });
+  expect(getVoiceRuntimeSnapshot().entries.at(-1)?.text).toBe("openwork_snapshot");
+
+  // Reset drops every retained entry and transcript, returning the exact
+  // initial snapshot object shape.
+  resetVoiceRuntimeSnapshot();
+  expect(getVoiceRuntimeSnapshot()).toEqual(initialVoiceRuntimeSnapshot);
+  expect(getVoiceRuntimeSnapshot().entries).toHaveLength(0);
+
+  // The panel's explicit-stop path (non-silent disconnect) is wired to the
+  // reset, while the silent reconnect path keeps the timeline.
+  const voicePanelSource = readFileSync(
+    fileURLToPath(new URL("../../apps/app/src/react-app/domains/session/voice/voice-panel.tsx", import.meta.url)),
+    "utf8",
+  );
+  const stopBranch = voicePanelSource.match(/if \(silent\) \{[\s\S]*?\} else \{([\s\S]*?)\n {4}\}/)?.[1] ?? "";
+  expect(stopBranch).toContain("resetVoiceRuntimeSnapshot()");
+});


### PR DESCRIPTION
## What

Three module-scope renderer caches grew without a bound for the lifetime of the app run. This bounds each one with no architecture change:

- **Voice Mode runtime snapshot** (`voice-panel.tsx`): the module-scope snapshot survived panel close and explicit stop, retaining timeline text and transcripts indefinitely. The snapshot store now lives in `voice-runtime.ts` (same behavior, same 120-entry timeline cap), and an explicit **Stop** releases the whole snapshot. The silent reconnect path keeps the timeline so the panel stays continuous mid-session.
- **Connected provider snapshots** (`provider-list-query.ts`): `connectedProviderSnapshots` / `connectedProviderSnapshotChanges` are keyed by `(baseUrl, directory)` and were only cleared on Den sign-out, so they accumulated one full provider/model snapshot per workspace ever opened. The maps are now capped at 16 keys; recording refreshes a key's recency and evicts the oldest keys past the cap.
- **Session activity `messageRoles`** (`session-activity-store.ts`): the dict grew one entry per message until the server deleted the session. It now keeps the 200 most recent marks per session, which covers the active-run assistant-output gating that consults it (`markAssistantOutput` only reads roles while a run is active).

## What was checked and intentionally not changed

- `artifact-panel.tsx` artifact query: already bounded on current `dev` — it uses `staleTime: Infinity` with `gcTime: 0`, so artifact/binary bodies are dropped as soon as the query unmounts.
- Composer attachment blob URLs on send failure: every failure path (`handleSend` catch, queued send catch, drain catch) keeps the attachments in the composer or re-queues them, where their previews are still rendered — revoking there would break visible chips. All actual removal paths (remove, queue removal, stop/clear, session clear, retained-diff after send) already revoke.

## Proof

Local lane, at this head:

- `pnpm --dir evals vitest run specs/renderer-bounded-caches.test.ts` — 3/3 passed. Asserts: `messageRoles` caps at 200 with oldest-first eviction and intact assistant-output gating (plus the below-cap negative half); the provider snapshot cache evicts oldest keys past 16 and refreshes recency without double-counting; the voice timeline caps at 120, preserves blank-text filtering, and reset returns the exact initial snapshot, with the stop branch wired to the reset.
- `pnpm --filter @openwork/app typecheck` — clean.
- `apps/app: bun test --isolate tests/` — 1065 pass / 5 fail; the same 5 failures reproduce on clean `dev` at the merge base with this diff stashed, so they are pre-existing and unrelated (they pass when their files run in isolation).