### PR TITLE
fix(app): preserve session activity snapshots

### DIFF
--- a/apps/app/src/react-app/domains/session/status/session-activity-store.ts
+++ b/apps/app/src/react-app/domains/session/status/session-activity-store.ts
@@ -219,32 +219,30 @@ export const useSessionActivityStore = create<SessionActivityStore>((set, get) =
     const id = workspaceId.trim();
     if (!id) return;
     set((state) => {
-      let nextState = state;
+      let nextState: Pick<SessionActivityStore, "recordsByWorkspaceId" | "statusesByWorkspaceId"> = state;
       for (const session of sessions) {
         const sessionId = session.id.trim();
         if (!sessionId) continue;
         const status = sessionRunStatus(session);
         if (status === undefined || status === null) continue;
-        nextState = {
-          ...nextState,
-          ...updateRecord(nextState, id, sessionId, (record) => {
-            const normalized = normalizeRunStatus(status);
-            const runActive = normalized === "running" || normalized === "retry";
-            if (!runActive && record.status !== "idle") return record;
-            return {
-              ...record,
-              runActive,
-              assistantOutput: runActive && record.runActive ? record.assistantOutput : false,
-              errorActive: runActive ? false : record.errorActive,
-              errorMessage: runActive ? null : record.errorMessage,
-              compacting: runActive ? record.compacting : false,
-              waitingPermissionIds: runActive ? record.waitingPermissionIds : [],
-              waitingQuestionIds: runActive ? record.waitingQuestionIds : [],
-            };
-          }),
-        };
+        nextState = updateRecord(nextState, id, sessionId, (record) => {
+          const normalized = normalizeRunStatus(status);
+          const runActive = normalized === "running" || normalized === "retry";
+          if (!runActive && record.status !== "idle") return record;
+          return {
+            ...record,
+            runActive,
+            assistantOutput: runActive && record.runActive ? record.assistantOutput : false,
+            errorActive: runActive ? false : record.errorActive,
+            errorMessage: runActive ? null : record.errorMessage,
+            compacting: runActive ? record.compacting : false,
+            waitingPermissionIds: runActive ? record.waitingPermissionIds : [],
+            waitingQuestionIds: runActive ? record.waitingQuestionIds : [],
+          };
+        });
       }
-      return nextState;
+      if (nextState === state) return state;
+      return { ...state, ...nextState };
     });
   },
   seedSessionRun: (workspaceId, sessionId, status, assistantOutput, options) => {

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -113,6 +113,36 @@ afterEach(() => {
 });
 
 describe("session run status ordering", () => {
+  test("preserves the activity snapshot when workspace seeds are unchanged", () => {
+    const store = useSessionActivityStore.getState();
+    store.seedWorkspaceSessions(workspaceId, [{ id: sessionId, status: { type: "idle" } }]);
+    const before = useSessionActivityStore.getState();
+    let notifications = 0;
+    const unsubscribe = useSessionActivityStore.subscribe(() => {
+      notifications += 1;
+    });
+
+    for (let index = 0; index < 60; index += 1) {
+      useSessionActivityStore.getState().seedWorkspaceSessions(
+        workspaceId,
+        [{ id: sessionId, status: { type: "idle" } }],
+      );
+    }
+
+    expect(useSessionActivityStore.getState()).toBe(before);
+    expect(notifications).toBe(0);
+
+    useSessionActivityStore.getState().seedWorkspaceSessions(
+      workspaceId,
+      [{ id: sessionId, status: { type: "busy" } }],
+    );
+    unsubscribe();
+
+    expect(useSessionActivityStore.getState()).not.toBe(before);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("thinking");
+    expect(notifications).toBe(1);
+  });
+
   test("does not publish duplicate activity observations", () => {
     useSessionActivityStore.getState().setRunStatus(workspaceId, sessionId, { type: "busy" });
     useSessionActivityStore.getState().markMessageRole(workspaceId, sessionId, "assistant-1", "assistant");

--- a/evals/specs/session-activity-snapshot-stability.test.ts
+++ b/evals/specs/session-activity-snapshot-stability.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { useSessionActivityStore } from "../../apps/app/src/react-app/domains/session/status/session-activity-store";
+
+test("unchanged live-session seeds preserve the external-store snapshot", ({ evidence }) => {
+  const workspaceId = "workspace-snapshot-stability";
+  const sessionId = "session-snapshot-stability";
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+
+  useSessionActivityStore.getState().seedWorkspaceSessions(
+    workspaceId,
+    [{ id: sessionId, status: { type: "idle" } }],
+  );
+  const initialSnapshot = useSessionActivityStore.getState();
+  let notifications = 0;
+  const unsubscribe = useSessionActivityStore.subscribe(() => {
+    notifications += 1;
+  });
+
+  // More repeated seeds than React's nested-update guard must remain true
+  // no-ops so a passive external-store subscriber cannot feed itself.
+  for (let index = 0; index < 60; index += 1) {
+    useSessionActivityStore.getState().seedWorkspaceSessions(
+      workspaceId,
+      [{ id: sessionId, status: { type: "idle" } }],
+    );
+  }
+
+  const stableSnapshot = useSessionActivityStore.getState() === initialSnapshot;
+  evidence.recordAssertionEvidence(
+    "Repeated unchanged live-session seeds preserve the external-store snapshot",
+    `After 60 identical seeds, snapshot identity remained stable=${stableSnapshot} and subscriber notifications=${notifications}.`,
+    stableSnapshot && notifications === 0,
+  );
+  expect(useSessionActivityStore.getState()).toBe(initialSnapshot);
+  expect(notifications).toBe(0);
+
+  // Negative half: a real activity transition still publishes once.
+  useSessionActivityStore.getState().seedWorkspaceSessions(
+    workspaceId,
+    [{ id: sessionId, status: { type: "busy" } }],
+  );
+  unsubscribe();
+
+  const changedSnapshot = useSessionActivityStore.getState() !== initialSnapshot;
+  const changedStatus = useSessionActivityStore.getState().getStatus(workspaceId, sessionId);
+  evidence.recordAssertionEvidence(
+    "A real live-session activity transition still publishes exactly once",
+    `The idle-to-busy seed changed snapshot identity=${changedSnapshot}, produced status=${changedStatus}, and subscriber notifications=${notifications}.`,
+    changedSnapshot && changedStatus === "thinking" && notifications === 1,
+  );
+  expect(useSessionActivityStore.getState()).not.toBe(initialSnapshot);
+  expect(changedStatus).toBe("thinking");
+  expect(notifications).toBe(1);
+});


### PR DESCRIPTION
## Summary

- preserve the Zustand session-activity snapshot when workspace session seeds are semantically unchanged
- stop no-op live-session reseeds from notifying React external-store subscribers
- continue publishing exactly once when a real session activity transition occurs

## Why

The production React #185 stack reaches the passive `useSyncExternalStore` snapshot reconciliation path. `seedWorkspaceSessions` previously allocated a fresh root store object on every seed, even when `updateRecord` found no semantic change. An active session can repeatedly refresh the route session groups, turning those no-op seeds into external-store notifications and a render feedback source.

This keeps state identity stable for no-op seeds without changing session status semantics.

## Verification

- `pnpm exec bun test --isolate tests/session-sync-run-status.test.ts` — 12 passed, 0 failed
- `pnpm typecheck` in `apps/app` — passed
- `OPENWORK_EVAL_DAYTONA=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/session-activity-snapshot-stability.test.ts` — 1 passed, 0 failed, 0 skipped

The regression proof repeats an unchanged live-session seed 60 times (past React’s 50-update guard), asserts zero external-store notifications and stable snapshot identity, then verifies that a real idle-to-busy transition still publishes once.