### PR TITLE
chore(evals): quantify test coverage and flake rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ ee/apps/*/dist/
 ee/packages/*/dist/
 ee/apps/inference/models-site/models/api.json
 tmp/
+coverage/
+evals/results/flake/
 
 # Local git worktrees
 _worktrees/

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 bun --conditions=development src/cli.ts",
     "test": "bun --conditions=development test",
+    "test:coverage": "bun --conditions=development test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "test:artifacts": "bun --conditions=development test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build:enterprise-mcp-client": "pnpm --filter @openwork/enterprise-mcp-client build",
     "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",

--- a/evals/package.json
+++ b/evals/package.json
@@ -4,6 +4,10 @@
   "type": "module",
   "scripts": {
     "test:pr": "vitest run --config vitest.config.ts --project pr",
+    "test:pr:coverage": "vitest run --config vitest.config.ts --project pr --coverage.enabled=true --coverage.provider=v8 --coverage.reporter=text-summary --coverage.reporter=lcov --coverage.reportsDirectory=./coverage",
+    "flake:collect": "node scripts/flake-report.mjs collect",
+    "flake:report": "node scripts/flake-report.mjs report",
+    "coverage:matrix": "node scripts/spec-coverage-matrix.mjs",
     "test:e2e": "vitest run --config vitest.config.ts --project e2e",
     "artifacts:index": "node packages/test-artifacts/bin/artifact-index.mjs",
     "artifacts:publish": "node packages/test-artifacts/bin/publish-pr.mjs",
@@ -12,7 +16,7 @@
     "evidence:judge": "node packages/test-evidence/bin/test-evidence-judge.mjs",
     "provision:org-connector-two-members": "node scripts/provision-org-connector-two-members.ts",
     "lint:layers": "depcruise --config .dependency-cruiser.cjs packages specs bin docs-shots runner scripts",
-    "test": "pnpm run lint:layers && node --test runner/*.test.ts packages/*/test/*.test.ts bin/*.test.mjs",
+    "test": "pnpm run lint:layers && node --test runner/*.test.ts packages/*/test/*.test.ts bin/*.test.mjs scripts/*.test.mjs",
     "typecheck": "tsc -p ."
   },
   "dependencies": {
@@ -27,6 +31,7 @@
     "@openwork/world": "link:../packages/world"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^3.2.4",
     "dependency-cruiser": "18.1.0",
     "vitest": "^3.2.4"
   },

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: link:../packages/world
         version: link:../packages/world
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.7(vitest@3.2.7(@types/node@26.1.2)(yaml@2.9.0))
       dependency-cruiser:
         specifier: 18.1.0
         version: 18.1.0
@@ -144,6 +147,31 @@ importers:
   packages/timeline: {}
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -301,8 +329,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -333,6 +379,10 @@ packages:
     resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -487,6 +537,15 @@ packages:
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
@@ -537,17 +596,46 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -576,6 +664,10 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -602,8 +694,17 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   effect@4.0.0-beta.83:
     resolution: {integrity: sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
@@ -644,6 +745,10 @@ packages:
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -654,6 +759,11 @@ packages:
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -669,6 +779,9 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -694,6 +807,10 @@ packages:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-installed-globally@1.0.0:
     resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
     engines: {node: '>=18'}
@@ -704,6 +821,31 @@ packages:
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -726,6 +868,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
@@ -733,8 +878,27 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -768,8 +932,19 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -825,8 +1000,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -844,6 +1031,22 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -863,6 +1066,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -983,10 +1190,23 @@ packages:
     engines: {node: ^22.13||^24||>=26}
     hasBin: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -997,6 +1217,26 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1076,7 +1316,30 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -1094,6 +1357,9 @@ snapshots:
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
@@ -1186,6 +1452,25 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@26.1.2)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@26.1.2)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -1244,13 +1529,37 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   assertion-error@2.0.1: {}
 
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   aws-ssl-profiles@1.1.2: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
 
   cac@6.7.14: {}
 
