### PR TITLE
fix(app): stop persisted composer draft reload loop

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -34,6 +34,7 @@ export type ComposerStateStore = {
   history: Record<string, string[]>;
   setDraft: (sessionId: string, draft: string) => void;
   replaceDraft: (sessionId: string, draft: string, revertMessageId?: string | null) => void;
+  hydrateDraft: (sessionId: string, draft: string) => void;
   clearRevertTarget: (sessionId: string) => void;
   setAttachments: (sessionId: string, attachments: ComposerAttachment[]) => void;
   setMentions: (sessionId: string, mentions: Record<string, ComposerMentionKind>) => void;
@@ -113,6 +114,28 @@ export const useComposerStateStore = create<ComposerStateStore>((set) => ({
     const target = revertMessageId?.trim() || null;
     if (current.draft === draft && current.revertMessageId === target) return state;
     return { sessions: { ...state.sessions, [sessionId]: { ...current, draft, revertMessageId: target } } };
+  }),
+  hydrateDraft: (sessionId, draft) => set((state) => {
+    const current = state.sessions[sessionId];
+    if (!draft) {
+      if (!current) return state;
+      const sessions = { ...state.sessions };
+      delete sessions[sessionId];
+      return { sessions };
+    }
+    if (
+      current?.draft === draft
+      && current.attachments.length === 0
+      && Object.keys(current.mentions).length === 0
+      && current.pasteParts.length === 0
+      && current.revertMessageId === null
+    ) return state;
+    return {
+      sessions: {
+        ...state.sessions,
+        [sessionId]: { ...createEmptyComposerSession(), draft },
+      },
+    };
   }),
   clearRevertTarget: (sessionId) => set((state) => {
     const current = state.sessions[sessionId];

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -876,6 +876,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     scopeKey: string;
     snapshot: typeof persistedDraftSnapshot;
   } | null>(null);
+  const pendingHydratedDraftRef = useRef<{ scopeKey: string; text: string } | null>(null);
 
   // Layout timing is intentional: an account/org boundary must replace the
   // previous scope's in-memory Zustand draft before the browser can paint it.
@@ -903,6 +904,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     for (const attachment of getComposerAttachments(currentState, props.sessionId)) {
       revokeAttachmentPreview(attachment);
     }
+    pendingHydratedDraftRef.current = { scopeKey: persistedDraftKey, text: nextDraft };
     hydrateComposerDraft(props.sessionId, nextDraft);
   }, [hydrateComposerDraft, persistedDraftKey, persistedDraftSnapshot, props.sessionId]);
   const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
@@ -1895,9 +1897,15 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     const nextDraft = buildDraft(draft, attachments);
-    persistDraft({ text: persistableComposerDraftText(nextDraft.text), mode: nextDraft.mode });
+    const persistableText = persistableComposerDraftText(nextDraft.text);
+    const pendingHydration = pendingHydratedDraftRef.current;
+    if (pendingHydration?.scopeKey === persistedDraftKey) {
+      pendingHydratedDraftRef.current = null;
+      if (persistableText !== pendingHydration.text) return;
+    }
+    persistDraft({ text: persistableText, mode: nextDraft.mode });
     props.onDraftChange(nextDraft);
-  }, [attachments, buildDraft, draft, persistDraft, props.onDraftChange]);
+  }, [attachments, buildDraft, draft, persistDraft, persistedDraftKey, props.onDraftChange]);
 
   const handleAttachFiles = useCallback((files: File[]) => {
     if (!props.attachmentsEnabled) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -876,7 +876,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     scopeKey: string;
     snapshot: typeof persistedDraftSnapshot;
   } | null>(null);
-  const pendingHydratedDraftRef = useRef<{ scopeKey: string; text: string } | null>(null);
+  const [hydratedDraftScopeKey, setHydratedDraftScopeKey] = useState<string | null>(null);
 
   // Layout timing is intentional: an account/org boundary must replace the
   // previous scope's in-memory Zustand draft before the browser can paint it.
@@ -894,18 +894,20 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const currentState = useComposerStateStore.getState();
     const currentDraft = getComposerDraft(currentState, props.sessionId);
     const nextDraft = persistedDraftSnapshot?.text ?? "";
-    if (!composerDraftNeedsHydration({
+    const needsHydration = composerDraftNeedsHydration({
       claimedScopeKey,
       nextScopeKey: persistedDraftKey,
       currentText: currentDraft,
       storedText: nextDraft,
-    })) return;
+    });
 
-    for (const attachment of getComposerAttachments(currentState, props.sessionId)) {
-      revokeAttachmentPreview(attachment);
+    if (needsHydration) {
+      for (const attachment of getComposerAttachments(currentState, props.sessionId)) {
+        revokeAttachmentPreview(attachment);
+      }
+      hydrateComposerDraft(props.sessionId, nextDraft);
     }
-    pendingHydratedDraftRef.current = { scopeKey: persistedDraftKey, text: nextDraft };
-    hydrateComposerDraft(props.sessionId, nextDraft);
+    setHydratedDraftScopeKey(persistedDraftKey);
   }, [hydrateComposerDraft, persistedDraftKey, persistedDraftSnapshot, props.sessionId]);
   const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
   const appendComposerHistory = useComposerStateStore((state) => state.appendHistory);
