### PR TITLE
perf(app): coalesce workspace session loads

### DIFF
--- a/apps/app/src/react-app/shell/route-refresh-control.ts
+++ b/apps/app/src/react-app/shell/route-refresh-control.ts
@@ -29,6 +29,16 @@ export type RouteRefreshLifecycle = {
   isInFlight(): boolean;
 };
 
+export type RouteWorkspaceLoadCoalescer = {
+  /**
+   * Run at most one session-list request chain per workspace. Concurrent
+   * callers share the active chain until it settles, including its backoff
+   * waits and retries.
+   */
+  run(workspaceId: string, load: () => Promise<void>): Promise<void>;
+  isInFlight(workspaceId: string): boolean;
+};
+
 export type LatestWorkspaceCommitter = {
   /** Queue the route's newest workspace. Intermediate requests are discarded. */
   request(workspaceId: string): void;
@@ -148,6 +158,33 @@ export async function mapRouteWorkspaceLoads<T, R>(
     results.push(...await Promise.all(workspaces.slice(offset, offset + batchSize).map(load)));
   }
   return results;
+}
+
+/**
+ * Coalesce the complete session-list load chain for each workspace.
+ *
+ * Cold OpenCode reads can legitimately outlive a fixed staleness threshold.
+ * Keeping ownership until the promise settles prevents route, settings, and
+ * visibility refreshes from starting overlapping retries for the same
+ * workspace while still allowing different workspaces to load concurrently.
+ */
+export function createRouteWorkspaceLoadCoalescer(): RouteWorkspaceLoadCoalescer {
+  const inFlight = new Map<string, Promise<void>>();
+
+  return {
+    run(workspaceId, load) {
+      const existing = inFlight.get(workspaceId);
+      if (existing) return existing;
+
+      const request = Promise.resolve().then(load);
+      const tracked = request.finally(() => {
+        if (inFlight.get(workspaceId) === tracked) inFlight.delete(workspaceId);
+      });
+      inFlight.set(workspaceId, tracked);
+      return tracked;
+    },
+    isInFlight: (workspaceId) => inFlight.has(workspaceId),
+  };
 }
 
 /**

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -51,6 +51,7 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import {
   commitRouteWorkspaceSelection,
   createRouteRefreshLifecycle,
+  createRouteWorkspaceLoadCoalescer,
   mapRouteWorkspaceLoads,
   planRouteConnectionGap,
   planRouteWorkspaceLoads,
@@ -233,7 +234,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const startupRetryTimerRef = useRef<number | null>(null);
   const [retryingWorkspaceIds, setRetryingWorkspaceIds] = useState<string[]>([]);
   const reconnectAttemptedWorkspaceIdRef = useRef("");
-  const backgroundSessionLoadInFlight = useRef<Map<string, number>>(new Map());
+  const backgroundSessionLoadCoalescerRef = useRef(createRouteWorkspaceLoadCoalescer());
   const loadedWorkspaceIdsRef = useRef(new Set<string>());
   const serverActiveWorkspaceIdRef = useRef("");
   const workspaceSelectionCommitTimerRef = useRef<number | null>(null);
@@ -308,7 +309,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       const MAX_ATTEMPTS = 6;
       const backoffMs = (attempt: number) => Math.min(500 * Math.pow(2, attempt), 4_000);
 
-      const fetchOnce = async (workspace: RouteWorkspace, attempt: number): Promise<void> => {
+      const fetchWithRetries = async (workspace: RouteWorkspace, attempt: number): Promise<void> => {
         const isRemoteOpenworkWorkspace = workspace.workspaceType === "remote" && workspace.remoteType !== "opencode";
         const endpoint = endpointForWorkspace(workspace);
         if (!endpoint) {
@@ -329,10 +330,6 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           }
           return;
         }
-        const startedAt = backgroundSessionLoadInFlight.current.get(workspace.id) ?? 0;
-        if (startedAt && Date.now() - startedAt < 5_000) return;
-        const requestStartedAt = Date.now();
-        backgroundSessionLoadInFlight.current.set(workspace.id, requestStartedAt);
         if (isRemoteOpenworkWorkspace) {
           setWorkspaceConnectionOverrides((current) => ({
             ...current,
@@ -385,9 +382,11 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           // empty while the managed engine finishes starting.
           if (items.length === 0 && attempt === 0) {
             window.setTimeout(() => {
-              if (backgroundSessionLoadInFlight.current.get(workspace.id)) return;
-              backgroundSessionLoadInFlight.current.delete(workspace.id);
-              void fetchOnce(workspace, 1);
+              if (backgroundSessionLoadCoalescerRef.current.isInFlight(workspace.id)) return;
+              void backgroundSessionLoadCoalescerRef.current.run(
+                workspace.id,
+                () => fetchWithRetries(workspace, 1),
+              );
             }, 3_000);
           }
         } catch (error) {
@@ -399,11 +398,8 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           // in the meantime instead of flashing "error" next to the
           // workspace name.
           if (attempt + 1 < MAX_ATTEMPTS && classifyRouteSessionReadError(error) === "retryable") {
-            if (backgroundSessionLoadInFlight.current.get(workspace.id) === requestStartedAt) {
-              backgroundSessionLoadInFlight.current.delete(workspace.id);
-            }
             await new Promise((r) => window.setTimeout(r, backoffMs(attempt)));
-            await fetchOnce(workspace, attempt + 1);
+            await fetchWithRetries(workspace, attempt + 1);
             return;
           }
           // Final failure: keep local workspace startup quiet, but give
@@ -424,14 +420,15 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           setRetryingWorkspaceIds((current) =>
             current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
           );
-        } finally {
-          if (backgroundSessionLoadInFlight.current.get(workspace.id) === requestStartedAt) {
-            backgroundSessionLoadInFlight.current.delete(workspace.id);
-          }
         }
       };
 
-      await mapRouteWorkspaceLoads(workspaces, (workspace) => fetchOnce(workspace, 0));
+      await mapRouteWorkspaceLoads(workspaces, (workspace) =>
+        backgroundSessionLoadCoalescerRef.current.run(
+          workspace.id,
+          () => fetchWithRetries(workspace, 0),
+        ),
+      );
     },
     [endpointForWorkspace, mergeFetchedSessionsWithPending],
   );

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -7,7 +7,10 @@ import {
   refreshRouteWorkspaceListState,
   stabilizeRouteWorkspaceOrder,
 } from "../src/react-app/shell/route-workspaces";
-import { mapRouteWorkspaceLoads } from "../src/react-app/shell/route-refresh-control";
+import {
+  createRouteWorkspaceLoadCoalescer,
+  mapRouteWorkspaceLoads,
+} from "../src/react-app/shell/route-refresh-control";
 import {
   mergeWorkspaceRouteSession,
   preserveWorkspaceRouteSession,
@@ -157,6 +160,39 @@ describe("workspace route session load budget", () => {
 
     expect(await resultPromise).toEqual(workspaces.map((workspace) => `workspace-${workspace}`));
     expect(peak).toBe(4);
+  });
+
+  test("coalesces one workspace load until its complete retry chain settles", async () => {
+    const coalescer = createRouteWorkspaceLoadCoalescer();
+    const starts: string[] = [];
+    let releaseWorkspaceA: (() => void) | undefined;
+
+    const firstWorkspaceA = coalescer.run("workspace-a", async () => {
+      starts.push("workspace-a");
+      await new Promise<void>((resolve) => {
+        releaseWorkspaceA = resolve;
+      });
+    });
+    const duplicateWorkspaceA = coalescer.run("workspace-a", async () => {
+      starts.push("workspace-a-duplicate");
+    });
+    const workspaceB = coalescer.run("workspace-b", async () => {
+      starts.push("workspace-b");
+    });
+
+    await Bun.sleep(0);
+    expect(duplicateWorkspaceA).toBe(firstWorkspaceA);
+    expect(starts).toEqual(["workspace-a", "workspace-b"]);
+    expect(coalescer.isInFlight("workspace-a")).toBe(true);
+
+    releaseWorkspaceA?.();
+    await Promise.all([firstWorkspaceA, duplicateWorkspaceA, workspaceB]);
+    expect(coalescer.isInFlight("workspace-a")).toBe(false);
+
+    await coalescer.run("workspace-a", async () => {
+      starts.push("workspace-a-after-settle");
+    });
+    expect(starts).toEqual(["workspace-a", "workspace-b", "workspace-a-after-settle"]);
   });
 });
 

--- a/evals/specs/workspace-session-load-coalescing.test.ts
+++ b/evals/specs/workspace-session-load-coalescing.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { createRouteWorkspaceLoadCoalescer } from "../../apps/app/src/react-app/shell/route-refresh-control";
+
+test("workspace session refreshes share an unsettled load", async ({ evidence }) => {
+  const coalescer = createRouteWorkspaceLoadCoalescer();
+  const starts: string[] = [];
+  let release: (() => void) | undefined;
+
+  const first = coalescer.run("workspace-a", async () => {
+    starts.push("workspace-a");
+    await new Promise<void>((resolve) => {
+      release = resolve;
+    });
+  });
+  const overlappingRefresh = coalescer.run("workspace-a", async () => {
+    starts.push("workspace-a-overlap");
+  });
+  const independentWorkspace = coalescer.run("workspace-b", async () => {
+    starts.push("workspace-b");
+  });
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  expect(overlappingRefresh).toBe(first);
+  expect(starts).toEqual(["workspace-a", "workspace-b"]);
+  expect(coalescer.isInFlight("workspace-a")).toBe(true);
+
+  release?.();
+  await Promise.all([first, overlappingRefresh, independentWorkspace]);
+  expect(coalescer.isInFlight("workspace-a")).toBe(false);
+
+  evidence.recordAssertionEvidence(
+    "An overlapping refresh cannot duplicate a workspace session load",
+    "Two refresh callers shared one unsettled workspace-a load while workspace-b remained independent.",
+    starts.join(",") === "workspace-a,workspace-b",
+  );
+});


### PR DESCRIPTION
## Summary

- coalesce the complete session-list request and retry chain per workspace
- keep independent workspaces loading concurrently while duplicate route refreshes share the active promise
- add focused product coverage and an app-less testkit proof for the overlap boundary

## Scope

This is a bounded session-list performance improvement. Cold OpenCode reads can outlive the previous five-second in-flight threshold, allowing duplicate reads for the same workspace. The coalescer retains ownership until the complete promise settles, including retry backoff, and releases the workspace immediately afterward.

This PR is not currently claimed as the root-cause fix for the separately reported active-session React error #185. That crash occurs after startup and its minified stack points to a useSyncExternalStore snapshot/update cycle; keep this PR draft until its independent performance value is reviewed.

## Verification

- corepack pnpm --filter @openwork/app exec bun test --isolate tests/workspace-routes.test.ts — 19 passed, 0 failed
- corepack pnpm --filter @openwork/app typecheck — passed
- OPENWORK_EVAL_DAYTONA=1 corepack pnpm evals:pr specs/workspace-session-load-coalescing.test.ts — 1 passed, 0 failed, 0 skipped

Verdict for the bounded coalescing claim: Passed.