### PR TITLE
refactor(server): render the injected engine config file workspace-independently

### DIFF
--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -38,6 +38,7 @@ import {
   syncAllWorkspacesRuntimeMcpToEngine,
 } from "./server.js";
 import {
+  writeGlobalRuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
   type RuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
@@ -261,7 +262,18 @@ async function createFixture(options?: {
     logRequests: false,
   };
   if (options?.withRuntime !== false) {
-    await writeRuntimeOpencodeConfig(config, workspace.id, () => options?.runtime ?? diagnosticRuntimeConfig());
+    const runtime = options?.runtime ?? diagnosticRuntimeConfig();
+    await writeRuntimeOpencodeConfig(config, workspace.id, () => runtime);
+    // Plugin specs and the default agent are engine-global: the injected
+    // engine config file is rendered from the ENGINE_GLOBAL row only.
+    const { plugin, default_agent: defaultAgent } = runtime;
+    if (plugin !== undefined || defaultAgent !== undefined) {
+      await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+        ...current,
+        ...(plugin !== undefined ? { plugin } : {}),
+        ...(defaultAgent !== undefined ? { default_agent: defaultAgent } : {}),
+      }));
+    }
   }
   return { root, workspaceRoot, workspace, config };
 }

--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -1301,7 +1301,10 @@ export async function runAgentContextDiagnostics(input: {
     : mergeRuntimeOpencodeConfigLayers(globalRuntimeInspection.config, runtimeInspection.config);
   input.dependencies?.signal?.throwIfAborted();
   const runtimeDuration = elapsed(runtimeStarted, now);
-  const expectedRuntimeConfig = buildOpenworkRuntimeConfigObjectFromSnapshot(runtime);
+  // The injected engine config file is rendered from the ENGINE_GLOBAL row
+  // only; the merged per-workspace runtime row informs MCP inventory below
+  // but is not part of the injected file.
+  const expectedRuntimeConfig = buildOpenworkRuntimeConfigObjectFromSnapshot(globalRuntimeInspection.config);
   const expectedAgents = isRecord(expectedRuntimeConfig.agent) ? expectedRuntimeConfig.agent : {};
   const expectedAgent = isRecord(expectedAgents.openwork) ? expectedAgents.openwork : null;
   const effectiveOpenworkAgent = effectiveEngine?.agents.find((agent) => agent.name === "openwork") ?? null;

--- a/apps/server/src/authorized-folders.e2e.test.ts
+++ b/apps/server/src/authorized-folders.e2e.test.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path";
 
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
-import { readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { readGlobalRuntimeOpencodeConfig, readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 
 type Served = {
   port: number;
@@ -156,8 +156,13 @@ describe("authorized folders routes", () => {
     expect(typeof body.updatedAt).toBe("number");
 
     expect(readExternalDirectory(await readFile(configPath, "utf8"))["/shared/*"]).toBeUndefined();
-    const runtimeConfig = await readRuntimeOpencodeConfig(config, "ws_1");
+    // Authorized folders are engine-global: the write lands in the ENGINE_GLOBAL
+    // row (the injected engine config file's only runtime source) and the legacy
+    // workspace row is cleaned so removals cannot be shadowed.
+    const runtimeConfig = await readGlobalRuntimeOpencodeConfig(config);
     const externalDirectory = runtimeConfig.permission?.external_directory ?? {};
+    const workspaceRuntimeConfig = await readRuntimeOpencodeConfig(config, "ws_1");
+    expect(workspaceRuntimeConfig.permission?.external_directory).toBeUndefined();
     expect(externalDirectory["/hidden"]).toBe("allow");
     expect(externalDirectory["/denied/*"]).toBe("deny");
     expect(externalDirectory["/shared/*"]).toBe("allow");

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -24,6 +24,7 @@ import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { migrateOpenworkCloudMcpRuntimeConfig } from "./cloud-mcp-health.js";
+import { migrateWorkspaceRuntimeConfigToEngineGlobal } from "./runtime-opencode-config-store.js";
 import { resolveOpencodeModelsUrl } from "./opencode-models-url.js";
 import { startWorkerActivityHeartbeat } from "./worker-activity-heartbeat.js";
 import pkg from "../package.json" with { type: "json" };
@@ -50,6 +51,7 @@ let enginePool: EnginePool | null = null;
 if (!config.readOnly) {
   await ensureLocalWorkspaceFiles(config.workspaces);
   await migrateOpenworkCloudMcpRuntimeConfig(config);
+  await migrateWorkspaceRuntimeConfigToEngineGlobal(config);
 }
 
 // Bind the HTTP server before spawning the engine: serve-node may fall back
@@ -70,8 +72,8 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
     // Server-managed config file: the engine re-reads it from disk on every
     // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
     // on every runtime-DB write — so disposes always pick up current state.
-    const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
-    keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
+    const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config);
+    keepOpenworkRuntimeConfigFileFresh(config);
     const managedOpencodeCwd = process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim() || workspace.path;
     await mkdir(managedOpencodeCwd, { recursive: true });
     const opencodeModelsUrl = await resolveOpencodeModelsUrl();

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -884,7 +884,7 @@ export class CloudProviderSync {
     const workspaceCleanup = await this.cleanupWorkspaceTakeovers();
     const engineWorkspace = findManagedEngineWorkspace(this.config.workspaces) ?? this.config.workspaces[0];
     const runtimeFileChanged = engineWorkspace
-      ? (await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id)).changed
+      ? (await writeOpenworkRuntimeConfigFile(this.config)).changed
       : false;
     // Credentials reach a live engine through PUT /auth/{providerID} below, so
     // a key rotation never needs a reload. Provider *config* (models, npm,
@@ -1014,7 +1014,7 @@ export class CloudProviderSync {
 
     const engineWorkspace = findManagedEngineWorkspace(this.config.workspaces) ?? this.config.workspaces[0];
     if (engineWorkspace) {
-      const fileResult = await writeOpenworkRuntimeConfigFile(this.config, engineWorkspace.id);
+      const fileResult = await writeOpenworkRuntimeConfigFile(this.config);
       this.reloadPending = this.reloadPending || providerChanged || fileResult.changed;
     }
     let reloadError: unknown;

--- a/apps/server/src/embedded-lifecycle.test.ts
+++ b/apps/server/src/embedded-lifecycle.test.ts
@@ -8,7 +8,7 @@ import { startEmbeddedServer, type EmbeddedServerHandle, type EmbeddedServerOpti
 import { readEngineRegistry } from "./engine-registry.js";
 import * as managedOpencodeModule from "./managed-opencode.js";
 import { writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
-import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { writeGlobalRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import * as serverModule from "./server.js";
 import type { ServerConfig } from "./types.js";
 
@@ -160,6 +160,16 @@ function workspaceId(config: ServerConfig): string {
   return id;
 }
 
+// The injected file is rendered from the ENGINE_GLOBAL row only, so file
+// barrier tests mutate the global row.
+async function mutateGlobalRuntime(config: ServerConfig, label: string): Promise<void> {
+  await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+    ...current,
+    mcp: { [label]: { type: "remote", url: `https://${label}.example.test/mcp` } },
+  }));
+}
+
+// Workspace rows never reach the injected file; used to witness inertness.
 async function mutateWorkspace(config: ServerConfig, id: string, label: string): Promise<void> {
   await writeRuntimeOpencodeConfig(config, id, (current) => ({
     ...current,
@@ -272,11 +282,10 @@ describe("embedded server lifecycle", () => {
     const fixture = await createFixture();
     try {
       const serverA = await startManaged(fixture, "server-a");
-      const id = workspaceId(serverA.config);
       await serverA.stop();
 
-      await mutateWorkspace(serverA.config, id, "stopped-server");
-      const barrier = await writeOpenworkRuntimeConfigFile(serverA.config, id);
+      await mutateGlobalRuntime(serverA.config, "stopped-server");
+      const barrier = await writeOpenworkRuntimeConfigFile(serverA.config);
 
       // The explicit barrier is the first writer only when the stopped
       // server's subscription did not enqueue a write ahead of it.
@@ -290,17 +299,15 @@ describe("embedded server lifecycle", () => {
     const fixture = await createFixture();
     try {
       const serverA = await startManaged(fixture, "server-a");
-      const serverAWorkspace = workspaceId(serverA.config);
       await serverA.stop();
       const serverB = await startManaged(fixture, "server-b");
-      const serverBWorkspace = workspaceId(serverB.config);
 
-      await mutateWorkspace(serverA.config, serverAWorkspace, "stale-server");
-      const afterStoppedServerMutation = await writeOpenworkRuntimeConfigFile(serverB.config, serverBWorkspace);
+      await mutateGlobalRuntime(serverA.config, "stale-server");
+      const afterStoppedServerMutation = await writeOpenworkRuntimeConfigFile(serverB.config);
       expect(afterStoppedServerMutation.changed).toBe(false);
 
-      await mutateWorkspace(serverB.config, serverBWorkspace, "active-server");
-      const afterActiveServerMutation = await writeOpenworkRuntimeConfigFile(serverB.config, serverBWorkspace);
+      await mutateGlobalRuntime(serverB.config, "active-server");
+      const afterActiveServerMutation = await writeOpenworkRuntimeConfigFile(serverB.config);
       expect(afterActiveServerMutation.changed).toBe(false);
     } finally {
       await fixture.restore();
@@ -420,9 +427,8 @@ describe("embedded server lifecycle", () => {
       if (!failedConfig) throw new Error("Expected startup to bind the HTTP server");
 
       const config = failedConfig;
-      const id = workspaceId(config);
-      await mutateWorkspace(config, id, "after-spawn-failure");
-      const barrier = await writeOpenworkRuntimeConfigFile(config, id);
+      await mutateGlobalRuntime(config, "after-spawn-failure");
+      const barrier = await writeOpenworkRuntimeConfigFile(config);
 
       expect(barrier.changed).toBe(true);
       expect(httpStopCalls).toBe(1);
@@ -470,7 +476,6 @@ describe("embedded server lifecycle", () => {
 
     try {
       const handle = await startManaged(fixture, "shutdown-failure");
-      const id = workspaceId(handle.config);
       const firstStop = handle.stop();
       const secondStop = handle.stop();
       expect(secondStop).toBe(firstStop);
@@ -485,8 +490,8 @@ describe("embedded server lifecycle", () => {
       if (!(observed instanceof AggregateError)) throw new Error("Expected aggregate shutdown failure");
       expect(observed.errors).toEqual([managedError, httpError]);
 
-      await mutateWorkspace(handle.config, id, "after-shutdown-failure");
-      const barrier = await writeOpenworkRuntimeConfigFile(handle.config, id);
+      await mutateGlobalRuntime(handle.config, "after-shutdown-failure");
+      const barrier = await writeOpenworkRuntimeConfigFile(handle.config);
       expect(barrier.changed).toBe(true);
       expect(managedCloseCalls).toBe(1);
       expect(httpStopCalls).toBe(1);

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -34,6 +34,7 @@ import { ensureLocalWorkspaceFiles } from "./workspace-init.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { migrateOpenworkCloudMcpRuntimeConfig } from "./cloud-mcp-health.js";
+import { migrateWorkspaceRuntimeConfigToEngineGlobal } from "./runtime-opencode-config-store.js";
 import { resolveOpencodeModelsUrl } from "./opencode-models-url.js";
 import type { ServeResult } from "./serve-node.js";
 import type { LocalManagedMcpVaultKeyProvider, ServerConfig } from "./types.js";
@@ -173,6 +174,7 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
   if (!config.readOnly) {
     await ensureLocalWorkspaceFiles(config.workspaces);
     await migrateOpenworkCloudMcpRuntimeConfig(config);
+    await migrateWorkspaceRuntimeConfigToEngineGlobal(config);
   }
 
   // Bind the HTTP server before spawning the engine: serve-node may fall back
@@ -194,8 +196,8 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
       // Server-managed config file: the engine re-reads it from disk on every
       // instance rebuild, and keepOpenworkRuntimeConfigFileFresh synchronizes it
       // on every runtime-DB write — so disposes always pick up current state.
-      const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config, workspace.id);
-      stopRuntimeConfigFileRefresh = keepOpenworkRuntimeConfigFileFresh(config, workspace.id);
+      const { path: runtimeConfigPath } = await writeOpenworkRuntimeConfigFile(config);
+      stopRuntimeConfigFileRefresh = keepOpenworkRuntimeConfigFileFresh(config);
       const cwd = options.opencodeCwd
         || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
         || workspace.path;

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -58,8 +58,8 @@ export type EnginePoolHooks = {
   engineBusy: (config: ServerConfig, workspace: WorkspaceInfo) => Promise<boolean>;
   /** Re-register runtime MCPs and reconcile cloud MCP against a fresh engine. */
   postRefreshSync: (config: ServerConfig, workspace: WorkspaceInfo) => Promise<void>;
-  /** Rebuild the engine-visible runtime config file. */
-  writeRuntimeConfigFile: (config: ServerConfig, workspaceId: string) => Promise<{ path: string }>;
+  /** Rebuild the engine-visible runtime config file (workspace-independent). */
+  writeRuntimeConfigFile: (config: ServerConfig) => Promise<{ path: string }>;
   registerTrusted: (config: ServerConfig, generation: { baseUrl: string; identity: string; isAlive: () => boolean }) => void;
   clearTrusted: (config: ServerConfig, identity: string) => void;
   spawn?: (template: EngineSpawnTemplate) => Promise<ManagedOpencodeServer>;
@@ -551,7 +551,7 @@ export class EnginePool {
     const { workspace, reason, manual, awaitPostRefreshSync, forceStandby } = request;
     // The standby reads config from disk at spawn, so make sure the file is
     // current before deciding anything.
-    await this.hooks.writeRuntimeConfigFile(this.config, workspace.id).catch(() => undefined);
+    await this.hooks.writeRuntimeConfigFile(this.config).catch(() => undefined);
     const fingerprint = await this.currentFingerprint();
     const primary = this.generations.find((entry) => entry.status === "primary") ?? null;
 

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -9,7 +9,7 @@ import {
   openworkRuntimeConfigFilePath,
   writeOpenworkRuntimeConfigFile,
 } from "./openwork-runtime-config.js";
-import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { writeGlobalRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
 const roots: string[] = [];
@@ -55,9 +55,9 @@ async function readConfigFile(config: ServerConfig): Promise<Record<string, unkn
 }
 
 describe("openwork runtime config file", () => {
-  test("writes runtime-DB MCPs and openwork defaults into the file", async () => {
+  test("writes global-row MCPs and openwork defaults into the file", async () => {
     const { config } = await setup();
-    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+    await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
       ...current,
       mcp: {
         posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true },
@@ -65,7 +65,7 @@ describe("openwork runtime config file", () => {
       },
     }));
 
-    const { path } = await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    const { path } = await writeOpenworkRuntimeConfigFile(config);
     expect(path).toBe(openworkRuntimeConfigFilePath(config));
 
     const parsed = await readConfigFile(config);
@@ -89,9 +89,23 @@ describe("openwork runtime config file", () => {
     });
   });
 
+  test("workspace runtime rows never reach the injected file", async () => {
+    const { config } = await setup();
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+      ...current,
+      mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true } },
+    }));
+
+    await writeOpenworkRuntimeConfigFile(config);
+
+    const parsed = await readConfigFile(config);
+    const mcp = (parsed.mcp ?? {}) as Record<string, Record<string, unknown>>;
+    expect(mcp.posthog).toBeUndefined();
+  });
+
   test("openwork prompt has a static search-first Memory Bank section, distinct from ## Memory", async () => {
     const { config } = await setup();
-    await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    await writeOpenworkRuntimeConfigFile(config);
 
     const parsed = await readConfigFile(config);
     const agent = parsed.agent as Record<string, { prompt?: string }>;
@@ -109,12 +123,12 @@ describe("openwork runtime config file", () => {
     expect(prompt).toMatch(/secret|credential|API key|token|PII/i);
   });
 
-  test("keepOpenworkRuntimeConfigFileFresh rewrites the file on runtime-DB writes", async () => {
+  test("keepOpenworkRuntimeConfigFileFresh rewrites the file on ENGINE_GLOBAL writes", async () => {
     const { config } = await setup();
-    await writeOpenworkRuntimeConfigFile(config, "ws_1");
-    cleanups.push(keepOpenworkRuntimeConfigFileFresh(config, "ws_1"));
+    await writeOpenworkRuntimeConfigFile(config);
+    cleanups.push(keepOpenworkRuntimeConfigFileFresh(config));
 
-    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+    await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
       ...current,
       mcp: { stripe: { type: "remote", url: "https://mcp.stripe.com", enabled: false } },
     }));
@@ -130,12 +144,12 @@ describe("openwork runtime config file", () => {
     expect(mcp.stripe?.enabled).toBe(false);
   });
 
-  test("writes for other workspaces do not rewrite the primary file", async () => {
+  test("workspace runtime writes do not rewrite the file", async () => {
     const { config } = await setup();
-    await writeOpenworkRuntimeConfigFile(config, "ws_1");
-    cleanups.push(keepOpenworkRuntimeConfigFileFresh(config, "ws_1"));
+    await writeOpenworkRuntimeConfigFile(config);
+    cleanups.push(keepOpenworkRuntimeConfigFileFresh(config));
 
-    await writeRuntimeOpencodeConfig(config, "ws_other", (current) => ({
+    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
       ...current,
       mcp: { other: { type: "remote", url: "https://example.com/mcp", enabled: true } },
     }));
@@ -148,20 +162,20 @@ describe("openwork runtime config file", () => {
 
   test("builds byte-stable config for repeated snapshots", async () => {
     const { config } = await setup();
-    await writeRuntimeOpencodeConfig(config, "ws_1", (current) => ({
+    await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
       ...current,
       mcp: { posthog: { type: "remote", url: "https://mcp.posthog.com/mcp" } },
     }));
 
-    const first = await buildOpenworkRuntimeConfig(config, "ws_1");
-    const second = await buildOpenworkRuntimeConfig(config, "ws_1");
+    const first = await buildOpenworkRuntimeConfig(config);
+    const second = await buildOpenworkRuntimeConfig(config);
 
     expect(second).toBe(first);
   });
 
   test("builds byte-stable config for equivalent snapshots with different key order", async () => {
     const { config } = await setup();
-    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
+    await writeGlobalRuntimeOpencodeConfig(config, () => ({
       mcp: {
         zeta: { url: "https://z.example/mcp", type: "remote" },
         alpha: { type: "remote", url: "https://a.example/mcp" },
@@ -171,9 +185,9 @@ describe("openwork runtime config file", () => {
         alpha: { name: "Alpha", npm: "@ai-sdk/openai-compatible" },
       },
     }));
-    const first = await buildOpenworkRuntimeConfig(config, "ws_1");
+    const first = await buildOpenworkRuntimeConfig(config);
 
-    await writeRuntimeOpencodeConfig(config, "ws_1", () => ({
+    await writeGlobalRuntimeOpencodeConfig(config, () => ({
       provider: {
         alpha: { npm: "@ai-sdk/openai-compatible", name: "Alpha" },
         zeta: { name: "Zeta", npm: "@ai-sdk/openai-compatible" },
@@ -183,7 +197,7 @@ describe("openwork runtime config file", () => {
         zeta: { type: "remote", url: "https://z.example/mcp" },
       },
     }));
-    const second = await buildOpenworkRuntimeConfig(config, "ws_1");
+    const second = await buildOpenworkRuntimeConfig(config);
 
     expect(second).toBe(first);
   });

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -27,7 +27,7 @@ import { runtimeStorageDir } from "./runtime-db.js";
 import {
   onRuntimeOpencodeConfigWrite,
   isEngineGlobalRuntimeConfigId,
-  readEffectiveRuntimeOpencodeConfig,
+  readGlobalRuntimeOpencodeConfig,
   runtimeDisabledProviderList,
   runtimeMcpMap,
   runtimeProviderMap,
@@ -89,9 +89,13 @@ Never persist secrets, credentials, API keys, tokens, or sensitive PII into a me
 
 export async function buildOpenworkRuntimeConfigObject(
   config?: ServerConfig,
-  workspaceId?: string,
 ): Promise<Record<string, unknown>> {
-  const runtimeConfig = config && workspaceId ? await readEffectiveRuntimeOpencodeConfig(config, workspaceId) : {};
+  // Workspace-independent by design: the injected engine config file is
+  // rendered from the ENGINE_GLOBAL runtime row plus static built-ins only,
+  // so workspace activation rewrites identical bytes and never varies the
+  // engine-pool fingerprint. Per-workspace MCPs reach the engine through the
+  // dynamic push path instead.
+  const runtimeConfig = config ? await readGlobalRuntimeOpencodeConfig(config) : {};
   return buildOpenworkRuntimeConfigObjectFromSnapshot(runtimeConfig);
 }
 
@@ -156,8 +160,8 @@ function stableStringify(value: unknown): string {
   return JSON.stringify(stableJsonValue(value));
 }
 
-export async function buildOpenworkRuntimeConfig(config?: ServerConfig, workspaceId?: string): Promise<string> {
-  return stableStringify(await buildOpenworkRuntimeConfigObject(config, workspaceId));
+export async function buildOpenworkRuntimeConfig(config?: ServerConfig): Promise<string> {
+  return stableStringify(await buildOpenworkRuntimeConfigObject(config));
 }
 
 export function openworkRuntimeConfigFilePath(config: ServerConfig): string {
@@ -181,11 +185,10 @@ const fileWriteQueue = new Map<string, Promise<OpenworkRuntimeConfigWriteResult>
  */
 export async function writeOpenworkRuntimeConfigFile(
   config: ServerConfig,
-  workspaceId: string,
 ): Promise<OpenworkRuntimeConfigWriteResult> {
   const path = openworkRuntimeConfigFilePath(config);
   const job = async () => {
-    const content = await buildOpenworkRuntimeConfig(config, workspaceId);
+    const content = await buildOpenworkRuntimeConfig(config);
     const current = await readFile(path, "utf8").catch(() => undefined);
     if (current === content) return { path, changed: false };
     await mkdir(runtimeStorageDir(config), { recursive: true });
@@ -205,9 +208,9 @@ export async function writeOpenworkRuntimeConfigFile(
  * instance rebuild reads fresh state instead of a spawn-time snapshot.
  * Returns an unsubscribe function.
  */
-export function keepOpenworkRuntimeConfigFileFresh(config: ServerConfig, workspaceId: string): () => void {
+export function keepOpenworkRuntimeConfigFileFresh(config: ServerConfig): () => void {
   return onRuntimeOpencodeConfigWrite((writeConfig, writtenWorkspaceId) => {
-    if (writtenWorkspaceId !== workspaceId && !isEngineGlobalRuntimeConfigId(writtenWorkspaceId)) return;
-    void writeOpenworkRuntimeConfigFile(writeConfig, workspaceId).catch(() => undefined);
+    if (!isEngineGlobalRuntimeConfigId(writtenWorkspaceId)) return;
+    void writeOpenworkRuntimeConfigFile(writeConfig).catch(() => undefined);
   });
 }

--- a/apps/server/src/plugins.ts
+++ b/apps/server/src/plugins.ts
@@ -6,7 +6,12 @@ import { readJsoncFile } from "./jsonc.js";
 import { opencodeConfigPath, projectPluginsDir } from "./workspace-files.js";
 import { exists } from "./utils.js";
 import { validatePluginSpec } from "./validators.js";
-import { readRuntimeOpencodeConfig, runtimePluginList, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import {
+  readEffectiveRuntimeOpencodeConfig,
+  readGlobalRuntimeOpencodeConfig,
+  runtimePluginList,
+  writeGlobalRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
 
 export function normalizePluginSpec(spec: string): string {
   const trimmed = spec.trim();
@@ -53,7 +58,7 @@ async function listPluginFiles(dir: string, scope: "project" | "global", workspa
 export async function listPlugins(serverConfig: ServerConfig, workspaceId: string, workspaceRoot: string, includeGlobal: boolean): Promise<{ items: PluginItem[]; loadOrder: string[] }> {
   const { data: config } = await readJsoncFile(opencodeConfigPath(workspaceRoot), {} as Record<string, unknown>, { allowInvalid: true });
   const pluginSpecs = pluginListFromConfig(config);
-  const runtimeSpecs = runtimePluginList(await readRuntimeOpencodeConfig(serverConfig, workspaceId));
+  const runtimeSpecs = runtimePluginList(await readEffectiveRuntimeOpencodeConfig(serverConfig, workspaceId));
   const items: PluginItem[] = pluginSpecs.map((spec) => ({
     spec,
     source: "config",
@@ -86,24 +91,26 @@ export async function listPlugins(serverConfig: ServerConfig, workspaceId: strin
   };
 }
 
-export async function addPlugin(serverConfig: ServerConfig, workspaceId: string, spec: string): Promise<boolean> {
+// Runtime-managed plugins are engine-global: the injected engine config file
+// is rendered from the ENGINE_GLOBAL row only, so plugin writes target it.
+export async function addPlugin(serverConfig: ServerConfig, spec: string): Promise<boolean> {
   validatePluginSpec(spec);
-  const runtimeConfig = await readRuntimeOpencodeConfig(serverConfig, workspaceId);
+  const runtimeConfig = await readGlobalRuntimeOpencodeConfig(serverConfig);
   const pluginSpecs = runtimePluginList(runtimeConfig);
   const normalized = normalizePluginSpec(spec);
   const existing = pluginSpecs.find((item) => normalizePluginSpec(item) === normalized);
   if (existing) return false;
   pluginSpecs.push(spec);
-  await writeRuntimeOpencodeConfig(serverConfig, workspaceId, (current) => ({ ...current, plugin: pluginSpecs }));
+  await writeGlobalRuntimeOpencodeConfig(serverConfig, (current) => ({ ...current, plugin: pluginSpecs }));
   return true;
 }
 
-export async function removePlugin(serverConfig: ServerConfig, workspaceId: string, name: string): Promise<boolean> {
-  const runtimeConfig = await readRuntimeOpencodeConfig(serverConfig, workspaceId);
+export async function removePlugin(serverConfig: ServerConfig, name: string): Promise<boolean> {
+  const runtimeConfig = await readGlobalRuntimeOpencodeConfig(serverConfig);
   const pluginSpecs = runtimePluginList(runtimeConfig);
   const normalized = normalizePluginSpec(name);
   const filtered = pluginSpecs.filter((item) => normalizePluginSpec(item) !== normalized);
   if (filtered.length === pluginSpecs.length) return false;
-  await writeRuntimeOpencodeConfig(serverConfig, workspaceId, (current) => ({ ...current, plugin: filtered }));
+  await writeGlobalRuntimeOpencodeConfig(serverConfig, (current) => ({ ...current, plugin: filtered }));
   return true;
 }

--- a/apps/server/src/routes/workspaces.ts
+++ b/apps/server/src/routes/workspaces.ts
@@ -26,11 +26,12 @@ interface RegisterWorkspaceRoutesOptions {
   ensureWritable: (config: ServerConfig) => void;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
   serializeWorkspace: (workspace: ServerConfig["workspaces"][number]) => unknown;
-  reloadOpencodeEngine: (
-    config: ServerConfig,
-    workspace: WorkspaceInfo,
-    options?: { awaitPostRefreshSync?: boolean },
-  ) => Promise<void>;
+  /**
+   * Dispose-free re-attach of the workspace's runtime MCPs via the engine's
+   * dynamic push. The injected engine config file is workspace-independent,
+   * so activation never reloads or disposes an engine instance.
+   */
+  syncWorkspaceRuntimeMcp: (config: ServerConfig, workspace: WorkspaceInfo) => Promise<void>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -250,7 +251,7 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
     ensureWritable,
     resolveWorkspace,
     serializeWorkspace,
-    reloadOpencodeEngine,
+    syncWorkspaceRuntimeMcp,
   } = options;
 
   const resolveWorkspaceForRegistry = async (id: string): Promise<WorkspaceInfo> => {
@@ -477,9 +478,11 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
       summary: "Switched active workspace",
       timestamp: Date.now(),
     });
-    // Re-activating the already-active workspace must not dispose its engine instance; switch reloads stay (#870).
+    // The injected engine config file is workspace-independent, so activation
+    // never disposes or reloads an engine instance. Fire-and-forget re-attach
+    // of the activated workspace's runtime MCPs via the dynamic push.
     if (!wasActive && workspace.workspaceType === "local" && resolveWorkspaceOpencodeConnection(config, workspace).baseUrl?.trim()) {
-      await reloadOpencodeEngine(config, workspace, { awaitPostRefreshSync: false });
+      void syncWorkspaceRuntimeMcp(config, workspace).catch(() => undefined);
     }
     return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace), persisted });
   });

--- a/apps/server/src/runtime-config-disabled-providers.test.ts
+++ b/apps/server/src/runtime-config-disabled-providers.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import { startServer } from "./server.js";
 import {
+  readGlobalRuntimeOpencodeConfig,
   readRuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
@@ -74,7 +75,9 @@ describe("runtime-config disabled providers route", () => {
     expect(response.status).toBe(200);
     const body: unknown = await response.json();
     expect(isRecord(body) ? body.disabledProviders : null).toEqual(["anthropic", "openai"]);
-    expect((await readRuntimeOpencodeConfig(config, "ws_1")).disabled_providers).toEqual(["anthropic", "openai"]);
+    // Disabled providers are engine-global so the injected file carries them.
+    expect((await readGlobalRuntimeOpencodeConfig(config)).disabled_providers).toEqual(["anthropic", "openai"]);
+    expect((await readRuntimeOpencodeConfig(config, "ws_1")).disabled_providers).toBeUndefined();
   });
 
   test("preserves other runtime keys while updating disabled providers", async () => {
@@ -92,8 +95,8 @@ describe("runtime-config disabled providers route", () => {
     });
 
     expect(response.status).toBe(200);
+    expect((await readGlobalRuntimeOpencodeConfig(config)).disabled_providers).toEqual(["openai"]);
     const runtime = await readRuntimeOpencodeConfig(config, "ws_1");
-    expect(runtime.disabled_providers).toEqual(["openai"]);
     expect(runtime.mcp?.notion?.url).toBe("https://notion.example/mcp");
     expect(runtime.provider?.local).toEqual({ npm: "@ai-sdk/openai-compatible" });
   });

--- a/apps/server/src/runtime-config-global-providers.test.ts
+++ b/apps/server/src/runtime-config-global-providers.test.ts
@@ -99,7 +99,7 @@ describe("global runtime providers", () => {
     const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
     expect(runtimeProviderMap(globalRuntime)).toEqual({ lpr_openrouter: openrouter });
 
-    const { path } = await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    const { path } = await writeOpenworkRuntimeConfigFile(config);
     expect(path).toBe(openworkRuntimeConfigFilePath(config));
     const raw = await readFile(path, "utf8");
     const parsed: unknown = JSON.parse(raw);

--- a/apps/server/src/runtime-opencode-config-store.test.ts
+++ b/apps/server/src/runtime-opencode-config-store.test.ts
@@ -7,8 +7,12 @@ import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
 import { readOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
 import { addPlugin, listPlugins, removePlugin } from "./plugins.js";
 import {
+  ENGINE_GLOBAL_RUNTIME_CONFIG_ID,
+  migrateWorkspaceRuntimeConfigToEngineGlobal,
   onRuntimeOpencodeConfigWrite,
+  readGlobalRuntimeOpencodeConfig,
   readRuntimeOpencodeConfig,
+  writeGlobalRuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
@@ -130,24 +134,26 @@ describe("runtime OpenCode config store", () => {
       const opencode = '{\n  "plugin": ["project-plugin"]\n}\n';
       await writeFile(opencodePath, opencode, "utf8");
 
-      expect(await addPlugin(config, WORKSPACE_ID, "runtime-plugin")).toBe(true);
-      expect(await removePlugin(config, WORKSPACE_ID, "runtime-plugin")).toBe(true);
-      expect(await addPlugin(config, WORKSPACE_ID, "runtime-plugin")).toBe(true);
+      expect(await addPlugin(config, "runtime-plugin")).toBe(true);
+      expect(await removePlugin(config, "runtime-plugin")).toBe(true);
+      expect(await addPlugin(config, "runtime-plugin")).toBe(true);
 
       expect(await readFile(opencodePath, "utf8")).toBe(opencode);
       await expectMissing(join(root, ".opencode", "openwork.json"));
-      expect((await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).plugin).toEqual(["runtime-plugin"]);
+      // Runtime plugins are engine-global so the injected file carries them.
+      expect((await readGlobalRuntimeOpencodeConfig(config)).plugin).toEqual(["runtime-plugin"]);
 
       const result = await listPlugins(config, WORKSPACE_ID, root, false);
       expect(result.items.map((item) => item.spec)).toEqual(["project-plugin", "runtime-plugin"]);
 
       await addMcp(config, WORKSPACE_ID, "runtime", { type: "remote", url: "https://runtime.example/mcp", enabled: true });
-      const runtimeConfig = JSON.parse(await buildOpenworkRuntimeConfig(config, WORKSPACE_ID)) as {
+      const runtimeConfig = JSON.parse(await buildOpenworkRuntimeConfig(config)) as {
         plugin?: string[];
         mcp?: Record<string, Record<string, unknown>>;
       };
       expect(runtimeConfig.plugin).toContain("runtime-plugin");
-      expect(runtimeConfig.mcp?.runtime?.url).toBe("https://runtime.example/mcp");
+      // Per-workspace MCPs reach the engine via the dynamic push, not the file.
+      expect(runtimeConfig.mcp?.runtime).toBeUndefined();
     });
   });
 
@@ -155,7 +161,7 @@ describe("runtime OpenCode config store", () => {
     await withWorkspace(async ({ root, config }) => {
       await writeFile(join(root, "opencode.jsonc"), '{ "mcp": {\n}\n}\n}\n', "utf8");
       await addMcp(config, WORKSPACE_ID, "runtime", { type: "remote", url: "https://runtime.example/mcp", enabled: true });
-      await addPlugin(config, WORKSPACE_ID, "runtime-plugin");
+      await addPlugin(config, "runtime-plugin");
 
       const mcpItems = await listMcp(config, WORKSPACE_ID, root);
       const pluginItems = await listPlugins(config, WORKSPACE_ID, root, false);
@@ -210,6 +216,66 @@ describe("runtime OpenCode config store", () => {
       } finally {
         await server.stop(true);
       }
+    });
+  });
+
+  test("folds workspace-scoped runtime config into the ENGINE_GLOBAL row once", async () => {
+    await withWorkspace(async ({ config }) => {
+      await writeRuntimeOpencodeConfig(config, "ws_a", () => ({
+        plugin: ["plugin-a", "plugin-shared"],
+        disabled_providers: ["anthropic"],
+        permission: { external_directory: { "/folders/a": "allow" } },
+        mcp: { notion: { type: "remote", url: "https://notion.example/mcp" } },
+        default_agent: "openwork",
+      }));
+      await writeRuntimeOpencodeConfig(config, "ws_b", () => ({
+        plugin: ["plugin-b", "plugin-shared"],
+        disabled_providers: ["anthropic", "openai"],
+        permission: { external_directory: { "/folders/b": "allow" } },
+      }));
+      await writeGlobalRuntimeOpencodeConfig(config, () => ({
+        plugin: ["plugin-global"],
+        provider: { local: { npm: "@ai-sdk/openai-compatible" } },
+      }));
+
+      const first = await migrateWorkspaceRuntimeConfigToEngineGlobal(config);
+      expect(first.changed).toBe(true);
+
+      const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
+      expect(globalRuntime.plugin).toEqual(["plugin-global", "plugin-a", "plugin-shared", "plugin-b"]);
+      expect(globalRuntime.disabled_providers).toEqual(["anthropic", "openai"]);
+      expect(globalRuntime.permission?.external_directory).toEqual({
+        "/folders/a": "allow",
+        "/folders/b": "allow",
+      });
+      // Unrelated global fields survive.
+      expect(globalRuntime.provider?.local).toEqual({ npm: "@ai-sdk/openai-compatible" });
+
+      // Workspace rows are cleaned; mcp stays per-workspace (dynamic push owns delivery).
+      const workspaceA = await readRuntimeOpencodeConfig(config, "ws_a");
+      expect(workspaceA.plugin).toBeUndefined();
+      expect(workspaceA.disabled_providers).toBeUndefined();
+      expect(workspaceA.permission).toBeUndefined();
+      expect(workspaceA.mcp?.notion?.url).toBe("https://notion.example/mcp");
+      expect(workspaceA.default_agent).toBe("openwork");
+      expect(await readRuntimeOpencodeConfig(config, "ws_b")).toEqual({});
+
+      const second = await migrateWorkspaceRuntimeConfigToEngineGlobal(config);
+      expect(second.changed).toBe(false);
+      expect(await readGlobalRuntimeOpencodeConfig(config)).toEqual(globalRuntime);
+    });
+  });
+
+  test("workspace-to-global migration does not touch a read-only runtime DB", async () => {
+    await withWorkspace(async ({ config }) => {
+      await writeRuntimeOpencodeConfig(config, "ws_a", () => ({ plugin: ["plugin-a"] }));
+      const readOnlyConfig: ServerConfig = { ...config, readOnly: true };
+
+      const result = await migrateWorkspaceRuntimeConfigToEngineGlobal(readOnlyConfig);
+
+      expect(result.changed).toBe(false);
+      expect((await readRuntimeOpencodeConfig(config, "ws_a")).plugin).toEqual(["plugin-a"]);
+      expect(await readRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID)).toEqual({});
     });
   });
 

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -278,6 +278,70 @@ export async function readEffectiveRuntimeOpencodeConfig(
   return mergeRuntimeOpencodeConfigLayers(globalRuntime, workspaceRuntime);
 }
 
+/**
+ * One-time (idempotent) startup migration for the workspace-independent
+ * injected engine config file: fold per-workspace `permission.external_directory`
+ * (union), `disabled_providers` (union), and `plugin` (union) into the
+ * ENGINE_GLOBAL row, then remove those fields from the workspace rows. `mcp`
+ * stays per-workspace — the dynamic engine push owns its delivery. No-op on
+ * repeat runs and when the config is read-only.
+ */
+export async function migrateWorkspaceRuntimeConfigToEngineGlobal(
+  config: ServerConfig,
+): Promise<{ changed: boolean }> {
+  const rows = await listRuntimeOpencodeConfigRows(config);
+  const workspaceRows = rows.filter((row) =>
+    !isEngineGlobalRuntimeConfigId(row.workspaceId)
+    && (
+      runtimePluginList(row.value).length > 0
+      || runtimeDisabledProviderList(row.value).length > 0
+      || Object.keys(runtimeExternalDirectory(row.value)).length > 0
+    ),
+  );
+  if (workspaceRows.length === 0 || config.readOnly) return { changed: false };
+
+  let changed = false;
+  const globalResult = await writeGlobalRuntimeOpencodeConfig(config, (current) => {
+    const plugin = uniqueStrings([
+      ...runtimePluginList(current),
+      ...workspaceRows.flatMap((row) => runtimePluginList(row.value)),
+    ]);
+    const disabledProviders = uniqueStrings([
+      ...runtimeDisabledProviderList(current),
+      ...workspaceRows.flatMap((row) => runtimeDisabledProviderList(row.value)),
+    ]);
+    const externalDirectory = {
+      ...workspaceRows.reduce<Record<string, unknown>>(
+        (union, row) => ({ ...union, ...runtimeExternalDirectory(row.value) }),
+        {},
+      ),
+      ...runtimeExternalDirectory(current),
+    };
+    return {
+      ...current,
+      ...(plugin.length ? { plugin } : {}),
+      ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
+      ...(Object.keys(externalDirectory).length
+        ? { permission: { ...(isRecord(current.permission) ? current.permission : {}), external_directory: externalDirectory } }
+        : {}),
+    };
+  });
+  changed = globalResult.changed;
+  for (const row of workspaceRows) {
+    const result = await writeRuntimeOpencodeConfig(config, row.workspaceId, (current) => {
+      const { plugin: _plugin, disabled_providers: _disabledProviders, permission, ...rest } = current;
+      // Strip only external_directory; any other permission keys stay put.
+      const { external_directory: _externalDirectory, ...permissionRest } = isRecord(permission) ? permission : {};
+      return {
+        ...rest,
+        ...(Object.keys(permissionRest).length ? { permission: permissionRest } : {}),
+      };
+    });
+    changed = result.changed || changed;
+  }
+  return { changed };
+}
+
 export type RuntimeOpencodeConfigInspection = {
   status: "available" | "database-missing" | "row-missing" | "table-missing" | "unreadable" | "invalid-row" | "remote-workspace";
   config: RuntimeOpencodeConfig;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -113,6 +113,7 @@ import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
 import {
   mergeOpencodeConfigs,
   mergeRuntimeProviderUpdate,
+  migrateWorkspaceRuntimeConfigToEngineGlobal,
   readEffectiveRuntimeOpencodeConfig,
   readGlobalRuntimeOpencodeConfig,
   readRuntimeOpencodeConfig,
@@ -2074,14 +2075,13 @@ function createRoutes(
     ensureWritable,
     resolveWorkspace,
     serializeWorkspace,
-    reloadOpencodeEngine: async (routeConfig, workspace, options) => {
-      await withEngineDirectoryFence(routeConfig, workspace, async () => {
-        if (await shouldDeferInPlaceEngineReload(routeConfig, workspace, engineHasActiveSessions)) {
-          return;
-        }
-        await reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState, options);
-      });
-    },
+    syncWorkspaceRuntimeMcp: (routeConfig, workspace) =>
+      enqueueWorkspaceMcpRefreshSync({
+        config: routeConfig,
+        workspace,
+        serverState: activeEngineMcpServerState(routeConfig),
+        trigger: "workspace_activate",
+      }),
   });
 
   registerSessionGroupRoutes({
@@ -2418,7 +2418,10 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const opencode = mergeOpencodeConfigs(
       await readOpencodeConfig(workspace.path),
-      await readRuntimeOpencodeConfig(config, workspace.id),
+      // Global-first: authorized folders live in the ENGINE_GLOBAL row; the
+      // effective read also surfaces legacy per-workspace entries until the
+      // startup migration folds them in.
+      await readEffectiveRuntimeOpencodeConfig(config, workspace.id),
     );
     const foldersConfig = readAuthorizedFoldersFromOpencodeConfig(opencode, workspace.path);
     return jsonResponse(buildAuthorizedFoldersResponse(workspace, foldersConfig));
@@ -2440,7 +2443,7 @@ function createRoutes(
     });
 
     const persistedOpencode = await readOpencodeConfig(workspace.path);
-    const runtimeOpencode = await readRuntimeOpencodeConfig(config, workspace.id);
+    const runtimeOpencode = await readEffectiveRuntimeOpencodeConfig(config, workspace.id);
     const existingOpencode = mergeOpencodeConfigs(persistedOpencode, runtimeOpencode);
     const existingFoldersConfig = readAuthorizedFoldersFromOpencodeConfig(existingOpencode, workspace.path);
     const nextExternalDirectory = mergeAuthorizedFoldersIntoExternalDirectory(
@@ -2448,13 +2451,26 @@ function createRoutes(
       existingFoldersConfig.hiddenEntries,
     );
 
-    await writeRuntimeOpencodeConfig(config, workspace.id, (current) => ({
+    // Authorized folders are engine-global: the injected engine config file is
+    // rendered from the ENGINE_GLOBAL row only. Any legacy per-workspace
+    // entries were folded into the effective read above, so clear them from
+    // the workspace row or removals could never take effect.
+    await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
       ...current,
       permission: {
         ...(ensurePlainObject(current.permission)),
         external_directory: nextExternalDirectory ?? {},
       },
     }));
+    await writeRuntimeOpencodeConfig(config, workspace.id, (current) => {
+      const { permission, ...rest } = current;
+      // Strip only the migrated external_directory; other permission keys stay.
+      const { external_directory: _legacyExternalDirectory, ...permissionRest } = ensurePlainObject(permission);
+      return {
+        ...rest,
+        ...(Object.keys(permissionRest).length ? { permission: permissionRest } : {}),
+      };
+    });
 
     const updatedAt = Date.now();
     await recordAudit(workspace.path, {
@@ -2487,7 +2503,9 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const providers = parseDisabledProvidersPayload(body.providers);
-    const result = await writeRuntimeOpencodeConfig(config, workspace.id, (current) => ({
+    // Disabled providers are engine-global: the injected engine config file is
+    // rendered from the ENGINE_GLOBAL row only.
+    const result = await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
       ...current,
       disabled_providers: providers,
     }));
@@ -2544,7 +2562,7 @@ function createRoutes(
       provider: mergeRuntimeProviderUpdate(current.provider, providerPatch),
     }));
 
-    const fileResult = await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    const fileResult = await writeOpenworkRuntimeConfigFile(config);
     const shouldReload = result.changed || fileResult.changed;
     // A rollover-capable pool can apply this immediately without disposing
     // the generation that owns live sessions. Legacy/external engines keep
@@ -2583,7 +2601,9 @@ function createRoutes(
     const rawGlobalOpencode = await readRawOpencodeConfig(globalOpencodePath);
     const emptyGlobalOpencode: Record<string, unknown> = {};
     const globalOpencode = (await readJsoncFile(globalOpencodePath, emptyGlobalOpencode, { allowInvalid: true })).data;
-    const effectiveRuntime = await buildOpenworkRuntimeConfigObject(config, workspace.id);
+    // The injected file is rendered from the ENGINE_GLOBAL row only; the
+    // workspace runtime row reaches the engine via the dynamic MCP push.
+    const effectiveRuntime = await buildOpenworkRuntimeConfigObject(config);
     const managedFile = await readManagedRuntimeConfigDebug(config);
 
     return jsonResponse({
@@ -2823,7 +2843,7 @@ function createRoutes(
       summary: `Add plugin ${spec}`,
       paths: [openworkConfigPath(workspace.path)],
     });
-    const changed = await addPlugin(config, workspace.id, spec);
+    const changed = await addPlugin(config, spec);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -2856,7 +2876,7 @@ function createRoutes(
       summary: `Remove plugin ${name}`,
       paths: [openworkConfigPath(workspace.path)],
     });
-    const removed = await removePlugin(config, workspace.id, name);
+    const removed = await removePlugin(config, name);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -4130,7 +4150,7 @@ async function postEngineRefreshSync(
   });
 }
 
-type WorkspaceMcpRefreshTrigger = "startup" | "engine_reload";
+type WorkspaceMcpRefreshTrigger = "startup" | "engine_reload" | "workspace_activate";
 
 type WorkspaceMcpRefreshRequest = {
   config: ServerConfig;
@@ -4185,14 +4205,13 @@ async function runWorkspaceMcpRefreshSync(input: WorkspaceMcpRefreshRequest): Pr
   } catch (error) {
     logPersistedCloudMcpReconcileError({ config, workspace, trigger, error });
   }
-  // The MCP re-registration above writes the runtime DB; refresh the
+  // The reconcile above may write the ENGINE_GLOBAL runtime row; refresh the
   // engine-visible file synchronously so the next provider-sync pass compares
   // against post-reload state instead of racing the async fresh-keeper and
   // reporting a phantom "changed" (which would schedule yet another reload).
   try {
-    const engineWorkspace = resolveEngineRuntimeWorkspace(config);
-    if (trigger === "engine_reload" && engineWorkspace.id === workspace.id) {
-      await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    if (trigger === "engine_reload") {
+      await writeOpenworkRuntimeConfigFile(config);
     }
   } catch {
     // Best-effort: the fresh-keeper listener still converges eventually.
@@ -4748,7 +4767,7 @@ export function createEnginePoolForConfig(input: {
         await postEngineRefreshSync(poolConfig, workspace, activeEngineMcpServerState(poolConfig));
         await syncAllWorkspacesRuntimeMcpToEngine(poolConfig);
       },
-      writeRuntimeConfigFile: (poolConfig, workspaceId) => writeOpenworkRuntimeConfigFile(poolConfig, workspaceId),
+      writeRuntimeConfigFile: (poolConfig) => writeOpenworkRuntimeConfigFile(poolConfig),
       registerTrusted: (poolConfig, generation) => registerTrustedOpencodeProcess(poolConfig, generation),
       clearTrusted: (poolConfig, identity) => clearTrustedOpencodeProcess(poolConfig, identity),
       logger: createServerLogger(config),
@@ -5163,7 +5182,7 @@ function deleteEngineMcpRegistration(
 function logPersistedCloudMcpReconcileResult(input: {
   config: ServerConfig;
   workspace: WorkspaceInfo;
-  trigger: "startup" | "engine_reload";
+  trigger: WorkspaceMcpRefreshTrigger;
   health: CloudMcpHealth;
 }): void {
   if (!input.health.desired.present || input.health.usable) return;
@@ -5186,7 +5205,7 @@ function logPersistedCloudMcpReconcileResult(input: {
 function logRuntimeMcpSyncError(input: {
   config: ServerConfig;
   workspace: WorkspaceInfo;
-  trigger: "startup" | "engine_reload";
+  trigger: WorkspaceMcpRefreshTrigger;
   error: unknown;
 }): void {
   createServerLogger(input.config).log(
@@ -5221,7 +5240,7 @@ function logDetachedPostEngineRefreshSyncError(input: {
 function logPersistedCloudMcpReconcileError(input: {
   config: ServerConfig;
   workspace: WorkspaceInfo;
-  trigger: "startup" | "engine_reload";
+  trigger: WorkspaceMcpRefreshTrigger;
   error: unknown;
 }): void {
   createServerLogger(input.config).log(
@@ -5243,6 +5262,7 @@ function logPersistedCloudMcpReconcileError(input: {
 // something re-syncs them. Best-effort.
 export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
   await migrateOpenworkCloudMcpRuntimeConfig(config);
+  await migrateWorkspaceRuntimeConfigToEngineGlobal(config);
   const serverState = activeEngineMcpServerState(config);
   for (const workspace of config.workspaces) {
     await enqueueWorkspaceMcpRefreshSync({ config, workspace, serverState, trigger: "startup" });

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer } from "./server.js";
+import { openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
@@ -87,7 +88,8 @@ function startMockOpencode() {
     port: 0,
     async fetch(request) {
       const url = new URL(request.url);
-      const directory = request.headers.get("x-opencode-directory");
+      // The engine accepts the directory as a header or a query param; record whichever arrived.
+      const directory = request.headers.get("x-opencode-directory") ?? url.searchParams.get("directory");
       requests.push({ method: request.method, pathname: url.pathname, search: url.search, directory });
 
       if (url.pathname === "/session/status") {
@@ -241,7 +243,7 @@ async function startOpenworkServerWithWorkspaces(input: {
 }
 
 describe("workspace activation", () => {
-  test("reloads the bound OpenCode engine on workspace switch only", async () => {
+  test("workspace switch never disposes the engine or patches its config", async () => {
     const firstRoot = await createWorkspaceRoot();
     const secondRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();
@@ -274,6 +276,9 @@ describe("workspace activation", () => {
     const disposeCount = () => mock.requests.filter(
       (request) => request.method === "POST" && request.pathname === "/instance/dispose",
     ).length;
+    const configPatchCount = () => mock.requests.filter(
+      (request) => request.method === "PATCH" && request.pathname === "/config",
+    ).length;
 
     const response = await fetch(`${base}/workspaces/ws_2/activate`, {
       method: "POST",
@@ -283,15 +288,10 @@ describe("workspace activation", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.activeId).toBe("ws_2");
-    expect(disposeCount()).toBe(1);
-
-    const reloadRequest = mock.requests.find(
-      (request) => request.method === "POST" && request.pathname === "/instance/dispose",
-    );
-    expect(reloadRequest).toBeDefined();
-    expect(reloadRequest?.search).toContain(
-      `directory=${encodeURIComponent(secondRoot)}`,
-    );
+    // The injected engine config file is workspace-independent: switching
+    // never rebuilds the engine instance.
+    expect(disposeCount()).toBe(0);
+    expect(configPatchCount()).toBe(0);
 
     const sameWorkspaceResponse = await fetch(`${base}/workspaces/ws_2/activate`, {
       method: "POST",
@@ -299,10 +299,115 @@ describe("workspace activation", () => {
     });
 
     expect(sameWorkspaceResponse.status).toBe(200);
-    expect(disposeCount()).toBe(1);
+    expect(disposeCount()).toBe(0);
+    expect(configPatchCount()).toBe(0);
   });
 
-  test("returns after dispose without waiting for post-refresh MCP registration", async () => {
+  test("activation re-attaches the target workspace's runtime MCPs without any dispose", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(firstRoot, "runtime.sqlite");
+    const mock = startMockOpencode();
+    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const workspaces: ServerConfig["workspaces"] = [
+      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+    ];
+    try {
+      const openwork = await startOpenworkServerWithWorkspaces({
+        configPath: join(firstRoot, "server.json"),
+        workspaces,
+        authorizedRoots: [firstRoot, secondRoot],
+      });
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_2", (current) => ({
+        ...current,
+        mcp: {
+          posthog: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true },
+        },
+      }));
+
+      const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspaces/ws_2/activate`, {
+        method: "POST",
+        headers: hostAuth(openwork.hostToken),
+      });
+      expect(response.status).toBe(200);
+
+      // The re-attach is fire-and-forget; poll for the dynamic push.
+      let mcpPushed = false;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        mcpPushed = mock.requests.some(
+          (request) => request.method === "POST" && request.pathname === "/mcp" && request.directory === secondRoot,
+        );
+        if (mcpPushed) break;
+        await Bun.sleep(20);
+      }
+      expect(mcpPushed).toBe(true);
+      // The runtime MCP reached the engine dynamically with no preceding dispose.
+      expect(mock.requests.some((request) => request.pathname === "/instance/dispose")).toBe(false);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("activation rewrites identical engine config file bytes", async () => {
+    const firstRoot = await createWorkspaceRoot();
+    const secondRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(firstRoot, "runtime.sqlite");
+    const mock = startMockOpencode();
+    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const workspaces: ServerConfig["workspaces"] = [
+      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+    ];
+    try {
+      const openwork = await startOpenworkServerWithWorkspaces({
+        configPath: join(firstRoot, "server.json"),
+        workspaces,
+        authorizedRoots: [firstRoot, secondRoot],
+      });
+      // Distinct per-workspace runtime MCP rows must not influence the file.
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+        ...current,
+        mcp: { one: { type: "remote", url: "https://one.example/mcp", enabled: true } },
+      }));
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_2", (current) => ({
+        ...current,
+        mcp: { two: { type: "remote", url: "https://two.example/mcp", enabled: true } },
+      }));
+      await writeOpenworkRuntimeConfigFile(openwork.config);
+      const filePath = openworkRuntimeConfigFilePath(openwork.config);
+      const before = await readFile(filePath, "utf8");
+
+      const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspaces/ws_2/activate`, {
+        method: "POST",
+        headers: hostAuth(openwork.hostToken),
+      });
+      expect(response.status).toBe(200);
+
+      // Wait for the fire-and-forget re-attach to settle before comparing.
+      let mcpPushed = false;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        mcpPushed = mock.requests.some(
+          (request) => request.method === "POST" && request.pathname === "/mcp" && request.directory === secondRoot,
+        );
+        if (mcpPushed) break;
+        await Bun.sleep(20);
+      }
+      expect(mcpPushed).toBe(true);
+      const rewritten = await writeOpenworkRuntimeConfigFile(openwork.config);
+      expect(rewritten.changed).toBe(false);
+      expect(await readFile(filePath, "utf8")).toBe(before);
+      expect(mock.requests.some((request) => request.pathname === "/instance/dispose")).toBe(false);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("returns without waiting for post-activation MCP registration", async () => {
     const firstRoot = await createWorkspaceRoot();
     const secondRoot = await createWorkspaceRoot();
     const previousDb = process.env.OPENWORK_RUNTIME_DB;
@@ -342,8 +447,7 @@ describe("workspace activation", () => {
           Bun.sleep(250).then(() => null),
         ]);
         expect(response?.status).toBe(200);
-        expect(mock.requests.findIndex((request) => request.pathname === "/instance/dispose"))
-          .toBeLessThan(mock.requests.findIndex((request) => request.pathname === "/mcp"));
+        expect(mock.requests.some((request) => request.pathname === "/instance/dispose")).toBe(false);
         expect(await Promise.race([
           heldRegistration.completed.then(() => true),
           Bun.sleep(25).then(() => false),
@@ -360,28 +464,14 @@ describe("workspace activation", () => {
     }
   });
 
-  test("does not dispose the target directory after its prompt was admitted before activation completes", async () => {
+  test("activation with busy sessions never probes, disposes, or aborts them", async () => {
     const firstRoot = await createWorkspaceRoot();
     const secondRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();
     const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
     const workspaces: ServerConfig["workspaces"] = [
-      {
-        id: "ws_1",
-        name: "One",
-        path: firstRoot,
-        preset: "starter",
-        workspaceType: "local",
-        baseUrl: opencodeBaseUrl,
-      },
-      {
-        id: "ws_2",
-        name: "Two",
-        path: secondRoot,
-        preset: "starter",
-        workspaceType: "local",
-        baseUrl: opencodeBaseUrl,
-      },
+      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
+      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
     ];
     const openwork = await startOpenworkServerWithWorkspaces({
       configPath: join(firstRoot, "server.json"),
@@ -405,97 +495,9 @@ describe("workspace activation", () => {
 
     expect(response.status).toBe(200);
     expect((await response.json()).activeId).toBe("ws_2");
-    expect(mock.requests.some(
-      (request) => request.pathname === "/session/status" && request.directory === secondRoot,
-    )).toBe(true);
-    expect(mock.requests.some(
-      (request) => request.pathname === "/session/status" && request.directory === firstRoot,
-    )).toBe(false);
+    // Without a reload there is no idle probe or dispose on activation.
+    expect(mock.requests.some((request) => request.pathname === "/session/status")).toBe(false);
     expect(mock.requests.some((request) => request.pathname === "/instance/dispose")).toBe(false);
-    expect(mock.busyDirectories.has(firstRoot)).toBe(true);
-    expect(mock.busyDirectories.has(secondRoot)).toBe(true);
-    expect(mock.abortedDirectories.size).toBe(0);
-  });
-
-  test("does not let a busy task in another directory block an idle target reload", async () => {
-    const firstRoot = await createWorkspaceRoot();
-    const secondRoot = await createWorkspaceRoot();
-    const mock = startMockOpencode();
-    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
-    const workspaces: ServerConfig["workspaces"] = [
-      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
-      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
-    ];
-    const openwork = await startOpenworkServerWithWorkspaces({
-      configPath: join(firstRoot, "server.json"),
-      workspaces,
-      authorizedRoots: [firstRoot, secondRoot],
-    });
-    mock.setBusy(firstRoot, true);
-
-    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/workspaces/ws_2/activate`, {
-      method: "POST",
-      headers: hostAuth(openwork.hostToken),
-    });
-
-    expect(response.status).toBe(200);
-    expect(mock.requests.some(
-      (request) => request.pathname === "/session/status" && request.directory === firstRoot,
-    )).toBe(false);
-    const dispose = mock.requests.find((request) => request.pathname === "/instance/dispose");
-    expect(dispose?.search).toContain(`directory=${encodeURIComponent(secondRoot)}`);
-    expect(mock.busyDirectories.has(firstRoot)).toBe(true);
-    expect(mock.abortedDirectories.size).toBe(0);
-  });
-
-  test("serializes target prompt admission against the idle-check-to-dispose window", async () => {
-    const firstRoot = await createWorkspaceRoot();
-    const secondRoot = await createWorkspaceRoot();
-    const mock = startMockOpencode();
-    const opencodeBaseUrl = `http://127.0.0.1:${mock.server.port}`;
-    const workspaces: ServerConfig["workspaces"] = [
-      { id: "ws_1", name: "One", path: firstRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
-      { id: "ws_2", name: "Two", path: secondRoot, preset: "starter", workspaceType: "local", baseUrl: opencodeBaseUrl },
-    ];
-    const openwork = await startOpenworkServerWithWorkspaces({
-      configPath: join(firstRoot, "server.json"),
-      workspaces,
-      authorizedRoots: [firstRoot, secondRoot],
-    });
-    const heldStatus = mock.holdNextStatus(secondRoot);
-    const base = `http://127.0.0.1:${openwork.server.port}`;
-
-    const activation = fetch(`${base}/workspaces/ws_2/activate`, {
-      method: "POST",
-      headers: hostAuth(openwork.hostToken),
-    });
-    await heldStatus.reached;
-
-    const otherDirectoryPrompt = await fetch(`${base}/workspace/ws_1/opencode/session/ses_a/prompt_async`, {
-      method: "POST",
-      headers: clientAuth(openwork.token),
-      body: JSON.stringify({ parts: [{ type: "text", text: "Continue independently" }] }),
-    });
-    expect(otherDirectoryPrompt.status).toBe(204);
-
-    const prompt = fetch(`${base}/workspace/ws_2/opencode/session/ses_b/prompt_async`, {
-      method: "POST",
-      headers: clientAuth(openwork.token),
-      body: JSON.stringify({ parts: [{ type: "text", text: "Start after activation" }] }),
-    });
-    await Bun.sleep(10);
-    expect(mock.requests.some(
-      (request) => request.pathname.endsWith("/prompt_async") && request.directory === secondRoot,
-    )).toBe(false);
-
-    heldStatus.release();
-    expect((await activation).status).toBe(200);
-    expect((await prompt).status).toBe(204);
-
-    const relevant = mock.requests.filter((request) =>
-      request.directory === secondRoot || request.search.includes(encodeURIComponent(secondRoot))
-    ).map((request) => request.pathname);
-    expect(relevant).toEqual(["/session/status", "/instance/dispose", "/session/ses_b/prompt_async"]);
     expect(mock.busyDirectories.has(firstRoot)).toBe(true);
     expect(mock.busyDirectories.has(secondRoot)).toBe(true);
     expect(mock.abortedDirectories.size).toBe(0);


### PR DESCRIPTION
Third PR of the global-first config stack (#4218 → #4225 → this). Makes the injected engine config file (`runtime-opencode-config.json`, delivered via `OPENCODE_CONFIG`) **workspace-independent**, which removes the last engine side effect of workspace activation.

## Problem

The file was rendered as `ENGINE_GLOBAL ⊕ activeWorkspace` — per-workspace state smuggled through opencode's *global* config layer. Consequences:
- switching workspaces rewrote the file → engine-pool fingerprint changed → instance dispose or blue/green rollover, tearing down MCP connections for a navigation click
- fields like authorized folders and disabled providers were only ever honored for `workspaces[0]` — other workspaces' entries silently never reached the engine

## Change

- **File = ENGINE_GLOBAL row + static built-ins, full stop.** `buildOpenworkRuntimeConfig`/`writeOpenworkRuntimeConfigFile`/`keepOpenworkRuntimeConfigFileFresh` drop `workspaceId`; the fresh-keeper rebuilds only on global-row writes.
- **Activation is engine-inert.** `POST /workspaces/:id/activate` no longer calls `reloadOpencodeEngine`; it fires a dispose-free dynamic re-attach of the activated workspace's runtime MCPs (the existing push path). Zero `/instance/dispose` on switch.
- **Writer retargets** (matching de-facto semantics — these were already only honored for the active workspace):
  - authorized folders PUT → global row, legacy workspace copy cleaned so removals can't be shadowed (only `external_directory` is stripped; other `permission` keys survive)
  - disabled providers POST → global row
  - runtime-managed plugin specs (`addPlugin`/`removePlugin`) → global row
- **Idempotent startup migration** folds existing per-workspace `external_directory`/`disabled_providers`/`plugin` into the global union, strips only those fields from workspace rows, no-ops on repeat, never mutates read-only servers. `mcp` stays per-workspace — the dynamic engine push owns delivery (per #4225).
- **Diagnostics** report the injected file truthfully as global-only.

## Semantics note

Authorized folders, disabled providers, and runtime plugin specs are now explicitly engine-global. Previously they were *implicitly* global-but-only-for-the-active-workspace, which was strictly worse: entries written from a non-active workspace never reached the engine at all.

## New regression witnesses

- activation rewrites **byte-identical** file content with distinct ws_1/ws_2 runtime MCP rows
- activation re-attaches the target workspace's runtime MCPs via `POST /mcp` with **zero** `/instance/dispose`
- fresh-keeper ignores workspace-row writes, rebuilds on global writes
- migration unions per-workspace fields into global, cleans workspace rows, preserves unrelated fields, second run is a no-op

## Validation

- `apps/server` + `apps/app` tsc clean
- workspace-activate e2e: 10/10; engine-pool + self-heal + embedded lifecycle: 33 pass; runtime-config suites: 20 pass; diagnostics: 67 pass; engine-sync + reconcile + plugins: green
- full `apps/server` suite: **790 pass / 8 skip / 2 fail / 1 error** — the failures are the two known environment items (DNS-guard fixture, bun `node:sqlite`) that reproduce identically on clean `origin/dev`

With this stack merged: workspace switching is pure navigation — no file rewrite, no fingerprint change, no dispose, no Connect MCP churn, and automations keep running in their pinned workspace.