@@ -1896,16 +1898,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.cloudMcpSubmissionState.status, props.sessionId]);
 
   useEffect(() => {
+    if (hydratedDraftScopeKey !== persistedDraftKey) return;
     const nextDraft = buildDraft(draft, attachments);
     const persistableText = persistableComposerDraftText(nextDraft.text);
-    const pendingHydration = pendingHydratedDraftRef.current;
-    if (pendingHydration?.scopeKey === persistedDraftKey) {
-      pendingHydratedDraftRef.current = null;
-      if (persistableText !== pendingHydration.text) return;
-    }
     persistDraft({ text: persistableText, mode: nextDraft.mode });
     props.onDraftChange(nextDraft);
-  }, [attachments, buildDraft, draft, persistDraft, persistedDraftKey, props.onDraftChange]);
+  }, [attachments, buildDraft, draft, hydratedDraftScopeKey, persistDraft, persistedDraftKey, props.onDraftChange]);
 
   const handleAttachFiles = useCallback((files: File[]) => {
     if (!props.attachmentsEnabled) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -861,6 +861,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const pasteParts = useComposerStateStore((state) => getComposerPasteParts(state, props.sessionId));
   const setComposerDraft = useComposerStateStore((state) => state.setDraft);
   const replaceComposerDraft = useComposerStateStore((state) => state.replaceDraft);
+  const hydrateComposerDraft = useComposerStateStore((state) => state.hydrateDraft);
   const clearComposerRevertTarget = useComposerStateStore((state) => state.clearRevertTarget);
   const setComposerAttachments = useComposerStateStore((state) => state.setAttachments);
   const setComposerMentions = useComposerStateStore((state) => state.setMentions);
@@ -902,9 +903,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     for (const attachment of getComposerAttachments(currentState, props.sessionId)) {
       revokeAttachmentPreview(attachment);
     }
-    clearComposerSession(props.sessionId);
-    if (nextDraft) replaceComposerDraft(props.sessionId, nextDraft);
-  }, [clearComposerSession, persistedDraftKey, persistedDraftSnapshot, props.sessionId, replaceComposerDraft]);
+    hydrateComposerDraft(props.sessionId, nextDraft);
+  }, [hydrateComposerDraft, persistedDraftKey, persistedDraftSnapshot, props.sessionId]);
   const inputHistory = useComposerStateStore((state) => getComposerHistory(state, props.sessionId));
   const appendComposerHistory = useComposerStateStore((state) => state.appendHistory);
   // Queued follow-up drafts live in the shared composer store keyed by session

--- a/apps/app/src/react-app/domains/session/sync/draft-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-store.ts
@@ -375,11 +375,20 @@ export function useSessionDraftState(
     () => sessionDraftScopeKey(scopeId, workspaceId, sessionId),
     [scopeId, workspaceId, sessionId],
   );
