### PR TITLE
fix(server): user-added providers must land in the engine-global runtime row

### DIFF
--- a/apps/server/src/runtime-config-patch-reload.e2e.test.ts
+++ b/apps/server/src/runtime-config-patch-reload.e2e.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { buildOpenworkRuntimeConfig } from "./openwork-runtime-config.js";
+import { readGlobalRuntimeOpencodeConfig, readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
 import type { ReloadEvent, ServerConfig } from "./types.js";
 
@@ -57,7 +59,7 @@ async function startOpenworkServer(workspaceRoot: string) {
   };
   const server = await startServer(config);
   stops.push(() => server.stop());
-  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token, config };
 }
 
 async function patchConfig(base: string, token: string, payload: Record<string, unknown>): Promise<void> {
@@ -112,5 +114,41 @@ describe("workspace config patch reload events", () => {
 
     const secondEvents = await readEvents(base, token);
     expect(secondEvents).toHaveLength(1);
+  });
+
+  test("workspace provider patches land in the global row and the injected engine file", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token, config } = await startOpenworkServer(root);
+    await patchConfig(base, token, {
+      opencode: {
+        provider: {
+          "user-lmstudio": {
+            npm: "@ai-sdk/openai-compatible",
+            options: { baseURL: "https://lmstudio.example/v1" },
+            models: { "model-a": { id: "model-a", name: "Model A" } },
+          },
+        },
+      },
+    });
+
+    // The provider must reach the ENGINE_GLOBAL row — a workspace-row write
+    // would never reach the engine because the injected file is global-only.
+    const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
+    expect(globalRuntime.provider?.["user-lmstudio"]).toMatchObject({ npm: "@ai-sdk/openai-compatible" });
+    expect((await readRuntimeOpencodeConfig(config, "ws_1")).provider).toBeUndefined();
+
+    const injected = JSON.parse(await buildOpenworkRuntimeConfig(config)) as Record<string, unknown>;
+    const providers = injected.provider as Record<string, unknown>;
+    expect(providers["user-lmstudio"]).toMatchObject({ npm: "@ai-sdk/openai-compatible" });
+
+    // The UI-facing effective config read keeps seeing the provider.
+    const read = await fetch(`${base}/workspace/ws_1/config`, { headers: auth(token) });
+    expect(read.status).toBe(200);
+    const body = await read.json() as { opencode?: { provider?: Record<string, unknown> } };
+    expect(body.opencode?.provider?.["user-lmstudio"]).toBeDefined();
+
+    // Explicit null deletes from the global row.
+    await patchConfig(base, token, { opencode: { provider: { "user-lmstudio": null } } });
+    expect((await readGlobalRuntimeOpencodeConfig(config)).provider?.["user-lmstudio"]).toBeUndefined();
   });
 });

--- a/apps/server/src/runtime-opencode-config-store.test.ts
+++ b/apps/server/src/runtime-opencode-config-store.test.ts
@@ -226,12 +226,15 @@ describe("runtime OpenCode config store", () => {
         disabled_providers: ["anthropic"],
         permission: { external_directory: { "/folders/a": "allow" } },
         mcp: { notion: { type: "remote", url: "https://notion.example/mcp" } },
+        provider: { "user-lmstudio": { npm: "@ai-sdk/openai-compatible", options: { baseURL: "https://a.example/v1" } }, local: { npm: "stale-copy" } },
         default_agent: "openwork",
       }));
