### PR TITLE
fix(app): keep Library skill details stable

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2081,7 +2081,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       enablementContext,
       isBuiltInConnected: extensionController.isConnected,
     }),
-    [connectionsSnapshot.mcpServers, enablementContext, extensionController, extensionsSnapshot, extensionsStore, orgMcpConnections.connections, quickConnectCatalog],
+    [connectionsSnapshot.mcpServers, enablementContext, extensionController.isConnected, extensionsSnapshot, extensionsStore, orgMcpConnections.connections, quickConnectCatalog],
   );
   // Every connection the organization provisioned for this member, connected
   // or not: one that still needs the member's sign-in is the whole reason the

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2087,6 +2087,33 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   // or not: one that still needs the member's sign-in is the whole reason the
   // "Needs your attention" group exists, so it must not be filtered out here.
   const orgMcpConnectionItems = extensionItems.orgMcpConnectionItems;
+  const librarySkills = useMemo(
+    () => [
+      ...extensionItems.installedSkills,
+      ...connectCapabilities.skills.filter(
+        (skill) => !extensionItems.installedSkills.some(
+          (installed) => installed.name.toLowerCase() === skill.name.toLowerCase(),
+        ),
+      ),
+    ],
+    [connectCapabilities.skills, extensionItems.installedSkills],
+  );
+  const libraryConnectMcpServers = useMemo(
+    () => connectCapabilities.mcpServers.filter(
+      (entry) => !orgMcpConnectionItems.some((item) =>
+        item.name.localeCompare(entry.name, undefined, { sensitivity: "accent" }) === 0
+      ),
+    ),
+    [connectCapabilities.mcpServers, orgMcpConnectionItems],
+  );
+  const libraryConnectPlugins = useMemo(
+    () => connectPluginsForComposer(connectCapabilities.plugins),
+    [connectCapabilities.plugins],
+  );
+  const readLibrarySkill = useCallback(
+    (name: string) => extensionsStore.readSkill(name),
+    [extensionsStore],
+  );
   const organizationConnectionsProbe = resolveOrganizationConnectionsProbe({
     signedIn: cloudSession.isSignedIn,
     activeOrganizationId: cloudSession.activeOrganization?.id,
@@ -2504,24 +2531,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                     : undefined
                 }
                 readConfigFile={readMcpConfigFile}
-                installedSkills={[
-                  ...extensionItems.installedSkills,
-                  ...connectCapabilities.skills.filter(
-                    (skill) => !extensionItems.installedSkills.some(
-                      (installed) => installed.name.toLowerCase() === skill.name.toLowerCase(),
-                    ),
-                  ),
-                ]}
+                installedSkills={librarySkills}
                 installedCommands={libraryCommands}
                 installedAgents={libraryAgents}
-                availableConnectMcpServers={connectCapabilities.mcpServers.filter(
-                  (entry) => !orgMcpConnectionItems.some((item) =>
-                    item.name.localeCompare(entry.name, undefined, { sensitivity: "accent" }) === 0
-                  ),
-                )}
+                availableConnectMcpServers={libraryConnectMcpServers}
                 availableConnectMcpStatuses={connectCapabilities.mcpStatuses}
                 inventoryLoading={connectCapabilitiesLoading || (orgMcpConnections.loading && !orgMcpConnections.loaded)}
-                installedPlugins={connectPluginsForComposer(connectCapabilities.plugins)}
+                installedPlugins={libraryConnectPlugins}
                 orgMcpItems={orgMcpConnectionItems}
                 organizationName={cloudSession.activeOrgName}
                 orgMcpError={orgMcpConnections.error}
@@ -2532,7 +2548,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 reconnectOrgMcp={(connectionId) => { void orgMcpConnections.connect(connectionId, { forceFreshAuthorization: true }); }}
                 orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
                 disconnectOrgMcp={(connectionId) => { void orgMcpConnections.disconnect(connectionId); }}
-                readSkill={(name) => extensionsStore.readSkill(name)}
+                readSkill={readLibrarySkill}
                 previewClaudePlugin={(url) => extensionsStore.previewClaudePlugin(url)}
                 installClaudePlugin={(url) => extensionsStore.installClaudePlugin(url)}
                 createLibraryItem={(kind, input) => extensionsStore.createLibraryItem(kind, input)}

--- a/evals/specs/library-config-read-budget.e2e.test.ts
+++ b/evals/specs/library-config-read-budget.e2e.test.ts
@@ -9,7 +9,7 @@ const requirements: TestNeeds = { optIn: ["OPENWORK_EVAL_E2E_TESTS"] };
 const missingRequirements = unmetNeeds(requirements, process.env);
 const title = missingRequirements.length > 0
   ? `library config read budget skipped — needs: ${missingRequirements.join(", ")}`
-  : "an idle Library page keeps opencode-config reads bounded";
+  : "an idle Library page keeps config reads bounded and skill details stable";
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 const IDLE_WINDOW_MS = 20_000;
@@ -32,11 +32,15 @@ test(title, { timeout: 300_000 }, async () => {
   const installed = await evalIn(app, `(() => {
     if (window.__opencodeConfigReads !== undefined) return true;
     window.__opencodeConfigReads = 0;
+    window.__librarySkillReads = 0;
     const originalFetch = window.fetch;
     window.fetch = function (...args) {
       const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
       if (typeof target === "string" && target.includes("/opencode-config")) {
         window.__opencodeConfigReads += 1;
+      }
+      if (typeof target === "string" && target.includes("/skills/browser-automation")) {
+        window.__librarySkillReads += 1;
       }
       return originalFetch.apply(this, args);
     };
@@ -94,4 +98,48 @@ test(title, { timeout: 300_000 }, async () => {
     `window.location.hash.includes("/settings/extensions")`,
   );
   expect(stillOnLibrary).toBe(true);
+
+  // Opening a local skill reads its body once. Unrelated server health ticks
+  // must not recreate the Library's derived arrays/callback and repeatedly
+  // clear + reload the detail body.
+  const openedSkill = await evalIn(app, `(() => {
+    const skill = [...document.querySelectorAll("button")]
+      .find((button) => button.textContent?.includes("browser-automation"));
+    if (!skill) return false;
+    skill.click();
+    return true;
+  })()`);
+  expect(openedSkill).toBe(true);
+  await waitFor(
+    app,
+    `window.location.hash.includes("skill%3Abrowser-automation")
+      && document.body.innerText.includes("known-good smoke prompt")`,
+    { timeoutMs: 30_000, label: "browser automation skill detail" },
+  );
+
+  const settledSkillReads = await evalIn(app, `window.__librarySkillReads`);
+  expect(typeof settledSkillReads).toBe("number");
+  await evalIn(app, `(() => {
+    window.__libraryDetailContentMissing = false;
+    window.__libraryDetailWatcher = window.setInterval(() => {
+      if (!document.body.innerText.includes("known-good smoke prompt")) {
+        window.__libraryDetailContentMissing = true;
+      }
+    }, 50);
+    return true;
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, IDLE_WINDOW_MS));
+  const detailResult = await evalIn(app, `(() => {
+    window.clearInterval(window.__libraryDetailWatcher);
+    return {
+      skillReads: window.__librarySkillReads,
+      contentMissing: window.__libraryDetailContentMissing,
+      contentVisible: document.body.innerText.includes("known-good smoke prompt"),
+    };
+  })()`);
+  expect(detailResult).toEqual({
+    skillReads: settledSkillReads,
+    contentMissing: false,
+    contentVisible: true,
+  });
 });

--- a/evals/specs/library-config-read-budget.e2e.test.ts
+++ b/evals/specs/library-config-read-budget.e2e.test.ts
@@ -18,7 +18,7 @@ const IDLE_WINDOW_MS = 20_000;
 // pair on every settings re-render: 8+ requests in the same window.
 const IDLE_READ_BUDGET = 2;
 
-test(title, { timeout: 300_000 }, async () => {
+test(title, { timeout: 300_000 }, async ({ evidence }) => {
   needs(requirements);
 
   await using app = await desktop({ name: "library-config-read-budget" });
@@ -87,6 +87,11 @@ test(title, { timeout: 300_000 }, async () => {
   expect(typeof afterIdle).toBe("number");
 
   const idleReads = Number(afterIdle) - Number(settled);
+  evidence.recordAssertionEvidence(
+    "Idle Library config reads stay bounded",
+    `${idleReads} opencode-config reads during a ${IDLE_WINDOW_MS / 1000}s settled idle window; budget ${IDLE_READ_BUDGET}.`,
+    idleReads <= IDLE_READ_BUDGET,
+  );
   expect(
     idleReads,
     `opencode-config was read ${idleReads} times during a ${IDLE_WINDOW_MS / 1000}s idle window (budget ${IDLE_READ_BUDGET}); the Library page is refetching config on unrelated re-renders`,
@@ -137,9 +142,15 @@ test(title, { timeout: 300_000 }, async () => {
       contentVisible: document.body.innerText.includes("known-good smoke prompt"),
     };
   })()`);
-  expect(detailResult).toEqual({
+  const expectedDetailResult = {
     skillReads: settledSkillReads,
     contentMissing: false,
     contentVisible: true,
-  });
+  };
+  evidence.recordAssertionEvidence(
+    "Open Library skill details stay visible without refetching",
+    `Settled reads: ${String(settledSkillReads)}; observed after ${IDLE_WINDOW_MS / 1000}s: ${JSON.stringify(detailResult)}.`,
+    JSON.stringify(detailResult) === JSON.stringify(expectedDetailResult),
+  );
+  expect(detailResult).toEqual(expectedDetailResult);
 });


### PR DESCRIPTION
## Summary
- stabilize Library inventory derivation instead of depending on a freshly-created extension controller object
- memoize the derived skill, MCP, plugin, and skill-reader props passed to `McpView`
- extend the existing Library request-budget E2E spec to prove an open skill detail neither refetches nor disappears while idle

## Reproduction
On the reported `v0.18.40-alpha.2585+c10eb81` source commit in Daytona, opening the `browser-automation` skill detail and idling for 30 seconds produced:
- 12 `GET /workspace/:id/skills/browser-automation` requests
- detail content alternating between visible and absent

Commit c7b3996 fixed repeated `opencode-config` reads, but `extensionItems` still depended on the unstable `extensionController` object and several derived `McpView` props were rebuilt on every settings render.

## Verification
Daytona lane, PR head `ad1da7d536d0780334d3de4e636389832d89c18c`:
- manual 30-second CDP observation: 0 skill-detail refetches; one stable visible detail state
- `pnpm --filter @openwork/app typecheck` — passed
- `DISPLAY=:99 OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/library-config-read-budget.e2e.test.ts` — 1 passed, 0 failed
- test evidence published on this PR
