### PR TITLE
fix(cloud): harden workspace recovery

### DIFF
--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -35,6 +35,7 @@ type CloudWorkspaceStatusContextValue = {
   instance: DenCloudInstance | null;
   requestFailed: boolean;
   updating: boolean;
+  retrying: boolean;
   viewModel: CloudWorkspaceViewModel;
   refresh: () => Promise<void>;
   retry: () => Promise<void>;
@@ -60,6 +61,7 @@ const fallbackCloudWorkspaceStatus: CloudWorkspaceStatusContextValue = {
   instance: null,
   requestFailed: false,
   updating: false,
+  retrying: false,
   viewModel: fallbackViewModel,
   refresh: noopRefresh,
   retry: noopRefresh,
@@ -102,10 +104,12 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
   const [instance, setInstance] = useState<DenCloudInstance | null>(null);
   const [requestFailed, setRequestFailed] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const [retrying, setRetrying] = useState(false);
   const [takeoverActive, setTakeoverActive] = useState(false);
   const lastAttemptedVersion = useRef<string | null>(null);
   const lastLoggedFailureReference = useRef<string | null>(null);
   const lastLoggedRequestFailure = useRef<string | null>(null);
+  const retryInFlight = useRef<Promise<void> | null>(null);
   const gatewayMode = isOpenworkGatewayRuntime();
   const settingsSnapshot = useSyncExternalStore(
     subscribeToDenSettings,
@@ -148,24 +152,34 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
     }
   }, [authToken, denClient, gatewayMode, orgId]);
 
