### PR TITLE
perf(server): use one global drain activity stream

### DIFF
--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -92,8 +92,8 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "      const sessionID = url.searchParams.get('session') ?? busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
     "      return Response.json([{ id: url.searchParams.get('request') ?? `req_${server.port}`, sessionID }]);",
     "    }",
-    "    if (url.pathname === '/event') {",
-    "      const frame = (id) => `data: ${JSON.stringify({ type: 'session.updated', properties: { sessionID: id } })}\\n\\n`;",
+    "    if (url.pathname === '/global/event') {",
+    "      const frame = (id) => `data: ${JSON.stringify({ directory: '/workspace', payload: { type: 'session.updated', properties: { sessionID: id } } })}\\n\\n`;",
     "      if (eventSessions(server.port) !== null) {",
     "        // Test-controlled live bus: emit an event per configured session",
     "        // every 50ms on a held stream, re-reading state between beats.",
@@ -108,6 +108,10 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "        });",
     "        return new Response(body, { headers: { 'content-type': 'text/event-stream' } });",
     "      }",
+    "      return new Response(frame(`ses_${server.port}`), { headers: { 'content-type': 'text/event-stream' } });",
+    "    }",
+    "    if (url.pathname === '/event') {",
+    "      const frame = (id) => `data: ${JSON.stringify({ type: 'session.updated', properties: { sessionID: id } })}\\n\\n`;",
     "      const sessionID = busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
     "      if (url.searchParams.has('hold')) {",
     "        const body = new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(frame(sessionID))); } });",
@@ -756,10 +760,18 @@ describe("engine pool", () => {
     expect(lines).toContain(`${oldPort} SIGTERM`);
   });
 
