### PR TITLE
fix(desktop): guard AppImage update permissions

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-install-error.test.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-install-error.test.ts
@@ -1,0 +1,19 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toEqual: (expected: unknown) => void;
+};
+
+import { resolveElectronUpdaterInstallError } from "./electron-updater-install-error";
+
+describe("electron updater install errors", () => {
+  test("maps a native AppImage permission reason to the visible install error state", () => {
+    const reason = "Copy or download the AppImage to ~/.local/bin, then run it from there.";
+
+    expect(resolveElectronUpdaterInstallError(reason)).toEqual({
+      state: "error",
+      message: reason,
+      failedAction: "install",
+    });
+  });
+});

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-install-error.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-install-error.ts
@@ -1,0 +1,7 @@
+export function resolveElectronUpdaterInstallError(reason?: string) {
+  return {
+    state: "error" as const,
+    message: reason ?? "Update install failed.",
+    failedAction: "install" as const,
+  };
+}

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -14,6 +14,7 @@ import {
 import type { ReleaseChannel } from "../../../../app/types";
 import { isElectronRuntime, safeStringify } from "../../../../app/utils";
 import { t } from "../../../../i18n";
+import { resolveElectronUpdaterInstallError } from "./electron-updater-install-error";
 import { useUpdateCheckRequestStore } from "./update-check-request";
 
 export type SettingsUpdateStatus = {
@@ -579,11 +580,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
           await runCheckForUpdates(undefined, true);
           return;
         }
-        setUpdateStatus({
-          state: "error",
-          message: result?.reason ?? "Update install failed.",
-          failedAction: "install",
-        });
+        setUpdateStatus(resolveElectronUpdaterInstallError(result?.reason));
       }
     } catch (error) {
       if (!isCurrentReleaseChannel()) return;

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -1,5 +1,5 @@
-import { readFile, mkdir, writeFile, rm } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { access as fsAccess, readFile, mkdir, writeFile, rm } from "node:fs/promises";
+import { constants as fsConstants, readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -303,7 +303,11 @@ export function registerUpdaterIpc({
   platform = process.platform,
   arch = process.arch,
   env = process.env,
+  checkPathAccess = fsAccess,
 }) {
+  const isLinuxAppImage = platform === "linux"
+    && typeof env.APPIMAGE === "string"
+    && env.APPIMAGE.length > 0;
   let autoUpdaterInstance = null;
   let autoUpdaterLoadPromise = null;
   let checkedUpdateVersion = null;
@@ -331,6 +335,17 @@ export function registerUpdaterIpc({
     }
   }
 
+  async function appImageInstallLocationError() {
+    if (!isLinuxAppImage) return null;
+    const appImageDirectory = path.dirname(env.APPIMAGE);
+    try {
+      await checkPathAccess(appImageDirectory, fsConstants.W_OK | fsConstants.X_OK);
+      return null;
+    } catch {
+      return `OpenWork can't install this update because the AppImage folder is not writable: ${appImageDirectory}. Copy or download the AppImage to a user-writable folder such as ~/.local/bin, then run it from there. Administrator access may be required to remove the original.`;
+    }
+  }
+
   async function ensureAutoUpdater() {
     if (!app.isPackaged) return null;
     if (!autoUpdaterLoadPromise) {
@@ -340,7 +355,7 @@ export function registerUpdaterIpc({
           autoUpdaterInstance = mod.autoUpdater ?? mod.default?.autoUpdater ?? null;
           if (autoUpdaterInstance) {
             autoUpdaterInstance.autoDownload = false;
-            autoUpdaterInstance.autoInstallOnAppQuit = true;
+            autoUpdaterInstance.autoInstallOnAppQuit = !isLinuxAppImage;
             // Differential (blockmap) downloads reconstruct the update zip from the
             // installed app + a diff. On macOS that reconstructed bundle is what
             // feeds Squirrel's fragile move-based install, and is a common trigger
@@ -545,6 +560,11 @@ export function registerUpdaterIpc({
     const updater = await ensureAutoUpdater();
     if (updater && app.isPackaged) {
       try {
+        const installLocationError = await appImageInstallLocationError();
+        if (installLocationError) {
+          preventPendingUpdaterInstall(updater);
+          return { ok: false, reason: installLocationError };
+        }
         await applyElectronUpdaterFeed(app, updater, release.version, manifestChannel, true);
         const result = await updater.checkForUpdates();
         if (compareVersions(result?.updateInfo?.version ?? "", release.version) !== 0) {
@@ -553,8 +573,13 @@ export function registerUpdaterIpc({
         if (compareStableVersions(release.version, currentVersion) === null) {
           throw new Error("Installed version could not be validated.");
         }
-        updater.autoInstallOnAppQuit = true;
+        updater.autoInstallOnAppQuit = !isLinuxAppImage;
         await updater.downloadUpdate();
+        const restartLocationError = await appImageInstallLocationError();
+        if (restartLocationError) {
+          preventPendingUpdaterInstall(updater);
+          return { ok: false, reason: restartLocationError };
+        }
         updater.quitAndInstall(false, true);
         return { ok: true, action: "install" };
       } catch (error) {
@@ -676,6 +701,11 @@ export function registerUpdaterIpc({
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
+      const installLocationError = await appImageInstallLocationError();
+      if (installLocationError) {
+        preventPendingUpdaterInstall(updater);
+        return { ok: false, reason: installLocationError };
+      }
       await applyElectronUpdaterFeed(
         app,
         updater,
@@ -707,7 +737,7 @@ export function registerUpdaterIpc({
       // Clear any stuck ShipIt state from a prior aborted install so this
       // download applies cleanly on quit.
       await cleanStaleUpdaterState(app, shipItDefaultsDomain);
-      updater.autoInstallOnAppQuit = true;
+      updater.autoInstallOnAppQuit = !isLinuxAppImage;
       await updater.downloadUpdate();
       updateDownloaded = true;
       return { ok: true };
@@ -722,6 +752,11 @@ export function registerUpdaterIpc({
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
+      const installLocationError = await appImageInstallLocationError();
+      if (installLocationError) {
+        preventPendingUpdaterInstall(updater);
+        return { ok: false, reason: installLocationError };
+      }
       // Re-assert the in-place-write default right before the swap; the ShipIt
       // defaults domain may have been wiped when stale state was cleaned.
       await enableSquirrelDirectContentsWrite();

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { constants as fsConstants, mkdtempSync, readFileSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -59,7 +59,7 @@ function fakeUpdaterHarness({ version }) {
   return { updater, listeners, calls, feeds, downloadFeeds };
 }
 
-async function registerFakeUpdaterIpc({ version }) {
+async function registerFakeUpdaterIpc({ version, registerOptions = {} }) {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "openwork-updater-test-"));
   const handlers = new Map();
   const harness = fakeUpdaterHarness({ version });
@@ -80,6 +80,7 @@ async function registerFakeUpdaterIpc({ version }) {
     ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
     getMainWindow: () => null,
     loadAutoUpdater: async () => ({ autoUpdater: harness.updater }),
+    ...registerOptions,
   });
   return { tempDir, handlers, ...harness };
 }
@@ -505,6 +506,107 @@ describe("installAndRestart", () => {
 });
 
 describe("downloaded update lifecycle", () => {
+  it("blocks downloads when the AppImage directory lacks replacement permissions", async () => {
+    const accessCalls = [];
+    const { tempDir, handlers, updater, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1",
+      registerOptions: {
+        platform: "linux",
+        env: { APPIMAGE: "/usr/local/bin/openwork" },
+        checkPathAccess: async (target, mode) => {
+          accessCalls.push([target, mode]);
+          if ((mode & fsConstants.X_OK) !== 0) throw new Error("EACCES");
+        },
+      },
+    });
+    try {
+      assert.equal((await handlers.get("openwork:updater:check")(null, "stable")).available, true);
+      const result = await handlers.get("openwork:updater:download")();
+
+      assert.equal(result.ok, false);
+      assert.match(result.reason, /AppImage folder is not writable: \/usr\/local\/bin/);
+      assert.match(result.reason, /Copy or download the AppImage/);
+      assert.match(result.reason, /~\/\.local\/bin/);
+      assert.match(result.reason, /Administrator access may be required to remove the original/);
+      assert.deepEqual(accessCalls, [["/usr/local/bin", fsConstants.W_OK | fsConstants.X_OK]]);
+      assert.deepEqual(calls, []);
+      assert.equal(updater.autoInstallOnAppQuit, false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rechecks AppImage permissions before restarting after download", async () => {
+    let accessChecks = 0;
+    const { tempDir, handlers, updater, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1",
+      registerOptions: {
+        platform: "linux",
+        env: { APPIMAGE: "/usr/local/bin/openwork" },
+        checkPathAccess: async () => {
+          accessChecks += 1;
+          if (accessChecks > 1) throw new Error("EACCES");
+        },
+      },
+    });
+    try {
+      assert.equal((await handlers.get("openwork:updater:check")(null, "stable")).available, true);
+      assert.deepEqual(await handlers.get("openwork:updater:download")(), { ok: true });
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      const result = await handlers.get("openwork:updater:installAndRestart")();
+
+      assert.equal(result.ok, false);
+      assert.match(result.reason, /AppImage folder is not writable/);
+      assert.equal(accessChecks, 2);
+      assert.deepEqual(calls, ["download"]);
+      assert.equal(updater.autoInstallOnAppQuit, false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("installs writable AppImages only through the guarded restart path", async () => {
+    let accessChecks = 0;
+    const { tempDir, handlers, updater, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1",
+      registerOptions: {
+        platform: "linux",
+        env: { APPIMAGE: "/home/test/.local/bin/openwork" },
+        checkPathAccess: async () => { accessChecks += 1; },
+      },
+    });
+    try {
+      assert.equal((await handlers.get("openwork:updater:check")(null, "stable")).available, true);
+      assert.deepEqual(await handlers.get("openwork:updater:download")(), { ok: true });
+      assert.equal(updater.autoInstallOnAppQuit, false);
+      assert.deepEqual(await handlers.get("openwork:updater:installAndRestart")(), { ok: true });
+      assert.equal(accessChecks, 2);
+      assert.deepEqual(calls, ["download", "quitAndInstall"]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps non-AppImage Linux updater behavior unchanged", async () => {
+    const { tempDir, handlers, updater, calls } = await registerFakeUpdaterIpc({
+      version: "0.17.1",
+      registerOptions: {
+        platform: "linux",
+        env: {},
+        checkPathAccess: async () => { throw new Error("unexpected access check"); },
+      },
+    });
+    try {
+      assert.equal((await handlers.get("openwork:updater:check")(null, "stable")).available, true);
+      assert.deepEqual(await handlers.get("openwork:updater:download")(), { ok: true });
+      assert.equal(updater.autoInstallOnAppQuit, true);
+      assert.deepEqual(await handlers.get("openwork:updater:installAndRestart")(), { ok: true });
+      assert.deepEqual(calls, ["download", "quitAndInstall"]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("a transient failed check does not invalidate a downloaded update", async () => {
     const { tempDir, handlers, updater, calls } = await registerFakeUpdaterIpc({
       version: "0.17.1",
@@ -519,6 +621,7 @@ describe("downloaded update lifecycle", () => {
 
       assert.equal((await check(null, "stable")).available, true);
       assert.deepEqual(await download(), { ok: true });
+      assert.equal(updater.autoInstallOnAppQuit, true);
       updater.checkForUpdates = async () => {
         throw new Error("network flake");
       };
@@ -581,6 +684,103 @@ describe("downloaded update lifecycle", () => {
       });
     } finally {
       await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("AppImage recovery installation", () => {
+  it("blocks recovery before downloading or restarting from an unwritable directory", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-appimage-recovery-"));
+    const handlers = new Map();
+    const harness = fakeUpdaterHarness({ version: "1.9.0" });
+    const manifest = `version: 1.9.0
+files:
+  - url: openwork-linux-x86_64-1.9.0.AppImage
+    sha512: verified-checksum
+`;
+    try {
+      isolatedUpdaterImportId += 1;
+      const isolated = await import(`./updater.mjs?appimage-recovery=${isolatedUpdaterImportId}`);
+      isolated.registerUpdaterIpc({
+        app: {
+          isPackaged: true,
+          getVersion: () => "2.0.0",
+          getPath: (key) => path.join(userData, key),
+        },
+        ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+        getMainWindow: () => null,
+        loadAutoUpdater: async () => ({ autoUpdater: harness.updater }),
+        electronNet: { fetch: async () => new Response(manifest) },
+        platform: "linux",
+        arch: "x64",
+        distribution: "public",
+        env: { APPIMAGE: "/usr/local/bin/openwork" },
+        checkPathAccess: async () => { throw new Error("EACCES"); },
+      });
+
+      const listed = await handlers.get("openwork:recovery:list")(null, {
+        versions: ["1.9.0"],
+        minimumVersion: "0.0.0",
+      });
+      assert.deepEqual(listed.releases, [{ id: "1.9.0", version: "1.9.0", marking: null }]);
+      const result = await handlers.get("openwork:recovery:use")(null, "1.9.0");
+
+      assert.equal(result.ok, false);
+      assert.match(result.reason, /AppImage folder is not writable/);
+      assert.deepEqual(harness.calls, []);
+      assert.equal(harness.updater.autoInstallOnAppQuit, false);
+    } finally {
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
+  it("rechecks recovery permissions after download before restarting", async () => {
+    const userData = await mkdtemp(path.join(os.tmpdir(), "openwork-appimage-recovery-"));
+    const handlers = new Map();
+    const harness = fakeUpdaterHarness({ version: "1.9.0" });
+    const manifest = `version: 1.9.0
+files:
+  - url: openwork-linux-x86_64-1.9.0.AppImage
+    sha512: verified-checksum
+`;
+    let accessChecks = 0;
+    try {
+      isolatedUpdaterImportId += 1;
+      const isolated = await import(`./updater.mjs?appimage-recovery=${isolatedUpdaterImportId}`);
+      isolated.registerUpdaterIpc({
+        app: {
+          isPackaged: true,
+          getVersion: () => "2.0.0",
+          getPath: (key) => path.join(userData, key),
+        },
+        ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+        getMainWindow: () => null,
+        loadAutoUpdater: async () => ({ autoUpdater: harness.updater }),
+        electronNet: { fetch: async () => new Response(manifest) },
+        platform: "linux",
+        arch: "x64",
+        distribution: "public",
+        env: { APPIMAGE: "/usr/local/bin/openwork" },
+        checkPathAccess: async () => {
+          accessChecks += 1;
+          if (accessChecks > 1) throw new Error("EACCES");
+        },
+      });
+
+      const listed = await handlers.get("openwork:recovery:list")(null, {
+        versions: ["1.9.0"],
+        minimumVersion: "0.0.0",
+      });
+      assert.deepEqual(listed.releases, [{ id: "1.9.0", version: "1.9.0", marking: null }]);
+      const result = await handlers.get("openwork:recovery:use")(null, "1.9.0");
+
+      assert.equal(result.ok, false);
+      assert.match(result.reason, /AppImage folder is not writable/);
+      assert.equal(accessChecks, 2);
+      assert.deepEqual(harness.calls, ["download"]);
+      assert.equal(harness.updater.autoInstallOnAppQuit, false);
+    } finally {
+      await rm(userData, { recursive: true, force: true });
     }
   });
 });

--- a/evals/specs/linux-appimage-update-permissions.test.ts
+++ b/evals/specs/linux-appimage-update-permissions.test.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const updaterUnitTest = fileURLToPath(new URL("../../apps/desktop/electron/updater.test.mjs", import.meta.url));
+const updaterInstallErrorTest = fileURLToPath(new URL(
+  "../../apps/app/src/react-app/domains/settings/state/electron-updater-install-error.test.ts",
+  import.meta.url,
+));
+
+test("Linux AppImage updates stop before restart when the install directory is not writable", async ({ evidence }) => {
+  const unit = spawnSync(process.execPath, [
+    "--test",
+    "--test-reporter=tap",
+    updaterUnitTest,
+  ], { encoding: "utf8" });
+
+  expect(unit.status, unit.stderr || unit.stdout).toBe(0);
+  expect(unit.stdout).toContain("blocks downloads when the AppImage directory lacks replacement permissions");
+  expect(unit.stdout).toContain("rechecks AppImage permissions before restarting after download");
+  expect(unit.stdout).toContain("blocks recovery before downloading or restarting from an unwritable directory");
+  expect(unit.stdout).toContain("rechecks recovery permissions after download before restarting");
+  expect(unit.stdout).not.toContain("not ok");
+  expect(unit.stdout).toMatch(/# fail 0\b/);
+
+  const renderer = spawnSync("bun", ["test", "--isolate", updaterInstallErrorTest], { encoding: "utf8" });
+  const rendererOutput = `${renderer.stdout}${renderer.stderr}`;
+  expect(renderer.status, rendererOutput).toBe(0);
+  expect(rendererOutput).toContain("maps a native AppImage permission reason to the visible install error state");
+
+  evidence.recordAssertionEvidence(
+    "Unwritable AppImage locations do not trigger a doomed restart",
+    "The updater returns actionable copy-or-download guidance that maps to the visible install error state, keeps automatic install-on-quit disabled for AppImages, and avoids download or restart when the AppImage parent directory cannot be replaced. It rechecks immediately before restart for both normal and updater-backed recovery installs.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary

- Stop Linux AppImage updates before download or restart when the install directory cannot replace the current file.
- Show copy-or-download guidance in the existing updater error UI.
- Route AppImage installs through the guarded restart path instead of automatic install-on-quit.

## Why

`electron-updater` must replace the running AppImage. In a root-owned directory such as `/usr/local/bin`, that swap fails with `EACCES` and the app does not restart or update.

## Issue

- Fixes #3750

## Scope

- AppImage permission checks for normal and updater-backed recovery installs
- Existing updater error-state mapping and focused regression coverage

## Out of scope

- Privilege elevation or automatic AppImage relocation
- Linux desktop integration ownership changes

## Testing

### Ran

- `node --test apps/desktop/electron/updater.test.mjs`
- `node --test apps/desktop/electron/linux-desktop-integration.test.mjs`
- `bun test --isolate apps/app/src/react-app/domains/settings/state/electron-updater-install-error.test.ts`
- `pnpm evals:pr specs/linux-appimage-update-permissions.test.ts`

### Result

- Updater: 34 passed, 1 platform-specific skip, 0 failed
- Linux integration and renderer state: 15 passed, 0 failed
- Testkit proof: 1 passed, 0 skipped or failed
- Eval dependency layers and outbound-access checks also passed

## CI status

- Local scoped checks pass.
- Full workspace tests and app typecheck were not run because the frozen install timed out fetching the unrelated SheetJS CDN package.
- GitHub test jobs await maintainer approval for this fork. The landing preview passed; app, Den, and diagnostics previews require Different AI team authorization.

## Manual verification

- The focused regression recreates the reported `/usr/local/bin` failure by injecting packaged Linux AppImage state and denying replacement permission on the parent directory.
- The updater returns guidance without downloading or restarting, and rechecks permissions after a staged download.
- The permission reason reaches the visible install-error state. Writable AppImages still use guarded restart, and non-AppImage Linux behavior is unchanged.

## Evidence

- Exact-head `@openwork/testkit` proof is published in the sticky PR comment.

## Risk

- Low. The guard is limited to Linux AppImages; non-AppImage and non-Linux update paths retain their previous behavior.

## Rollback

- Revert the commit to restore the previous AppImage update behavior.
