### PR TITLE
fix(aur): point /usr/bin/openwork at the real binary

### DIFF
--- a/.github/workflows/aur-validate.yml
+++ b/.github/workflows/aur-validate.yml
@@ -388,6 +388,18 @@ jobs:
             exit 1
           fi
 
+          # openwork.desktop launches via Exec=openwork, which resolves through
+          # /usr/bin/openwork. A dangling symlink there makes the app fail to
+          # start with no error, and the candidate fallback below would still
+          # find /opt/openwork/openwork and report success. Assert the real
+          # entry point resolves before falling back to anything.
+          if [ ! -x /usr/bin/openwork ]; then
+            echo "/usr/bin/openwork does not resolve to an executable" >&2
+            ls -l /usr/bin/openwork >&2 || true
+            echo "resolves to: $(readlink -f /usr/bin/openwork 2>/dev/null || echo '<unresolvable>')" >&2
+            exit 1
+          fi
+
           launch_bin=""
           for candidate in \
             "$(command -v openwork 2>/dev/null || true)" \

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -40,7 +40,7 @@ package() {
   cp -a "${bundle_dir}/." "${pkgdir}/opt/openwork/"
 
   install -d "${pkgdir}/usr/bin"
-  ln -s /opt/openwork/@openworkdesktop "${pkgdir}/usr/bin/openwork"
+  ln -s /opt/openwork/openwork "${pkgdir}/usr/bin/openwork"
 
   install -Dm644 "${pkgdir}/opt/openwork/resources/app-dist/openwork-logo-square.svg" \
     "${pkgdir}/usr/share/icons/hicolor/scalable/apps/openwork.svg"


### PR DESCRIPTION
## Summary
- `packaging/aur/PKGBUILD` symlinked `/usr/bin/openwork` to `/opt/openwork/@openworkdesktop`, a path the release tarball does not contain. Point it at the real launcher, `/opt/openwork/openwork`.
- Assert in `aur-validate.yml` that `/usr/bin/openwork` resolves to an executable, so this class of breakage fails CI instead of shipping.

## Why
- The Electron tarball ships its launcher as plain `openwork`. Nothing matching `*openworkdesktop*` exists anywhere in the installed bundle.
- `openwork.desktop` uses `Exec=openwork`, which resolves through `/usr/bin/openwork`. With that link dangling, clicking the launcher does nothing — no error, no dialog.
- `/usr/bin/openwork` is a package-owned file, so a manual `ln -sfn` repair is reverted by the next upgrade. It re-breaks on every install/upgrade.
- The existing `aur-validate` "Smoke launch" step cannot catch this: `[ -x "$candidate" ]` dereferences symlinks, so a dangling `/usr/bin/openwork` fails that test, the loop falls through to `/opt/openwork/openwork`, and the step reports success.

## Issue
- Closes # — none filed. Happy to open one if you'd prefer it tracked.

## Scope
- `packaging/aur/PKGBUILD`: symlink target only.
- `.github/workflows/aur-validate.yml`: one guard added to the existing "Smoke launch" step.

## Out of scope
- The candidate fallback list in "Smoke launch" is left as-is.
- `.SRCINFO` is unchanged — it carries no `package()` content, so it does not encode the symlink.
- The `namcap` invocations remain `|| true`; tightening those is a separate discussion.

## Testing
### Ran
Against `openwork 0.18.39-1` installed from the AUR on Arch x86_64:
- `ls -l /usr/bin/openwork` and `readlink -f /usr/bin/openwork`
- `find /opt/openwork -maxdepth 2 -name '*openworkdesktop*'`
- `file /opt/openwork/openwork`
- the new guard's condition, executed verbatim against the live broken link and against the corrected target
- `bash -n` on the patched "Smoke launch" script, extracted from the workflow
- YAML parse of the patched workflow

### Result
- pass:
  - `/usr/bin/openwork -> /opt/openwork/@openworkdesktop`, dangling — reproduces on a stock AUR install
  - `find` for `*openworkdesktop*` under `/opt/openwork`: no matches
  - `/opt/openwork/openwork`: `ELF 64-bit LSB pie executable, x86-64` — the correct target
  - new guard against the live broken link: exits 1, prints `resolves to: /opt/openwork/@openworkdesktop`
  - new guard against `/opt/openwork/openwork`: passes
  - `bash -n`: OK
  - YAML parse: OK
- if fail, exact files/errors: n/a
- **not run:** `makepkg` locally, so the built-package path is unverified on my side. `aur-validate` is the appropriate check — see CI status.

## CI status
- pass: n/a — `aur-validate` is `workflow_dispatch` / `workflow_call` only, so it does not run on pull requests.
- code-related failures: none known
- external/env/auth blockers: dispatching `aur-validate` needs write access to this repo, which I don't have. Please run it (`mode: publish-ready`) against this branch before merging.

## Manual verification
1. On Arch, install the current AUR package (`yay -S openwork`). `ls -l /usr/bin/openwork` points at `/opt/openwork/@openworkdesktop`; `test -x /usr/bin/openwork` fails; launching OpenWork from the desktop menu does nothing.
2. Build this branch: `cd packaging/aur && makepkg -si`.
3. `/usr/bin/openwork` now resolves to `/opt/openwork/openwork`, `test -x` succeeds, and the desktop entry launches the app.

## Evidence
Live reproduction on a stock AUR install of `0.18.39-1`:

```
$ ls -l /usr/bin/openwork
lrwxrwxrwx 1 root root 30 Aug 29 18:49 /usr/bin/openwork -> /opt/openwork/@openworkdesktop

$ readlink -f /usr/bin/openwork
/opt/openwork/@openworkdesktop          # does not exist

$ find /opt/openwork -maxdepth 2 -name '*openworkdesktop*'
                                        # no matches

$ file /opt/openwork/openwork
/opt/openwork/openwork: ELF 64-bit LSB pie executable, x86-64, ...
```

It re-breaks on every release, since pacman restores the packaged link:

```
Jul 28   0.18.6  -> 0.18.7
Jul 31   0.18.7  -> 0.18.12
Aug 27   0.18.12 -> 0.18.38
Aug 29   0.18.38 -> 0.18.39
```

## Risk
Low. One symlink target changed to a path verified present in the shipped bundle, plus a CI assertion that can only fail when `/usr/bin/openwork` is genuinely unusable. No runtime code, no dependency changes, `.SRCINFO` untouched.

If the bundle's launcher name changes again in future, the new guard turns that into a loud CI failure instead of a silent one — which is the point.

## Rollback
Revert the commit. The package returns to its current behaviour (dangling symlink) and the smoke test passes regardless, as it does today.