@@ -1276,6 +1585,12 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@15.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
@@ -1309,6 +1624,8 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
+  eastasianwidth@0.2.0: {}
+
   effect@4.0.0-beta.83:
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1321,6 +1638,10 @@ snapshots:
       toml: 4.3.0
       uuid: 14.0.2
       yaml: 2.9.0
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.24.2:
     dependencies:
@@ -1376,6 +1697,11 @@ snapshots:
 
   find-my-way-ts@0.1.6: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -1384,6 +1710,15 @@ snapshots:
   generate-function@2.3.1:
     dependencies:
       is-property: 1.0.2
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   global-directory@4.0.1:
     dependencies:
@@ -1396,6 +1731,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  html-escaper@2.0.2: {}
 
   iconv-lite@0.7.3:
     dependencies:
@@ -1413,6 +1750,8 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-installed-globally@1.0.0:
     dependencies:
       global-directory: 4.0.1
@@ -1421,6 +1760,37 @@ snapshots:
   is-path-inside@4.0.0: {}
 
   is-property@1.0.2: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -1434,13 +1804,35 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru.min@1.1.4: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -1485,7 +1877,16 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -1560,7 +1961,15 @@ snapshots:
 
   semver@7.8.5: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
 
@@ -1571,6 +1980,26 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
 
   strip-bom@3.0.0: {}
 
@@ -1585,6 +2014,12 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.3.3: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
 
   tinybench@2.9.0: {}
 
@@ -1697,10 +2132,26 @@ snapshots:
 
   watskeburt@6.0.0: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   yaml@2.9.0: {}
 