-  const retry = useCallback(async () => {
+  const retry = useCallback(() => {
+    if (retryInFlight.current) return retryInFlight.current;
     if (!gatewayMode || !authToken || !orgId) {
       setRequestFailed(true);
-      return;
+      return Promise.resolve();
     }
-    try {
-      const next = await denClient.retryCloudInstance(orgId);
-      setInstance(next);
-      setRequestFailed(false);
-      lastLoggedRequestFailure.current = null;
-      if (next.failure && next.failure.reference !== lastLoggedFailureReference.current) {
-        lastLoggedFailureReference.current = next.failure.reference;
-        console.error("[cloud-workspace] sandbox recovery requested", cloudWorkspaceFailureLogFields(next.failure));
+
+    setRetrying(true);
+    const operation = (async () => {
+      try {
+        const next = await denClient.retryCloudInstance(orgId);
+        setInstance(next);
+        setRequestFailed(false);
+        lastLoggedRequestFailure.current = null;
+        if (next.failure && next.failure.reference !== lastLoggedFailureReference.current) {
+          lastLoggedFailureReference.current = next.failure.reference;
+          console.error("[cloud-workspace] sandbox recovery requested", cloudWorkspaceFailureLogFields(next.failure));
+        }
+      } catch (error) {
+        setRequestFailed(true);
+        console.error("[cloud-workspace] sandbox recovery request failed", cloudWorkspaceRequestFailureLogFields(error));
       }
-    } catch (error) {
-      setRequestFailed(true);
-      console.error("[cloud-workspace] sandbox recovery request failed", cloudWorkspaceRequestFailureLogFields(error));
-    }
+    })().finally(() => {
+      if (retryInFlight.current === operation) retryInFlight.current = null;
+      setRetrying(false);
+    });
+    retryInFlight.current = operation;
+    return operation;
   }, [authToken, denClient, gatewayMode, orgId]);
 
   const viewModel = useMemo(
@@ -246,6 +260,7 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
     instance,
     requestFailed,
     updating,
+    retrying,
     viewModel,
     refresh,
     retry,
@@ -253,7 +268,7 @@ export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
     updateNow,
     takeoverActive,
     setTakeoverActive,
-  }), [gatewayMode, instance, refresh, requestFailed, retry, signOut, takeoverActive, updateNow, updating, viewModel, visible]);
+  }), [gatewayMode, instance, refresh, requestFailed, retry, retrying, signOut, takeoverActive, updateNow, updating, viewModel, visible]);
 
   return (
     <CloudWorkspaceStatusContext.Provider value={value}>
@@ -339,7 +354,9 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
 
   const { viewModel } = cloudWorkspace;
   const failed = viewModel.variant === "failed";
-  const slow = !failed && cloudWorkspaceBootIsSlow(elapsedMs);
+  const unavailable = viewModel.variant === "unavailable";
+  const attention = failed || unavailable;
+  const slow = !attention && cloudWorkspaceBootIsSlow(elapsedMs);
   const copy = cloudWorkspaceTakeoverCopy({ variant: viewModel.variant, slow });
   const stages = cloudWorkspaceBootStages(viewModel.variant);
 
@@ -347,7 +364,7 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
     <LazyMotion features={domMax}>
       <div
         className="flex h-full min-h-[420px] items-center justify-center px-6 py-16"
-        role={failed ? "alert" : "status"}
+        role={attention ? "alert" : "status"}
         aria-live="polite"
         data-testid="cloud-workspace-takeover"
         data-cloud-workspace-state={viewModel.variant}
@@ -360,7 +377,7 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
           transition={{ duration: 0.32, ease: "easeOut" }}
           className={cn(
             "w-full max-w-md rounded-[20px] border p-6 shadow-[var(--dls-card-shadow)]",
-            failed
+            attention
               ? "border-amber-7/35 bg-amber-3/30"
               : "border-dls-border bg-dls-surface",
           )}
@@ -369,12 +386,12 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
             <div
               className={cn(
                 "flex size-12 shrink-0 items-center justify-center rounded-2xl border",
-                failed
+                attention
                   ? "border-amber-7/35 bg-amber-3/60 text-amber-11"
                   : "border-dls-border bg-dls-hover text-dls-accent",
               )}
             >
-              {failed ? (
+              {attention ? (
                 <AlertTriangle className="size-5" aria-hidden="true" />
               ) : (
                 <m.span layoutId={gatewayIndicatorLayoutId} className="flex items-center justify-center">
@@ -411,10 +428,16 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
             </m.ul>
           ) : null}
 
-          {failed || slow ? (
+          {attention || slow ? (
             <m.div layout className="mt-5 flex items-center gap-2">
-              <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.retry()}>
-                Retry
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void (failed ? cloudWorkspace.retry() : cloudWorkspace.refresh())}
+                disabled={failed && cloudWorkspace.retrying}
+              >
+                {failed ? cloudWorkspace.retrying ? "Retrying…" : "Retry" : slow ? "Check again" : "Try again"}
               </Button>
               <Button type="button" size="sm" variant="ghost" onClick={cloudWorkspace.signOut}>
                 Sign out
@@ -439,7 +462,9 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
 export function CloudWorkspaceStatusPanel(props: {
   viewModel: CloudWorkspaceViewModel;
   updating: boolean;
+  retrying: boolean;
   onRefresh: () => void;
+  onRetry: () => void;
   onSignOut: () => void;
   onUpdateNow: () => void;
 }) {
@@ -475,8 +500,14 @@ export function CloudWorkspaceStatusPanel(props: {
       ) : null}
       <div className="flex items-center justify-end gap-2">
         {viewModel.showRetry ? (
-          <Button type="button" size="sm" variant="outline" onClick={props.onRefresh}>
-            Retry
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={viewModel.variant === "failed" ? props.onRetry : props.onRefresh}
+            disabled={viewModel.variant === "failed" && props.retrying}
+          >
+            {viewModel.variant === "failed" && props.retrying ? "Retrying…" : "Retry"}
           </Button>
         ) : null}
         <Button type="button" size="sm" variant="ghost" onClick={props.onSignOut}>
@@ -548,7 +579,9 @@ function CloudWorkspaceOverlayInner() {
             <CloudWorkspaceStatusPanel
               viewModel={viewModel}
               updating={cloudWorkspace.updating}
-              onRefresh={() => void cloudWorkspace.retry()}
+              retrying={cloudWorkspace.retrying}
+              onRefresh={() => void cloudWorkspace.refresh()}
+              onRetry={() => void cloudWorkspace.retry()}
               onUpdateNow={cloudWorkspace.updateNow}
               onSignOut={() => {
                 cloudWorkspace.signOut();

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -15,6 +15,7 @@ export type CloudWorkspacePillVariant =
   | "waking"
   | "provisioning"
   | "updating"
+  | "unavailable"
   | "failed";
 
 export type CloudWorkspaceViewModel = {
@@ -101,10 +102,16 @@ export function cloudWorkspaceTakeoverCopy(input: {
       body: "We couldn’t start the sandbox. Retry, or sign out and reconnect.",
     };
   }
+  if (input.variant === "unavailable") {
+    return {
+      title: "Couldn’t check your workspace",
+      body: "OpenWork Cloud didn’t answer. Your sandbox may still be running, so try checking again.",
+    };
+  }
   if (input.slow) {
     return {
       title: "Still working on it…",
-      body: "This is taking longer than usual. Nothing is broken — wait it out, or retry.",
+      body: "This is taking longer than usual. You can keep waiting or check again.",
     };
   }
   if (input.variant === "provisioning") {
@@ -186,7 +193,10 @@ export function shouldShowCloudWorkspaceStatusPill(input: {
   requestFailed: boolean;
 }): boolean {
   if (!input.hasInstance && !input.requestFailed) return false;
-  return input.variant === "waking" || input.variant === "provisioning" || input.variant === "failed";
+  return input.variant === "waking"
+    || input.variant === "provisioning"
+    || input.variant === "unavailable"
+    || input.variant === "failed";
 }
 
 export function mapCloudWorkspaceMainContentDecision(input: {
@@ -248,7 +258,21 @@ export function mapCloudWorkspaceState(input: {
   const updateAvailable = cloudWorkspaceUpdateAvailable(input.instance);
   const lines = baseLines(input.instance, updateAvailable);
 
-  if (input.requestFailed || input.instance?.status === "failed") {
+  if (input.requestFailed) {
+    return {
+      variant: "unavailable",
+      label: "Couldn’t check workspace",
+      tone: "amber",
+      statusLine: "Couldn’t check workspace status",
+      ...lines,
+      updateAvailable,
+      showUpdate: false,
+      showRetry: true,
+      pollMs: 5_000,
+    };
+  }
+
+  if (input.instance?.status === "failed") {
     return {
       variant: "failed",
       label: "Workspace needs attention",

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -112,6 +112,13 @@ describe("cloud workspace overlay state", () => {
     expect(failed.tone).toBe("amber");
     expect(failed.label).toBe("Workspace needs attention");
     expect(failed.showRetry).toBe(true);
+
+    const unavailable = mapCloudWorkspaceState({ instance: null, updating: false, requestFailed: true });
+    expect(unavailable.variant).toBe("unavailable");
+    expect(unavailable.label).toBe("Couldn’t check workspace");
+    expect(unavailable.statusLine).toBe("Couldn’t check workspace status");
+    expect(cloudWorkspaceTakeoverCopy({ variant: unavailable.variant, slow: false }).body)
+      .toContain("sandbox may still be running");
   });
 
   test("shows the corner pill only for resolved degraded states", () => {
@@ -119,6 +126,7 @@ describe("cloud workspace overlay state", () => {
     expect(shouldShowCloudWorkspaceStatusPill({ variant: "waking", hasInstance: true, requestFailed: false })).toBe(true);
     expect(shouldShowCloudWorkspaceStatusPill({ variant: "provisioning", hasInstance: true, requestFailed: false })).toBe(true);
     expect(shouldShowCloudWorkspaceStatusPill({ variant: "failed", hasInstance: false, requestFailed: true })).toBe(true);
+    expect(shouldShowCloudWorkspaceStatusPill({ variant: "unavailable", hasInstance: false, requestFailed: true })).toBe(true);
     expect(shouldShowCloudWorkspaceStatusPill({ variant: "ready", hasInstance: true, requestFailed: false })).toBe(false);
     expect(shouldShowCloudWorkspaceStatusPill({ variant: "stale", hasInstance: true, requestFailed: false })).toBe(false);
     expect(shouldShowCloudWorkspaceStatusPill({ variant: "updating", hasInstance: true, requestFailed: false })).toBe(false);
@@ -143,6 +151,7 @@ describe("cloud workspace overlay state", () => {
       ["waking", "takeover"],
       ["provisioning", "takeover"],
       ["updating", "takeover"],
+      ["unavailable", "takeover"],
       ["failed", "takeover"],
     ];
     const withReadyContent: [CloudWorkspacePillVariant, CloudWorkspaceMainContentDecision][] = [
@@ -151,6 +160,7 @@ describe("cloud workspace overlay state", () => {
       ["waking", "content"],
       ["provisioning", "content"],
       ["updating", "content"],
+      ["unavailable", "content"],
       ["failed", "takeover"],
     ];
 
@@ -163,7 +173,7 @@ describe("cloud workspace overlay state", () => {
   });
 
   test("passes all cloud states through outside gateway mode", () => {
-    const statuses: CloudWorkspacePillVariant[] = ["ready", "stale", "waking", "provisioning", "updating", "failed"];
+    const statuses: CloudWorkspacePillVariant[] = ["ready", "stale", "waking", "provisioning", "updating", "unavailable", "failed"];
 
     for (const status of statuses) {
       expect(mapCloudWorkspaceMainContentDecision({ status, hasWorkspaces: false, gatewayMode: false })).toBe("content");
@@ -172,7 +182,7 @@ describe("cloud workspace overlay state", () => {
   });
 
   test("does not allow not-found errors before a gateway worker is ready", () => {
-    const notReady: CloudWorkspacePillVariant[] = ["waking", "provisioning", "updating", "failed"];
+    const notReady: CloudWorkspacePillVariant[] = ["waking", "provisioning", "updating", "unavailable", "failed"];
 
     for (const status of notReady) {
       expect(cloudWorkspaceStatusHasReadyContent(status)).toBe(false);
@@ -258,7 +268,7 @@ describe("cloud workspace slow boot escalation", () => {
 
     expect(early.title).toBe("Starting your workspace…");
     expect(late.title).toBe("Still working on it…");
-    expect(late.body).toContain("Nothing is broken");
+    expect(late.body).toContain("check again");
   });
 
   test("keeps the failure message even when the wait has gone long", () => {
@@ -274,7 +284,7 @@ describe("cloud workspace slow boot escalation", () => {
   });
 });
 
-function renderTakeover(status: DenCloudInstance["status"]) {
+function renderTakeover(status: DenCloudInstance["status"], retrying = false) {
   const viewModel = mapCloudWorkspaceState({ instance: instance({ status }), updating: false });
 
   return renderToStaticMarkup(
@@ -285,6 +295,7 @@ function renderTakeover(status: DenCloudInstance["status"]) {
         instance: instance({ status }),
         requestFailed: false,
         updating: false,
+        retrying,
         viewModel,
         refresh: async () => {},
         retry: async () => {},
@@ -370,6 +381,13 @@ describe("cloud workspace boot takeover", () => {
     expect(html).toContain("Retry");
     expect(html).toContain("Sign out");
   });
+
+  test("disables repeated recovery requests while retry is already in flight", () => {
+    const html = renderTakeover("failed", true);
+
+    expect(html).toContain("Retrying…");
+    expect(html).toContain("disabled");
+  });
 });
 
 describe("cloud workspace overlay gateway gating", () => {
@@ -405,7 +423,9 @@ describe("cloud workspace overlay diagnostics", () => {
       <CloudWorkspaceStatusPanel
         viewModel={viewModel}
         updating={false}
+        retrying={false}
         onRefresh={() => {}}
+        onRetry={() => {}}
         onSignOut={() => {}}
         onUpdateNow={() => {}}
       />,
@@ -422,7 +442,9 @@ describe("cloud workspace overlay diagnostics", () => {
       <CloudWorkspaceStatusPanel
         viewModel={viewModel}
         updating={false}
+        retrying={false}
         onRefresh={() => {}}
+        onRetry={() => {}}
         onSignOut={() => {}}
         onUpdateNow={() => {}}
       />,

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -21,12 +21,14 @@ import {
   resolveCloudRuntimeState,
   type CloudRuntimeSandboxInspection,
   type CloudRuntimeSandboxRecord,
+  type CloudRuntimeState,
   type CloudRuntimeStore,
   type CloudRuntimeWorker,
 } from "../../workers/worker-access.js"
 import { appLogger } from "../../observability/logger.js"
 import {
   cloudStartupFailureFromWorker,
+  cloudStartupFailureUpdate,
   publicCloudStartupFailure,
   type PublicCloudStartupFailure,
 } from "../../workers/cloud-failure.js"
@@ -87,8 +89,15 @@ type CloudInstanceUpdateResponse =
   | { ok: false; error: "already_current" | "flush_failed" }
 type CloudWorkerStore = CloudRuntimeStore & {
   getCloudWorker: (input: { orgId: OrgId; userId: UserId }) => Promise<CloudWorker | null>
-  insertCloudWorker: (input: { workerId: WorkerId; orgId: OrgId; userId: UserId; name: string }) => Promise<void>
-  insertWorkerTokens: (input: { workerId: WorkerId; hostToken: string; clientToken: string; activityToken: string }) => Promise<void>
+  insertCloudWorkerWithTokens: (input: {
+    workerId: WorkerId
+    orgId: OrgId
+    userId: UserId
+    name: string
+    hostToken: string
+    clientToken: string
+    activityToken: string
+  }) => Promise<void>
   deleteCreateRaceLoser: (workerId: WorkerId) => Promise<void>
 }
 type EnsureCloudWorker = (input: {
@@ -266,39 +275,39 @@ const databaseCloudWorkerStore: CloudWorkerStore = {
 
     return rows[0] ?? null
   },
-  async insertCloudWorker(input) {
-    await db.insert(WorkerTable).values({
-      id: input.workerId,
-      org_id: input.orgId,
-      created_by_user_id: input.userId,
-      name: input.name,
-      description: "OpenWork Cloud browser instance",
-      destination: "cloud",
-      status: "provisioning",
-      sandbox_backend: CLOUD_INSTANCE_BACKEND,
+  async insertCloudWorkerWithTokens(input) {
+    await db.transaction(async (tx) => {
+      await tx.insert(WorkerTable).values({
+        id: input.workerId,
+        org_id: input.orgId,
+        created_by_user_id: input.userId,
+        name: input.name,
+        description: "OpenWork Cloud browser instance",
+        destination: "cloud",
+        status: "provisioning",
+        sandbox_backend: CLOUD_INSTANCE_BACKEND,
+      })
+      await tx.insert(WorkerTokenTable).values([
+        {
+          id: createDenTypeId("workerToken"),
+          worker_id: input.workerId,
+          scope: "host",
+          token: input.hostToken,
+        },
+        {
+          id: createDenTypeId("workerToken"),
+          worker_id: input.workerId,
+          scope: "client",
+          token: input.clientToken,
+        },
+        {
+          id: createDenTypeId("workerToken"),
+          worker_id: input.workerId,
+          scope: "activity",
+          token: input.activityToken,
+        },
+      ])
     })
-  },
-  async insertWorkerTokens(input) {
-    await db.insert(WorkerTokenTable).values([
-      {
-        id: createDenTypeId("workerToken"),
-        worker_id: input.workerId,
-        scope: "host",
-        token: input.hostToken,
-      },
-      {
-        id: createDenTypeId("workerToken"),
-        worker_id: input.workerId,
-        scope: "client",
-        token: input.clientToken,
-      },
-      {
-        id: createDenTypeId("workerToken"),
-        worker_id: input.workerId,
-        scope: "activity",
-        token: input.activityToken,
-      },
-    ])
   },
   async deleteCreateRaceLoser(workerId) {
     await db.transaction(async (tx) => {
@@ -328,16 +337,16 @@ const databaseCloudWorkerStore: CloudWorkerStore = {
       .from(WorkerTokenTable)
       .where(and(eq(WorkerTokenTable.worker_id, workerId), isNull(WorkerTokenTable.revoked_at)))
   },
-  async markProvisioningWorkerFailed(workerId) {
+  async markProvisioningWorkerFailed(workerId, failure) {
     await db
       .update(WorkerTable)
-      .set({ status: "failed" })
+      .set({ status: "failed", ...(failure ? cloudStartupFailureUpdate(failure) : {}) })
       .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "provisioning")))
   },
-  async markHealthyWorkerFailed(workerId) {
+  async markHealthyWorkerFailed(workerId, failure) {
     await db
       .update(WorkerTable)
-      .set({ status: "failed" })
+      .set({ status: "failed", ...(failure ? cloudStartupFailureUpdate(failure) : {}) })
       .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "healthy")))
   },
 }
@@ -419,8 +428,15 @@ async function createCloudWorker(input: {
   const clientToken = token()
   const activityToken = token()
 
-  await input.store.insertCloudWorker({ workerId, orgId: input.orgId, userId: input.createdByUserId, name: input.name })
-  await input.store.insertWorkerTokens({ workerId, hostToken, clientToken, activityToken })
+  await input.store.insertCloudWorkerWithTokens({
+    workerId,
+    orgId: input.orgId,
+    userId: input.createdByUserId,
+    name: input.name,
+    hostToken,
+    clientToken,
+    activityToken,
+  })
 
   const canonical = await getCloudWorker(input.orgId, input.createdByUserId, input.store)
   if (canonical && canonical.id !== workerId) {
@@ -499,9 +515,11 @@ function cloudInstanceName(worker: CloudWorker, sandbox: CloudSandboxRecord | nu
   return null
 }
 
-function memberCloudInstanceResponse(worker: CloudWorker, instance: CloudInstanceResponse, sandbox: CloudSandboxRecord | null): CloudInstanceMemberResponse {
+function memberCloudInstanceResponse(worker: CloudWorker, instance: CloudRuntimeState, sandbox: CloudSandboxRecord | null): CloudInstanceMemberResponse {
   const instanceName = cloudInstanceName(worker, sandbox)
-  const failure = cloudStartupFailureFromWorker(worker)
+  const failure = instance.status === "ready"
+    ? null
+    : instance.failure ?? cloudStartupFailureFromWorker(worker)
   return {
     status: instance.status,
     url: instance.url,
@@ -538,7 +556,6 @@ async function resolveCloudInstanceForMember(input: {
     worker,
     organizationId: input.payload.organization.id,
   }, {
-    continueProvisioning: input.continueProvisioning,
     refreshSignedPreview: input.refreshSignedPreview,
     getSandboxRecord: input.getSandboxRecord,
     inspectSandbox: input.inspectSandbox,
@@ -624,7 +641,6 @@ async function resolveCloudInstanceForGateway(input: {
       continueProvisioning: input.continueProvisioning,
       store: input.store,
     }),
-    continueProvisioning: input.continueProvisioning,
     refreshSignedPreview: input.refreshSignedPreview,
     getSandboxRecord: input.getSandboxRecord,
     inspectSandbox: input.inspectSandbox,

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -58,6 +58,7 @@ export type DaytonaSandboxRuntime = {
   target: string | null
   refreshData: () => Promise<unknown>
   start: (timeout?: number) => Promise<unknown>
+  stop: (timeout?: number) => Promise<unknown>
   delete: (timeout?: number) => Promise<unknown>
   getSignedPreviewUrl: (port: number, expiresInSeconds?: number) => Promise<{ url: string }>
   process: {
@@ -93,6 +94,7 @@ const signedPreviewRefreshLeadMs = 5 * 60 * 1000
 const wakeStartMaxAttempts = 3
 const wakeStartRetryBackoffMs = 250
 const wakeStartStateChangeTimeoutMs = 60_000
+const healthRequestTimeoutMs = 5_000
 const createConflictLookupMaxAttempts = 6
 const createConflictLookupBackoffMs = 2_000
 const logger = appLogger.child({ component: "daytona_provisioner" })
@@ -219,6 +221,13 @@ function daytonaSandboxLookupNames(input: ProvisionInput) {
     }
   }
   return names
+}
+
+function recoveryDaytonaSandboxName(input: SandboxNameInput) {
+  const suffix = randomUUID().replace(/-/g, "").slice(0, 8)
+  const base = currentDaytonaSandboxName(input)
+  const baseLength = Math.max(1, 63 - suffix.length - 10)
+  return slug(`${base.slice(0, baseLength)}-recovery-${suffix}`).slice(0, 63)
 }
 
 function isStoppedSandboxState(state: string | null) {
@@ -656,12 +665,16 @@ async function cleanupWorkerDataOnDaytona(daytona: Daytona, workerId: WorkerId) 
   }
 }
 
-async function waitForHealth(url: string, timeoutMs: number, sandbox: DaytonaSandboxRuntime, sessionId: string, commandId: string) {
+export async function waitForHealth(url: string, timeoutMs: number, sandbox: DaytonaSandboxRuntime, sessionId: string, commandId: string) {
   const startedAt = Date.now()
 
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const response = await fetch(`${url.replace(/\/$/, "")}/health`, { method: "GET" })
+      const remainingMs = timeoutMs - (Date.now() - startedAt)
+      const response = await fetch(`${url.replace(/\/$/, "")}/health`, {
+        method: "GET",
+        signal: AbortSignal.timeout(Math.max(1, Math.min(remainingMs, healthRequestTimeoutMs))),
+      })
       if (response.ok) {
         return
       }
@@ -689,7 +702,10 @@ async function waitForHealth(url: string, timeoutMs: number, sandbox: DaytonaSan
       }
     }
 
-    await sleep(env.daytona.pollIntervalMs)
+    const remainingAfterProbeMs = timeoutMs - (Date.now() - startedAt)
+    if (remainingAfterProbeMs > 0) {
+      await sleep(Math.min(env.daytona.pollIntervalMs, remainingAfterProbeMs))
+    }
   }
 
   const logs = await sandbox.process.getSessionCommandLogs(sessionId, commandId).catch(
@@ -862,6 +878,7 @@ function toDaytonaSandboxRuntime(sandbox: Sandbox): DaytonaSandboxRuntime {
     },
     refreshData: () => sandbox.refreshData(),
     start: (timeout) => sandbox.start(timeout),
+    stop: (timeout) => sandbox.stop(timeout),
     delete: (timeout) => sandbox.delete(timeout),
     getSignedPreviewUrl: (port, expiresInSeconds) => sandbox.getSignedPreviewUrl(port, expiresInSeconds),
     process: {
@@ -1164,9 +1181,14 @@ async function wakeExistingDaytonaSandbox(input: {
   dataVolumeId: string
   imageVersion?: string | null
 }) {
-  if (isStoppedSandboxState(input.sandbox.state)) {
-    await startDaytonaSandboxForWake({ workerId: input.provisionInput.workerId, sandbox: input.sandbox })
+  if (isStartedSandboxState(input.sandbox.state)) {
+    // A failed health probe means an already-running OpenWork process cannot be
+    // trusted. Restart the sandbox before launching a new process so recovery
+    // cannot leave two servers competing for the same port and state files.
+    await input.sandbox.stop(env.daytona.stopTimeoutSeconds ?? env.daytona.deleteTimeoutSeconds)
+    await input.sandbox.refreshData()
   }
+  await startDaytonaSandboxForWake({ workerId: input.provisionInput.workerId, sandbox: input.sandbox })
 
   return startOpenWorkOnDaytonaSandbox({
     provisionInput: input.provisionInput,
@@ -1187,12 +1209,18 @@ async function recycleDaytonaSandbox(input: {
   oldWorkspaceVolumeId: string
   oldDataVolumeId: string
   oldImageVersion: string | null
+  replacementName?: string
+  requireRestoreMarker?: boolean
 }): Promise<ProvisionedInstance> {
   let replacementSandbox: DaytonaSandboxRuntime | null = null
 
   try {
     replacementSandbox = await input.runtime.createSandbox(
-      buildDaytonaCreateParams(input.provisionInput, currentDaytonaSandboxName(input.provisionInput), input.sharedVolume),
+      buildDaytonaCreateParams(
+        input.provisionInput,
+        input.replacementName ?? currentDaytonaSandboxName(input.provisionInput),
+        input.sharedVolume,
+      ),
     )
     const started = await startOpenWorkProcessOnDaytonaSandbox({
       provisionInput: input.provisionInput,
@@ -1200,7 +1228,9 @@ async function recycleDaytonaSandbox(input: {
       sandbox: replacementSandbox,
       sessionId: `openwork-recycle-${workerHint(input.provisionInput.workerId)}-${Date.now()}`,
     })
-    const restored = await input.runtime.verifyRestoreMarker(replacementSandbox)
+    const restored = input.requireRestoreMarker === false
+      ? true
+      : await input.runtime.verifyRestoreMarker(replacementSandbox)
     if (!restored) {
       throw new Error("Daytona replacement did not restore an OpenWork checkpoint")
     }
@@ -1383,14 +1413,40 @@ export async function wakeWorkerOnDaytonaWithRuntime(
     }
   }
 
-  return wakeExistingDaytonaSandbox({
-    provisionInput: input,
-    runtime,
-    sandbox,
-    workspaceVolumeId: record.workspace_volume_id,
-    dataVolumeId: record.data_volume_id,
-    imageVersion: workerImageVersion,
-  })
+  try {
+    return await wakeExistingDaytonaSandbox({
+      provisionInput: input,
+      runtime,
+      sandbox,
+      workspaceVolumeId: record.workspace_volume_id,
+      dataVolumeId: record.data_volume_id,
+      imageVersion: workerImageVersion,
+    })
+  } catch (wakeError) {
+    const sharedVolume = await getSharedDaytonaVolume(runtime)
+    const hasCheckpoint = await runtime.checkpointExists({ workerId: input.workerId, sharedVolume })
+    if (!hasCheckpoint && workerImageVersion !== null) {
+      throw wakeError
+    }
+
+    logger.warn("Daytona sandbox wake failed; replacing the unhealthy sandbox", {
+      worker_id: input.workerId,
+      sandbox_id: sandbox.id,
+      checkpoint_available: hasCheckpoint,
+      error: wakeError,
+    })
+    return recycleDaytonaSandbox({
+      provisionInput: input,
+      runtime,
+      oldSandbox: sandbox,
+      sharedVolume,
+      oldWorkspaceVolumeId: record.workspace_volume_id,
+      oldDataVolumeId: record.data_volume_id,
+      oldImageVersion: workerImageVersion,
+      replacementName: recoveryDaytonaSandboxName(input),
+      requireRestoreMarker: hasCheckpoint,
+    })
+  }
 }
 
 export async function wakeWorkerOnDaytona(

--- a/ee/apps/den-api/src/workers/worker-access.ts
+++ b/ee/apps/den-api/src/workers/worker-access.ts
@@ -15,7 +15,6 @@ import { fetchWithConnectRetry, previewFetch } from "./preview-fetch.js"
 import {
   cloudStartupFailureFromWorker,
   cloudStartupFailureUpdate,
-  createCloudStartupFailure,
   createKnownCloudStartupFailure,
   type CloudStartupFailure,
 } from "./cloud-failure.js"
@@ -43,14 +42,6 @@ export type CloudRuntimeStore = {
 type OrganizationId = typeof WorkerTable.$inferSelect.org_id
 type UserId = NonNullable<typeof WorkerTable.$inferSelect.created_by_user_id>
 type WorkerId = typeof WorkerTable.$inferSelect.id
-type ContinueProvisioning = (input: {
-  workerId: WorkerId
-  orgId?: OrganizationId
-  name: string
-  hostToken: string
-  clientToken: string
-  activityToken: string
-}) => Promise<void>
 type GetSandboxRecord = (workerId: WorkerId) => Promise<CloudRuntimeSandboxRecord | null>
 type InspectSandbox = (workerId: WorkerId) => Promise<CloudRuntimeSandboxInspection>
 type RefreshSignedPreview = (workerId: WorkerId) => Promise<CloudRuntimeSandboxRecord | null>
@@ -63,9 +54,9 @@ export type CloudRuntimeOwnership =
 
 export type CloudRuntimeState =
   | { status: "ready"; url: string; expiresAt: Date }
-  | { status: "waking"; url: null; reason?: "stopped" | "recovering" | "reprovisioning" | "unreachable" }
-  | { status: "provisioning"; url: null; reason?: "unreachable" }
-  | { status: "failed"; url: null; reason?: "missing_tokens" | "unreachable" | "preview_expired" }
+  | { status: "waking"; url: null; reason?: "stopped" | "recovering" | "reprovisioning" | "unreachable"; failure?: CloudStartupFailure }
+  | { status: "provisioning"; url: null; reason?: "unreachable"; failure?: CloudStartupFailure }
+  | { status: "failed"; url: null; reason?: "missing_tokens" | "unreachable" | "preview_expired"; failure?: CloudStartupFailure }
 
 export type CloudWorkerAccess = {
   url: string
@@ -83,7 +74,6 @@ export type CloudRuntimeAccessResult =
   | { status: "missing" }
 
 export type ResolveCloudRuntimeStateOptions = {
-  continueProvisioning: ContinueProvisioning
   refreshSignedPreview: RefreshSignedPreview
   getSandboxRecord: GetSandboxRecord
   inspectSandbox: InspectSandbox
@@ -109,7 +99,6 @@ const failedHealCooldownMs = 60_000
 const explicitFailedHealCooldownMs = 60_000
 const signedPreviewProbeTimeoutMs = 2_500
 const signedPreviewHealthCacheMs = 15_000
-const failedHealAttempts = new Map<WorkerId, number>()
 const explicitFailedHealAttempts = new Map<WorkerId, number>()
 const signedPreviewHealthCache = new Map<WorkerId, { url: string; healthyUntilMs: number }>()
 const wakingWorkers = new Set<WorkerId>()
@@ -223,11 +212,6 @@ export async function probeCloudRuntimeSignedPreview(signedPreviewUrl: string) {
   }
 }
 
-async function defaultContinueProvisioning(input: Parameters<ContinueProvisioning>[0]) {
-  const { continueCloudProvisioning } = await import("../routes/workers/shared.js")
-  return continueCloudProvisioning(input)
-}
-
 function startDefaultWake(workerId: WorkerId) {
   if (wakingWorkers.has(workerId)) return
   wakingWorkers.add(workerId)
@@ -252,57 +236,27 @@ function rememberHealthyPreview(workerId: WorkerId, url: string, now: number, ex
   })
 }
 
-async function startFailedCloudHeal(input: {
+async function startClaimedCloudRecovery(input: {
   worker: CloudRuntimeWorker
-  orgId: OrganizationId
-  continueProvisioning: ContinueProvisioning
+  startRecovery: StartWake
   store: CloudRuntimeStore
 }) {
   const claimed = await input.store.claimFailedWorker(input.worker.id)
   if (!claimed) return false
-
-  void (async () => {
-    const tokens = await input.store.getActiveTokens(input.worker.id)
-    const hostToken = tokenByScope(tokens, "host")
-    const clientToken = tokenByScope(tokens, "client")
-    const activityToken = tokenByScope(tokens, "activity")
-    if (!hostToken || !clientToken || !activityToken) {
-      const failure = createKnownCloudStartupFailure({ code: "access_tokens_missing", stage: "recovery" })
-      await input.store.markProvisioningWorkerFailed(input.worker.id, failure)
-      logger.error("cloud failed-worker heal failed", {
-        worker_id: input.worker.id,
-        failure_code: failure.code,
-        failure_stage: failure.stage,
-        failure_reference: failure.reference,
-      })
-      return
-    }
-    await input.continueProvisioning({
-      workerId: input.worker.id,
-      orgId: input.orgId,
-      name: input.worker.name,
-      hostToken,
-      clientToken,
-      activityToken,
-    })
-  })().catch(async (error) => {
-    const failure = createCloudStartupFailure({ stage: "recovery", error })
-    await input.store.markProvisioningWorkerFailed(input.worker.id, failure).catch(() => undefined)
-    logger.error("cloud failed-worker heal failed", {
-      worker_id: input.worker.id,
-      failure_code: failure.code,
-      failure_stage: failure.stage,
-      failure_reference: failure.reference,
-      error,
-    })
-  })
+  input.startRecovery(input.worker.id)
   return true
+}
+
+function recoveryFailureIsCoolingDown(worker: CloudRuntimeWorker, now: number) {
+  if (worker.cloud_failure_stage !== "recovery") return false
+  const failedAt = worker.cloud_failure_at
+  if (!(failedAt instanceof Date)) return false
+  const elapsedMs = now - failedAt.getTime()
+  return elapsedMs >= 0 && elapsedMs < failedHealCooldownMs
 }
 
 async function resolveFailedCloudRuntime(input: {
   worker: CloudRuntimeWorker
-  orgId: OrganizationId
-  continueProvisioning: ContinueProvisioning
   getSandboxRecord: GetSandboxRecord
   startRecovery: StartWake
   store: CloudRuntimeStore
@@ -310,26 +264,22 @@ async function resolveFailedCloudRuntime(input: {
   forceRecovery?: boolean
 }): Promise<CloudRuntimeState> {
   const now = input.now()
-  const lastAttempt = failedHealAttempts.get(input.worker.id)
+  const failure = cloudStartupFailureFromWorker(input.worker) ?? undefined
   const lastExplicitAttempt = explicitFailedHealAttempts.get(input.worker.id)
   if (input.forceRecovery) {
     if (lastExplicitAttempt !== undefined && now - lastExplicitAttempt < explicitFailedHealCooldownMs) {
-      return { status: "failed", url: null }
+      return { status: "failed", url: null, ...(failure ? { failure } : {}) }
     }
     explicitFailedHealAttempts.set(input.worker.id, now)
-  } else if (lastAttempt !== undefined && now - lastAttempt < failedHealCooldownMs) {
-    return { status: "failed", url: null }
+  } else if (recoveryFailureIsCoolingDown(input.worker, now)) {
+    return { status: "failed", url: null, ...(failure ? { failure } : {}) }
   }
-  failedHealAttempts.set(input.worker.id, now)
   const sandbox = await input.getSandboxRecord(input.worker.id)
-  if (sandbox) {
-    const claimed = await input.store.claimFailedWorker(input.worker.id)
-    if (!claimed) return { status: "failed", url: null }
-    input.startRecovery(input.worker.id)
-    return { status: "waking", url: null, reason: "recovering" }
-  }
-  const started = await startFailedCloudHeal(input)
-  return started ? { status: "provisioning", url: null } : { status: "failed", url: null }
+  const started = await startClaimedCloudRecovery(input)
+  if (!started) return { status: "failed", url: null, ...(failure ? { failure } : {}) }
+  return sandbox
+    ? { status: "waking", url: null, reason: "recovering", ...(failure ? { failure } : {}) }
+    : { status: "provisioning", url: null, ...(failure ? { failure } : {}) }
 }
 
 async function readyFromSignedPreview(input: {
@@ -408,8 +358,6 @@ async function startStaleStoppedRecycle(input: {
 
 async function recoverUnhealthyCloudSandbox(input: {
   worker: CloudRuntimeWorker
-  orgId: OrganizationId
-  continueProvisioning: ContinueProvisioning
   inspectSandbox: InspectSandbox
   startRecovery: StartWake
   store: CloudRuntimeStore
@@ -429,8 +377,8 @@ async function recoverUnhealthyCloudSandbox(input: {
   unreachableWorkers.add(input.worker.id)
   const failure = createKnownCloudStartupFailure({ code: "runtime_unreachable", stage: "runtime" })
   await input.store.markHealthyWorkerFailed(input.worker.id, failure)
-  await startFailedCloudHeal(input)
-  return { status: "waking", url: null, reason: "unreachable" }
+  await startClaimedCloudRecovery(input)
+  return { status: "waking", url: null, reason: "unreachable", failure }
 }
 
 export async function resolveCloudRuntimeState(input: {
@@ -440,8 +388,6 @@ export async function resolveCloudRuntimeState(input: {
   if (input.worker.status === "failed") {
     return resolveFailedCloudRuntime({
       worker: input.worker,
-      orgId: input.organizationId,
-      continueProvisioning: options.continueProvisioning,
       getSandboxRecord: options.getSandboxRecord,
       startRecovery: options.startRecovery,
       store: options.store,
@@ -471,13 +417,12 @@ export async function resolveCloudRuntimeState(input: {
     if (input.worker.status === "healthy") {
       const failure = createKnownCloudStartupFailure({ code: "sandbox_missing", stage: "runtime" })
       await options.store.markHealthyWorkerFailed(input.worker.id, failure)
-      await startFailedCloudHeal({
+      await startClaimedCloudRecovery({
         worker: input.worker,
-        orgId: input.organizationId,
-        continueProvisioning: options.continueProvisioning,
+        startRecovery: options.startRecovery,
         store: options.store,
       })
-      return { status: "waking", url: null, reason: "reprovisioning" }
+      return { status: "waking", url: null, reason: "reprovisioning", failure }
     }
     return { status: "provisioning", url: null }
   }
@@ -508,13 +453,11 @@ export async function resolveCloudRuntimeState(input: {
   if (refreshedReady?.status === "failed") {
     const failure = createKnownCloudStartupFailure({ code: "preview_expired", stage: "runtime" })
     await options.store.markHealthyWorkerFailed(input.worker.id, failure)
-    return refreshedReady
+    return { ...refreshedReady, failure }
   }
   if (refreshedReady) return refreshedReady
   return recoverUnhealthyCloudSandbox({
     worker: input.worker,
-    orgId: input.organizationId,
-    continueProvisioning: options.continueProvisioning,
     inspectSandbox: options.inspectSandbox,
     startRecovery: options.startRecovery,
     store: options.store,
@@ -525,12 +468,12 @@ export async function resolveCloudRuntimeAccess(
   ownership: CloudRuntimeOwnership,
   options: ResolveCloudRuntimeAccessOptions = {},
 ): Promise<CloudRuntimeAccessResult> {
-  const worker = await (options.loadWorker ?? loadOwnedCloudWorker)(ownership)
+  const loadWorker = options.loadWorker ?? loadOwnedCloudWorker
+  const worker = await loadWorker(ownership)
   if (!worker) return { status: "missing" }
 
   const store = options.store ?? databaseCloudRuntimeStore
   const state = await resolveCloudRuntimeState({ worker, organizationId: ownership.organizationId }, {
-    continueProvisioning: options.continueProvisioning ?? defaultContinueProvisioning,
     refreshSignedPreview: options.refreshSignedPreview ?? refreshDaytonaSignedPreview,
     getSandboxRecord: options.getSandboxRecord ?? getDaytonaSandboxRecord,
     inspectSandbox: options.inspectSandbox ?? inspectDaytonaSandbox,
@@ -541,7 +484,7 @@ export async function resolveCloudRuntimeAccess(
     now: options.now ?? Date.now,
     forceFailedRecovery: options.forceFailedRecovery,
   })
-  const failure = cloudStartupFailureFromWorker(worker)
+  const failure = state.status === "ready" ? null : state.failure ?? cloudStartupFailureFromWorker(worker)
   if (state.status === "provisioning") {
     const reason: "unreachable" | undefined = unreachableWorkers.has(worker.id) ? "unreachable" : undefined
     return {
@@ -561,7 +504,7 @@ export async function resolveCloudRuntimeAccess(
   }
 
   unreachableWorkers.delete(worker.id)
-  failedHealAttempts.delete(worker.id)
+  explicitFailedHealAttempts.delete(worker.id)
   const tokens = await store.getActiveTokens(worker.id)
   const clientToken = tokenByScope(tokens, "client")
   const hostToken = tokenByScope(tokens, "host")

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -170,6 +170,7 @@ function makeCloudWorkerStore(input: {
   initialWorkers?: StoredCloudWorker[]
   tokens?: StoredToken[]
   injectCanonicalCreateRace?: boolean
+  failAtomicCreate?: boolean
 } = {}) {
   let sequence = 0
   const workers = [...(input.initialWorkers ?? [])]
@@ -187,16 +188,21 @@ function makeCloudWorkerStore(input: {
         .sort((left, right) => left.createdAt - right.createdAt)
       return rows[0] ?? null
     },
-    async insertCloudWorker(row) {
+    async insertCloudWorkerWithTokens(row) {
+      if (input.failAtomicCreate) {
+        throw new Error("token insert failed")
+      }
       if (input.injectCanonicalCreateRace) {
+        const canonicalId = createDenTypeId("worker")
         workers.push({
-          id: createDenTypeId("worker"),
+          id: canonicalId,
           name: "Cloud — Canonical",
           status: "provisioning",
           orgId: row.orgId,
           userId: row.userId,
           createdAt: sequence,
         })
+        tokens.push(makeToken(canonicalId, "host"), makeToken(canonicalId, "client"), makeToken(canonicalId, "activity"))
       }
 
       sequence += 1
@@ -208,8 +214,6 @@ function makeCloudWorkerStore(input: {
         userId: row.userId,
         createdAt: sequence,
       })
-    },
-    async insertWorkerTokens(row) {
       tokens.push(makeToken(row.workerId, "host"), makeToken(row.workerId, "client"), makeToken(row.workerId, "activity"))
     },
     async deleteCreateRaceLoser(workerId) {
@@ -239,18 +243,30 @@ function makeCloudWorkerStore(input: {
     async getActiveTokens(workerId) {
       return tokens.filter((entry) => entry.workerId === workerId)
     },
-    async markProvisioningWorkerFailed(workerId) {
+    async markProvisioningWorkerFailed(workerId, failure) {
       provisioningFailures += 1
       const worker = workers.find((entry) => entry.id === workerId)
       if (worker?.status === "provisioning") {
         worker.status = "failed"
+        if (failure) {
+          worker.cloud_failure_code = failure.code
+          worker.cloud_failure_stage = failure.stage
+          worker.cloud_failure_reference = failure.reference
+          worker.cloud_failure_at = failure.occurredAt
+        }
       }
     },
-    async markHealthyWorkerFailed(workerId) {
+    async markHealthyWorkerFailed(workerId, failure) {
       healthyFailures += 1
       const worker = workers.find((entry) => entry.id === workerId)
       if (worker?.status === "healthy") {
         worker.status = "failed"
+        if (failure) {
+          worker.cloud_failure_code = failure.code
+          worker.cloud_failure_stage = failure.stage
+          worker.cloud_failure_reference = failure.reference
+          worker.cloud_failure_at = failure.occurredAt
+        }
       }
     },
   }
@@ -1076,6 +1092,31 @@ describe("Cloud instance per-user workers", () => {
     expect(provisionCalls).toBe(0)
   })
 
+  test("does not publish or provision a worker when the atomic worker-and-token insert fails", async () => {
+    const store = makeCloudWorkerStore({ failAtomicCreate: true })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let provisionCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => null,
+      continueProvisioning: async () => {
+        provisionCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(500)
+    expect(store.workers).toHaveLength(0)
+    expect(store.tokens).toHaveLength(0)
+    expect(provisionCalls).toBe(0)
+  })
+
   test("uses the org member display name for the human-readable worker name", async () => {
     const orgId = createDenTypeId("organization")
     const userId = createDenTypeId("user")
@@ -1107,8 +1148,13 @@ describe("Cloud instance per-user workers", () => {
 describe("Cloud instance failed self-heal", () => {
   test("returns the durable safe diagnostic while recovery starts", async () => {
     const occurredAt = new Date("2026-08-28T12:00:00.000Z")
+    const context = organizationContext(JSON.stringify({ capabilities: { cloud: true } }))
     const worker = {
-      ...storedWorker({ status: "failed" }),
+      ...storedWorker({
+        orgId: context.organization.id,
+        userId: context.currentMember.userId,
+        status: "failed",
+      }),
       cloud_failure_code: "runtime_health_timeout",
       cloud_failure_stage: "recovery",
       cloud_failure_reference: "cwf_route-test",
@@ -1119,16 +1165,20 @@ describe("Cloud instance failed self-heal", () => {
       tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
     })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let recoveryCalls = 0
 
     routes.registerCloudRoutes(app, {
-      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      memberRoute: contextMiddleware(context),
       orgMode: "multi_org",
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
       ensureCloudWorker: async () => worker,
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => null,
-      continueProvisioning: async () => undefined,
+      now: () => occurredAt.getTime() + 120_000,
+      recoverCloudWorker: async () => {
+        recoveryCalls += 1
+      },
     })
 
     const response = await app.request("http://den.local/v1/cloud/instance")
@@ -1144,6 +1194,7 @@ describe("Cloud instance failed self-heal", () => {
         occurredAt: occurredAt.toISOString(),
       },
     })
+    expect(recoveryCalls).toBe(1)
     expect(JSON.stringify(payload)).not.toContain("token")
   })
 
@@ -1154,7 +1205,6 @@ describe("Cloud instance failed self-heal", () => {
       tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
     })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
-    let provisionCalls = 0
     let wakeCalls = 0
 
     routes.registerCloudRoutes(app, {
@@ -1167,10 +1217,7 @@ describe("Cloud instance failed self-heal", () => {
       getSandboxRecord: async () => fakeSandbox(),
       inspectSandbox: async () => ({ state: "stopped" }),
       probeSignedPreview: async () => true,
-      continueProvisioning: async () => {
-        provisionCalls += 1
-      },
-      wakeCloudWorker: async () => {
+      recoverCloudWorker: async () => {
         wakeCalls += 1
         worker.status = "healthy"
       },
@@ -1182,7 +1229,6 @@ describe("Cloud instance failed self-heal", () => {
     await flushMicrotasks()
 
     expect(store.claimAttempts).toBe(1)
-    expect(provisionCalls).toBe(0)
     expect(wakeCalls).toBe(1)
     expect(worker.status).not.toBe("failed")
 
@@ -1190,15 +1236,21 @@ describe("Cloud instance failed self-heal", () => {
       .resolves.toEqual(expectedCloudInstance({ status: "ready", url: "https://preview.example.test" }))
   })
 
-  test("lets one explicit retry bypass passive cooldown but rate-limits repeated retries", async () => {
-    const worker = storedWorker({ status: "failed" })
+  test("keeps passive cooldown durable and rate-limits repeated explicit retries", async () => {
+    let now = 1_000
+    const worker = {
+      ...storedWorker({ status: "failed" }),
+      cloud_failure_code: "provider_operation_failed",
+      cloud_failure_stage: "provisioning",
+      cloud_failure_reference: "cwf_initial-provisioning",
+      cloud_failure_at: new Date(now),
+    } satisfies StoredCloudWorker
     const store = makeCloudWorkerStore({
       initialWorkers: [worker],
       tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
     })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
-    let provisionCalls = 0
-    let now = 1_000
+    let recoveryCalls = 0
 
     routes.registerCloudRoutes(app, {
       memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
@@ -1209,49 +1261,72 @@ describe("Cloud instance failed self-heal", () => {
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => null,
       now: () => now,
-      continueProvisioning: async () => {
-        provisionCalls += 1
+      recoverCloudWorker: async () => {
+        recoveryCalls += 1
       },
     })
 
+    const publicInitialFailure = {
+      code: "provider_operation_failed",
+      stage: "provisioning",
+      reference: "cwf_initial-provisioning",
+      occurredAt: new Date(1_000).toISOString(),
+    }
     const first = await app.request("http://den.local/v1/cloud/instance")
     expect(first.status).toBe(200)
-    await expect(first.json()).resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
+    await expect(first.json()).resolves.toEqual({
+      ...expectedCloudInstance({ status: "provisioning", url: null }),
+      failure: publicInitialFailure,
+    })
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(1)
-    expect(provisionCalls).toBe(1)
+    expect(recoveryCalls).toBe(1)
 
     worker.status = "failed"
+    worker.cloud_failure_stage = "recovery"
+    worker.cloud_failure_at = new Date(now)
     now += 10_000
     const second = await app.request("http://den.local/v1/cloud/instance")
     expect(second.status).toBe(200)
-    await expect(second.json()).resolves.toEqual(expectedCloudInstance({ status: "failed", url: null }))
+    await expect(second.json()).resolves.toEqual({
+      ...expectedCloudInstance({ status: "failed", url: null }),
+      failure: { ...publicInitialFailure, stage: "recovery" },
+    })
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(1)
-    expect(provisionCalls).toBe(1)
+    expect(recoveryCalls).toBe(1)
 
     const retry = await app.request("http://den.local/v1/cloud/instance/retry", { method: "POST" })
     expect(retry.status).toBe(200)
-    await expect(retry.json()).resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
+    await expect(retry.json()).resolves.toEqual({
+      ...expectedCloudInstance({ status: "provisioning", url: null }),
+      failure: { ...publicInitialFailure, stage: "recovery" },
+    })
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(2)
-    expect(provisionCalls).toBe(2)
+    expect(recoveryCalls).toBe(2)
 
     worker.status = "failed"
     const repeatedRetry = await app.request("http://den.local/v1/cloud/instance/retry", { method: "POST" })
     expect(repeatedRetry.status).toBe(200)
-    await expect(repeatedRetry.json()).resolves.toEqual(expectedCloudInstance({ status: "failed", url: null }))
+    await expect(repeatedRetry.json()).resolves.toEqual({
+      ...expectedCloudInstance({ status: "failed", url: null }),
+      failure: { ...publicInitialFailure, stage: "recovery" },
+    })
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(2)
-    expect(provisionCalls).toBe(2)
+    expect(recoveryCalls).toBe(2)
 
     now += 60_000
     const cooledRetry = await app.request("http://den.local/v1/cloud/instance/retry", { method: "POST" })
     expect(cooledRetry.status).toBe(200)
-    await expect(cooledRetry.json()).resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
+    await expect(cooledRetry.json()).resolves.toEqual({
+      ...expectedCloudInstance({ status: "provisioning", url: null }),
+      failure: { ...publicInitialFailure, stage: "recovery" },
+    })
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(3)
-    expect(provisionCalls).toBe(3)
+    expect(recoveryCalls).toBe(3)
   })
 
   test("two concurrent failed GETs start exactly one heal", async () => {
@@ -1261,7 +1336,7 @@ describe("Cloud instance failed self-heal", () => {
       tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
     })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
-    let provisionCalls = 0
+    let recoveryCalls = 0
 
     routes.registerCloudRoutes(app, {
       memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
@@ -1272,8 +1347,8 @@ describe("Cloud instance failed self-heal", () => {
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => null,
       now: () => 5_000,
-      continueProvisioning: async () => {
-        provisionCalls += 1
+      recoverCloudWorker: async () => {
+        recoveryCalls += 1
       },
     })
 
@@ -1286,8 +1361,8 @@ describe("Cloud instance failed self-heal", () => {
     expect(payloads).toContainEqual(expectedCloudInstance({ status: "provisioning", url: null }))
     expect(payloads).toContainEqual(expectedCloudInstance({ status: "failed", url: null }))
     await flushMicrotasks()
-    expect(store.claimAttempts).toBe(1)
-    expect(provisionCalls).toBe(1)
+    expect(store.claimAttempts).toBe(2)
+    expect(recoveryCalls).toBe(1)
   })
 })
 
@@ -1332,17 +1407,22 @@ describe("Cloud instance ready liveness", () => {
     expect(store.recycleClaimAttempts).toBe(1)
   })
 
-  test("marks missing sandboxes failed, kicks heal, and reports waking", async () => {
-    const worker = storedWorker({ status: "healthy" })
+  test("persists a same-poll diagnostic before recovering an unreachable running sandbox", async () => {
+    const context = organizationContext(JSON.stringify({ capabilities: { cloud: true } }))
+    const worker = storedWorker({
+      orgId: context.organization.id,
+      userId: context.currentMember.userId,
+      status: "healthy",
+    })
     const store = makeCloudWorkerStore({
       initialWorkers: [worker],
       tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
     })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
-    let provisionCalls = 0
+    let recoveryCalls = 0
 
     routes.registerCloudRoutes(app, {
-      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      memberRoute: contextMiddleware(context),
       orgMode: "multi_org",
       provisionerMode: "daytona",
       daytonaApiKey: "daytona-test-key",
@@ -1352,19 +1432,27 @@ describe("Cloud instance ready liveness", () => {
       refreshSignedPreview: async () => null,
       probeSignedPreview: async () => false,
       inspectSandbox: async () => null,
-      continueProvisioning: async () => {
-        provisionCalls += 1
+      recoverCloudWorker: async () => {
+        recoveryCalls += 1
       },
     })
 
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
+    await expect(response.json()).resolves.toEqual({
+      ...expectedCloudInstance({ status: "waking", url: null }),
+      failure: {
+        code: "runtime_unreachable",
+        stage: "runtime",
+        reference: expect.stringMatching(/^cwf_/),
+        occurredAt: expect.any(String),
+      },
+    })
     await flushMicrotasks()
     expect(store.healthyFailures).toBe(1)
     expect(store.claimAttempts).toBe(1)
-    expect(provisionCalls).toBe(1)
+    expect(recoveryCalls).toBe(1)
   })
 
   test("caches healthy preview probes for 15 seconds", async () => {

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -145,6 +145,9 @@ function makeDaytonaWakeRuntime(input: {
       }
       state = "started"
     },
+    async stop() {
+      state = "stopped"
+    },
     async delete() {},
     async getSignedPreviewUrl() {
       return { url: "https://wake.preview.example.test" }

--- a/ee/apps/den-api/test/cloud-runtime-access.test.ts
+++ b/ee/apps/den-api/test/cloud-runtime-access.test.ts
@@ -72,7 +72,6 @@ function options(input: {
   return {
     loadWorker: async () => input.runtimeWorker,
     store: input.runtimeStore ?? store(),
-    continueProvisioning: async () => {},
     getSandboxRecord: async () => ({
       signed_preview_url: input.signedPreviewUrl ?? "https://fresh.preview.example.test",
       signed_preview_url_expires_at: input.expiresAt ?? new Date("2026-08-27T12:00:00.000Z"),
@@ -178,7 +177,12 @@ describe("Cloud runtime access resolver", () => {
       },
     })
 
-    expect(result).toEqual({ status: "failed", workerId: runtimeWorker.id, reason: "preview_expired" })
+    expect(result).toEqual(expect.objectContaining({
+      status: "failed",
+      workerId: runtimeWorker.id,
+      reason: "preview_expired",
+      failure: expect.objectContaining({ code: "preview_expired", stage: "runtime" }),
+    }))
     expect(probes).toBe(0)
   })
 
@@ -235,7 +239,12 @@ describe("Cloud runtime access resolver", () => {
       workerId: runtimeWorker.id,
     }, resolverOptions)
 
-    expect(first).toEqual({ status: "waking", workerId: runtimeWorker.id, reason: "unreachable" })
+    expect(first).toEqual(expect.objectContaining({
+      status: "waking",
+      workerId: runtimeWorker.id,
+      reason: "unreachable",
+      failure: expect.objectContaining({ code: "runtime_unreachable", stage: "runtime" }),
+    }))
     expect(recovering).toEqual({ status: "waking", workerId: runtimeWorker.id, reason: "unreachable" })
   })
 

--- a/ee/apps/den-api/test/daytona-provisioning.test.ts
+++ b/ee/apps/den-api/test/daytona-provisioning.test.ts
@@ -46,11 +46,13 @@ function makeSandbox(input: {
   state: string
   startError?: Error
   startErrors?: Error[]
+  stopError?: Error
   refreshStates?: string[]
   onSignedPreview?: () => void
 }) {
   let state = input.state
   let startCalls = 0
+  let stopCalls = 0
   let deleteCalls = 0
   let refreshCalls = 0
   const sandbox = {
@@ -75,6 +77,11 @@ function makeSandbox(input: {
         throw startError
       }
       state = "started"
+    },
+    async stop() {
+      stopCalls += 1
+      if (input.stopError) throw input.stopError
+      state = "stopped"
     },
     async delete() {
       deleteCalls += 1
@@ -101,6 +108,9 @@ function makeSandbox(input: {
     sandbox,
     get startCalls() {
       return startCalls
+    },
+    get stopCalls() {
+      return stopCalls
     },
     get deleteCalls() {
       return deleteCalls
@@ -206,6 +216,46 @@ function makeRuntime(input: {
   }
 }
 
+describe("Daytona Cloud health deadline", () => {
+  test("aborts a hung health request within the remaining readiness budget", async () => {
+    const originalFetch = globalThis.fetch
+    let aborted = false
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: ((_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        if (!signal) {
+          reject(new Error("health request did not receive an abort signal"))
+          return
+        }
+        const onAbort = () => {
+          aborted = true
+          reject(signal.reason)
+        }
+        if (signal.aborted) onAbort()
+        else signal.addEventListener("abort", onAbort, { once: true })
+      })) satisfies typeof fetch,
+    })
+    const sandbox = makeSandbox({ id: "sbx_hung_health", state: "started" })
+    const startedAt = Date.now()
+
+    try {
+      await expect(daytona.waitForHealth(
+        "https://hung.preview.example.test",
+        20,
+        sandbox.sandbox,
+        "session_hung_health",
+        "command_hung_health",
+      )).rejects.toThrow("Timed out waiting for Daytona worker health")
+    } finally {
+      Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch })
+    }
+
+    expect(aborted).toBe(true)
+    expect(Date.now() - startedAt).toBeLessThan(500)
+  })
+})
+
 describe("Daytona Cloud provisioning adoption", () => {
   test("adopts the existing sandbox when create races and Daytona returns a conflict", async () => {
     const input = provisionInput()
@@ -255,6 +305,8 @@ describe("Daytona Cloud provisioning adoption", () => {
     expect(runtime.nameLookups.filter((name) => name === sandboxName)).toHaveLength(7)
     expect(sleeps).toEqual([2_000, 2_000, 2_000, 2_000, 2_000])
     expect(runtime.upserts[0]?.sandboxId).toBe("sbx_late_visible")
+    expect(existing.stopCalls).toBe(1)
+    expect(existing.startCalls).toBe(1)
   })
 
   test("bounds create-conflict rechecks when the sandbox stays missing", async () => {
@@ -382,7 +434,7 @@ describe("Daytona Cloud version-aware recycle", () => {
     expect(replacement.deleteCalls).toBe(0)
   })
 
-  test("does not recycle a stale running sandbox", async () => {
+  test("restarts rather than duplicates the process on a stale running sandbox", async () => {
     const input = provisionInput()
     const old = makeSandbox({ id: "sbx_running", state: "started" })
     const runtime = makeRuntime({
@@ -402,8 +454,96 @@ describe("Daytona Cloud version-aware recycle", () => {
     expect(result.imageVersion).toBe("openwork-0.18.7")
     expect(runtime.createCalls).toBe(0)
     expect(runtime.checkpointChecks).toBe(0)
+    expect(old.stopCalls).toBe(1)
+    expect(old.startCalls).toBe(1)
     expect(old.deleteCalls).toBe(0)
     expect(runtime.upserts[0]?.sandboxId).toBe("sbx_running")
+  })
+
+  test("replaces an unrecoverable running sandbox when a checkpoint can restore it", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({
+      id: "sbx_unrecoverable",
+      state: "started",
+      stopError: new Error("provider refused sandbox stop"),
+    })
+    const replacement = makeSandbox({ id: "sbx_recovery_replacement", state: "started" })
+    const runtime = makeRuntime({
+      createdSandbox: replacement.sandbox,
+      checkpointExists: true,
+      restoreMarkerVerified: true,
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(input, {
+      ...runtime.runtime,
+      async getSandbox() {
+        return old.sandbox
+      },
+    }, {
+      sandbox_id: old.sandbox.id,
+      workspace_volume_id: "vol_shared",
+      data_volume_id: "vol_shared",
+    }, "openwork-0.18.8")
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(1)
+    expect(runtime.createInputs[0]?.name).toContain("recovery")
+    expect(runtime.checkpointChecks).toBe(1)
+    expect(runtime.restoreMarkerChecks).toBe(1)
+    expect(old.stopCalls).toBe(1)
+    expect(old.deleteCalls).toBe(1)
+    expect(replacement.deleteCalls).toBe(0)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_recovery_replacement")
+  })
+
+  test("does not destroy an established workspace when failed wake has no checkpoint", async () => {
+    const input = provisionInput()
+    const wakeError = new Error("provider refused sandbox stop")
+    const old = makeSandbox({ id: "sbx_unrecoverable_no_checkpoint", state: "started", stopError: wakeError })
+    const runtime = makeRuntime({ checkpointExists: false })
+
+    await expect(daytona.wakeWorkerOnDaytonaWithRuntime(input, {
+      ...runtime.runtime,
+      async getSandbox() {
+        return old.sandbox
+      },
+    }, {
+      sandbox_id: old.sandbox.id,
+      workspace_volume_id: "vol_shared",
+      data_volume_id: "vol_shared",
+    }, "openwork-0.18.8")).rejects.toBe(wakeError)
+
+    expect(runtime.checkpointChecks).toBe(1)
+    expect(runtime.createCalls).toBe(0)
+    expect(old.deleteCalls).toBe(0)
+  })
+
+  test("replaces a never-healthy sandbox even before its first checkpoint", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({
+      id: "sbx_initial_failure",
+      state: "started",
+      stopError: new Error("provider refused sandbox stop"),
+    })
+    const replacement = makeSandbox({ id: "sbx_initial_replacement", state: "started" })
+    const runtime = makeRuntime({ createdSandbox: replacement.sandbox, checkpointExists: false })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(input, {
+      ...runtime.runtime,
+      async getSandbox() {
+        return old.sandbox
+      },
+    }, {
+      sandbox_id: old.sandbox.id,
+      workspace_volume_id: "vol_shared",
+      data_volume_id: "vol_shared",
+    }, null)
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(1)
+    expect(runtime.restoreMarkerChecks).toBe(0)
+    expect(old.deleteCalls).toBe(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_initial_replacement")
   })
 
   test("does not recycle a stale stopped sandbox before a checkpoint exists", async () => {

--- a/ee/apps/den-api/test/worker-runtime-signed-preview.test.ts
+++ b/ee/apps/den-api/test/worker-runtime-signed-preview.test.ts
@@ -78,7 +78,6 @@ test("generic Daytona runtime routes refresh expiry and request only the fresh p
     resolveCloudAccess: (ownership) => access.resolveCloudRuntimeAccess(ownership, {
       loadWorker: async () => runtimeWorker,
       store: runtimeStore(),
-      continueProvisioning: async () => {},
       getSandboxRecord: async () => ({
         signed_preview_url: "https://expired.preview.example.test",
         signed_preview_url_expires_at: new Date("2026-08-27T09:00:00.000Z"),

--- a/evals/specs/cloud-runtime-signed-preview.test.ts
+++ b/evals/specs/cloud-runtime-signed-preview.test.ts
@@ -71,7 +71,6 @@ test("Cloud runtime access refreshes signed previews behind stable legacy routin
   }, {
     loadWorker: async () => runtimeWorker,
     store: runtimeStore,
-    continueProvisioning: async () => {},
     getSandboxRecord: async () => ({
       signed_preview_url: "https://expired.preview.example.test",
       signed_preview_url_expires_at: new Date("2026-08-27T09:00:00.000Z"),

--- a/evals/specs/cloud-startup-diagnostics.test.ts
+++ b/evals/specs/cloud-startup-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { test } from "@openwork/testkit";
 import { expect } from "vitest";
 import { createDenTypeId } from "../../ee/packages/utils/src/typeid.js";
+import type { DaytonaProvisioningRuntime, DaytonaSandboxRuntime } from "../../ee/apps/den-api/src/workers/daytona.js";
 import type { CloudRuntimeStore, CloudRuntimeWorker } from "../../ee/apps/den-api/src/workers/worker-access.js";
 
 function seedRequiredEnv() {
@@ -10,15 +11,19 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790";
   process.env.CORS_ORIGINS ??= "http://127.0.0.1:8790";
   process.env.PROVISIONER_MODE = "stub";
+  process.env.DAYTONA_API_KEY ??= "daytona-test-key";
+  process.env.DAYTONA_SNAPSHOT ??= "openwork-test-snapshot";
 }
 
 test("Cloud startup failures are diagnosable and explicitly retryable without leaking credentials", async ({ evidence }) => {
   seedRequiredEnv();
-  const [failureModule, runtimeModule, gatewayModule, clientModule] = await Promise.all([
+  const [failureModule, runtimeModule, gatewayModule, clientModule, workspaceStatusModule, daytonaModule] = await Promise.all([
     import("../../ee/apps/den-api/src/workers/cloud-failure.js"),
     import("../../ee/apps/den-api/src/workers/worker-access.js"),
     import("../../ee/apps/den-gateway/src/app.js"),
     import("../../apps/app/src/app/lib/den.js"),
+    import("../../apps/app/src/react-app/shell/cloud-workspace-status.js"),
+    import("../../ee/apps/den-api/src/workers/daytona.js"),
   ]);
 
   const failure = failureModule.createCloudStartupFailure({
@@ -39,13 +44,19 @@ test("Cloud startup failures are diagnosable and explicitly retryable without le
     id: createDenTypeId("worker"),
     name: "Cloud diagnostics proof",
     status: "failed",
+    cloud_failure_code: "provider_operation_failed",
+    cloud_failure_stage: "provisioning",
+    cloud_failure_reference: "cwf_initial-proof",
+    cloud_failure_at: new Date(1_000),
   };
   let claimAttempts = 0;
-  let provisionCalls = 0;
   let now = 1_000;
+  let recoveryCalls = 0;
   const store: CloudRuntimeStore = {
     async claimFailedWorker() {
       claimAttempts += 1;
+      if (worker.status !== "failed") return false;
+      worker.status = "provisioning";
       return true;
     },
     async claimRecycleWorker() { return false; },
@@ -60,13 +71,12 @@ test("Cloud startup failures are diagnosable and explicitly retryable without le
     async markHealthyWorkerFailed() {},
   };
   const options = {
-    continueProvisioning: async () => { provisionCalls += 1; },
     refreshSignedPreview: async () => null,
     getSandboxRecord: async () => null,
     inspectSandbox: async () => null,
     probeSignedPreview: async () => false,
     startWake: () => {},
-    startRecovery: () => {},
+    startRecovery: () => { recoveryCalls += 1; },
     store,
     now: () => now,
   };
@@ -75,6 +85,9 @@ test("Cloud startup failures are diagnosable and explicitly retryable without le
     worker,
     organizationId: createDenTypeId("organization"),
   }, options);
+  worker.status = "failed";
+  worker.cloud_failure_stage = "recovery";
+  worker.cloud_failure_at = new Date(1_000);
   const passive = await runtimeModule.resolveCloudRuntimeState({
     worker,
     organizationId: createDenTypeId("organization"),
@@ -83,6 +96,7 @@ test("Cloud startup failures are diagnosable and explicitly retryable without le
     worker,
     organizationId: createDenTypeId("organization"),
   }, { ...options, forceFailedRecovery: true });
+  worker.status = "failed";
   const repeatedExplicit = await runtimeModule.resolveCloudRuntimeState({
     worker,
     organizationId: createDenTypeId("organization"),
@@ -101,10 +115,221 @@ test("Cloud startup failures are diagnosable and explicitly retryable without le
   expect(repeatedExplicit.status).toBe("failed");
   expect(cooledExplicit.status).toBe("provisioning");
   expect(claimAttempts).toBe(3);
-  expect(provisionCalls).toBe(3);
+  expect(recoveryCalls).toBe(3);
   evidence.recordAssertionEvidence(
-    "Retry bypasses passive recovery without allowing an unbounded request loop",
-    "The first explicit retry bypassed passive polling's cooldown, an immediate repeated retry made no provider attempt, and retry became available again after the separate 60-second limit.",
+    "Recovery uses a durable passive cooldown and a bounded explicit retry",
+    "A persisted recovery failure throttled passive polling without process-local memory, one explicit retry bypassed that cooldown, an immediate repeated retry made no provider attempt, and retry became available again after 60 seconds.",
+    true,
+  );
+
+  const unavailable = workspaceStatusModule.mapCloudWorkspaceState({
+    instance: null,
+    updating: false,
+    requestFailed: true,
+  });
+  const sandboxFailed = workspaceStatusModule.mapCloudWorkspaceState({
+    instance: {
+      status: "failed",
+      url: null,
+      imageVersion: "openwork-test-snapshot",
+      latestVersion: "openwork-test-snapshot",
+    },
+    updating: false,
+    requestFailed: false,
+  });
+  expect(unavailable.variant).toBe("unavailable");
+  expect(unavailable.statusLine).toBe("Couldn’t check workspace status");
+  expect(sandboxFailed.variant).toBe("failed");
+  expect(workspaceStatusModule.cloudWorkspaceTakeoverCopy({ variant: unavailable.variant, slow: false }).body)
+    .toContain("sandbox may still be running");
+  evidence.recordAssertionEvidence(
+    "A control-plane request failure is not mislabeled as a sandbox failure",
+    "A failed status request maps to the unavailable state and explicitly says the sandbox may still be running, while a durable failed instance keeps the workspace-needs-attention recovery state.",
+    true,
+  );
+
+  let sandboxState = "started";
+  let stopCalls = 0;
+  let startCalls = 0;
+  let processStarts = 0;
+  const recoverySandbox = {
+    id: "sandbox_recovery_proof",
+    get state() { return sandboxState; },
+    get target() { return "us-test"; },
+    async refreshData() {},
+    async start() {
+      startCalls += 1;
+      sandboxState = "started";
+    },
+    async stop() {
+      stopCalls += 1;
+      sandboxState = "stopped";
+    },
+    async delete() {},
+    async getSignedPreviewUrl() {
+      return { url: "https://recovered.preview.example.test" };
+    },
+    process: {
+      async createSession() {},
+      async executeSessionCommand() {
+        processStarts += 1;
+        return { cmdId: "command_recovery_proof" };
+      },
+      async getSessionCommand() { return { exitCode: null }; },
+      async getSessionCommandLogs() { return { stdout: "", stderr: "" }; },
+    },
+  } satisfies DaytonaSandboxRuntime;
+  const persistedSandboxes: Array<Parameters<DaytonaProvisioningRuntime["upsertSandbox"]>[0]> = [];
+  const recoveryRuntime = {
+    async getVolume() { return { id: "volume_recovery_proof", state: "ready" }; },
+    async getSandbox() { return recoverySandbox; },
+    async createSandbox() { throw new Error("recovery must reuse the existing sandbox"); },
+    async upsertSandbox(input) { persistedSandboxes.push(input); },
+    async checkpointExists() { return false; },
+    async verifyRestoreMarker() { return false; },
+    async waitForHealth() {},
+    now: () => new Date("2026-08-28T12:00:00.000Z").getTime(),
+  } satisfies DaytonaProvisioningRuntime;
+  const recoveryWorkerId = createDenTypeId("worker");
+  const recovered = await daytonaModule.wakeWorkerOnDaytonaWithRuntime({
+    workerId: recoveryWorkerId,
+    name: "Cloud recovery proof",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  }, recoveryRuntime, {
+    sandbox_id: recoverySandbox.id,
+    workspace_volume_id: "volume_recovery_proof",
+    data_volume_id: "volume_recovery_proof",
+  }, "openwork-test-snapshot");
+  expect(recovered.status).toBe("healthy");
+  expect(stopCalls).toBe(1);
+  expect(startCalls).toBe(1);
+  expect(processStarts).toBe(1);
+  expect(persistedSandboxes).toHaveLength(1);
+  evidence.recordAssertionEvidence(
+    "Recovery replaces an untrusted running process instead of duplicating it",
+    "The production Daytona wake path stopped and restarted an already-running sandbox once, launched exactly one OpenWork process, passed health, and persisted one refreshed preview.",
+    true,
+  );
+
+  let failedSandboxDeletes = 0;
+  const failedStopSandbox = {
+    id: "sandbox_failed_stop_proof",
+    state: "started",
+    target: "us-test",
+    async refreshData() {},
+    async start() {},
+    async stop() { throw new Error("provider refused sandbox stop"); },
+    async delete() { failedSandboxDeletes += 1; },
+    async getSignedPreviewUrl() { return { url: "https://failed.preview.example.test" }; },
+    process: {
+      async createSession() {},
+      async executeSessionCommand() { return { cmdId: "command_failed_stop_proof" }; },
+      async getSessionCommand() { return { exitCode: null }; },
+      async getSessionCommandLogs() { return { stdout: "", stderr: "" }; },
+    },
+  } satisfies DaytonaSandboxRuntime;
+  let replacementProcessStarts = 0;
+  const replacementSandbox = {
+    id: "sandbox_replacement_proof",
+    state: "started",
+    target: "us-test",
+    async refreshData() {},
+    async start() {},
+    async stop() {},
+    async delete() {},
+    async getSignedPreviewUrl() { return { url: "https://replacement.preview.example.test" }; },
+    process: {
+      async createSession() {},
+      async executeSessionCommand() {
+        replacementProcessStarts += 1;
+        return { cmdId: "command_replacement_proof" };
+      },
+      async getSessionCommand() { return { exitCode: null }; },
+      async getSessionCommandLogs() { return { stdout: "", stderr: "" }; },
+    },
+  } satisfies DaytonaSandboxRuntime;
+  let replacementCreates = 0;
+  let replacementCheckpointChecks = 0;
+  let replacementRestoreChecks = 0;
+  const replacementRows: Array<Parameters<DaytonaProvisioningRuntime["upsertSandbox"]>[0]> = [];
+  const replacementRuntime = {
+    async getVolume() { return { id: "volume_replacement_proof", state: "ready" }; },
+    async getSandbox() { return failedStopSandbox; },
+    async createSandbox() {
+      replacementCreates += 1;
+      return replacementSandbox;
+    },
+    async upsertSandbox(input) { replacementRows.push(input); },
+    async checkpointExists() {
+      replacementCheckpointChecks += 1;
+      return true;
+    },
+    async verifyRestoreMarker() {
+      replacementRestoreChecks += 1;
+      return true;
+    },
+    async waitForHealth() {},
+    now: () => new Date("2026-08-28T12:00:00.000Z").getTime(),
+  } satisfies DaytonaProvisioningRuntime;
+  const replacementResult = await daytonaModule.wakeWorkerOnDaytonaWithRuntime({
+    workerId: createDenTypeId("worker"),
+    name: "Cloud replacement proof",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  }, replacementRuntime, {
+    sandbox_id: failedStopSandbox.id,
+    workspace_volume_id: "volume_replacement_proof",
+    data_volume_id: "volume_replacement_proof",
+  }, "openwork-test-snapshot");
+  expect(replacementResult.status).toBe("healthy");
+  expect(replacementCreates).toBe(1);
+  expect(replacementCheckpointChecks).toBe(1);
+  expect(replacementRestoreChecks).toBe(1);
+  expect(replacementProcessStarts).toBe(1);
+  expect(failedSandboxDeletes).toBe(1);
+  expect(replacementRows).toHaveLength(1);
+  expect(replacementRows[0]?.sandboxId).toBe(replacementSandbox.id);
+  evidence.recordAssertionEvidence(
+    "A provider-level wake failure escalates to a restored replacement sandbox",
+    "When the existing sandbox could not be stopped, recovery found the shared checkpoint, started and verified one replacement, switched the durable sandbox record, and deleted the unhealthy sandbox only after the replacement was healthy.",
+    true,
+  );
+
+  const originalHealthFetch = globalThis.fetch;
+  let healthRequestAborted = false;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: ((_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) return reject(new Error("health request did not receive a deadline"));
+      const onAbort = () => {
+        healthRequestAborted = true;
+        reject(signal.reason);
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    })) satisfies typeof fetch,
+  });
+  const healthStartedAt = Date.now();
+  try {
+    await expect(daytonaModule.waitForHealth(
+      "https://hung.preview.example.test",
+      20,
+      recoverySandbox,
+      "session_health_proof",
+      "command_health_proof",
+    )).rejects.toThrow("Timed out waiting for Daytona worker health");
+  } finally {
+    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalHealthFetch });
+  }
+  expect(healthRequestAborted).toBe(true);
+  expect(Date.now() - healthStartedAt).toBeLessThan(500);
+  evidence.recordAssertionEvidence(
+    "A hung health request cannot exceed the sandbox readiness budget",
+    "The health request received an abort deadline, was cancelled inside the 20 ms readiness budget, and the recovery wait completed in under 500 ms instead of hanging indefinitely.",
     true,
   );
 

--- a/evals/specs/cloud-worker-provisioning-recovery.test.ts
+++ b/evals/specs/cloud-worker-provisioning-recovery.test.ts
@@ -90,7 +90,8 @@ function makeDaytonaRuntime(lookupName: string, visibleAtLookup: number | null) 
     state: "started",
     target: "us-test",
     async refreshData() {},
-    async start() {},
+    async start() { sandbox.state = "started"; },
+    async stop() { sandbox.state = "stopped"; },
     async delete() {},
     async getSignedPreviewUrl() {
       return { url: "https://late-visible.preview.example.test" };


### PR DESCRIPTION
## Summary

Originally stacked on #4219. The parent has merged, and this branch is now restacked directly on current `dev`.

- make worker plus host/client/activity token creation atomic
- persist and return the safe failure raised in the current recovery poll
- use one claimed production recovery path for failed, missing, stopped, and unreachable sandboxes
- keep passive cooldown durable across Den replicas while preserving the parent PR's bounded explicit retry
- deduplicate an in-flight browser Retry request and distinguish control-plane unavailability from a sandbox failure
- restart an untrusted running sandbox before launching OpenWork so recovery cannot create competing processes
- abort hung health requests within the overall readiness deadline
- escalate a provider-level wake failure to a separate replacement sandbox on the same shared volume
  - established workspaces require a verified checkpoint before the old sandbox is removed
  - a never-healthy initial sandbox can be replaced before its first checkpoint
  - the durable sandbox record changes only after replacement health and restore verification pass

## Proof

Exact head: `863fceac981782b9f54543d3efdd29ce785e30f9`

Verdict: **Passed** (local fallback; Daytona CLI was available but Daytona credentials were unavailable in this checkout).

- `pnpm evals:pr specs/cloud-startup-diagnostics.test.ts` — 1 passed, 0 failed, 0 skipped; 8/8 evidence assertions passed
- focused app tests — 28 passed, 0 failed
- Cloud instance route tests — 36 passed, 0 failed
- runtime access tests — 10 passed, 0 failed
- lifecycle tests — 14 passed, 0 failed
- Daytona provisioning/recovery tests — 20 passed, 0 failed
- signed-preview tests — 12 passed, 0 failed
- app typecheck — passed
- Den API typecheck — passed

## Restack verification

#4219 was squash-merged as `cc3b6de34ab7c1a41d50067e2f4222430df0b3c4`. This branch contains exactly one child commit on that `dev` commit; its merge base is the same SHA. Focused checks and exact-head testkit proof were rerun after the history rewrite.