-  const snapshot = useSyncExternalStore(
+  const serializedSnapshot = useSyncExternalStore(
     subscribeBrowserDraftStore,
-    () => key ? getSessionDraft(scopeId, workspaceId, sessionId) : null,
-    () => null,
+    () => {
+      const current = key ? getSessionDraft(scopeId, workspaceId, sessionId) : null;
+      return current ? JSON.stringify(current) : "";
+    },
+    () => "",
   );
+  const snapshot = useMemo(() => {
+    if (!serializedSnapshot) return null;
+    const parsed: unknown = JSON.parse(serializedSnapshot);
+    if (!isRecord(parsed) || typeof parsed.text !== "string" || !isPromptMode(parsed.mode)) return null;
+    return { text: parsed.text, mode: parsed.mode };
+  }, [serializedSnapshot]);
 
   const save = useCallback(
     (nextSnapshot: SessionDraftSnapshot) => saveSessionDraft(scopeId, workspaceId, sessionId, nextSnapshot),

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -225,8 +225,9 @@ if (process.env.OPENWORK_ELECTRON_SKIP_SHARED_PREPARE !== "1") {
   runSync(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", "--outdir", electronHelperDir], { cwd: desktopRoot });
 }
 
-// Build the server TS → JS so Electron can import it in-process
-console.log("[electron-dev] Building openwork-server (tsc)...");
+// Build workspace packages that Electron imports from their dist output.
+console.log("[electron-dev] Building Electron workspace dependencies...");
+runSync(pnpmCmd, ["--filter", "@openwork/headless-threads", "build"], { cwd: repoRoot });
 runSync(pnpmCmd, ["--filter", "openwork-server", "build"], { cwd: repoRoot });
 
 const initialProbeUrls = [startUrl, ...viteProbeUrls].filter(Boolean);

--- a/evals/specs/composer-draft-hydration.test.ts
+++ b/evals/specs/composer-draft-hydration.test.ts
@@ -21,6 +21,11 @@ test("persisted composer draft hydration is idempotent", () => {
   setMentions("session-a", { "@notes": "file" });
   setPasteParts("session-a", [{ id: "paste-a", label: "Pasted text", text: "notes", lines: 1 }]);
 
+  const notificationsBeforeHydration = notifications;
+  const observedSessions: unknown[] = [];
+  const unsubscribeObserved = useComposerStateStore.subscribe((state) => {
+    observedSessions.push(state.sessions["session-a"]);
+  });
   hydrateDraft("session-a", "persisted draft");
   const hydratedState = useComposerStateStore.getState();
   const notificationsAfterHydration = notifications;
@@ -33,7 +38,10 @@ test("persisted composer draft hydration is idempotent", () => {
     pasteParts: [],
     revertMessageId: null,
   });
+  expect(notificationsAfterHydration).toBe(notificationsBeforeHydration + 1);
+  expect(observedSessions).toEqual([hydratedState.sessions["session-a"]]);
   expect(useComposerStateStore.getState()).toBe(hydratedState);
   expect(notifications).toBe(notificationsAfterHydration);
+  unsubscribeObserved();
   unsubscribe();
 });

--- a/evals/specs/composer-draft-hydration.test.ts
+++ b/evals/specs/composer-draft-hydration.test.ts
@@ -1,0 +1,39 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { useComposerStateStore } from "../../apps/app/src/react-app/domains/session/surface/composer-state-store";
+
+test("persisted composer draft hydration is idempotent", () => {
+  useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });
+  const { hydrateDraft, replaceDraft, setAttachments, setMentions, setPasteParts } = useComposerStateStore.getState();
+  let notifications = 0;
+  const unsubscribe = useComposerStateStore.subscribe(() => notifications += 1);
+
+  replaceDraft("session-a", "stale draft", "message-a");
+  setAttachments("session-a", [{
+    id: "attachment-a",
+    name: "notes.txt",
+    mimeType: "text/plain",
+    size: 5,
+    kind: "file",
+    file: new File(["notes"], "notes.txt", { type: "text/plain" }),
+  }]);
+  setMentions("session-a", { "@notes": "file" });
+  setPasteParts("session-a", [{ id: "paste-a", label: "Pasted text", text: "notes", lines: 1 }]);
+
+  hydrateDraft("session-a", "persisted draft");
+  const hydratedState = useComposerStateStore.getState();
+  const notificationsAfterHydration = notifications;
+  hydrateDraft("session-a", "persisted draft");
+
+  expect(hydratedState.sessions["session-a"]).toEqual({
+    draft: "persisted draft",
+    attachments: [],
+    mentions: {},
+    pasteParts: [],
+    revertMessageId: null,
+  });
+  expect(useComposerStateStore.getState()).toBe(hydratedState);
+  expect(notifications).toBe(notificationsAfterHydration);
+  unsubscribe();
+});

--- a/evals/specs/composer-draft-reload.e2e.test.ts
+++ b/evals/specs/composer-draft-reload.e2e.test.ts
@@ -1,0 +1,64 @@
+import { expect } from "vitest";
+import {
+  control,
+  createAndSelectWorkspace,
+  evalIn,
+  readComposerState,
+  waitFor,
+  writeComposerText,
+} from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "reloading a session with a persisted composer draft keeps the renderer stable"
+  : "composer draft reload skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+test.skipIf(!e2eTestsEnabled)(title, { timeout: 600_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "composer-draft-reload", host: place.host() });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-composer-draft-reload-${Date.now()}`,
+  });
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "new task control ready" },
+  );
+  const sessionId = await control(app, "session.create_task");
+  expect(sessionId).toMatch(/^ses_/);
+
+  const persistedDraft = "Keep this persisted draft through reload";
+  await writeComposerText(app, persistedDraft);
+  await waitFor(
+    app,
+    `localStorage.getItem("openwork.session-drafts.v2")?.includes(${JSON.stringify(persistedDraft)}) === true`,
+    { timeoutMs: 10_000, label: "composer draft persisted" },
+  );
+
+  const previousTimeOrigin = await evalIn(app, "performance.timeOrigin");
+  await evalIn(app, "location.reload(); true").catch(() => undefined);
+  await waitFor(app, `performance.timeOrigin !== ${JSON.stringify(previousTimeOrigin)}`, {
+    timeoutMs: 30_000,
+    label: "renderer reloaded",
+  });
+  await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+  const rendererState = await evalIn(app, `({
+    rootChildren: document.querySelector("#root")?.childElementCount ?? 0,
+    bodyTextLength: document.body.innerText.trim().length,
+  })`);
+  const composerState = await readComposerState(app);
+
+  expect(rendererState.rootChildren).toBeGreaterThan(0);
+  expect(rendererState.bodyTextLength).toBeGreaterThan(40);
+  expect(composerState.composerEditable).toBe(true);
+  expect(composerState.draftText.trim()).toBe(persistedDraft);
+  evidence.recordAssertionEvidence(
+    "A persisted composer draft survives renderer reload without unmounting the app",
+    `Session ${sessionId} reloaded with a non-empty root and preserved the exact draft text.`,
+    true,
+  );
+});

