### PR TITLE
fix(app): keep macOS titlebar controls clear

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1411,7 +1411,12 @@ export function SessionPage(props: SessionPageProps) {
             onSendFeedback: props.onSendFeedback,
           }}
         />
-        <SidebarInset className="min-h-0 overflow-hidden bg-sidebar mac:bg-transparent mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-34 mac:max-md:[&_header]:pl-34">
+        <SidebarInset
+          className={cn(
+            "min-h-0 overflow-hidden bg-sidebar mac:bg-transparent mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-34 mac:max-md:[&_header]:pl-34",
+            !shellConfig.sidebar && "mac:[&_header]:pl-34",
+          )}
+        >
           <div className="flex min-h-0 flex-1 max-lg:p-0 lg:py-2 lg:pl-2">
           <ResizablePanelGroup
             orientation="horizontal"
@@ -1983,7 +1988,7 @@ export function SessionPage(props: SessionPageProps) {
           </aside>
           </div>
         </SidebarInset>
-        {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[88px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
+        {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[88px] mac:size-8! top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
       </SidebarProvider>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}

--- a/evals/specs/mac-sidebar-toggle-clearance.e2e.test.ts
+++ b/evals/specs/mac-sidebar-toggle-clearance.e2e.test.ts
@@ -69,6 +69,8 @@ const geometryExpression = `(() => {
     position: getComputedStyle(toggle).position,
     left: toggleRect.left,
     right: toggleRect.right,
+    width: toggleRect.width,
+    height: toggleRect.height,
     headingLeft: headingRect ? headingRect.left : null,
     headingText: heading instanceof HTMLElement ? (heading.textContent ?? "").trim() : "",
     overlapsHeading: headingRect ? toggleRect.right > headingRect.left : false,
@@ -82,6 +84,8 @@ interface Geometry {
   position: string;
   left: number;
   right: number;
+  width: number;
+  height: number;
   headingLeft: number | null;
   headingText: string;
   overlapsHeading: boolean;
@@ -96,11 +100,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function geometry(value: unknown, label: string): Geometry {
   if (!isRecord(value)) throw new Error(`${label} was not readable: ${JSON.stringify(value)}`);
   if (value.found !== true) throw new Error(`${label} found no painted sidebar toggle: ${JSON.stringify(value)}`);
-  const { position, left, right, headingLeft, headingText, overlapsHeading, hitsToggle, hitTag } = value;
+  const { position, left, right, width, height, headingLeft, headingText, overlapsHeading, hitsToggle, hitTag } = value;
   if (
     typeof position !== "string" ||
     typeof left !== "number" ||
     typeof right !== "number" ||
+    typeof width !== "number" ||
+    typeof height !== "number" ||
     typeof headingText !== "string" ||
     typeof overlapsHeading !== "boolean" ||
     typeof hitsToggle !== "boolean" ||
@@ -109,7 +115,7 @@ function geometry(value: unknown, label: string): Geometry {
   ) {
     throw new Error(`${label} returned an unexpected shape: ${JSON.stringify(value)}`);
   }
-  return { found: true, position, left, right, headingLeft, headingText, overlapsHeading, hitsToggle, hitTag };
+  return { found: true, position, left, right, width, height, headingLeft, headingText, overlapsHeading, hitsToggle, hitTag };
 }
 
 /**
@@ -201,6 +207,26 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
     true,
   );
 
+  // Compact desktop widths apply a generic 44px touch target to sidebar
+  // triggers. The floating macOS titlebar control must remain the native-sized
+  // 32px variant or it crowds the session title despite keeping the same left
+  // offset.
+  await app.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 900,
+    height: 700,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await waitForTitleSettled(app, "compact desktop width");
+  const compact = geometry(await evalIn(app, geometryExpression), "sidebar toggle at compact desktop width");
+  expect(compact.width).toBe(32);
+  expect(compact.height).toBe(32);
+  evidence.recordAssertionEvidence(
+    "The macOS titlebar toggle stays compact at narrower desktop widths",
+    `At 900px wide the painted titlebar toggle remains ${compact.width}×${compact.height}px instead of inheriting the generic enlarged touch target.`,
+    true,
+  );
+
   await setSidebar(app, "collapsed");
   const collapsed = geometry(await evalIn(app, geometryExpression), "sidebar toggle while collapsed");
 
@@ -233,6 +259,32 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   evidence.recordAssertionEvidence(
     "Clicking the cleared toggle still shows and hides the sidebar",
     `Clicking the floating toggle drove the sidebar collapsed and back to ${JSON.stringify(reopened)}.`,
+    true,
+  );
+
+  // Thin/custom shells can intentionally remove the sidebar and therefore the
+  // floating toggle. Their title still needs the same traffic-light clearance.
+  await evalIn(
+    app,
+    `(() => {
+      const key = "openwork.shell-config";
+      const current = JSON.parse(localStorage.getItem(key) ?? "{}");
+      localStorage.setItem(key, JSON.stringify({ ...current, sidebar: false }));
+      location.reload();
+      return true;
+    })()`,
+  ).catch(() => undefined);
+  await waitFor(app, `Boolean(document.querySelector("header h1"))`, {
+    timeoutMs: 60_000,
+    label: "session header restored without sidebar",
+  });
+  await waitForTitleSettled(app, "sidebar hidden");
+  const titleWithoutSidebar = await evalIn(app, titleLeftExpression);
+  if (typeof titleWithoutSidebar !== "number") throw new Error("The sidebar-free title had no measurable position.");
+  expect(titleWithoutSidebar).toBeGreaterThanOrEqual(136);
+  evidence.recordAssertionEvidence(
+    "Sidebar-free macOS shells keep titles clear of the traffic lights",
+    `With the sidebar and floating toggle disabled, the session title starts at ${titleWithoutSidebar}px, beyond the 136px reserved titlebar area.`,
     true,
   );
 });


### PR DESCRIPTION
## Summary
- keep the floating macOS sidebar toggle at 32px on compact desktop widths
- reserve traffic-light clearance when custom shells hide the sidebar
- extend the macOS titlebar geometry regression spec

## Verification
- `tsc --noEmit -p apps/app/tsconfig.json`
- focused Vitest spec collected successfully (runtime test requires `OPENWORK_EVAL_E2E_TESTS=1`)
- full Electron E2E could not launch locally because Corepack pnpm exits with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`