--- a/evals/scripts/flake-report.mjs
+++ b/evals/scripts/flake-report.mjs
@@ -1,0 +1,167 @@
+// Flake-rate reporting over repeated vitest runs.
+//
+// collect: run one lane with the vitest JSON reporter and save the receipt.
+//   node scripts/flake-report.mjs collect [--project pr|e2e] [-- <extra vitest args>]
+// report: aggregate every saved receipt into per-spec pass rates.
+//   node scripts/flake-report.mjs report [--project pr|e2e] [--threshold 0.95]
+//
+// A spec is "flaky" when the same spec file both passed and failed across the
+// collected runs. Specs below the pass-rate threshold belong on the quarantine
+// list until diagnosed (see diagnose-a-red-run).
+import { execFileSync } from "node:child_process"
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const evalsRoot = fileURLToPath(new URL("..", import.meta.url))
+
+export function runsDirectory(project) {
+  return resolve(evalsRoot, "results", "flake", project)
+}
+
+function parseArguments(argv) {
+  const separator = argv.indexOf("--")
+  const own = separator === -1 ? argv : argv.slice(0, separator)
+  const passthrough = separator === -1 ? [] : argv.slice(separator + 1)
+  const mode = own[0]
+  if (mode !== "collect" && mode !== "report") {
+    throw new Error("usage: flake-report.mjs <collect|report> [--project pr|e2e] [--threshold 0.95] [-- vitest args]")
+  }
+  let project = "pr"
+  let threshold = 0.95
+  for (let index = 1; index < own.length; index += 1) {
+    if (own[index] === "--project") {
+      project = own[index + 1] ?? ""
+      index += 1
+    } else if (own[index] === "--threshold") {
+      threshold = Number(own[index + 1])
+      index += 1
+    } else {
+      throw new Error(`unknown argument: ${own[index]}`)
+    }
+  }
+  if (project !== "pr" && project !== "e2e") throw new Error("--project must be pr or e2e")
+  if (!Number.isFinite(threshold) || threshold <= 0 || threshold > 1) throw new Error("--threshold must be in (0, 1]")
+  return { mode, project, threshold, passthrough }
+}
+
+export function normalizeRun(receipt, root) {
+  if (typeof receipt !== "object" || receipt === null || !Array.isArray(receipt.testResults)) {
+    throw new Error("receipt is not a vitest JSON reporter payload")
+  }
+  return receipt.testResults.map((file) => {
+    const tests = Array.isArray(file.assertionResults) ? file.assertionResults : []
+    const durationMs = tests.reduce((total, test) => total + (typeof test.duration === "number" ? test.duration : 0), 0)
+    return {
+      spec: relative(root, file.name).replaceAll("\\", "/"),
+      passed: file.status === "passed",
+      skipped: tests.length > 0 && tests.every((test) => test.status === "pending" || test.status === "skipped" || test.status === "todo"),
+      durationMs,
+    }
+  })
+}
+
+export function aggregate(runs, threshold) {
+  const bySpec = new Map()
+  for (const run of runs) {
+    for (const entry of run) {
+      if (entry.skipped) continue
+      const current = bySpec.get(entry.spec) ?? { spec: entry.spec, runs: 0, passes: 0, durationsMs: [] }
+      current.runs += 1
+      if (entry.passed) current.passes += 1
+      current.durationsMs.push(entry.durationMs)
+      bySpec.set(entry.spec, current)
+    }
+  }
+  const specs = [...bySpec.values()]
+    .map((entry) => {
+      const passRate = entry.passes / entry.runs
+      const meanDurationMs = entry.durationsMs.reduce((total, value) => total + value, 0) / entry.runs
+      return {
+        spec: entry.spec,
+        runs: entry.runs,
+        passes: entry.passes,
+        passRate,
+        flaky: entry.passes > 0 && entry.passes < entry.runs,
+        quarantine: passRate < threshold,
+        meanDurationMs: Math.round(meanDurationMs),
+        maxDurationMs: Math.round(Math.max(...entry.durationsMs)),
+      }
+    })
+    .sort((left, right) => left.passRate - right.passRate || right.maxDurationMs - left.maxDurationMs)
+  return {
+    threshold,
+    totalRuns: runs.length,
+    totalSpecs: specs.length,
+    flakySpecs: specs.filter((entry) => entry.flaky).length,
+    quarantineSpecs: specs.filter((entry) => entry.quarantine).length,
+    specs,
+  }
+}
+
+export function renderMarkdown(report, project) {
+  const lines = [
+    `# Flake report — ${project} lane`,
+    "",
+    `Runs aggregated: ${report.totalRuns} · Specs: ${report.totalSpecs} · Flaky: ${report.flakySpecs} · Below ${Math.round(report.threshold * 100)}% pass rate: ${report.quarantineSpecs}`,
+    "",
+    "| Spec | Runs | Pass rate | Flaky | Quarantine | Mean ms | Max ms |",
+    "| --- | ---: | ---: | :---: | :---: | ---: | ---: |",
+  ]
+  for (const entry of report.specs) {
+    lines.push(
+      `| ${entry.spec} | ${entry.runs} | ${(entry.passRate * 100).toFixed(1)}% | ${entry.flaky ? "yes" : ""} | ${entry.quarantine ? "yes" : ""} | ${entry.meanDurationMs} | ${entry.maxDurationMs} |`,
+    )
+  }
+  return `${lines.join("\n")}\n`
+}
+
+function collect(project, passthrough) {
+  const directory = runsDirectory(project)
+  mkdirSync(directory, { recursive: true })
+  const outputFile = join(directory, `run-${new Date().toISOString().replaceAll(":", "-")}.json`)
+  const vitestBin = resolve(evalsRoot, "node_modules", ".bin", process.platform === "win32" ? "vitest.CMD" : "vitest")
+  const args = [
+    "run",
+    "--config",
+    "vitest.config.ts",
+    "--project",
+    project,
+    "--reporter=default",
+    "--reporter=json",
+    `--outputFile=${outputFile}`,
+    ...passthrough,
+  ]
+  let failed = false
+  try {
+    execFileSync(vitestBin, args, { cwd: evalsRoot, stdio: "inherit" })
+  } catch {
+    failed = true
+  }
+  console.log(`\nflake-report: saved ${relative(evalsRoot, outputFile)} (${failed ? "red" : "green"} run)`)
+}
+
+function report(project, threshold) {
+  const directory = runsDirectory(project)
+  let files = []
+  try {
+    files = readdirSync(directory).filter((name) => name.startsWith("run-") && name.endsWith(".json"))
+  } catch {
+    throw new Error(`no collected runs in ${relative(evalsRoot, directory)}; run flake:collect first`)
+  }
+  if (files.length === 0) throw new Error(`no collected runs in ${relative(evalsRoot, directory)}; run flake:collect first`)
+  const runs = files.map((name) => normalizeRun(JSON.parse(readFileSync(join(directory, name), "utf8")), evalsRoot))
+  const result = aggregate(runs, threshold)
+  const markdown = renderMarkdown(result, project)
+  writeFileSync(join(directory, "flake-report.md"), markdown)
+  writeFileSync(join(directory, "flake-report.json"), `${JSON.stringify(result, null, 2)}\n`)
+  console.log(markdown)
+  console.log(`flake-report: wrote ${relative(evalsRoot, join(directory, "flake-report.md"))}`)
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (invokedDirectly) {
+  const { mode, project, threshold, passthrough } = parseArguments(process.argv.slice(2))
+  if (mode === "collect") collect(project, passthrough)
+  else report(project, threshold)
+}

--- a/evals/scripts/flake-report.test.mjs
+++ b/evals/scripts/flake-report.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { aggregate, normalizeRun, renderMarkdown } from "./flake-report.mjs"
+
+const root = "/repo/evals"
+
+function receipt(entries) {
+  return {
+    testResults: entries.map((entry) => ({
+      name: `${root}/specs/${entry.spec}`,
+      status: entry.passed ? "passed" : "failed",
+      assertionResults: [{ status: entry.passed ? "passed" : "failed", duration: entry.durationMs }],
+    })),
+  }
+}
+
+test("normalizeRun maps vitest JSON receipts to repo-relative spec results", () => {
+  const run = normalizeRun(receipt([{ spec: "a.test.ts", passed: true, durationMs: 120 }]), root)
+  assert.deepEqual(run, [{ spec: "specs/a.test.ts", passed: true, skipped: false, durationMs: 120 }])
+})
+
+test("normalizeRun rejects non-vitest payloads", () => {
+  assert.throws(() => normalizeRun({ nope: true }, root), /vitest JSON reporter payload/)
+})
+
+test("normalizeRun marks fully skipped files as skipped", () => {
+  const run = normalizeRun(
+    {
+      testResults: [
+        {
+          name: `${root}/specs/skipped.test.ts`,
+          status: "passed",
+          assertionResults: [{ status: "pending" }, { status: "todo" }],
+        },
+      ],
+    },
+    root,
+  )
+  assert.equal(run[0].skipped, true)
+})
+
+test("aggregate computes pass rate, flaky, and quarantine flags", () => {
+  const runs = [
+    normalizeRun(
+      receipt([
+        { spec: "stable.test.ts", passed: true, durationMs: 100 },
+        { spec: "flaky.test.ts", passed: true, durationMs: 200 },
+        { spec: "broken.test.ts", passed: false, durationMs: 50 },
+      ]),
+      root,
+    ),
+    normalizeRun(
+      receipt([
+        { spec: "stable.test.ts", passed: true, durationMs: 110 },
+        { spec: "flaky.test.ts", passed: false, durationMs: 900 },
+        { spec: "broken.test.ts", passed: false, durationMs: 60 },
+      ]),
+      root,
+    ),
+  ]
+  const result = aggregate(runs, 0.95)
+  assert.equal(result.totalRuns, 2)
+  assert.equal(result.totalSpecs, 3)
+  assert.equal(result.flakySpecs, 1)
+  assert.equal(result.quarantineSpecs, 2)
+
+  const flaky = result.specs.find((entry) => entry.spec === "specs/flaky.test.ts")
+  assert.equal(flaky.passRate, 0.5)
+  assert.equal(flaky.flaky, true)
+  assert.equal(flaky.quarantine, true)
+  assert.equal(flaky.meanDurationMs, 550)
+  assert.equal(flaky.maxDurationMs, 900)
+
+  const broken = result.specs.find((entry) => entry.spec === "specs/broken.test.ts")
+  assert.equal(broken.flaky, false)
+  assert.equal(broken.quarantine, true)
+
+  const stable = result.specs.find((entry) => entry.spec === "specs/stable.test.ts")
+  assert.equal(stable.passRate, 1)
+  assert.equal(stable.quarantine, false)
+
+  // Worst pass rate sorts first.
+  assert.equal(result.specs[0].passRate <= result.specs[result.specs.length - 1].passRate, true)
+})
+
+test("renderMarkdown emits one row per spec with the summary line", () => {
+  const runs = [normalizeRun(receipt([{ spec: "a.test.ts", passed: true, durationMs: 10 }]), root)]
+  const markdown = renderMarkdown(aggregate(runs, 0.95), "pr")
+  assert.match(markdown, /# Flake report — pr lane/)
+  assert.match(markdown, /Runs aggregated: 1 · Specs: 1 · Flaky: 0/)
+  assert.match(markdown, /\| specs\/a\.test\.ts \| 1 \| 100\.0% \|/)
+})

--- a/evals/scripts/spec-coverage-matrix.mjs
+++ b/evals/scripts/spec-coverage-matrix.mjs
@@ -1,0 +1,104 @@
+// Scenario coverage matrix for evals/specs.
+//
+//   node scripts/spec-coverage-matrix.mjs [--out <file.md>]
+//
+// Quantifies scenario coverage two ways:
+//   1. Per contract in specs/contracts.snapshot.json: how many pr-lane,
+//      e2e-lane, and live specs prove it, and which lanes are missing.
+//   2. Specs not referenced by any contract (unmapped coverage), grouped by
+//      slug prefix so gaps in the contract map are visible.
+import { readdirSync, readFileSync, writeFileSync } from "node:fs"
+import { relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const evalsRoot = fileURLToPath(new URL("..", import.meta.url))
+const specsDirectory = resolve(evalsRoot, "specs")
+
+export function laneOf(specName) {
+  if (specName.endsWith(".e2e.test.ts")) return "e2e"
+  if (specName.endsWith(".live.test.ts")) return "live"
+  if (specName.endsWith(".test.ts")) return "pr"
+  return null
+}
+
+export function areaOf(specName) {
+  return specName.split("-")[0].replace(/\..*$/, "")
+}
+
+export function buildMatrix(specNames, contracts) {
+  const lanes = new Map(specNames.map((name) => [name, laneOf(name)]))
+  const mapped = new Set()
+  const contractRows = contracts.map((contract) => {
+    const specs = contract.specs
+      .map((path) => path.replace(/^evals\/specs\//, ""))
+      .filter((name) => lanes.has(name))
+    for (const name of specs) mapped.add(name)
+    const counts = { pr: 0, e2e: 0, live: 0 }
+    for (const name of specs) counts[lanes.get(name)] += 1
+    const missingLanes = ["pr", "e2e"].filter((lane) => counts[lane] === 0)
+    return { id: contract.id, description: contract.description, counts, specCount: specs.length, missingLanes }
+  })
+  const unmapped = specNames.filter((name) => !mapped.has(name))
+  const unmappedByArea = new Map()
+  for (const name of unmapped) {
+    const area = areaOf(name)
+    const entry = unmappedByArea.get(area) ?? { area, pr: 0, e2e: 0, live: 0 }
+    entry[lanes.get(name)] += 1
+    unmappedByArea.set(area, entry)
+  }
+  return {
+    totalSpecs: specNames.length,
+    mappedSpecs: mapped.size,
+    unmappedSpecs: unmapped.length,
+    contracts: contractRows.sort((left, right) => left.specCount - right.specCount || left.id.localeCompare(right.id)),
+    unmappedAreas: [...unmappedByArea.values()].sort((left, right) => left.area.localeCompare(right.area)),
+  }
+}
+
+export function renderMarkdown(matrix) {
+  const lines = [
+    "# Scenario coverage matrix",
+    "",
+    `Specs: ${matrix.totalSpecs} · Mapped to a contract: ${matrix.mappedSpecs} · Unmapped: ${matrix.unmappedSpecs}`,
+    "",
+    "## Contracts",
+    "",
+    "| Contract | pr | e2e | live | Missing lanes |",
+    "| --- | ---: | ---: | ---: | --- |",
+  ]
+  for (const row of matrix.contracts) {
+    lines.push(
+      `| ${row.id} | ${row.counts.pr} | ${row.counts.e2e} | ${row.counts.live} | ${row.missingLanes.join(", ") || "—"} |`,
+    )
+  }
+  lines.push(
+    "",
+    "## Specs without a contract (by area)",
+    "",
+    "These specs run but are invisible to spec-impact analysis. Add them to",
+    "`specs/contracts.snapshot.json` or confirm they are intentionally standalone.",
+    "",
+    "| Area | pr | e2e | live |",
+    "| --- | ---: | ---: | ---: |",
+  )
+  for (const row of matrix.unmappedAreas) {
+    lines.push(`| ${row.area} | ${row.pr} | ${row.e2e} | ${row.live} |`)
+  }
+  return `${lines.join("\n")}\n`
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (invokedDirectly) {
+  const outFlag = process.argv.indexOf("--out")
+  const specNames = readdirSync(specsDirectory).filter((name) => laneOf(name) !== null)
+  const snapshot = JSON.parse(readFileSync(resolve(specsDirectory, "contracts.snapshot.json"), "utf8"))
+  const matrix = buildMatrix(specNames, snapshot.contracts)
+  const markdown = renderMarkdown(matrix)
+  if (outFlag !== -1) {
+    const outPath = resolve(process.cwd(), process.argv[outFlag + 1])
+    writeFileSync(outPath, markdown)
+    console.log(`spec-coverage-matrix: wrote ${relative(process.cwd(), outPath)}`)
+  } else {
+    console.log(markdown)
+  }
+}

--- a/evals/scripts/spec-coverage-matrix.test.mjs
+++ b/evals/scripts/spec-coverage-matrix.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { areaOf, buildMatrix, laneOf, renderMarkdown } from "./spec-coverage-matrix.mjs"
+
+test("laneOf classifies spec lanes", () => {
+  assert.equal(laneOf("a.test.ts"), "pr")
+  assert.equal(laneOf("a.e2e.test.ts"), "e2e")
+  assert.equal(laneOf("a.live.test.ts"), "live")
+  assert.equal(laneOf("contracts.snapshot.json"), null)
+})
+
+test("areaOf groups by slug prefix", () => {
+  assert.equal(areaOf("automation-revision-revert.e2e.test.ts"), "automation")
+  assert.equal(areaOf("workflows.e2e.test.ts"), "workflows")
+})
+
+test("buildMatrix counts lanes per contract and finds unmapped specs", () => {
+  const specNames = [
+    "automation-a.e2e.test.ts",
+    "automation-b.test.ts",
+    "workflow-x.e2e.test.ts",
+    "orphan-thing.test.ts",
+    "orphan-thing-two.e2e.test.ts",
+  ]
+  const contracts = [
+    {
+      id: "desktop.automations",
+      description: "automations",
+      specs: ["evals/specs/automation-a.e2e.test.ts", "evals/specs/automation-b.test.ts"],
+    },
+    { id: "den.workflows", description: "workflows", specs: ["evals/specs/workflow-x.e2e.test.ts"] },
+  ]
+  const matrix = buildMatrix(specNames, contracts)
+  assert.equal(matrix.totalSpecs, 5)
+  assert.equal(matrix.mappedSpecs, 3)
+  assert.equal(matrix.unmappedSpecs, 2)
+
+  const automations = matrix.contracts.find((row) => row.id === "desktop.automations")
+  assert.deepEqual(automations.counts, { pr: 1, e2e: 1, live: 0 })
+  assert.deepEqual(automations.missingLanes, [])
+
+  const workflows = matrix.contracts.find((row) => row.id === "den.workflows")
+  assert.deepEqual(workflows.missingLanes, ["pr"])
+
+  assert.deepEqual(matrix.unmappedAreas, [{ area: "orphan", pr: 1, e2e: 1, live: 0 }])
+})
+
+test("renderMarkdown includes contract rows and unmapped areas", () => {
+  const matrix = buildMatrix(
+    ["automation-a.e2e.test.ts", "orphan-thing.test.ts"],
+    [{ id: "desktop.automations", description: "automations", specs: ["evals/specs/automation-a.e2e.test.ts"] }],
+  )
+  const markdown = renderMarkdown(matrix)
+  assert.match(markdown, /\| desktop\.automations \| 0 \| 1 \| 0 \| pr \|/)
+  assert.match(markdown, /\| orphan \| 1 \| 0 \| 0 \|/)
+})


### PR DESCRIPTION
## Why

CI reliability issues. This makes two numbers measurable: what is covered, and which specs are unreliable.

## What

**Code coverage (classical tests)**
- `apps/server`: `pnpm test:coverage` → `bun test --coverage` (text + lcov into `apps/server/coverage/`).
- `evals` pr lane: `pnpm --dir evals test:pr:coverage` → vitest v8 coverage (`@vitest/coverage-v8` devDep, lcov + text-summary).
- Both `coverage/` outputs and `evals/results/flake/` gitignored.

**Flake-rate reporting — `evals/scripts/flake-report.mjs`**
- `pnpm --dir evals flake:collect [--project pr|e2e] [-- <vitest filter>]` runs the lane once with the vitest JSON reporter and saves a receipt under `evals/results/flake/<project>/`.
- `pnpm --dir evals flake:report [--project pr|e2e] [--threshold 0.95]` aggregates all receipts into per-spec pass rate, flaky flag (passed and failed across runs), quarantine flag (below threshold), and mean/max duration; writes `flake-report.md` + `.json`.

**Scenario coverage matrix — `evals/scripts/spec-coverage-matrix.mjs`**
- `pnpm --dir evals coverage:matrix [--out file.md]` cross-references every spec in `evals/specs` against `specs/contracts.snapshot.json`: per-contract pr/e2e/live counts, missing lanes, and unmapped specs grouped by slug area.
- Current finding: only 11 of 217 specs are mapped to a contract, so `spec-impact.mjs` is blind to ~95% of the suite.

## Verification

- `node --test scripts/flake-report.test.mjs scripts/spec-coverage-matrix.test.mjs` → 9/9 pass (unit tests wired into the `pnpm --dir evals test` glob).
- `depcruise --config .dependency-cruiser.cjs packages specs bin docs-shots runner scripts` → no violations (613 modules).
- Flake pipeline end-to-end: 2× `flake:collect --project pr -- specs/capability-search-status-ranking.test.ts` → `flake:report` shows 100% pass rate over 2 runs.
- `bun test src/utils.test.ts --coverage` in `apps/server` → coverage table renders (80% funcs / 67.6% lines for utils).
- Tooling-only change: no product runtime behavior touched; pre-existing `packages/*/test/*.test.ts` node-version failures are unrelated and unchanged.