--- a/evals/specs/composer-draft-reload.e2e.test.ts
+++ b/evals/specs/composer-draft-reload.e2e.test.ts
@@ -38,27 +38,34 @@ test.skipIf(!e2eTestsEnabled)(title, { timeout: 600_000 }, async ({ evidence, pl
     { timeoutMs: 10_000, label: "composer draft persisted" },
   );
 
-  const previousTimeOrigin = await evalIn(app, "performance.timeOrigin");
-  await evalIn(app, "location.reload(); true").catch(() => undefined);
-  await waitFor(app, `performance.timeOrigin !== ${JSON.stringify(previousTimeOrigin)}`, {
-    timeoutMs: 30_000,
-    label: "renderer reloaded",
-  });
-  await new Promise((resolve) => setTimeout(resolve, 2_000));
+  const revisionBeforeReloads = await evalIn(app, `JSON.parse(
+    localStorage.getItem("openwork.session-drafts.v2") ?? "{}"
+  ).nextRevision`);
+  for (let reload = 1; reload <= 3; reload += 1) {
+    const previousTimeOrigin = await evalIn(app, "performance.timeOrigin");
+    await evalIn(app, "location.reload(); true").catch(() => undefined);
+    await waitFor(app, `performance.timeOrigin !== ${JSON.stringify(previousTimeOrigin)}`, {
+      timeoutMs: 30_000,
+      label: `renderer reload ${reload}`,
+    });
+    await waitFor(app, `document.querySelector("#root")?.childElementCount > 0
+      && document.body.innerText.trim().length > 40
+      && Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
+      timeoutMs: 30_000,
+      label: `stable composer after reload ${reload}`,
+    });
 
-  const rendererState = await evalIn(app, `({
-    rootChildren: document.querySelector("#root")?.childElementCount ?? 0,
-    bodyTextLength: document.body.innerText.trim().length,
-  })`);
-  const composerState = await readComposerState(app);
-
-  expect(rendererState.rootChildren).toBeGreaterThan(0);
-  expect(rendererState.bodyTextLength).toBeGreaterThan(40);
-  expect(composerState.composerEditable).toBe(true);
-  expect(composerState.draftText.trim()).toBe(persistedDraft);
+    const composerState = await readComposerState(app);
+    expect(composerState.composerEditable).toBe(true);
+    expect(composerState.draftText.trim()).toBe(persistedDraft);
+  }
+  const revisionAfterReloads = await evalIn(app, `JSON.parse(
+    localStorage.getItem("openwork.session-drafts.v2") ?? "{}"
+  ).nextRevision`);
+  expect(revisionAfterReloads).toBe(revisionBeforeReloads);
   evidence.recordAssertionEvidence(
     "A persisted composer draft survives renderer reload without unmounting the app",
-    `Session ${sessionId} reloaded with a non-empty root and preserved the exact draft text.`,
+    `Session ${sessionId} survived three reloads with an editable composer, the exact draft text, and no draft revision churn.`,
     true,
   );
 });


### PR DESCRIPTION
## Summary
- make composer draft hydration atomic and gate persistence until hydration completes
- stabilize external-store snapshots across renderer initialization
- add deterministic regression coverage for three persisted-draft reloads without renderer failure or revision churn
- build the headless-threads workspace dependency before Electron dev startup so clean Daytona boots succeed

Fixes #4236.

## Verification
- `OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_REF=fix/composer-draft-reload ./node_modules/.bin/vitest run --config vitest.config.ts --project e2e specs/composer-draft-reload.e2e.test.ts` — 1 passed
- `./node_modules/.bin/vitest run --config vitest.config.ts --project pr specs/composer-draft-hydration.test.ts` — 1 passed
- `bun test --isolate tests/draft-store.test.ts tests/composer-state-store.test.ts` — 17 passed
- `../../node_modules/.bin/tsc -p tsconfig.json --noEmit` — passed
- `node --check apps/desktop/scripts/electron-dev.mjs` — passed