### PR TITLE
fix(app): dedupe session search results

### DIFF
--- a/apps/app/src/react-app/domains/session/search/session-search.ts
+++ b/apps/app/src/react-app/domains/session/search/session-search.ts
@@ -9,6 +9,20 @@ export type SearchableSession = {
   updatedAt: number;
 };
 
+export function searchableSessionKey(session: SearchableSession): string {
+  return `${session.workspaceId}\u0000${session.sessionId}`;
+}
+
+export function dedupeSearchableSessions(sessions: SearchableSession[]): SearchableSession[] {
+  const unique = new Map<string, SearchableSession>();
+  for (const session of sessions) {
+    const key = searchableSessionKey(session);
+    const existing = unique.get(key);
+    if (!existing || session.updatedAt > existing.updatedAt) unique.set(key, session);
+  }
+  return [...unique.values()];
+}
+
 export type SessionSearchSnippet = {
   before: string;
   match: string;

--- a/apps/app/src/react-app/shell/session-search-dialog.tsx
+++ b/apps/app/src/react-app/shell/session-search-dialog.tsx
@@ -23,6 +23,8 @@ import {
 import { formatRelativeTime } from "@/app/utils";
 import {
   createSessionSearcher,
+  dedupeSearchableSessions,
+  searchableSessionKey,
   type SearchableSession,
   type SessionMessageFetcher,
   type SessionSearchMatch,
@@ -117,6 +119,7 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
 
   const debouncedQuery = useDebouncedValue(query.trim(), DEBOUNCE_MS);
   const deepQuery = debouncedQuery.length >= MIN_QUERY_LENGTH ? debouncedQuery : "";
+  const sessions = useMemo(() => dedupeSearchableSessions(props.sessions), [props.sessions]);
 
   // The searcher caches transcripts by session id + updatedAt, so it must
   // outlive individual keystrokes and dialog open/close cycles.
@@ -140,7 +143,7 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
     const collected: SessionSearchMatch[] = [];
     const run = searcher.search({
       query: deepQuery,
-      sessions: props.sessions,
+      sessions,
       onMatch: (match) => {
         collected.push(match);
         setMatches([...collected]);
@@ -148,12 +151,12 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
       onProgress: setProgress,
     });
     return () => run.cancel();
-  }, [props.open, props.sessions, searcher, deepQuery]);
+  }, [props.open, sessions, searcher, deepQuery]);
 
   const groups = useMemo<ResultGroup[]>(() => {
     const trimmed = query.trim();
     if (!trimmed) {
-      const recent = [...props.sessions]
+      const recent = [...sessions]
         .sort((a, b) => b.updatedAt - a.updatedAt)
         .slice(0, RECENT_LIMIT)
         .map((session) => ({
@@ -169,13 +172,13 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
     const seen = new Set<string>();
 
     const titleItems: ResultItem[] = [];
-    const titleHits = fuzzysort.go(trimmed, props.sessions, {
+    const titleHits = fuzzysort.go(trimmed, sessions, {
       keys: ["title", "workspaceTitle"],
       limit: TITLE_LIMIT,
     });
     for (const hit of titleHits) {
       const session = hit.obj;
-      seen.add(session.sessionId);
+      seen.add(searchableSessionKey(session));
       titleItems.push({
         id: `title:${session.workspaceId}:${session.sessionId}`,
         kind: "title",
@@ -188,8 +191,9 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
       (a, b) => b.session.updatedAt - a.session.updatedAt,
     );
     for (const match of messageHits) {
-      if (seen.has(match.session.sessionId)) continue;
-      seen.add(match.session.sessionId);
+      const sessionKey = searchableSessionKey(match.session);
+      if (seen.has(sessionKey)) continue;
+      seen.add(sessionKey);
       if (titleItems.length + messageItems.length >= RESULT_LIMIT) break;
       messageItems.push({
         id: `message:${match.session.workspaceId}:${match.session.sessionId}`,
@@ -209,7 +213,7 @@ export function SessionSearchDialog(props: SessionSearchDialogProps) {
       out.push({ value: "Messages", kind: "message", items: messageItems });
     }
     return out;
-  }, [matches, props.sessions, query]);
+  }, [matches, query, sessions]);
 
   const resultCount = useMemo(
     () => groups.reduce((sum, group) => sum + group.items.length, 0),

--- a/evals/specs/session-search-identity.test.ts
+++ b/evals/specs/session-search-identity.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import {
+  dedupeSearchableSessions,
+  searchableSessionKey,
+  type SearchableSession,
+} from "../../apps/app/src/react-app/domains/session/search/session-search";
+
+const session = (workspaceId: string, sessionId: string, updatedAt: number): SearchableSession => ({
+  workspaceId,
+  sessionId,
+  title: `${workspaceId} ${sessionId} ${updatedAt}`,
+  workspaceTitle: workspaceId,
+  updatedAt,
+});
+
+test("session search keeps one fresh result per workspace session", () => {
+  const stale = session("workspace-a", "session-1", 10);
+  const fresh = session("workspace-a", "session-1", 20);
+  const otherWorkspace = session("workspace-b", "session-1", 15);
+
+  const unique = dedupeSearchableSessions([stale, otherWorkspace, fresh]);
+
+  expect(unique).toEqual([fresh, otherWorkspace]);
+  expect(unique.map(searchableSessionKey)).toEqual([
+    "workspace-a\u0000session-1",
+    "workspace-b\u0000session-1",
+  ]);
+  expect(new Set(unique.map(searchableSessionKey)).size).toBe(unique.length);
+});

--- a/evals/specs/session-search-identity.test.ts
+++ b/evals/specs/session-search-identity.test.ts
@@ -14,7 +14,7 @@ const session = (workspaceId: string, sessionId: string, updatedAt: number): Sea
   updatedAt,
 });
 
-test("session search keeps one fresh result per workspace session", () => {
+test("session search keeps one fresh result per workspace session", ({ evidence }) => {
   const stale = session("workspace-a", "session-1", 10);
   const fresh = session("workspace-a", "session-1", 20);
   const otherWorkspace = session("workspace-b", "session-1", 15);
@@ -27,4 +27,10 @@ test("session search keeps one fresh result per workspace session", () => {
     "workspace-b\u0000session-1",
   ]);
   expect(new Set(unique.map(searchableSessionKey)).size).toBe(unique.length);
+
+  evidence.recordAssertionEvidence(
+    "Session search renders one result per workspace session identity",
+    "Duplicate entries collapsed to the freshest record while an identical session id in another workspace remained distinct.",
+    true,
+  );
 });


### PR DESCRIPTION
## Summary
- deduplicate session-search inputs by workspace and session identity
- retain the freshest duplicate and keep same session IDs in different workspaces distinct
- add a testkit regression spec for stable unique result identities

## Verification
**Passed** (local PR lane)

- `pnpm evals:pr specs/session-search-identity.test.ts` — exit 0; 1 passed, 0 failed, 0 skipped
- `pnpm --filter @openwork/app typecheck` — exit 0
- `pnpm --filter @openwork/app exec bun test --isolate tests/session-search.test.ts` — exit 0; 1 passed, 0 failed