### PR TITLE
ci: publish nightly pr-lane flake report and alert on unreliable specs

### DIFF
--- a/.github/workflows/e2e-test-failure-alerts.yml
+++ b/.github/workflows/e2e-test-failure-alerts.yml
@@ -8,6 +8,7 @@ on:
     workflows:
       - Nightly Critical-Path E2E Journey
       - Daytona E2E Regression Suite
+      - Nightly Flake Report
     types:
       - completed
 
@@ -46,6 +47,7 @@ jobs:
           case "$RUN_NAME" in
             "Nightly Critical-Path E2E Journey") issue_title="Nightly critical-path E2E journey failed" ;;
             "Daytona E2E Regression Suite") issue_title="Daytona E2E regression suite failed" ;;
+            "Nightly Flake Report") issue_title="Nightly flake report found unreliable specs" ;;
             *) echo "Unexpected workflow: $RUN_NAME" >&2; exit 1 ;;
           esac
 

--- a/.github/workflows/nightly-flake-report.yml
+++ b/.github/workflows/nightly-flake-report.yml
@@ -1,0 +1,114 @@
+# Quantifies test reliability: runs the hermetic pr lane several times,
+# aggregates per-spec pass rates with evals/scripts/flake-report.mjs, publishes
+# the report to the run summary and artifacts, and fails when any spec is
+# flaky or below the pass-rate threshold so the failure-alert workflow files
+# a developer-facing issue.
+name: Nightly Flake Report
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "How many times to run the pr lane"
+        required: false
+        default: "3"
+        type: string
+      threshold:
+        description: "Quarantine pass-rate threshold (0-1]"
+        required: false
+        default: "0.95"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-flake-report
+  cancel-in-progress: false
+
+jobs:
+  flake-report:
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.4.0
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+          pnpm --dir evals install --frozen-lockfile
+
+      - name: Collect pr-lane runs
+        shell: bash
+        working-directory: evals
+        env:
+          FLAKE_RUNS: ${{ inputs.runs || '3' }}
+        run: |
+          set -euo pipefail
+          for index in $(seq 1 "$FLAKE_RUNS"); do
+            echo "::group::flake:collect run $index of $FLAKE_RUNS"
+            node scripts/flake-report.mjs collect --project pr
+            echo "::endgroup::"
+          done
+
+      - name: Aggregate flake report
+        shell: bash
+        working-directory: evals
+        env:
+          FLAKE_THRESHOLD: ${{ inputs.threshold || '0.95' }}
+        run: |
+          set -euo pipefail
+          node scripts/flake-report.mjs report --project pr --threshold "$FLAKE_THRESHOLD"
+          cat results/flake/pr/flake-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish scenario coverage matrix
+        shell: bash
+        working-directory: evals
+        run: |
+          set -euo pipefail
+          node scripts/spec-coverage-matrix.mjs --out results/flake/spec-coverage-matrix.md
+          {
+            echo ""
+            head -3 results/flake/spec-coverage-matrix.md
+            echo ""
+            echo "Full matrix in the run artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload flake report artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nightly-flake-report
+          path: evals/results/flake/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Fail on flaky or quarantined specs
+        shell: bash
+        working-directory: evals
+        run: |
+          set -euo pipefail
+          flaky="$(node -p "JSON.parse(require('node:fs').readFileSync('results/flake/pr/flake-report.json', 'utf8')).flakySpecs")"
+          quarantine="$(node -p "JSON.parse(require('node:fs').readFileSync('results/flake/pr/flake-report.json', 'utf8')).quarantineSpecs")"
+          if [ "$flaky" != "0" ] || [ "$quarantine" != "0" ]; then
+            echo "::error::Flake report found $flaky flaky and $quarantine below-threshold specs. See the run summary."
+            exit 1
+          fi
+          echo "All specs stable across the collected runs."


### PR DESCRIPTION
Follow-up to #4213 (the reporting destination for the flake tooling; the tooling merged before this wiring commit was pushed).

## What

**New workflow: `Nightly Flake Report`** (`.github/workflows/nightly-flake-report.yml`)
- Nightly at 04:17 UTC + `workflow_dispatch` with `runs` (default 3) and `threshold` (default 0.95) inputs.
- Loops `node scripts/flake-report.mjs collect --project pr` N times, then aggregates with `flake-report.mjs report`.
- Publishes:
  - the per-spec pass-rate table to the run summary (`$GITHUB_STEP_SUMMARY`),
  - flake receipts + `flake-report.md`/`.json` + the scenario coverage matrix as the `nightly-flake-report` artifact (30-day retention),
  - the matrix headline (currently 217 specs, 11 mapped to a contract) to the summary.
- Fails the run when any spec is flaky (passed and failed across runs) or below the pass-rate threshold.

**Alert wiring** (`e2e-test-failure-alerts.yml`)
- Added `Nightly Flake Report` to the watched workflows, so a red flake run opens/updates a "Nightly flake report found unreliable specs" issue with the run link — same path as the existing E2E failure alerts.

## Verification

- Both workflow files parse as YAML.
- Simulated the workflow body locally end-to-end: 2× `flake:collect --project pr` on a fast spec → `flake:report --threshold 0.95` → matrix `--out` → gate step read `flakySpecs=0 quarantineSpecs=0` from `flake-report.json` and passed.
- CI-config-only change; no product runtime behavior touched. The scheduled run itself is the runtime proof once merged (or trigger via `workflow_dispatch`).