### PR TITLE
fix(ci): install Bun for nightly flake report

### DIFF
--- a/.github/workflows/nightly-flake-report.yml
+++ b/.github/workflows/nightly-flake-report.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           version: 11.4.0
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
       - name: Install dependencies
         shell: bash
         run: |

--- a/evals/specs/nightly-flake-report-toolchain.test.ts
+++ b/evals/specs/nightly-flake-report-toolchain.test.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/nightly-flake-report.yml", import.meta.url),
+);
+
+test("the nightly flake report installs Bun before running the PR lane", async ({ evidence }) => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const setupBun = workflow.indexOf("- name: Setup Bun");
+  const installDependencies = workflow.indexOf("- name: Install dependencies");
+  const collectRuns = workflow.indexOf("- name: Collect pr-lane runs");
+
+  expect(setupBun).toBeGreaterThan(-1);
+  expect(workflow).toContain(
+    "uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2",
+  );
+  expect(workflow).toContain("bun-version: 1.3.14");
+  expect(setupBun).toBeLessThan(installDependencies);
+  expect(installDependencies).toBeLessThan(collectRuns);
+
+  evidence.recordAssertionEvidence(
+    "Nightly PR-lane reliability runs have their required Bun runtime",
+    "The workflow installs pinned Bun 1.3.14 before dependencies and before collecting any PR-lane run, preventing Bun-backed specs from being misreported as unreliable when the executable is absent.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- install pinned Bun 1.3.14 before the nightly PR-lane reliability runs
- add a testkit spec that locks the required toolchain ordering
- keep all 19 reported specs; they failed because the workflow had no `bun` executable, not because they were flaky

Fixes #4235

## Verification
- `pnpm evals:pr specs/nightly-flake-report-toolchain.test.ts` — 1 passed
- Nightly Flake Report workflow dispatch, 3 runs — passed: https://github.com/different-ai/openwork/actions/runs/33260315284