### PR TITLE
fix(server): isolate provider sync contexts

### DIFF
--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -232,15 +232,16 @@ describe("cloud provider sync gateway", () => {
       expect((await putSession("org_first")).status).toBe(204);
       const sameContextRuns = [runSync(base, "app_launch"), runSync(base, "app_resume")];
 
-      expect((await putSession("org_changed")).status).toBe(204);
-      const changedContextRuns = [runSync(base, "sign_in"), runSync(base, "focus")];
+      const changedSessionResponse = putSession("org_changed");
       await Bun.sleep(25);
       expect(listOrgIds).toEqual(["org_first"]);
       expect(maxListRequestsInFlight).toBe(1);
 
       releaseFirstList();
+      expect((await changedSessionResponse).status).toBe(204);
+      const changedContextRuns = [runSync(base, "sign_in"), runSync(base, "focus")];
       const results = await Promise.all([...sameContextRuns, ...changedContextRuns]);
-      expect(results.map((result) => result.status)).toEqual(["applied", "applied", "noop", "noop"]);
+      expect(results.map((result) => result.status)).toEqual(["no_session", "no_session", "applied", "applied"]);
       expect(listOrgIds).toEqual(["org_first", "org_changed"]);
       expect(maxListRequestsInFlight).toBe(1);
 
@@ -250,6 +251,77 @@ describe("cloud provider sync gateway", () => {
     } finally {
       releaseFirstList();
     }
+  });
+
+  test("quarantines the old organization before a failing new-organization sync", async () => {
+    const root = await createRoot();
+    const provider: FakeProvider = {
+      ...buildProvider([{ id: "model-context", name: "Context model", config: {} }]),
+      id: "lpr_context",
+      name: "Context provider",
+      apiKey: "sk-org-a",
+      providerConfig: {
+        env: ["CONTEXT_PROVIDER_API_KEY"],
+        npm: "@ai-sdk/openai-compatible",
+      },
+    };
+    const config = serverConfig(root, "https://engine.example.test");
+    let engineBusy = false;
+    let reloads = 0;
+    const fetchImpl = Object.assign(async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init?: Parameters<typeof globalThis.fetch>[1],
+    ) => {
+      const url = new URL(String(input));
+      if (url.hostname === "den.example.test") {
+        const orgId = new Headers(init?.headers).get("x-openwork-legacy-org-id");
+        if (orgId === "org_b") return Response.json({ error: "not_found" }, { status: 404 });
+        if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: [provider] });
+        if (url.pathname === `/v1/llm-providers/${provider.id}/connect`) {
+          return Response.json({ llmProvider: provider });
+        }
+      }
+      if (url.hostname === "engine.example.test" && url.pathname === `/auth/${provider.id}`) {
+        return Response.json(true);
+      }
+      return Response.json({ error: "not_found" }, { status: 404 });
+    }, { preconnect: globalThis.fetch.preconnect });
+    const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
+    const sync = new CloudProviderSync({
+      config,
+      env,
+      fetchImpl,
+      engineBusy: async () => engineBusy,
+      reloadEngine: async () => {
+        reloads += 1;
+      },
+      intervalMs: 3_600_000,
+    });
+    stops.push(() => sync.stop());
+
+    await sync.setSession({
+      baseUrl: "https://den.example.test",
+      token: "token-a",
+      orgId: "org_a",
+    });
+    expect((await sync.run("org-a")).status).toBe("applied");
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_context).toBeDefined();
+    expect((await env.list()).some((entry) => entry.key === "CONTEXT_PROVIDER_API_KEY")).toBe(true);
+    expect(reloads).toBe(1);
+
+    engineBusy = true;
+    await sync.setSession({
+      baseUrl: "https://den.example.test",
+      token: "token-b",
+      orgId: "org_b",
+    });
+    expect((await sync.run("org-b")).status).toBe("failed");
+
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config)).lpr_context).toBeUndefined();
+    expect((await env.list()).some((entry) => entry.key === "CONTEXT_PROVIDER_API_KEY")).toBe(false);
+    expect(sync.status().providers).toEqual([]);
+    expect(sync.status().lastRun?.message).toBe("den_request_failed_404");
+    expect(reloads).toBe(2);
   });
 
   test("materializes providers before the first workspace exists and finishes setup later", async () => {

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -186,6 +186,14 @@ describe("cloud provider sync gateway", () => {
     const firstListReleased = new Promise<void>((resolve) => {
       releaseFirstList = resolve;
     });
+    let markSecondListReached: () => void = () => undefined;
+    const secondListReached = new Promise<void>((resolve) => {
+      markSecondListReached = resolve;
+    });
+    let releaseSecondList: () => void = () => undefined;
+    const secondListReleased = new Promise<void>((resolve) => {
+      releaseSecondList = resolve;
+    });
     const listOrgIds: string[] = [];
     let listRequestsInFlight = 0;
     let maxListRequestsInFlight = 0;
@@ -197,12 +205,16 @@ describe("cloud provider sync gateway", () => {
           return Response.json({ error: "not_found" }, { status: 404 });
         }
         listOrgIds.push(request.headers.get("x-openwork-legacy-org-id") ?? "");
+        const listIndex = listOrgIds.length;
         listRequestsInFlight += 1;
         maxListRequestsInFlight = Math.max(maxListRequestsInFlight, listRequestsInFlight);
         try {
-          if (listOrgIds.length === 1) {
+          if (listIndex === 1) {
             markFirstListReached();
             await firstListReleased;
+          } else if (listIndex === 2) {
+            markSecondListReached();
+            await secondListReleased;
           }
           return Response.json({ llmProviders: [] });
         } finally {
@@ -239,7 +251,12 @@ describe("cloud provider sync gateway", () => {
 
       releaseFirstList();
       expect((await changedSessionResponse).status).toBe(204);
+      // The replacement session fires its own sync pass; hold its Den list open
+      // so both explicit runs deterministically join that active pass.
+      await secondListReached;
       const changedContextRuns = [runSync(base, "sign_in"), runSync(base, "focus")];
+      await Bun.sleep(25);
+      releaseSecondList();
       const results = await Promise.all([...sameContextRuns, ...changedContextRuns]);
       expect(results.map((result) => result.status)).toEqual(["no_session", "no_session", "applied", "applied"]);
       expect(listOrgIds).toEqual(["org_first", "org_changed"]);
@@ -250,6 +267,7 @@ describe("cloud provider sync gateway", () => {
       expect(listOrgIds).toEqual(["org_first", "org_changed"]);
     } finally {
       releaseFirstList();
+      releaseSecondList();
     }
   });
 

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -140,6 +140,7 @@ type CloudProviderSyncLogger = {
 
 type CloudProviderSyncRequest = {
   contextKey: string;
+  generation: number;
   session: CloudProviderDenSession;
   reason?: string;
 };
@@ -153,6 +154,11 @@ type CloudProviderSyncTrailingRun = CloudProviderSyncRun & {
   request: CloudProviderSyncRequest;
   resolve: (result: CloudProviderSyncRunResult) => void;
   reject: (error: unknown) => void;
+};
+
+type CloudProviderSyncPendingSession = {
+  contextKey: string;
+  promise: Promise<void>;
 };
 
 export type CloudProviderSyncOptions = {
@@ -585,6 +591,8 @@ export class CloudProviderSync {
   private importedAtByCloudProviderId = new Map<string, number>();
   private reloadPending = false;
   private queue: Promise<void> = Promise.resolve();
+  private contextGeneration = 0;
+  private pendingSession: CloudProviderSyncPendingSession | null = null;
   private activeRun: CloudProviderSyncRun | null = null;
   private trailingRun: CloudProviderSyncTrailingRun | null = null;
   private interval: ReturnType<typeof setInterval> | null = null;
@@ -602,15 +610,59 @@ export class CloudProviderSync {
     this.reloadRetryMs = configuredReloadRetryMs();
   }
 
-  setSession(session: CloudProviderDenSession): void {
+  setSession(session: CloudProviderDenSession): Promise<void> {
     const contextKey = this.sessionContextKey(session);
-    if (this.session && this.sessionContextKey(this.session) === contextKey) return;
-    this.session = session;
-    this.startInterval();
-    void this.run("den_session_updated");
+    if (this.session && this.sessionContextKey(this.session) === contextKey) return Promise.resolve();
+    if (this.pendingSession?.contextKey === contextKey) return this.pendingSession.promise;
+
+    const hasMaterializedContext = this.session !== null
+      || this.managedProviderIds.size > 0
+      || this.ownedEnvKeys.size > 0;
+    this.contextGeneration += 1;
+
+    if (!hasMaterializedContext) {
+      this.session = session;
+      this.startInterval();
+      void this.run("den_session_updated");
+      return Promise.resolve();
+    }
+
+    const generation = this.contextGeneration;
+    this.session = null;
+    this.stopInterval();
+    this.stopReloadRetry();
+    const trailing = this.trailingRun;
+    this.trailingRun = null;
+    trailing?.resolve({ status: "no_session" });
+    this.lastRun = null;
+    this.providers = [];
+    this.skippedProviders = [];
+
+    const promise = this.enqueue(async () => {
+      if (generation !== this.contextGeneration) return;
+      await this.sweep({ forceReload: true });
+      this.resetMaterializationState();
+      if (generation !== this.contextGeneration) return;
+      this.session = session;
+      this.startInterval();
+      void this.run("den_session_updated");
+    });
+    const pending = { contextKey, promise };
+    this.pendingSession = pending;
+    void promise.then(
+      () => {
+        if (this.pendingSession === pending) this.pendingSession = null;
+      },
+      () => {
+        if (this.pendingSession === pending) this.pendingSession = null;
+      },
+    );
+    return promise;
   }
 
   async clearSession(): Promise<void> {
+    this.contextGeneration += 1;
+    this.pendingSession = null;
     this.session = null;
     this.stopInterval();
     const trailing = this.trailingRun;
@@ -618,19 +670,13 @@ export class CloudProviderSync {
     trailing?.resolve({ status: "no_session" });
     await this.enqueue(async () => {
       try {
-        await this.sweep();
+        await this.sweep({ forceReload: true });
       } catch (error) {
         this.logger?.error("cloud provider sweep failed", {
           message: error instanceof Error ? error.message : "cloud_provider_sweep_failed",
         });
       } finally {
-        this.lastRun = null;
-        this.providers = [];
-        this.skippedProviders = [];
-        this.fingerprint = null;
-        this.ownedEnvKeys.clear();
-        this.managedProviderIds.clear();
-        this.importedAtByCloudProviderId.clear();
+        this.resetMaterializationState();
       }
     });
   }
@@ -640,6 +686,7 @@ export class CloudProviderSync {
     if (!session) return Promise.resolve({ status: "no_session" });
     const request = {
       contextKey: this.sessionContextKey(session),
+      generation: this.contextGeneration,
       session,
       reason,
     };
@@ -694,6 +741,16 @@ export class CloudProviderSync {
 
   private sessionContextKey(session: CloudProviderDenSession): string {
     return `${session.baseUrl}\u0000${session.orgId}\u0000${session.token}`;
+  }
+
+  private resetMaterializationState(): void {
+    this.lastRun = null;
+    this.providers = [];
+    this.skippedProviders = [];
+    this.fingerprint = null;
+    this.ownedEnvKeys.clear();
+    this.managedProviderIds.clear();
+    this.importedAtByCloudProviderId.clear();
   }
 
   private createTrailingRun(request: CloudProviderSyncRequest): Promise<CloudProviderSyncRunResult> {
@@ -818,6 +875,7 @@ export class CloudProviderSync {
     const { reason, session } = request;
     try {
       const prepared = prepareMaterialization(await fetchProviders(this.fetchImpl, session));
+      if (request.generation !== this.contextGeneration) return { status: "no_session" };
       const { changed, detail, reloadError } = await this.apply(prepared);
       // The materialization itself succeeded (config + env writes landed), so
       // record it even when the engine reload failed: hiding the providers
@@ -835,6 +893,7 @@ export class CloudProviderSync {
       this.lastRun = { at: new Date().toISOString(), status, detail };
       return { status };
     } catch (error) {
+      if (request.generation !== this.contextGeneration) return { status: "no_session" };
       const message = error instanceof Error ? error.message : "cloud_provider_sync_failed";
       this.lastRun = { at: new Date().toISOString(), status: "failed", message };
       this.logger?.warn("cloud provider sync failed", { reason, message });
@@ -1006,7 +1065,7 @@ export class CloudProviderSync {
     });
   }
 
-  private async sweep(): Promise<void> {
+  private async sweep(options: { forceReload?: boolean } = {}): Promise<void> {
     const providerPatch = Object.fromEntries([...this.managedProviderIds].map((providerId) => [providerId, null]));
     let providerChanged = false;
     if (Object.keys(providerPatch).length > 0) {
@@ -1033,7 +1092,7 @@ export class CloudProviderSync {
       || authResult.delivered.length > 0
       || authResult.removed.length > 0;
     let reloadError: unknown;
-    if (this.reloadPending && (await this.reloadDeferredByActivity())) {
+    if (this.reloadPending && !options.forceReload && (await this.reloadDeferredByActivity())) {
       this.scheduleReloadRetry();
     } else if (this.reloadPending) {
       try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2594,7 +2594,7 @@ function createRoutes(
     ensureWritable(config);
     const session = parseCloudProviderDenSession(await readJsonBody(ctx.request));
     if (!session) throw new ApiError(400, "invalid_payload", "baseUrl, token, and orgId are required");
-    cloudProviderSync.setSession(session);
+    await cloudProviderSync.setSession(session);
     return new Response(null, { status: 204 });
   });
 

--- a/evals/specs/provider-sync-context-isolation.test.ts
+++ b/evals/specs/provider-sync-context-isolation.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { CloudProviderSync } from "../../apps/server/src/cloud-provider-sync.js";
+import { EnvService } from "../../apps/server/src/env-file.js";
+import { resetManagedProviderAuthCache } from "../../apps/server/src/managed-provider-auth.js";
+import {
+  readGlobalRuntimeOpencodeConfig,
+  runtimeProviderMap,
+} from "../../apps/server/src/runtime-opencode-config-store.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+
+const PROVIDER_ID = "lpr_context_isolation";
+const ENV_KEY = "CONTEXT_ISOLATION_API_KEY";
+
+test("a failed organization transition cannot retain the prior provider context", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-provider-context-isolation-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  resetManagedProviderAuthCache();
+
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: "client-token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_context_isolation",
+      name: "Context isolation",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: "https://engine.example.test",
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const provider: Record<string, unknown> = {
+    id: PROVIDER_ID,
+    providerId: "openai-compatible",
+    name: "Context isolation provider",
+    source: "custom",
+    updatedAt: "2026-08-28T00:00:00.000Z",
+    providerConfig: {
+      env: [ENV_KEY],
+      npm: "@ai-sdk/openai-compatible",
+    },
+    apiKey: "test-only-org-a-credential",
+    apiKeys: null,
+    models: [{ id: "context-isolation-model", name: "Context isolation model", config: {} }],
+  };
+  const fetchImpl: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.hostname === "den.example.test") {
+      const orgId = new Headers(init?.headers).get("x-openwork-legacy-org-id");
+      if (orgId === "org_b") return Response.json({ error: "not_found" }, { status: 404 });
+      if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: [provider] });
+      if (url.pathname === `/v1/llm-providers/${PROVIDER_ID}/connect`) {
+        return Response.json({ llmProvider: provider });
+      }
+    }
+    if (url.hostname === "engine.example.test" && url.pathname === `/auth/${PROVIDER_ID}`) {
+      return Response.json(true);
+    }
+    return Response.json({ error: "not_found" }, { status: 404 });
+  };
+  const env = new EnvService({ path: join(root, "env.json") });
+  let engineBusy = false;
+  let reloads = 0;
+  const sync = new CloudProviderSync({
+    config,
+    env,
+    fetchImpl,
+    engineBusy: async () => engineBusy,
+    reloadEngine: async () => {
+      reloads += 1;
+    },
+    intervalMs: 3_600_000,
+  });
+
+  try {
+    await sync.setSession({ baseUrl: "https://den.example.test", token: "token-a", orgId: "org_a" });
+    expect((await sync.run("org-a")).status).toBe("applied");
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[PROVIDER_ID]).toBeDefined();
+    expect((await env.list()).some((entry) => entry.key === ENV_KEY)).toBe(true);
+    evidence.recordAssertionEvidence(
+      "Organization A materializes its own managed provider context",
+      `The runtime provider and its named environment entry were both present after one successful pass.`,
+      true,
+    );
+
+    engineBusy = true;
+    await sync.setSession({ baseUrl: "https://den.example.test", token: "token-b", orgId: "org_b" });
+    expect((await sync.run("org-b")).status).toBe("failed");
+
+    const providerAfterFailure = runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[PROVIDER_ID];
+    const envAfterFailure = (await env.list()).some((entry) => entry.key === ENV_KEY);
+    expect(providerAfterFailure).toBeUndefined();
+    expect(envAfterFailure).toBe(false);
+    expect(sync.status().providers).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "A new organization is not acknowledged until the old context is quarantined",
+      `The old runtime provider, named environment entry, and visible provider status were absent after the transition.`,
+      providerAfterFailure === undefined && !envAfterFailure && sync.status().providers.length === 0,
+    );
+
+    expect(sync.status().lastRun?.message).toBe("den_request_failed_404");
+    expect(reloads).toBe(2);
+    evidence.recordAssertionEvidence(
+      "A failing replacement sync cannot keep the old engine generation alive",
+      `The replacement list failed with a terminal 404 after the security cleanup forced the second engine reload.`,
+      sync.status().lastRun?.message === "den_request_failed_404" && reloads === 2,
+    );
+  } finally {
+    sync.stop();
+    resetManagedProviderAuthCache();
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- await old provider cleanup before accepting a replacement Den session
- bind sync passes to the active context generation so stale fetches cannot materialize
- force provider, environment, auth, and engine cleanup across identity transitions even when the old engine reports active work

## Verification

- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-server test -- src/cloud-provider-sync.e2e.test.ts (5 passed, 0 failed)
- pnpm evals:pr specs/provider-sync-context-isolation.test.ts (1 passed, 0 failed, 0 skipped)

The testkit proof covers the negative boundary: organization A materializes successfully, organization B returns 404, and no organization A runtime provider, environment entry, visible provider status, or old engine generation remains.