### PR TITLE
fix(app): stop den-session settings echo loop

### DIFF
--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -142,8 +142,15 @@ export function useDenSession({
   }, [activeOrg, activeOrgId, authToken, baseUrl]);
 
   React.useEffect(() => {
-    if (authToken.trim() && denAuth.user) {
-      setUser(denAuth.user);
+    const nextUser = denAuth.user;
+    if (authToken.trim() && nextUser) {
+      setUser((current) => (
+        current?.id === nextUser.id
+        && current.email === nextUser.email
+        && current.name === nextUser.name
+          ? current
+          : nextUser
+      ));
     }
   }, [authToken, denAuth.user, setUser]);
 
@@ -370,7 +377,18 @@ export function useDenSession({
 
       try {
         const response = await client.listOrgs();
-        setOrgs(response.orgs);
+        setOrgs((currentOrgs) => (
+          currentOrgs.length === response.orgs.length
+          && currentOrgs.every((org, index) => {
+            const nextOrg = response.orgs[index];
+            return org.id === nextOrg?.id
+              && org.name === nextOrg.name
+              && org.slug === nextOrg.slug
+              && org.role === nextOrg.role;
+          })
+            ? currentOrgs
+            : response.orgs
+        ));
         const current = activeOrgId.trim();
 
         // Determine the next org to select:
@@ -386,7 +404,7 @@ export function useDenSession({
         // else: leave next = "" so the org picker is shown
 
         const nextOrg = next ? (response.orgs.find((org) => org.id === next) ?? null) : null;
-        setActiveOrgId(next);
+        setActiveOrgId((currentId) => currentId === next ? currentId : next);
         writeDenSettings({
           baseUrl,
           authToken: authToken || null,
@@ -396,7 +414,14 @@ export function useDenSession({
         });
         // Push to context immediately so consumers see the new org
         if (nextOrg) {
-          setActiveOrganization({ id: nextOrg.id, name: nextOrg.name, role: nextOrg.role, slug: nextOrg.slug });
+          setActiveOrganization((currentOrg) => (
+            currentOrg?.id === nextOrg.id
+            && currentOrg.name === nextOrg.name
+            && currentOrg.role === nextOrg.role
+            && currentOrg.slug === nextOrg.slug
+              ? currentOrg
+              : { id: nextOrg.id, name: nextOrg.name, role: nextOrg.role, slug: nextOrg.slug }
+          ));
         } else if (!next) {
           setActiveOrganization(null);
         }
@@ -415,10 +440,11 @@ export function useDenSession({
     [activeOrgId, authToken, baseUrl, client, setActiveOrganization],
   );
 
+  const userId = user?.id ?? "";
   React.useEffect(() => {
-    if (!user) return;
+    if (!userId) return;
     void refreshOrgs(true);
-  }, [refreshOrgs, user]);
+  }, [refreshOrgs, userId]);
 
   React.useEffect(() => {
     const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {

--- a/evals/specs/library-signed-in-render-stability.e2e.test.ts
+++ b/evals/specs/library-signed-in-render-stability.e2e.test.ts
@@ -48,28 +48,17 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
     { timeoutMs: 60_000, label: "signed-in Library" },
   );
 
+  // Signed-in inventory shows the built-in extension catalog. The regression
+  // this spec guards against fires on the Library route itself: repeated Den
+  // settings echoes retrigger provider sync and remove/re-add inventory cards.
   await waitFor(
     desktopApp,
-    `[...document.querySelectorAll("button")]
-      .some((button) => button.textContent?.includes("browser-automation"))`,
-    { timeoutMs: 120_000, label: "browser automation skill card" },
-  );
-  const openedSkill = await evalIn(desktopApp, `(() => {
-    const skill = [...document.querySelectorAll("button")]
-      .find((button) => button.textContent?.includes("browser-automation"));
-    if (!skill) return false;
-    skill.click();
-    return true;
-  })()`);
-  expect(openedSkill).toBe(true);
-  await waitFor(
-    desktopApp,
-    `location.hash.includes("skill%3Abrowser-automation")
-      && document.body.innerText.includes("known-good smoke prompt")`,
-    { timeoutMs: 30_000, label: "signed-in Library skill detail" },
+    `document.body.innerText.includes("READY TO USE")
+      && document.body.innerText.includes("OpenWork Browser")`,
+    { timeoutMs: 120_000, label: "signed-in Library inventory" },
   );
 
-  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await new Promise((resolve) => setTimeout(resolve, 10_000));
   await evalIn(desktopApp, `(() => {
     window.__libraryStability.requests = [];
     window.__libraryStability.denEvents = 0;
@@ -77,7 +66,8 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
     window.__libraryStability.sampler = window.setInterval(() => {
       window.__libraryStability.samples.push({
         buttons: document.querySelectorAll("button").length,
-        contentVisible: document.body.innerText.includes("known-good smoke prompt"),
+        contentVisible: document.body.innerText.includes("READY TO USE")
+          && document.body.innerText.includes("OpenWork Browser"),
       });
     }, 50);
     return true;
@@ -89,7 +79,7 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
     const requests = window.__libraryStability.requests;
     const count = (part) => requests.filter((target) => target.includes(part)).length;
     const buttonCounts = window.__libraryStability.samples.map((sample) => sample.buttons);
-    const detailStayedVisible = window.__libraryStability.samples.every((sample) => sample.contentVisible);
+    const inventoryStayedVisible = window.__libraryStability.samples.every((sample) => sample.contentVisible);
     const minButtons = Math.min(...buttonCounts);
     const maxButtons = Math.max(...buttonCounts);
     const observed = {
@@ -97,7 +87,7 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
       providerConfigReads: count("/opencode/config?"),
       providerSyncStatusReads: count("/cloud-provider-sync/status"),
       providerSyncRuns: count("/cloud-provider-sync/run"),
-      detailStayedVisible,
+      inventoryStayedVisible,
       minButtons,
       maxButtons,
     };
@@ -107,7 +97,7 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
         && observed.providerConfigReads <= 2
         && observed.providerSyncStatusReads <= 2
         && observed.providerSyncRuns <= 1
-        && observed.detailStayedVisible
+        && observed.inventoryStayedVisible
         && observed.minButtons === observed.maxButtons,
     };
   })()`);
@@ -119,7 +109,7 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
   );
   expect(result).toMatchObject({
     stable: true,
-    detailStayedVisible: true,
+    inventoryStayedVisible: true,
     denEvents: expect.any(Number),
     providerConfigReads: expect.any(Number),
     providerSyncStatusReads: expect.any(Number),

--- a/evals/specs/library-signed-in-render-stability.e2e.test.ts
+++ b/evals/specs/library-signed-in-render-stability.e2e.test.ts
@@ -48,6 +48,12 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
     { timeoutMs: 60_000, label: "signed-in Library" },
   );
 
+  await waitFor(
+    desktopApp,
+    `[...document.querySelectorAll("button")]
+      .some((button) => button.textContent?.includes("browser-automation"))`,
+    { timeoutMs: 120_000, label: "browser automation skill card" },
+  );
   const openedSkill = await evalIn(desktopApp, `(() => {
     const skill = [...document.querySelectorAll("button")]
       .find((button) => button.textContent?.includes("browser-automation"));

--- a/evals/specs/library-signed-in-render-stability.e2e.test.ts
+++ b/evals/specs/library-signed-in-render-stability.e2e.test.ts
@@ -1,0 +1,121 @@
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { app, needs, server, test } from "@openwork/testkit";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "signed-in Library stays rendered without provider refresh storms"
+  : "signed-in Library stability skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  await using den = await server({
+    place,
+    org: {
+      name: "Library Render Stability",
+      admin: { name: "Library Admin" },
+      members: { member: { name: "Library Member" } },
+    },
+  });
+  await using desktopApp = await app({ den, as: "member", place });
+  const workspace = await createAndSelectWorkspace(desktopApp, { path: repoRoot });
+
+  const instrumented = await evalIn(desktopApp, `(() => {
+    window.__libraryStability = {
+      requests: [],
+      denEvents: 0,
+      samples: [],
+    };
+    const originalFetch = window.fetch;
+    window.fetch = function (...args) {
+      const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
+      window.__libraryStability.requests.push(String(target));
+      return originalFetch.apply(this, args);
+    };
+    window.addEventListener("openwork-den-settings-changed", () => {
+      window.__libraryStability.denEvents += 1;
+    });
+    location.hash = ${JSON.stringify(`#/workspace/${workspace.workspaceId}/extensions`)};
+    return true;
+  })()`);
+  expect(instrumented).toBe(true);
+  await waitFor(
+    desktopApp,
+    `location.hash.includes("/extensions")
+      && [...document.querySelectorAll("h1, h2")].some((heading) => heading.textContent?.trim() === "Library")`,
+    { timeoutMs: 60_000, label: "signed-in Library" },
+  );
+
+  const openedSkill = await evalIn(desktopApp, `(() => {
+    const skill = [...document.querySelectorAll("button")]
+      .find((button) => button.textContent?.includes("browser-automation"));
+    if (!skill) return false;
+    skill.click();
+    return true;
+  })()`);
+  expect(openedSkill).toBe(true);
+  await waitFor(
+    desktopApp,
+    `location.hash.includes("skill%3Abrowser-automation")
+      && document.body.innerText.includes("known-good smoke prompt")`,
+    { timeoutMs: 30_000, label: "signed-in Library skill detail" },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  await evalIn(desktopApp, `(() => {
+    window.__libraryStability.requests = [];
+    window.__libraryStability.denEvents = 0;
+    window.__libraryStability.samples = [];
+    window.__libraryStability.sampler = window.setInterval(() => {
+      window.__libraryStability.samples.push({
+        buttons: document.querySelectorAll("button").length,
+        contentVisible: document.body.innerText.includes("known-good smoke prompt"),
+      });
+    }, 50);
+    return true;
+  })()`);
+  await new Promise((resolve) => setTimeout(resolve, 20_000));
+
+  const result = await evalIn(desktopApp, `(() => {
+    window.clearInterval(window.__libraryStability.sampler);
+    const requests = window.__libraryStability.requests;
+    const count = (part) => requests.filter((target) => target.includes(part)).length;
+    const buttonCounts = window.__libraryStability.samples.map((sample) => sample.buttons);
+    const detailStayedVisible = window.__libraryStability.samples.every((sample) => sample.contentVisible);
+    const minButtons = Math.min(...buttonCounts);
+    const maxButtons = Math.max(...buttonCounts);
+    const observed = {
+      denEvents: window.__libraryStability.denEvents,
+      providerConfigReads: count("/opencode/config?"),
+      providerSyncStatusReads: count("/cloud-provider-sync/status"),
+      providerSyncRuns: count("/cloud-provider-sync/run"),
+      detailStayedVisible,
+      minButtons,
+      maxButtons,
+    };
+    return {
+      ...observed,
+      stable: observed.denEvents <= 1
+        && observed.providerConfigReads <= 2
+        && observed.providerSyncStatusReads <= 2
+        && observed.providerSyncRuns <= 1
+        && observed.detailStayedVisible
+        && observed.minButtons === observed.maxButtons,
+    };
+  })()`);
+  const passed = JSON.stringify(result).includes('"stable":true');
+  evidence.recordAssertionEvidence(
+    "Signed-in Library remains stable after its initial load",
+    `Twenty-second settled observation: ${JSON.stringify(result)}.`,
+    passed,
+  );
+  expect(result).toMatchObject({
+    stable: true,
+    detailStayedVisible: true,
+    denEvents: expect.any(Number),
+    providerConfigReads: expect.any(Number),
+    providerSyncStatusReads: expect.any(Number),
+  });
+});


### PR DESCRIPTION
## Summary
- keep `useDenSession` from replacing equivalent user/org state on every session read
- skip redundant `setOrgs`/`setActiveOrganization`/`setActiveOrgId` writes when the fetched values are unchanged
- key the org refresh effect on the user id instead of the user object identity
- add a signed-in Library E2E spec asserting Den settings events, provider sync traffic, and inventory stability stay bounded

## Live reproduction (dev `e192c64`, attached CDP)
Opening Library on the running dev app produced, in 20 seconds:
- 290–324 renderer requests, including 132–154 `opencode/config` reads and 67–79 `cloud-provider-sync/status` reads
- 18 identical `openwork-den-settings-changed` dispatches
- Library inventory oscillating between 236 and 263 buttons (visible flicker)

Cause: each `getSession`/`listOrgs` response produced new-but-equivalent objects, `syncCurrentDenSettings` rewrote the same Den settings, the settings event re-armed provider sync, and the resulting re-render restarted the cycle.

## Verification
Same live scenario after the fix (HMR-applied on the running dev app):
- 108 requests total; `opencode/config` 25; `cloud-provider-sync/status` 15; sync runs 2
- 4 mount-time settings events, none sustained
- inventory converges to a single stable state (no flicker)

Daytona lane, PR head `08091db63c295c05af4262e44ade971d059d8d62`:
- `bun test` provider/den-session suites (11 files, 75 tests) — passed
- `pnpm --filter @openwork/app typecheck` — passed
- `specs/library-signed-in-render-stability.e2e.test.ts` — 1 passed
- `specs/library-config-read-budget.e2e.test.ts` — 1 passed
