### PR TITLE
fix(app): optimistic model selection and an honest account status row

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -124,7 +124,6 @@ type PendingConversationHistoryNavigation = {
 
 /** Live status the route feeds into the sidebar footer account menu. */
 type StatusBarOverrides = {
-  loading: boolean;
   showSettingsButton: boolean;
   reloadBusy: boolean;
   reloadError: string | null;
@@ -1403,7 +1402,6 @@ export function SessionPage(props: SessionPageProps) {
             showConnectionStatus: Boolean(props.selectedWorkspaceId),
             providerConnectedIds: props.providerConnectedIds,
             mcpConnectedCount: props.mcpConnectedCount,
-            loading: props.statusBar?.loading ?? false,
             showSettingsButton: props.statusBar?.showSettingsButton,
             reloadBusy: props.statusBar?.reloadBusy,
             reloadError: props.statusBar?.reloadError,

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -87,13 +87,12 @@ type RuntimeStatus = {
 type RuntimeStatusInput = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
-  loading?: boolean;
   initializing: boolean;
   reloadBusy?: boolean;
   reloadError?: string | null;
 };
 
-function resolveRuntimeStatus(input: RuntimeStatusInput): RuntimeStatus {
+export function resolveRuntimeStatus(input: RuntimeStatusInput): RuntimeStatus {
   if (input.reloadBusy) {
     return {
       variant: "loading",
@@ -104,7 +103,10 @@ function resolveRuntimeStatus(input: RuntimeStatusInput): RuntimeStatus {
   if (input.reloadError) {
     return { variant: "disconnected", label: t("system.reload_failed"), detail: input.reloadError };
   }
-  if (input.loading || (input.openworkServerStatus === "disconnected" && input.initializing)) {
+  // This row renders app-scoped facts only. Per-session loading (messages
+  // still fetching, a model verdict still pending) stays in the pane and the
+  // composer — one session's state must not paint the whole app as booting.
+  if (input.openworkServerStatus === "disconnected" && input.initializing) {
     return {
       variant: "loading",
       label: t("session.preparing_workspace"),
@@ -188,7 +190,6 @@ export type AccountStatusMenuProps = {
   showConnectionStatus: boolean;
   providerConnectedIds: string[];
   mcpConnectedCount: number;
-  loading?: boolean;
   reloadBusy?: boolean;
   reloadError?: string | null;
   openWorkConnectState?: SessionCloudMcpMaintenanceState;
@@ -283,7 +284,6 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
     ? resolveRuntimeStatus({
       clientConnected: props.clientConnected,
       openworkServerStatus: props.openworkServerStatus,
-      loading: props.loading,
       initializing,
       reloadBusy: props.reloadBusy,
       reloadError: props.reloadError,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -146,7 +146,6 @@ import {
   type ModelEntitlementOption,
 } from "@/react-app/domains/connections/provider-auth/provider-policy";
 import {
-  isManagedModelAvailabilityPending,
   isOrganizationModelsEmpty,
   shouldAutoOpenUnavailableModelPicker,
 } from "@/react-app/domains/connections/provider-auth/managed-models-recovery";
@@ -1072,9 +1071,6 @@ export function SessionRoute() {
     window.addEventListener(openModelPickerEvent, handler);
     return () => window.removeEventListener(openModelPickerEvent, handler);
   }, []);
-  const selectedModelUsesCloudProvider = Boolean(
-    local.prefs.defaultModel && isCloudManagedProviderKey(local.prefs.defaultModel.providerID),
-  );
   const entitledOrgDefaultModel = useMemo(() => {
     const runtimeOptions = providerListModelEntitlementOptions(
       cloudProviderList ?? providerListQuery.data,
@@ -1098,12 +1094,6 @@ export function SessionRoute() {
   useEffect(() => {
     if (entitledOrgDefaultModel) writeStoredDefaultModel(entitledOrgDefaultModel);
   }, [entitledOrgDefaultModel]);
-  const selectedModelAvailabilityPending = isManagedModelAvailabilityPending({
-    signedIn: denAuth.isSignedIn,
-    selectedModelUsesCloudProvider,
-    cloudProviderSyncReady,
-    openWorkModelsSyncing,
-  });
   // Availability is resolved per effective model identity: the New Task
   // composer validates the global default while each conversation validates
   // its OWN remembered provider/model against the current workspace's
@@ -1206,18 +1196,22 @@ export function SessionRoute() {
     modelPicker.setOpen(true);
   }, [activeComposerTargetsSession, cloudProviderSyncReady, denAuth.isSignedIn, entitledOrgDefaultModel, modelPicker.setCompactOpen, modelPicker.setOpen, modelPicker.setQuery, modelPicker.setRecentProviderIds, organizationModelsEmpty, selectedModelUnavailableKey, selectedSessionId]);
 
+  // Optimistic model selection: a remembered model is treated as valid until
+  // the availability gate CONFIRMS it absent (selectedModelUnavailable).
+  // A merely-pending verdict (cloud sync settling, catalog reloading) never
+  // blocks task creation or paints loading chrome — if the optimism turns out
+  // wrong, the send-time re-check and the composer's model-unavailable pill
+  // surface it where the person can act on it.
   const hasUsableModel = Boolean(
     local.prefs.defaultModel &&
-      !selectedModelUnavailable &&
-      !selectedModelAvailabilityPending,
+      !selectedModelUnavailable,
   );
   const canCreateTask = Boolean(
     opencodeClient &&
       selectedWorkspaceId &&
       !loading &&
       !selectedWorkspaceError &&
-      !selectedModelUnavailable &&
-      !selectedModelAvailabilityPending,
+      !selectedModelUnavailable,
   );
 
   const {
@@ -1239,12 +1233,6 @@ export function SessionRoute() {
     : selectedModelUnavailable
       ? t("models.model_unavailable_short")
       : null;
-  const showPreparingStatus =
-    !organizationModelsEmpty &&
-    (effectiveLoading ||
-      selectedModelAvailabilityPending ||
-      (!canCreateTask && !routeError && !selectedWorkspaceError));
-
   useEffect(() => {
     if (!opencodeClient) {
       setProviders([]);
@@ -3438,7 +3426,9 @@ export function SessionRoute() {
       }
       onArchiveSession={opencodeClient ? handleArchiveSession : undefined}
       statusBar={{
-        loading: showPreparingStatus,
+        // No per-session loading state here: the account row renders only
+        // app-scoped facts. Session loading lives in the pane; an unresolved
+        // model surfaces in the composer where the person can act on it.
         reloadBusy: reloadCoordinator.reloadBusy,
         reloadError: reloadCoordinator.reloadError,
         openWorkConnectState: sessionMcpMaintenance,

--- a/apps/app/tests/account-status-runtime.test.ts
+++ b/apps/app/tests/account-status-runtime.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+import { resolveRuntimeStatus } from "@/react-app/domains/session/sidebar/account-status-menu";
+
+const read = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+describe("account status row renders app-scoped facts only", () => {
+  test("a connected client is ready even while session-level work is in flight", () => {
+    // The old per-session `loading` input no longer exists: one session's
+    // pending messages or model verdict must not paint the app as booting.
+    const status = resolveRuntimeStatus({
+      clientConnected: true,
+      openworkServerStatus: "connected",
+      initializing: false,
+    });
+    expect(status.variant).toBe("connected");
+  });
+
+  test("first boot still shows preparing while the server is disconnected", () => {
+    const status = resolveRuntimeStatus({
+      clientConnected: false,
+      openworkServerStatus: "disconnected",
+      initializing: true,
+    });
+    expect(status.variant).toBe("loading");
+  });
+
+  test("reload busy and reload failure stay visible", () => {
+    expect(resolveRuntimeStatus({
+      clientConnected: true,
+      openworkServerStatus: "connected",
+      initializing: false,
+      reloadBusy: true,
+    }).variant).toBe("loading");
+    expect(resolveRuntimeStatus({
+      clientConnected: true,
+      openworkServerStatus: "connected",
+      initializing: false,
+      reloadError: "boom",
+    }).variant).toBe("disconnected");
+  });
+
+  test("a disconnected server after boot reports disconnected, not preparing", () => {
+    const status = resolveRuntimeStatus({
+      clientConnected: false,
+      openworkServerStatus: "disconnected",
+      initializing: false,
+    });
+    expect(status.variant).toBe("disconnected");
+  });
+});
+
+describe("optimistic model selection wiring", () => {
+  const sessionRoute = read("../src/react-app/shell/session-route.tsx");
+
+  test("a pending model verdict never gates task creation or usable-model state", () => {
+    // Only a CONFIRMED absence (selectedModelUnavailable, post confirmation
+    // gate) may block; the coarse pending flag is gone.
+    expect(sessionRoute).not.toContain("selectedModelAvailabilityPending");
+    expect(sessionRoute).toContain("!selectedModelUnavailable");
+  });
+
+  test("the status bar no longer carries a per-session loading flag", () => {
+    expect(sessionRoute).not.toContain("loading: showPreparingStatus");
+    expect(sessionRoute).not.toContain("showPreparingStatus");
+    const accountMenu = read("../src/react-app/domains/session/sidebar/account-status-menu.tsx");
+    expect(accountMenu).not.toContain("input.loading");
+  });
+
+  test("send-time re-check of the exact model still blocks a confirmed-missing model", () => {
+    expect(sessionRoute).toContain('resolveModelAvailability(sendModel ?? null).status === "unavailable"');
+  });
+});


### PR DESCRIPTION
Follow-up to the global-first stack, fixing the UX disease behind the eternal **"Preparing workspace / Pulling in the latest messages for this task"**.

## Problem

The account row (bottom-left, under the user name) rendered a catch-all per-session loading flag:

```ts
showPreparingStatus = effectiveLoading || selectedModelAvailabilityPending || (!canCreateTask && …)
```

`selectedModelAvailabilityPending` is a coarse boolean with **no terminal failure state** — a session whose remembered model couldn't be re-verified painted the whole app as booting, forever, while server/engine/providers/messages were all provably healthy. Wrong scope (per-session state in app chrome), wrong words (no workspace is being prepared), unbounded pending.

## Change

**Optimistic model selection** — a remembered model is valid until the availability gate *confirms* it absent:
- the pending flag no longer gates `hasUsableModel` / `canCreateTask` and no longer feeds status chrome
- confirmed absence (post 1.2s confirmation gate) keeps all existing teeth: New Task disabled, composer model-unavailable pill + retry, auto-open picker recovery, send-time exact-model re-check, `SessionErrorCard` model-not-found recovery — all pre-existing, unchanged

**Honest status row** — the account row renders app-scoped facts only: reload busy/failed, server disconnected, first-boot window. The per-session `loading` input is deleted end to end (`session-route` statusBar → `session-page` StatusBarOverrides → `account-status-menu` RuntimeStatusInput). Session loading stays in the pane; model problems surface in the composer where the person can act.

## Safety

Send-gating was already independent of the removed flag: `onSendDraft` re-resolves the exact model and throws on confirmed absence; queued drain re-queues on error; the engine's `ProviderModelNotFoundError` renders a recovery card. The only things the pending flag gated were the pessimistic blocks this PR removes.

## Witnesses

- connected client reports **ready** while session-level work is in flight (the old lie is structurally impossible)
- first-boot disconnected window still shows preparing; reload busy/failed and post-boot disconnected survive
- pending flag absent from task gating; send-time exact-model re-check pinned
- 36 pass across account-status (new), model-availability, composer-controls, managed-models-recovery; app tsc clean
- full local app suite crashes identically on the unmodified baseline (pre-existing local bun issue); CI is authoritative