+      await Bun.sleep(2);
       await writeRuntimeOpencodeConfig(config, "ws_b", () => ({
         plugin: ["plugin-b", "plugin-shared"],
         disabled_providers: ["anthropic", "openai"],
         permission: { external_directory: { "/folders/b": "allow" } },
+        provider: { "user-lmstudio": { npm: "@ai-sdk/openai-compatible", options: { baseURL: "https://b.example/v1" } } },
       }));
       await writeGlobalRuntimeOpencodeConfig(config, () => ({
         plugin: ["plugin-global"],
@@ -248,14 +251,21 @@ describe("runtime OpenCode config store", () => {
         "/folders/a": "allow",
         "/folders/b": "allow",
       });
-      // Unrelated global fields survive.
+      // Providers fold globally: the global row wins per key (cloud-managed
+      // authority beats the stale ws_a copy of `local`), and the newest
+      // workspace write wins between workspace rows.
       expect(globalRuntime.provider?.local).toEqual({ npm: "@ai-sdk/openai-compatible" });
+      expect(globalRuntime.provider?.["user-lmstudio"]).toEqual({
+        npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: "https://b.example/v1" },
+      });
 
       // Workspace rows are cleaned; mcp stays per-workspace (dynamic push owns delivery).
       const workspaceA = await readRuntimeOpencodeConfig(config, "ws_a");
       expect(workspaceA.plugin).toBeUndefined();
       expect(workspaceA.disabled_providers).toBeUndefined();
       expect(workspaceA.permission).toBeUndefined();
+      expect(workspaceA.provider).toBeUndefined();
       expect(workspaceA.mcp?.notion?.url).toBe("https://notion.example/mcp");
       expect(workspaceA.default_agent).toBe("openwork");
       expect(await readRuntimeOpencodeConfig(config, "ws_b")).toEqual({});

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -296,10 +296,14 @@ export async function migrateWorkspaceRuntimeConfigToEngineGlobal(
       runtimePluginList(row.value).length > 0
       || runtimeDisabledProviderList(row.value).length > 0
       || Object.keys(runtimeExternalDirectory(row.value)).length > 0
+      || Object.keys(runtimeProviderMap(row.value)).length > 0
     ),
   );
   if (workspaceRows.length === 0 || config.readOnly) return { changed: false };
 
+  // Oldest write first so the newest workspace edit of a provider key wins;
+  // the global row (cloud-managed authority) wins over every legacy copy.
+  const rowsByAge = [...workspaceRows].sort((left, right) => left.updatedAt - right.updatedAt);
   let changed = false;
   const globalResult = await writeGlobalRuntimeOpencodeConfig(config, (current) => {
     const plugin = uniqueStrings([
@@ -317,10 +321,18 @@ export async function migrateWorkspaceRuntimeConfigToEngineGlobal(
       ),
       ...runtimeExternalDirectory(current),
     };
+    const provider = {
+      ...rowsByAge.reduce<Record<string, unknown>>(
+        (union, row) => ({ ...union, ...runtimeProviderMap(row.value) }),
+        {},
+      ),
+      ...runtimeProviderMap(current),
+    };
     return {
       ...current,
       ...(plugin.length ? { plugin } : {}),
       ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
+      ...(Object.keys(provider).length ? { provider } : {}),
       ...(Object.keys(externalDirectory).length
         ? { permission: { ...(isRecord(current.permission) ? current.permission : {}), external_directory: externalDirectory } }
         : {}),
@@ -329,7 +341,7 @@ export async function migrateWorkspaceRuntimeConfigToEngineGlobal(
   changed = globalResult.changed;
   for (const row of workspaceRows) {
     const result = await writeRuntimeOpencodeConfig(config, row.workspaceId, (current) => {
-      const { plugin: _plugin, disabled_providers: _disabledProviders, permission, ...rest } = current;
+      const { plugin: _plugin, disabled_providers: _disabledProviders, provider: _provider, permission, ...rest } = current;
       // Strip only external_directory; any other permission keys stay put.
       const { external_directory: _externalDirectory, ...permissionRest } = isRecord(permission) ? permission : {};
       return {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2191,9 +2191,12 @@ function createRoutes(
   addRoute(routes, "GET", "/workspace/:id/config", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const openwork = await readOpenworkConfigForWorkspace(config, workspace);
+    // Effective runtime view (ENGINE_GLOBAL ⊕ workspace row): providers,
+    // plugins, and authorized folders live in the global row now, and the UI
+    // must keep seeing them after migration.
     const opencode = mergeOpencodeConfigs(
       await readOpencodeConfig(workspace.path),
-      await readRuntimeOpencodeConfig(config, workspace.id),
+      await readEffectiveRuntimeOpencodeConfig(config, workspace.id),
     );
     const lastAudit = await readLastAudit(workspace.path, workspace.id);
     return jsonResponse({ opencode, openwork, updatedAt: lastAudit?.timestamp ?? null });
@@ -2747,39 +2750,50 @@ function createRoutes(
       // Per-provider merge: record values upsert, explicit `null` deletes
       // (mergeRuntimeProviderUpdate) — so clients can remove runtime-managed
       // providers (e.g. cloud imports) without read-modify-write races.
+      // Providers are engine-global: the injected engine config file is
+      // rendered from the ENGINE_GLOBAL row only, so a workspace-row write
+      // would never reach the engine.
       const providerUpdate = isRecord(provider) ? provider : {};
       if (Object.keys(providerUpdate).length) {
-        const currentRuntime = await readRuntimeOpencodeConfig(config, workspace.id);
-        logicalUpdates.provider = mergeRuntimeProviderUpdate(currentRuntime.provider, providerUpdate);
+        const providerResult = await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+          ...current,
+          provider: mergeRuntimeProviderUpdate(current.provider, providerUpdate),
+        }));
+        runtimeChanged = providerResult.changed || runtimeChanged;
       }
 
       const permissionUpdate = ensurePlainObject(permission);
       if (Object.prototype.hasOwnProperty.call(permissionUpdate, "external_directory")) {
-        const existingRuntime = await readRuntimeOpencodeConfig(config, workspace.id);
-        const existingPermission = ensurePlainObject(existingRuntime.permission);
+        // Authorized folders are engine-global for the same reason as providers.
         const nextExternalDirectory = permissionUpdate.external_directory;
-        const existingPermissionKeys = Object.keys(existingPermission);
-        const removePermissionParent =
-          typeof nextExternalDirectory === "undefined" &&
-            (existingPermissionKeys.length === 0 ||
-            (existingPermissionKeys.length === 1 && Object.prototype.hasOwnProperty.call(existingPermission, "external_directory")));
-
-        if (removePermissionParent) {
-          logicalUpdates.permission = undefined;
-        } else {
-          logicalUpdates.permission = {
-            ...existingPermission,
-            external_directory: nextExternalDirectory,
+        const permissionResult = await writeGlobalRuntimeOpencodeConfig(config, (current) => {
+          const existingPermission = ensurePlainObject(current.permission);
+          const existingPermissionKeys = Object.keys(existingPermission);
+          const removePermissionParent =
+            typeof nextExternalDirectory === "undefined" &&
+              (existingPermissionKeys.length === 0 ||
+              (existingPermissionKeys.length === 1 && Object.prototype.hasOwnProperty.call(existingPermission, "external_directory")));
+          if (removePermissionParent) {
+            const { permission: _removed, ...rest } = current;
+            return rest;
+          }
+          return {
+            ...current,
+            permission: {
+              ...existingPermission,
+              external_directory: ensurePlainObject(nextExternalDirectory),
+            },
           };
-        }
+        });
+        runtimeChanged = permissionResult.changed || runtimeChanged;
       }
 
-      if (Object.keys(logicalUpdates).length || Object.prototype.hasOwnProperty.call(logicalUpdates, "permission")) {
+      if (Object.keys(logicalUpdates).length) {
         const result = await writeRuntimeOpencodeConfig(config, workspace.id, (current) => ({
           ...current,
           ...logicalUpdates,
         }));
-        runtimeChanged = result.changed;
+        runtimeChanged = result.changed || runtimeChanged;
       }
     }
     if (openwork) {


### PR DESCRIPTION
Fixes the regression you hit on the stack branch: **"Preparing workspace / Pulling in the latest messages for this task" never clears.**

## Root cause

The app saves user-added/local providers (Settings > AI Providers, provider-auth flows, eval mock models) through `PATCH /workspace/:id/config`, which wrote the **workspace** runtime row. After the workspace-independent engine config file change, the injected file is rendered from the ENGINE_GLOBAL row only — so those providers **never reached the engine**. The model picker could not resolve the selected model and the session view sat in the preparing state forever.

Confirmed live on the running world: `~/.config/openwork/runtime.sqlite` had a workspace row full of providers (written minutes earlier) that were absent from `runtime-opencode-config.json`.

## Fix

- `PATCH /workspace/:id/config` provider merges (upsert + explicit-`null` delete) and `permission.external_directory` updates now write the **ENGINE_GLOBAL** row
- the startup migration also folds legacy per-workspace `provider` maps into the global row (newest workspace write wins per key; the existing global row — cloud-managed authority — wins over stale legacy copies) and strips `provider` from workspace rows
- `GET /workspace/:id/config` returns the effective (global ⊕ workspace) view so Settings keeps seeing providers after migration

## Witnesses

- PATCH provider → lands in global row, appears in the injected engine file, workspace row stays clean, effective config read exposes it, explicit null deletes from global
- migration folds providers with conflict precedence; repeat run no-op

## Validation

- `apps/server` tsc clean; patch/store suites 10/10
- full `apps/server` suite **798 pass / 8 skip** with only the two known environment failures (DNS-guard fixture, bun `node:sqlite`) that reproduce on clean dev

After merging: restart the app once — the startup migration promotes your existing workspace-row providers to the global row and models resolve again.