-  test("never aborts an actively streaming session at the drain deadline, then retires the engine once it idles", async () => {
+  test("uses one global activity stream across many workspaces and never aborts an active session", async () => {
     setEnv("OPENWORK_ENGINE_DRAIN_TIMEOUT_MS", "300");
     setEnv("OPENWORK_ENGINE_ABORT_SETTLE_MS", "100");
     const fixture = await createFixture();
+    for (let index = 1; index < 32; index += 1) {
+      fixture.config.workspaces.push({
+        ...fixture.workspace,
+        id: `ws_pool_${index}`,
+        name: `Pool workspace ${index}`,
+        path: join(fixture.root, `workspace-${index}`),
+      });
+    }
     const { pool, primary } = await createPool(fixture);
     const oldPort = portOf(primary.url);
     // The run keeps streaming: the engine event bus names it continuously.
@@ -769,12 +781,17 @@ describe("engine pool", () => {
 
     expect((await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace })).action)
       .toBe("rolled_over");
+    expect(await waitUntil(async () => (await fixture.logLines()).includes(`${oldPort} GET /global/event`), 2_000))
+      .toBe(true);
 
     // Wait out four full grace periods: an actively working session must
     // never be aborted, so the draining engine stays alive the whole time.
     await new Promise((resolve) => setTimeout(resolve, 1_200));
     expect(primary.isAlive()).toBe(true);
-    expect((await fixture.logLines()).some((line) => line.includes("/abort"))).toBe(false);
+    const activeLines = await fixture.logLines();
+    expect(activeLines.filter((line) => line === `${oldPort} GET /global/event`)).toHaveLength(1);
+    expect(activeLines.some((line) => line === `${oldPort} GET /event`)).toBe(false);
+    expect(activeLines.some((line) => line.includes("/abort"))).toBe(false);
 
     // The run finishes: the engine idles and the drained generation closes
     // without ever aborting anything.

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -811,28 +811,24 @@ export class EnginePool {
   }
 
   /**
-   * Hold an event-stream subscription per instance directory on the draining
-   * engine so owned-session activity keeps extending the drain deadline. The
-   * client event fan-in only exists while a client is attached; the pool owns
-   * this watch so a background run with no observer still counts as active.
+   * Hold one global event-stream subscription on the draining engine so
+   * owned-session activity keeps extending the drain deadline. The client
+   * event fan-in only exists while a client is attached; the pool owns this
+   * watch so a background run with no observer still counts as active.
    */
   private watchDrainActivity(generation: Generation): void {
     const controller = new AbortController();
     generation.drainActivityWatch = controller;
-    for (const directory of this.engineProbeDirectories()) {
-      void this.runDrainActivityWatch(generation, directory, controller.signal).catch(() => undefined);
-    }
+    void this.runDrainActivityWatch(generation, controller.signal).catch(() => undefined);
   }
 
   private async runDrainActivityWatch(
     generation: Generation,
-    directory: string | null,
     signal: AbortSignal,
   ): Promise<void> {
     while (!signal.aborted && generation.status === "draining") {
       try {
-        const url = new URL("/event", generation.handle.url);
-        if (directory !== null) url.searchParams.set("directory", directory);
+        const url = new URL("/global/event", generation.handle.url);
         const response = await loopbackFetch(url.toString(), {
           headers: { Authorization: buildEngineAuthProbeHeader(generation.handle.username, generation.handle.password) },
           signal,

--- a/evals/specs/engine-drain-activity-survival.test.ts
+++ b/evals/specs/engine-drain-activity-survival.test.ts
@@ -31,6 +31,8 @@ type FakeEngine = {
   aborted: string[];
   setBusy: (sessionIds: string[]) => void;
   emit: (sessionId: string) => void;
+  globalEventSubscriptions: () => number;
+  instanceEventSubscriptions: () => number;
   isClosed: () => boolean;
   stop: () => Promise<void>;
 };
@@ -39,6 +41,8 @@ async function startFakeEngine(): Promise<FakeEngine> {
   const busy = new Set<string>();
   const aborted: string[] = [];
   const eventClients = new Set<ServerResponse>();
+  let globalEventSubscriptions = 0;
+  let instanceEventSubscriptions = 0;
   let closed = false;
 
   const server: Server = createServer((request, response) => {
@@ -48,10 +52,16 @@ async function startFakeEngine(): Promise<FakeEngine> {
       response.end(JSON.stringify(Object.fromEntries([...busy].map((id) => [id, { type: "busy" }]))));
       return;
     }
-    if (url.pathname === "/event") {
+    if (url.pathname === "/global/event") {
+      globalEventSubscriptions += 1;
       response.writeHead(200, { "content-type": "text/event-stream" });
       eventClients.add(response);
       request.on("close", () => eventClients.delete(response));
+      return;
+    }
+    if (url.pathname === "/event") {
+      instanceEventSubscriptions += 1;
+      response.writeHead(200, { "content-type": "text/event-stream" });
       return;
     }
     const abortMatch = url.pathname.match(/^\/session\/([^/]+)\/abort$/);
@@ -90,12 +100,17 @@ async function startFakeEngine(): Promise<FakeEngine> {
       close: stop,
     },
     aborted,
+    globalEventSubscriptions: () => globalEventSubscriptions,
+    instanceEventSubscriptions: () => instanceEventSubscriptions,
     setBusy: (sessionIds) => {
       busy.clear();
       for (const id of sessionIds) busy.add(id);
     },
     emit: (sessionId) => {
-      const frame = `data: ${JSON.stringify({ type: "session.updated", properties: { sessionID: sessionId } })}\n\n`;
+      const frame = `data: ${JSON.stringify({
+        directory: "/workspace",
+        payload: { type: "session.updated", properties: { sessionID: sessionId } },
+      })}\n\n`;
       for (const client of eventClients) client.write(frame);
     },
     isClosed: () => closed,
@@ -112,20 +127,22 @@ type Scenario = {
   dispose: () => Promise<void>;
 };
 
-async function startScenario(root: string, name: string): Promise<Scenario> {
+async function startScenario(root: string, name: string, workspaceCount = 1): Promise<Scenario> {
   const old = await startFakeEngine();
   const next = await startFakeEngine();
   const runtimeConfigPath = join(root, `${name}-runtime-config.json`);
   await writeFile(runtimeConfigPath, JSON.stringify({ scenario: name }));
 
-  const workspace: WorkspaceInfo = {
-    id: `ws_${name}`,
-    name: `Drain ${name}`,
-    path: join(root, name),
+  const workspaces = Array.from({ length: workspaceCount }, (_, index): WorkspaceInfo => ({
+    id: `ws_${name}_${index}`,
+    name: `Drain ${name} ${index}`,
+    path: join(root, `${name}-${index}`),
     preset: "starter",
     workspaceType: "local",
     baseUrl: old.handle.url,
-  };
+  }));
+  const workspace = workspaces[0];
+  if (!workspace) throw new Error("a drain scenario needs at least one workspace");
   const config = {
     host: "127.0.0.1",
     port: 0,
@@ -133,7 +150,7 @@ async function startScenario(root: string, name: string): Promise<Scenario> {
     configPath: join(root, `${name}-server.json`),
     approval: { mode: "auto", timeoutMs: 1_000 },
     corsOrigins: ["*"],
-    workspaces: [workspace],
+    workspaces,
     authorizedRoots: [root],
     readOnly: false,
     startedAt: Date.now(),
@@ -208,6 +225,9 @@ briefTest(testBrief({
     inactivityBound: claim("a non-idle session that emits nothing for the whole grace period is aborted and its generation force-retired", {
       never: "keep a wedged generation alive indefinitely once activity stops",
     }),
+    boundedActivityWatch: claim("one global engine event subscription covers activity across 32 local workspaces", {
+      never: "open one event subscription per workspace and multiply engine event queues",
+    }),
   },
 }), async ({ prove }) => {
   const savedEnv = new Map<string, string | undefined>();
@@ -219,7 +239,7 @@ briefTest(testBrief({
   const scenarios: Scenario[] = [];
   try {
     // activeRunSurvival + cleanRetire — one continuously streaming session.
-    const streaming = await startScenario(root, "streaming");
+    const streaming = await startScenario(root, "streaming", 32);
     scenarios.push(streaming);
     streaming.old.setBusy(["ses_streaming"]);
     const streamingRollover = await streaming.rollover();
@@ -229,6 +249,10 @@ briefTest(testBrief({
     prove.activeRunSurvival(
       streamingRollover.action === "rolled_over" && survivedFourGracePeriods,
       `Rollover ${streamingRollover.action}; after 1200ms of streaming against a 300ms grace period the draining engine was ${streaming.old.isClosed() ? "closed" : "alive"} with ${streaming.old.aborted.length} aborts.`,
+    );
+    prove.boundedActivityWatch(
+      streaming.old.globalEventSubscriptions() === 1 && streaming.old.instanceEventSubscriptions() === 0,
+      `Across 32 local workspaces the draining generation opened ${streaming.old.globalEventSubscriptions()} global and ${streaming.old.instanceEventSubscriptions()} instance event subscriptions.`,
     );
 
     clearInterval(heartbeat);


### PR DESCRIPTION
## Summary

- replace one directory-scoped `/event` subscription per local workspace with one `/global/event` subscription per draining engine generation
- preserve owned-session filtering, reconnect behavior, and inactivity-deadline extension for nested global event payloads
- cover 32 local workspaces and assert the drain monitor opens exactly one global stream and zero instance streams

## Why

The drain activity monitor only needs generation-wide activity for sessions owned by the superseded engine. Opening a separate OpenCode event stream for every workspace multiplies per-stream event delivery and queueing during long drains without adding signal.

## Verification

- `pnpm --filter openwork-server test src/engine-pool.test.ts` — 19 passed, 0 failed
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm evals:pr specs/engine-drain-activity-survival.test.ts` — 1 passed, 0 failed, 0 skipped

Testkit proof ran on the supported local lane because Daytona credentials were unavailable in the current environment. The exact-head evidence run is bound to `0ba08c6d8d137babc4a08048ab230bd1c81f4c74`.