### PR TITLE
fix(app): stop desktop policy refresh request storms

### DIFF
--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -499,11 +499,13 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     };
   }, [applyDesktopConfigActions]);
 
+  const configRef = useRef(config);
+  configRef.current = config;
+  const checkRestriction = useCallback<DesktopAppRestrictionChecker>(
+    ({ restriction }) => checkDesktopAppRestriction({ config: configRef.current, restriction }),
+    [],
+  );
   const value = useMemo<DesktopConfigStore>(() => {
-    // Bind the checker to the latest `config` so callers see the most
-    // recent org restrictions without having to recompute every render.
-    const checkRestriction: DesktopAppRestrictionChecker = ({ restriction }) =>
-      checkDesktopAppRestriction({ config, restriction });
     return {
       config,
       freshConfigStatus,
@@ -513,7 +515,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       checkRestriction,
       connectPolicySync,
     };
-  }, [config, freshConfigStatus, loading, refresh, refreshFresh, connectPolicySync]);
+  }, [checkRestriction, config, freshConfigStatus, loading, refresh, refreshFresh, connectPolicySync]);
 
   return (
     <DesktopConfigContext.Provider value={value}>

--- a/evals/specs/library-config-read-budget.e2e.test.ts
+++ b/evals/specs/library-config-read-budget.e2e.test.ts
@@ -17,6 +17,7 @@ const IDLE_WINDOW_MS = 20_000;
 // navigation). The regression this guards against produced a project+global
 // pair on every settings re-render: 8+ requests in the same window.
 const IDLE_READ_BUDGET = 2;
+const LIFECYCLE_READ_BUDGET = 10;
 
 test(title, { timeout: 300_000 }, async ({ evidence }) => {
   needs(requirements);
@@ -33,6 +34,7 @@ test(title, { timeout: 300_000 }, async ({ evidence }) => {
     if (window.__opencodeConfigReads !== undefined) return true;
     window.__opencodeConfigReads = 0;
     window.__librarySkillReads = 0;
+    window.__libraryLifecycleReads = 0;
     const originalFetch = window.fetch;
     window.fetch = function (...args) {
       const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
@@ -41,6 +43,14 @@ test(title, { timeout: 300_000 }, async ({ evidence }) => {
       }
       if (typeof target === "string" && target.includes("/skills/browser-automation")) {
         window.__librarySkillReads += 1;
+      }
+      if (typeof target === "string" && (
+        target.includes("/cloud-provider-sync/status")
+        || target.includes("/opencode/config?")
+        || target.endsWith("/mcp")
+        || target.endsWith("/den-session")
+      )) {
+        window.__libraryLifecycleReads += 1;
       }
       return originalFetch.apply(this, args);
     };
@@ -126,6 +136,7 @@ test(title, { timeout: 300_000 }, async ({ evidence }) => {
   expect(typeof settledSkillReads).toBe("number");
   await evalIn(app, `(() => {
     window.__libraryDetailContentMissing = false;
+    window.__libraryLifecycleReads = 0;
     window.__libraryPolicyTick = 0;
     window.__libraryDetailWatcher = window.setInterval(() => {
       if (!document.body.innerText.includes("known-good smoke prompt")) {
@@ -148,10 +159,12 @@ test(title, { timeout: 300_000 }, async ({ evidence }) => {
       skillReads: window.__librarySkillReads,
       contentMissing: window.__libraryDetailContentMissing,
       contentVisible: document.body.innerText.includes("known-good smoke prompt"),
+      lifecycleReads: window.__libraryLifecycleReads,
       policyTicks: window.__libraryPolicyTick,
       stable: window.__librarySkillReads === ${Number(settledSkillReads)}
         && !window.__libraryDetailContentMissing
         && document.body.innerText.includes("known-good smoke prompt")
+        && window.__libraryLifecycleReads <= ${LIFECYCLE_READ_BUDGET}
         && window.__libraryPolicyTick > 0,
     };
   })()`);
@@ -167,6 +180,7 @@ test(title, { timeout: 300_000 }, async ({ evidence }) => {
     contentVisible: true,
     stable: true,
   });
+  expect(detailResult).toMatchObject({ lifecycleReads: expect.any(Number) });
   expect(detailResult).toMatchObject({ policyTicks: expect.any(Number) });
   expect(detailResult).not.toMatchObject({ policyTicks: 0 });
 });

--- a/evals/specs/library-config-read-budget.e2e.test.ts
+++ b/evals/specs/library-config-read-budget.e2e.test.ts
@@ -126,31 +126,47 @@ test(title, { timeout: 300_000 }, async ({ evidence }) => {
   expect(typeof settledSkillReads).toBe("number");
   await evalIn(app, `(() => {
     window.__libraryDetailContentMissing = false;
+    window.__libraryPolicyTick = 0;
     window.__libraryDetailWatcher = window.setInterval(() => {
       if (!document.body.innerText.includes("known-good smoke prompt")) {
         window.__libraryDetailContentMissing = true;
       }
     }, 50);
+    window.__libraryPolicyWatcher = window.setInterval(() => {
+      window.__libraryPolicyTick += 1;
+      window.__openworkApplyDesktopConfig?.({
+        allowZenModel: window.__libraryPolicyTick % 2 === 0,
+      });
+    }, 100);
     return true;
   })()`);
   await new Promise((resolve) => setTimeout(resolve, IDLE_WINDOW_MS));
   const detailResult = await evalIn(app, `(() => {
     window.clearInterval(window.__libraryDetailWatcher);
+    window.clearInterval(window.__libraryPolicyWatcher);
     return {
       skillReads: window.__librarySkillReads,
       contentMissing: window.__libraryDetailContentMissing,
       contentVisible: document.body.innerText.includes("known-good smoke prompt"),
+      policyTicks: window.__libraryPolicyTick,
+      stable: window.__librarySkillReads === ${Number(settledSkillReads)}
+        && !window.__libraryDetailContentMissing
+        && document.body.innerText.includes("known-good smoke prompt")
+        && window.__libraryPolicyTick > 0,
     };
   })()`);
-  const expectedDetailResult = {
-    skillReads: settledSkillReads,
-    contentMissing: false,
-    contentVisible: true,
-  };
+  const detailStable = JSON.stringify(detailResult).includes('"stable":true');
   evidence.recordAssertionEvidence(
     "Open Library skill details stay visible without refetching",
     `Settled reads: ${String(settledSkillReads)}; observed after ${IDLE_WINDOW_MS / 1000}s: ${JSON.stringify(detailResult)}.`,
-    JSON.stringify(detailResult) === JSON.stringify(expectedDetailResult),
+    detailStable,
   );
-  expect(detailResult).toEqual(expectedDetailResult);
+  expect(detailResult).toMatchObject({
+    skillReads: settledSkillReads,
+    contentMissing: false,
+    contentVisible: true,
+    stable: true,
+  });
+  expect(detailResult).toMatchObject({ policyTicks: expect.any(Number) });
+  expect(detailResult).not.toMatchObject({ policyTicks: 0 });
 });


### PR DESCRIPTION
## Summary
- make `useCheckDesktopRestriction()` return the stable checker its contract promises
- keep the checker bound to the latest desktop policy through a ref
- prevent Settings stores from being disposed and recreated whenever desktop-policy provider state refreshes
- extend the Library E2E witness with 198 policy updates and an explicit lifecycle-request budget

## Live reproduction
Attached through the supported eval CDP seam to `prod-live-dev` at `http://127.0.0.1:59224` (`OpenWorkEvalworld-prod-live-dev-main`).

In a 20-second Library window on merged `dev` (`86ccda51d`), the renderer issued:
- 55 `cloud-provider-sync/status` reads
- 41 OpenCode config reads
- 14 MCP reads
- 14 health + 14 capabilities reads

With a skill detail open it also issued 64 repeated skill reads and the detail body disappeared during the observation. Fetch stack traces showed `providerAuthStore.syncFromOptions()` and the Settings store lifecycle re-firing. The cause was `DesktopConfigProvider` recreating `checkRestriction` whenever provider status changed, despite `useCheckDesktopRestriction` documenting stable identity.

## Verification
Daytona lane, exact head `32afc2bc09977383ca545eeb9538253ebd1318f8`:
- `pnpm --filter @openwork/app typecheck` — passed
- `DISPLAY=:99 OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/library-config-read-budget.e2e.test.ts` — 1 passed, 0 failed
- witness applied 198 desktop-policy updates over 20 seconds
- observed 0 lifecycle refetches, 0 extra skill reads, and continuously visible skill content
