### PR TITLE
refactor(server): make the Connect MCP desired config account-global

### DIFF
--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -52,7 +52,9 @@ import {
 import { resolveWorkspaceOpencodeConnection } from "./opencode-connection.js";
 import { buildOpenworkRuntimeConfigObjectFromSnapshot } from "./openwork-runtime-config.js";
 import {
+  ENGINE_GLOBAL_RUNTIME_CONFIG_ID,
   inspectRuntimeOpencodeConfigState,
+  mergeRuntimeOpencodeConfigLayers,
   runtimeMcpMap,
   type RuntimeOpencodeConfig,
   type RuntimeOpencodeConfigInspection,
@@ -1289,9 +1291,16 @@ export async function runAgentContextDiagnostics(input: {
   const managedVaultInspection = input.workspace.workspaceType === "remote"
     ? null
     : await inspectLocalManagedMcpVault(input.config);
+  const globalRuntimeInspection = await inspectRuntimeOpencodeConfigState(
+    input.config,
+    ENGINE_GLOBAL_RUNTIME_CONFIG_ID,
+    { signal: input.dependencies?.signal },
+  );
+  const runtime = input.workspace.workspaceType === "remote"
+    ? globalRuntimeInspection.config
+    : mergeRuntimeOpencodeConfigLayers(globalRuntimeInspection.config, runtimeInspection.config);
   input.dependencies?.signal?.throwIfAborted();
   const runtimeDuration = elapsed(runtimeStarted, now);
-  const runtime = runtimeInspection.config;
   const expectedRuntimeConfig = buildOpenworkRuntimeConfigObjectFromSnapshot(runtime);
   const expectedAgents = isRecord(expectedRuntimeConfig.agent) ? expectedRuntimeConfig.agent : {};
   const expectedAgent = isRecord(expectedAgents.openwork) ? expectedAgents.openwork : null;

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -23,6 +23,7 @@ import {
 import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
+import { migrateOpenworkCloudMcpRuntimeConfig } from "./cloud-mcp-health.js";
 import { resolveOpencodeModelsUrl } from "./opencode-models-url.js";
 import { startWorkerActivityHeartbeat } from "./worker-activity-heartbeat.js";
 import pkg from "../package.json" with { type: "json" };
@@ -48,6 +49,7 @@ let enginePool: EnginePool | null = null;
 
 if (!config.readOnly) {
   await ensureLocalWorkspaceFiles(config.workspaces);
+  await migrateOpenworkCloudMcpRuntimeConfig(config);
 }
 
 // Bind the HTTP server before spawning the engine: serve-node may fall back

--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -10,11 +10,18 @@ import {
   clearOpenworkCloudMcpProbeFlights,
   OPENWORK_CLOUD_EXPECTED_TOOLS,
   OPENWORK_CLOUD_PLUGIN_CANARIES,
+  migrateOpenworkCloudMcpRuntimeConfig,
   readOpenworkCloudMcpHealth,
 } from "./cloud-mcp-health.js";
 import { sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
 import { diagnoseMcpToolDeniesFromConfigs } from "./mcp.js";
-import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  readEffectiveRuntimeOpencodeConfig,
+  readGlobalRuntimeOpencodeConfig,
+  readRuntimeOpencodeConfig,
+  writeGlobalRuntimeOpencodeConfig,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 const workspace: WorkspaceInfo = {
@@ -243,15 +250,10 @@ async function setupDirectProbeHarness(mode: DirectProbeMode, workspaceIds = ["w
     headers: { Authorization: "Bearer owt_health_cloud_token" },
     oauth: false,
   };
-  for (const testWorkspace of workspaces) {
-    await writeRuntimeOpencodeConfig(config, testWorkspace.id, (current) => ({
-      ...current,
-      mcp: {
-        ...current.mcp,
-        "openwork-cloud": desiredConfig,
-      },
-    }));
-  }
+  await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+    ...current,
+    mcp: { ...current.mcp, "openwork-cloud": desiredConfig },
+  }));
   const read = async (workspaceId = primary.id, providerModel?: { provider: string; model: string }) => {
     const testWorkspace = workspaces.find((entry) => entry.id === workspaceId);
     if (!testWorkspace) throw new Error(`Unknown direct-probe workspace ${workspaceId}`);
@@ -359,6 +361,80 @@ describe("cloud MCP health foundation", () => {
     const changed = store.snapshot(workspace, workspace.path, "rev_2");
     expect(changed.state).toBe("pending");
     expect(changed.appliedRevision).toBeNull();
+  });
+
+  test("migrates the newest valid workspace config globally and preserves workspace state", async () => {
+    const root = await createRoot("openwork-cloud-migration-");
+    const workspaceA = { ...workspace, id: "ws_a", path: join(root, "a") };
+    const workspaceB = { ...workspace, id: "ws_b", path: join(root, "b") };
+    const workspaceC = { ...workspace, id: "ws_c", path: join(root, "c") };
+    const config = serverConfig(root, workspaceA);
+    config.workspaces = [workspaceA, workspaceB, workspaceC];
+    process.env.OPENWORK_RUNTIME_DB = await createRuntimeDbPath("openwork-cloud-migration-runtime-");
+    const older = { type: "remote", url: "https://older.example/mcp/agent", enabled: true, headers: { Authorization: "Bearer older" }, oauth: false };
+    const newer = { ...older, url: "https://newer.example/mcp/agent", headers: { Authorization: "Bearer newer" } };
+    await writeRuntimeOpencodeConfig(config, workspaceA.id, () => ({
+      plugin: ["keep-a"],
+      mcp: { "openwork-cloud": older, posthog: { type: "remote", url: "https://posthog.example/mcp" } },
+    }));
+    await Bun.sleep(2);
+    await writeRuntimeOpencodeConfig(config, workspaceB.id, () => ({
+      disabled_providers: ["keep-b"],
+      mcp: { "openwork-cloud": newer, stripe: { type: "remote", url: "https://stripe.example/mcp" } },
+    }));
+    await Bun.sleep(2);
+    await writeRuntimeOpencodeConfig(config, workspaceC.id, () => ({
+      mcp: {
+        "openwork-cloud": { ...newer, headers: {} },
+        linear: { type: "remote", url: "https://linear.example/mcp" },
+      },
+    }));
+
+    expect(await migrateOpenworkCloudMcpRuntimeConfig(config)).toMatchObject({ config: newer, changed: true });
+    expect((await readGlobalRuntimeOpencodeConfig(config)).mcp?.["openwork-cloud"]).toEqual(newer);
+    expect(await readRuntimeOpencodeConfig(config, workspaceA.id)).toEqual({
+      plugin: ["keep-a"],
+      mcp: { posthog: { type: "remote", url: "https://posthog.example/mcp" } },
+    });
+    expect(await readRuntimeOpencodeConfig(config, workspaceB.id)).toEqual({
+      disabled_providers: ["keep-b"],
+      mcp: { stripe: { type: "remote", url: "https://stripe.example/mcp" } },
+    });
+    expect((await readRuntimeOpencodeConfig(config, workspaceC.id)).mcp).toEqual({
+      linear: { type: "remote", url: "https://linear.example/mcp" },
+    });
+    expect((await readEffectiveRuntimeOpencodeConfig(config, workspaceA.id)).mcp?.["openwork-cloud"]).toEqual(newer);
+    expect((await readEffectiveRuntimeOpencodeConfig(config, workspaceB.id)).mcp?.["openwork-cloud"]).toEqual(newer);
+    expect(await migrateOpenworkCloudMcpRuntimeConfig(config)).toEqual({ config: newer, changed: false });
+  });
+
+  test("does not mutate legacy rows while the server is read-only", async () => {
+    const root = await createRoot("openwork-cloud-readonly-migration-");
+    const config = serverConfig(root, workspace);
+    process.env.OPENWORK_RUNTIME_DB = await createRuntimeDbPath("openwork-cloud-readonly-migration-runtime-");
+    const desired = { type: "remote", url: "https://cloud.example/mcp/agent", enabled: true, headers: { Authorization: "Bearer token" }, oauth: false };
+    await writeRuntimeOpencodeConfig(config, workspace.id, () => ({ mcp: { "openwork-cloud": desired } }));
+    config.readOnly = true;
+
+    expect(await migrateOpenworkCloudMcpRuntimeConfig(config)).toEqual({ config: desired, changed: false });
+    expect((await readGlobalRuntimeOpencodeConfig(config)).mcp?.["openwork-cloud"]).toBeUndefined();
+    expect((await readRuntimeOpencodeConfig(config, workspace.id)).mcp?.["openwork-cloud"]).toEqual(desired);
+  });
+
+  test("keeps delivery state independent for two directories sharing global desired state", () => {
+    const store = new CloudMcpDeliveryStateStore();
+    const workspaceB = { ...workspace, id: "ws_b", path: "/workspace-b" };
+    const metadata = {
+      token: { present: true, metadata: {} },
+      connectCatalogEnabled: true,
+      updatedAt: 1,
+    };
+    store.markDesired(workspace, workspace.path, "global-revision", metadata);
+    store.markDesired(workspaceB, workspaceB.path, "global-revision", metadata);
+    store.markReady(workspace, workspace.path, "global-revision");
+
+    expect(store.snapshot(workspace, workspace.path, "global-revision").state).toBe("ready");
+    expect(store.snapshot(workspaceB, workspaceB.path, "global-revision").state).toBe("pending");
   });
 
   test("diagnoses project and global OpenCode tool denies for exact Cloud IDs", () => {
@@ -526,7 +602,7 @@ describe("cloud MCP health foundation", () => {
       ...harness.desiredConfig,
       headers: { Authorization: "Bearer owt_health_cloud_token_changed" },
     };
-    await writeRuntimeOpencodeConfig(harness.config, workspaceA.id, (current) => ({
+    await writeGlobalRuntimeOpencodeConfig(harness.config, (current) => ({
       ...current,
       mcp: { ...current.mcp, "openwork-cloud": changedConfig },
     }));

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -5,7 +5,15 @@ import { ApiError } from "./errors.js";
 import { diagnoseMcpToolDenies, type McpToolDeny } from "./mcp.js";
 import { openworkPluginPath } from "./openwork-extensions-plugin-path.js";
 import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
-import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  ENGINE_GLOBAL_RUNTIME_CONFIG_ID,
+  listRuntimeOpencodeConfigRows,
+  readGlobalRuntimeOpencodeConfig,
+  readRuntimeOpencodeConfig,
+  runtimeMcpMap,
+  writeGlobalRuntimeOpencodeConfig,
+  writeRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
 import { externalFetch } from "./server-fetch.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 import { validateMcpConfig } from "./validators.js";
@@ -856,8 +864,7 @@ async function readDesiredState(input: {
   directory: string | null;
   connectCatalogEnabled?: boolean;
 }): Promise<CloudMcpDesiredState> {
-  const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);
-  const entry = runtimeMcpMap(runtimeConfig)[OPENWORK_CLOUD_MCP_NAME];
+  const entry = await readPersistedDesiredConfig(input.config, input.workspace.id);
   if (!entry) {
     const metadata = defaultDesiredMetadata(null, input.connectCatalogEnabled ?? false);
     return { present: false, revision: null, config: null, redactedConfig: null, metadata };
@@ -876,6 +883,83 @@ async function readDesiredState(input: {
     metadata: revisionMetadata,
     ...(validationProblem ? { validationProblem } : {}),
   };
+}
+
+async function readPersistedDesiredConfig(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const globalEntry = runtimeMcpMap(await readGlobalRuntimeOpencodeConfig(config))[OPENWORK_CLOUD_MCP_NAME];
+  if (globalEntry) return globalEntry;
+  return runtimeMcpMap(await readRuntimeOpencodeConfig(config, workspaceId))[OPENWORK_CLOUD_MCP_NAME];
+}
+
+export async function migrateOpenworkCloudMcpRuntimeConfig(
+  config: ServerConfig,
+): Promise<{ config: Record<string, unknown> | null; changed: boolean }> {
+  const rows = await listRuntimeOpencodeConfigRows(config);
+  const globalRow = rows.find((row) => row.workspaceId === ENGINE_GLOBAL_RUNTIME_CONFIG_ID);
+  const globalEntry = globalRow
+    ? runtimeMcpMap(globalRow.value)[OPENWORK_CLOUD_MCP_NAME]
+    : undefined;
+  const newestValidLegacy = rows
+    .filter((row) => row.workspaceId !== ENGINE_GLOBAL_RUNTIME_CONFIG_ID)
+    .flatMap((row) => {
+      const entry = runtimeMcpMap(row.value)[OPENWORK_CLOUD_MCP_NAME];
+      if (!entry || !isRecord(entry)) return [];
+      const normalized = canonicalizeCloudMcpConfig(entry);
+      const metadata = defaultDesiredMetadata(normalized, true);
+      return strictCloudMcpDesiredConfigProblem(normalized, metadata)
+        ? []
+        : [{ config: normalized, updatedAt: row.updatedAt, workspaceId: row.workspaceId }];
+    })
+    .sort((left, right) => right.updatedAt - left.updatedAt || left.workspaceId.localeCompare(right.workspaceId))[0];
+  const selected = globalEntry ?? newestValidLegacy?.config;
+  if (!selected || config.readOnly) return { config: selected ?? null, changed: false };
+
+  let changed = false;
+  if (!globalEntry) {
+    const result = await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+      ...current,
+      mcp: { ...runtimeMcpMap(current), [OPENWORK_CLOUD_MCP_NAME]: selected },
+    }));
+    changed = result.changed;
+  }
+  for (const row of rows) {
+    if (
+      row.workspaceId === ENGINE_GLOBAL_RUNTIME_CONFIG_ID
+      || !Object.hasOwn(runtimeMcpMap(row.value), OPENWORK_CLOUD_MCP_NAME)
+    ) continue;
+    const result = await writeRuntimeOpencodeConfig(config, row.workspaceId, (current) => ({
+      ...current,
+      mcp: Object.fromEntries(Object.entries(runtimeMcpMap(current))
+        .filter(([name]) => name !== OPENWORK_CLOUD_MCP_NAME)),
+    }));
+    changed = result.changed || changed;
+  }
+  return { config: selected, changed };
+}
+
+export async function removeOpenworkCloudMcpDesiredConfig(config: ServerConfig): Promise<boolean> {
+  let changed = false;
+  for (const row of await listRuntimeOpencodeConfigRows(config)) {
+    if (!Object.hasOwn(runtimeMcpMap(row.value), OPENWORK_CLOUD_MCP_NAME)) continue;
+    const result = row.workspaceId === ENGINE_GLOBAL_RUNTIME_CONFIG_ID
+      ? await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+          ...current,
+          mcp: Object.fromEntries(Object.entries(runtimeMcpMap(current))
+            .filter(([name]) => name !== OPENWORK_CLOUD_MCP_NAME)),
+        }))
+      : await writeRuntimeOpencodeConfig(config, row.workspaceId, (current) => ({
+          ...current,
+          mcp: Object.fromEntries(Object.entries(runtimeMcpMap(current))
+            .filter(([name]) => name !== OPENWORK_CLOUD_MCP_NAME)),
+        }));
+    changed = result.changed || changed;
+  }
+  const { writeConnectCloudMcp } = await import("./connect-state.js");
+  await writeConnectCloudMcp(config, null);
+  return changed;
 }
 
 function locationParams(directory: string | null): { directory?: string } {
@@ -2053,7 +2137,7 @@ async function readOpenworkCloudMcpHealthInternal(
       stage: "desired_config",
       retryable: false,
       recommendedAction: "Connect OpenWork Cloud",
-      message: "No openwork-cloud MCP desired config is persisted for this workspace.",
+      message: "No global openwork-cloud MCP desired config is persisted.",
       aliases: ["cloud_desired_missing"],
     }));
   }
@@ -2192,8 +2276,9 @@ export async function readOpenworkCloudMcpHealth(input: ReadOpenworkCloudMcpHeal
   return readOpenworkCloudMcpHealthInternal(input);
 }
 
-async function persistDesiredConfig(config: ServerConfig, workspaceId: string, desiredConfig: Record<string, unknown>): Promise<void> {
-  await writeRuntimeOpencodeConfig(config, workspaceId, (current) => ({
+async function persistDesiredConfig(config: ServerConfig, desiredConfig: Record<string, unknown>): Promise<{ changed: boolean }> {
+  const migrated = await migrateOpenworkCloudMcpRuntimeConfig(config);
+  const written = await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
     ...current,
     mcp: {
       ...runtimeMcpMap(current),
@@ -2204,6 +2289,7 @@ async function persistDesiredConfig(config: ServerConfig, workspaceId: string, d
   // Dynamic import avoids a connect-state <-> cloud-mcp-health cycle.
   const { writeConnectCloudMcp } = await import("./connect-state.js");
   await writeConnectCloudMcp(config, desiredConfig);
+  return { changed: migrated.changed || written.changed };
 }
 
 function registrationFailure(failures: CloudMcpRuntimeRegistrationFailure[]): CloudMcpFailure {
@@ -2284,6 +2370,7 @@ export async function reconcileOpenworkCloudMcp(input: {
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
+  fanoutGlobalDesired?: boolean;
 }): Promise<CloudMcpHealth> {
   const readHealth = (directProbeReuse?: DirectProbeReuse) => readOpenworkCloudMcpHealthInternal({
     config: input.config,
@@ -2305,8 +2392,25 @@ export async function reconcileOpenworkCloudMcp(input: {
     return healthWithFailure(await readHealth(), validationFailure);
   }
   const desiredRevision = calculateCloudMcpDesiredRevision(desiredConfig, metadata);
-  await persistDesiredConfig(input.config, input.workspace.id, desiredConfig);
+  const persisted = await persistDesiredConfig(input.config, desiredConfig);
   cloudMcpDeliveryState.markDesired(input.workspace, input.directory, desiredRevision, metadata);
+
+  // Re-deliver to other workspaces only when the global desired config actually
+  // changed: an unchanged reconcile must not bounce healthy connections elsewhere.
+  if (persisted.changed && input.fanoutGlobalDesired !== false) {
+    await Promise.all(input.config.workspaces
+      .filter((workspace) => workspace.id !== input.workspace.id)
+      .map(async (workspace) => {
+        const directory = workspace.workspaceType === "local" ? workspace.path : workspace.directory ?? null;
+        if (!directory) return;
+        await input.createWorkspaceOpencodeClient(input.config, workspace).mcp.disconnect({
+          name: OPENWORK_CLOUD_MCP_NAME,
+          ...locationParams(directory),
+        }).catch(() => undefined);
+        await input.registerRuntimeMcp(input.config, workspace, [OPENWORK_CLOUD_MCP_NAME], { throwOnFailure: false })
+          .catch(() => undefined);
+      }));
+  }
 
   if (!input.directory) {
     const directoryFailure = failure({
@@ -2393,8 +2497,9 @@ export async function reconcilePersistedOpenworkCloudMcp(input: {
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
   trigger?: string;
 }): Promise<CloudMcpHealth> {
-  const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);
-  const desiredConfig = runtimeMcpMap(runtimeConfig)[OPENWORK_CLOUD_MCP_NAME];
+  const migrated = await migrateOpenworkCloudMcpRuntimeConfig(input.config);
+  if (input.config.readOnly) return readOpenworkCloudMcpHealth(input);
+  const desiredConfig = migrated.config ?? await readPersistedDesiredConfig(input.config, input.workspace.id);
   if (!desiredConfig) {
     return readOpenworkCloudMcpHealth(input);
   }
@@ -2404,6 +2509,7 @@ export async function reconcilePersistedOpenworkCloudMcp(input: {
       config: desiredConfig,
       ...(input.trigger ? { trigger: input.trigger } : {}),
     },
+    fanoutGlobalDesired: false,
   });
 }
 
@@ -2463,8 +2569,7 @@ export async function refreshOpenworkCloudMcpEngine(input: {
     health,
   });
 
-  const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);
-  const desiredConfig = runtimeMcpMap(runtimeConfig)[OPENWORK_CLOUD_MCP_NAME];
+  const desiredConfig = await readPersistedDesiredConfig(input.config, input.workspace.id);
   if (!desiredConfig) {
     return finish(false, await readOpenworkCloudMcpHealth({ ...input, probe: true }), "desired_missing");
   }

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   readOpenWorkConnectMcpAppHostCatalog,
   type OpenWorkConnectMcpServerIndex,
 } from "./connect-mcp-server-catalog.js";
-import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { readGlobalRuntimeOpencodeConfig, readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { inspectEngineMcpRegistration, registerTrustedOpencodeProcess, startServer } from "./server.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
@@ -351,7 +351,8 @@ describe("openwork-cloud MCP strict reconcile", () => {
     expect(requireRecord(requireRecord(body.compatibility, "compatibility").opencode, "opencode").expectedVersion).toBeTruthy();
     expect(requireRecord(requireRecord(body.compatibility, "compatibility").experimentalToolIds, "experimentalToolIds")).toMatchObject({ includesMcpTools: true });
     expect(requireRecord(requireRecord(body.compatibility, "compatibility").experimentalProviderTools, "experimentalProviderTools")).toMatchObject({ includesMcpTools: true });
-    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]?.url).toBe(cloudConfigForOpenwork(openwork.base).url);
+    expect((await readGlobalRuntimeOpencodeConfig(openwork.config)).mcp?.["openwork-cloud"]?.url).toBe(cloudConfigForOpenwork(openwork.base).url);
+    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]).toBeUndefined();
 
     const mcpPosts = mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp");
     expect(mcpPosts.length).toBe(1);
@@ -392,7 +393,8 @@ describe("openwork-cloud MCP strict reconcile", () => {
 
     const runtime = await readRuntimeOpencodeConfig(openwork.config, "ws_1");
     expect(runtime.mcp?.["user-server"]).toEqual({ type: "remote", url: "https://user.example/mcp" });
-    expect(runtime.mcp?.["openwork-cloud"]).toBeTruthy();
+    expect(runtime.mcp?.["openwork-cloud"]).toBeUndefined();
+    expect((await readGlobalRuntimeOpencodeConfig(openwork.config)).mcp?.["openwork-cloud"]).toBeTruthy();
     expect(Object.keys(runtime.mcp ?? {}).filter((name) => name.startsWith("openwork-connect-"))).toEqual([]);
     expect((await readOpenWorkConnectMcpAppHostCatalog(openwork.config, "ws_1")).servers).toEqual([
       expect.objectContaining({ connectionId, name: "Private fixture provider" }),
@@ -470,7 +472,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
       config: { ...CLOUD_CONFIG, url },
     }));
     expect(body.phase).toBe("ready");
-    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]?.url).toBe(url.slice(0, -1));
+    expect((await readGlobalRuntimeOpencodeConfig(openwork.config)).mcp?.["openwork-cloud"]?.url).toBe(url.slice(0, -1));
   });
 
   test("GET health reports persisted malformed desired config even when the engine looks live", async () => {
@@ -551,7 +553,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
     expect(response.status).toBe(200);
     expect(firstFailure(body).code).toBe("opencode_mcp_sync_failed");
     expect(delivery(body).appliedRevision).toBeNull();
-    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]?.url).toBe(cloudConfigForOpenwork(openwork.base).url);
+    expect((await readGlobalRuntimeOpencodeConfig(openwork.config)).mcp?.["openwork-cloud"]?.url).toBe(cloudConfigForOpenwork(openwork.base).url);
   });
 
   test("uses the exact secondary workspace directory", async () => {
@@ -567,8 +569,40 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const response = await reconcile(openwork.base, "ws_2");
     const body = await responseRecord(response);
     expect(body.phase).toBe("ready");
-    const post = mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp");
+    const post = mock.requests.find((request) => request.method === "POST"
+      && request.pathname === "/mcp"
+      && new URLSearchParams(request.search).get("directory") === rootB);
     expectDirectoryQuery(post?.search, rootB);
+    expect(mock.requests.some((request) => request.method === "POST"
+      && request.pathname === "/mcp"
+      && new URLSearchParams(request.search).get("directory") === rootA)).toBe(true);
+  });
+
+  test("removes global desired state and disconnects every workspace directory", async () => {
+    const rootA = await createRoot("openwork-cloud-remove-a-");
+    const rootB = await createRoot("openwork-cloud-remove-b-");
+    const mock = startMockOpencode();
+    const baseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const openwork = await startOpenwork([
+      workspace("ws_1", rootA, baseUrl),
+      workspace("ws_2", rootB, baseUrl),
+    ]);
+    expect((await responseRecord(await reconcile(openwork.base))).phase).toBe("ready");
+    const disconnectsBeforeRemoval = mock.requests
+      .filter((request) => request.pathname === "/mcp/openwork-cloud/disconnect").length;
+
+    const removed = await fetch(`${openwork.base}/workspace/ws_1/mcp/openwork-cloud`, {
+      method: "DELETE",
+      headers: headers(),
+    });
+    expect(removed.status).toBe(200);
+    expect((await readGlobalRuntimeOpencodeConfig(openwork.config)).mcp?.["openwork-cloud"]).toBeUndefined();
+    const disconnectDirectories = mock.requests
+      .filter((request) => request.pathname === "/mcp/openwork-cloud/disconnect")
+      .slice(disconnectsBeforeRemoval)
+      .map((request) => new URLSearchParams(request.search).get("directory"))
+      .sort();
+    expect(disconnectDirectories).toEqual([rootA, rootB].sort());
   });
 
   test("uses an explicit remote workspace directory and refuses ambiguous remotes", async () => {
@@ -583,7 +617,9 @@ describe("openwork-cloud MCP strict reconcile", () => {
 
     const ready = await reconcile(openwork.base, "ws_remote");
     expect((await responseRecord(ready)).phase).toBe("ready");
-    expectDirectoryQuery(mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp")?.search, explicitDirectory);
+    expectDirectoryQuery(mock.requests.find((request) => request.method === "POST"
+      && request.pathname === "/mcp"
+      && new URLSearchParams(request.search).get("directory") === explicitDirectory)?.search, explicitDirectory);
 
     const catalogReadsBeforeAmbiguous = mock.requests.filter((request) => (
       isRecord(request.body) && request.body.method === "resources/read"

--- a/apps/server/src/connect-automation-catalog.ts
+++ b/apps/server/src/connect-automation-catalog.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { escapeXml, readMcpResourceText, type McpFetch } from "./connect-mcp-transport.js";
 import { readConnectCloudMcp } from "./connect-state.js";
-import { readRuntimeMcpConfig } from "./runtime-opencode-config-store.js";
+import { readGlobalRuntimeMcpConfig, readRuntimeMcpConfig } from "./runtime-opencode-config-store.js";
 import { externalFetch } from "./server-fetch.js";
 import type { ServerConfig } from "./types.js";
 
@@ -80,6 +80,8 @@ export async function readOpenWorkAutomationCatalog(
 ): Promise<OpenWorkAutomationIndex | null> {
   try {
     const candidates: Array<Record<string, unknown>> = [];
+    const globalCloud = await readGlobalRuntimeMcpConfig(config, OPENWORK_CLOUD_MCP_NAME);
+    if (globalCloud) candidates.push(globalCloud);
     const serverCloud = await readConnectCloudMcp(config);
     if (serverCloud) candidates.push(serverCloud);
     for (const workspace of config.workspaces) {

--- a/apps/server/src/connect-mcp-server-catalog.ts
+++ b/apps/server/src/connect-mcp-server-catalog.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { readMcpResourceText, type McpFetch } from "./connect-mcp-transport.js";
 import { readActivatedEnterpriseDenOrigin } from "./enterprise-den-origin.js";
 import {
+  readGlobalRuntimeMcpConfig,
   readRuntimeMcpConfig,
   runtimeMcpMap,
   writeRuntimeOpencodeConfig,
@@ -252,7 +253,8 @@ export async function refreshOpenWorkConnectMcpAppHostCatalog(
   workspaceId: string,
   fetcher?: McpFetch,
 ): Promise<{ status: "synced" | "unavailable"; appHostNames: string[] }> {
-  const cloudMcp = await readRuntimeMcpConfig(config, workspaceId, "openwork-cloud");
+  const cloudMcp = await readGlobalRuntimeMcpConfig(config, "openwork-cloud")
+    ?? await readRuntimeMcpConfig(config, workspaceId, "openwork-cloud");
   if (!cloudMcp || !await trustedAppHostCloudEndpoint(cloudMcp)) {
     return { status: "unavailable", appHostNames: [] };
   }

--- a/apps/server/src/connect-skill-catalog.ts
+++ b/apps/server/src/connect-skill-catalog.ts
@@ -10,7 +10,7 @@ import {
   type McpFetch,
 } from "./connect-mcp-transport.js";
 import { readConnectCloudMcp, writeConnectCloudMcp } from "./connect-state.js";
-import { readRuntimeMcpConfig } from "./runtime-opencode-config-store.js";
+import { readGlobalRuntimeMcpConfig, readRuntimeMcpConfig } from "./runtime-opencode-config-store.js";
 import { externalFetch } from "./server-fetch.js";
 import type { ServerConfig } from "./types.js";
 
@@ -89,8 +89,8 @@ async function readIndexCached(cloud: Record<string, unknown>, fetcher: McpFetch
 
 /**
  * Resolve the skill catalog from the first *working* openwork-cloud config.
- * Candidates are tried in order: the server-scoped connect-state copy, then
- * each workspace runtime row (legacy scope). Stale rows — e.g. a revoked token
+ * Candidates are tried in order: the global runtime row, the server-scoped
+ * connect-state cache, then each workspace runtime row (legacy scope). Stale rows — e.g. a revoked token
  * or a dead local Den URL left behind by an old session — are skipped instead
  * of shadowing a valid config, and the winning workspace copy is promoted to
  * server scope so Connect stays account-level.
@@ -102,6 +102,8 @@ export async function readOpenWorkConnectSkillCatalog(
   try {
     const serverCloud = await readConnectCloudMcp(config);
     const candidates: Array<{ cloud: Record<string, unknown>; source: "server" | "workspace" }> = [];
+    const globalCloud = await readGlobalRuntimeMcpConfig(config, OPENWORK_CLOUD_MCP_NAME);
+    if (globalCloud) candidates.push({ cloud: globalCloud, source: "server" });
     if (serverCloud) candidates.push({ cloud: serverCloud, source: "server" });
     for (const workspace of config.workspaces) {
       const cloud = await readRuntimeMcpConfig(config, workspace.id, OPENWORK_CLOUD_MCP_NAME);

--- a/apps/server/src/connect-state.inspect.test.ts
+++ b/apps/server/src/connect-state.inspect.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { inspectConnectSnapshot, inspectConnectState } from "./connect-state.js";
+import { ENGINE_GLOBAL_RUNTIME_CONFIG_ID } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
 function serverConfig(root: string): ServerConfig {
@@ -28,7 +29,7 @@ function serverConfig(root: string): ServerConfig {
 }
 
 describe("Connect state inspection", () => {
-  test("treats server-scoped cloudMcp as present without scanning workspaces", async () => {
+  test("does not treat the legacy host cache as desired runtime config", async () => {
     const root = await mkdtemp(join(tmpdir(), "openwork-connect-state-server-mcp-"));
     const previousDb = process.env.OPENWORK_RUNTIME_DB;
     process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
@@ -48,8 +49,17 @@ describe("Connect state inspection", () => {
         status: "available",
         snapshot: {
           connectEnabled: true,
-          cloudMcpPresent: true,
+          cloudMcpPresent: false,
         },
+      });
+
+      const sqlite = new Database(process.env.OPENWORK_RUNTIME_DB, { create: true });
+      sqlite.run("CREATE TABLE runtime_opencode_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
+      sqlite.query("INSERT INTO runtime_opencode_configs (workspace_id, config_json, updated_at) VALUES (?, ?, ?)")
+        .run(ENGINE_GLOBAL_RUNTIME_CONFIG_ID, JSON.stringify({ mcp: { "openwork-cloud": { type: "remote" } } }), 124);
+      sqlite.close();
+      expect(await inspectConnectSnapshot(config)).toMatchObject({
+        snapshot: { cloudMcpPresent: true },
       });
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -13,6 +13,7 @@ import { googleWorkspaceLegacyConfigured } from "./extensions/google-workspace.j
 import { readBoundedRegularTextFile } from "./jsonc.js";
 import { runtimeStorageDir } from "./runtime-db.js";
 import {
+  ENGINE_GLOBAL_RUNTIME_CONFIG_ID,
   inspectRuntimeOpencodeConfigState,
   runtimeMcpMap,
 } from "./runtime-opencode-config-store.js";
@@ -339,8 +340,16 @@ async function inspectConnectRuntime(
   config: ServerConfig,
   options?: ConnectStateInspectionOptions,
 ): Promise<{ cloudMcpPresent: boolean; complete: boolean }> {
-  const serverCloudMcp = await readConnectCloudMcp(config);
-  if (serverCloudMcp) return { cloudMcpPresent: true, complete: true };
+  const globalInspection = await inspectRuntimeOpencodeConfigState(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, {
+    maxBytes: options?.runtimeConfigMaxBytes,
+    signal: options?.signal,
+  });
+  if (globalInspection.status === "unreadable" || globalInspection.status === "invalid-row") {
+    return { cloudMcpPresent: false, complete: false };
+  }
+  if (Object.hasOwn(runtimeMcpMap(globalInspection.config), OPENWORK_CLOUD_MCP_NAME)) {
+    return { cloudMcpPresent: true, complete: true };
+  }
 
   const configuredMaxRows = options?.maxRuntimeRows;
   const maxRuntimeRows = typeof configuredMaxRows === "number"

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -33,6 +33,7 @@ import {
 import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
+import { migrateOpenworkCloudMcpRuntimeConfig } from "./cloud-mcp-health.js";
 import { resolveOpencodeModelsUrl } from "./opencode-models-url.js";
 import type { ServeResult } from "./serve-node.js";
 import type { LocalManagedMcpVaultKeyProvider, ServerConfig } from "./types.js";
@@ -171,6 +172,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
 
   if (!config.readOnly) {
     await ensureLocalWorkspaceFiles(config.workspaces);
+    await migrateOpenworkCloudMcpRuntimeConfig(config);
   }
 
   // Bind the HTTP server before spawning the engine: serve-node may fall back

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -11,7 +11,7 @@ import {
   startServer,
   syncAllWorkspacesRuntimeMcpToEngine,
 } from "./server.js";
-import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { readRuntimeOpencodeConfig, writeGlobalRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
 type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
@@ -1108,6 +1108,10 @@ describe("runtime MCP engine sync", () => {
 
       await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({ ...current, mcp: { posthog: POSTHOG_CONFIG } }));
       await writeRuntimeOpencodeConfig(config, "ws_2", (current) => ({ ...current, mcp: { stripe: POSTHOG_CONFIG } }));
+      await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+        ...current,
+        mcp: { ...current.mcp, "openwork-cloud": POSTHOG_CONFIG },
+      }));
 
       await syncAllWorkspacesRuntimeMcpToEngine(config);
 
@@ -1115,6 +1119,11 @@ describe("runtime MCP engine sync", () => {
       const byName = new Map(syncs.map((entry) => [(entry.body as { name?: string } | null)?.name, entry.search]));
       expect(byName.get("posthog")).toContain(`directory=${encodeURIComponent(rootA)}`);
       expect(byName.get("stripe")).toContain(`directory=${encodeURIComponent(rootB)}`);
+      const cloudSyncs = syncs.filter((entry) => (entry.body as { name?: string } | null)?.name === "openwork-cloud");
+      expect(cloudSyncs.map((entry) => entry.search).sort()).toEqual([
+        `?directory=${encodeURIComponent(rootA)}`,
+        `?directory=${encodeURIComponent(rootB)}`,
+      ].sort());
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -18,6 +18,9 @@ export type RuntimeOpencodeConfig = {
 
 export const ENGINE_GLOBAL_RUNTIME_CONFIG_ID = "__openwork_engine_global__";
 
+/** Reserved Connect MCP name; kept in sync with OPENWORK_CLOUD_MCP_NAME in cloud-mcp-health.ts. */
+const OPENWORK_CLOUD_MCP_RESERVED_NAME = "openwork-cloud";
+
 export function isEngineGlobalRuntimeConfigId(workspaceId: string): boolean {
   return workspaceId === ENGINE_GLOBAL_RUNTIME_CONFIG_ID;
 }
@@ -104,6 +107,13 @@ export async function readRuntimeMcpConfig(
   return runtimeMcpMap(await readRuntimeOpencodeConfig(config, workspaceId))[name] ?? null;
 }
 
+export async function readGlobalRuntimeMcpConfig(
+  config: ServerConfig,
+  name: string,
+): Promise<Record<string, unknown> | null> {
+  return await readRuntimeMcpConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, name);
+}
+
 export function runtimeExternalDirectory(config: RuntimeOpencodeConfig): Record<string, unknown> {
   const permission = isRecord(config.permission) ? config.permission : null;
   const externalDirectory = permission && isRecord(permission.external_directory) ? permission.external_directory : null;
@@ -139,6 +149,63 @@ export async function readGlobalRuntimeOpencodeConfig(config: ServerConfig): Pro
   return await readRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID);
 }
 
+export type RuntimeOpencodeConfigRow = {
+  workspaceId: string;
+  value: RuntimeOpencodeConfig;
+  updatedAt: number;
+};
+
+function runtimeOpencodeConfigRow(value: unknown): RuntimeOpencodeConfigRow | null {
+  if (
+    !isRecord(value)
+    || typeof value.workspaceId !== "string"
+    || typeof value.configJson !== "string"
+    || typeof value.updatedAt !== "number"
+  ) return null;
+  return {
+    workspaceId: value.workspaceId,
+    value: parseRuntimeOpencodeConfig(value.configJson),
+    updatedAt: value.updatedAt,
+  };
+}
+
+/** Read all runtime config rows without creating or modifying the runtime DB. */
+export async function listRuntimeOpencodeConfigRows(config: ServerConfig): Promise<RuntimeOpencodeConfigRow[]> {
+  const path = runtimeDbPath(config);
+  if (!existsSync(path)) return [];
+  const sql = `
+    SELECT workspace_id AS workspaceId, config_json AS configJson, updated_at AS updatedAt
+    FROM runtime_opencode_configs
+  `;
+  try {
+    let rows: unknown[];
+    if (typeof process.versions.bun === "string") {
+      const { Database } = await import("bun:sqlite");
+      const sqlite = new Database(path, { readonly: true, create: false });
+      try {
+        rows = sqlite.query(sql).all();
+      } finally {
+        sqlite.close();
+      }
+    } else {
+      const { DatabaseSync } = await importNodeSqlite();
+      const sqlite = new DatabaseSync(path, { readOnly: true });
+      try {
+        rows = sqlite.prepare(sql).all();
+      } finally {
+        sqlite.close();
+      }
+    }
+    return rows.flatMap((row) => {
+      const parsed = runtimeOpencodeConfigRow(row);
+      return parsed ? [parsed] : [];
+    });
+  } catch (error) {
+    if (classifyReadonlySqliteFailure(error) === "table-missing") return [];
+    throw error;
+  }
+}
+
 export async function writeGlobalRuntimeOpencodeConfig(
   config: ServerConfig,
   updater: (current: RuntimeOpencodeConfig) => RuntimeOpencodeConfig,
@@ -150,7 +217,7 @@ function uniqueStrings(items: string[]): string[] {
   return items.filter((item, index, list) => list.indexOf(item) === index);
 }
 
-function mergeRuntimeOpencodeConfigLayers(
+export function mergeRuntimeOpencodeConfigLayers(
   base: RuntimeOpencodeConfig,
   overlay: RuntimeOpencodeConfig,
 ): RuntimeOpencodeConfig {
@@ -166,6 +233,11 @@ function mergeRuntimeOpencodeConfigLayers(
     ...runtimeMcpMap(base),
     ...runtimeMcpMap(overlay),
   };
+  // The Connect MCP is account-scoped: the global row is authoritative, so a
+  // stale legacy per-workspace copy must not shadow it. Mirrors
+  // OPENWORK_CLOUD_MCP_NAME in cloud-mcp-health.ts (import would be cyclic).
+  const globalCloudMcp = runtimeMcpMap(base)[OPENWORK_CLOUD_MCP_RESERVED_NAME];
+  if (globalCloudMcp) mcp[OPENWORK_CLOUD_MCP_RESERVED_NAME] = globalCloudMcp;
   const basePermission = isRecord(base.permission) ? base.permission : {};
   const overlayPermission = isRecord(overlay.permission) ? overlay.permission : {};
   const externalDirectory = {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -101,7 +101,10 @@ import {
 } from "./local-managed-mcp.js";
 import {
   markOpenworkCloudMcpStale,
+  migrateOpenworkCloudMcpRuntimeConfig,
+  OPENWORK_CLOUD_MCP_NAME,
   reconcilePersistedOpenworkCloudMcp,
+  removeOpenworkCloudMcpDesiredConfig,
   type CloudMcpHealth,
 } from "./cloud-mcp-health.js";
 import { runAgentContextDiagnostics } from "./agent-context-diagnostics.js";
@@ -110,6 +113,7 @@ import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
 import {
   mergeOpencodeConfigs,
   mergeRuntimeProviderUpdate,
+  readEffectiveRuntimeOpencodeConfig,
   readGlobalRuntimeOpencodeConfig,
   readRuntimeOpencodeConfig,
   runtimeDisabledProviderList,
@@ -3245,8 +3249,12 @@ function createRoutes(
       summary: `Remove MCP ${name}`,
       paths: [openworkConfigPath(workspace.path)],
     });
-    const managedRemoved = await deleteLocalManagedMcp(config, workspace.id, name);
-    const removed = managedRemoved || await removeMcp(config, workspace.id, name);
+    const managedRemoved = name === OPENWORK_CLOUD_MCP_NAME
+      ? false
+      : await deleteLocalManagedMcp(config, workspace.id, name);
+    const removed = name === OPENWORK_CLOUD_MCP_NAME
+      ? await removeOpenworkCloudMcpDesiredConfig(config)
+      : managedRemoved || await removeMcp(config, workspace.id, name);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -3257,8 +3265,11 @@ function createRoutes(
       timestamp: Date.now(),
     });
     if (removed) {
-      deleteEngineMcpRegistration(config, engineMcpServerState, workspace, name);
-      await disconnectMcpFromOpencodeEngine(config, workspace, name).catch(() => undefined);
+      const affectedWorkspaces = name === OPENWORK_CLOUD_MCP_NAME ? config.workspaces : [workspace];
+      await Promise.all(affectedWorkspaces.map(async (affectedWorkspace) => {
+        deleteEngineMcpRegistration(config, engineMcpServerState, affectedWorkspace, name);
+        await disconnectMcpFromOpencodeEngine(config, affectedWorkspace, name).catch(() => undefined);
+      }));
       emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
         type: "mcp",
         name,
@@ -4236,7 +4247,7 @@ async function runRuntimeMcpSyncToOpencodeEngine(
     return { status: "skipped", syncedNames: [], failures: [] };
   }
 
-  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
+  const runtimeConfig = await readEffectiveRuntimeOpencodeConfig(config, workspace.id);
   const entries = Object.entries(runtimeMcpMap(runtimeConfig)).filter(
     ([name]) => !name.startsWith(CONNECT_MCP_SERVER_NAME_PREFIX)
       && (!onlyNames || onlyNames.includes(name)),
@@ -5231,6 +5242,7 @@ function logPersistedCloudMcpReconcileError(input: {
 // only, so other workspaces' runtime MCPs are invisible to the engine until
 // something re-syncs them. Best-effort.
 export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
+  await migrateOpenworkCloudMcpRuntimeConfig(config);
   const serverState = activeEngineMcpServerState(config);
   for (const workspace of config.workspaces) {
     await enqueueWorkspaceMcpRefreshSync({ config, workspace, serverState, trigger: "startup" });


### PR DESCRIPTION
Second PR of the global-first config stack (on #4218). Moves the `openwork-cloud` Connect MCP **desired config** from N per-workspace runtime rows to the single ENGINE_GLOBAL runtime row, so every OpenCode directory instance receives one identical account-scoped entry and workspace switching can never rewrite or bounce it.

## Problem

The Connect token is minted per user/org, but the entry was persisted per workspace:
- N copies of the same credential to keep converged (staleness ledger, per-workspace reconcile)
- a stale legacy workspace row could shadow a fresh one in the effective merge
- switching workspaces could change the engine-visible entry and tear down/re-establish the connection

## Change

**Globalized (desired state only):**
- `persistDesiredConfig` writes the ENGINE_GLOBAL row; host `connect-state.json` copy kept as catalog cache
- idempotent migration: newest *valid* legacy workspace entry promotes to global **before** workspace rows are cleaned; unrelated MCPs/fields preserved; second run is a no-op; read-only servers never mutate; the connect-state host cache is never treated as desired config
- effective-config merge special-cases `openwork-cloud`: the global entry wins over leftover legacy copies
- dynamic engine MCP sync reads the *effective* config, so the global entry reaches every directory instance
- `DELETE` of `openwork-cloud` clears global desired state and disconnects every workspace directory
- catalogs, passive Connect inspection, and agent-context diagnostics read global first (legacy fallback kept for the migration window)

**Deliberately still per workspace/directory:** delivery ledger, engine reachability/registration health, probes, and all generic MCP CRUD. A/B directories can be ready/pending independently.

**Churn guard:** fan-out re-delivery to other workspaces happens only when the persisted config actually changed — an unchanged reconcile cannot bounce healthy connections.

## New test witnesses

- reconcile persists under ENGINE_GLOBAL; initiating workspace row stays clean
- A/B/C legacy rows: newest valid entry migrates, invalid entry rejected, unrelated MCPs survive, effective configs for A and B identical, repeat migration no-op
- read-only server: no mutation
- delivery state independent for two directories sharing global desired state
- removal disconnects every workspace directory
- legacy host cache is not resurrected as desired config

## Validation

- `apps/server` tsc clean
- health/state/inspect/skill-catalog: 40 pass; cloud-mcp-reconcile e2e: 26 pass; mcp.engine-sync e2e: 22 pass; diagnostics + mcp-app-host: 90 pass
- full `apps/server` suite: **787 pass / 8 skip / 2 fail / 1 error**, where the failures (local DNS-guard fixture, bun `node:sqlite` resolution) reproduce identically on a clean `origin/dev` worktree — pre-existing environment issues, not from this change