### PR TITLE
fix(web): enforce Den organization access at hosted origin

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -3102,6 +3102,21 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
     },
 
     async getOpenWorkWebAccess(orgId: string): Promise<DenOpenWorkWebAccess> {
+      const context = await requestJson<unknown>(baseUrls, "/v1/org", {
+        method: "GET",
+        token,
+        organizationId: orgId,
+      });
+      const capabilities = isRecord(context) && isRecord(context.capabilities)
+        ? context.capabilities
+        : null;
+      // Missing means unsupported. This follows the established Den capability
+      // negotiation pattern so a newer hosted client never calls the Web billing
+      // route on an older Den deployment that does not advertise the contract.
+      if (capabilities?.openworkWeb !== true) {
+        return { hasAccess: false, accessSource: null };
+      }
+
       const payload = await requestJson<unknown>(baseUrls, "/v1/billing/web", {
         method: "GET",
         token,

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -426,6 +426,13 @@ export type DenBillingSummary = {
   benefitId: string | null;
 };
 
+export type DenOpenWorkWebAccessSource = "subscription" | "complimentary" | null;
+
+export type DenOpenWorkWebAccess = {
+  hasAccess: boolean;
+  accessSource: DenOpenWorkWebAccessSource;
+};
+
 type DenAuthResult = {
   user: DenUser | null;
   token: string | null;
@@ -2708,6 +2715,34 @@ function getBillingSummary(payload: unknown): DenBillingSummary | null {
   };
 }
 
+export function parseDenOpenWorkWebAccess(payload: unknown): DenOpenWorkWebAccess | null {
+  if (!isRecord(payload) || !isRecord(payload.billing)) return null;
+  const stripe = payload.billing.stripe;
+  if (!isRecord(stripe) || !isRecord(stripe.web)) return null;
+
+  const web = stripe.web;
+  const accessSource: DenOpenWorkWebAccessSource | undefined =
+    web.accessSource === "subscription" || web.accessSource === "complimentary"
+      ? web.accessSource
+      : web.accessSource === null
+        ? null
+        : undefined;
+  if (
+    typeof web.hasAccess !== "boolean"
+    || accessSource === undefined
+    || web.hasAccess !== (accessSource !== null)
+    || (accessSource === "subscription" && web.hasEligibleSubscription !== true)
+    || (accessSource === "complimentary" && web.complimentaryAccess !== true)
+  ) {
+    return null;
+  }
+
+  return {
+    hasAccess: web.hasAccess,
+    accessSource,
+  };
+}
+
 // Den requests target a control plane that does not answer CORS preflights.
 // On desktop, route cross-origin Den calls (including a Den API on a different
 // loopback port than the renderer) through the Electron main process so the
@@ -3064,6 +3099,19 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         throw new DenApiError(500, "invalid_cloud_instance_payload", "Cloud instance response was invalid.");
       }
       return instance;
+    },
+
+    async getOpenWorkWebAccess(orgId: string): Promise<DenOpenWorkWebAccess> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/billing/web", {
+        method: "GET",
+        token,
+        organizationId: orgId,
+      });
+      const access = parseDenOpenWorkWebAccess(payload);
+      if (!access) {
+        throw new DenApiError(500, "invalid_openwork_web_access_payload", "OpenWork Web access response was invalid.");
+      }
+      return access;
     },
 
     async updateCloudInstance(orgId: string): Promise<DenCloudInstanceUpdateResult> {

--- a/apps/app/src/react-app/domains/cloud/openwork-web-access-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/openwork-web-access-gate.tsx
@@ -1,0 +1,204 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
+import { AlertTriangle, ArrowUpRight } from "lucide-react";
+
+import {
+  clearDenSession,
+  createDenClient,
+  readDenSettings,
+} from "@/app/lib/den";
+import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { isOpenworkGatewayRuntime } from "@/app/lib/gateway-runtime";
+import { Button } from "@/components/ui/button";
+import { usePlatform } from "@/react-app/kernel/platform";
+import { OwDotTicker } from "@/react-app/shell/dot-ticker";
+import { useDenAuth } from "./den-auth-provider";
+import {
+  resolveOpenWorkWebAccessGateState,
+  type OpenWorkWebAccessCheck,
+  type OpenWorkWebAccessGateState,
+} from "./openwork-web-access-state";
+
+export {
+  resolveOpenWorkWebAccessGateState,
+  type OpenWorkWebAccessCheck,
+  type OpenWorkWebAccessGateState,
+} from "./openwork-web-access-state";
+
+function readDenSettingsSnapshot() {
+  const settings = readDenSettings();
+  return JSON.stringify({
+    baseUrl: settings.baseUrl,
+    authToken: settings.authToken ?? "",
+    activeOrgId: settings.activeOrgId ?? "",
+    activeOrgName: settings.activeOrgName ?? "",
+  });
+}
+
+function subscribeToDenSettings(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(denSettingsChangedEvent, onStoreChange);
+  return () => window.removeEventListener(denSettingsChangedEvent, onStoreChange);
+}
+
+function denWebBillingUrl(baseUrl: string) {
+  try {
+    return new URL("/dashboard/web", baseUrl).toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
+export function OpenWorkWebAccessGateScreen(props: {
+  state: Exclude<OpenWorkWebAccessGateState, "inactive" | "granted">;
+  organizationName: string;
+  onManageAccess: () => void;
+  onRetry: () => void;
+  onSignOut: () => void;
+}) {
+  const checking = props.state === "checking";
+  const denied = props.state === "denied";
+  const organizationName = props.organizationName || "this organization";
+
+  return (
+    <main
+      className="flex min-h-dvh items-center justify-center bg-background px-6 py-16 text-foreground"
+      data-testid="openwork-web-access-gate"
+      data-state={props.state}
+    >
+      <section className="w-full max-w-lg rounded-[24px] border border-border bg-background p-7 shadow-[var(--dls-card-shadow)] sm:p-9">
+        <div className="flex items-start gap-4">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-border bg-muted/40">
+            {checking
+              ? <OwDotTicker size="lg" />
+              : <AlertTriangle className="size-5 text-amber-11" aria-hidden="true" />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              OpenWork Web
+            </p>
+            <h1 className="mt-2 text-[26px] font-semibold leading-tight tracking-[-0.03em]">
+              {checking
+                ? "Checking workspace access…"
+                : denied
+                  ? "OpenWork Web access is required"
+                  : "OpenWork Web remains locked"}
+            </h1>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              {checking
+                ? `Waiting for Den to confirm access for ${organizationName}.`
+                : denied
+                  ? `${organizationName} does not have an active OpenWork Web subscription or complimentary admin grant.`
+                  : `Den could not confirm OpenWork Web access for ${organizationName}. The workspace stays locked until it can.`}
+            </p>
+          </div>
+        </div>
+
+        {!checking ? (
+          <div className="mt-7 flex flex-wrap items-center gap-2">
+            {denied ? (
+              <Button type="button" onClick={props.onManageAccess}>
+                Manage access in Den
+                <ArrowUpRight className="size-4" aria-hidden="true" />
+              </Button>
+            ) : (
+              <Button type="button" onClick={props.onRetry}>Retry</Button>
+            )}
+            {denied ? (
+              <Button type="button" variant="outline" onClick={props.onRetry}>Check again</Button>
+            ) : null}
+            <Button type="button" variant="ghost" onClick={props.onSignOut}>Sign out</Button>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+export function OpenWorkWebAccessGate({ children }: { children: ReactNode }) {
+  const denAuth = useDenAuth();
+  const platform = usePlatform();
+  const gatewayMode = isOpenworkGatewayRuntime();
+  const settingsSnapshot = useSyncExternalStore(
+    subscribeToDenSettings,
+    readDenSettingsSnapshot,
+    readDenSettingsSnapshot,
+  );
+  const settings = useMemo(() => readDenSettings(), [settingsSnapshot]);
+  const authToken = settings.authToken?.trim() ?? "";
+  const organizationId = settings.activeOrgId?.trim() ?? "";
+  const principalId = denAuth.verifiedIdentity?.principalId.trim() ?? "";
+  const verifiedOrganizationId = denAuth.verifiedIdentity?.organizationId.trim() ?? "";
+  const expectedScope =
+    gatewayMode
+    && authToken
+    && organizationId
+    && principalId
+    && verifiedOrganizationId === organizationId
+      ? `${principalId}\u0000${organizationId}\u0000${authToken}`
+      : null;
+  const [check, setCheck] = useState<OpenWorkWebAccessCheck | null>(null);
+  const [retry, setRetry] = useState(0);
+
+  useEffect(() => {
+    if (!gatewayMode || typeof window === "undefined") return;
+    const checkAgain = () => setRetry((value) => value + 1);
+    window.addEventListener("focus", checkAgain);
+    return () => window.removeEventListener("focus", checkAgain);
+  }, [gatewayMode]);
+
+  useEffect(() => {
+    if (!expectedScope || denAuth.status !== "signed_in") return;
+
+    let cancelled = false;
+    const client = createDenClient({ baseUrl: settings.baseUrl, token: authToken });
+    void client.getOpenWorkWebAccess(organizationId).then(
+      (access) => {
+        if (cancelled) return;
+        setCheck({
+          scope: expectedScope,
+          state: access.hasAccess ? "granted" : "denied",
+          accessSource: access.accessSource,
+        });
+      },
+      () => {
+        if (cancelled) return;
+        setCheck({ scope: expectedScope, state: "error", accessSource: null });
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authToken, denAuth.status, expectedScope, organizationId, retry, settings.baseUrl]);
+
+  const state = resolveOpenWorkWebAccessGateState({
+    gatewayMode,
+    authStatus: denAuth.status,
+    authToken,
+    organizationId,
+    verifiedIdentity: denAuth.verifiedIdentity,
+    expectedScope,
+    check,
+  });
+
+  if (state === "inactive" || state === "granted") return children;
+
+  const signOut = () => {
+    if (authToken) {
+      void createDenClient({ baseUrl: settings.baseUrl, token: authToken }).signOut().catch(() => undefined);
+    }
+    clearDenSession();
+    void denAuth.refresh();
+  };
+
+  return (
+    <OpenWorkWebAccessGateScreen
+      state={state}
+      organizationName={settings.activeOrgName?.trim() ?? ""}
+      onManageAccess={() => platform.openLink(denWebBillingUrl(settings.baseUrl))}
+      onRetry={() => setRetry((value) => value + 1)}
+      onSignOut={signOut}
+    />
+  );
+}

--- a/apps/app/src/react-app/domains/cloud/openwork-web-access-state.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-web-access-state.ts
@@ -1,0 +1,32 @@
+import type { DenOpenWorkWebAccessSource } from "../../../app/lib/den";
+
+export type OpenWorkWebAccessCheck = {
+  scope: string;
+  state: "granted" | "denied" | "error";
+  accessSource: DenOpenWorkWebAccessSource;
+};
+
+export type OpenWorkWebAccessGateState = "inactive" | "checking" | "granted" | "denied" | "error";
+
+export function resolveOpenWorkWebAccessGateState(input: {
+  gatewayMode: boolean;
+  authStatus: "checking" | "signed_in" | "unavailable" | "signed_out";
+  authToken: string;
+  organizationId: string;
+  verifiedIdentity: { principalId: string; organizationId: string } | null;
+  expectedScope: string | null;
+  check: OpenWorkWebAccessCheck | null;
+}): OpenWorkWebAccessGateState {
+  if (!input.gatewayMode || !input.authToken || !input.organizationId) return "inactive";
+  if (input.authStatus === "unavailable") return "error";
+  if (input.authStatus !== "signed_in") return "checking";
+  if (
+    !input.verifiedIdentity
+    || input.verifiedIdentity.organizationId !== input.organizationId
+    || !input.expectedScope
+  ) {
+    return "checking";
+  }
+  if (!input.check || input.check.scope !== input.expectedScope) return "checking";
+  return input.check.state;
+}

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -25,6 +25,7 @@ import {
 } from "../domains/connections/cloud-inventory-cache";
 import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { EnterpriseActivationGate } from "../domains/cloud/enterprise-activation-gate";
+import { OpenWorkWebAccessGate } from "../domains/cloud/openwork-web-access-gate";
 import { OrgOnboardingPage } from "../domains/cloud/org-onboarding-page";
 import { NewProvidersListener } from "./new-providers-listener";
 import { useDesktopFontZoomBehavior } from "./font-zoom";
@@ -385,10 +386,11 @@ export function AppRoot() {
           <OpenworkContextPublisher />
           <DenAuthControlActions />
           <BrandThemeControlActions />
-          <CloudWorkspaceStatusProvider>
           <EnterpriseActivationGate>
-          <DenSigninGate>
-            <Routes>
+            <DenSigninGate>
+              <OpenWorkWebAccessGate>
+                <CloudWorkspaceStatusProvider>
+                  <Routes>
               <Route
                 path="/signin"
                 element={
@@ -498,12 +500,13 @@ export function AppRoot() {
                   settings deliberately via the sidebar or command palette. */}
               <Route path="/" element={<Navigate to="/session" replace />} />
               <Route path="*" element={<Navigate to="/session" replace />} />
-            </Routes>
-          </DenSigninGate>
-          <LoadingOverlay />
+                  </Routes>
+                  <LoadingOverlay />
+                  <CloudWorkspaceOverlay />
+                </CloudWorkspaceStatusProvider>
+              </OpenWorkWebAccessGate>
+            </DenSigninGate>
           </EnterpriseActivationGate>
-          <CloudWorkspaceOverlay />
-          </CloudWorkspaceStatusProvider>
         </OpenworkControlProvider>
         </AppMenuProvider>
         </ShellConfigProvider>

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -257,12 +257,16 @@ describe("gateway runtime mode", () => {
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,
       value: async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = getRequestUrl(input);
         const headers = new Headers(init?.headers);
         requests.push({
-          url: getRequestUrl(input),
+          url,
           authorization: headers.get("authorization"),
           organizationId: headers.get("x-openwork-org-id"),
         });
+        if (new URL(url).pathname === "/api/den/v1/org") {
+          return Response.json({ capabilities: { openworkWeb: true } });
+        }
         return Response.json({
           billing: {
             stripe: {
@@ -284,11 +288,38 @@ describe("gateway runtime mode", () => {
     }).getOpenWorkWebAccess("org_test");
 
     expect(access).toEqual({ hasAccess: true, accessSource: "complimentary" });
-    expect(requests).toEqual([{
-      url: "https://gw.example/api/den/v1/billing/web",
-      authorization: "Bearer tok_test",
-      organizationId: "org_test",
-    }]);
+    expect(requests).toEqual([
+      {
+        url: "https://gw.example/api/den/v1/org",
+        authorization: "Bearer tok_test",
+        organizationId: "org_test",
+      },
+      {
+        url: "https://gw.example/api/den/v1/billing/web",
+        authorization: "Bearer tok_test",
+        organizationId: "org_test",
+      },
+    ]);
+  });
+
+  test("keeps Web locked without calling billing when an older Den omits the capability", async () => {
+    installWindow({ origin: "https://gw.example", gateway: true });
+    const requestedUrls: string[] = [];
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: RequestInfo | URL) => {
+        requestedUrls.push(getRequestUrl(input));
+        return Response.json({ capabilities: {} });
+      },
+    });
+
+    const access = await createDenClient({
+      baseUrl: readDenSettings().baseUrl,
+      token: "tok_test",
+    }).getOpenWorkWebAccess("org_test");
+
+    expect(access).toEqual({ hasAccess: false, accessSource: null });
+    expect(requestedUrls).toEqual(["https://gw.example/api/den/v1/org"]);
   });
 
   test("uses the gateway Den API proxy for MCP", () => {

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -247,6 +247,50 @@ describe("gateway runtime mode", () => {
     ]);
   });
 
+  test("reads Den-authored Web access through the gateway for the selected organization", async () => {
+    installWindow({ origin: "https://gw.example", gateway: true });
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      organizationId: string | null;
+    }> = [];
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        requests.push({
+          url: getRequestUrl(input),
+          authorization: headers.get("authorization"),
+          organizationId: headers.get("x-openwork-org-id"),
+        });
+        return Response.json({
+          billing: {
+            stripe: {
+              web: {
+                hasAccess: true,
+                accessSource: "complimentary",
+                hasEligibleSubscription: false,
+                complimentaryAccess: true,
+              },
+            },
+          },
+        });
+      },
+    });
+
+    const access = await createDenClient({
+      baseUrl: readDenSettings().baseUrl,
+      token: "tok_test",
+    }).getOpenWorkWebAccess("org_test");
+
+    expect(access).toEqual({ hasAccess: true, accessSource: "complimentary" });
+    expect(requests).toEqual([{
+      url: "https://gw.example/api/den/v1/billing/web",
+      authorization: "Bearer tok_test",
+      organizationId: "org_test",
+    }]);
+  });
+
   test("uses the gateway Den API proxy for MCP", () => {
     installWindow({ origin: "https://gw.example", gateway: true });
 

--- a/apps/app/tests/openwork-web-access-gate.test.tsx
+++ b/apps/app/tests/openwork-web-access-gate.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { parseDenOpenWorkWebAccess } from "../src/app/lib/den";
+import {
+  OpenWorkWebAccessGateScreen,
+  resolveOpenWorkWebAccessGateState,
+} from "../src/react-app/domains/cloud/openwork-web-access-gate";
+
+function billingWeb(input: Record<string, unknown>) {
+  return { billing: { stripe: { web: input } } };
+}
+
+describe("OpenWork Web access payload", () => {
+  test("accepts subscription and complimentary access authored by Den", () => {
+    expect(parseDenOpenWorkWebAccess(billingWeb({
+      hasAccess: true,
+      accessSource: "subscription",
+      hasEligibleSubscription: true,
+      complimentaryAccess: false,
+    }))).toEqual({ hasAccess: true, accessSource: "subscription" });
+
+    expect(parseDenOpenWorkWebAccess(billingWeb({
+      hasAccess: true,
+      accessSource: "complimentary",
+      hasEligibleSubscription: false,
+      complimentaryAccess: true,
+    }))).toEqual({ hasAccess: true, accessSource: "complimentary" });
+  });
+
+  test("accepts a Den denial and rejects inconsistent access claims", () => {
+    expect(parseDenOpenWorkWebAccess(billingWeb({
+      hasAccess: false,
+      accessSource: null,
+      hasEligibleSubscription: false,
+      complimentaryAccess: false,
+    }))).toEqual({ hasAccess: false, accessSource: null });
+
+    expect(parseDenOpenWorkWebAccess(billingWeb({
+      hasAccess: true,
+      accessSource: null,
+      hasEligibleSubscription: false,
+      complimentaryAccess: false,
+    }))).toBeNull();
+    expect(parseDenOpenWorkWebAccess(billingWeb({
+      hasAccess: true,
+      accessSource: "complimentary",
+      hasEligibleSubscription: false,
+      complimentaryAccess: false,
+    }))).toBeNull();
+  });
+});
+
+describe("OpenWork Web product-origin gate", () => {
+  const identity = { principalId: "user_1", organizationId: "org_1" };
+  const scope = "user_1\u0000org_1\u0000token_1";
+
+  test("stays closed until the current principal and organization have a matching result", () => {
+    const base = {
+      gatewayMode: true,
+      authStatus: "signed_in" as const,
+      authToken: "token_1",
+      organizationId: "org_1",
+      verifiedIdentity: identity,
+      expectedScope: scope,
+    };
+
+    expect(resolveOpenWorkWebAccessGateState({ ...base, check: null })).toBe("checking");
+    expect(resolveOpenWorkWebAccessGateState({
+      ...base,
+      check: { scope: "user_1\u0000org_other\u0000token_1", state: "granted", accessSource: "complimentary" },
+    })).toBe("checking");
+    expect(resolveOpenWorkWebAccessGateState({
+      ...base,
+      check: { scope, state: "denied", accessSource: null },
+    })).toBe("denied");
+    expect(resolveOpenWorkWebAccessGateState({
+      ...base,
+      check: { scope, state: "granted", accessSource: "complimentary" },
+    })).toBe("granted");
+  });
+
+  test("fails closed when Den is unavailable and stays inert outside the gateway", () => {
+    expect(resolveOpenWorkWebAccessGateState({
+      gatewayMode: true,
+      authStatus: "unavailable",
+      authToken: "token_1",
+      organizationId: "org_1",
+      verifiedIdentity: identity,
+      expectedScope: scope,
+      check: { scope, state: "granted", accessSource: "subscription" },
+    })).toBe("error");
+
+    expect(resolveOpenWorkWebAccessGateState({
+      gatewayMode: false,
+      authStatus: "signed_in",
+      authToken: "token_1",
+      organizationId: "org_1",
+      verifiedIdentity: identity,
+      expectedScope: scope,
+      check: null,
+    })).toBe("inactive");
+  });
+
+  test("renders distinct Den-denied and unavailable recovery surfaces", () => {
+    const denied = renderToStaticMarkup(
+      <OpenWorkWebAccessGateScreen
+        state="denied"
+        organizationName="Acme"
+        onManageAccess={() => {}}
+        onRetry={() => {}}
+        onSignOut={() => {}}
+      />,
+    );
+    expect(denied).toContain('data-state="denied"');
+    expect(denied).toContain("complimentary admin grant");
+    expect(denied).toContain("Manage access in Den");
+    expect(denied).toContain("Check again");
+
+    const unavailable = renderToStaticMarkup(
+      <OpenWorkWebAccessGateScreen
+        state="error"
+        organizationName="Acme"
+        onManageAccess={() => {}}
+        onRetry={() => {}}
+        onSignOut={() => {}}
+      />,
+    );
+    expect(unavailable).toContain('data-state="error"');
+    expect(unavailable).toContain("OpenWork Web remains locked");
+    expect(unavailable).toContain("Retry");
+  });
+});

--- a/ee/apps/den-api/src/openwork-web-access.ts
+++ b/ee/apps/den-api/src/openwork-web-access.ts
@@ -53,15 +53,7 @@ export function resolveOpenWorkWebAccess(input: {
   accessSource: OpenWorkWebAccessSource
   complimentaryAccess: boolean
 } {
-  if (!input.deploymentAvailable) {
-    return {
-      hasAccess: false,
-      accessSource: null,
-      complimentaryAccess: input.complimentaryAccess,
-    }
-  }
-
-  const accessSource: OpenWorkWebAccessSource = input.hasEligibleSubscription
+  const accessSource: OpenWorkWebAccessSource = input.deploymentAvailable && input.hasEligibleSubscription
     ? "subscription"
     : input.complimentaryAccess
       ? "complimentary"

--- a/ee/apps/den-api/src/openwork-web-availability.ts
+++ b/ee/apps/den-api/src/openwork-web-availability.ts
@@ -1,4 +1,5 @@
 import { env } from "./env.js"
+import { hasOpenWorkWebComplimentaryAccess } from "./openwork-web-access.js"
 
 export function openWorkWebDeploymentAvailable(enabled: boolean) {
   return enabled === true
@@ -6,4 +7,17 @@ export function openWorkWebDeploymentAvailable(enabled: boolean) {
 
 export function isOpenWorkWebAvailable() {
   return openWorkWebDeploymentAvailable(env.openworkWebEnabled)
+}
+
+export function openWorkWebAvailableForOrganization(
+  enabled: boolean,
+  metadata: Record<string, unknown> | string | null | undefined,
+) {
+  return openWorkWebDeploymentAvailable(enabled) || hasOpenWorkWebComplimentaryAccess(metadata)
+}
+
+export function isOpenWorkWebAvailableForOrganization(
+  metadata: Record<string, unknown> | string | null | undefined,
+) {
+  return openWorkWebAvailableForOrganization(env.openworkWebEnabled, metadata)
 }

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -11,6 +11,7 @@ import { env, type DenOrgMode } from "../../env.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { materializeCloudWorkerProviders } from "../../llm/cloud-provider-materialization.js"
+import { getOpenWorkWebBillingSummary } from "../../stripe-billing.js"
 import { currentDaytonaSandboxName, flushWorkerCheckpointOnDaytona, getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview, stopWorkerOnDaytona } from "../../workers/daytona.js"
 import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
 import { recoverClaimedCloudWorker as defaultRecoverCloudWorker, wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
@@ -45,6 +46,7 @@ type CloudRouteOptions = {
   flushWorkerCheckpoint?: FlushWorkerCheckpoint
   stopCloudWorker?: StopCloudWorker
   materializeProviders?: typeof materializeCloudWorkerProviders
+  getOpenWorkWebAccess?: (organizationId: OrgId) => Promise<{ hasAccess: boolean }>
   now?: () => number
 }
 
@@ -133,8 +135,20 @@ const cloudGatewayInstanceResponseSchema = z.object({
   }).optional(),
 }).meta({ ref: "CloudGatewayInstanceResponse" })
 
+const openWorkWebAccessRequiredSchema = z.object({
+  error: z.literal("openwork_web_access_required"),
+  message: z.string(),
+}).meta({ ref: "OpenWorkWebAccessRequiredError" })
+
 function cloudNotFound() {
   return { error: "cloud_not_found" }
+}
+
+function openWorkWebAccessRequired() {
+  return {
+    error: "openwork_web_access_required" as const,
+    message: "OpenWork Web access is not active for this organization.",
+  }
 }
 
 const logger = appLogger.child({ component: "cloud_routes" })
@@ -641,6 +655,7 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
 ) {
   const orgMemberRouteMiddleware = options.memberRoute ?? orgMemberRoute()
   const materializeProviders = options.materializeProviders ?? materializeCloudWorkerProviders
+  const getOpenWorkWebAccess = options.getOpenWorkWebAccess ?? getOpenWorkWebBillingSummary
   const continueProvisioning: typeof continueCloudProvisioning = options.continueProvisioning
     ?? ((input, continueOptions = {}) => continueCloudProvisioning(input, { ...continueOptions, materializeProviders }))
   const refreshSignedPreview = options.refreshSignedPreview ?? refreshDaytonaSignedPreview
@@ -769,6 +784,7 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
       responses: {
         200: jsonResponse("Cloud instance status returned successfully for the gateway.", cloudGatewayInstanceResponseSchema),
         401: jsonResponse("The caller must be signed in to open Cloud.", unauthorizedSchema),
+        403: jsonResponse("OpenWork Web access is not active for the organization.", openWorkWebAccessRequiredSchema),
         404: jsonResponse("Cloud is not available for this organization or gateway.", notFoundSchema),
       },
     }),
@@ -789,6 +805,11 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
       const user = c.get("user")
       if (!hasCloudUserId(user)) {
         return c.json({ error: "unauthorized" }, 401)
+      }
+
+      const webAccess = await getOpenWorkWebAccess(payload.organization.id)
+      if (!webAccess.hasAccess) {
+        return c.json(openWorkWebAccessRequired(), 403)
       }
 
       const instance = await resolveCloudInstanceForGateway({

--- a/ee/apps/den-api/src/routes/org/billing.ts
+++ b/ee/apps/den-api/src/routes/org/billing.ts
@@ -8,7 +8,7 @@ import { forbiddenSchema, jsonResponse, unauthorizedSchema } from "../../openapi
 import { getRequiredUserEmail } from "../../user.js"
 import { env } from "../../env.js"
 import { ORGANIZATION_SUPER_ADMIN_ROLE, organizationRoleValueSatisfies } from "../../organization-role-hierarchy.js"
-import { isOpenWorkWebAvailable } from "../../openwork-web-availability.js"
+import { isOpenWorkWebAvailableForOrganization } from "../../openwork-web-availability.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, ensureOrganizationSuperAdmin, orgAccessFailureStatus } from "./shared.js"
 
@@ -26,7 +26,7 @@ const openWorkWebUnavailableSchema = z.object({
 function openWorkWebUnavailableResponse(): { error: "openwork_web_not_available"; message: string } {
   return {
     error: "openwork_web_not_available",
-    message: "OpenWork Web is not available on this deployment.",
+    message: "OpenWork Web is not available for this organization.",
   }
 }
 
@@ -128,15 +128,15 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
       responses: {
         200: jsonResponse("OpenWork Web billing eligibility returned successfully.", stripeBillingResponseSchema),
         401: jsonResponse("The caller must be an organization member.", unauthorizedSchema),
-        404: jsonResponse("OpenWork Web is not available on this deployment.", openWorkWebUnavailableSchema),
+        404: jsonResponse("OpenWork Web is not available for this organization.", openWorkWebUnavailableSchema),
       },
     }),
     orgRoleRoute(["member"]),
     async (c) => {
-      if (!isOpenWorkWebAvailable()) {
+      const payload = c.get("organizationContext")
+      if (!isOpenWorkWebAvailableForOrganization(payload.organization.metadata)) {
         return c.json(openWorkWebUnavailableResponse(), 404)
       }
-      const payload = c.get("organizationContext")
       const web = await getOpenWorkWebBillingSummary(payload.organization.id)
       return c.json({ billing: { stripe: { web } } })
     },
@@ -193,7 +193,7 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
         200: jsonResponse("Stripe Checkout session created successfully.", stripeCheckoutResponseSchema),
         401: jsonResponse("The caller must be signed in to start billing.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can start billing.", forbiddenSchema),
-        404: jsonResponse("OpenWork Web is not available on this deployment.", openWorkWebUnavailableSchema),
+        404: jsonResponse("OpenWork Web is not available for this organization.", openWorkWebUnavailableSchema),
       },
     }),
     orgRoleRoute(["admin"]),
@@ -214,7 +214,7 @@ export function registerOrgBillingRoutes<T extends { Variables: OrgRouteVariable
       }
       const payload = c.get("organizationContext")
       const subscriptionType = parsed.data.type ?? "inference"
-      if (subscriptionType === "web" && !isOpenWorkWebAvailable()) {
+      if (subscriptionType === "web" && !isOpenWorkWebAvailableForOrganization(payload.organization.metadata)) {
         return c.json(openWorkWebUnavailableResponse(), 404)
       }
       if (subscriptionType === "web") {

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -19,7 +19,7 @@ import { jsonValidator, orgMemberRoute, orgRoleRoute, publicRoute, queryValidato
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { validateInvitationAcceptVerification } from "../../organization-join-verification.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
-import { isOpenWorkWebAvailable } from "../../openwork-web-availability.js"
+import { isOpenWorkWebAvailableForOrganization } from "../../openwork-web-availability.js"
 import {
   acceptInvitationForUser,
   createOrganizationForUser,
@@ -710,11 +710,10 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
           installLinks: organizationInstallLinksEnabled(payload.organization.metadata, {
             gatingEnabled: env.installLinksGatingEnabled,
           }),
-          // Deployment capability: OpenWork Web is generally available to all
-          // organizations only when a hosted-style multi-org Den has the
-          // dedicated Stripe Web product configured. This is never read from
-          // mutable organization metadata.
-          openworkWeb: isOpenWorkWebAvailable(),
+          // Effective offer: the deployment switch enables Web generally,
+          // while the platform-admin complimentary grant enables only this
+          // organization when the deployment switch is off.
+          openworkWeb: isOpenWorkWebAvailableForOrganization(payload.organization.metadata),
           ...(cloudEnabled ? { cloud: true } : {}),
         },
         authMethods: {

--- a/ee/apps/den-api/test/admin-organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-organization-capabilities.test.ts
@@ -272,8 +272,8 @@ test("platform admins grant and revoke audited complimentary Web access", async 
     organization: {
       id: organizationId,
       openworkWebAccess: {
-        hasAccess: false,
-        accessSource: null,
+        hasAccess: true,
+        accessSource: "complimentary",
         complimentaryAccess: true,
         hasOngoingSubscription: false,
       },

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -339,6 +339,8 @@ describe("Cloud instance route gate", () => {
 })
 
 describe("Cloud gateway resolve route", () => {
+  const grantedOpenWorkWebAccess = async () => ({ hasAccess: true })
+
   test("returns 404 when the gateway key is not configured", async () => {
     const app = new Hono<{ Variables: OrgRouteVariables }>()
     routes.registerCloudRoutes(app, {
@@ -409,6 +411,34 @@ describe("Cloud gateway resolve route", () => {
     await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
   })
 
+  test("denies Web gateway resolution before provisioning when Den has not granted access", async () => {
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let ensureCalls = 0
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      gatewayKey: "gateway-secret",
+      getOpenWorkWebAccess: async () => ({ hasAccess: false }),
+      ensureCloudWorker: async () => {
+        ensureCalls += 1
+        return fakeWorker("provisioning")
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/gateway/resolve", {
+      headers: { "X-OpenWork-Gateway-Key": "gateway-secret" },
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: "openwork_web_access_required",
+      message: "OpenWork Web access is not active for this organization.",
+    })
+    expect(ensureCalls).toBe(0)
+  })
+
   test("returns the gateway tokens only when the instance is ready", async () => {
     const provisioningWorker = fakeWorker("provisioning")
     const provisioningApp = new Hono<{ Variables: OrgRouteVariables }>()
@@ -418,6 +448,7 @@ describe("Cloud gateway resolve route", () => {
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       gatewayKey: "gateway-secret",
+      getOpenWorkWebAccess: grantedOpenWorkWebAccess,
       ensureCloudWorker: async () => provisioningWorker,
       getSandboxRecord: async () => null,
     })
@@ -438,6 +469,7 @@ describe("Cloud gateway resolve route", () => {
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       gatewayKey: "gateway-secret",
+      getOpenWorkWebAccess: grantedOpenWorkWebAccess,
       ensureCloudWorker: async () => readyWorker,
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandbox(),
@@ -495,6 +527,7 @@ describe("Cloud gateway resolve route", () => {
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       gatewayKey: "gateway-secret",
+      getOpenWorkWebAccess: grantedOpenWorkWebAccess,
       ensureCloudWorker: async () => readyWorker,
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandboxWithId("den-daytona-worker-cloud-test"),
@@ -528,6 +561,7 @@ describe("Cloud gateway resolve route", () => {
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       gatewayKey: "gateway-secret",
+      getOpenWorkWebAccess: grantedOpenWorkWebAccess,
       ensureCloudWorker: async () => readyWorker,
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandbox(),
@@ -571,6 +605,7 @@ describe("Cloud gateway resolve route", () => {
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       gatewayKey: "gateway-secret",
+      getOpenWorkWebAccess: grantedOpenWorkWebAccess,
       ensureCloudWorker: async () => readyWorker,
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandbox(),

--- a/ee/apps/den-api/test/openwork-web-access.test.ts
+++ b/ee/apps/den-api/test/openwork-web-access.test.ts
@@ -34,25 +34,25 @@ test("revoking the only complimentary grant removes the empty metadata group", (
   expect(setOpenWorkWebComplimentaryAccess({ complimentaryAccess: { openworkWeb: true } }, false)).toEqual({})
 })
 
-test("complimentary Web access fails closed behind the deployment switch", () => {
+test("complimentary Web access is the only organization grant that overrides the deployment switch", () => {
   expect(resolveOpenWorkWebAccess({
     deploymentAvailable: false,
-    hasEligibleSubscription: false,
-    complimentaryAccess: true,
-  })).toEqual({
-    hasAccess: false,
-    accessSource: null,
-    complimentaryAccess: true,
-  })
-
-  expect(resolveOpenWorkWebAccess({
-    deploymentAvailable: true,
     hasEligibleSubscription: false,
     complimentaryAccess: true,
   })).toEqual({
     hasAccess: true,
     accessSource: "complimentary",
     complimentaryAccess: true,
+  })
+
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: false,
+    hasEligibleSubscription: true,
+    complimentaryAccess: false,
+  })).toEqual({
+    hasAccess: false,
+    accessSource: null,
+    complimentaryAccess: false,
   })
 })
 

--- a/ee/apps/den-api/test/stripe-billing.test.ts
+++ b/ee/apps/den-api/test/stripe-billing.test.ts
@@ -159,7 +159,7 @@ const {
   upsertOrgSubscriptionFromStripe,
 } = await import("../src/stripe-billing.js")
 const { env } = await import("../src/env.js")
-const { openWorkWebDeploymentAvailable } = await import("../src/openwork-web-availability.js")
+const { openWorkWebAvailableForOrganization, openWorkWebDeploymentAvailable } = await import("../src/openwork-web-availability.js")
 
 function webSubscription(input?: { status?: string; quantity?: number; organizationId?: string }) {
   const organizationId = input?.organizationId ?? "org_test"
@@ -291,9 +291,13 @@ test("only active and trialing Web subscriptions are eligible", () => {
   }
 })
 
-test("Web availability follows only the explicit deployment flag", () => {
+test("the deployment flag is global while the complimentary override is organization-scoped", () => {
   expect(openWorkWebDeploymentAvailable(true)).toBe(true)
   expect(openWorkWebDeploymentAvailable(false)).toBe(false)
+  expect(openWorkWebAvailableForOrganization(false, {})).toBe(false)
+  expect(openWorkWebAvailableForOrganization(false, { capabilities: { openworkWeb: true } })).toBe(false)
+  expect(openWorkWebAvailableForOrganization(false, { complimentaryAccess: { openworkWeb: true } })).toBe(true)
+  expect(openWorkWebAvailableForOrganization(true, {})).toBe(true)
 
   env.orgMode = "single_org"
   expect(openWorkWebDeploymentAvailable(env.openworkWebEnabled)).toBe(true)
@@ -357,7 +361,7 @@ test("the Web flag controls availability while Stripe readiness controls purchas
   expect(summary.hasAccess).toBe(false)
 })
 
-test("complimentary Web access works without Stripe configuration but remains behind the deployment flag", async () => {
+test("complimentary Web access works without Stripe configuration and overrides the deployment flag for that organization", async () => {
   env.stripe.secretKey = ""
   selectResults.push([], [{ count: 2 }], [{ metadata: { complimentaryAccess: { openworkWeb: true } } }])
 
@@ -375,9 +379,19 @@ test("complimentary Web access works without Stripe configuration but remains be
   selectResults.push([], [{ count: 2 }], [{ metadata: { complimentaryAccess: { openworkWeb: true } } }])
   const disabledSummary = await getOpenWorkWebBillingSummary("org_test")
   expect(disabledSummary).toMatchObject({
+    configured: false,
+    hasAccess: true,
+    accessSource: "complimentary",
+    complimentaryAccess: true,
+  })
+
+  selectResults.push([], [{ count: 2 }], [{ metadata: {} }])
+  const ungrantedSummary = await getOpenWorkWebBillingSummary("org_other")
+  expect(ungrantedSummary).toMatchObject({
+    configured: false,
     hasAccess: false,
     accessSource: null,
-    complimentaryAccess: true,
+    complimentaryAccess: false,
   })
 })
 

--- a/ee/apps/den-gateway/test/gateway.test.mjs
+++ b/ee/apps/den-gateway/test/gateway.test.mjs
@@ -247,6 +247,29 @@ describe("den-gateway static UI", () => {
 })
 
 describe("den-gateway proxy", () => {
+  test("passes through Den's Web access denial without resolving an instance", async () => {
+    let instanceCalls = 0
+    const gateway = startGateway({
+      denApiBase: "https://den.example",
+      gatewayKey: "gateway-secret",
+      fetchImpl: async (url) => {
+        if (new URL(url).pathname === "/v1/cloud/gateway/resolve") {
+          return Response.json({ error: "openwork_web_access_required" }, { status: 403 })
+        }
+        instanceCalls += 1
+        return new Response("unexpected")
+      },
+    })
+
+    const response = await fetch(`${serverBase(gateway)}/status`, {
+      headers: { Authorization: "Bearer den-token" },
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: "gateway_resolve_rejected" })
+    expect(instanceCalls).toBe(0)
+  })
+
   test("retries one connect-phase failure and passes through success", async () => {
     const injected = injectedInstanceFetch((_url, _init, call) => {
       if (call === 1) {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -245,7 +245,7 @@ export type DenOrgCapabilities = {
   mcpConnections: boolean;
   /** Always on: Workflows/Code Mode shipped for every organization. Older servers may still return false. */
   workflows: boolean;
-  /** Deployment-wide Web offer; true only when Den explicitly enables OpenWork Web. */
+  /** Effective Web offer; true for the global switch or this organization's complimentary admin grant. */
   openworkWeb: boolean;
   cloud: boolean;
 };

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -414,8 +414,8 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const mcpConnectionsEnabled = orgContext?.capabilities.mcpConnections === true;
   const orgManagedDashboardsEnabled = orgContext?.capabilities.orgManagedDashboards === true;
   const workflowsEnabled = orgContext?.capabilities.workflows === true;
-  // Web is a deployment offer rather than an organization rollout flag. Den API
-  // advertises it only when the operator explicitly enables OpenWork Web.
+  // Den API advertises the effective organization offer: either the deployment
+  // switch is on or a platform admin granted this organization complimentary access.
   const showWeb = runtimeConfigLoaded
     && orgContext?.capabilities.openworkWeb === true;
 

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -2780,9 +2780,7 @@ export function DenAdminPanel() {
                           {org.openworkWebAccess.hasOngoingSubscription
                             ? `A ${org.openworkWebAccess.subscriptionStatus ?? "current"} Stripe subscription controls access and billing.`
                             : org.openworkWebAccess.complimentaryAccess
-                              ? org.openworkWebAccess.hasAccess
-                                ? "All joined members can use OpenWork Web without a Stripe subscription or per-member charge."
-                                : "The complimentary grant is stored, but this deployment has not enabled OpenWork Web."
+                              ? "All joined members can use OpenWork Web without a Stripe subscription or per-member charge, even when deployment-wide availability is off."
                               : "No complimentary grant or ongoing paid OpenWork Web subscription."}
                         </p>
                       </div>
@@ -3127,7 +3125,7 @@ export function DenAdminPanel() {
             </h2>
             <p className="mt-2 text-sm leading-6 text-slate-600">
               {openworkWebAccessDialog.enabled
-                ? `${openworkWebAccessDialog.org.name} will receive OpenWork Web for every joined member without a Stripe subscription or per-member charge.`
+                ? `${openworkWebAccessDialog.org.name} will receive OpenWork Web for every joined member without a Stripe subscription or per-member charge, even when deployment-wide availability is off.`
                 : `${openworkWebAccessDialog.org.name} will lose complimentary access immediately unless an independently eligible paid subscription exists.`}
             </p>
 

--- a/ee/apps/den-web/tests/openwork-web-billing.test.ts
+++ b/ee/apps/den-web/tests/openwork-web-billing.test.ts
@@ -142,6 +142,8 @@ describe("OpenWork Web billing data", () => {
     expect(source).toContain("Revoke complimentary access");
     expect(source).toContain("Reason for audit log");
     expect(source).toContain("Cancel or finish the paid subscription in Stripe");
+    expect(source).toContain("even when deployment-wide availability is off");
+    expect(source).not.toContain("grant is stored, but this deployment has not enabled");
     expect(source).toContain("/openwork-web-access");
   });
 });

--- a/ee/apps/den-web/tests/web-page.test.ts
+++ b/ee/apps/den-web/tests/web-page.test.ts
@@ -75,7 +75,7 @@ describe("Web dashboard page", () => {
     confirming: false,
   };
 
-  test("uses the deployment Web offer and fails closed while billing resolves", () => {
+  test("uses Den's effective organization Web offer and fails closed while billing resolves", () => {
     expect(getWebPageAccessState({
       ...accessInput,
       webAvailable: false,

--- a/evals/specs/openwork-web-billing.test.ts
+++ b/evals/specs/openwork-web-billing.test.ts
@@ -36,6 +36,9 @@ briefTest(testBrief({
     complimentaryContract: claim("platform admins can explicitly grant and revoke audited complimentary Web access", {
       never: "infer free access from an email, organization role, plan, capability, or a deployment where Web is disabled, or overlap an ongoing paid Web subscription",
     }),
+    originContract: claim("the hosted OpenWork Web origin enforces Den's access result for the exact signed-in organization", {
+      never: "provision or proxy a workspace from a client-authored flag, a stale organization result, an inconsistent payload, or an unavailable Den",
+    }),
     checkoutContract: claim("Checkout, return sync, and webhooks bind one subscription to the intended organization", {
       never: "open duplicate subscriptions or grant access from an unrelated or unconfirmed Checkout session",
     }),
@@ -81,6 +84,11 @@ briefTest(testBrief({
     adminRoutesSource,
     adminPanelSource,
     auditEventsSource,
+    cloudRoutesSource,
+    gatewaySource,
+    appRootSource,
+    productAccessGateSource,
+    productAccessStateSource,
   ] = await Promise.all([
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "env.ts"), "utf8"),
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "openwork-web-availability.ts"), "utf8"),
@@ -99,6 +107,11 @@ briefTest(testBrief({
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "routes", "admin", "index.ts"), "utf8"),
     readFile(join(repoRoot, "ee", "apps", "den-web", "components", "den-admin-panel.tsx"), "utf8"),
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "audit-events.ts"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-api", "src", "routes", "cloud", "index.ts"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-gateway", "src", "app.ts"), "utf8"),
+    readFile(join(repoRoot, "apps", "app", "src", "react-app", "shell", "app-root.tsx"), "utf8"),
+    readFile(join(repoRoot, "apps", "app", "src", "react-app", "domains", "cloud", "openwork-web-access-gate.tsx"), "utf8"),
+    readFile(join(repoRoot, "apps", "app", "src", "react-app", "domains", "cloud", "openwork-web-access-state.ts"), "utf8"),
   ]);
 
   expect(subscriptionSchemaSource).toMatch(/OrgSubscriptionType\s*=\s*\[[^\]]*"web"/s);
@@ -228,6 +241,97 @@ briefTest(testBrief({
   prove.complimentaryContract(
     true,
     "The explicit metadata grant preserved unrelated organization settings; the deployment-off matrix remained locked; paid access won if both sources existed; the platform-admin route required an audit reason, rejected ongoing subscriptions twice around the transaction, and Checkout refused a complimentary organization.",
+  );
+
+  const { createGatewayApp } = await import("../../ee/apps/den-gateway/src/app");
+  const { parseDenOpenWorkWebAccess } = await import("../../apps/app/src/app/lib/den");
+  const { resolveOpenWorkWebAccessGateState } = await import(
+    "../../apps/app/src/react-app/domains/cloud/openwork-web-access-state"
+  );
+  let instanceRequests = 0;
+  const gateway = createGatewayApp({
+    denApiBase: "https://den.example",
+    gatewayKey: "gateway-secret",
+    logRequests: false,
+    fetchImpl: async (url) => {
+      if (new URL(url).pathname === "/v1/cloud/gateway/resolve") {
+        return Response.json({ error: "openwork_web_access_required" }, { status: 403 });
+      }
+      instanceRequests += 1;
+      return new Response("unexpected");
+    },
+  });
+  const deniedGatewayResponse = await gateway.request("https://web.openworklabs.com/status", {
+    headers: { Authorization: "Bearer den-session" },
+  });
+  expect(deniedGatewayResponse.status).toBe(403);
+  await expect(deniedGatewayResponse.json()).resolves.toEqual({ error: "gateway_resolve_rejected" });
+  expect(instanceRequests).toBe(0);
+
+  const complimentaryPayload = {
+    billing: {
+      stripe: {
+        web: {
+          hasAccess: true,
+          accessSource: "complimentary",
+          hasEligibleSubscription: false,
+          complimentaryAccess: true,
+        },
+      },
+    },
+  };
+  expect(parseDenOpenWorkWebAccess(complimentaryPayload)).toEqual({
+    hasAccess: true,
+    accessSource: "complimentary",
+  });
+  expect(parseDenOpenWorkWebAccess({
+    billing: {
+      stripe: {
+        web: {
+          hasAccess: true,
+          accessSource: null,
+          hasEligibleSubscription: false,
+          complimentaryAccess: false,
+        },
+      },
+    },
+  })).toBeNull();
+
+  const accessScope = "user_acme\u0000org_acme\u0000token_acme";
+  const gateInput = {
+    gatewayMode: true,
+    authStatus: "signed_in" as const,
+    authToken: "token_acme",
+    organizationId: "org_acme",
+    verifiedIdentity: { principalId: "user_acme", organizationId: "org_acme" },
+    expectedScope: accessScope,
+  };
+  expect(resolveOpenWorkWebAccessGateState({
+    ...gateInput,
+    check: { scope: accessScope, state: "granted", accessSource: "complimentary" },
+  })).toBe("granted");
+  expect(resolveOpenWorkWebAccessGateState({
+    ...gateInput,
+    check: { scope: "user_acme\u0000org_other\u0000token_acme", state: "granted", accessSource: "complimentary" },
+  })).toBe("checking");
+  expect(resolveOpenWorkWebAccessGateState({
+    ...gateInput,
+    authStatus: "unavailable",
+    check: { scope: accessScope, state: "granted", accessSource: "complimentary" },
+  })).toBe("error");
+  expect(cloudRoutesSource).toMatch(
+    /await getOpenWorkWebAccess\(payload\.organization\.id\)[\s\S]*?if \(!webAccess\.hasAccess\)[\s\S]*?resolveCloudInstanceForGateway/,
+  );
+  expect(gatewaySource).toContain('"gateway_resolve_rejected"');
+  expect(productAccessGateSource).toContain('getOpenWorkWebAccess(organizationId)');
+  expect(productAccessStateSource).toContain('input.authStatus === "unavailable"');
+  expect(productAccessStateSource).toContain('input.check.scope !== input.expectedScope');
+  expect(appRootSource).toMatch(
+    /<OpenWorkWebAccessGate>[\s\S]*?<CloudWorkspaceStatusProvider>/,
+  );
+  prove.originContract(
+    true,
+    "A Den 403 kept the hosted gateway closed without any instance request; the product parser rejected an inconsistent client-shaped claim; only the exact verified principal/org/token scope opened; an organization mismatch waited; Den unavailability locked; and the Web gate mounts before cloud workspace provisioning.",
   );
 
   expect(openWorkWebCheckoutIdempotencyKey({

--- a/evals/specs/openwork-web-billing.test.ts
+++ b/evals/specs/openwork-web-billing.test.ts
@@ -19,13 +19,13 @@ function seedAppLessDenEnvironment() {
 }
 
 briefTest(testBrief({
-  behavior: "OpenWork Web resolves paid or explicitly granted complimentary organization access behind one fail-closed deployment gate.",
+  behavior: "OpenWork Web resolves paid or explicitly granted complimentary organization access behind a fail-closed global default with a platform-admin organization override.",
   claims: {
     priceContract: claim("OpenWork Web has a dedicated recurring USD monthly price contract", {
       never: "reuse the generic seat product or silently drift from $50 per user each month",
     }),
-    availabilityContract: claim("every organization sees Web only when the deployment explicitly enables it", {
-      never: "surface Web when the flag is missing or false, or infer availability from tenancy, Stripe configuration, or organization metadata",
+    availabilityContract: claim("the deployment switch enables Web globally while a complimentary admin grant enables only its organization", {
+      never: "surface Web for an ungranted organization when the switch is missing or false, or infer availability from tenancy, Stripe configuration, or unrelated organization metadata",
     }),
     quantityContract: claim("billing quantity counts joined, non-removed organization members", {
       never: "charge for pending invitations, removed members, roles, or free-seat offsets",
@@ -34,7 +34,7 @@ briefTest(testBrief({
       never: "unlock for payment failure, cancellation, expiry, incomplete checkout, unpaid, or paused states",
     }),
     complimentaryContract: claim("platform admins can explicitly grant and revoke audited complimentary Web access", {
-      never: "infer free access from an email, organization role, plan, capability, or a deployment where Web is disabled, or overlap an ongoing paid Web subscription",
+      never: "infer free access from an email, organization role, plan, generic capability, or another organization's grant, or overlap an ongoing paid Web subscription",
     }),
     originContract: claim("the hosted OpenWork Web origin enforces Den's access result for the exact signed-in organization", {
       never: "provision or proxy a workspace from a client-authored flag, a stale organization result, an inconsistent payload, or an unavailable Den",
@@ -60,7 +60,10 @@ briefTest(testBrief({
     openWorkWebCheckoutIdempotencyKey,
     openWorkWebPaymentStatus,
   } = await import("../../ee/apps/den-api/src/stripe-billing");
-  const { openWorkWebDeploymentAvailable } = await import("../../ee/apps/den-api/src/openwork-web-availability");
+  const {
+    openWorkWebAvailableForOrganization,
+    openWorkWebDeploymentAvailable,
+  } = await import("../../ee/apps/den-api/src/openwork-web-availability");
   const {
     hasOpenWorkWebComplimentaryAccess,
     resolveOpenWorkWebAccess,
@@ -130,15 +133,20 @@ briefTest(testBrief({
 
   expect(openWorkWebDeploymentAvailable(true)).toBe(true);
   expect(openWorkWebDeploymentAvailable(false)).toBe(false);
+  expect(openWorkWebAvailableForOrganization(false, {})).toBe(false);
+  expect(openWorkWebAvailableForOrganization(false, { capabilities: { openworkWeb: true } })).toBe(false);
+  expect(openWorkWebAvailableForOrganization(false, { complimentaryAccess: { openworkWeb: true } })).toBe(true);
+  expect(openWorkWebAvailableForOrganization(true, {})).toBe(true);
   expect(environmentSource).toContain("DEN_OPENWORK_WEB_ENABLED: z.string().optional()");
   expect(environmentSource).toContain('parseBooleanFlag(parsed.DEN_OPENWORK_WEB_ENABLED ?? "false")');
   expect(availabilitySource).toContain("env.openworkWebEnabled");
   expect(availabilitySource).not.toContain("orgMode");
   expect(availabilitySource).not.toContain("stripeSecretKey");
   expect(availabilitySource).not.toContain("openWorkWebPriceId");
+  expect(availabilitySource).toContain("hasOpenWorkWebComplimentaryAccess(metadata)");
   expect(helmValuesSource).toContain('openworkWebEnabled: "false"');
   expect(helmConfigMapSource).toContain("DEN_OPENWORK_WEB_ENABLED: {{ .Values.config.public.openworkWebEnabled | quote }}");
-  expect(orgCoreSource).toContain("openworkWeb: isOpenWorkWebAvailable()");
+  expect(orgCoreSource).toContain("openworkWeb: isOpenWorkWebAvailableForOrganization(payload.organization.metadata)");
   expect(dashboardShellSource).toContain("const showWeb = runtimeConfigLoaded\n    && orgContext?.capabilities.openworkWeb === true");
   expect(dashboardShellSource).not.toMatch(/const showWeb =[\s\S]{0,160}runtimeConfig\.orgMode/);
   expect(dashboardShellSource).toContain("orgContext?.capabilities.openworkWeb === true");
@@ -149,11 +157,11 @@ briefTest(testBrief({
   expect(billingPageSource).not.toContain('runtimeConfig.orgMode === "multi_org"');
   expect(billingPageSource).toContain("orgContext?.capabilities.openworkWeb === true");
   expect(billingRoutesSource).toContain("openwork_web_not_available");
-  expect(billingRoutesSource).toContain('subscriptionType === "web" && !isOpenWorkWebAvailable()');
+  expect(billingRoutesSource).toContain("isOpenWorkWebAvailableForOrganization(payload.organization.metadata)");
   expect(stripeSource).toContain("Boolean(env.stripe.secretKey && env.stripe.openworkWebPriceId)");
   prove.availabilityContract(
     true,
-    "The deployment gate passed only for an explicit enabled value; the environment and Helm defaults are false, every organization reads one server-advertised capability, and tenancy, Stripe presence, and mutable org metadata do not decide availability.",
+    "The environment and Helm defaults remain false; the switch enabled every organization, the platform-admin complimentary grant enabled only its organization, and tenancy, Stripe presence, and unrelated metadata or capabilities did not decide availability.",
   );
 
   const now = new Date("2026-08-25T00:00:00.000Z");
@@ -212,7 +220,12 @@ briefTest(testBrief({
     deploymentAvailable: false,
     hasEligibleSubscription: false,
     complimentaryAccess: true,
-  })).toEqual({ hasAccess: false, accessSource: null, complimentaryAccess: true });
+  })).toEqual({ hasAccess: true, accessSource: "complimentary", complimentaryAccess: true });
+  expect(resolveOpenWorkWebAccess({
+    deploymentAvailable: false,
+    hasEligibleSubscription: true,
+    complimentaryAccess: false,
+  })).toEqual({ hasAccess: false, accessSource: null, complimentaryAccess: false });
   expect(resolveOpenWorkWebAccess({
     deploymentAvailable: true,
     hasEligibleSubscription: false,
@@ -238,9 +251,10 @@ briefTest(testBrief({
   expect(adminPanelSource).toContain("OpenWork Web billing access");
   expect(adminPanelSource).toContain("Grant complimentary access");
   expect(adminPanelSource).toContain("Reason for audit log");
+  expect(adminPanelSource).toContain("even when deployment-wide availability is off");
   prove.complimentaryContract(
     true,
-    "The explicit metadata grant preserved unrelated organization settings; the deployment-off matrix remained locked; paid access won if both sources existed; the platform-admin route required an audit reason, rejected ongoing subscriptions twice around the transaction, and Checkout refused a complimentary organization.",
+    "The explicit metadata grant preserved unrelated organization settings and opened only that organization while the deployment switch was off; an ungranted paid subscription stayed locked, paid access won when the switch was on, and the platform-admin route required an audit reason, rejected ongoing subscriptions twice around the transaction, and Checkout refused a complimentary organization.",
   );
 
   const { createGatewayApp } = await import("../../ee/apps/den-gateway/src/app");
@@ -503,6 +517,6 @@ briefTest(testBrief({
   expect(billingPageSource).toContain("without a Stripe subscription or per-member charge");
   prove.surfaceContract(
     true,
-    "The paywall uses the deployment Web offer, waits for server-resolved access, renders complimentary access without a purchase action or charge, and otherwise offers the exact $50/user/month purchase; Billing keeps paid lifecycle management while labeling complimentary members as covered rather than billed.",
+    "The paywall uses the server-advertised effective organization offer, waits for server-resolved access, renders complimentary access without a purchase action or charge, and otherwise offers the exact $50/user/month purchase; Billing keeps paid lifecycle management while labeling complimentary members as covered rather than billed.",
   );
 });

--- a/evals/specs/openwork-web-billing.test.ts
+++ b/evals/specs/openwork-web-billing.test.ts
@@ -37,7 +37,7 @@ briefTest(testBrief({
       never: "infer free access from an email, organization role, plan, generic capability, or another organization's grant, or overlap an ongoing paid Web subscription",
     }),
     originContract: claim("the hosted OpenWork Web origin enforces Den's access result for the exact signed-in organization", {
-      never: "provision or proxy a workspace from a client-authored flag, a stale organization result, an inconsistent payload, or an unavailable Den",
+      never: "provision or proxy a workspace from a client-authored flag, a stale organization result, an inconsistent payload, an unavailable Den, or an older Den that does not advertise the Web protocol",
     }),
     checkoutContract: claim("Checkout, return sync, and webhooks bind one subscription to the intended organization", {
       never: "open duplicate subscriptions or grant access from an unrelated or unconfirmed Checkout session",
@@ -89,6 +89,7 @@ briefTest(testBrief({
     auditEventsSource,
     cloudRoutesSource,
     gatewaySource,
+    denClientSource,
     appRootSource,
     productAccessGateSource,
     productAccessStateSource,
@@ -112,6 +113,7 @@ briefTest(testBrief({
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "audit-events.ts"), "utf8"),
     readFile(join(repoRoot, "ee", "apps", "den-api", "src", "routes", "cloud", "index.ts"), "utf8"),
     readFile(join(repoRoot, "ee", "apps", "den-gateway", "src", "app.ts"), "utf8"),
+    readFile(join(repoRoot, "apps", "app", "src", "app", "lib", "den.ts"), "utf8"),
     readFile(join(repoRoot, "apps", "app", "src", "react-app", "shell", "app-root.tsx"), "utf8"),
     readFile(join(repoRoot, "apps", "app", "src", "react-app", "domains", "cloud", "openwork-web-access-gate.tsx"), "utf8"),
     readFile(join(repoRoot, "apps", "app", "src", "react-app", "domains", "cloud", "openwork-web-access-state.ts"), "utf8"),
@@ -337,6 +339,9 @@ briefTest(testBrief({
     /await getOpenWorkWebAccess\(payload\.organization\.id\)[\s\S]*?if \(!webAccess\.hasAccess\)[\s\S]*?resolveCloudInstanceForGateway/,
   );
   expect(gatewaySource).toContain('"gateway_resolve_rejected"');
+  expect(denClientSource).toMatch(
+    /requestJson<unknown>\(baseUrls, "\/v1\/org"[\s\S]*?capabilities\?\.openworkWeb !== true[\s\S]*?requestJson<unknown>\(baseUrls, "\/v1\/billing\/web"/,
+  );
   expect(productAccessGateSource).toContain('getOpenWorkWebAccess(organizationId)');
   expect(productAccessStateSource).toContain('input.authStatus === "unavailable"');
   expect(productAccessStateSource).toContain('input.check.scope !== input.expectedScope');
@@ -345,7 +350,7 @@ briefTest(testBrief({
   );
   prove.originContract(
     true,
-    "A Den 403 kept the hosted gateway closed without any instance request; the product parser rejected an inconsistent client-shaped claim; only the exact verified principal/org/token scope opened; an organization mismatch waited; Den unavailability locked; and the Web gate mounts before cloud workspace provisioning.",
+    "A Den 403 kept the hosted gateway closed without any instance request; an older Den that omitted the Web capability stayed locked without receiving the billing request; the product parser rejected an inconsistent client-shaped claim; only the exact verified principal/org/token scope opened; an organization mismatch waited; Den unavailability locked; and the Web gate mounts before cloud workspace provisioning.",
   );
 
   expect(openWorkWebCheckoutIdempotencyKey({

--- a/packages/docs/cloud/run-in-the-cloud/open-cloud-in-browser.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/open-cloud-in-browser.mdx
@@ -4,7 +4,7 @@ description: "Open a full OpenWork instance in your browser with nothing to inst
 ---
 
 <Warning>
-**Hosted access.** OpenWork Web is available to every organization when an OpenWork-hosted deployment explicitly enables it. Web billing must also be configured before an owner or admin can purchase it. It costs **$50 per joined organization member per month**; pending invitations are not billed until they are accepted.
+**Hosted access.** OpenWork Web is available to every organization when an OpenWork-hosted deployment explicitly enables it. A platform admin in Den `/admin` can also grant complimentary access to one specific organization while deployment-wide availability is off. Web billing must be configured before an owner or admin can purchase it. It costs **$50 per joined organization member per month**; pending invitations are not billed until they are accepted.
 </Warning>
 
 Open `/dashboard/web` to see the price, billable member quantity, expected monthly total, and purchase action. Access opens only after the organization's subscription is confirmed.
@@ -13,7 +13,7 @@ Open `/dashboard/web` to see the price, billable member quantity, expected month
 
 Every joined member can see OpenWork Web when the hosted deployment offers it. An organization owner or admin purchases the subscription; all joined members receive access after it becomes active.
 
-Self-hosted deployments do not show OpenWork Web by default: a missing or false `DEN_OPENWORK_WEB_ENABLED` value fails closed. If you use an OpenWork-hosted organization and do not see it in the sidebar, email [team@openworklabs.com](mailto:team@openworklabs.com) so the deployment configuration can be checked.
+Self-hosted deployments do not show OpenWork Web by default: a missing or false `DEN_OPENWORK_WEB_ENABLED` value fails closed unless a platform admin in Den `/admin` has explicitly granted complimentary access to that organization. If you use an OpenWork-hosted organization and do not see it in the sidebar, email [team@openworklabs.com](mailto:team@openworklabs.com) so the deployment configuration or organization grant can be checked.
 
 ## Open OpenWork Web
 

--- a/packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
@@ -4,7 +4,7 @@ description: "Run a full OpenWork workspace in the browser, hosted by OpenWork"
 ---
 
 <Warning>
-**Hosted access.** OpenWork Web is available to every organization when an OpenWork-hosted deployment explicitly enables it. Web billing must also be configured before an owner or admin can purchase it. It costs **$50 per joined organization member per month**; pending invitations are not billed until they are accepted.
+**Hosted access.** OpenWork Web is available to every organization when an OpenWork-hosted deployment explicitly enables it. A platform admin in Den `/admin` can also grant complimentary access to one specific organization while deployment-wide availability is off. Web billing must be configured before an owner or admin can purchase it. It costs **$50 per joined organization member per month**; pending invitations are not billed until they are accepted.
 </Warning>
 
 OpenWork Web gives your team a full OpenWork workspace in the browser, hosted and managed for you — nothing to install. An organization owner or admin can purchase it directly from the organization dashboard.
@@ -31,7 +31,7 @@ Use OpenWork Web when your team needs a hosted OpenWork runtime, a stable place 
 
 ## Notes
 
-- OpenWork Web appears only when the deployment sets `DEN_OPENWORK_WEB_ENABLED=true`. Missing or false keeps self-hosted deployments fail-closed; organization mode, Stripe-variable presence, and organization metadata do not act as rollout signals.
+- `DEN_OPENWORK_WEB_ENABLED=true` makes OpenWork Web available to every organization. Missing or false remains fail-closed except for an organization with an explicit complimentary grant from a platform admin in Den `/admin`; organization mode, Stripe-variable presence, and ordinary organization metadata do not act as rollout signals.
 - A workspace must be `Ready` before it can be opened.
 - Hosted workspace limits follow your OpenWork plan.
 - If you prefer to self-host a runtime instead, run `openwork-server` and connect the desktop app to that server URL.


### PR DESCRIPTION
## Summary

- require the trusted gateway resolver to confirm Den OpenWork Web access for the exact signed-in organization before provisioning or returning worker tokens
- use the existing audited Den `/admin` complimentary grant as the only organization-specific override when `DEN_OPENWORK_WEB_ENABLED=false`; no new flag or generic capability bypass is introduced
- negotiate the established Web protocol through `/v1/org` before calling `/v1/billing/web`, so an older Den that omits `capabilities.openworkWeb` stays locked without receiving the newer request
- have Den API author the effective organization capability and billing result, then make the hosted OpenWork Web origin fail closed for mismatched, malformed, denied, stale, or unavailable results
- keep ungranted organizations locked while the global switch is off, including organizations with a paid subscription alone, and leave desktop and non-gateway Web flows unchanged

## Proof

- focused Den API, Den Web, hosted product-origin, cloud route, database-backed admin route, and gateway tests: 176 passed, 0 failed
- `pnpm evals:pr specs/openwork-web-billing.test.ts`: Passed, 1 test, 8/8 claims, 0 skipped
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --filter @openwork-ee/den-gateway build`
- production Den API and Den Web builds
- database-backed admin grant/revoke test ran against a fresh disposable local MySQL database; the existing tunneled database was not modified

Daytona proof was unavailable because `DAYTONA_API_KEY` is not configured, so the required head-matching testkit proof ran locally and is published in the PR evidence comment.
