### PR TITLE
fix(evals): resolve Agent Plugin workspace imports from source

### DIFF
--- a/evals/specs/agent-plugin-import-compat.test.ts
+++ b/evals/specs/agent-plugin-import-compat.test.ts
@@ -19,6 +19,8 @@ function runBunTests(input: {
     "exec",
     "bun",
     "test",
+    "--conditions",
+    "development",
     ...input.files,
     "--reporter=junit",
     `--reporter-outfile=${input.reportPath}`,


### PR DESCRIPTION
## Summary

- run the nested Den API Bun tests with the same development export condition as the package test script
- resolve private workspace packages from their checked-in TypeScript sources on fresh CI installs
- remove the order dependency on another eval building `@openwork/enterprise-mcp-client` first

## Root cause

The Agent Plugin compatibility spec spawned selected Den API tests without Bun’s `development` export condition. After the merged Agent Plugin work pulled `@openwork/enterprise-mcp-client` into that import path, Bun followed the package default export to an unbuilt `dist/index.js`. A concurrent production-package spec could build that output first and mask the defect, making the full lane order-dependent.

## Verification

- `pnpm evals:pr specs/agent-plugin-import-compat.test.ts` — 1 passed, 0 failed, 0 skipped; nested Den API tests 30 passed, 0 failed
- `git diff --check` — passed
- Full local PR lane reached the repaired spec successfully; two unrelated local-world checks exercised local MySQL instead of taking the CI skip path and failed on their existing fixtures. The PR OpenWork Tests matrix is the authoritative full-lane confirmation.