### PR TITLE
feat: opencode v2 parallel engine lane + settings preview flag (hot provider injection, no engine reload)

### DIFF
--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -1,6 +1,7 @@
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, unwrap, type FieldsResult } from "./opencode";
+import { createClientV2, isOpencodeV2BaseUrl } from "./opencode-v2-adapter";
 import type { OpenworkSessionSnapshot } from "./openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "./workspace-endpoint";
 
@@ -20,7 +21,9 @@ export type NativeSessionDependencies = {
 };
 
 function createNativeOperations(endpoint: NativeSessionEndpoint): NativeSessionOperations {
-  const client = createClient(endpoint.opencodeBaseUrl, undefined, { mode: "openwork", token: endpoint.token });
+  const client = isOpencodeV2BaseUrl(endpoint.opencodeBaseUrl)
+    ? createClientV2(endpoint.opencodeBaseUrl, undefined, { token: endpoint.token })
+    : createClient(endpoint.opencodeBaseUrl, undefined, { mode: "openwork", token: endpoint.token });
   return {
     get: (sessionId, options) => client.session.get({ sessionID: sessionId }, options),
     messages: (sessionId, limit, options) => client.session.messages({ sessionID: sessionId, limit }, options),

--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1,0 +1,923 @@
+import type {
+  Model,
+  Provider,
+  ProviderListResponse,
+  Session,
+  TextPart,
+} from "@opencode-ai/sdk/v2/client";
+
+import { createClient, createDesktopFetch, type FieldsResult } from "./opencode";
+import { isDesktopRuntime } from "./runtime-env";
+import type { OpencodeEvent } from "../types";
+
+type RequestOptions = {
+  signal?: AbortSignal;
+  throwOnError?: boolean;
+};
+
+type DirectoryParameters = {
+  directory?: string;
+  workspace?: string;
+};
+
+type SessionParameters = DirectoryParameters & {
+  sessionID: string;
+};
+
+type ModelBinding = {
+  providerID: string;
+  modelID?: string;
+  id?: string;
+};
+
+type PromptPart = {
+  type?: unknown;
+  text?: unknown;
+};
+
+type PromptParameters = SessionParameters & {
+  model?: { providerID: string; modelID: string };
+  parts?: PromptPart[];
+  messageID?: string;
+  agent?: string;
+  noReply?: boolean;
+  tools?: Record<string, boolean>;
+  system?: string;
+  variant?: string;
+  reasoning_effort?: string;
+};
+
+type SessionCreateParameters = DirectoryParameters & {
+  model?: ModelBinding;
+};
+
+type SessionUpdateParameters = SessionParameters & {
+  title?: string;
+  time?: { archived?: number };
+};
+
+type V2MessageRole = "user" | "assistant" | "system";
+
+export type V2MappedMessage = {
+  info: {
+    id: string;
+    sessionID: string;
+    role: V2MessageRole;
+    time: {
+      created: number;
+      completed?: number;
+    };
+  };
+  parts: TextPart[];
+};
+
+type TextStream = {
+  sessionID: string;
+  messageID: string;
+  partID: string;
+  ordinal: number;
+  text: string;
+};
+
+export type V2EventTranslationState = {
+  streams: Map<string, TextStream>;
+  latestStreamKeyBySession: Map<string, string>;
+  nextOrdinalByMessage: Map<string, number>;
+  unknownTypes: Set<string>;
+};
+
+type TransportResult = {
+  payload: unknown;
+  request: Request;
+  response: Response;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRecord(value: unknown, key: string): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const nested = value[key];
+  return isRecord(nested) ? nested : null;
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" ? field : undefined;
+}
+
+function readNumber(value: unknown, key: string): number | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function responseData(value: unknown): unknown {
+  return isRecord(value) && "data" in value ? value.data : value;
+}
+
+function responseItems(value: unknown): unknown[] {
+  const data = responseData(value);
+  return Array.isArray(data) ? data : [];
+}
+
+function eventProperties(value: Record<string, unknown>): Record<string, unknown> {
+  const data = readRecord(value, "data");
+  if (data) return data;
+  const properties = readRecord(value, "properties");
+  return properties ?? value;
+}
+
+function readSessionID(value: Record<string, unknown>): string {
+  return readString(value, "sessionID") ?? readString(value, "sessionId") ?? "";
+}
+
+function readMessageID(value: Record<string, unknown>): string {
+  return readString(value, "assistantMessageID") ?? readString(value, "messageID") ?? readString(value, "messageId") ?? "";
+}
+
+function readTimestamp(value: Record<string, unknown>): number {
+  return readNumber(value, "timestamp") ?? Date.now();
+}
+
+function mapV2Session(value: unknown, directory: string | undefined): Session | null {
+  const data = responseData(value);
+  if (!isRecord(data)) return null;
+  const source = readRecord(data, "info") ?? data;
+  const id = readString(source, "id") ?? readString(source, "sessionID");
+  if (!id) return null;
+  const time = readRecord(source, "time");
+  const location = readRecord(source, "location");
+  const created = readNumber(time, "created") ?? readNumber(source, "created") ?? 0;
+  const updated = readNumber(time, "updated") ?? readNumber(source, "updated") ?? created;
+  const archived = readNumber(time, "archived");
+  const parentID = readString(source, "parentID");
+  const mapped: Session = {
+    id,
+    slug: readString(source, "slug") ?? id,
+    projectID: readString(source, "projectID") ?? "v2",
+    directory: readString(source, "directory") ?? readString(location, "directory") ?? directory ?? "",
+    title: readString(source, "title") ?? "Untitled session",
+    version: readString(source, "version") ?? "v2",
+    time: {
+      created,
+      updated,
+      ...(archived === undefined ? {} : { archived }),
+    },
+    ...(parentID ? { parentID } : {}),
+  };
+  return mapped;
+}
+
+function messageRole(value: Record<string, unknown>): V2MessageRole {
+  const raw = readString(value, "role") ?? readString(value, "type");
+  if (raw === "user") return "user";
+  if (raw === "system" || raw === "synthetic" || raw === "compaction") return "system";
+  return "assistant";
+}
+
+function messageTextEntries(value: Record<string, unknown>): string[] {
+  const content = value.content;
+  if (Array.isArray(content)) {
+    return content.flatMap((entry) => {
+      if (!isRecord(entry) || readString(entry, "type") !== "text") return [];
+      const text = readString(entry, "text");
+      return text === undefined ? [] : [text];
+    });
+  }
+  const text = readString(value, "text");
+  return text === undefined ? [] : [text];
+}
+
+function mapV2Message(value: unknown, sessionID: string): V2MappedMessage | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value, "id") ?? readString(value, "messageID");
+  if (!id) return null;
+  const time = readRecord(value, "time");
+  const created = readNumber(time, "created") ?? readNumber(value, "timestamp") ?? 0;
+  const completed = readNumber(time, "completed");
+  const resolvedSessionID = readString(value, "sessionID") ?? sessionID;
+  const parts = messageTextEntries(value).map<TextPart>((text, ordinal) => ({
+    id: `${id}:${ordinal}`,
+    messageID: id,
+    sessionID: resolvedSessionID,
+    type: "text",
+    text,
+  }));
+  return {
+    info: {
+      id,
+      sessionID: resolvedSessionID,
+      role: messageRole(value),
+      time: {
+        created,
+        ...(completed === undefined ? {} : { completed }),
+      },
+    },
+    parts,
+  };
+}
+
+function modelStatus(value: unknown): Model["status"] {
+  return value === "alpha" || value === "beta" || value === "deprecated" || value === "active"
+    ? value
+    : "active";
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function mapV2Model(value: unknown): Model | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value, "id");
+  const providerID = readString(value, "providerID");
+  if (!id || !providerID) return null;
+  const rawApi = readRecord(value, "api");
+  const rawCapabilities = readRecord(value, "capabilities");
+  const rawLimit = readRecord(value, "limit");
+  const rawTime = readRecord(value, "time");
+  const rawCosts = value.cost;
+  const firstCost = Array.isArray(rawCosts) && rawCosts.length > 0 && isRecord(rawCosts[0])
+    ? rawCosts[0]
+    : isRecord(rawCosts)
+      ? rawCosts
+      : null;
+  const rawCacheCost = readRecord(firstCost, "cache");
+  const inputCapabilities = stringArray(rawCapabilities?.input);
+  const outputCapabilities = stringArray(rawCapabilities?.output);
+  const toolcall = rawCapabilities?.tools === true;
+  const released = readNumber(rawTime, "released");
+  return {
+    id,
+    providerID,
+    api: {
+      id: readString(rawApi, "id") ?? id,
+      url: readString(rawApi, "url") ?? "",
+      npm: readString(rawApi, "npm") ?? readString(rawApi, "package") ?? "",
+    },
+    name: readString(value, "name") ?? id,
+    capabilities: {
+      temperature: false,
+      reasoning: outputCapabilities.includes("reasoning"),
+      attachment: inputCapabilities.some((kind) => kind !== "text"),
+      toolcall,
+      input: {
+        text: inputCapabilities.length === 0 || inputCapabilities.includes("text"),
+        audio: inputCapabilities.includes("audio"),
+        image: inputCapabilities.includes("image"),
+        video: inputCapabilities.includes("video"),
+        pdf: inputCapabilities.includes("pdf"),
+      },
+      output: {
+        text: outputCapabilities.length === 0 || outputCapabilities.includes("text"),
+        audio: outputCapabilities.includes("audio"),
+        image: outputCapabilities.includes("image"),
+        video: outputCapabilities.includes("video"),
+        pdf: outputCapabilities.includes("pdf"),
+      },
+      interleaved: false,
+    },
+    cost: {
+      input: readNumber(firstCost, "input") ?? 0,
+      output: readNumber(firstCost, "output") ?? 0,
+      cache: {
+        read: readNumber(rawCacheCost, "read") ?? 0,
+        write: readNumber(rawCacheCost, "write") ?? 0,
+      },
+    },
+    limit: {
+      context: readNumber(rawLimit, "context") ?? 0,
+      output: readNumber(rawLimit, "output") ?? 0,
+      ...(readNumber(rawLimit, "input") === undefined ? {} : { input: readNumber(rawLimit, "input") }),
+    },
+    status: modelStatus(value.status),
+    options: {},
+    headers: {},
+    release_date: released === undefined ? "" : new Date(released).toISOString(),
+  };
+}
+
+function mapDefaultModels(value: unknown): Record<string, string> {
+  const data = responseData(value);
+  const defaults: Record<string, string> = {};
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      if (!isRecord(item)) continue;
+      const providerID = readString(item, "providerID");
+      const modelID = readString(item, "modelID") ?? readString(item, "id");
+      if (providerID && modelID) defaults[providerID] = modelID;
+    }
+    return defaults;
+  }
+  if (!isRecord(data)) return defaults;
+  const providerID = readString(data, "providerID");
+  const modelID = readString(data, "modelID") ?? readString(data, "id");
+  if (providerID && modelID) defaults[providerID] = modelID;
+  for (const [key, item] of Object.entries(data)) {
+    if (typeof item === "string") defaults[key] = item;
+  }
+  return defaults;
+}
+
+function errorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  if (isRecord(value)) {
+    const direct = readString(value, "message");
+    if (direct) return direct;
+    if ("error" in value) return errorMessage(value.error);
+  }
+  try {
+    return JSON.stringify(value) || "OpenCode v2 execution failed.";
+  } catch {
+    return "OpenCode v2 execution failed.";
+  }
+}
+
+function streamKey(properties: Record<string, unknown>, sessionID: string, messageID: string): string {
+  const explicit = readString(properties, "textID") ?? readString(properties, "textId");
+  if (explicit) return explicit;
+  const ordinal = readNumber(properties, "ordinal");
+  // v2 emits one text stream per (assistantMessageID, ordinal); keying on the
+  // event-provided ordinal keeps multi-part messages from merging into one part.
+  return ordinal === undefined ? `${sessionID}:${messageID}` : `${messageID}:${ordinal}`;
+}
+
+function resolveTextStream(
+  properties: Record<string, unknown>,
+  state: V2EventTranslationState,
+): TextStream | null {
+  const sessionID = readSessionID(properties);
+  const messageID = readMessageID(properties);
+  const explicitKey = streamKey(properties, sessionID, messageID);
+  const byExplicitKey = state.streams.get(explicitKey);
+  if (byExplicitKey) return byExplicitKey;
+  const latestKey = sessionID ? state.latestStreamKeyBySession.get(sessionID) : undefined;
+  if (latestKey) return state.streams.get(latestKey) ?? null;
+  return null;
+}
+
+function terminalEvents(sessionID: string, error?: unknown): OpencodeEvent[] {
+  const events: OpencodeEvent[] = [];
+  if (error !== undefined) {
+    events.push({
+      type: "session.error",
+      properties: {
+        sessionID,
+        error: { name: "UnknownError", data: { message: errorMessage(error) } },
+      },
+    });
+  }
+  events.push(
+    { type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+    { type: "session.idle", properties: { sessionID } },
+  );
+  return events;
+}
+
+export function createV2EventTranslationState(): V2EventTranslationState {
+  return {
+    streams: new Map(),
+    latestStreamKeyBySession: new Map(),
+    nextOrdinalByMessage: new Map(),
+    unknownTypes: new Set(),
+  };
+}
+
+export function translateV2Event(
+  value: unknown,
+  state: V2EventTranslationState,
+): OpencodeEvent[] | null {
+  if (!isRecord(value)) return null;
+  const type = readString(value, "type");
+  if (!type) return null;
+  const properties = eventProperties(value);
+  const sessionID = readSessionID(properties);
+
+  if (type === "session.execution.started") {
+    if (!sessionID) return null;
+    return [{ type: "session.status", properties: { sessionID, status: { type: "busy" } } }];
+  }
+
+  if (type === "session.text.started" || type === "session.next.text.started") {
+    const messageID = readMessageID(properties);
+    if (!sessionID || !messageID) return null;
+    const key = streamKey(properties, sessionID, messageID);
+    const existing = state.streams.get(key);
+    const ordinal = readNumber(properties, "ordinal")
+      ?? existing?.ordinal
+      ?? state.nextOrdinalByMessage.get(messageID)
+      ?? 0;
+    const stream = existing ?? {
+      sessionID,
+      messageID,
+      partID: `${messageID}:${ordinal}`,
+      ordinal,
+      text: "",
+    };
+    state.streams.set(key, stream);
+    state.latestStreamKeyBySession.set(sessionID, key);
+    if (!existing) state.nextOrdinalByMessage.set(messageID, ordinal + 1);
+    const part: TextPart = {
+      id: stream.partID,
+      messageID,
+      sessionID,
+      type: "text",
+      text: "",
+    };
+    return [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: messageID,
+            sessionID,
+            role: "assistant",
+            time: { created: readTimestamp(properties) },
+          },
+        },
+      },
+      { type: "message.part.updated", properties: { part } },
+    ];
+  }
+
+  if (type === "session.text.delta" || type === "session.next.text.delta") {
+    const stream = resolveTextStream(properties, state);
+    const delta = readString(properties, "delta");
+    if (!stream || delta === undefined) return null;
+    stream.text += delta;
+    return [{
+      type: "message.part.delta",
+      properties: {
+        sessionID: stream.sessionID,
+        messageID: stream.messageID,
+        partID: stream.partID,
+        field: "text",
+        delta,
+      },
+    }];
+  }
+
+  if (type === "session.text.ended" || type === "session.next.text.ended") {
+    const stream = resolveTextStream(properties, state);
+    if (!stream) return null;
+    const fullText = readString(properties, "text");
+    if (fullText !== undefined) stream.text = fullText;
+    const part: TextPart = {
+      id: stream.partID,
+      messageID: stream.messageID,
+      sessionID: stream.sessionID,
+      type: "text",
+      text: stream.text,
+    };
+    return [{ type: "message.part.updated", properties: { part } }];
+  }
+
+  if (
+    type === "session.execution.succeeded" ||
+    type === "session.execution.interrupted"
+  ) {
+    return sessionID ? terminalEvents(sessionID) : null;
+  }
+
+  if (type === "session.execution.failed") {
+    return sessionID ? terminalEvents(sessionID, properties.error ?? properties) : null;
+  }
+
+  if (type === "session.status") {
+    if (!sessionID || !isRecord(properties.status)) return null;
+    return [{ type: "session.status", properties: { sessionID, status: properties.status } }];
+  }
+
+  if (type === "session.idle") {
+    return sessionID ? [{ type: "session.idle", properties: { sessionID } }] : null;
+  }
+
+  if (type === "session.created" || type === "session.renamed") {
+    const info = mapV2Session(properties, undefined);
+    if (!info) return null;
+    return [{
+      type: type === "session.created" ? "session.created" : "session.updated",
+      properties: { info },
+    }];
+  }
+
+  if (type === "session.deleted") {
+    const info = mapV2Session(properties, undefined);
+    const deletedSessionID = sessionID || info?.id || "";
+    if (!deletedSessionID) return null;
+    return [{
+      type: "session.deleted",
+      properties: { sessionID: deletedSessionID, ...(info ? { info } : {}) },
+    }];
+  }
+
+  if (!state.unknownTypes.has(type)) {
+    state.unknownTypes.add(type);
+    console.debug(`[opencode-v2] skipping unsupported event type: ${type}`);
+  }
+  return null;
+}
+
+async function* translateV2Events(
+  response: Response,
+  signal: AbortSignal | undefined,
+): AsyncGenerator<OpencodeEvent> {
+  if (!response.body) return;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const state = createV2EventTranslationState();
+  let buffer = "";
+  try {
+    while (!signal?.aborted) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data:")) continue;
+        const text = line.slice("data:".length).trim();
+        if (!text) continue;
+        let event: unknown;
+        try {
+          event = JSON.parse(text);
+        } catch {
+          continue;
+        }
+        const translated = translateV2Event(event, state);
+        if (!translated) continue;
+        for (const item of translated) yield item;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function createWebFetch(auth: { token?: string }): typeof globalThis.fetch {
+  return (input, init) => {
+    const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+    if (auth.token && !headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${auth.token}`);
+    }
+    if (input instanceof Request) {
+      return globalThis.fetch(new Request(input, { headers }), init);
+    }
+    return globalThis.fetch(input, { ...init, headers });
+  };
+}
+
+function createV2Fetch(auth: { token?: string }): typeof globalThis.fetch {
+  return isDesktopRuntime()
+    ? createDesktopFetch({ mode: "openwork", token: auth.token })
+    : createWebFetch(auth);
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+  if (response.status === 204) return null;
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function successfulResult<T>(transport: TransportResult, data: T): FieldsResult<T> {
+  return { data, request: transport.request, response: transport.response };
+}
+
+function failedResult<T>(transport: TransportResult): FieldsResult<T> {
+  return {
+    error: transport.payload ?? { name: "OpenCodeV2RequestFailed" },
+    request: transport.request,
+    response: transport.response,
+  };
+}
+
+function localResult<T>(baseUrl: string, path: string, data: T): FieldsResult<T> {
+  return {
+    data,
+    request: new Request(`${baseUrl}${path}`),
+    response: new Response(null, { status: 200 }),
+  };
+}
+
+function unsupportedResult<T>(baseUrl: string, operation: string): FieldsResult<T> {
+  return {
+    error: { name: "UnsupportedInV2Preview", operation },
+    request: new Request(`${baseUrl}/unsupported/${encodeURIComponent(operation)}`),
+    response: new Response(null, { status: 501, statusText: "Unsupported in OpenCode v2 preview" }),
+  };
+}
+
+export function isOpencodeV2BaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).pathname.replace(/\/+$/, "").endsWith("/opencode2");
+  } catch {
+    return baseUrl.replace(/\/+$/, "").endsWith("/opencode2");
+  }
+}
+
+export function createClientV2(
+  opencode2BaseUrl: string,
+  directory: string | undefined,
+  auth: { token?: string },
+): ReturnType<typeof createClient> {
+  const baseUrl = opencode2BaseUrl.replace(/\/+$/, "");
+  const fetchImpl = createV2Fetch(auth);
+  const compatibilityClient = createClient(baseUrl, directory, { mode: "openwork", token: auth.token });
+
+  const request = async (
+    method: string,
+    path: string,
+    body?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<TransportResult> => {
+    const headers = new Headers();
+    if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
+    if (body) headers.set("Content-Type", "application/json");
+    const transportRequest = new Request(`${baseUrl}${path}`, {
+      method,
+      headers,
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      ...(signal ? { signal } : {}),
+    });
+    const response = await fetchImpl(transportRequest);
+    return { payload: await readPayload(response), request: transportRequest, response };
+  };
+
+  const getSession = async (
+    parameters: SessionParameters,
+    options?: RequestOptions,
+  ): Promise<FieldsResult<Session>> => {
+    const result = await request("GET", `/api/session/${encodeURIComponent(parameters.sessionID)}`, undefined, options?.signal);
+    if (!result.response.ok) return failedResult(result);
+    const session = mapV2Session(result.payload, directory);
+    if (session) return successfulResult(result, session);
+    return failedResult({ ...result, payload: { name: "InvalidV2SessionResponse" } });
+  };
+
+  const createSession = async (
+    parameters: SessionCreateParameters = {},
+    options?: RequestOptions,
+  ): Promise<FieldsResult<Session>> => {
+    const modelID = parameters.model?.id ?? parameters.model?.modelID;
+    const model = parameters.model && modelID
+      ? { providerID: parameters.model.providerID, id: modelID }
+      : undefined;
+    // v2 binds a session's location through the create BODY; the query-param
+    // location middleware does not apply to session.create (verified against
+    // the running engine: query-only creates land in the engine cwd project).
+    const location = parameters.directory ?? directory;
+    const result = await request("POST", "/api/session", {
+      ...(model ? { model } : {}),
+      ...(location ? { location: { directory: location } } : {}),
+    }, options?.signal);
+    if (!result.response.ok) return failedResult(result);
+    const session = mapV2Session(result.payload, directory);
+    if (session) return successfulResult(result, session);
+    return failedResult({ ...result, payload: { name: "InvalidV2SessionResponse" } });
+  };
+
+  const session = {
+    list: async (
+      parameters: DirectoryParameters & { limit?: number } = {},
+      options?: RequestOptions,
+    ): Promise<FieldsResult<Session[]>> => {
+      const query = new URLSearchParams();
+      if (parameters.limit !== undefined) query.set("limit", String(parameters.limit));
+      const suffix = query.size ? `?${query.toString()}` : "";
+      const result = await request("GET", `/api/session${suffix}`, undefined, options?.signal);
+      if (!result.response.ok) return failedResult(result);
+      const data = responseItems(result.payload).flatMap((item) => {
+        const mapped = mapV2Session(item, directory);
+        return mapped ? [mapped] : [];
+      });
+      return successfulResult(result, data);
+    },
+    create: createSession,
+    get: getSession,
+    messages: async (
+      parameters: SessionParameters & { limit?: number; before?: string },
+      options?: RequestOptions,
+    ): Promise<FieldsResult<V2MappedMessage[]>> => {
+      const query = new URLSearchParams();
+      if (parameters.limit !== undefined) query.set("limit", String(parameters.limit));
+      const suffix = query.size ? `?${query.toString()}` : "";
+      const result = await request(
+        "GET",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/message${suffix}`,
+        undefined,
+        options?.signal,
+      );
+      if (!result.response.ok) return failedResult(result);
+      const data = responseItems(result.payload).flatMap((item) => {
+        const mapped = mapV2Message(item, parameters.sessionID);
+        return mapped ? [mapped] : [];
+      });
+      return successfulResult(result, data);
+    },
+    todo: async (parameters: SessionParameters): Promise<FieldsResult<never[]>> =>
+      localResult(baseUrl, `/api/session/${encodeURIComponent(parameters.sessionID)}/todo`, []),
+    status: async (): Promise<FieldsResult<Record<string, never>>> =>
+      localResult(baseUrl, "/api/session/status", {}),
+    promptAsync: async (
+      parameters: PromptParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<Record<string, never>>> => {
+      if (!parameters.model) {
+        return {
+          error: { name: "ModelRequiredInV2Preview" },
+          request: new Request(`${baseUrl}/api/session/${encodeURIComponent(parameters.sessionID)}/model`),
+          response: new Response(null, { status: 400 }),
+        };
+      }
+      const modelResult = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/model`,
+        { model: { providerID: parameters.model.providerID, id: parameters.model.modelID } },
+        options?.signal,
+      );
+      if (!modelResult.response.ok) return failedResult(modelResult);
+      const text = (parameters.parts ?? [])
+        .filter((part) => part.type === "text" && typeof part.text === "string")
+        .map((part) => typeof part.text === "string" ? part.text : "")
+        .join("");
+      const promptResult = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/prompt`,
+        { text },
+        options?.signal,
+      );
+      if (!promptResult.response.ok) return failedResult(promptResult);
+      return successfulResult(promptResult, {});
+    },
+    abort: async (
+      parameters: SessionParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<boolean>> => {
+      const result = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/interrupt`,
+        {},
+        options?.signal,
+      );
+      return result.response.ok ? successfulResult(result, true) : failedResult(result);
+    },
+    update: async (
+      parameters: SessionUpdateParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<Session>> => {
+      if (!parameters.title) return getSession(parameters, options);
+      const result = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/rename`,
+        { title: parameters.title },
+        options?.signal,
+      );
+      if (!result.response.ok) return failedResult(result);
+      const mapped = mapV2Session(result.payload, directory);
+      return mapped ? successfulResult(result, mapped) : getSession(parameters, options);
+    },
+    delete: async (
+      parameters: SessionParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<boolean>> => {
+      const result = await request(
+        "DELETE",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}`,
+        undefined,
+        options?.signal,
+      );
+      return result.response.ok ? successfulResult(result, true) : failedResult(result);
+    },
+    fork: async (): Promise<FieldsResult<Session>> => unsupportedResult(baseUrl, "session.fork"),
+    revert: async (): Promise<FieldsResult<Session>> => unsupportedResult(baseUrl, "session.revert"),
+    unrevert: async (): Promise<FieldsResult<Session>> => unsupportedResult(baseUrl, "session.unrevert"),
+    summarize: async (): Promise<FieldsResult<boolean>> => unsupportedResult(baseUrl, "session.summarize"),
+    shell: async (): Promise<FieldsResult<Record<string, never>>> => unsupportedResult(baseUrl, "session.shell"),
+    command: async (): Promise<FieldsResult<Record<string, never>>> => unsupportedResult(baseUrl, "session.command"),
+  };
+
+  const adapter = {
+    global: {
+      health: async (options?: RequestOptions): Promise<FieldsResult<{ healthy: boolean; version: string }>> => {
+        const result = await request("GET", "/api/health", undefined, options?.signal);
+        if (!result.response.ok) return failedResult(result);
+        const data = responseData(result.payload);
+        return successfulResult(result, {
+          healthy: isRecord(data) && data.healthy === true,
+          version: readString(data, "version") ?? "v2",
+        });
+      },
+    },
+    session,
+    config: {
+      get: async (): Promise<FieldsResult<Record<string, never>>> => localResult(baseUrl, "/api/config", {}),
+    },
+    provider: {
+      list: async (
+        _parameters: DirectoryParameters = {},
+        options?: RequestOptions,
+      ): Promise<FieldsResult<ProviderListResponse>> => {
+        const modelsResult = await request("GET", "/api/model", undefined, options?.signal);
+        if (!modelsResult.response.ok) return failedResult(modelsResult);
+        const defaultsResult = await request("GET", "/api/model/default", undefined, options?.signal);
+        const models = responseItems(modelsResult.payload).flatMap((item) => {
+          const mapped = mapV2Model(item);
+          return mapped ? [mapped] : [];
+        });
+        const providersByID = new Map<string, Provider>();
+        for (const model of models) {
+          const current = providersByID.get(model.providerID);
+          if (current) {
+            current.models[model.id] = model;
+            continue;
+          }
+          providersByID.set(model.providerID, {
+            id: model.providerID,
+            name: model.providerID,
+            source: "config",
+            env: [],
+            options: {},
+            models: { [model.id]: model },
+          });
+        }
+        const all = [...providersByID.values()];
+        return successfulResult(modelsResult, {
+          all,
+          connected: all.map((provider) => provider.id),
+          default: defaultsResult.response.ok ? mapDefaultModels(defaultsResult.payload) : {},
+        });
+      },
+    },
+    app: {
+      agents: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/agent", []),
+    },
+    command: {
+      list: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/command", []),
+    },
+    permission: {
+      list: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/permission", []),
+    },
+    question: {
+      list: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/question", []),
+    },
+    v2: {
+      session: {
+        permission: {
+          list: async (): Promise<FieldsResult<{ data: never[] }>> =>
+            localResult(baseUrl, "/api/session/permission", { data: [] }),
+        },
+      },
+    },
+    find: {
+      files: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/fs/find", []),
+    },
+    mcp: {
+      status: async (): Promise<FieldsResult<Record<string, never>>> => localResult(baseUrl, "/api/mcp", {}),
+    },
+    event: {
+      subscribe: async (
+        _parameters?: DirectoryParameters,
+        options?: RequestOptions,
+      ): Promise<{ stream: AsyncGenerator<OpencodeEvent> }> => {
+        const headers = new Headers({ Accept: "text/event-stream" });
+        if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
+        const eventRequest = new Request(`${baseUrl}/api/event`, {
+          headers,
+          ...(options?.signal ? { signal: options.signal } : {}),
+        });
+        const response = await fetchImpl(eventRequest);
+        if (!response.ok) {
+          const error = new Error(errorMessage(await readPayload(response)));
+          Object.assign(error, { status: response.status, response });
+          throw error;
+        }
+        return { stream: translateV2Events(response, options?.signal) };
+      },
+    },
+  };
+
+  Object.assign(compatibilityClient.global, adapter.global);
+  Object.assign(compatibilityClient.session, adapter.session);
+  Object.assign(compatibilityClient.config, adapter.config);
+  Object.assign(compatibilityClient.provider, adapter.provider);
+  Object.assign(compatibilityClient.app, adapter.app);
+  Object.assign(compatibilityClient.command, adapter.command);
+  Object.assign(compatibilityClient.permission, adapter.permission);
+  Object.assign(compatibilityClient.question, adapter.question);
+  Object.assign(compatibilityClient.v2.session.permission, adapter.v2.session.permission);
+  Object.assign(compatibilityClient.find, adapter.find);
+  Object.assign(compatibilityClient.mcp, adapter.mcp);
+  Object.assign(compatibilityClient.event, adapter.event);
+  return compatibilityClient;
+}
+
+export type OpencodeV2Client = ReturnType<typeof createClientV2>;

--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -217,7 +217,7 @@ function nativeFetchRef(): typeof globalThis.fetch {
   return globalThis.fetch as typeof globalThis.fetch;
 }
 
-const createDesktopFetch = (auth?: OpencodeAuth) => {
+export const createDesktopFetch = (auth?: OpencodeAuth) => {
   const authHeader = resolveAuthHeader(auth);
   const addAuth = (headers: Headers) => {
     if (!authHeader || headers.has("Authorization")) return;

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -69,6 +69,7 @@ export type OpenworkCloudProviderSyncStatus = {
 export interface EngineV2PreviewStatus {
   enabled: boolean;
   running: boolean;
+  chatRouting: boolean;
   version?: string;
   pid?: number;
   binSource?: string;
@@ -93,6 +94,7 @@ function parseEngineV2PreviewStatus(value: unknown): EngineV2PreviewStatus {
   return {
     enabled: value.enabled,
     running: value.running,
+    chatRouting: "chatRouting" in value && typeof value.chatRouting === "boolean" ? value.chatRouting : false,
     version: "version" in value && typeof value.version === "string" ? value.version : undefined,
     pid: "pid" in value && typeof value.pid === "number" ? value.pid : undefined,
     binSource: "binSource" in value && typeof value.binSource === "string" ? value.binSource : undefined,
@@ -1568,6 +1570,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         token,
         method: "PUT",
         body: { enabled },
+        timeoutMs: timeouts.config,
+      })),
+    setEngineV2PreviewChatRouting: async (chatRouting: boolean): Promise<EngineV2PreviewStatus> =>
+      parseEngineV2PreviewStatus(await requestJson<unknown>(baseUrl, "/experimental/engine-v2-preview", {
+        token,
+        method: "PUT",
+        body: { chatRouting },
         timeoutMs: timeouts.config,
       })),
     setConnectState: (connectEnabled: boolean) => requestJson<OpenworkConnectState>(baseUrl, "/experimental/connect/state", { token, hostToken, method: "PUT", body: { connectEnabled }, timeoutMs: timeouts.config }),

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -66,6 +66,44 @@ export type OpenworkCloudProviderSyncStatus = {
   skippedProviders: OpenworkCloudProviderSyncSkippedProvider[];
 };
 
+export interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  version?: string;
+  pid?: number;
+  binSource?: string;
+  mirroredProviderIds: string[];
+  skippedProviderIds: string[];
+  catalogModelIds: string[];
+  lastMirroredAt?: string;
+  lastError?: string;
+}
+
+function parseEngineV2PreviewStatus(value: unknown): EngineV2PreviewStatus {
+  if (
+    !value || typeof value !== "object" ||
+    !("enabled" in value) || typeof value.enabled !== "boolean" ||
+    !("running" in value) || typeof value.running !== "boolean" ||
+    !("mirroredProviderIds" in value) || !Array.isArray(value.mirroredProviderIds) || !value.mirroredProviderIds.every((item) => typeof item === "string") ||
+    !("skippedProviderIds" in value) || !Array.isArray(value.skippedProviderIds) || !value.skippedProviderIds.every((item) => typeof item === "string") ||
+    !("catalogModelIds" in value) || !Array.isArray(value.catalogModelIds) || !value.catalogModelIds.every((item) => typeof item === "string")
+  ) {
+    throw new Error("Invalid OpenCode v2 engine preview status response.");
+  }
+  return {
+    enabled: value.enabled,
+    running: value.running,
+    version: "version" in value && typeof value.version === "string" ? value.version : undefined,
+    pid: "pid" in value && typeof value.pid === "number" ? value.pid : undefined,
+    binSource: "binSource" in value && typeof value.binSource === "string" ? value.binSource : undefined,
+    mirroredProviderIds: value.mirroredProviderIds,
+    skippedProviderIds: value.skippedProviderIds,
+    catalogModelIds: value.catalogModelIds,
+    lastMirroredAt: "lastMirroredAt" in value && typeof value.lastMirroredAt === "string" ? value.lastMirroredAt : undefined,
+    lastError: "lastError" in value && typeof value.lastError === "string" ? value.lastError : undefined,
+  };
+}
+
 function parseCloudProviderSyncRun(value: unknown): OpenworkCloudProviderSyncRun {
   if (!value || typeof value !== "object" || !("status" in value)) throw new Error("Invalid cloud provider sync response.");
   const status = value.status;
@@ -1518,6 +1556,18 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     getCloudProviderSyncStatus: async () =>
       parseCloudProviderSyncStatus(await requestJson<unknown>(baseUrl, "/cloud-provider-sync/status", {
         token,
+        timeoutMs: timeouts.config,
+      })),
+    getEngineV2PreviewStatus: async (): Promise<EngineV2PreviewStatus> =>
+      parseEngineV2PreviewStatus(await requestJson<unknown>(baseUrl, "/experimental/engine-v2-preview/status", {
+        token,
+        timeoutMs: timeouts.config,
+      })),
+    setEngineV2PreviewEnabled: async (enabled: boolean): Promise<EngineV2PreviewStatus> =>
+      parseEngineV2PreviewStatus(await requestJson<unknown>(baseUrl, "/experimental/engine-v2-preview", {
+        token,
+        method: "PUT",
+        body: { enabled },
         timeoutMs: timeouts.config,
       })),
     setConnectState: (connectEnabled: boolean) => requestJson<OpenworkConnectState>(baseUrl, "/experimental/connect/state", { token, hostToken, method: "PUT", body: { connectEnabled }, timeoutMs: timeouts.config }),

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -6,6 +6,7 @@ import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
+import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { isGeneratedSessionTitle } from "@/app/lib/session-title";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
@@ -144,14 +145,20 @@ type SessionStatusFetcher = (
   signal: AbortSignal,
 ) => Promise<Record<string, SessionStatus>>;
 
+function createSyncClient(baseUrl: string, openworkToken: string) {
+  return isOpencodeV2BaseUrl(baseUrl)
+    ? createClientV2(baseUrl, undefined, { token: openworkToken })
+    : createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+}
+
 const defaultSyncSubscriptionFactory: SyncSubscriptionFactory = async (baseUrl, openworkToken, signal) => {
-  const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+  const client = createSyncClient(baseUrl, openworkToken);
   const subscription = await client.event.subscribe(undefined, { signal });
   return subscription.stream;
 };
 
 const defaultSessionStatusFetcher: SessionStatusFetcher = async (baseUrl, openworkToken, signal) => {
-  const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+  const client = createSyncClient(baseUrl, openworkToken);
   const result = await client.session.status(undefined, { signal });
   if (result.data !== undefined) return result.data;
   throw result.error;
@@ -1242,7 +1249,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   };
   created.titleRecovery = createSessionTitleRecovery({
     fetch: async (sessionId) => {
-      const client = createClient(input.baseUrl, undefined, { token: created.openworkToken, mode: "openwork" });
+      const client = createSyncClient(input.baseUrl, created.openworkToken);
       const [session, messages] = await Promise.all([
         client.session.get({ sessionID: sessionId }).then(unwrap),
         client.session.messages({ sessionID: sessionId, limit: 20 }).then(unwrap),

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -774,6 +774,7 @@ export function AdvancedFeatureFlagsSection(props: AdvancedFeatureFlagsSectionPr
 interface AdvancedEngineV2PreviewSectionProps {
   getStatus: () => Promise<EngineV2PreviewStatus>;
   setEnabled: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
+  setChatRouting: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
 }
 
 export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSectionProps) {
@@ -822,9 +823,21 @@ export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSec
     }
   };
 
+  const setChatRouting = async (enabled: boolean) => {
+    setBusy(true);
+    setLoadError(null);
+    try {
+      setStatus(await props.setChatRouting(enabled));
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : "Failed to update OpenCode v2 chat routing.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const skippedCount = status?.skippedProviderIds.length ?? 0;
   const runningStatus = status?.enabled && status.running
-    ? `Running v${status.version ?? "unknown"} (pid ${status.pid ?? "unknown"}) — ${status.mirroredProviderIds.length} providers mirrored, ${status.catalogModelIds.length} models${skippedCount ? `, ${skippedCount} skipped` : ""}`
+    ? `Running v${status.version ?? "unknown"} (pid ${status.pid ?? "unknown"}) — ${status.mirroredProviderIds.length} providers mirrored, ${status.catalogModelIds.length} models${skippedCount ? `, ${skippedCount} skipped` : ""}${status.chatRouting ? " — chat routed to v2" : ""}`
     : null;
   const error = (status?.enabled && !status.running ? status.lastError : null) ?? loadError;
   const starting = status?.enabled && !status.running && !error ? "Starting the OpenCode v2 sidecar…" : null;
@@ -839,7 +852,7 @@ export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSec
         <LayoutSectionItemHeader>
           <LayoutSectionItemTitle>OpenCode v2 engine preview</LayoutSectionItemTitle>
           <LayoutSectionItemDescription>
-            Experimental: runs the OpenCode v2 engine as a parallel sidecar and mirrors provider changes into it live — no engine reload. The app keeps using the current engine.
+            Experimental: runs the OpenCode v2 engine as a parallel sidecar and mirrors provider changes into it live — no engine reload.
           </LayoutSectionItemDescription>
           <LayoutSectionItemHeaderActions>
             <Switch
@@ -854,6 +867,25 @@ export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSec
         {starting ? <div className="text-xs text-gray-11">{starting}</div> : null}
         {error ? <div className="text-xs text-red-11">{error}</div> : null}
       </LayoutSectionItem>
+
+      {status?.enabled ? (
+        <LayoutSectionItem>
+          <LayoutSectionItemHeader>
+            <LayoutSectionItemTitle>Route chat through OpenCode v2</LayoutSectionItemTitle>
+            <LayoutSectionItemDescription>
+              Text chat uses the preview sidecar. Unsupported commands, tools, permissions, and file search remain unavailable in this preview.
+            </LayoutSectionItemDescription>
+            <LayoutSectionItemHeaderActions>
+              <Switch
+                aria-label="Route chat through OpenCode v2"
+                checked={status.chatRouting}
+                disabled={!status.running || busy}
+                onCheckedChange={(enabled) => { void setChatRouting(enabled); }}
+              />
+            </LayoutSectionItemHeaderActions>
+          </LayoutSectionItemHeader>
+        </LayoutSectionItem>
+      ) : null}
     </LayoutSection>
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useState, type ComponentProps, type ReactNode } from "react";
+import { useEffect, useState, type ComponentProps, type ReactNode } from "react";
 import { CircleAlert, Cpu, Info, RefreshCcw, Server } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import type { OpenworkCloudMcpHealth, OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
+import type { EngineV2PreviewStatus, OpenworkCloudMcpHealth, OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
 import { sanitizeCloudMcpHealthDiagnostic, sanitizeDiagnosticRecord } from "@/app/lib/diagnostic-sanitizer";
 import {
   DEFAULT_DEN_API_BASE_URL,
@@ -766,6 +766,93 @@ export function AdvancedFeatureFlagsSection(props: AdvancedFeatureFlagsSectionPr
             />
           </LayoutSectionItemHeaderActions>
         </LayoutSectionItemHeader>
+      </LayoutSectionItem>
+    </LayoutSection>
+  );
+}
+
+interface AdvancedEngineV2PreviewSectionProps {
+  getStatus: () => Promise<EngineV2PreviewStatus>;
+  setEnabled: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
+}
+
+export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSectionProps) {
+  const [status, setStatus] = useState<EngineV2PreviewStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    void props.getStatus().then((nextStatus) => {
+      if (mounted) {
+        setStatus(nextStatus);
+        setLoadError(null);
+      }
+    }).catch((error: unknown) => {
+      if (mounted) setLoadError(error instanceof Error ? error.message : "Failed to load OpenCode v2 engine preview status.");
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [props.getStatus]);
+
+  useEffect(() => {
+    if (!status?.enabled) return;
+    let mounted = true;
+    const interval = window.setInterval(() => {
+      void props.getStatus().then((nextStatus) => {
+        if (mounted) setStatus(nextStatus);
+      }).catch(() => undefined);
+    }, 5_000);
+    return () => {
+      mounted = false;
+      window.clearInterval(interval);
+    };
+  }, [props.getStatus, status?.enabled]);
+
+  const setEnabled = async (enabled: boolean) => {
+    setBusy(true);
+    setLoadError(null);
+    try {
+      setStatus(await props.setEnabled(enabled));
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : "Failed to update OpenCode v2 engine preview.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const skippedCount = status?.skippedProviderIds.length ?? 0;
+  const runningStatus = status?.enabled && status.running
+    ? `Running v${status.version ?? "unknown"} (pid ${status.pid ?? "unknown"}) — ${status.mirroredProviderIds.length} providers mirrored, ${status.catalogModelIds.length} models${skippedCount ? `, ${skippedCount} skipped` : ""}`
+    : null;
+  const error = (status?.enabled && !status.running ? status.lastError : null) ?? loadError;
+  const starting = status?.enabled && !status.running && !error ? "Starting the OpenCode v2 sidecar…" : null;
+
+  return (
+    <LayoutSection>
+      <LayoutSectionHeader>
+        <LayoutSectionTitle>Experimental engine</LayoutSectionTitle>
+      </LayoutSectionHeader>
+
+      <LayoutSectionItem>
+        <LayoutSectionItemHeader>
+          <LayoutSectionItemTitle>OpenCode v2 engine preview</LayoutSectionItemTitle>
+          <LayoutSectionItemDescription>
+            Experimental: runs the OpenCode v2 engine as a parallel sidecar and mirrors provider changes into it live — no engine reload. The app keeps using the current engine.
+          </LayoutSectionItemDescription>
+          <LayoutSectionItemHeaderActions>
+            <Switch
+              aria-label="OpenCode v2 engine preview"
+              checked={status?.enabled ?? false}
+              disabled={busy || !status || !isDesktopRuntime()}
+              onCheckedChange={(enabled) => { void setEnabled(enabled); }}
+            />
+          </LayoutSectionItemHeaderActions>
+        </LayoutSectionItemHeader>
+        {runningStatus ? <div className="text-xs text-gray-11">{runningStatus}</div> : null}
+        {starting ? <div className="text-xs text-gray-11">{starting}</div> : null}
+        {error ? <div className="text-xs text-red-11">{error}</div> : null}
       </LayoutSectionItem>
     </LayoutSection>
   );

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -4,7 +4,7 @@ import { useEffect, useReducer, useState } from "react";
 import { Separator } from "@/components/ui/separator";
 
 import type { OpencodeConnectStatus } from "@/app/types";
-import type { OpenworkCloudMcpHealth, OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
+import type { EngineV2PreviewStatus, OpenworkCloudMcpHealth, OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
 import { t } from "@/i18n";
 import { LayoutStack } from "../settings-layout";
 import type { useDenSession } from "../cloud/use-den-session";
@@ -12,6 +12,7 @@ import type { useDenSession } from "../cloud/use-den-session";
 import { advancedLocalReducer, initialAdvancedLocalState } from "./advanced-view-state";
 import {
   AdvancedDeveloperSection,
+  AdvancedEngineV2PreviewSection,
   AdvancedCloudMcpDiagnosticsSection,
   AdvancedOrganizationServerSection,
   AdvancedRuntimeConfigSourcesSection,
@@ -47,6 +48,8 @@ export type AdvancedViewProps = {
   cloudMcpUrl: string | null;
   cloudMcpHealth: OpenworkCloudMcpHealth | null;
   refreshCloudMcpHealth: () => Promise<OpenworkCloudMcpHealth | null>;
+  getEngineV2PreviewStatus: () => Promise<EngineV2PreviewStatus>;
+  setEngineV2PreviewEnabled: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
 };
 
 type AdvancedStatusTone = "ready" | "warning" | "error" | "neutral";
@@ -191,6 +194,11 @@ export function AdvancedView(props: AdvancedViewProps) {
         configStatusBusy={configStatusBusy}
         configStatusError={configStatusError}
         onRefresh={refreshRuntimeConfigStatus}
+      />
+
+      <AdvancedEngineV2PreviewSection
+        getStatus={props.getEngineV2PreviewStatus}
+        setEnabled={props.setEngineV2PreviewEnabled}
       />
 
       <AdvancedDeveloperSection

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -50,6 +50,7 @@ export type AdvancedViewProps = {
   refreshCloudMcpHealth: () => Promise<OpenworkCloudMcpHealth | null>;
   getEngineV2PreviewStatus: () => Promise<EngineV2PreviewStatus>;
   setEngineV2PreviewEnabled: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
+  setEngineV2PreviewChatRouting: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
 };
 
 type AdvancedStatusTone = "ready" | "warning" | "error" | "neutral";
@@ -199,6 +200,7 @@ export function AdvancedView(props: AdvancedViewProps) {
       <AdvancedEngineV2PreviewSection
         getStatus={props.getEngineV2PreviewStatus}
         setEnabled={props.setEngineV2PreviewEnabled}
+        setChatRouting={props.setEngineV2PreviewChatRouting}
       />
 
       <AdvancedDeveloperSection

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2210,11 +2210,13 @@ export function SessionRoute() {
     if (!endpoint || !endpoint.token) {
       return null;
     }
-    const workspaceClient = createClient(
-      endpoint.opencodeBaseUrl,
-      workspace.path?.trim() || undefined,
-      { token: endpoint.token, mode: "openwork" },
-    );
+    const workspaceClient = workspaceId === selectedWorkspaceId && opencodeClient
+      ? opencodeClient
+      : createClient(
+          endpoint.opencodeBaseUrl,
+          workspace.path?.trim() || undefined,
+          { token: endpoint.token, mode: "openwork" },
+        );
     try {
       setErrorsByWorkspaceId((current) => ({ ...current, [workspaceId]: null }));
       setRouteError(null);
@@ -2271,7 +2273,7 @@ export function SessionRoute() {
       }
       return null;
     }
-  }, [applyLastUsedModelToSession, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
+  }, [applyLastUsedModelToSession, endpointForWorkspace, loading, navigateToWorkspaceSession, opencodeClient, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2615,6 +2615,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             }}
             cloudMcpHealth={cloudMcpHealth}
             refreshCloudMcpHealth={refreshCloudMcpHealth}
+            getEngineV2PreviewStatus={async () => {
+              if (!openworkClient) throw new Error("OpenWork server is not connected.");
+              return openworkClient.getEngineV2PreviewStatus();
+            }}
+            setEngineV2PreviewEnabled={async (enabled) => {
+              if (!openworkClient) throw new Error("OpenWork server is not connected.");
+              return openworkClient.setEngineV2PreviewEnabled(enabled);
+            }}
             organizationServer={denSession}
           />
         );

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2623,6 +2623,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               if (!openworkClient) throw new Error("OpenWork server is not connected.");
               return openworkClient.setEngineV2PreviewEnabled(enabled);
             }}
+            setEngineV2PreviewChatRouting={async (enabled) => {
+              if (!openworkClient) throw new Error("OpenWork server is not connected.");
+              return openworkClient.setEngineV2PreviewChatRouting(enabled);
+            }}
             organizationServer={denSession}
           />
         );

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -23,6 +23,7 @@ import {
   type WorkspaceList,
 } from "@/app/lib/desktop";
 import { createClient } from "@/app/lib/opencode";
+import { createClientV2 } from "@/app/lib/opencode-v2-adapter";
 import { getNativeSession } from "@/app/lib/opencode-session-native";
 import { createOpenworkServerClient, type OpenworkServerClient } from "@/app/lib/openwork-server";
 import { readDenBootstrapConfig } from "@/app/lib/den";
@@ -179,6 +180,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const [client, setClient] = useState<OpenworkServerClient | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
   const [token, setToken] = useState("");
+  const [engineV2ChatRouting, setEngineV2ChatRouting] = useState(false);
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
   const [workspaceOrderIds, setWorkspaceOrderIds] = useState<string[]>(() => readWorkspaceOrderIds());
   const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, RouteSession[]>>({});
@@ -995,7 +997,34 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   // local workspaces it's the user's local OpenWork server.
   const selectedWorkspaceEndpoint = useWorkspaceServerClient(selectedWorkspace, { baseUrl, token });
   const selectedWorkspaceServerToken = selectedWorkspaceEndpoint?.token ?? "";
-  const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
+  const defaultOpencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
+  const opencode2BaseUrl = selectedWorkspaceEndpoint ? `${selectedWorkspaceEndpoint.mountedBaseUrl}/opencode2` : "";
+  useEffect(() => {
+    const openworkClient = selectedWorkspaceEndpoint?.client;
+    if (!openworkClient) {
+      setEngineV2ChatRouting(false);
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const status = await openworkClient.getEngineV2PreviewStatus();
+        if (!cancelled) setEngineV2ChatRouting(status.enabled && status.running && status.chatRouting);
+      } catch (error) {
+        if (cancelled) return;
+        setEngineV2ChatRouting(false);
+        console.warn("[opencode-v2] failed to read chat routing status; retaining the current engine", error);
+      }
+    };
+    setEngineV2ChatRouting(false);
+    void refresh();
+    const interval = window.setInterval(() => { void refresh(); }, 15_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [selectedWorkspaceEndpoint?.baseUrl, selectedWorkspaceEndpoint?.client, selectedWorkspaceEndpoint?.workspaceId]);
+  const opencodeBaseUrl = engineV2ChatRouting ? opencode2BaseUrl : defaultOpencodeBaseUrl;
   const selectedWorkspaceError = errorsByWorkspaceId[selectedWorkspaceId] ?? null;
   const selectedSessionKnown = Boolean(
     selectedSessionId &&
@@ -1125,12 +1154,16 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const opencodeClient = useMemo(
     () =>
       opencodeBaseUrl && selectedWorkspaceServerToken && !selectedWorkspaceError
-        ? createClient(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
-            token: selectedWorkspaceServerToken,
-            mode: "openwork",
-          })
+        ? engineV2ChatRouting
+          ? createClientV2(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
+              token: selectedWorkspaceServerToken,
+            })
+          : createClient(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
+              token: selectedWorkspaceServerToken,
+              mode: "openwork",
+            })
         : null,
-    [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
+    [engineV2ChatRouting, opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
   useEffect(() => {
     if (!developerMode || !opencodeClient) return;

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createV2EventTranslationState,
+  translateV2Event,
+} from "../src/app/lib/opencode-v2-adapter";
+
+describe("OpenCode v2 event translation", () => {
+  test("uses one stable text part id from start through the cumulative end update", () => {
+    const state = createV2EventTranslationState();
+
+    expect(translateV2Event({
+      type: "session.text.started",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_1",
+        textID: "txt_1",
+        timestamp: 10,
+      },
+    }, state)).toEqual([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_1",
+            sessionID: "ses_1",
+            role: "assistant",
+            time: { created: 10 },
+          },
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "msg_1:0",
+            messageID: "msg_1",
+            sessionID: "ses_1",
+            type: "text",
+            text: "",
+          },
+        },
+      },
+    ]);
+
+    expect(translateV2Event({
+      type: "session.text.delta",
+      data: { sessionID: "ses_1", textID: "txt_1", delta: "Hello " },
+    }, state)).toEqual([{
+      type: "message.part.delta",
+      properties: {
+        sessionID: "ses_1",
+        messageID: "msg_1",
+        partID: "msg_1:0",
+        field: "text",
+        delta: "Hello ",
+      },
+    }]);
+    translateV2Event({
+      type: "session.text.delta",
+      data: { sessionID: "ses_1", textID: "txt_1", delta: "world" },
+    }, state);
+
+    expect(translateV2Event({
+      type: "session.text.ended",
+      data: { sessionID: "ses_1", textID: "txt_1" },
+    }, state)).toEqual([{
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "msg_1:0",
+          messageID: "msg_1",
+          sessionID: "ses_1",
+          type: "text",
+          text: "Hello world",
+        },
+      },
+    }]);
+  });
+
+  test("uses event-provided ordinals to keep same-message text parts distinct", () => {
+    const state = createV2EventTranslationState();
+
+    const firstStarted = translateV2Event({
+      type: "session.text.started",
+      data: { sessionID: "ses_ordinal", assistantMessageID: "msg_ordinal", ordinal: 0 },
+    }, state);
+    const secondStarted = translateV2Event({
+      type: "session.text.started",
+      data: { sessionID: "ses_ordinal", assistantMessageID: "msg_ordinal", ordinal: 1 },
+    }, state);
+
+    expect(firstStarted?.[1]).toMatchObject({
+      type: "message.part.updated",
+      properties: { part: { id: "msg_ordinal:0" } },
+    });
+    expect(secondStarted?.[1]).toMatchObject({
+      type: "message.part.updated",
+      properties: { part: { id: "msg_ordinal:1" } },
+    });
+
+    const delta = translateV2Event({
+      type: "session.text.delta",
+      data: { sessionID: "ses_ordinal", assistantMessageID: "msg_ordinal", ordinal: 1, delta: "second" },
+    }, state);
+    expect(delta).toEqual([{
+      type: "message.part.delta",
+      properties: {
+        sessionID: "ses_ordinal",
+        messageID: "msg_ordinal",
+        partID: "msg_ordinal:1",
+        field: "text",
+        delta: "second",
+      },
+    }]);
+    expect(delta).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ properties: expect.objectContaining({ partID: "msg_ordinal:0" }) }),
+    ]));
+  });
+
+  test("translates captured v2 text lifecycle events through terminal idle", () => {
+    const state = createV2EventTranslationState();
+    const captured = [
+      { type: "session.text.started", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0 } },
+      { type: "session.text.delta", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: "hello world" } },
+      { type: "session.text.ended", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, text: "hello world" } },
+      { type: "session.execution.succeeded", data: { sessionID: "s" } },
+    ];
+    const translated = captured.flatMap((event) => translateV2Event(event, state) ?? []);
+
+    expect(translated).toEqual([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "m",
+            sessionID: "s",
+            role: "assistant",
+            time: { created: expect.any(Number) },
+          },
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: { id: "m:0", messageID: "m", sessionID: "s", type: "text", text: "" },
+        },
+      },
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "s",
+          messageID: "m",
+          partID: "m:0",
+          field: "text",
+          delta: "hello world",
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: { id: "m:0", messageID: "m", sessionID: "s", type: "text", text: "hello world" },
+        },
+      },
+      { type: "session.status", properties: { sessionID: "s", status: { type: "idle" } } },
+      { type: "session.idle", properties: { sessionID: "s" } },
+    ]);
+  });
+
+  test("emits an error before terminal idle events for failed execution", () => {
+    const state = createV2EventTranslationState();
+    expect(translateV2Event({
+      type: "session.execution.failed",
+      properties: { sessionID: "ses_2", error: { message: "provider failed" } },
+    }, state)).toEqual([
+      {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_2",
+          error: { name: "UnknownError", data: { message: "provider failed" } },
+        },
+      },
+      { type: "session.status", properties: { sessionID: "ses_2", status: { type: "idle" } } },
+      { type: "session.idle", properties: { sessionID: "ses_2" } },
+    ]);
+  });
+});

--- a/apps/server/src/engine-v2-preview.test.ts
+++ b/apps/server/src/engine-v2-preview.test.ts
@@ -1,6 +1,67 @@
 import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { mapRuntimeProvidersToV2Specs } from "./engine-v2-preview.js";
+import {
+  createEngineV2Preview,
+  mapRuntimeProvidersToV2Specs,
+  readEngineV2PreviewState,
+  writeEngineV2PreviewState,
+} from "./engine-v2-preview.js";
+import type { ServerConfig } from "./types.js";
+
+function testConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "client-token",
+    hostToken: "host-token",
+    configPath: join(root, "openwork-server.json"),
+    approval: { mode: "manual", timeoutMs: 1_000 },
+    corsOrigins: [],
+    workspaces: [],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+test("round trips enabled and chat routing state and defaults corrupt state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-engine-v2-preview-"));
+  const config = testConfig(root);
+  try {
+    await writeEngineV2PreviewState(config, { enabled: true, chatRouting: true });
+    expect(readEngineV2PreviewState(config)).toEqual({ enabled: true, chatRouting: true });
+
+    await writeFile(join(root, "engine-v2-preview.json"), "{invalid", "utf8");
+    expect(readEngineV2PreviewState(config)).toEqual({ enabled: false, chatRouting: false });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("persists chat routing and includes it in preview status without starting the engine", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-engine-v2-preview-"));
+  const config = testConfig(root);
+  const preview = createEngineV2Preview({ config });
+  try {
+    expect(preview.status().chatRouting).toBe(false);
+    const status = await preview.setChatRouting(true);
+    expect(status.chatRouting).toBe(true);
+    expect(status.enabled).toBe(false);
+    expect(status.running).toBe(false);
+    expect(preview.connection()).toBeUndefined();
+    expect(readEngineV2PreviewState(config)).toEqual({ enabled: false, chatRouting: true });
+  } finally {
+    await preview.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("maps runtime provider fields and models to an OpenCode v2 spec", () => {
   expect(mapRuntimeProvidersToV2Specs({

--- a/apps/server/src/engine-v2-preview.test.ts
+++ b/apps/server/src/engine-v2-preview.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+
+import { mapRuntimeProvidersToV2Specs } from "./engine-v2-preview.js";
+
+test("maps runtime provider fields and models to an OpenCode v2 spec", () => {
+  expect(mapRuntimeProvidersToV2Specs({
+    example: {
+      name: "Example Provider",
+      npm: "@ai-sdk/openai-compatible",
+      options: { baseURL: "https://example.test/v1", apiKey: "secret" },
+      models: {
+        "model-b": {},
+        "model-a": { name: "Model A" },
+      },
+    },
+  })).toEqual({
+    specs: [{
+      id: "example",
+      name: "Example Provider",
+      baseUrl: "https://example.test/v1",
+      apiKey: "secret",
+      models: [
+        { id: "model-a", name: "Model A" },
+        { id: "model-b", name: "model-b" },
+      ],
+    }],
+    skippedProviderIds: [],
+  });
+});
+
+test("skips providers without a non-empty base URL", () => {
+  const result = mapRuntimeProvidersToV2Specs({ missing: { options: { apiKey: "secret" } } });
+  expect(result.skippedProviderIds).toEqual(["missing"]);
+  expect(result.specs).toEqual([]);
+});
+
+test("maps providers without an API key using the preview sentinel", () => {
+  expect(mapRuntimeProvidersToV2Specs({
+    noKey: { options: { baseURL: "https://example.test/v1" } },
+  }).specs).toEqual([{
+    id: "noKey",
+    name: "noKey",
+    baseUrl: "https://example.test/v1",
+    apiKey: "openwork-engine-v2-preview-unset",
+    models: [],
+  }]);
+});
+
+test("skips non-record provider values without throwing", () => {
+  expect(mapRuntimeProvidersToV2Specs({ array: [], nil: null, number: 42, text: "provider" })).toEqual({
+    specs: [],
+    skippedProviderIds: ["array", "nil", "number", "text"],
+  });
+});
+
+test("sorts mapped and skipped provider IDs deterministically", () => {
+  const result = mapRuntimeProvidersToV2Specs({
+    zebra: { options: { baseURL: "https://zebra.test/v1" } },
+    yak: {},
+    alpha: { options: { baseURL: "https://alpha.test/v1" } },
+    beta: null,
+  });
+  expect(result.specs.map((spec) => spec.id)).toEqual(["alpha", "zebra"]);
+  expect(result.skippedProviderIds).toEqual(["beta", "yak"]);
+});

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -1,0 +1,387 @@
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import constants from "../../../constants.json" with { type: "json" };
+import {
+  createManagedOpencodeV2Server,
+  type ManagedOpencodeV2Server,
+  type OpencodeV2ProviderSpec,
+} from "./managed-opencode-v2.js";
+import { runtimeStorageDir } from "./runtime-db.js";
+import {
+  isEngineGlobalRuntimeConfigId,
+  onRuntimeOpencodeConfigWrite,
+  readGlobalRuntimeOpencodeConfig,
+  runtimeProviderMap,
+} from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+const OPENCODE_V2_VERSION = constants.opencodeV2Version;
+const PREVIEW_STATE_FILE = "engine-v2-preview.json";
+const UNSET_API_KEY = "openwork-engine-v2-preview-unset";
+
+export interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  version?: string;
+  pid?: number;
+  binSource?: "env" | "path" | "cache";
+  mirroredProviderIds: string[];
+  skippedProviderIds: string[];
+  catalogModelIds: string[];
+  lastMirroredAt?: string;
+  lastError?: string;
+}
+
+export interface RuntimeProviderRecordLike {
+  name?: string;
+  npm?: string;
+  options?: {
+    baseURL?: string;
+    apiKey?: string;
+  };
+  models?: Record<string, unknown>;
+}
+
+export interface EngineV2Preview {
+  status(): EngineV2PreviewStatus;
+  setEnabled(enabled: boolean): Promise<EngineV2PreviewStatus>;
+  stop(): Promise<void>;
+}
+
+interface ResolvedBinary {
+  bin: string;
+  source: "env" | "path" | "cache";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function statePath(config: ServerConfig): string {
+  return join(runtimeStorageDir(config), PREVIEW_STATE_FILE);
+}
+
+function readEnabled(config: ServerConfig): boolean {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(statePath(config), "utf8"));
+    return isRecord(parsed) && parsed.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+async function persistEnabled(config: ServerConfig, enabled: boolean): Promise<void> {
+  await mkdir(runtimeStorageDir(config), { recursive: true });
+  await writeFile(statePath(config), `${JSON.stringify({ enabled }, null, 2)}\n`, "utf8");
+}
+
+function exec(file: string, args: string[], options: { cwd?: string; timeout?: number } = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveBinary(config: ServerConfig): Promise<ResolvedBinary> {
+  const override = process.env.OPENWORK_OPENCODE2_BIN?.trim();
+  if (override) return { bin: override, source: "env" };
+
+  let pathError = "not found";
+  try {
+    await exec("opencode2", ["--version"]);
+    return { bin: "opencode2", source: "path" };
+  } catch (error) {
+    pathError = errorMessage(error);
+  }
+
+  const cacheDir = join(runtimeStorageDir(config), "opencode-v2", OPENCODE_V2_VERSION);
+  const binary = join(cacheDir, "node_modules", ".bin", "opencode2");
+  try {
+    await mkdir(cacheDir, { recursive: true });
+    const packageJson = join(cacheDir, "package.json");
+    if (!(await pathExists(packageJson))) await writeFile(packageJson, '{"private":true}\n', "utf8");
+    if (!(await pathExists(binary))) {
+      await exec(
+        "npm",
+        ["install", "--no-fund", "--no-audit", "--no-save", `@opencode-ai/cli@${OPENCODE_V2_VERSION}`],
+        { cwd: cacheDir, timeout: 180_000 },
+      );
+    }
+    if (!(await pathExists(binary))) throw new Error(`installation did not create ${binary}`);
+    return { bin: binary, source: "cache" };
+  } catch (error) {
+    throw new Error(
+      `Unable to resolve OpenCode v2 (${pathError}; cache install: ${errorMessage(error)}). Set OPENWORK_OPENCODE2_BIN to a working opencode2 binary.`,
+    );
+  }
+}
+
+export function mapRuntimeProvidersToV2Specs(
+  providerMap: Record<string, unknown>,
+): { specs: OpencodeV2ProviderSpec[]; skippedProviderIds: string[] } {
+  const specs: OpencodeV2ProviderSpec[] = [];
+  const skippedProviderIds: string[] = [];
+
+  for (const [id, value] of Object.entries(providerMap)) {
+    if (!isRecord(value) || !isRecord(value.options)) {
+      skippedProviderIds.push(id);
+      continue;
+    }
+    const baseUrl = value.options.baseURL;
+    if (typeof baseUrl !== "string" || baseUrl.trim() === "") {
+      skippedProviderIds.push(id);
+      continue;
+    }
+
+    const models = isRecord(value.models)
+      ? Object.entries(value.models)
+        .map(([modelId, model]) => ({
+          id: modelId,
+          name: isRecord(model) && typeof model.name === "string" ? model.name : modelId,
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id))
+      : [];
+    specs.push({
+      id,
+      name: typeof value.name === "string" ? value.name : id,
+      baseUrl,
+      apiKey: typeof value.options.apiKey === "string" && value.options.apiKey !== ""
+        ? value.options.apiKey
+        : UNSET_API_KEY,
+      models,
+    });
+  }
+
+  specs.sort((left, right) => left.id.localeCompare(right.id));
+  skippedProviderIds.sort((left, right) => left.localeCompare(right));
+  return { specs, skippedProviderIds };
+}
+
+function catalogModelIds(payload: unknown, mirroredProviderIds: string[]): string[] {
+  const mirrored = new Set(mirroredProviderIds);
+  const ids = new Set<string>();
+
+  function visit(value: unknown, withinMirroredProvider: boolean): void {
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry, withinMirroredProvider);
+      return;
+    }
+    if (!isRecord(value)) return;
+
+    const providerId = typeof value.providerID === "string"
+      ? value.providerID
+      : typeof value.providerId === "string"
+        ? value.providerId
+        : undefined;
+    const withinProvider = withinMirroredProvider || (providerId !== undefined && mirrored.has(providerId));
+    if (withinProvider && typeof value.id === "string" && !mirrored.has(value.id)) ids.add(value.id);
+    if (withinProvider && isRecord(value.models)) {
+      for (const modelId of Object.keys(value.models)) ids.add(modelId);
+    }
+    for (const [key, child] of Object.entries(value)) {
+      visit(child, withinProvider || mirrored.has(key));
+    }
+  }
+
+  visit(payload, false);
+  return [...ids].sort((left, right) => left.localeCompare(right));
+}
+
+export function createEngineV2Preview(options: { config: ServerConfig }): EngineV2Preview {
+  const { config } = options;
+  const rootDir = join(runtimeStorageDir(config), "opencode-v2", "state");
+  const workspaceDir = join(rootDir, "workspace");
+  let enabled = readEnabled(config);
+  let allowRunning = true;
+  let running = false;
+  let version: string | undefined;
+  let pid: number | undefined;
+  let binSource: EngineV2PreviewStatus["binSource"];
+  let mirroredProviderIds: string[] = [];
+  let skippedProviderIds: string[] = [];
+  let currentCatalogModelIds: string[] = [];
+  let lastMirroredAt: string | undefined;
+  let lastError: string | undefined;
+  let sidecar: ManagedOpencodeV2Server | undefined;
+  let unsubscribe: (() => void) | undefined;
+  let startPromise: Promise<void> | undefined;
+  let mirrorInFlight: Promise<void> | undefined;
+  let mirrorDirty = false;
+
+  function status(): EngineV2PreviewStatus {
+    return {
+      enabled,
+      running,
+      ...(version === undefined ? {} : { version }),
+      ...(pid === undefined ? {} : { pid }),
+      ...(binSource === undefined ? {} : { binSource }),
+      mirroredProviderIds: [...mirroredProviderIds],
+      skippedProviderIds: [...skippedProviderIds],
+      catalogModelIds: [...currentCatalogModelIds],
+      ...(lastMirroredAt === undefined ? {} : { lastMirroredAt }),
+      ...(lastError === undefined ? {} : { lastError }),
+    };
+  }
+
+  async function mirrorProviders(): Promise<void> {
+    const active = sidecar;
+    if (!active) return;
+    const providerMap = runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config));
+    const mapped = mapRuntimeProvidersToV2Specs(providerMap);
+    await active.setProviders(mapped.specs);
+    const nextMirroredProviderIds = mapped.specs.map((spec) => spec.id);
+    const expectedModelIds = mapped.specs.flatMap((spec) => spec.models.map((model) => model.id));
+    const deadline = Date.now() + 15_000;
+    let catalog = await active.fetchJson("/api/model", { directory: workspaceDir });
+    let nextCatalogModelIds = catalogModelIds(catalog.json, nextMirroredProviderIds);
+    while (expectedModelIds.some((modelId) => !nextCatalogModelIds.includes(modelId)) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      catalog = await active.fetchJson("/api/model", { directory: workspaceDir });
+      nextCatalogModelIds = catalogModelIds(catalog.json, nextMirroredProviderIds);
+    }
+    currentCatalogModelIds = nextCatalogModelIds;
+    mirroredProviderIds = nextMirroredProviderIds;
+    skippedProviderIds = [...mapped.skippedProviderIds];
+    lastMirroredAt = new Date().toISOString();
+    lastError = undefined;
+  }
+
+  function scheduleMirror(): void {
+    mirrorDirty = true;
+    if (mirrorInFlight) return;
+    mirrorInFlight = (async () => {
+      try {
+        while (mirrorDirty && allowRunning && sidecar) {
+          mirrorDirty = false;
+          try {
+            await mirrorProviders();
+          } catch (error) {
+            lastError = errorMessage(error);
+          }
+        }
+      } finally {
+        mirrorInFlight = undefined;
+        if (mirrorDirty && allowRunning && sidecar) scheduleMirror();
+      }
+    })();
+    void mirrorInFlight;
+  }
+
+  async function closeSidecar(): Promise<void> {
+    const active = sidecar;
+    sidecar = undefined;
+    running = false;
+    version = undefined;
+    pid = undefined;
+    if (!active) return;
+    try {
+      await active.close();
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+  }
+
+  async function startSidecar(): Promise<void> {
+    const resolved = await resolveBinary(config);
+    binSource = resolved.source;
+    if (!enabled || !allowRunning) return;
+    await mkdir(workspaceDir, { recursive: true });
+    const managed = await createManagedOpencodeV2Server({ bin: resolved.bin, rootDir });
+    sidecar = managed;
+    if (!enabled || !allowRunning) {
+      await closeSidecar();
+      return;
+    }
+    try {
+      const health = await managed.health();
+      version = health.version;
+      pid = health.pid;
+      running = health.healthy;
+      unsubscribe = onRuntimeOpencodeConfigWrite((_writeConfig, workspaceId) => {
+        if (!isEngineGlobalRuntimeConfigId(workspaceId)) return;
+        scheduleMirror();
+      });
+      scheduleMirror();
+      if (mirrorInFlight) await mirrorInFlight;
+      if (!enabled || !allowRunning) {
+        await closeSidecar();
+        return;
+      }
+    } catch (error) {
+      await closeSidecar();
+      throw error;
+    }
+  }
+
+  async function start(): Promise<void> {
+    if (sidecar) return;
+    if (startPromise) {
+      await startPromise;
+      return;
+    }
+    const pending = startSidecar();
+    startPromise = pending;
+    try {
+      await pending;
+    } finally {
+      if (startPromise === pending) startPromise = undefined;
+    }
+  }
+
+  function recordStartError(error: unknown): void {
+    running = false;
+    lastError = `${errorMessage(error)} Set OPENWORK_OPENCODE2_BIN to a working opencode2 binary to override resolution.`;
+  }
+
+  async function stopRuntime(): Promise<void> {
+    allowRunning = false;
+    unsubscribe?.();
+    unsubscribe = undefined;
+    mirrorDirty = false;
+    if (startPromise) await startPromise.catch(() => undefined);
+    if (mirrorInFlight) await mirrorInFlight;
+    await closeSidecar();
+  }
+
+  async function setEnabled(nextEnabled: boolean): Promise<EngineV2PreviewStatus> {
+    if (nextEnabled && enabled && running) return status();
+    await persistEnabled(config, nextEnabled);
+    enabled = nextEnabled;
+    if (!enabled) {
+      await stopRuntime();
+      return status();
+    }
+    allowRunning = true;
+    lastError = undefined;
+    // Fire and forget: binary resolution can install from npm and boot can take
+    // tens of seconds, while renderer config requests time out after 10s. The
+    // status endpoint reports progress and records failures via lastError.
+    void start().catch(recordStartError);
+    return status();
+  }
+
+  async function stop(): Promise<void> {
+    await stopRuntime();
+  }
+
+  if (enabled) void start().catch(recordStartError);
+  return { status, setEnabled, stop };
+}

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -24,6 +24,7 @@ const UNSET_API_KEY = "openwork-engine-v2-preview-unset";
 
 export interface EngineV2PreviewStatus {
   enabled: boolean;
+  chatRouting: boolean;
   running: boolean;
   version?: string;
   pid?: number;
@@ -48,7 +49,14 @@ export interface RuntimeProviderRecordLike {
 export interface EngineV2Preview {
   status(): EngineV2PreviewStatus;
   setEnabled(enabled: boolean): Promise<EngineV2PreviewStatus>;
+  setChatRouting(chatRouting: boolean): Promise<EngineV2PreviewStatus>;
+  connection(): { url: string; username: string; password: string } | undefined;
   stop(): Promise<void>;
+}
+
+export interface EngineV2PreviewState {
+  enabled: boolean;
+  chatRouting?: boolean;
 }
 
 interface ResolvedBinary {
@@ -68,18 +76,28 @@ function statePath(config: ServerConfig): string {
   return join(runtimeStorageDir(config), PREVIEW_STATE_FILE);
 }
 
-function readEnabled(config: ServerConfig): boolean {
+export function readEngineV2PreviewState(config: ServerConfig): EngineV2PreviewState {
   try {
     const parsed: unknown = JSON.parse(readFileSync(statePath(config), "utf8"));
-    return isRecord(parsed) && parsed.enabled === true;
+    if (
+      !isRecord(parsed)
+      || typeof parsed.enabled !== "boolean"
+      || (parsed.chatRouting !== undefined && typeof parsed.chatRouting !== "boolean")
+    ) {
+      return { enabled: false, chatRouting: false };
+    }
+    return { enabled: parsed.enabled, chatRouting: parsed.chatRouting === true };
   } catch {
-    return false;
+    return { enabled: false, chatRouting: false };
   }
 }
 
-async function persistEnabled(config: ServerConfig, enabled: boolean): Promise<void> {
+export async function writeEngineV2PreviewState(
+  config: ServerConfig,
+  state: EngineV2PreviewState,
+): Promise<void> {
   await mkdir(runtimeStorageDir(config), { recursive: true });
-  await writeFile(statePath(config), `${JSON.stringify({ enabled }, null, 2)}\n`, "utf8");
+  await writeFile(statePath(config), `${JSON.stringify(state, null, 2)}\n`, "utf8");
 }
 
 function exec(file: string, args: string[], options: { cwd?: string; timeout?: number } = {}): Promise<void> {
@@ -209,7 +227,9 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
   const { config } = options;
   const rootDir = join(runtimeStorageDir(config), "opencode-v2", "state");
   const workspaceDir = join(rootDir, "workspace");
-  let enabled = readEnabled(config);
+  const persistedState = readEngineV2PreviewState(config);
+  let enabled = persistedState.enabled;
+  let chatRouting = persistedState.chatRouting === true;
   let allowRunning = true;
   let running = false;
   let version: string | undefined;
@@ -229,6 +249,7 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
   function status(): EngineV2PreviewStatus {
     return {
       enabled,
+      chatRouting,
       running,
       ...(version === undefined ? {} : { version }),
       ...(pid === undefined ? {} : { pid }),
@@ -363,7 +384,7 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
 
   async function setEnabled(nextEnabled: boolean): Promise<EngineV2PreviewStatus> {
     if (nextEnabled && enabled && running) return status();
-    await persistEnabled(config, nextEnabled);
+    await writeEngineV2PreviewState(config, { enabled: nextEnabled, chatRouting });
     enabled = nextEnabled;
     if (!enabled) {
       await stopRuntime();
@@ -378,10 +399,21 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
     return status();
   }
 
+  async function setChatRouting(nextChatRouting: boolean): Promise<EngineV2PreviewStatus> {
+    await writeEngineV2PreviewState(config, { enabled, chatRouting: nextChatRouting });
+    chatRouting = nextChatRouting;
+    return status();
+  }
+
+  function connection(): { url: string; username: string; password: string } | undefined {
+    if (!running || !sidecar) return undefined;
+    return { url: sidecar.url, username: sidecar.username, password: sidecar.password };
+  }
+
   async function stop(): Promise<void> {
     await stopRuntime();
   }
 
   if (enabled) void start().catch(recordStartError);
-  return { status, setEnabled, stop };
+  return { status, setEnabled, setChatRouting, connection, stop };
 }

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -6,6 +6,8 @@ import { mkdir, rename, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { join } from "node:path";
 
+import { loopbackFetch } from "./server-fetch.js";
+
 export interface OpencodeV2ModelSpec {
   id: string;
   name: string;
@@ -131,7 +133,7 @@ export async function createManagedOpencodeV2Server(
     const requestPath = init.directory === undefined
       ? path
       : `${path}${separator}location%5Bdirectory%5D=${encodeURIComponent(init.directory)}`;
-    const response = await fetch(`${url}${requestPath}`, {
+    const response = await loopbackFetch(`${url}${requestPath}`, {
       method: init.method,
       headers: {
         authorization,

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -1,0 +1,241 @@
+// Parallel v2 lane prototype: provider injection is a watched-config write. This module
+// deliberately has no reload/dispose call, unlike managed-opencode.ts and server.ts reloadOpencodeEngine.
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { join } from "node:path";
+
+export interface OpencodeV2ModelSpec {
+  id: string;
+  name: string;
+}
+
+export interface OpencodeV2ProviderSpec {
+  id: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  models: OpencodeV2ModelSpec[];
+}
+
+export interface ManagedOpencodeV2ServerOptions {
+  bin: string;
+  rootDir: string;
+  hostname?: string;
+  port?: number;
+  env?: Record<string, string>;
+  bootTimeoutMs?: number;
+}
+
+export interface OpencodeV2Health {
+  healthy: boolean;
+  version: string;
+  pid: number;
+}
+
+export interface ManagedOpencodeV2Server {
+  url: string;
+  username: string;
+  password: string;
+  childPid: number | undefined;
+  readonly exitCode: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  health(): Promise<OpencodeV2Health>;
+  fetchJson(path: string, init?: { method?: string; body?: unknown; directory?: string }): Promise<{ status: number; json: unknown }>;
+  injectProvider(spec: OpencodeV2ProviderSpec): Promise<void>;
+  close(): Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function freePort(hostname: string): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, hostname, () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(new Error("Failed to allocate a free TCP port"));
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
+
+function diagnostics(exitCode: number | null, stdout: string, stderr: string): Error {
+  const tail = (value: string) => value.slice(-4_000);
+  return new Error(
+    `OpenCode v2 server exited with code ${String(exitCode)}\nstdout:\n${tail(stdout)}\nstderr:\n${tail(stderr)}`,
+  );
+}
+
+export async function createManagedOpencodeV2Server(
+  options: ManagedOpencodeV2ServerOptions,
+): Promise<ManagedOpencodeV2Server> {
+  const hostname = options.hostname ?? "127.0.0.1";
+  const port = options.port ?? await freePort(hostname);
+  const bootTimeoutMs = options.bootTimeoutMs ?? 60_000;
+  const configDir = join(options.rootDir, "config");
+  const password = randomBytes(24).toString("base64url");
+  const username = "opencode";
+  const url = `http://${hostname}:${port}`;
+  const providers = new Map<string, OpencodeV2ProviderSpec>();
+
+  await mkdir(configDir, { recursive: true });
+  const child = spawn(options.bin, ["serve", "--hostname", hostname, "--port", String(port)], {
+    env: {
+      ...process.env,
+      ...options.env,
+      OPENCODE_PASSWORD: password,
+      OPENCODE_DB: join(options.rootDir, "opencode.db"),
+      OPENCODE_CONFIG_DIR: configDir,
+      OPENCODE_DISABLE_MODELS_FETCH: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let spawnError: Error | undefined;
+  child.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  child.on("error", (error) => {
+    spawnError = error;
+  });
+
+  const authorization = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+
+  async function fetchJson(
+    path: string,
+    init: { method?: string; body?: unknown; directory?: string } = {},
+  ): Promise<{ status: number; json: unknown }> {
+    const separator = path.includes("?") ? "&" : "?";
+    const requestPath = init.directory === undefined
+      ? path
+      : `${path}${separator}location%5Bdirectory%5D=${encodeURIComponent(init.directory)}`;
+    const response = await fetch(`${url}${requestPath}`, {
+      method: init.method,
+      headers: {
+        authorization,
+        "content-type": "application/json",
+      },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    });
+    const text = await response.text();
+    let json: unknown = text;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // Non-JSON engine responses remain observable as raw text.
+    }
+    return { status: response.status, json };
+  }
+
+  async function health(): Promise<OpencodeV2Health> {
+    const response = await fetchJson("/api/health");
+    if (response.status !== 200 || !isRecord(response.json)) {
+      throw new Error(`OpenCode v2 health returned HTTP ${response.status}`);
+    }
+    const { healthy, version, pid } = response.json;
+    if (typeof healthy !== "boolean" || typeof version !== "string" || typeof pid !== "number") {
+      throw new Error("OpenCode v2 health returned an invalid payload");
+    }
+    return { healthy, version, pid };
+  }
+
+  async function close(): Promise<void> {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    const exit = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    child.kill("SIGTERM");
+    const exited = await Promise.race([
+      exit.then(() => true),
+      sleep(2_000).then(() => false),
+    ]);
+    if (!exited && child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await exit;
+    }
+  }
+
+  const managed: ManagedOpencodeV2Server = {
+    url,
+    username,
+    password,
+    childPid: child.pid,
+    get exitCode() {
+      return child.exitCode;
+    },
+    get stdout() {
+      return stdout;
+    },
+    get stderr() {
+      return stderr;
+    },
+    health,
+    fetchJson,
+    async injectProvider(spec) {
+      providers.set(spec.id, spec);
+      const providerConfig: Record<string, unknown> = {};
+      for (const provider of providers.values()) {
+        const models: Record<string, unknown> = {};
+        for (const model of provider.models) {
+          models[model.id] = {
+            name: model.name,
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+            limit: { context: 128_000, output: 8_192 },
+          };
+        }
+        providerConfig[provider.id] = {
+          name: provider.name,
+          package: "@opencode-ai/ai/providers/openai-compatible",
+          settings: { baseURL: provider.baseUrl, apiKey: provider.apiKey, name: provider.id },
+          models,
+        };
+      }
+      const target = join(configDir, "opencode.json");
+      const temporary = `${target}.tmp-${randomBytes(8).toString("hex")}`;
+      await writeFile(temporary, `${JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        providers: providerConfig,
+      }, null, 2)}\n`);
+      await rename(temporary, target);
+    },
+    close,
+  };
+
+  const deadline = Date.now() + bootTimeoutMs;
+  while (Date.now() < deadline) {
+    if (spawnError !== undefined) {
+      await close();
+      throw new Error(`Failed to start OpenCode v2 server: ${spawnError.message}`);
+    }
+    if (child.exitCode !== null || child.signalCode !== null) throw diagnostics(child.exitCode, stdout, stderr);
+    try {
+      const state = await health();
+      if (state.healthy) return managed;
+    } catch {
+      // The engine can return 503 or refuse connections while booting.
+    }
+    await sleep(250);
+  }
+
+  await close();
+  throw new Error(`Timed out waiting ${bootTimeoutMs}ms for OpenCode v2 health\nstdout:\n${stdout.slice(-4_000)}\nstderr:\n${stderr.slice(-4_000)}`);
+}

--- a/apps/server/src/managed-opencode-v2.ts
+++ b/apps/server/src/managed-opencode-v2.ts
@@ -45,6 +45,7 @@ export interface ManagedOpencodeV2Server {
   health(): Promise<OpencodeV2Health>;
   fetchJson(path: string, init?: { method?: string; body?: unknown; directory?: string }): Promise<{ status: number; json: unknown }>;
   injectProvider(spec: OpencodeV2ProviderSpec): Promise<void>;
+  setProviders(specs: OpencodeV2ProviderSpec[]): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -160,6 +161,33 @@ export async function createManagedOpencodeV2Server(
     return { healthy, version, pid };
   }
 
+  async function writeProviders(): Promise<void> {
+    const providerConfig: Record<string, unknown> = {};
+    for (const provider of providers.values()) {
+      const models: Record<string, unknown> = {};
+      for (const model of provider.models) {
+        models[model.id] = {
+          name: model.name,
+          capabilities: { tools: true, input: ["text"], output: ["text"] },
+          limit: { context: 128_000, output: 8_192 },
+        };
+      }
+      providerConfig[provider.id] = {
+        name: provider.name,
+        package: "@opencode-ai/ai/providers/openai-compatible",
+        settings: { baseURL: provider.baseUrl, apiKey: provider.apiKey, name: provider.id },
+        models,
+      };
+    }
+    const target = join(configDir, "opencode.json");
+    const temporary = `${target}.tmp-${randomBytes(8).toString("hex")}`;
+    await writeFile(temporary, `${JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      providers: providerConfig,
+    }, null, 2)}\n`);
+    await rename(temporary, target);
+  }
+
   async function close(): Promise<void> {
     if (child.exitCode !== null || child.signalCode !== null) return;
     const exit = new Promise<void>((resolve) => child.once("exit", () => resolve()));
@@ -192,30 +220,14 @@ export async function createManagedOpencodeV2Server(
     fetchJson,
     async injectProvider(spec) {
       providers.set(spec.id, spec);
-      const providerConfig: Record<string, unknown> = {};
-      for (const provider of providers.values()) {
-        const models: Record<string, unknown> = {};
-        for (const model of provider.models) {
-          models[model.id] = {
-            name: model.name,
-            capabilities: { tools: true, input: ["text"], output: ["text"] },
-            limit: { context: 128_000, output: 8_192 },
-          };
-        }
-        providerConfig[provider.id] = {
-          name: provider.name,
-          package: "@opencode-ai/ai/providers/openai-compatible",
-          settings: { baseURL: provider.baseUrl, apiKey: provider.apiKey, name: provider.id },
-          models,
-        };
+      await writeProviders();
+    },
+    async setProviders(specs) {
+      providers.clear();
+      for (const spec of specs) {
+        providers.set(spec.id, spec);
       }
-      const target = join(configDir, "opencode.json");
-      const temporary = `${target}.tmp-${randomBytes(8).toString("hex")}`;
-      await writeFile(temporary, `${JSON.stringify({
-        $schema: "https://opencode.ai/config.json",
-        providers: providerConfig,
-      }, null, 2)}\n`);
-      await rename(temporary, target);
+      await writeProviders();
     },
     close,
   };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -134,6 +134,7 @@ import {
 import { buildOpenworkRuntimeConfigObject, openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
 import { CloudProviderSync, parseCloudProviderDenSession } from "./cloud-provider-sync.js";
+import { createEngineV2Preview, type EngineV2Preview } from "./engine-v2-preview.js";
 import pkg from "../package.json" with { type: "json" };
 import constants from "../../../constants.json" with { type: "json" };
 
@@ -920,6 +921,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
       : engineHasActiveSessions(config, resolveEngineRuntimeWorkspace(config)),
     logger: toManagedProviderAuthLogger(logger),
   });
+  const engineV2Preview = createEngineV2Preview({ config });
   const routes = createRoutes(
     config,
     approvals,
@@ -929,6 +931,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     engineMcpServerState,
     logger,
     cloudProviderSync,
+    engineV2Preview,
   );
 
   const serverOptions: {
@@ -1130,6 +1133,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   } catch (error) {
     captureServerException(error, { method: "START", route: "startServer" });
     cloudProviderSync.stop();
+    await engineV2Preview.stop().catch(() => undefined);
     engineInstanceReaper.close();
     clearEngineInstanceReaperForConfig(config);
     invalidateEngineMcpServerState(config, engineMcpServerState);
@@ -1170,6 +1174,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
     ...server,
     stop: async () => {
       cloudProviderSync.stop();
+      await engineV2Preview.stop().catch(() => undefined);
       engineInstanceReaper.close();
       clearEngineInstanceReaperForConfig(config);
       invalidateEngineMcpServerState(config, engineMcpServerState);
@@ -2046,6 +2051,7 @@ function createRoutes(
   engineMcpServerState: EngineMcpServerState,
   logger: ServerLogger,
   cloudProviderSync: CloudProviderSync,
+  engineV2Preview: EngineV2Preview,
 ): Route[] {
   const routes: Route[] = [];
   registerCoreRoutes({
@@ -2561,6 +2567,20 @@ function createRoutes(
 
   addRoute(routes, "GET", "/cloud-provider-sync/status", "client", async () => {
     return jsonResponse(cloudProviderSync.status());
+  });
+
+  addRoute(routes, "GET", "/experimental/engine-v2-preview/status", "client", async () => {
+    return jsonResponse(engineV2Preview.status());
+  });
+
+  addRoute(routes, "PUT", "/experimental/engine-v2-preview", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const body = await readJsonBody(ctx.request);
+    if (!isRecord(body) || typeof body.enabled !== "boolean") {
+      throw new ApiError(400, "invalid_payload", "enabled must be a boolean");
+    }
+    return jsonResponse(await engineV2Preview.setEnabled(body.enabled));
   });
 
   addRoute(routes, "PATCH", "/runtime-config/providers", "host-token", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -796,6 +796,19 @@ function parseWorkspaceOpencodeMount(pathname: string): { workspaceId: string; r
   return { workspaceId: decodeURIComponent(workspaceId), restPath };
 }
 
+function parseWorkspaceOpencodeV2Mount(pathname: string): { workspaceId: string; restPath: string } | null {
+  if (!pathname.startsWith("/workspace/")) return null;
+  const remainder = pathname.slice("/workspace/".length);
+  if (!remainder) return null;
+  const slash = remainder.indexOf("/");
+  if (slash === -1) return null;
+  const workspaceId = remainder.slice(0, slash);
+  const restPath = remainder.slice(slash) || "/";
+  if (!workspaceId.trim()) return null;
+  if (restPath !== "/opencode2" && !restPath.startsWith("/opencode2/")) return null;
+  return { workspaceId: decodeURIComponent(workspaceId), restPath };
+}
+
 function normalizeOpencodeProxyPath(proxyPath: string): string {
   const raw = (proxyPath ?? "").trim() || "/";
   const withoutPrefix = raw.startsWith("/opencode") ? raw.slice("/opencode".length) : raw;
@@ -1007,6 +1020,42 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
         }
       };
 
+      const proxyWorkspaceOpencodeV2Mount = async (mount: { workspaceId: string; restPath: string }) => {
+        authMode = "client";
+        try {
+          const actor = await requireClient(request, config, tokens);
+          assertOpencodeProxyAllowed(actor, request.method, mount.restPath);
+          const workspace = await resolveWorkspaceWithoutBootstrap(config, mount.workspaceId);
+          const connection = engineV2Preview.connection();
+          if (!connection) {
+            return finalize(jsonResponse({ error: "engine_v2_preview_not_running" }, 503));
+          }
+          proxyService = "opencode";
+          proxyBaseUrl = connection.url;
+          const response = await proxyOpencodeV2Request({
+            config,
+            request,
+            url,
+            workspace,
+            proxyPath: mount.restPath,
+            connection,
+          });
+          return finalize(response);
+        } catch (error) {
+          const requestCanceled = isExpectedRequestCancellation(error, request.signal);
+          if (!(error instanceof ApiError) && !requestCanceled) {
+            captureServerException(error, { method: request.method, route: "/workspace/:id/opencode2/*", requestSignal: request.signal });
+          }
+          const apiError = error instanceof ApiError
+            ? error
+            : requestCanceled
+              ? new ApiError(499, "request_aborted", "Request was canceled")
+              : new ApiError(500, "internal_error", "Unexpected server error");
+          recordApiError(apiError);
+          return finalize(jsonResponse(formatError(apiError), apiError.status));
+        }
+      };
+
       if (request.method === "OPTIONS") {
         return finalize(new Response(null, { status: 204 }));
       }
@@ -1014,6 +1063,11 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
       const canonicalOpencodeMount = parseWorkspaceOpencodeMount(url.pathname);
       if (canonicalOpencodeMount) {
         return proxyWorkspaceOpencodeMount(canonicalOpencodeMount);
+      }
+
+      const canonicalOpencodeV2Mount = parseWorkspaceOpencodeV2Mount(url.pathname);
+      if (canonicalOpencodeV2Mount) {
+        return proxyWorkspaceOpencodeV2Mount(canonicalOpencodeV2Mount);
       }
 
       const mount = parseWorkspaceMount(url.pathname);
@@ -1191,6 +1245,43 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   target.pathname = trimmedPath.startsWith("/") ? trimmedPath : `/${trimmedPath}`;
   target.search = search;
   return target.toString();
+}
+
+async function proxyOpencodeV2Request(input: {
+  config: ServerConfig;
+  request: Request;
+  url: URL;
+  workspace: WorkspaceInfo;
+  proxyPath: string;
+  connection: { url: string; username: string; password: string };
+}): Promise<Response> {
+  const method = input.request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") ensureWritable(input.config);
+
+  const withoutPrefix = input.proxyPath.slice("/opencode2".length);
+  const forwardedPath = withoutPrefix || "/";
+  const target = new URL(input.connection.url);
+  target.pathname = forwardedPath;
+  target.search = input.url.search;
+  if (forwardedPath.startsWith("/api/")) {
+    const hasLocation = [...target.searchParams.keys()]
+      .some((key) => key === "location" || key.startsWith("location["));
+    if (!hasLocation) target.searchParams.append("location[directory]", input.workspace.path);
+  }
+
+  const headers = new Headers(input.request.headers);
+  headers.delete("authorization");
+  headers.delete("x-openwork-host-token");
+  headers.delete("x-openwork-client-id");
+  headers.delete("host");
+  headers.delete("origin");
+  headers.set("authorization", `Basic ${Buffer.from(`opencode:${input.connection.password}`).toString("base64")}`);
+
+  const body = method === "GET" || method === "HEAD"
+    ? undefined
+    : await input.request.arrayBuffer().then((buffer) => buffer.byteLength > 0 ? buffer : undefined);
+  const response = await loopbackFetch(target.toString(), { method, headers, body });
+  return sanitizeProxyResponse(response);
 }
 
 function opencodeUnreachableError(error: unknown, path: string): ApiError {
@@ -2577,10 +2668,19 @@ function createRoutes(
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
     const body = await readJsonBody(ctx.request);
-    if (!isRecord(body) || typeof body.enabled !== "boolean") {
+    if (!isRecord(body) || (body.enabled === undefined && body.chatRouting === undefined)) {
+      throw new ApiError(400, "invalid_payload", "enabled or chatRouting must be provided");
+    }
+    if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
       throw new ApiError(400, "invalid_payload", "enabled must be a boolean");
     }
-    return jsonResponse(await engineV2Preview.setEnabled(body.enabled));
+    if (body.chatRouting !== undefined && typeof body.chatRouting !== "boolean") {
+      throw new ApiError(400, "invalid_payload", "chatRouting must be a boolean");
+    }
+    let status = engineV2Preview.status();
+    if (typeof body.enabled === "boolean") status = await engineV2Preview.setEnabled(body.enabled);
+    if (typeof body.chatRouting === "boolean") status = await engineV2Preview.setChatRouting(body.chatRouting);
+    return jsonResponse(status);
   });
 
   addRoute(routes, "PATCH", "/runtime-config/providers", "host-token", async (ctx) => {

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,4 @@
 {
-  "opencodeVersion": "v1.18.18"
+  "opencodeVersion": "v1.18.18",
+  "opencodeV2Version": "0.0.0-beta-18707"
 }

--- a/docs/opencode-v1-v2-benchmarks.md
+++ b/docs/opencode-v1-v2-benchmarks.md
@@ -1,0 +1,335 @@
+# OpenCode v1 vs v2 benchmarks
+
+This note records two benchmark lanes run on the same machine with the same
+deterministic witness provider. All durations are milliseconds. Medians and
+ranges below are calculated directly from the sample arrays in:
+
+- `evals/bench/results/2026-08-31-m3max-engines.json`
+- `evals/bench/results/2026-08-31-m3max-app-v1.json`
+- `evals/bench/results/2026-09-01-m3max-app-v2.json`
+
+## What was asked and what each lane answers
+
+The original questions map to the measured scenarios as follows.
+
+| User question | App-perspective metric | Engine-perspective metric |
+| --- | --- | --- |
+| Time to first session, first load, and first send | `cold_boot_to_composer`, `first_send_cold` | `boot_ready`, `spawn_to_first_api_ok`, `first_prompt_cold` |
+| Time to a ready session | `new_session_ready` | `session_create` |
+| Workspace switch speed | `workspace_switch.aToB`, `workspace_switch.bToA` | `directory_switch` |
+| Message response time | `message_rtt.userRendered`, `firstToken`, `complete` | `message.accepted`, `witness_first_byte`, `first_token`, `complete` |
+| Very long message and compaction | `long_message`, `uiCompactionAvailable` | `long.*`, `compaction` |
+
+### Lane A: app perspective, pure CDP
+
+Lane A runs the real OpenWork Electron app on the v1 engine. It drives the app
+only through the UI: CDP `Input.insertText` types into the real composer and
+the real controls are clicked.
+
+The witness provider is provisioned by a file on disk before workspace
+creation. The benchmark chooses its model through the picker UI. There is zero
+API seeding of workspaces, sessions, messages, or model selection.
+
+This is the lane that answers what an OpenWork user sees today.
+
+### Lane B: engine vs engine
+
+Lane B compares the v1 engine, `opencode` 1.18.18, with the v2 engine,
+`opencode2` 0.0.0-beta-18707. It sends identical user-shaped sequences over
+each engine's own HTTP dialect and routes both engines to the same kind of
+witness.
+
+This isolates the engine boundary from OpenWork renderer and Electron costs.
+
+### Why the pure-CDP v2 app lane arrived through the adapter
+
+OpenWork's UI now routes chat through v2 behind the preview flag and the
+**Route chat through OpenCode v2** toggle from
+`feat/opencode-v2-chat-routing`. Lane A was rerun in that mode with
+`OPENWORK_BENCH_ENGINE=v2`, using the server-to-engine dialect adapter.
+
+Historically, the v2 stack's own drivable surface was not a substitute. Its web
+UI, bundled in the `opencode2` binary, crashed on `/new-session` with:
+
+```text
+Error: TitlebarRight must be used within TitlebarRightProvider
+```
+
+That failure was reproduced through CDP in Chrome 152 on 2026-08-30 with both
+0.0.0-beta-18707 and 0.0.0-dev-18710. A narrow-viewport layout crashed the same
+way. The older 0.0.0-beta-17823 home screen never opened a session view.
+
+Building the v2 desktop app from source would have benchmarked a different app,
+not the proposed engine swap inside OpenWork. That is why the app lane arrived
+through OpenWork's adapter rather than through the v2 web or desktop UI.
+
+## Method
+
+### Deterministic witness
+
+Both lanes use a local HTTP witness provider. It streams exactly 20 tokens at
+20 ms pacing, which imposes a 400 ms floor on completion. Usage is fixed.
+
+The engine lane gives v1 and v2 separate API keys and asserts that every
+request carries the correct lane key, model, and nonempty prompt. This catches
+cross-lane traffic. The app lane similarly asserts its app-only key and model.
+
+### Samples and machine
+
+- Iterations: N=5.
+- Exception: `first_prompt_cold` is intentionally one cold sample per engine.
+- Reported values: median with minimum-maximum range.
+- Platform: darwin arm64.
+- Processor: Apple M3 Max, 16 CPUs.
+- Memory: 48 GB.
+- Node: v24.15.0.
+- Lane B API polling resolution: 25 ms.
+- Lane A UI polling resolution: 50 ms, from `pollResolutionMs`.
+- Lane A app commit: `8d8d0105fd9e5bea4b7ff254833ee649b604e691`.
+
+### Important cold-boot qualification
+
+**Lane A runs a DEV BUILD: a Vite development server plus Electron dev. Its
+cold-boot timings are not comparable to packaged-app startup.**
+
+Each cold sample uses a fresh profile and workspace. Warm scenarios run in the
+last cold instance only. The first cold iteration also pays first-compile cost,
+which is visible in its higher sample.
+
+### Metric boundaries
+
+Lane B boundaries are:
+
+- `boot_ready`: process spawn start until the managed engine reports ready; v2
+  is additionally health-gated.
+- `spawn_to_first_api_ok`: the same process spawn start through the first
+  successful session-list response.
+- `session_create`: immediately before the create request through a successful
+  response containing a session ID.
+- `first_prompt_cold`: immediately before the first prompt call through the
+  message list containing the final witness token.
+- `message.accepted`: prompt timer start through prompt admission response.
+- `message.witness_first_byte`: prompt timer start until the witness receives
+  the request.
+- `message.first_token`: prompt timer start until a 25 ms message-list poll
+  sees the witness nonce and `token 1`.
+- `message.complete`: prompt timer start until a message-list poll sees the
+  final witness token.
+- `directory_switch`: immediately before listing a never-seen directory through
+  that list and the first successful session creation in that directory.
+- `long.*`: the message boundaries above, using an exact 200,000-character
+  prompt.
+- `compaction`: immediately before v1 `summarize` or v2 `compact` through a
+  polled completed compaction record and a witnessed provider request.
+
+Lane A boundaries are:
+
+- `appInteractive`: desktop launch start until the desktop harness returns an
+  interactive app.
+- `workspaceReady`: that same launch start through UI workspace creation and
+  selection.
+- `composerReady`: that same launch start until the composer is editable and
+  the Run task control is visible.
+- `first_send_cold`: after untimed model selection, Run task click through the
+  rendered final witness token and disappearance of the session loading
+  indicator.
+- `new_session_ready`: New task click until a distinct session route and
+  surface exist, with an editable composer and visible Run task control.
+- `message.userRendered`: Run task click until the exact new user turn appears.
+- `message.firstToken`: the same click until `token 1` appears in the latest
+  assistant turn.
+- `message.complete`: the same click until the final token and witness nonce
+  appear and the loading indicator is absent.
+- `workspace_switch`: session-row click until the target workspace and session
+  surface match and its composer is typable.
+- `long.insertMs`: immediately before CDP `Input.insertText` until the composer
+  contains the exact long payload; its other fields use the prepared-send
+  boundaries above.
+
+Timings are data, not performance assertions. The specs assert completion,
+exact payload handling, workspace isolation, and witness fidelity only.
+
+### Reproduction
+
+```sh
+OPENWORK_BENCH_ITERATIONS=5 pnpm evals:pr specs/bench-opencode-engines.test.ts
+OPENWORK_BENCH_ITERATIONS=5 OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/bench-openwork-app-v1.e2e.test.ts
+```
+
+Set `OPENWORK_BENCH_RESULTS_DIR` to retain the generated JSON files.
+
+## Lane B results: engine vs engine (medians, N=5)
+
+Delta is v2 minus v1. Negative means v2 completed this boundary sooner.
+`first_prompt_cold` has one sample rather than five.
+
+| Scenario | v1 median (min-max) | v2 median (min-max) | Delta |
+| --- | ---: | ---: | ---: |
+| `boot_ready` | 540 (526-565) | 516 (511-779) | -24 |
+| `spawn_to_first_api_ok` | 683 (664-706) | 520 (514-787) | -163 |
+| `session_create` | 7 (3-9) | 55 (49-119) | +48 |
+| `first_prompt_cold` | 3494 (3494-3494) | 4502 (4502-4502) | +1008 |
+| `message.accepted` | 4 (4-6) | 3 (2-3) | -1 |
+| `message.witness_first_byte` | 11 (10-18) | 9 (9-10) | -2 |
+| `message.first_token` | 447 (445-480) | 516 (491-546) | +69 |
+| `message.complete` | 452 (447-481) | 517 (494-547) | +65 |
+| `directory_switch` | 13 (10-21) | 49 (49-61) | +36 |
+| `long.accepted` | 6 (5-12) | 14 (13-21) | +8 |
+| `long.witness_first_byte` | 25 (17-51) | 10 (10-18) | -15 |
+| `long.complete` | 487 (465-543) | 525 (514-537) | +38 |
+| `compaction` | 469 (451-500) | 452 (446-480) | -17 |
+
+### Interpretation
+
+- **Boot to usable API:** v2 is faster on `spawn_to_first_api_ok`. This is a
+  single daemon with health-gated readiness, measured from spawn through the
+  first successful list call.
+- **Session creation:** v1's 7 ms median is effectively in-memory-scale here;
+  v2's 55 ms includes durable SQLite and location-graph work. Both are
+  imperceptible beside UI session setup.
+- **Directory switch:** v1 wins the measured first-list-plus-create boundary.
+  This needs a prominent laziness caveat: v1 defers real instance/provider cost,
+  and its cold cost appears in `first_prompt_cold`. V2 pays a bounded `LayerMap`
+  location build during first touch.
+- **Cold first prompt:** v1 npm-installs `@ai-sdk/openai-compatible` at first
+  provider use; this is real product behavior. V2 bundles the compatible
+  provider, yet its cold first prompt is higher in this run. **Hypothesis, not a
+  measured explanation:** catalog/plugin generation settling plus the model-read
+  gate on the first location account for some of that result.
+- **Message dispatch:** witness arrival is about 10 ms in both lanes, so wire
+  dispatch is effectively immediate.
+- **Completion:** against the 400 ms witness pacing floor, median overhead is
+  52 ms for v1 and 117 ms for v2.
+- **First-token caveat:** Lane B `first_token` is when a message-list poll sees
+  persisted text. It is not user-perceived streaming. OpenWork receives push
+  events; Lane A measures a 92 ms v1 user-visible first token.
+- **Compaction:** v1 `summarize` and v2 `compact` are witness-served and nearly
+  equal on this boundary. Both are verified to reach the provider with their
+  lane-specific key.
+- **Overall:** at user-perceptible scales, warm engine message flows are within
+  about 10% in this run. V2's case is architectural rather than raw latency:
+  [no-reload provider injection](opencode-v2-parallel-lane.md#providers-on-v2-why-no-reload-is-needed),
+  durable sessions, and one daemon for many directories.
+
+## Lane A results: OpenWork app on v1, pure CDP (medians, N=5)
+
+### Cold boot to composer: DEV BUILD, not packaged startup
+
+| Metric | Median (min-max) |
+| --- | ---: |
+| `appInteractive` | 27089 (27022-36513) |
+| `workspaceReady` | 38536 (38489-51020) |
+| `composerReady` | 38537 (38490-51020) |
+
+Iteration 1 is higher because it includes first compilation. Do not use this
+table to predict packaged-app startup.
+
+### Session and regular message flow
+
+| Metric | Median (min-max) |
+| --- | ---: |
+| `first_send_cold.complete` | 2885 (2325-3583) |
+| `new_session_ready` | 355 (335-403) |
+| `message_rtt.userRendered` | 76 (75-83) |
+| `message_rtt.firstToken` | 92 (88-133) |
+| `message_rtt.complete` | 506 (490-523) |
+| `workspace_switch.aToB` | 107 (97-133) |
+| `workspace_switch.bToA` | 93 (89-132) |
+
+A new prompt-ready session takes about 355 ms. Workspace restoration is about
+100 ms. The first witness token is visible about 92 ms after clicking Run task.
+
+### Exact 200,000-character message
+
+| Metric | Median (min-max) |
+| --- | ---: |
+| `long_message.insertMs` | 43 (42-50) |
+| `long_message.userRendered` | 108 (94-124) |
+| `long_message.firstToken` | 167 (131-167) |
+| `long_message.complete` | 540 (524-552) |
+
+The 200,000-character CDP insertion itself takes 43 ms. Compared with the
+regular-message medians, the long turn adds 32 ms to user render, 75 ms to
+first token, and 34 ms to completion. In practical terms, the 200 KB paste adds
+roughly 40-70 ms around the normal round trip, with the exact observed boundary
+deltas stated above.
+
+`uiCompactionAvailable=false`: OpenWork has no user-facing compact or summarize
+control in this UI today. Engine-side compaction is covered in Lane B.
+
+## Lane A results: OpenWork app on v2 (adapter preview), pure CDP (medians, N=5)
+
+Delta is app on v2 minus app on v1. Negative means v2 completed this boundary
+sooner.
+
+| Metric | App on v1 median (min-max) | App on v2 median (min-max) | Delta |
+| --- | ---: | ---: | ---: |
+| `cold_boot_to_composer.appInteractive` | 27089 (27022-36513) | 20100 (19217-22136) | -6989 |
+| `cold_boot_to_composer.workspaceReady` | 38536 (38489-51020) | 31499 (26839-35337) | -7037 |
+| `cold_boot_to_composer.composerReady` | 38537 (38490-51020) | 31499 (26840-35338) | -7038 |
+| `cold_boot_to_composer.appReadinessMs` | 7025 (6821-7690) | 5075 (4284-6456) | -1950 |
+| `first_send_cold.complete` | 2885 (2325-3583) | 602 (581-649) | -2283 |
+| `new_session_ready` | 355 (335-403) | 291 (183-396) | -64 |
+| `message_rtt.userRendered` | 76 (75-83) | 588 (568-636) | +512 |
+| `message_rtt.firstToken` | 92 (88-133) | 589 (569-640) | +497 |
+| `message_rtt.complete` | 506 (490-523) | 589 (569-641) | +83 |
+| `workspace_switch.aToB` | 107 (97-133) | 170 (151-438) | +63 |
+| `workspace_switch.bToA` | 93 (89-132) | 127 (98-142) | +34 |
+| `long_message.insertMs` | 43 (42-50) | 57 (55-118) | +14 |
+| `long_message.userRendered` | 108 (94-124) | 589 (570-716) | +481 |
+| `long_message.firstToken` | 167 (131-167) | 592 (571-718) | +425 |
+| `long_message.complete` | 540 (524-552) | 593 (572-718) | +53 |
+
+### Interpretation
+
+- **First send cold:** v2 takes 602 ms versus v1's 2885 ms, about 4.8x
+  faster to the first-ever reply. V2 needs no runtime npm provider install;
+  v1 installs `@ai-sdk/openai-compatible` on first use.
+- **New session ready:** v2 takes 291 ms versus v1's 355 ms.
+- **Streaming gap (v0 finding):** on v2, `userRendered`, `firstToken`, and
+  `complete` are approximately equal in every iteration, at roughly 570-640
+  ms. The adapter currently renders complete turns rather than incremental
+  tokens. V1 renders the user message at about 76 ms, the first token at about
+  92 ms, and completion at about 506 ms. **Hypothesis:** the adapter's
+  `promptAsync` performs a model-switch round trip before the prompt POST,
+  delaying the optimistic user render. **Hypothesis:** delta events lack an
+  established part anchor until the cumulative `part.updated` at `text.ended`,
+  so token deltas do not paint incrementally. This is the top adapter follow-up;
+  engine-side completion is equivalent (Lane B: 452 ms versus 517 ms over a
+  400 ms pacing floor).
+- **Workspace switch:** v2 takes about 170 ms A→B and 127 ms B→A versus v1's
+  107 ms and 93 ms, respectively. It is slightly slower. **Hypothesis:** extra
+  preview-status and lane checks account for part of the difference.
+- **Cold boot:** the lanes are comparable and dev-build-dominated. The dev-build
+  warning above applies to both; these values do not predict packaged startup.
+- **Setup asymmetry:** v2 mode provisions the witness through the runtime
+  provider path, mirrored to the sidecar, and enables the preview flag through
+  the API as untimed scaffolding. All measured interactions remain pure CDP in
+  both app lanes.
+
+## Answers to the five questions
+
+| Question | Metric today: v1 app and engine | V2 preview app and engine | Likely user-visible change after adoption |
+| --- | --- | --- | --- |
+| First session, load, and send | DEV composer ready 38537 ms; cold first send 2885 ms; engine API usable 683 ms | DEV composer ready 31499 ms; cold first send 602 ms; API usable 520 ms; cold first engine prompt 4502 ms | Packaged startup must be measured separately; first send is about 4.8x faster because v2 avoids the runtime provider install |
+| Ready session | App ready 355 ms; engine create 7 ms | App ready 291 ms; engine create 55 ms | The measured v2 preview is 64 ms faster at the app boundary |
+| Workspace switch | 107 ms A→B and 93 ms B→A; unseen-directory engine touch 13 ms | 170 ms A→B and 127 ms B→A; unseen-directory touch 49 ms | Preview app revisits are slightly slower, as is first directory touch |
+| Message response | User visible 76 ms, first token 92 ms, complete 506 ms; engine complete 452 ms | User visible 588 ms, first token 589 ms, complete 589 ms; engine complete 517 ms | Completion remains close, but the preview adapter currently paints complete turns instead of streaming incrementally |
+| Long message and compaction | Exact 200000 chars insert in 43 ms and complete in 540 ms; no UI compaction control; engine summarize 469 ms | Exact 200000 chars insert in 57 ms and complete in 593 ms; engine compact 452 ms; compaction unsupported in the preview adapter because it has no UI control | Long-message completion is close at this pacing floor; compaction remains engine-only |
+
+V2 can apply provider changes without reloading the engine, reflected in the
+much faster cold first send. Warm engine completion remains broadly equivalent,
+but the preview adapter's lack of incremental painting is a clear user-visible
+regression. Session create adds about 50 ms engine-side while the app's new-task
+boundary is 64 ms faster; workspace revisits are slightly slower.
+
+## Follow-ups
+
+- Fix incremental streaming in the v2 adapter, including part anchoring and
+  optimistic user render, then re-measure `message_rtt`.
+- Report the `/new-session` web UI crash upstream against the anomalyco/opencode
+  v2 branch, including the exact provider error and affected builds above.
+- Per-engine app numbers still need to be rerun on packaged builds.
+- N=5 on one machine is directional evidence, not a population study. Treat
+  single-digit-millisecond deltas as noise. The 400 ms pacing floor dominates
+  completion metrics by design.

--- a/docs/opencode-v2-parallel-lane.md
+++ b/docs/opencode-v2-parallel-lane.md
@@ -23,7 +23,15 @@ This PR adds a parallel prototype lane in
 `apps/server/src/managed-opencode-v2.ts`, pins it through
 `constants.json` `opencodeV2Version`, and adds the proof spec
 `evals/specs/opencode-v2-provider-hot-inject.test.ts`.
-It changes zero v1 behavior.
+
+It also ships the testing surface: an experimental Settings feature flag
+("OpenCode v2 engine preview", Settings > Advanced, default off) backed by
+`apps/server/src/engine-v2-preview.ts`. When enabled, openwork-server runs the
+v2 engine as a parallel sidecar and hot-mirrors every provider change from the
+runtime provider store into it with no reload, while the app keeps using the
+v1 engine. Live status (`GET /experimental/engine-v2-preview/status`) reports
+pid, mirrored and skipped providers, and the sidecar's ingested model ids.
+With the flag off (the default), nothing starts and zero v1 behavior changes.
 
 ## Why now
 
@@ -260,6 +268,21 @@ The equivalent manual smoke produced the same result:
 - The engine PID did not change.
 - Stdout contained one `server listening on` line.
 
+The feature flag has its own proof,
+`evals/specs/engine-v2-preview-flag.e2e.test.ts` (app-driving):
+
+| Claim | Observable proof |
+| --- | --- |
+| F1 | A fresh desktop reports the flag disabled with no sidecar pid, and the Settings switch renders unchecked. |
+| F2 | Enabling from Settings > Advanced boots the sidecar (status turns running with a pid) while the v1 server keeps serving. |
+| F3 | A provider added through the product config path is mirrored into the running sidecar: its model id appears in the sidecar catalog, a baseURL-less record lands in skipped (never mirrored), and the sidecar pid is unchanged. |
+| F4 | Disabling from Settings stops the sidecar and it stays stopped. |
+
+The pure v1-to-v2 provider mapping is unit-covered in
+`apps/server/src/engine-v2-preview.test.ts`.
+The end-to-end completion round trip is deliberately proven in the app-less
+spec, not the e2e spec, so the e2e run needs no witness endpoint.
+
 ## How a full OpenWork-on-v2 lane would work (design)
 
 ### 1. Spawn and handshake
@@ -338,16 +361,18 @@ That is the proposed continuity path for sessions and credentials.
 
 ### Rollout stages
 
-1. This PR: land the pinned parallel lane and proof spec in
-   `apps/server/src/managed-opencode-v2.ts`, `constants.json`, and
-   `evals/specs/opencode-v2-provider-hot-inject.test.ts`.
-2. Add opt-in `OPENWORK_ENGINE_LANE=v2` selection to openwork-server boot for
-   headless worlds, beside the current manager at
-   `apps/server/src/managed-opencode.ts:147-248`.
-3. Add a desktop dev-mode toggle through the existing boot chain
-   (`apps/desktop/electron/main.mjs:1385-1445`,
-   `apps/desktop/electron/runtime.mjs:1882-2028`,
-   `apps/server/src/embedded.ts:190-281`).
+1. This PR: land the pinned parallel lane, the proof specs, and the
+   experimental Settings flag that runs the v2 sidecar with live provider
+   mirroring (`apps/server/src/managed-opencode-v2.ts`,
+   `apps/server/src/engine-v2-preview.ts`, `constants.json`,
+   `evals/specs/opencode-v2-provider-hot-inject.test.ts`,
+   `evals/specs/engine-v2-preview-flag.e2e.test.ts`).
+2. Dogfood the flag; extend mirroring coverage (headers, model limits,
+   disabled providers) and bridge sidecar SSE events into diagnostics.
+3. Add a v2 dialect adapter behind the four server-to-engine touchpoints so a
+   workspace can select the v2 lane end to end
+   (`apps/server/src/server.ts:1246-1280`, `:1302+`, `:3930-3942`,
+   `apps/server/src/managed-provider-auth.ts:256,295`).
 4. On the v2 lane, remove the provider settings call to
    `refreshProviders({dispose:true})` at
    `apps/app/src/react-app/domains/connections/provider-auth/store.ts:1623-1651`.

--- a/docs/opencode-v2-parallel-lane.md
+++ b/docs/opencode-v2-parallel-lane.md
@@ -1,0 +1,398 @@
+# OpenCode v2 parallel lane
+
+## Summary
+
+OpenCode v2 is a contract-first rewrite on the `v2` branch of
+`github.com/anomalyco/opencode`.
+It is published under the npm `beta` dist-tag, for example as
+`@opencode-ai/cli@0.0.0-beta-18707`, and installs the `opencode2` binary.
+Its architecture combines an Effect-TS server, a typed protocol with generated
+clients in `packages/protocol`, SQLite storage, and one shared daemon serving
+many directories (v2 `packages/protocol/src/api.ts:151-191`,
+`packages/core/src/location-services.ts:25-44`).
+
+The key property for OpenWork is that providers become usable at runtime with
+no process restart and no instance reload.
+The proof is `evals/specs/opencode-v2-provider-hot-inject.test.ts` in this PR,
+using pinned binary `0.0.0-beta-18707`.
+An injected provider appeared in about 750ms, served a prompt, retained the
+same engine PID, and required only one engine boot
+(`evals/specs/opencode-v2-provider-hot-inject.test.ts`).
+
+This PR adds a parallel prototype lane in
+`apps/server/src/managed-opencode-v2.ts`, pins it through
+`constants.json` `opencodeV2Version`, and adds the proof spec
+`evals/specs/opencode-v2-provider-hot-inject.test.ts`.
+It changes zero v1 behavior.
+
+## Why now
+
+Provider changes in the current v1 integration force an engine reload.
+Every provider add follows this path:
+
+1. `PATCH /workspace/:id/config` updates the workspace configuration.
+2. The server persists a runtime SQLite row in
+   `apps/server/src/runtime-opencode-config-store.ts`.
+3. The server materializes an `OPENCODE_CONFIG` file
+   (`apps/server/src/openwork-runtime-config.ts:186-204`).
+4. The server invokes `reloadOpencodeEngine`
+   (`apps/server/src/server.ts:4063-4080`).
+5. The reload either disposes the engine in place
+   (`apps/server/src/server.ts:4082-4154`) or performs a blue/green rollover
+   (`apps/server/src/engine-pool.ts:570-632`).
+6. A rollover creates a standby process
+   (`apps/server/src/engine-pool.ts:1094-1106`).
+
+Authentication has a separate but coupled ordering requirement.
+Keys are delivered through `PUT /auth/{providerID}` before the configuration
+rebuild (`apps/server/src/managed-provider-auth.ts:256-260`).
+The server enforces that ordering
+(`apps/server/src/server.ts:2577-2584`), as does cloud provider sync
+(`apps/server/src/cloud-provider-sync.ts:890-899`).
+
+Reloads must account for interrupted or queued work, defer while busy
+(`apps/server/src/engine-reload-defer.ts:15-22`), coordinate rollover, and
+avoid credential, configuration, and readiness races. A live-config engine
+eliminates those costs for provider changes
+(v2 `packages/core/src/config.ts:287-338`,
+`packages/core/src/model-resolver.ts:274-303`).
+
+## v1 integration map (what exists today)
+
+| Area | Current v1 integration |
+| --- | --- |
+| Engine binary | OpenWork uses the anomalyco/opencode fork pinned in `constants.json` as `"opencodeVersion": "v1.18.18"`; desktop sidecar preparation downloads it in `apps/desktop/scripts/prepare-sidecar.mjs:35-48`. |
+| Spawn | `apps/server/src/managed-opencode.ts:147-234` runs `opencode serve --hostname --port --cors '*'`, supplies `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD`, waits for stdout `opencode server listening on <url>`, and sets `OPENCODE_CONFIG` to the runtime configuration file. |
+| Desktop boot | `apps/desktop/electron/main.mjs:1385-1445` enters `apps/desktop/electron/runtime.mjs:1882-2028` through `startOpenworkServerInner`, then starts the in-process server at `apps/server/src/embedded.ts:190-281`, which owns the child engine. |
+| Server client | The engine client factory is `apps/server/src/server.ts:1246-1280`. |
+| Raw proxy | The raw engine proxy begins at `apps/server/src/server.ts:1302+` and mounts at `:986` and `:1038`. |
+| Dispose | The dispose URL builder is `apps/server/src/server.ts:3930-3942`. |
+| Credentials | Credential delivery occurs at `apps/server/src/managed-provider-auth.ts:256,295`. |
+| Renderer | `apps/app/src/app/lib/opencode.ts:272-328` wraps `@opencode-ai/sdk/v2/client`; that `/v2/` is the v1 SDK client namespace, not the v2 engine. |
+| Provider settings | API-key setup calls engine `auth.set` and then `refreshProviders({dispose:true})` at `apps/app/src/react-app/domains/connections/provider-auth/store.ts:1623-1651`; cloud import is at `apps/app/src/react-app/domains/connections/provider-auth/store.ts:1653-1754`. |
+
+There are exactly four server-to-engine touchpoints to adapt:
+
+1. The client factory (`apps/server/src/server.ts:1246-1280`).
+2. The raw proxy (`apps/server/src/server.ts:1302+`, mounts `:986`, `:1038`).
+3. The dispose URL builder (`apps/server/src/server.ts:3930-3942`).
+4. Credential delivery (`apps/server/src/managed-provider-auth.ts:256,295`).
+
+## opencode v2 architecture (what we verified)
+
+### Boot and authentication
+
+The server starts with:
+
+```text
+opencode2 serve --hostname <host> --port <port> [--cors ...]
+```
+
+Basic authentication is mandatory.
+The username is `opencode`, and the password comes from `OPENCODE_PASSWORD`
+(v2 `packages/server/src/process.ts:54-55`,
+`packages/cli/src/server-process.ts:68-80`).
+
+Readiness can be observed either from stdout line
+`server listening on <url>` or from `GET /api/health`, whose response contains
+`{healthy, version, pid}` (v2 `packages/server/src/process.ts:179-228`).
+
+### Isolation knobs
+
+The v2 child can be isolated with these environment variables
+(v2 `packages/cli/src/server-process.ts:83-128`):
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENCODE_DB` | SQLite database path. |
+| `OPENCODE_CONFIG_DIR` | Always-watched global configuration directory. |
+| `OPENCODE_DISABLE_MODELS_FETCH` | Disable network model-catalog fetching. |
+| `OPENCODE_MODELS_URL` | Override the model source URL. |
+| `OPENCODE_MODELS_PATH` | Override the model snapshot path. |
+| `OPENCODE_CONFIG` | Point to a configuration file. |
+| `OPENCODE_CONFIG_CONTENT` | Supply configuration content directly. |
+
+### One daemon, many directories
+
+Requests are scoped by `?location[directory]=...` query parameters.
+The `x-opencode-directory` header remains supported
+(v2 `packages/server/src/location.ts:69-79`).
+
+The daemon caches per-location service graphs in a `LayerMap`
+(v2 `packages/core/src/location-services.ts:25-44`).
+
+### Typed API
+
+The protocol is a typed `HttpApi` contract assembled in
+v2 `packages/protocol/src/api.ts:151-191`.
+The server publishes OpenAPI at `/openapi.json`
+(v2 `packages/server/src/routes.ts:152`).
+
+The relevant session calls are:
+
+| Operation | Endpoint and shape |
+| --- | --- |
+| Create session | `POST /api/session`; choose the model with `model: {providerID, id}` (v2 `packages/protocol/src/groups/session.ts:170-186`). |
+| Prompt | `POST /api/session/:id/prompt` with `{text, files?, agents?, skills?}` (v2 `packages/protocol/src/groups/session.ts:338-358`, `packages/schema/src/prompt-input.ts:29-34`). |
+| Switch model | `POST /api/session/:id/model` (v2 `packages/protocol/src/groups/session.ts:302`). |
+| Events | SSE at `GET /api/event`, including `catalog.updated`, `credential.updated`, and `config.updated` (v2 `packages/protocol/src/groups/event.ts:34`, `packages/server/src/handlers/event.ts:12-35`). |
+
+### Storage
+
+V2 stores sessions, messages, credentials, and a durable event log in one
+SQLite `opencode.db` rather than v1 JSON files.
+Provider API keys live in the `credential` table, not `auth.json`
+(v2 `packages/core/src/credential/sql.ts:5-14`).
+
+### Service discovery
+
+`opencode2 serve --service` writes
+`$XDG_STATE_HOME/opencode/service.json` with
+`{id, version, url, pid, password}` and mode `0600`
+(v2 `packages/cli/src/services/service-registration.ts:13-70`).
+The TUI and desktop use that file for single-daemon discovery
+(v2 `packages/cli/src/services/service-registration.ts:13-70`).
+
+The OpenWork lane instead owns an isolated child in
+`apps/server/src/managed-opencode-v2.ts` and does not use service discovery.
+
+## Providers on v2: why no reload is needed
+
+### Catalog as a projection
+
+The provider catalog is a rebuildable projection rather than a static registry
+(v2 `packages/core/src/catalog.ts:84-140`).
+Catalog transforms replay on `reload()`, and state reload uses a 500ms debounce
+(v2 `packages/core/src/state.ts:42,80-188`).
+
+### Credentials resolved per request
+
+Every prompt resolves its provider and credential from the live SQLite table,
+then injects the key into SDK settings for that request
+(v2 `packages/core/src/model-resolver.ts:274-303`,
+`packages/core/src/integration.ts:660-689`).
+Credentials are not cached
+(v2 `packages/core/src/model-resolver.ts:274-303`).
+
+### Content-keyed AI SDK instances
+
+AI SDK instances are cached by the JSON content of provider settings,
+including `apiKey` and `baseURL`
+(v2 `packages/core/src/aisdk.ts:194-206,249-292`).
+A changed key or base URL lazily creates a fresh SDK instance, and there is no
+dispose step (v2 `packages/core/src/aisdk.ts:194-206,249-292`).
+
+### Watched configuration and plugin rebuilds
+
+Configuration files are watched
+(v2 `packages/core/src/config.ts:287-338`).
+A `config.updated` event causes `ConfigProviderPlugin` and `PluginSupervisor`
+to rebuild integration and catalog state in roughly 100-600ms
+(v2 `packages/core/src/config/plugin/provider.ts:15-19`,
+`packages/core/src/plugin/supervisor.ts:133-154`).
+
+Model reads wait up to five seconds for the generation to settle
+(v2 `packages/server/src/handlers/plugin-readiness.ts:5-13`).
+
+A configuration provider with `activation = "enabled"` is available with zero
+credential rows when its settings include an inline `apiKey`
+(v2 `packages/core/src/catalog.ts:67-69`,
+`packages/core/src/model-resolver.ts:274-303`).
+This is the `Auth.none` path used by the proof lane
+(v2 `packages/core/src/model-resolver.ts:274-303`).
+
+### Provider package loading
+
+Built-in SDK packages such as
+`@opencode-ai/ai/providers/openai-compatible` are compiled into the binary
+(v2 `packages/core/src/provider.ts:36-74`).
+Unknown `aisdk:<pkg>` specifiers are npm-installed on demand
+(v2 `packages/core/src/provider.ts:76-103`).
+
+### Runtime injection mechanisms
+
+V2 offers three runtime injection mechanisms:
+
+1. `POST /api/integration/:id/connect/key` adds a credential row for a stock,
+   cataloged provider; live credential resolution picks it up on the next
+   request (v2 `packages/core/src/credential/sql.ts:5-14`,
+   `packages/core/src/model-resolver.ts:274-303`).
+2. OpenWork can atomically write managed provider configuration into the
+   always-watched `OPENCODE_CONFIG_DIR`; this lets OpenWork own both key
+   material and configuration materialization, and is the mechanism used by
+   `evals/specs/opencode-v2-provider-hot-inject.test.ts`
+   (v2 `packages/cli/src/server-process.ts:83-128`,
+   `packages/core/src/config.ts:287-338`).
+3. `POST /api/experimental/integration/wellknown` accepts remote manifests
+   (v2 `packages/protocol/src/groups/integration.ts:40-53`,
+   `packages/core/src/wellknown.ts:147-160`).
+
+Only boot-fixed `ServerOptions` require a restart: hostname, port, password,
+CORS, database path, and models URL
+(v2 `packages/server/src/options.ts:6-46`).
+Provider configuration and credentials are not in that set
+(v2 `packages/server/src/options.ts:6-46`,
+`packages/core/src/config.ts:287-338`).
+
+## Proof (this PR)
+
+`apps/server/src/managed-opencode-v2.ts` spawns and manages
+`opencode2 serve` with an isolated database and configuration directory.
+It uses health-based readiness and implements `injectProvider()` as an atomic
+configuration write.
+There is no reload or dispose call in
+`apps/server/src/managed-opencode-v2.ts`.
+
+`evals/specs/opencode-v2-provider-hot-inject.test.ts` covers five claims:
+
+| Claim | Observable proof |
+| --- | --- |
+| C1 | The injected provider is absent from the baseline catalog (`evals/specs/opencode-v2-provider-hot-inject.test.ts`). |
+| C2 | Hot injection becomes listed within 15 seconds (`evals/specs/opencode-v2-provider-hot-inject.test.ts`). |
+| C3 | A prompt round-trips through the witness with the injected key, with key isolation between two providers (`evals/specs/opencode-v2-provider-hot-inject.test.ts`). |
+| C4 | The engine PID stays the same, the child never exits, and stdout contains exactly one boot line (`evals/specs/opencode-v2-provider-hot-inject.test.ts`). |
+| C5 | A second provider can be injected warm while the first remains available (`evals/specs/opencode-v2-provider-hot-inject.test.ts`). |
+
+The equivalent manual smoke produced the same result:
+
+- The model appeared about 750ms after the configuration write.
+- The witness observed `Bearer witness-key-123`.
+- The engine PID did not change.
+- Stdout contained one `server listening on` line.
+
+## How a full OpenWork-on-v2 lane would work (design)
+
+### 1. Spawn and handshake
+
+Keep `apps/server/src/managed-opencode-v2.ts` as a sibling of the current
+manager at `apps/server/src/managed-opencode.ts:147-248`.
+Select the manager per workspace with an engine-lane flag.
+Provide an `OPENWORK_OPENCODE_BIN`-style override named
+`OPENWORK_OPENCODE2_BIN` for the v2 binary.
+
+The adapter starts the v2 command and uses Basic auth plus health readiness
+(v2 `packages/cli/src/server-process.ts:68-80`,
+`packages/server/src/process.ts:179-228`).
+
+### 2. Engine pool
+
+V2 makes most provider-change behavior in `engine-pool.ts` unnecessary because
+configuration updates do not need rollovers
+(v2 `packages/core/src/config.ts:287-338`).
+Retain the pool only for engine-version upgrades.
+
+If we preserve the pool abstraction, `EngineSpawnTemplate` and
+`EnginePoolHooks` are already injectable at
+`apps/server/src/engine-pool.ts:39-70`.
+
+### 3. Server-to-engine dialect
+
+Place a v2 adapter behind the four existing touchpoints:
+
+| V1 seam | V2 replacement |
+| --- | --- |
+| Client factory (`apps/server/src/server.ts:1246-1280`) | Construct a generated v2 client or a narrow adapter around the typed v2 API (`packages/protocol/src/api.ts:151-191`). |
+| Raw proxy (`apps/server/src/server.ts:1302+`, mounts `:986`, `:1038`) | Keep `/workspace/:id/opencode/*`, translate to Basic auth, and inject `location[directory]` (`packages/server/src/location.ts:69-79`). |
+| Dispose URL (`apps/server/src/server.ts:3930-3942`) | Make workspace dispose a no-op or call `DELETE /api/debug/location` in the v2 dialect (v2 `packages/server/src/handlers/debug.ts:16-25`). |
+| Credential delivery (`apps/server/src/managed-provider-auth.ts:256,295`) | Call `POST /api/integration/:id/connect/key` for stock providers or perform a managed configuration write (`packages/core/src/credential/sql.ts:5-14`, `packages/core/src/config.ts:287-338`). |
+
+### 4. Configuration materialization
+
+Keep `apps/server/src/runtime-opencode-config-store.ts` as the OpenWork source
+of truth.
+Render a v2 dialect using the `providers` key and v2 schema into
+`OPENCODE_CONFIG_DIR/opencode.json`, following the existing
+`buildOpenworkRuntimeConfigObjectFromSnapshot` materialization style at
+`apps/server/src/openwork-runtime-config.ts:102-143`.
+
+After that write, do not call reload.
+The v2 watcher rebuilds the integration and catalog
+(v2 `packages/core/src/config.ts:287-338`,
+`packages/core/src/config/plugin/provider.ts:15-19`).
+
+The v1 auth-before-reload invariant at
+`apps/server/src/server.ts:2577-2584` dissolves in this lane.
+The replacement invariant is that the managed configuration write must be
+atomic using a temporary file and rename, matching
+`apps/server/src/managed-opencode-v2.ts`.
+
+### 5. Renderer
+
+Point `createClient` at `apps/app/src/app/lib/opencode.ts:272` to a v2 client
+adapter or to the openwork-server proxy when the workspace selects v2.
+Keep the v1 SDK types in place for the v1 lane
+(`apps/app/src/app/lib/opencode.ts:272-328`).
+
+### 6. Events
+
+Bridge v2 SSE events `catalog.updated` and `credential.updated` into the
+existing reload-event plumbing so the model picker refreshes without polling
+(v2 `packages/protocol/src/groups/event.ts:34`,
+`packages/schema/src/catalog.ts:5`).
+
+### 7. Migration
+
+V2 includes a v1 importer at `GET /api/experimental/migration/v1` in
+v2 `packages/core/src/database/v1-migration.bun.ts`.
+That is the proposed continuity path for sessions and credentials.
+
+### Rollout stages
+
+1. This PR: land the pinned parallel lane and proof spec in
+   `apps/server/src/managed-opencode-v2.ts`, `constants.json`, and
+   `evals/specs/opencode-v2-provider-hot-inject.test.ts`.
+2. Add opt-in `OPENWORK_ENGINE_LANE=v2` selection to openwork-server boot for
+   headless worlds, beside the current manager at
+   `apps/server/src/managed-opencode.ts:147-248`.
+3. Add a desktop dev-mode toggle through the existing boot chain
+   (`apps/desktop/electron/main.mjs:1385-1445`,
+   `apps/desktop/electron/runtime.mjs:1882-2028`,
+   `apps/server/src/embedded.ts:190-281`).
+4. On the v2 lane, remove the provider settings call to
+   `refreshProviders({dispose:true})` at
+   `apps/app/src/react-app/domains/connections/provider-auth/store.ts:1623-1651`.
+5. Flip the default only after the parity checklist is complete.
+
+### Parity gaps / risks
+
+- V2 uses `0.0.0-beta-N` releases and has no stable semver contract yet.
+- V2 Basic auth and password lifecycle differ from v1 per-boot environment
+  credentials (v2 `packages/server/src/process.ts:54-55`,
+  `packages/cli/src/server-process.ts:68-80`;
+  v1 `apps/server/src/managed-opencode.ts:147-234`).
+- The v2 single-daemon model differs from OpenWork's current per-workspace
+  engine assumption. Location scoping covers directory isolation
+  (v2 `packages/server/src/location.ts:69-79`), but `EngineInfo` IPC shapes must
+  be versioned (`packages/types/src/desktop-ipc.ts:36-52,88-114`).
+- `/api/experimental/*` surfaces may move, including the v1 importer at
+  v2 `packages/core/src/database/v1-migration.bun.ts`.
+- Plugin and tool ecosystems differ between the v1 and v2 engines.
+- V2 requires network access for models.dev unless
+  `OPENCODE_DISABLE_MODELS_FETCH=1` is paired with a bundled snapshot
+  (v2 `packages/cli/src/server-process.ts:83-128`).
+
+The parity checklist should therefore cover provider discovery, provider auth,
+session creation, prompting, events, tools, plugins, persistence, migration,
+proxy compatibility, desktop IPC, shutdown, and upgrades at the four existing
+server seams (`apps/server/src/server.ts:1246-1280`,
+`apps/server/src/server.ts:1302+`, `apps/server/src/server.ts:3930-3942`,
+`apps/server/src/managed-provider-auth.ts:256,295`).
+
+## Alternatives considered
+
+### Embed `@opencode-ai/sdk` v2 in-process
+
+Rejected for this lane.
+The v2 implementation has Bun-flavored runtime dependencies, while OpenWork's
+embedded server runs in Electron's Node environment.
+The subprocess approach matches the existing managed-engine boundary at
+`apps/server/src/managed-opencode.ts:147-234` and preserves process isolation.
+
+### Wait for v2 GA
+
+Rejected.
+The parallel lane changes zero v1 behavior and allows provider UX work to begin
+against the hot-injection architecture now.
+Beta churn remains contained by the explicit `opencodeV2Version` pin in
+`constants.json` and the isolated manager in
+`apps/server/src/managed-opencode-v2.ts`.

--- a/evals/bench/results/2026-08-31-m3max-app-v1.json
+++ b/evals/bench/results/2026-08-31-m3max-app-v1.json
@@ -1,0 +1,158 @@
+{
+  "lane": "app-v1",
+  "createdAt": "2026-08-31T04:30:19.876Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpus": 16,
+    "cpuModel": "Apple M3 Max",
+    "memGB": 48,
+    "node": "v24.15.0"
+  },
+  "appCommit": "8d8d0105fd9e5bea4b7ff254833ee649b604e691",
+  "iterations": 5,
+  "pacingMs": 20,
+  "tokens": 20,
+  "pollResolutionMs": 50,
+  "executionPlan": {
+    "coldInstances": 5,
+    "warmIterations": 5,
+    "warmScenariosRunIn": "last cold instance only"
+  },
+  "modelReselectedPerSession": false,
+  "uiCompactionAvailable": false,
+  "results": {
+    "cold_boot_to_composer": [
+      {
+        "appInteractive": 36513,
+        "workspaceReady": 51020,
+        "composerReady": 51020,
+        "desktopTotalMs": 36513,
+        "appReadinessMs": 7690
+      },
+      {
+        "appInteractive": 27089,
+        "workspaceReady": 38536,
+        "composerReady": 38537,
+        "desktopTotalMs": 27089,
+        "appReadinessMs": 7025
+      },
+      {
+        "appInteractive": 27022,
+        "workspaceReady": 38489,
+        "composerReady": 38490,
+        "desktopTotalMs": 27022,
+        "appReadinessMs": 6958
+      },
+      {
+        "appInteractive": 27039,
+        "workspaceReady": 38495,
+        "composerReady": 38495,
+        "desktopTotalMs": 27039,
+        "appReadinessMs": 7448
+      },
+      {
+        "appInteractive": 27439,
+        "workspaceReady": 38923,
+        "composerReady": 38924,
+        "desktopTotalMs": 27439,
+        "appReadinessMs": 6821
+      }
+    ],
+    "first_send_cold": [
+      2382,
+      3433,
+      2885,
+      2325,
+      3583
+    ],
+    "new_session_ready": [
+      372,
+      403,
+      335,
+      355,
+      346
+    ],
+    "message_rtt": [
+      {
+        "userRendered": 75,
+        "firstToken": 133,
+        "complete": 500
+      },
+      {
+        "userRendered": 76,
+        "firstToken": 96,
+        "complete": 490
+      },
+      {
+        "userRendered": 80,
+        "firstToken": 89,
+        "complete": 523
+      },
+      {
+        "userRendered": 76,
+        "firstToken": 92,
+        "complete": 522
+      },
+      {
+        "userRendered": 83,
+        "firstToken": 88,
+        "complete": 506
+      }
+    ],
+    "workspace_switch": [
+      {
+        "aToB": 133,
+        "bToA": 92
+      },
+      {
+        "aToB": 97,
+        "bToA": 93
+      },
+      {
+        "aToB": 107,
+        "bToA": 94
+      },
+      {
+        "aToB": 105,
+        "bToA": 89
+      },
+      {
+        "aToB": 109,
+        "bToA": 132
+      }
+    ],
+    "long_message": [
+      {
+        "insertMs": 50,
+        "userRendered": 124,
+        "firstToken": 131,
+        "complete": 524
+      },
+      {
+        "insertMs": 43,
+        "userRendered": 94,
+        "firstToken": 159,
+        "complete": 535
+      },
+      {
+        "insertMs": 42,
+        "userRendered": 108,
+        "firstToken": 167,
+        "complete": 544
+      },
+      {
+        "insertMs": 43,
+        "userRendered": 110,
+        "firstToken": 167,
+        "complete": 552
+      },
+      {
+        "insertMs": 46,
+        "userRendered": 108,
+        "firstToken": 167,
+        "complete": 540
+      }
+    ]
+  }
+}

--- a/evals/bench/results/2026-08-31-m3max-engines.json
+++ b/evals/bench/results/2026-08-31-m3max-engines.json
@@ -1,0 +1,219 @@
+{
+  "lane": "engines",
+  "createdAt": "2026-08-31T04:24:12.229Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpus": 16,
+    "cpuModel": "Apple M3 Max",
+    "memGB": 48,
+    "node": "v24.15.0"
+  },
+  "versions": {
+    "v1": "1.18.18",
+    "v2": "0.0.0-beta-18707"
+  },
+  "iterations": 5,
+  "pacingMs": 20,
+  "tokens": 20,
+  "results": {
+    "v1": {
+      "boot_ready": [
+        542,
+        532,
+        526,
+        565,
+        540
+      ],
+      "spawn_to_first_api_ok": [
+        683,
+        669,
+        664,
+        706,
+        689
+      ],
+      "session_create": [
+        9,
+        9,
+        6,
+        3,
+        7
+      ],
+      "first_prompt_cold": [
+        3494
+      ],
+      "message_rtt": [
+        {
+          "accepted": 5,
+          "witnessFirstByte": 11,
+          "firstToken": 445,
+          "complete": 447
+        },
+        {
+          "accepted": 6,
+          "witnessFirstByte": 12,
+          "firstToken": 450,
+          "complete": 452
+        },
+        {
+          "accepted": 4,
+          "witnessFirstByte": 18,
+          "firstToken": 480,
+          "complete": 481
+        },
+        {
+          "accepted": 4,
+          "witnessFirstByte": 10,
+          "firstToken": 445,
+          "complete": 452
+        },
+        {
+          "accepted": 4,
+          "witnessFirstByte": 10,
+          "firstToken": 447,
+          "complete": 456
+        }
+      ],
+      "directory_switch": [
+        13,
+        20,
+        21,
+        13,
+        10
+      ],
+      "long_message": [
+        {
+          "accepted": 5,
+          "witnessFirstByte": 25,
+          "complete": 487
+        },
+        {
+          "accepted": 6,
+          "witnessFirstByte": 27,
+          "complete": 479
+        },
+        {
+          "accepted": 5,
+          "witnessFirstByte": 17,
+          "complete": 465
+        },
+        {
+          "accepted": 12,
+          "witnessFirstByte": 25,
+          "complete": 543
+        },
+        {
+          "accepted": 7,
+          "witnessFirstByte": 51,
+          "complete": 529
+        }
+      ],
+      "compaction": [
+        500,
+        474,
+        469,
+        451,
+        461
+      ]
+    },
+    "v2": {
+      "boot_ready": [
+        779,
+        516,
+        511,
+        517,
+        514
+      ],
+      "spawn_to_first_api_ok": [
+        787,
+        520,
+        514,
+        522,
+        517
+      ],
+      "session_create": [
+        119,
+        49,
+        50,
+        55,
+        57
+      ],
+      "first_prompt_cold": [
+        4502
+      ],
+      "message_rtt": [
+        {
+          "accepted": 3,
+          "witnessFirstByte": 9,
+          "firstToken": 546,
+          "complete": 547
+        },
+        {
+          "accepted": 3,
+          "witnessFirstByte": 10,
+          "firstToken": 524,
+          "complete": 526
+        },
+        {
+          "accepted": 2,
+          "witnessFirstByte": 9,
+          "firstToken": 516,
+          "complete": 517
+        },
+        {
+          "accepted": 2,
+          "witnessFirstByte": 9,
+          "firstToken": 515,
+          "complete": 516
+        },
+        {
+          "accepted": 3,
+          "witnessFirstByte": 10,
+          "firstToken": 491,
+          "complete": 494
+        }
+      ],
+      "directory_switch": [
+        61,
+        49,
+        49,
+        49,
+        53
+      ],
+      "long_message": [
+        {
+          "accepted": 14,
+          "witnessFirstByte": 10,
+          "complete": 525
+        },
+        {
+          "accepted": 18,
+          "witnessFirstByte": 10,
+          "complete": 537
+        },
+        {
+          "accepted": 21,
+          "witnessFirstByte": 18,
+          "complete": 522
+        },
+        {
+          "accepted": 13,
+          "witnessFirstByte": 10,
+          "complete": 514
+        },
+        {
+          "accepted": 14,
+          "witnessFirstByte": 10,
+          "complete": 532
+        }
+      ],
+      "compaction": [
+        452,
+        446,
+        480,
+        448,
+        460
+      ]
+    }
+  }
+}

--- a/evals/bench/results/2026-09-01-m3max-app-v2.json
+++ b/evals/bench/results/2026-09-01-m3max-app-v2.json
@@ -1,0 +1,158 @@
+{
+  "lane": "app-v2",
+  "createdAt": "2026-08-31T22:16:37.442Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpus": 16,
+    "cpuModel": "Apple M3 Max",
+    "memGB": 48,
+    "node": "v24.15.0"
+  },
+  "appCommit": "6bf01c58dc0aae18ab3e6bd479610a324b3d0ece",
+  "iterations": 5,
+  "pacingMs": 20,
+  "tokens": 20,
+  "pollResolutionMs": 50,
+  "executionPlan": {
+    "coldInstances": 5,
+    "warmIterations": 5,
+    "warmScenariosRunIn": "last cold instance only"
+  },
+  "modelReselectedPerSession": false,
+  "uiCompactionAvailable": false,
+  "results": {
+    "cold_boot_to_composer": [
+      {
+        "appInteractive": 21054,
+        "workspaceReady": 32987,
+        "composerReady": 32988,
+        "desktopTotalMs": 21054,
+        "appReadinessMs": 4284
+      },
+      {
+        "appInteractive": 22136,
+        "workspaceReady": 35337,
+        "composerReady": 35338,
+        "desktopTotalMs": 22136,
+        "appReadinessMs": 6456
+      },
+      {
+        "appInteractive": 19746,
+        "workspaceReady": 31093,
+        "composerReady": 31096,
+        "desktopTotalMs": 19746,
+        "appReadinessMs": 5123
+      },
+      {
+        "appInteractive": 19217,
+        "workspaceReady": 26839,
+        "composerReady": 26840,
+        "desktopTotalMs": 19217,
+        "appReadinessMs": 4827
+      },
+      {
+        "appInteractive": 20100,
+        "workspaceReady": 31499,
+        "composerReady": 31499,
+        "desktopTotalMs": 20100,
+        "appReadinessMs": 5075
+      }
+    ],
+    "first_send_cold": [
+      581,
+      649,
+      587,
+      628,
+      602
+    ],
+    "new_session_ready": [
+      396,
+      304,
+      291,
+      183,
+      258
+    ],
+    "message_rtt": [
+      {
+        "userRendered": 636,
+        "firstToken": 640,
+        "complete": 641
+      },
+      {
+        "userRendered": 627,
+        "firstToken": 628,
+        "complete": 630
+      },
+      {
+        "userRendered": 577,
+        "firstToken": 578,
+        "complete": 578
+      },
+      {
+        "userRendered": 568,
+        "firstToken": 569,
+        "complete": 569
+      },
+      {
+        "userRendered": 588,
+        "firstToken": 589,
+        "complete": 589
+      }
+    ],
+    "workspace_switch": [
+      {
+        "aToB": 151,
+        "bToA": 142
+      },
+      {
+        "aToB": 202,
+        "bToA": 99
+      },
+      {
+        "aToB": 438,
+        "bToA": 142
+      },
+      {
+        "aToB": 166,
+        "bToA": 98
+      },
+      {
+        "aToB": 170,
+        "bToA": 127
+      }
+    ],
+    "long_message": [
+      {
+        "insertMs": 78,
+        "userRendered": 631,
+        "firstToken": 632,
+        "complete": 633
+      },
+      {
+        "insertMs": 118,
+        "userRendered": 716,
+        "firstToken": 718,
+        "complete": 718
+      },
+      {
+        "insertMs": 57,
+        "userRendered": 571,
+        "firstToken": 572,
+        "complete": 572
+      },
+      {
+        "insertMs": 57,
+        "userRendered": 589,
+        "firstToken": 592,
+        "complete": 593
+      },
+      {
+        "insertMs": 55,
+        "userRendered": 570,
+        "firstToken": 571,
+        "complete": 572
+      }
+    ]
+  }
+}

--- a/evals/specs/bench-opencode-engines.test.ts
+++ b/evals/specs/bench-opencode-engines.test.ts
@@ -1,0 +1,880 @@
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage } from "node:http";
+import { arch, cpus, platform, tmpdir, totalmem } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { eventually, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+import {
+  createManagedOpencodeServer,
+  type ManagedOpencodeServer,
+} from "../../apps/server/src/managed-opencode";
+import {
+  createManagedOpencodeV2Server,
+  type ManagedOpencodeV2Server,
+} from "../../apps/server/src/managed-opencode-v2";
+
+const execFileAsync = promisify(execFile);
+const iterations = Number(process.env.OPENWORK_BENCH_ITERATIONS ?? "1");
+const pacingMs = 20;
+const tokenCount = 20;
+const pollIntervalMs = 25;
+
+type Lane = "v1" | "v2";
+
+interface WitnessRequest {
+  at: number;
+  auth: string;
+  model: string;
+  promptChars: number;
+  stream: boolean;
+}
+
+interface Witness {
+  url: string;
+  nonce: string;
+  requests: WitnessRequest[];
+  close(): Promise<void>;
+}
+
+interface HttpResult {
+  status: number;
+  json: unknown;
+  text: string;
+}
+
+interface BenchEngine {
+  lane: Lane;
+  rootDir: string;
+  directory: string;
+  spawnStartedAt: number;
+  bootReadyMs: number;
+  list(directory: string): Promise<HttpResult>;
+  create(directory: string): Promise<HttpResult>;
+  prompt(sessionID: string, directory: string, text: string): Promise<HttpResult>;
+  messages(sessionID: string, directory: string): Promise<HttpResult>;
+  compact(sessionID: string, directory: string): Promise<HttpResult>;
+  close(): Promise<void>;
+}
+
+interface MessageTiming {
+  accepted: number;
+  witnessFirstByte: number;
+  firstToken: number;
+  complete: number;
+}
+
+interface LongMessageTiming {
+  accepted: number;
+  witnessFirstByte: number;
+  complete: number;
+}
+
+interface EngineResults {
+  boot_ready: number[];
+  spawn_to_first_api_ok: number[];
+  session_create: number[];
+  first_prompt_cold: number[];
+  message_rtt: MessageTiming[];
+  directory_switch: number[];
+  long_message: LongMessageTiming[];
+  compaction: number[];
+}
+
+interface LaneRun {
+  results: EngineResults;
+  requests: WitnessRequest[];
+}
+
+interface Versions {
+  v1: string;
+  v2: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readVersions(): Promise<Versions> {
+  const constants: unknown = JSON.parse(
+    await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"),
+  );
+  if (
+    !isRecord(constants) ||
+    typeof constants.opencodeVersion !== "string" ||
+    typeof constants.opencodeV2Version !== "string"
+  ) {
+    throw new Error("constants.json must define opencodeVersion and opencodeV2Version");
+  }
+  const v1 = constants.opencodeVersion.startsWith("v")
+    ? constants.opencodeVersion.slice(1)
+    : constants.opencodeVersion;
+  return { v1, v2: constants.opencodeV2Version };
+}
+
+async function provisionBinary(
+  cacheName: string,
+  version: string,
+  packageName: string,
+  binaryName: string,
+  overrideName: string,
+): Promise<string> {
+  const override = process.env[overrideName];
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const cache = join(tmpdir(), cacheName, version);
+  const binary = join(cache, "node_modules", ".bin", binaryName);
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, "{\"private\":true}\n");
+    await execFileAsync(
+      "pnpm",
+      ["add", "--ignore-workspace", "--save-exact", `${packageName}@${version}`],
+      { cwd: cache, timeout: 300_000 },
+    );
+  }
+  if (packageName === "opencode-ai" && await exists(binary)) {
+    try {
+      await execFileAsync(binary, ["--version"], { cwd: cache, timeout: 15_000 });
+    } catch {
+      await execFileAsync("pnpm", ["exec", "node", "postinstall.mjs"], {
+        cwd: join(cache, "node_modules", packageName),
+        timeout: 300_000,
+      });
+    }
+  }
+  if (!(await exists(binary))) {
+    throw new Error(
+      `${packageName}@${version} did not provide ${binary}; set ${overrideName} to a working binary`,
+    );
+  }
+  return binary;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text === "" ? {} : JSON.parse(text);
+}
+
+function completionBase(model: string, nonce: string): {
+  id: string;
+  created: number;
+  model: string;
+} {
+  return {
+    id: `chatcmpl-${nonce}`,
+    created: Math.floor(Date.now() / 1_000),
+    model,
+  };
+}
+
+async function startWitness(lane: Lane): Promise<Witness> {
+  const nonce = `BENCH-${lane}-${randomBytes(12).toString("hex")}`;
+  const requests: WitnessRequest[] = [];
+  const server = createServer(async (request, response) => {
+    if (
+      request.method !== "POST" ||
+      (request.url !== "/v1/chat/completions" && request.url !== "/chat/completions")
+    ) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "not found" }));
+      return;
+    }
+
+    const at = Date.now();
+    try {
+      const body = await readRequestBody(request);
+      const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
+      const messages = isRecord(body) ? body.messages : null;
+      const serializedMessages = messages === undefined ? "null" : JSON.stringify(messages);
+      const stream = isRecord(body) && body.stream === true;
+      requests.push({
+        at,
+        auth: request.headers.authorization ?? "",
+        model,
+        promptChars: serializedMessages.length,
+        stream,
+      });
+
+      const base = completionBase(model, nonce);
+      if (!stream) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          ...base,
+          object: "chat.completion",
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: `${nonce} ${Array.from({ length: tokenCount }, (_, index) => `token ${index + 1} `).join("")}`,
+            },
+            finish_reason: "stop",
+          }],
+          usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+        }));
+        return;
+      }
+
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      response.write(`data: ${JSON.stringify({
+        ...base,
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: { role: "assistant", content: `${nonce} ` }, finish_reason: null }],
+      })}\n\n`);
+      for (let index = 1; index <= tokenCount; index += 1) {
+        await sleep(pacingMs);
+        response.write(`data: ${JSON.stringify({
+          ...base,
+          object: "chat.completion.chunk",
+          choices: [{ index: 0, delta: { content: `token ${index} ` }, finish_reason: null }],
+        })}\n\n`);
+      }
+      response.write(`data: ${JSON.stringify({
+        ...base,
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+      })}\n\n`);
+      response.end("data: [DONE]\n\n");
+    } catch (error) {
+      if (!response.headersSent) response.writeHead(400, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error(`The ${lane} witness failed to bind a TCP port`);
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    nonce,
+    requests,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    }),
+  };
+}
+
+function basicAuthorization(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
+async function fetchJson(
+  baseUrl: string,
+  authorization: string,
+  path: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    directory: string;
+    lane: Lane;
+  },
+): Promise<HttpResult> {
+  const url = new URL(path, baseUrl);
+  const headers = new Headers({
+    authorization,
+    "content-type": "application/json",
+  });
+  if (options.lane === "v1") {
+    headers.set("x-opencode-directory", options.directory);
+  } else {
+    url.searchParams.set("location[directory]", options.directory);
+  }
+  const response = await fetch(url, {
+    method: options.method,
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    signal: AbortSignal.timeout(180_000),
+  });
+  const text = await response.text();
+  let json: unknown = text;
+  if (text !== "") {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // Raw engine diagnostics remain available in text.
+    }
+  }
+  return { status: response.status, json, text };
+}
+
+function v1Config(witnessUrl: string): unknown {
+  return {
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      "bench-witness": {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Bench Witness",
+        options: { baseURL: `${witnessUrl}/v1`, apiKey: "bench-key-v1" },
+        models: { "bench-model": { name: "Bench Model" } },
+      },
+    },
+  };
+}
+
+function v2Config(witnessUrl: string): unknown {
+  return {
+    $schema: "https://opencode.ai/config.json",
+    providers: {
+      "bench-witness": {
+        name: "Bench Witness",
+        package: "@opencode-ai/ai/providers/openai-compatible",
+        settings: { baseURL: `${witnessUrl}/v1`, apiKey: "bench-key-v2", name: "bench-witness" },
+        models: {
+          "bench-model": {
+            name: "Bench Model",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+            limit: { context: 128_000, output: 8_192 },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildEngine(
+  lane: Lane,
+  rootDir: string,
+  directory: string,
+  spawnStartedAt: number,
+  bootReadyMs: number,
+  server: ManagedOpencodeServer | ManagedOpencodeV2Server,
+): BenchEngine {
+  const authorization = basicAuthorization(server.username, server.password);
+  const request = (path: string, options: { method?: string; body?: unknown; directory: string }) =>
+    fetchJson(server.url, authorization, path, { ...options, lane });
+
+  return {
+    lane,
+    rootDir,
+    directory,
+    spawnStartedAt,
+    bootReadyMs,
+    list(targetDirectory) {
+      return request(lane === "v1" ? "/session" : "/api/session", { directory: targetDirectory });
+    },
+    create(targetDirectory) {
+      const body = lane === "v1"
+        ? {
+            title: "Engine benchmark",
+            model: { providerID: "bench-witness", id: "bench-model" },
+          }
+        : { model: { providerID: "bench-witness", id: "bench-model" } };
+      return request(lane === "v1" ? "/session" : "/api/session", {
+        method: "POST",
+        body,
+        directory: targetDirectory,
+      });
+    },
+    prompt(sessionID, targetDirectory, text) {
+      const body = lane === "v1"
+        ? {
+            model: { providerID: "bench-witness", modelID: "bench-model" },
+            parts: [{ type: "text", text }],
+          }
+        : { text };
+      const path = lane === "v1"
+        ? `/session/${encodeURIComponent(sessionID)}/prompt_async`
+        : `/api/session/${encodeURIComponent(sessionID)}/prompt`;
+      return request(path, { method: "POST", body, directory: targetDirectory });
+    },
+    messages(sessionID, targetDirectory) {
+      const path = lane === "v1"
+        ? `/session/${encodeURIComponent(sessionID)}/message`
+        : `/api/session/${encodeURIComponent(sessionID)}/message`;
+      return request(path, { directory: targetDirectory });
+    },
+    compact(sessionID, targetDirectory) {
+      const path = lane === "v1"
+        ? `/session/${encodeURIComponent(sessionID)}/summarize`
+        : `/api/session/${encodeURIComponent(sessionID)}/compact`;
+      const body = lane === "v1"
+        ? { providerID: "bench-witness", modelID: "bench-model", auto: false }
+        : {};
+      return request(path, { method: "POST", body, directory: targetDirectory });
+    },
+    close: () => server.close(),
+  };
+}
+
+async function bootEngine(lane: Lane, binary: string, witnessUrl: string): Promise<BenchEngine> {
+  const rootDir = await mkdtemp(join(tmpdir(), `bench-opencode-${lane}-`));
+  const directory = join(rootDir, "workspace");
+  await mkdir(directory);
+  try {
+    if (lane === "v1") {
+      const configPath = join(rootDir, "opencode.json");
+      await writeFile(configPath, `${JSON.stringify(v1Config(witnessUrl), null, 2)}\n`);
+      const startedAt = Date.now();
+      const server = await createManagedOpencodeServer({
+        bin: binary,
+        cwd: directory,
+        timeoutMs: 60_000,
+        env: {
+          OPENCODE_CONFIG: configPath,
+          OPENCODE_DISABLE_AUTOUPDATE: "1",
+          OPENCODE_DISABLE_MODELS_FETCH: "1",
+          XDG_CACHE_HOME: join(rootDir, "cache"),
+          XDG_CONFIG_HOME: join(rootDir, "xdg-config"),
+          XDG_DATA_HOME: join(rootDir, "data"),
+          XDG_STATE_HOME: join(rootDir, "state"),
+        },
+      });
+      return buildEngine(lane, rootDir, directory, startedAt, Date.now() - startedAt, server);
+    }
+
+    const configDir = join(rootDir, "config");
+    await mkdir(configDir);
+    await writeFile(
+      join(configDir, "opencode.json"),
+      `${JSON.stringify(v2Config(witnessUrl), null, 2)}\n`,
+    );
+    const startedAt = Date.now();
+    const server = await createManagedOpencodeV2Server({ bin: binary, rootDir });
+    const health = await server.health();
+    if (!health.healthy) throw new Error("OpenCode v2 health was not healthy after boot");
+    return buildEngine(lane, rootDir, directory, startedAt, Date.now() - startedAt, server);
+  } catch (error) {
+    await rm(rootDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function requireStatus(result: HttpResult, expected: number[], operation: string): void {
+  if (!expected.includes(result.status)) {
+    throw new Error(`${operation} returned HTTP ${result.status}: ${result.text.slice(0, 2_000)}`);
+  }
+}
+
+function readSessionID(payload: unknown): string | undefined {
+  if (isRecord(payload) && typeof payload.id === "string") return payload.id;
+  if (isRecord(payload) && isRecord(payload.data) && typeof payload.data.id === "string") {
+    return payload.data.id;
+  }
+  return undefined;
+}
+
+async function createSession(engine: BenchEngine, directory: string): Promise<string> {
+  const result = await engine.create(directory);
+  requireStatus(result, [200], `${engine.lane} session create`);
+  const id = readSessionID(result.json);
+  if (id === undefined) {
+    throw new Error(`${engine.lane} session create did not return an id: ${result.text.slice(0, 2_000)}`);
+  }
+  return id;
+}
+
+function containsV1Summary(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsV1Summary);
+  if (!isRecord(value)) return false;
+  if (value.summary === true || value.type === "compaction") return true;
+  return Object.values(value).some(containsV1Summary);
+}
+
+function containsV2CompletedCompaction(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsV2CompletedCompaction);
+  if (!isRecord(value)) return false;
+  if (value.type === "compaction" && value.status === "completed") return true;
+  return Object.values(value).some(containsV2CompletedCompaction);
+}
+
+async function waitForMessages(
+  engine: BenchEngine,
+  sessionID: string,
+  directory: string,
+  label: string,
+  condition: (payload: unknown) => boolean,
+  within: number,
+): Promise<HttpResult> {
+  const result = await eventually(
+    () => engine.messages(sessionID, directory),
+    {
+      within,
+      intervalMs: pollIntervalMs,
+      label,
+      until: (response) => response.status === 200 && condition(response.json),
+    },
+  );
+  requireStatus(result, [200], label);
+  return result;
+}
+
+async function waitForWitnessRequest(
+  witness: Witness,
+  startIndex: number,
+  label: string,
+  within: number,
+): Promise<WitnessRequest> {
+  const request = await eventually(
+    () => witness.requests[startIndex],
+    {
+      within,
+      intervalMs: pollIntervalMs,
+      label,
+      until: (entry) => entry !== undefined,
+    },
+  );
+  if (request === undefined) throw new Error(`${label} did not reach the witness`);
+  return request;
+}
+
+async function completePrompt(
+  engine: BenchEngine,
+  witness: Witness,
+  sessionID: string,
+  directory: string,
+  text: string,
+  label: string,
+  within: number,
+): Promise<MessageTiming> {
+  const witnessIndex = witness.requests.length;
+  const startedAt = Date.now();
+  const accepted = await engine.prompt(sessionID, directory, text);
+  requireStatus(accepted, engine.lane === "v1" ? [204] : [200], `${label} prompt admission`);
+  const acceptedMs = Date.now() - startedAt;
+  const witnessRequest = await waitForWitnessRequest(witness, witnessIndex, `${label} witness request`, within);
+  await waitForMessages(
+    engine,
+    sessionID,
+    directory,
+    `${label} first token`,
+    (payload) => {
+      const serialized = JSON.stringify(payload);
+      return serialized.includes(witness.nonce) && serialized.includes("token 1 ");
+    },
+    within,
+  );
+  const firstTokenMs = Date.now() - startedAt;
+  await waitForMessages(
+    engine,
+    sessionID,
+    directory,
+    `${label} completion`,
+    (payload) => {
+      const serialized = JSON.stringify(payload);
+      return serialized.includes(witness.nonce) && serialized.includes(`token ${tokenCount} `);
+    },
+    within,
+  );
+  return {
+    accepted: acceptedMs,
+    witnessFirstByte: witnessRequest.at - startedAt,
+    firstToken: firstTokenMs,
+    complete: Date.now() - startedAt,
+  };
+}
+
+function longPrompt(): string {
+  let value = "";
+  let index = 0;
+  while (value.length < 200_000) {
+    value += `lorem-${index} `;
+    index += 1;
+  }
+  return value.slice(0, 200_000);
+}
+
+async function runLane(lane: Lane, binary: string): Promise<LaneRun> {
+  const witness = await startWitness(lane);
+  const engines: BenchEngine[] = [];
+  const extraDirectories: string[] = [];
+  const results: EngineResults = {
+    boot_ready: [],
+    spawn_to_first_api_ok: [],
+    session_create: [],
+    first_prompt_cold: [],
+    message_rtt: [],
+    directory_switch: [],
+    long_message: [],
+    compaction: [],
+  };
+
+  try {
+    let engine: BenchEngine | undefined;
+    for (let index = 0; index < iterations; index += 1) {
+      const booted = await bootEngine(lane, binary, witness.url);
+      engines.push(booted);
+      results.boot_ready.push(booted.bootReadyMs);
+      const firstApi = await booted.list(booted.directory);
+      requireStatus(firstApi, [200], `${lane} first session-list API`);
+      results.spawn_to_first_api_ok.push(Date.now() - booted.spawnStartedAt);
+      if (index === iterations - 1) engine = booted;
+      else await booted.close();
+    }
+    if (engine === undefined) throw new Error(`${lane} did not retain a benchmark engine`);
+
+    const scenarioSessions: string[] = [];
+    for (let index = 0; index < iterations; index += 1) {
+      const startedAt = Date.now();
+      const sessionID = await createSession(engine, engine.directory);
+      results.session_create.push(Date.now() - startedAt);
+      scenarioSessions.push(sessionID);
+    }
+
+    const coldSession = scenarioSessions[0];
+    if (coldSession === undefined) throw new Error(`${lane} did not create a cold-prompt session`);
+    const coldStartedAt = Date.now();
+    await completePrompt(
+      engine,
+      witness,
+      coldSession,
+      engine.directory,
+      "bench first prompt cold",
+      `${lane} first prompt cold`,
+      180_000,
+    );
+    results.first_prompt_cold.push(Date.now() - coldStartedAt);
+
+    // Cold behavior is retained above; this untimed prompt leaves both lanes in the
+    // same warm-provider state before the repeatable message scenarios begin.
+    const warmupSession = await createSession(engine, engine.directory);
+    await completePrompt(
+      engine,
+      witness,
+      warmupSession,
+      engine.directory,
+      "bench untimed provider warmup",
+      `${lane} untimed provider warmup`,
+      180_000,
+    );
+
+    for (let index = 0; index < iterations; index += 1) {
+      const sessionID = await createSession(engine, engine.directory);
+      results.message_rtt.push(await completePrompt(
+        engine,
+        witness,
+        sessionID,
+        engine.directory,
+        `bench message ${index}`,
+        `${lane} message RTT ${index}`,
+        60_000,
+      ));
+    }
+
+    for (let index = 0; index < iterations; index += 1) {
+      const directory = await mkdtemp(join(tmpdir(), `bench-${lane}-directory-`));
+      extraDirectories.push(directory);
+      const startedAt = Date.now();
+      const listed = await engine.list(directory);
+      requireStatus(listed, [200], `${lane} directory switch list ${index}`);
+      await createSession(engine, directory);
+      results.directory_switch.push(Date.now() - startedAt);
+    }
+
+    const prompt = longPrompt();
+    const longSessions: string[] = [];
+    for (let index = 0; index < iterations; index += 1) {
+      const sessionID = await createSession(engine, engine.directory);
+      longSessions.push(sessionID);
+      const timing = await completePrompt(
+        engine,
+        witness,
+        sessionID,
+        engine.directory,
+        prompt,
+        `${lane} long message ${index}`,
+        90_000,
+      );
+      results.long_message.push({
+        accepted: timing.accepted,
+        witnessFirstByte: timing.witnessFirstByte,
+        complete: timing.complete,
+      });
+    }
+
+    for (let index = 0; index < longSessions.length; index += 1) {
+      const sessionID = longSessions[index];
+      if (sessionID === undefined) throw new Error(`${lane} long-message session ${index} is missing`);
+      const witnessIndex = witness.requests.length;
+      const startedAt = Date.now();
+      const compacted = await engine.compact(sessionID, engine.directory);
+      requireStatus(compacted, [200], `${lane} compaction ${index}`);
+      await waitForMessages(
+        engine,
+        sessionID,
+        engine.directory,
+        `${lane} completed compaction ${index}`,
+        lane === "v1" ? containsV1Summary : containsV2CompletedCompaction,
+        90_000,
+      );
+      const compactionRequest = await waitForWitnessRequest(
+        witness,
+        witnessIndex,
+        `${lane} compaction witness ${index}`,
+        90_000,
+      );
+      const expectedKey = lane === "v1" ? "bench-key-v1" : "bench-key-v2";
+      if (compactionRequest.auth !== `Bearer ${expectedKey}`) {
+        throw new Error(`${lane} compaction did not carry its lane key`);
+      }
+      results.compaction.push(Date.now() - startedAt);
+    }
+
+    return { results, requests: [...witness.requests] };
+  } finally {
+    for (const engine of engines) await engine.close();
+    await witness.close();
+    await Promise.all([
+      ...engines.map((engine) => rm(engine.rootDir, { recursive: true, force: true })),
+      ...extraDirectories.map((directory) => rm(directory, { recursive: true, force: true })),
+    ]);
+  }
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const upper = sorted[middle];
+  if (upper === undefined) return 0;
+  if (sorted.length % 2 === 1) return upper;
+  const lower = sorted[middle - 1];
+  return lower === undefined ? upper : Math.round((lower + upper) / 2);
+}
+
+function medianRows(v1: EngineResults, v2: EngineResults): Array<[string, number, number]> {
+  return [
+    ["boot_ready", median(v1.boot_ready), median(v2.boot_ready)],
+    ["spawn_to_first_api_ok", median(v1.spawn_to_first_api_ok), median(v2.spawn_to_first_api_ok)],
+    ["session_create", median(v1.session_create), median(v2.session_create)],
+    ["first_prompt_cold", median(v1.first_prompt_cold), median(v2.first_prompt_cold)],
+    ["message.accepted", median(v1.message_rtt.map((sample) => sample.accepted)), median(v2.message_rtt.map((sample) => sample.accepted))],
+    ["message.witness_first_byte", median(v1.message_rtt.map((sample) => sample.witnessFirstByte)), median(v2.message_rtt.map((sample) => sample.witnessFirstByte))],
+    ["message.first_token", median(v1.message_rtt.map((sample) => sample.firstToken)), median(v2.message_rtt.map((sample) => sample.firstToken))],
+    ["message.complete", median(v1.message_rtt.map((sample) => sample.complete)), median(v2.message_rtt.map((sample) => sample.complete))],
+    ["directory_switch", median(v1.directory_switch), median(v2.directory_switch)],
+    ["long.accepted", median(v1.long_message.map((sample) => sample.accepted)), median(v2.long_message.map((sample) => sample.accepted))],
+    ["long.witness_first_byte", median(v1.long_message.map((sample) => sample.witnessFirstByte)), median(v2.long_message.map((sample) => sample.witnessFirstByte))],
+    ["long.complete", median(v1.long_message.map((sample) => sample.complete)), median(v2.long_message.map((sample) => sample.complete))],
+    ["compaction", median(v1.compaction), median(v2.compaction)],
+  ];
+}
+
+function assertFiniteSamples(values: number[], expected: number): void {
+  expect(values).toHaveLength(expected);
+  expect(values.every((value) => Number.isFinite(value) && value >= 0)).toBe(true);
+}
+
+function assertCompleted(results: EngineResults): void {
+  assertFiniteSamples(results.boot_ready, iterations);
+  assertFiniteSamples(results.spawn_to_first_api_ok, iterations);
+  assertFiniteSamples(results.session_create, iterations);
+  assertFiniteSamples(results.first_prompt_cold, 1);
+  expect(results.message_rtt).toHaveLength(iterations);
+  expect(results.message_rtt.every((sample) =>
+    [sample.accepted, sample.witnessFirstByte, sample.firstToken, sample.complete]
+      .every((value) => Number.isFinite(value) && value >= 0))).toBe(true);
+  assertFiniteSamples(results.directory_switch, iterations);
+  expect(results.long_message).toHaveLength(iterations);
+  expect(results.long_message.every((sample) =>
+    [sample.accepted, sample.witnessFirstByte, sample.complete]
+      .every((value) => Number.isFinite(value) && value >= 0))).toBe(true);
+  assertFiniteSamples(results.compaction, iterations);
+}
+
+test("benchmarks OpenCode v1 and v2 engines with identical client sequences", async ({ evidence }) => {
+  if (!Number.isInteger(iterations) || iterations < 1) {
+    throw new Error("OPENWORK_BENCH_ITERATIONS must be a positive integer");
+  }
+
+  const versions = await readVersions();
+  const v1Binary = await provisionBinary(
+    "openwork-opencode-v1-cache",
+    versions.v1,
+    "opencode-ai",
+    "opencode",
+    "OPENWORK_EVAL_OPENCODE_BIN_V1",
+  );
+  const v2Binary = await provisionBinary(
+    "openwork-opencode-v2-cache",
+    versions.v2,
+    "@opencode-ai/cli",
+    "opencode2",
+    "OPENWORK_EVAL_OPENCODE2_BIN",
+  );
+
+  const v1 = await runLane("v1", v1Binary);
+  const v2 = await runLane("v2", v2Binary);
+  assertCompleted(v1.results);
+  assertCompleted(v2.results);
+
+  const laneAssertions: Array<{
+    lane: Lane;
+    run: LaneRun;
+    expectedKey: string;
+    wrongKey: string;
+  }> = [
+    { lane: "v1", run: v1, expectedKey: "bench-key-v1", wrongKey: "bench-key-v2" },
+    { lane: "v2", run: v2, expectedKey: "bench-key-v2", wrongKey: "bench-key-v1" },
+  ];
+  for (const { lane, run, expectedKey, wrongKey } of laneAssertions) {
+    expect(run.requests.length).toBeGreaterThan(0);
+    expect(run.requests.every((request) => request.auth === `Bearer ${expectedKey}`)).toBe(true);
+    expect(run.requests.every((request) => request.model === "bench-model")).toBe(true);
+    expect(run.requests.every((request) => request.promptChars > 0)).toBe(true);
+    expect(run.requests.some((request) => request.auth === `Bearer ${wrongKey}`)).toBe(false);
+    evidence.recordAssertionEvidence(
+      `${lane} engine benchmark completion and witness fidelity`,
+      `${lane} completed boot, API readiness, create, cold prompt, warm RTT, directory switch, 200k message, and compaction samples; every witness request used only Bearer ${expectedKey} with bench-model.`,
+      true,
+    );
+  }
+
+  const cpu = cpus();
+  const resultsDir = process.env.OPENWORK_BENCH_RESULTS_DIR ?? tmpdir();
+  await mkdir(resultsDir, { recursive: true });
+  const outputPath = join(resultsDir, `bench-opencode-engines-${Date.now()}.json`);
+  await writeFile(outputPath, `${JSON.stringify({
+    lane: "engines",
+    createdAt: new Date().toISOString(),
+    machine: {
+      platform: platform(),
+      arch: arch(),
+      cpus: cpu.length,
+      cpuModel: cpu[0]?.model ?? "unknown",
+      memGB: Math.round((totalmem() / 1024 ** 3) * 10) / 10,
+      node: process.version,
+    },
+    versions,
+    iterations,
+    pacingMs,
+    tokens: tokenCount,
+    results: { v1: v1.results, v2: v2.results },
+  }, null, 2)}\n`);
+
+  const table = medianRows(v1.results, v2.results)
+    .map(([scenario, v1Median, v2Median]) => `${scenario}\t${v1Median}\t${v2Median}`)
+    .join("\n");
+  console.info(`[bench-opencode-engines] medians (ms)\nscenario\tv1\tv2\n${table}\nresults\t${outputPath}`);
+}, 600_000);

--- a/evals/specs/bench-openwork-app-v1.e2e.test.ts
+++ b/evals/specs/bench-openwork-app-v1.e2e.test.ts
@@ -1,0 +1,1286 @@
+import { execFile } from "node:child_process";
+import { access, writeFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { ServerResponse } from "node:http";
+import { arch, cpus, platform, tmpdir, totalmem } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { clickButton, createAndSelectWorkspace, evalIn, readComposerState } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { desktop, localHost } from "@openwork/hosts";
+import type { DesktopHandle } from "@openwork/hosts";
+import { eventually, needs, test } from "@openwork/testkit";
+import { timeline } from "../packages/timeline/src/index.ts";
+import { expect } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const benchEngine = process.env.OPENWORK_BENCH_ENGINE === "v2" ? "v2" : "v1";
+const title = enabled
+  ? `OpenWork Electron ${benchEngine} engine completes the CDP benchmark with faithful witness traffic`
+  : `OpenWork Electron ${benchEngine} benchmark skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1`;
+const providerId = "bench-witness";
+const modelId = "bench-model";
+const modelName = "Bench Model";
+const pacingMs = 20;
+const tokenCount = 20;
+const pollResolutionMs = 50;
+const rendererRoutingPollMs = 15_500;
+const longMessageChars = 200_000;
+
+interface WitnessRequest {
+  at: string;
+  auth: string;
+  model: string;
+  promptChars: number;
+}
+
+interface Witness {
+  url: string;
+  requests: WitnessRequest[];
+  close(): Promise<void>;
+}
+
+interface ColdTiming {
+  appInteractive: number;
+  workspaceReady: number;
+  composerReady: number;
+  desktopTotalMs: number;
+  appReadinessMs?: number;
+}
+
+interface MessageTiming {
+  userRendered: number;
+  firstToken: number;
+  complete: number;
+}
+
+interface SwitchTiming {
+  aToB: number;
+  bToA: number;
+}
+
+interface LongMessageTiming extends MessageTiming {
+  insertMs: number;
+}
+
+interface BenchmarkResults {
+  cold_boot_to_composer: ColdTiming[];
+  first_send_cold: number[];
+  new_session_ready: number[];
+  message_rtt: MessageTiming[];
+  workspace_switch: SwitchTiming[];
+  long_message: LongMessageTiming[];
+}
+
+interface SendFacts {
+  timing: MessageTiming;
+  sessionId: string;
+  assistantText: string;
+  userLength: number;
+}
+
+interface Chat {
+  workspaceId: string;
+  sessionId: string;
+  title: string;
+}
+
+interface ServerInfo {
+  baseUrl: string;
+  token: string;
+}
+
+interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  chatRouting: boolean;
+  mirroredProviderIds: string[];
+  catalogModelIds: string[];
+}
+
+interface V1SessionFreezeCheck {
+  workspaceId: string;
+  before: number;
+  after: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOpencodeV2Bin(): Promise<string> {
+  const override = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const constants: unknown = JSON.parse(await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"));
+  if (!isRecord(constants) || typeof constants.opencodeV2Version !== "string") {
+    throw new Error("constants.json must define a string opencodeV2Version");
+  }
+  const cache = join(tmpdir(), "openwork-opencode-v2-cache", constants.opencodeV2Version);
+  const binary = join(cache, "node_modules", ".bin", "opencode2");
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, '{"private":true}\n');
+    await execFileAsync(
+      "pnpm",
+      ["add", "--ignore-workspace", "--save-exact", `@opencode-ai/cli@${constants.opencodeV2Version}`],
+      { cwd: cache, timeout: 180_000 },
+    );
+  }
+  if (!(await exists(binary))) {
+    throw new Error(`OpenCode v2 binary was not installed at ${binary}; set OPENWORK_EVAL_OPENCODE2_BIN to a working opencode2 binary`);
+  }
+  return binary;
+}
+
+function bodyFromJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function textChars(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  if (Array.isArray(value)) return value.reduce((total, entry) => total + textChars(entry), 0);
+  if (!isRecord(value)) return 0;
+  if (typeof value.text === "string") return value.text.length;
+  return textChars(value.content);
+}
+
+function promptChars(body: unknown): number {
+  if (!isRecord(body) || !Array.isArray(body.messages)) return 0;
+  return body.messages.reduce((total, message) => {
+    if (!isRecord(message)) return total;
+    return total + textChars(message.content);
+  }, 0);
+}
+
+function authorization(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value.join(",");
+  return value ?? "";
+}
+
+function writeSse(response: ServerResponse, payload: unknown): boolean {
+  if (response.destroyed || response.writableEnded) return false;
+  response.write(`data: ${JSON.stringify(payload)}\n\n`);
+  return true;
+}
+
+async function streamWitnessCompletion(
+  response: ServerResponse,
+  requestId: string,
+  nonce: string,
+  model: string,
+  requestPromptChars: number,
+): Promise<void> {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  writeSse(response, {
+    id: requestId,
+    object: "chat.completion.chunk",
+    model,
+    choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+  });
+  for (let token = 1; token <= tokenCount; token += 1) {
+    await sleep(pacingMs);
+    const content = token === tokenCount ? `token ${tokenCount} ${nonce}` : `token ${token} `;
+    if (!writeSse(response, {
+      id: requestId,
+      object: "chat.completion.chunk",
+      model,
+      choices: [{ index: 0, delta: { content }, finish_reason: null }],
+    })) return;
+  }
+  writeSse(response, {
+    id: requestId,
+    object: "chat.completion.chunk",
+    model,
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: Math.max(1, Math.ceil(requestPromptChars / 4)),
+      completion_tokens: tokenCount,
+      total_tokens: Math.max(1, Math.ceil(requestPromptChars / 4)) + tokenCount,
+    },
+  });
+  if (!response.destroyed && !response.writableEnded) response.end("data: [DONE]\n\n");
+}
+
+async function startWitness(nonce: string): Promise<Witness> {
+  const requests: WitnessRequest[] = [];
+  let requestNumber = 0;
+  const server = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && (url.startsWith("/v1/models") || url.startsWith("/models"))) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+    if (request.method !== "POST" || (url !== "/v1/chat/completions" && url !== "/chat/completions")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "not found" } }));
+      return;
+    }
+
+    request.setEncoding("utf8");
+    let rawBody = "";
+    request.on("data", (chunk: string) => {
+      rawBody += chunk;
+    });
+    request.on("end", () => {
+      const body = bodyFromJson(rawBody);
+      const requestedModel = isRecord(body) && typeof body.model === "string" ? body.model : "";
+      const requestPromptChars = promptChars(body);
+      requestNumber += 1;
+      requests.push({
+        at: new Date().toISOString(),
+        auth: authorization(request.headers.authorization),
+        model: requestedModel,
+        promptChars: requestPromptChars,
+      });
+
+      const requestId = `chatcmpl-openwork-v1-bench-${requestNumber}`;
+      if (isRecord(body) && body.stream === false) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          id: requestId,
+          object: "chat.completion",
+          model: requestedModel,
+          choices: [{ index: 0, message: { role: "assistant", content: "Bench session title" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+        }));
+        return;
+      }
+      void streamWitnessCompletion(response, requestId, nonce, requestedModel, requestPromptChars)
+        .catch(() => response.destroy());
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Benchmark witness did not bind a TCP port.");
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    async close() {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    },
+  };
+}
+
+async function writeProviderConfig(workspacePath: string, witnessUrl: string): Promise<void> {
+  await writeFile(join(workspacePath, "opencode.json"), `${JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Bench Witness",
+        options: { baseURL: `${witnessUrl}/v1`, apiKey: "bench-key-app" },
+        models: { [modelId]: { name: modelName } },
+      },
+    },
+  }, null, 2)}\n`);
+}
+
+async function readServerInfo(app: Surface): Promise<ServerInfo> {
+  const value = await evalIn(app, `(async () => {
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    return { baseUrl, token };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.baseUrl !== "string" || !value.baseUrl || typeof value.token !== "string" || !value.token) {
+    throw new Error(`Local server credentials are unavailable: ${JSON.stringify(value)}`);
+  }
+  return { baseUrl: value.baseUrl, token: value.token };
+}
+
+function authHeaders(info: ServerInfo): { Authorization: string } {
+  return { Authorization: `Bearer ${info.token}` };
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`Engine v2 status ${field} was not a string array: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseStatus(value: unknown): EngineV2PreviewStatus {
+  if (
+    !isRecord(value)
+    || typeof value.enabled !== "boolean"
+    || typeof value.running !== "boolean"
+    || typeof value.chatRouting !== "boolean"
+  ) {
+    throw new Error(`Unexpected engine v2 preview status: ${JSON.stringify(value)}`);
+  }
+  return {
+    enabled: value.enabled,
+    running: value.running,
+    chatRouting: value.chatRouting,
+    mirroredProviderIds: stringArray(value.mirroredProviderIds, "mirroredProviderIds"),
+    catalogModelIds: stringArray(value.catalogModelIds, "catalogModelIds"),
+  };
+}
+
+async function readStatus(info: ServerInfo): Promise<EngineV2PreviewStatus> {
+  const response = await fetch(`${info.baseUrl}/experimental/engine-v2-preview/status`, {
+    headers: authHeaders(info),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const value: unknown = await response.json();
+  if (response.status !== 200) throw new Error(`Engine v2 status returned ${response.status}: ${JSON.stringify(value)}`);
+  return parseStatus(value);
+}
+
+async function untilStatus(
+  info: ServerInfo,
+  predicate: (status: EngineV2PreviewStatus) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<EngineV2PreviewStatus> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await readStatus(info);
+  while (Date.now() < deadline) {
+    if (predicate(last)) return last;
+    await sleep(1_000);
+    last = await readStatus(info);
+  }
+  throw new Error(`Timed out waiting for ${label}; last status: ${JSON.stringify(last)}`);
+}
+
+async function setupV2Routing(app: Surface, workspaceId: string, witnessUrl: string): Promise<ServerInfo> {
+  const info = await readServerInfo(app);
+  const enableResponse = await fetch(`${info.baseUrl}/experimental/engine-v2-preview`, {
+    method: "PUT",
+    headers: { ...authHeaders(info), "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true, chatRouting: true }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const enableValue: unknown = await enableResponse.json();
+  if (enableResponse.status !== 200) {
+    throw new Error(`Enabling engine v2 routing returned ${enableResponse.status}: ${JSON.stringify(enableValue)}`);
+  }
+  parseStatus(enableValue);
+  await untilStatus(info, (status) => status.running && status.chatRouting, 120_000, "engine v2 routed lane to start");
+
+  const patchResponse = await fetch(`${info.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/config`, {
+    method: "PATCH",
+    headers: { ...authHeaders(info), "content-type": "application/json" },
+    body: JSON.stringify({
+      opencode: {
+        provider: {
+          [providerId]: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "Bench Witness",
+            options: { baseURL: `${witnessUrl}/v1`, apiKey: "bench-key-app" },
+            models: { [modelId]: { name: modelName } },
+          },
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const patchValue: unknown = await patchResponse.json();
+  if (patchResponse.status !== 200) {
+    throw new Error(`Provisioning the v2 benchmark provider returned ${patchResponse.status}: ${JSON.stringify(patchValue)}`);
+  }
+  await untilStatus(
+    info,
+    (status) => status.mirroredProviderIds.includes(providerId),
+    60_000,
+    "the benchmark provider to be mirrored into v2",
+  );
+  return info;
+}
+
+async function v1EngineSessionCount(info: ServerInfo, workspaceId: string): Promise<number> {
+  const response = await fetch(
+    `${info.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/opencode/session`,
+    { headers: authHeaders(info), signal: AbortSignal.timeout(15_000) },
+  );
+  const value: unknown = await response.json();
+  if (!response.ok) throw new Error(`v1 session list returned ${response.status}: ${JSON.stringify(value)}`);
+  if (!Array.isArray(value)) throw new Error(`Unexpected v1 session list: ${JSON.stringify(value)}`);
+  return value.length;
+}
+
+async function pollExpression(
+  app: Surface,
+  expression: string,
+  label: string,
+  within = 120_000,
+): Promise<void> {
+  await eventually(() => evalIn(app, expression), {
+    within,
+    intervalMs: pollResolutionMs,
+    label,
+    until: (value) => value === true,
+  });
+}
+
+async function waitForComposerReady(app: Surface, label: string): Promise<void> {
+  await eventually(() => readComposerState(app), {
+    within: 120_000,
+    intervalMs: pollResolutionMs,
+    label,
+    until: (state) => state.composerEditable && state.runTaskVisible,
+  });
+}
+
+async function selectBenchModel(app: Surface): Promise<void> {
+  await pollExpression(
+    app,
+    `Boolean(document.querySelector('button[aria-label="Change model"]'))`,
+    "bench model picker trigger",
+  );
+  const opened = await evalIn(app, `(() => {
+    const trigger = document.querySelector('button[aria-label="Change model"]');
+    if (!(trigger instanceof HTMLButtonElement)) return false;
+    trigger.click();
+    return true;
+  })()`);
+  expect(opened).toBe(true);
+  await pollExpression(
+    app,
+    `Boolean(document.querySelector('[data-slot="popover-content"]'))`,
+    "open bench model picker",
+    30_000,
+  );
+  const modelPaneOpened = await evalIn(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    if (!(popover instanceof HTMLElement)) return false;
+    if ([...popover.querySelectorAll('[data-slot="command-item"]')]
+      .some((item) => (item.textContent ?? "").includes(${JSON.stringify(modelName)}))) return true;
+    const modelButton = [...popover.querySelectorAll('button')]
+      .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
+    if (!(modelButton instanceof HTMLButtonElement)) return false;
+    modelButton.click();
+    return true;
+  })()`);
+  expect(modelPaneOpened).toBe(true);
+  await pollExpression(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    if (!(popover instanceof HTMLElement)) return false;
+    return [...popover.querySelectorAll('[data-slot="command-item"]')]
+      .some((item) => (item.textContent ?? "").includes(${JSON.stringify(modelName)}));
+  })()`, "Bench Model listed in picker");
+  const picked = await evalIn(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+      .find((candidate) => (candidate.textContent ?? "").includes(${JSON.stringify(modelName)}));
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(picked).toBe(true);
+  await pollExpression(
+    app,
+    `(document.querySelector('button[aria-label="Change model"]')?.textContent ?? "").includes(${JSON.stringify(modelName)})`,
+    "Bench Model selected",
+    30_000,
+  );
+}
+
+async function closeModelPicker(app: Surface): Promise<void> {
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+}
+
+async function selectBenchModelV2(app: Surface): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  await pollExpression(
+    app,
+    `Boolean(document.querySelector('button[aria-label="Change model"]'))`,
+    "v2 bench model picker trigger",
+    60_000,
+  );
+  let lastItems: string[] = [];
+  while (Date.now() < deadline) {
+    const opened = await evalIn(app, `(() => {
+      if (document.querySelector('[data-slot="popover-content"]')) return true;
+      const trigger = document.querySelector('button[aria-label="Change model"]');
+      if (!(trigger instanceof HTMLButtonElement)) return false;
+      trigger.click();
+      return true;
+    })()`);
+    if (opened === true) {
+      await sleep(300);
+      await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return false;
+        const matches = (text) => text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+        if ([...popover.querySelectorAll('[data-slot="command-item"]')]
+          .some((item) => matches(item.textContent ?? ""))) return true;
+        const modelButton = [...popover.querySelectorAll('button')]
+          .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
+        if (!(modelButton instanceof HTMLButtonElement)) return false;
+        modelButton.click();
+        return true;
+      })()`);
+      await sleep(200);
+      const items = await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return [];
+        return [...popover.querySelectorAll('[data-slot="command-item"]')]
+          .map((item) => (item.textContent ?? "").trim());
+      })()`);
+      if (Array.isArray(items) && items.every((item) => typeof item === "string")) {
+        lastItems = items;
+        if (items.some((item) => item.includes(modelName) || item.includes(modelId))) {
+          const picked = await evalIn(app, `(() => {
+            const popover = document.querySelector('[data-slot="popover-content"]');
+            const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+              .find((candidate) => {
+                const text = candidate.textContent ?? "";
+                return text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+              });
+            if (!(item instanceof HTMLElement)) return false;
+            item.click();
+            return true;
+          })()`);
+          expect(picked).toBe(true);
+          const remaining = Math.max(1, deadline - Date.now());
+          await pollExpression(
+            app,
+            `(() => {
+              const text = document.querySelector('button[aria-label="Change model"]')?.textContent ?? "";
+              return text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+            })()`,
+            "v2 Bench Model selected",
+            remaining,
+          );
+          return;
+        }
+      }
+    }
+    await closeModelPicker(app);
+    await sleep(700);
+  }
+  throw new Error(`Timed out waiting for the v2 bench model in the picker; last items: ${JSON.stringify(lastItems)}`);
+}
+
+async function ensureBenchModel(app: Surface): Promise<boolean> {
+  await waitForComposerReady(app, "composer before checking persisted model");
+  const state = await readComposerState(app);
+  if (state.selectedModelLabel.includes(modelName)) return false;
+  await selectBenchModel(app);
+  return true;
+}
+
+async function ensureBenchModelV2(app: Surface): Promise<boolean> {
+  await waitForComposerReady(app, "composer before checking persisted v2 model");
+  const state = await readComposerState(app);
+  if (state.selectedModelLabel.includes(modelName) || state.selectedModelLabel.includes(modelId)) return false;
+  await selectBenchModelV2(app);
+  return true;
+}
+
+async function typeIntoComposer(app: Surface, text: string): Promise<void> {
+  await pollExpression(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    return editor instanceof HTMLElement && (editor.innerText ?? "").trim() === "";
+  })()`, "empty composer ready");
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text });
+  const expectedLength = text.length;
+  const expectedStart = text.slice(0, 64);
+  const expectedEnd = text.slice(-64);
+  await pollExpression(app, `(() => {
+    const value = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "";
+    return value.length === ${expectedLength}
+      && value.startsWith(${JSON.stringify(expectedStart)})
+      && value.endsWith(${JSON.stringify(expectedEnd)});
+  })()`, `composer contains ${expectedLength} inserted characters`);
+}
+
+async function activeSessionId(app: Surface): Promise<string> {
+  return eventually(async () => {
+    const value = await evalIn(
+      app,
+      `document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""`,
+    );
+    return typeof value === "string" ? value : "";
+  }, {
+    within: 60_000,
+    intervalMs: pollResolutionMs,
+    label: "active session id",
+    until: (value) => value.startsWith("ses_"),
+  });
+}
+
+async function measurePreparedSend(
+  app: Surface,
+  beforeUserCount: number,
+  expectedUserMarker: string,
+  witnessNonce: string,
+): Promise<SendFacts> {
+  const startedAt = Date.now();
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
+  await pollExpression(app, `(() => {
+    const messages = [...document.querySelectorAll('[data-message-role="user"]')];
+    const latest = messages[messages.length - 1];
+    return messages.length > ${beforeUserCount}
+      && (latest?.innerText ?? "").includes(${JSON.stringify(expectedUserMarker)});
+  })()`, `user message rendered for ${expectedUserMarker.slice(0, 80)}`);
+  const userRendered = Date.now() - startedAt;
+  const sessionId = await activeSessionId(app);
+  await pollExpression(app, `(() => {
+    const messages = [...document.querySelectorAll('[data-message-role="assistant"]')];
+    const latest = messages[messages.length - 1];
+    return (latest?.innerText ?? "").includes("token 1 ");
+  })()`, `first witness token in ${sessionId}`);
+  const firstToken = Date.now() - startedAt;
+  await pollExpression(app, `(() => {
+    const messages = [...document.querySelectorAll('[data-message-role="assistant"]')];
+    const latest = messages[messages.length - 1];
+    const text = latest?.innerText ?? "";
+    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${sessionId}"]`)});
+    return Boolean(row)
+      && text.includes("token 20")
+      && text.includes(${JSON.stringify(witnessNonce)})
+      && !row.querySelector("[data-session-loading-indicator]");
+  })()`, `completed witness stream in ${sessionId}`);
+  const complete = Date.now() - startedAt;
+  const facts = await evalIn(app, `(() => {
+    const users = [...document.querySelectorAll('[data-message-role="user"]')];
+    const assistants = [...document.querySelectorAll('[data-message-role="assistant"]')];
+    const latestUser = users[users.length - 1];
+    return {
+      userLength: latestUser?.querySelector("span.whitespace-pre-wrap")?.textContent?.length ?? 0,
+      assistantText: assistants[assistants.length - 1]?.innerText ?? "",
+    };
+  })()`);
+  if (!isRecord(facts) || typeof facts.userLength !== "number" || typeof facts.assistantText !== "string") {
+    throw new Error(`Could not read completed message facts: ${JSON.stringify(facts)}`);
+  }
+  return {
+    timing: { userRendered, firstToken, complete },
+    sessionId,
+    assistantText: facts.assistantText,
+    userLength: facts.userLength,
+  };
+}
+
+async function sendMessage(app: Surface, text: string, witnessNonce: string): Promise<SendFacts> {
+  const before = await readComposerState(app);
+  await typeIntoComposer(app, text);
+  return measurePreparedSend(app, before.userMessageCount, text, witnessNonce);
+}
+
+async function createNewSession(app: Surface): Promise<{ sessionId: string; ms: number }> {
+  const previousSessionId = await evalIn(
+    app,
+    `document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""`,
+  );
+  const previous = typeof previousSessionId === "string" ? previousSessionId : "";
+  await pollExpression(app, `Boolean(document.querySelector("[data-sidebar-new-chat]"))`, "sidebar New task control");
+  const startedAt = Date.now();
+  const clicked = await evalIn(app, `(() => {
+    const button = document.querySelector("[data-sidebar-new-chat]");
+    if (!(button instanceof HTMLElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+  const sessionId = await eventually(async () => {
+    const value = await evalIn(app, `(() => {
+      const match = /\\/session\\/(ses_[^/?#]+)/.exec(window.location.hash);
+      return match?.[1] ?? "";
+    })()`);
+    return typeof value === "string" ? value : "";
+  }, {
+    within: 60_000,
+    intervalMs: pollResolutionMs,
+    label: "new session route",
+    until: (value) => value.startsWith("ses_") && value !== previous,
+  });
+  await pollExpression(app, `(() => {
+    const surface = document.querySelector("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(sessionId)};
+  })()`, `new session surface ${sessionId}`);
+  await waitForComposerReady(app, `new session ${sessionId} composer and Run task`);
+  return { sessionId, ms: Date.now() - startedAt };
+}
+
+async function createSecondWorkspaceViaUi(app: Surface, firstWorkspaceId: string, workspacePath: string): Promise<string> {
+  await pollExpression(
+    app,
+    `Boolean(document.querySelector('button[aria-label="Add workspace"]'))`,
+    "Add workspace control",
+  );
+  const addClicked = await evalIn(app, `(() => {
+    const button = document.querySelector('button[aria-label="Add workspace"]');
+    if (!(button instanceof HTMLButtonElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(addClicked).toBe(true);
+  await pollExpression(app, `(() => [...document.querySelectorAll("button")]
+    .some((button) => (button.textContent ?? "").trim().startsWith("Local workspace") && !button.disabled))()`, "Local workspace option");
+  const localClicked = await evalIn(app, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((candidate) => (candidate.textContent ?? "").trim().startsWith("Local workspace") && !candidate.disabled);
+    if (!(button instanceof HTMLButtonElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(localClicked).toBe(true);
+  await pollExpression(app, `document.body.innerText.includes("No folder selected yet.")`, "local workspace folder chooser");
+
+  // CDP cannot operate Electron's native folder dialog. Dispatching the same
+  // selected-folder reducer event used after that dialog returns keeps the rest
+  // of workspace creation on the visible Add workspace flow.
+  const injected = await evalIn(app, `(() => {
+    const placeholder = [...document.querySelectorAll("span, div, p")]
+      .find((node) => (node.textContent ?? "").includes("No folder selected yet."));
+    if (!placeholder) return { ok: false, reason: "folder placeholder not found" };
+    const key = Object.keys(placeholder).find((candidate) => candidate.startsWith("__reactFiber$"));
+    let fiber = key ? placeholder[key] : null;
+    while (fiber) {
+      const componentName = fiber.elementType?.name || fiber.type?.name || "";
+      if (componentName === "CreateWorkspaceModal") break;
+      fiber = fiber.return;
+    }
+    if (!fiber) return { ok: false, reason: "CreateWorkspaceModal fiber not found" };
+    let hook = fiber.memoizedState;
+    while (hook) {
+      if (hook.queue?.dispatch) {
+        hook.queue.dispatch({ type: "set", key: "selectedFolder", value: ${JSON.stringify(workspacePath)} });
+        hook.queue.dispatch({ type: "set", key: "pickingFolder", value: false });
+        return { ok: true };
+      }
+      hook = hook.next;
+    }
+    return { ok: false, reason: "folder reducer dispatch not found" };
+  })()`);
+  if (!isRecord(injected) || injected.ok !== true) {
+    throw new Error(`Could not simulate the native folder selection: ${JSON.stringify(injected)}`);
+  }
+  await clickButton(app, "Create Workspace", { timeoutMs: 30_000 });
+  const workspaceId = await eventually(async () => {
+    const value = await evalIn(app, `localStorage.getItem("openwork.react.activeWorkspace") ?? ""`);
+    return typeof value === "string" ? value : "";
+  }, {
+    within: 120_000,
+    intervalMs: pollResolutionMs,
+    label: "second workspace selected from Add workspace flow",
+    until: (value) => value.length > 0 && value !== firstWorkspaceId,
+  });
+  await pollExpression(
+    app,
+    `Boolean(document.querySelector(${JSON.stringify(`[data-sidebar-workspace-id="${workspaceId}"]`)}))`,
+    "second workspace visible in sidebar",
+  );
+  await waitForComposerReady(app, "second workspace composer ready");
+  return workspaceId;
+}
+
+async function clickSessionRow(app: Surface, chat: Chat): Promise<void> {
+  const clicked = await evalIn(app, `(() => {
+    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${chat.sessionId}"][data-sidebar-session-workspace-id="${chat.workspaceId}"]`)});
+    const control = row?.querySelector(${JSON.stringify(`[data-session-tab-id="${chat.sessionId}"]`)});
+    if (!(row instanceof HTMLElement) || !(control instanceof HTMLElement)) return false;
+    row.scrollIntoView({ block: "center" });
+    control.click();
+    return true;
+  })()`);
+  expect(clicked, `sidebar row for ${chat.title}`).toBe(true);
+}
+
+async function waitForChatSurface(app: Surface, chat: Chat): Promise<void> {
+  await pollExpression(app, `(() => {
+    const surface = document.querySelector("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(chat.sessionId)}
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(chat.workspaceId)};
+  })()`, `surface for ${chat.title}`);
+}
+
+async function switchAndMeasure(app: Surface, chat: Chat): Promise<number> {
+  const startedAt = Date.now();
+  await clickSessionRow(app, chat);
+  await waitForChatSurface(app, chat);
+  await waitForComposerReady(app, `typable composer in ${chat.title}`);
+  return Date.now() - startedAt;
+}
+
+async function visibleUserTexts(app: Surface): Promise<string[]> {
+  const value = await evalIn(
+    app,
+    `[...document.querySelectorAll('[data-message-role="user"]')].map((message) => message.innerText ?? "")`,
+  );
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`Visible user messages were malformed: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function deterministicLongMessage(index: number, nonce: string): { text: string; marker: string } {
+  const marker = `bench-long-${index}-${nonce}`;
+  const prefix = `${marker} `;
+  if (prefix.length >= longMessageChars) throw new Error("Long-message marker exceeded the benchmark payload size.");
+  return { marker, text: `${prefix}${"x".repeat(longMessageChars - prefix.length)}` };
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const upper = sorted[middle];
+  if (upper === undefined) return null;
+  if (sorted.length % 2 === 1) return upper;
+  const lower = sorted[middle - 1];
+  return lower === undefined ? upper : (lower + upper) / 2;
+}
+
+function medianTable(results: BenchmarkResults): string {
+  const rows: { scenario: string; metric: string; value: number | null }[] = [
+    { scenario: "cold_boot_to_composer", metric: "appInteractive", value: median(results.cold_boot_to_composer.map((entry) => entry.appInteractive)) },
+    { scenario: "cold_boot_to_composer", metric: "workspaceReady", value: median(results.cold_boot_to_composer.map((entry) => entry.workspaceReady)) },
+    { scenario: "cold_boot_to_composer", metric: "composerReady", value: median(results.cold_boot_to_composer.map((entry) => entry.composerReady)) },
+    { scenario: "cold_boot_to_composer", metric: "appReadinessMs", value: median(results.cold_boot_to_composer.flatMap((entry) => entry.appReadinessMs === undefined ? [] : [entry.appReadinessMs])) },
+    { scenario: "first_send_cold", metric: "complete", value: median(results.first_send_cold) },
+    { scenario: "new_session_ready", metric: "ready", value: median(results.new_session_ready) },
+    { scenario: "message_rtt", metric: "userRendered", value: median(results.message_rtt.map((entry) => entry.userRendered)) },
+    { scenario: "message_rtt", metric: "firstToken", value: median(results.message_rtt.map((entry) => entry.firstToken)) },
+    { scenario: "message_rtt", metric: "complete", value: median(results.message_rtt.map((entry) => entry.complete)) },
+    { scenario: "workspace_switch", metric: "aToB", value: median(results.workspace_switch.map((entry) => entry.aToB)) },
+    { scenario: "workspace_switch", metric: "bToA", value: median(results.workspace_switch.map((entry) => entry.bToA)) },
+    { scenario: "long_message", metric: "insertMs", value: median(results.long_message.map((entry) => entry.insertMs)) },
+    { scenario: "long_message", metric: "userRendered", value: median(results.long_message.map((entry) => entry.userRendered)) },
+    { scenario: "long_message", metric: "firstToken", value: median(results.long_message.map((entry) => entry.firstToken)) },
+    { scenario: "long_message", metric: "complete", value: median(results.long_message.map((entry) => entry.complete)) },
+  ];
+  const header = "scenario                     metric             median_ms";
+  return [header, ...rows.map((row) => (
+    `${row.scenario.padEnd(28)} ${row.metric.padEnd(18)} ${row.value === null ? "n/a" : row.value}`
+  ))].join("\n");
+}
+
+function gitCommit(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("git", ["rev-parse", "HEAD"], { cwd: import.meta.dirname, encoding: "utf8" }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const iterations = Number(process.env.OPENWORK_BENCH_ITERATIONS ?? "1");
+  expect(Number.isInteger(iterations) && iterations > 0, "OPENWORK_BENCH_ITERATIONS must be a positive integer").toBe(true);
+  const opencodeV2Bin = benchEngine === "v2" ? await resolveOpencodeV2Bin() : undefined;
+  const runNonce = `${Date.now().toString(36)}-${process.pid}`;
+  const results: BenchmarkResults = {
+    cold_boot_to_composer: [],
+    first_send_cold: [],
+    new_session_ready: [],
+    message_rtt: [],
+    workspace_switch: [],
+    long_message: [],
+  };
+  const allWitnessRequests: WitnessRequest[] = [];
+  const coldWorkspaceIds: string[] = [];
+  const warmupCompletions: boolean[] = [];
+  const newSessionIds: string[] = [];
+  const messageCompletions: boolean[] = [];
+  const switchTargetChecks: boolean[] = [];
+  const switchIsolationChecks: boolean[] = [];
+  const longMessageChecks: boolean[] = [];
+  const v1SessionFreezeChecks: V1SessionFreezeCheck[] = [];
+  let modelReselectedPerSession = false;
+  let uiCompactionAvailable = false;
+  const host = localHost();
+
+  try {
+    for (let coldIndex = 0; coldIndex < iterations; coldIndex += 1) {
+      const witnessNonce = `${runNonce}-cold-${coldIndex}`;
+      const witness = await startWitness(witnessNonce);
+      const profileDir = await mkdtemp(join(tmpdir(), `openwork-bench-${benchEngine}-profile-`));
+      const workspaceAPath = await mkdtemp(join(tmpdir(), `openwork-bench-${benchEngine}-workspace-a-`));
+      const workspaceBPath = coldIndex === iterations - 1
+        ? await mkdtemp(join(tmpdir(), `openwork-bench-${benchEngine}-workspace-b-`))
+        : null;
+      // Keep the project provider file in both modes so workspace setup stays
+      // symmetric and the v1 picker remains deterministic. The v2 routed lane
+      // receives the identical provider separately through the runtime PATCH.
+      await writeProviderConfig(workspaceAPath, witness.url);
+      if (workspaceBPath) await writeProviderConfig(workspaceBPath, witness.url);
+      let app: DesktopHandle | undefined;
+      let serverInfo: ServerInfo | undefined;
+      const v1SessionSnapshots = new Map<string, number>();
+
+      try {
+        const appName = `bench-openwork-app-${benchEngine}-${coldIndex}`;
+        const timelineStart = timeline().length;
+        const coldStartedAt = Date.now();
+        app = await desktop({
+          name: appName,
+          host,
+          profileDir,
+          env: {
+            ANTHROPIC_API_KEY: "",
+            OPENAI_API_KEY: "",
+            OPENROUTER_API_KEY: "",
+            GOOGLE_GENERATIVE_AI_API_KEY: "",
+            OPENWORK_API_KEY: "",
+            OPENWORK_INFERENCE_BASE_URL: "",
+            ...(opencodeV2Bin === undefined ? {} : { OPENWORK_OPENCODE2_BIN: opencodeV2Bin }),
+          },
+        });
+        const appInteractive = Date.now() - coldStartedAt;
+        let appReadinessMs: number | undefined;
+        for (const span of timeline().slice(timelineStart)) {
+          if (span.label === "app.readiness" && span.detail === appName) appReadinessMs = span.ms;
+        }
+        const workspaceA = await createAndSelectWorkspace(app, { path: workspaceAPath });
+        coldWorkspaceIds.push(workspaceA.workspaceId);
+        const workspaceReady = Date.now() - coldStartedAt;
+        await waitForComposerReady(app, `cold composer ${coldIndex}`);
+        const composerReady = Date.now() - coldStartedAt;
+        const coldTiming: ColdTiming = {
+          appInteractive,
+          workspaceReady,
+          composerReady,
+          desktopTotalMs: appInteractive,
+        };
+        if (appReadinessMs !== undefined) coldTiming.appReadinessMs = appReadinessMs;
+        results.cold_boot_to_composer.push(coldTiming);
+
+        if (benchEngine === "v2") {
+          serverInfo = await setupV2Routing(app, workspaceA.workspaceId, witness.url);
+          await sleep(rendererRoutingPollMs);
+          await selectBenchModelV2(app);
+          v1SessionSnapshots.set(
+            workspaceA.workspaceId,
+            await v1EngineSessionCount(serverInfo, workspaceA.workspaceId),
+          );
+          await createNewSession(app);
+          if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+        } else {
+          await selectBenchModel(app);
+        }
+        const warmupPrompt = `bench first send cold ${coldIndex} ${witnessNonce}`;
+        const warmup = await sendMessage(app, warmupPrompt, witnessNonce);
+        results.first_send_cold.push(warmup.timing.complete);
+        const warmupComplete = warmup.assistantText.includes(`token 20 ${witnessNonce}`)
+          && warmup.userLength === warmupPrompt.length;
+        warmupCompletions.push(warmupComplete);
+        expect(warmupComplete).toBe(true);
+
+        if (coldIndex === iterations - 1) {
+          if (!workspaceBPath) throw new Error("Last cold instance has no second workspace directory.");
+          const workspaceBId = await createSecondWorkspaceViaUi(app, workspaceA.workspaceId, workspaceBPath);
+          expect(workspaceBId).not.toBe(workspaceA.workspaceId);
+          if (benchEngine === "v2") {
+            if (!serverInfo) throw new Error("The v2 benchmark server connection was not initialized.");
+            await sleep(rendererRoutingPollMs);
+            await selectBenchModelV2(app);
+            v1SessionSnapshots.set(workspaceBId, await v1EngineSessionCount(serverInfo, workspaceBId));
+            // The workspace switch can leave the pre-flip v1 session selected.
+            // Create the routed session after the untimed switch boundary, then
+            // reselect the v2 model before any workspace B send is measured.
+            await createNewSession(app);
+            if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+          } else {
+            await selectBenchModel(app);
+          }
+          const bNonces: string[] = [];
+          const setupNonce = `bench-b-setup-${witnessNonce}`;
+          bNonces.push(setupNonce);
+          const setup = await sendMessage(app, setupNonce, witnessNonce);
+          expect(setup.assistantText).toContain(`token 20 ${witnessNonce}`);
+          let latestBChat: Chat = { workspaceId: workspaceBId, sessionId: setup.sessionId, title: "workspace B setup" };
+          let latestBMarker = setupNonce;
+
+          for (let warmIndex = 0; warmIndex < iterations; warmIndex += 1) {
+            const created = await createNewSession(app);
+            results.new_session_ready.push(created.ms);
+            newSessionIds.push(created.sessionId);
+            if (benchEngine === "v2") {
+              if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+            } else if (await ensureBenchModel(app)) {
+              modelReselectedPerSession = true;
+            }
+
+            const messageNonce = `${witnessNonce}-message-${warmIndex}`;
+            const message = `bench message ${warmIndex} ${messageNonce}`;
+            bNonces.push(messageNonce);
+            const messageRun = await sendMessage(app, message, witnessNonce);
+            results.message_rtt.push(messageRun.timing);
+            const messageComplete = messageRun.sessionId === created.sessionId
+              && messageRun.userLength === message.length
+              && messageRun.assistantText.includes(`token 20 ${witnessNonce}`);
+            messageCompletions.push(messageComplete);
+            expect(messageComplete).toBe(true);
+
+            await createNewSession(app);
+            if (benchEngine === "v2") {
+              if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+            } else if (await ensureBenchModel(app)) {
+              modelReselectedPerSession = true;
+            }
+            const longMessage = deterministicLongMessage(warmIndex, witnessNonce);
+            bNonces.push(longMessage.marker);
+            const beforeLong = await readComposerState(app);
+            const insertStartedAt = Date.now();
+            await typeIntoComposer(app, longMessage.text);
+            const insertMs = Date.now() - insertStartedAt;
+            const longRun = await measurePreparedSend(
+              app,
+              beforeLong.userMessageCount,
+              longMessage.marker,
+              witnessNonce,
+            );
+            results.long_message.push({ insertMs, ...longRun.timing });
+            const longComplete = longRun.userLength === longMessageChars
+              && longRun.assistantText.includes(`token 20 ${witnessNonce}`);
+            longMessageChecks.push(longComplete);
+            expect(longComplete).toBe(true);
+            latestBChat = { workspaceId: workspaceBId, sessionId: longRun.sessionId, title: `workspace B long ${warmIndex}` };
+            latestBMarker = longMessage.marker;
+          }
+
+          const workspaceAChat: Chat = {
+            workspaceId: workspaceA.workspaceId,
+            sessionId: warmup.sessionId,
+            title: "workspace A warmup",
+          };
+          await switchAndMeasure(app, workspaceAChat);
+          if (benchEngine === "v2") {
+            await sleep(rendererRoutingPollMs);
+            await selectBenchModelV2(app);
+          }
+          for (let switchIndex = 0; switchIndex < iterations; switchIndex += 1) {
+            const aToB = await switchAndMeasure(app, latestBChat);
+            const bTexts = await visibleUserTexts(app);
+            const bTargetVisible = bTexts.some((text) => text.includes(latestBMarker));
+            if (benchEngine === "v2") {
+              await sleep(rendererRoutingPollMs);
+              await selectBenchModelV2(app);
+            }
+            const bToA = await switchAndMeasure(app, workspaceAChat);
+            const aTexts = await visibleUserTexts(app);
+            const aIsolated = bNonces.every((nonce) => aTexts.every((text) => !text.includes(nonce)));
+            if (benchEngine === "v2") {
+              await sleep(rendererRoutingPollMs);
+              await selectBenchModelV2(app);
+            }
+            results.workspace_switch.push({ aToB, bToA });
+            switchTargetChecks.push(bTargetVisible);
+            switchIsolationChecks.push(aIsolated);
+            expect(bTargetVisible, `workspace B transcript after switch ${switchIndex}`).toBe(true);
+            expect(aIsolated, `workspace A transcript after switch ${switchIndex}`).toBe(true);
+          }
+
+          const compactionProbe = await evalIn(app, `(() => {
+            const root = document.querySelector("[data-session-surface-id]") ?? document;
+            const controls = [...root.querySelectorAll('button, [role="menuitem"], [role="option"], [data-slot="command-item"]')];
+            return controls.some((control) => {
+              const label = [control.textContent, control.getAttribute("aria-label"), control.getAttribute("title")]
+                .filter(Boolean)
+                .join(" ")
+                .toLowerCase();
+              return label.includes("compact") || label.includes("summarize");
+            });
+          })()`);
+          uiCompactionAvailable = compactionProbe === true;
+        }
+
+        if (benchEngine === "v2") {
+          if (!serverInfo) throw new Error("The v2 benchmark server connection was not initialized.");
+          for (const [workspaceId, before] of v1SessionSnapshots) {
+            const after = await v1EngineSessionCount(serverInfo, workspaceId);
+            v1SessionFreezeChecks.push({ workspaceId, before, after });
+            expect(after, `v1 sessions stayed frozen for ${workspaceId}`).toBe(before);
+          }
+        }
+      } finally {
+        try {
+          if (app) await app.stop();
+        } finally {
+          await witness.close();
+          allWitnessRequests.push(...witness.requests);
+          await rm(profileDir, { recursive: true, force: true });
+          await rm(workspaceAPath, { recursive: true, force: true });
+          if (workspaceBPath) await rm(workspaceBPath, { recursive: true, force: true });
+        }
+      }
+    }
+
+    expect(results.cold_boot_to_composer).toHaveLength(iterations);
+    expect(results.first_send_cold).toHaveLength(iterations);
+    expect(new Set(coldWorkspaceIds).size).toBe(iterations);
+    expect(warmupCompletions).toHaveLength(iterations);
+    expect(warmupCompletions.every(Boolean)).toBe(true);
+    evidence.recordAssertionEvidence(
+      `Each cold ${benchEngine} desktop reaches a ready composer from a fresh profile and workspace`,
+      `${iterations} unique workspaces reached appInteractive, workspaceReady and composerReady. No profile or workspace was reused.`,
+      results.cold_boot_to_composer.length === iterations
+        && new Set(coldWorkspaceIds).size === iterations,
+    );
+    evidence.recordAssertionEvidence(
+      `Each cold ${benchEngine} engine's first send completes after the untimed model selection`,
+      `${iterations} first sends rendered exact user messages and the final token-20 witness nonce; completion ms=${JSON.stringify(results.first_send_cold)}. No first send was incomplete.`,
+      results.first_send_cold.length === iterations && warmupCompletions.every(Boolean),
+    );
+
+    expect(results.new_session_ready).toHaveLength(iterations);
+    expect(new Set(newSessionIds).size).toBe(iterations);
+    evidence.recordAssertionEvidence(
+      "Every sidebar New task click reaches a distinct prompt-ready session",
+      `${iterations} New task clicks produced ${new Set(newSessionIds).size} distinct session ids with editable composers and visible Run task controls; ms=${JSON.stringify(results.new_session_ready)}.`,
+      results.new_session_ready.length === iterations && new Set(newSessionIds).size === iterations,
+    );
+
+    expect(results.message_rtt).toHaveLength(iterations);
+    expect(messageCompletions).toHaveLength(iterations);
+    expect(messageCompletions.every(Boolean)).toBe(true);
+    evidence.recordAssertionEvidence(
+      "Every regular message renders the user turn, streams the witness reply, and completes",
+      `${iterations} fresh sessions rendered exact user messages and the final token-20 witness nonce with no incomplete reply; timings=${JSON.stringify(results.message_rtt)}.`,
+      messageCompletions.length === iterations && messageCompletions.every(Boolean),
+    );
+
+    expect(results.workspace_switch).toHaveLength(iterations);
+    expect(switchTargetChecks.every(Boolean)).toBe(true);
+    expect(switchIsolationChecks.every(Boolean)).toBe(true);
+    evidence.recordAssertionEvidence(
+      "Cross-workspace sidebar switches restore the target transcript without leaking workspace B messages into A",
+      `${iterations} A→B and B→A switches restored their target session; B's marker was present in B and every B nonce was absent from A; timings=${JSON.stringify(results.workspace_switch)}.`,
+      switchTargetChecks.length === iterations
+        && switchTargetChecks.every(Boolean)
+        && switchIsolationChecks.length === iterations
+        && switchIsolationChecks.every(Boolean),
+    );
+
+    expect(results.long_message).toHaveLength(iterations);
+    expect(longMessageChecks).toHaveLength(iterations);
+    expect(longMessageChecks.every(Boolean)).toBe(true);
+    const longWitnessRequests = allWitnessRequests.filter((request) => request.promptChars >= longMessageChars);
+    expect(longWitnessRequests.length).toBeGreaterThanOrEqual(iterations);
+    evidence.recordAssertionEvidence(
+      "Every 200,000-character composer message survives insertion, render, provider transport, and completion",
+      `${iterations} exact-length user turns completed; witness requests with at least ${longMessageChars} prompt characters=${longWitnessRequests.length}; timings=${JSON.stringify(results.long_message)}. No long user turn was truncated.`,
+      longMessageChecks.length === iterations
+        && longMessageChecks.every(Boolean)
+        && longWitnessRequests.length >= iterations,
+    );
+
+    expect(allWitnessRequests.length).toBeGreaterThan(0);
+    const unfaithfulRequests = allWitnessRequests.filter((request) => (
+      request.auth !== "Bearer bench-key-app" || request.model !== modelId
+    ));
+    expect(unfaithfulRequests).toEqual([]);
+    evidence.recordAssertionEvidence(
+      `All ${benchEngine} app completions use only the Bench Witness model and key`,
+      `${allWitnessRequests.length} completion requests all carried Bearer bench-key-app and model bench-model; mismatches=${JSON.stringify(unfaithfulRequests)}. No request escaped to another configured provider.`,
+      allWitnessRequests.length > 0 && unfaithfulRequests.length === 0,
+    );
+
+    if (benchEngine === "v2") {
+      expect(v1SessionFreezeChecks).toHaveLength(iterations + 1);
+      expect(v1SessionFreezeChecks.every((check) => check.after === check.before)).toBe(true);
+      evidence.recordAssertionEvidence(
+        "Routed v2 benchmark scenarios never create a session in the v1 engine",
+        `${v1SessionFreezeChecks.length} workspace snapshots remained unchanged after their routed scenarios: ${JSON.stringify(v1SessionFreezeChecks)}.`,
+        v1SessionFreezeChecks.length === iterations + 1
+          && v1SessionFreezeChecks.every((check) => check.after === check.before),
+      );
+    }
+
+    const cpuList = cpus();
+    const report = {
+      lane: `app-${benchEngine}`,
+      createdAt: new Date().toISOString(),
+      machine: {
+        platform: platform(),
+        arch: arch(),
+        cpus: cpuList.length,
+        cpuModel: cpuList[0]?.model ?? "unknown",
+        memGB: Math.round((totalmem() / 1024 ** 3) * 10) / 10,
+        node: process.version,
+      },
+      appCommit: await gitCommit(),
+      iterations,
+      pacingMs,
+      tokens: tokenCount,
+      pollResolutionMs,
+      executionPlan: {
+        coldInstances: iterations,
+        warmIterations: iterations,
+        warmScenariosRunIn: "last cold instance only",
+      },
+      modelReselectedPerSession,
+      uiCompactionAvailable,
+      results,
+    };
+    const resultsDir = process.env.OPENWORK_BENCH_RESULTS_DIR ?? tmpdir();
+    await mkdir(resultsDir, { recursive: true });
+    const resultsPath = join(resultsDir, `bench-openwork-app-${benchEngine}-${Date.now()}.json`);
+    await writeFile(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+    console.info(`[bench-openwork-app-${benchEngine}] medians\n${medianTable(results)}`);
+    console.info(`[bench-openwork-app-${benchEngine}] results=${resultsPath} uiCompactionAvailable=${uiCompactionAvailable}`);
+  } finally {
+    await host.stop();
+  }
+});

--- a/evals/specs/engine-v2-preview-flag.e2e.test.ts
+++ b/evals/specs/engine-v2-preview-flag.e2e.test.ts
@@ -1,0 +1,315 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import { desktop, localHost } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "the OpenCode v2 engine preview flag controls a hot-mirroring parallel sidecar"
+  : "OpenCode v2 engine preview flag skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+interface ServerInfo {
+  baseUrl: string;
+  token: string;
+}
+
+interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  version?: string;
+  pid?: number;
+  binSource?: string;
+  mirroredProviderIds: string[];
+  skippedProviderIds: string[];
+  catalogModelIds: string[];
+  lastMirroredAt?: string;
+  lastError?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOpencodeV2Bin(): Promise<string> {
+  const override = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const constants: unknown = JSON.parse(await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"));
+  if (!isRecord(constants) || typeof constants.opencodeV2Version !== "string") {
+    throw new Error("constants.json must define a string opencodeV2Version");
+  }
+  const cache = join(tmpdir(), "openwork-opencode-v2-cache", constants.opencodeV2Version);
+  const binary = join(cache, "node_modules", ".bin", "opencode2");
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, '{"private":true}\n');
+    await execFileAsync(
+      "pnpm",
+      ["add", "--ignore-workspace", "--save-exact", `@opencode-ai/cli@${constants.opencodeV2Version}`],
+      { cwd: cache, timeout: 180_000 },
+    );
+  }
+  if (!(await exists(binary))) {
+    throw new Error(`OpenCode v2 binary was not installed at ${binary}; set OPENWORK_EVAL_OPENCODE2_BIN to a working opencode2 binary`);
+  }
+  return binary;
+}
+
+async function readServerInfo(app: Parameters<typeof evalIn>[0]): Promise<ServerInfo> {
+  const value = await evalIn(app, `(async () => {
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    return { baseUrl, token };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.baseUrl !== "string" || !value.baseUrl || typeof value.token !== "string" || !value.token) {
+    throw new Error(`Local server credentials are unavailable: ${JSON.stringify(value)}`);
+  }
+  return { baseUrl: value.baseUrl, token: value.token };
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`Engine v2 status ${field} was not a string array: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseStatus(value: unknown): EngineV2PreviewStatus {
+  if (!isRecord(value) || typeof value.enabled !== "boolean" || typeof value.running !== "boolean") {
+    throw new Error(`Unexpected engine v2 preview status: ${JSON.stringify(value)}`);
+  }
+  if (value.pid !== undefined && typeof value.pid !== "number") throw new Error(`Unexpected engine v2 pid: ${JSON.stringify(value.pid)}`);
+  return {
+    enabled: value.enabled,
+    running: value.running,
+    ...(typeof value.version === "string" ? { version: value.version } : {}),
+    ...(typeof value.pid === "number" ? { pid: value.pid } : {}),
+    ...(typeof value.binSource === "string" ? { binSource: value.binSource } : {}),
+    mirroredProviderIds: stringArray(value.mirroredProviderIds, "mirroredProviderIds"),
+    skippedProviderIds: stringArray(value.skippedProviderIds, "skippedProviderIds"),
+    catalogModelIds: stringArray(value.catalogModelIds, "catalogModelIds"),
+    ...(typeof value.lastMirroredAt === "string" ? { lastMirroredAt: value.lastMirroredAt } : {}),
+    ...(typeof value.lastError === "string" ? { lastError: value.lastError } : {}),
+  };
+}
+
+function authHeaders(info: ServerInfo): { Authorization: string } {
+  return { Authorization: `Bearer ${info.token}` };
+}
+
+async function readStatus(info: ServerInfo): Promise<EngineV2PreviewStatus> {
+  const response = await fetch(`${info.baseUrl}/experimental/engine-v2-preview/status`, {
+    headers: authHeaders(info),
+  });
+  const value: unknown = await response.json();
+  expect(response.status).toBe(200);
+  return parseStatus(value);
+}
+
+async function untilStatus(
+  info: ServerInfo,
+  predicate: (status: EngineV2PreviewStatus) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<EngineV2PreviewStatus> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await readStatus(info);
+  while (Date.now() < deadline) {
+    if (predicate(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    last = await readStatus(info);
+  }
+  throw new Error(`Timed out waiting for ${label}; last status: ${JSON.stringify(last)}`);
+}
+
+async function clickPreviewSwitch(app: Parameters<typeof evalIn>[0]): Promise<void> {
+  const point = await evalIn(app, `(() => {
+    const control = Array.from(document.querySelectorAll('[aria-label="OpenCode v2 engine preview"]'))
+      .find((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      });
+    if (!(control instanceof HTMLElement)) return null;
+    control.scrollIntoView({ block: "center", behavior: "instant" });
+    const rect = control.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (
+    !isRecord(point)
+    || typeof point.x !== "number"
+    || typeof point.y !== "number"
+  ) {
+    throw new Error(`Could not resolve the OpenCode v2 preview switch: ${JSON.stringify(point)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
+}
+
+const switchCheckedExpression = `(() => {
+  const labelled = document.querySelector('[aria-label="OpenCode v2 engine preview"]');
+  if (!labelled) return null;
+  const control = labelled.hasAttribute("aria-checked") ? labelled : labelled.querySelector('[aria-checked]');
+  return control?.getAttribute("aria-checked") ?? null;
+})()`;
+
+const switchReadyUncheckedExpression = `(() => {
+  const labelled = document.querySelector('[aria-label="OpenCode v2 engine preview"]');
+  if (!labelled || labelled.getAttribute("aria-disabled") === "true" || labelled.hasAttribute("data-disabled")) return false;
+  const control = labelled.hasAttribute("aria-checked") ? labelled : labelled.querySelector('[aria-checked]');
+  return control?.getAttribute("aria-checked") === "false";
+})()`;
+
+test.skipIf(!enabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  const binPath = await resolveOpencodeV2Bin();
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-engine-v2-preview-eval-"));
+  const workspacePath = join(profileDir, "workspace");
+  await using host = localHost();
+  let app: Awaited<ReturnType<typeof desktop>> | undefined;
+
+  try {
+    app = await desktop({
+      name: "engine-v2-preview-flag",
+      host,
+      profileDir,
+      env: { OPENWORK_OPENCODE2_BIN: binPath },
+    });
+    const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
+    const serverInfo = await readServerInfo(app);
+
+    const defaultStatus = await readStatus(serverInfo);
+    expect(defaultStatus).toMatchObject({ enabled: false, running: false });
+    expect(Object.hasOwn(defaultStatus, "pid")).toBe(false);
+    await go(app, `/workspace/${workspaceId}/settings/advanced`);
+    await waitFor(app, switchReadyUncheckedExpression, {
+      timeoutMs: 60_000,
+      label: "ready, disabled OpenCode v2 engine preview switch",
+    });
+    evidence.recordAssertionEvidence(
+      "F1 the preview defaults off without a sidecar",
+      "The server reported enabled=false and running=false with no pid, while Advanced Settings exposed the unchecked preview switch.",
+      true,
+    );
+
+    await clickPreviewSwitch(app);
+    await waitFor(app, `${switchCheckedExpression} === "true"`, {
+      timeoutMs: 30_000,
+      label: "enabled OpenCode v2 engine preview switch",
+    });
+    const runningStatus = await untilStatus(
+      serverInfo,
+      (status) => status.enabled && status.running && typeof status.pid === "number",
+      120_000,
+      "the OpenCode v2 sidecar to start",
+    );
+    const pid0 = runningStatus.pid;
+    if (pid0 === undefined) throw new Error("Running OpenCode v2 status did not contain a pid");
+    await waitFor(app, `document.body.innerText.includes("Running v")`, {
+      timeoutMs: 30_000,
+      label: "OpenCode v2 running status line",
+    });
+    const healthResponse = await fetch(`${serverInfo.baseUrl}/health`, { headers: authHeaders(serverInfo) });
+    expect(healthResponse.status).toBe(200);
+    evidence.recordAssertionEvidence(
+      "F2 enabling starts the parallel sidecar without replacing v1",
+      `The UI showed a running OpenCode v2 sidecar at pid ${pid0}, while the existing server health endpoint continued returning 200.`,
+      true,
+    );
+
+    const patchResponse = await fetch(`${serverInfo.baseUrl}/workspace/${workspaceId}/config`, {
+      method: "PATCH",
+      headers: { ...authHeaders(serverInfo), "content-type": "application/json" },
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            "openwork-witness-e2e": {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Witness E2E",
+              options: { baseURL: "http://127.0.0.1:65533/v1", apiKey: "witness-key-e2e" },
+              models: { "witness-model-e2e": { name: "Witness Model E2E" } },
+            },
+            "openwork-skip-e2e": { name: "Skip E2E", options: {} },
+          },
+        },
+      }),
+    });
+    expect(patchResponse.status).toBe(200);
+    const patchCompletedAt = Date.now();
+    const mirroredStatus = await untilStatus(
+      serverInfo,
+      (status) => status.mirroredProviderIds.includes("openwork-witness-e2e"),
+      60_000,
+      "the witness provider to be mirrored",
+    );
+    const mirrorLatencyMs = Date.now() - patchCompletedAt;
+    console.info(`[engine-v2-preview-flag] mirror latency after PATCH 200: ${mirrorLatencyMs}ms`);
+    expect(mirroredStatus.catalogModelIds).toContain("witness-model-e2e");
+    expect(mirroredStatus.skippedProviderIds).toContain("openwork-skip-e2e");
+    expect(mirroredStatus.mirroredProviderIds).not.toContain("openwork-skip-e2e");
+    expect(mirroredStatus.pid).toBe(pid0);
+    expect(mirroredStatus.running).toBe(true);
+    evidence.recordAssertionEvidence(
+      "F3 provider changes hot-mirror without restarting the sidecar",
+      `The witness provider and model appeared after ${mirrorLatencyMs}ms, the invalid provider was skipped and never mirrored, and the sidecar remained running at pid ${pid0}.`,
+      true,
+    );
+
+    await clickPreviewSwitch(app);
+    const disabledStatus = await untilStatus(
+      serverInfo,
+      (status) => !status.enabled && !status.running,
+      60_000,
+      "the OpenCode v2 sidecar to stop",
+    );
+    expect(Object.hasOwn(disabledStatus, "pid")).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    const settledDisabledStatus = await readStatus(serverInfo);
+    expect(settledDisabledStatus).toMatchObject({ enabled: false, running: false });
+    expect(Object.hasOwn(settledDisabledStatus, "pid")).toBe(false);
+    await waitFor(app, `${switchCheckedExpression} === "false"`, {
+      timeoutMs: 30_000,
+      label: "disabled OpenCode v2 engine preview switch after shutdown",
+    });
+    evidence.recordAssertionEvidence(
+      "F4 disabling stops the sidecar without a zombie restart",
+      "The server remained disabled and not running with no pid after a two-second settling period, and the UI switch returned to unchecked.",
+      true,
+    );
+  } finally {
+    if (app !== undefined) await app.stop();
+    await rm(profileDir, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/opencode-v2-chat-routing.e2e.test.ts
+++ b/evals/specs/opencode-v2-chat-routing.e2e.test.ts
@@ -1,0 +1,654 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { clickButton, createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { desktop, localHost } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "chat routing switches live between OpenCode v1 and the v2 preview sidecar"
+  : "OpenCode v2 chat routing skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+const keyV1 = "key-v1";
+const keyV2 = "key-v2";
+const modelIdV1 = "witness-model-v1";
+const modelIdV2 = "witness-model-v2";
+const modelNameV1 = "Witness Model V1";
+const modelNameV2 = "Witness Model V2";
+
+interface ServerInfo {
+  baseUrl: string;
+  token: string;
+}
+
+interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  chatRouting: boolean;
+  pid?: number;
+  mirroredProviderIds: string[];
+  skippedProviderIds: string[];
+  catalogModelIds: string[];
+  lastError?: string;
+}
+
+interface WitnessRequest {
+  at: number;
+  auth: string;
+  model: string;
+  stream: boolean;
+  nonce: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOpencodeV2Bin(): Promise<string> {
+  const override = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const constants: unknown = JSON.parse(await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"));
+  if (!isRecord(constants) || typeof constants.opencodeV2Version !== "string") {
+    throw new Error("constants.json must define a string opencodeV2Version");
+  }
+  const cache = join(tmpdir(), "openwork-opencode-v2-cache", constants.opencodeV2Version);
+  const binary = join(cache, "node_modules", ".bin", "opencode2");
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, '{"private":true}\n');
+    await execFileAsync(
+      "pnpm",
+      ["add", "--ignore-workspace", "--save-exact", `@opencode-ai/cli@${constants.opencodeV2Version}`],
+      { cwd: cache, timeout: 180_000 },
+    );
+  }
+  if (!(await exists(binary))) {
+    throw new Error(`OpenCode v2 binary was not installed at ${binary}; set OPENWORK_EVAL_OPENCODE2_BIN to a working opencode2 binary`);
+  }
+  return binary;
+}
+
+async function readServerInfo(app: Surface): Promise<ServerInfo> {
+  const value = await evalIn(app, `(async () => {
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    return { baseUrl, token };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.baseUrl !== "string" || !value.baseUrl || typeof value.token !== "string" || !value.token) {
+    throw new Error(`Local server credentials are unavailable: ${JSON.stringify(value)}`);
+  }
+  return { baseUrl: value.baseUrl, token: value.token };
+}
+
+function authHeaders(info: ServerInfo): { Authorization: string } {
+  return { Authorization: `Bearer ${info.token}` };
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`Engine v2 status ${field} was not a string array: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseStatus(value: unknown): EngineV2PreviewStatus {
+  if (
+    !isRecord(value)
+    || typeof value.enabled !== "boolean"
+    || typeof value.running !== "boolean"
+    || typeof value.chatRouting !== "boolean"
+  ) {
+    throw new Error(`Unexpected engine v2 preview status: ${JSON.stringify(value)}`);
+  }
+  if (value.pid !== undefined && typeof value.pid !== "number") {
+    throw new Error(`Unexpected engine v2 pid: ${JSON.stringify(value.pid)}`);
+  }
+  return {
+    enabled: value.enabled,
+    running: value.running,
+    chatRouting: value.chatRouting,
+    ...(typeof value.pid === "number" ? { pid: value.pid } : {}),
+    mirroredProviderIds: stringArray(value.mirroredProviderIds, "mirroredProviderIds"),
+    skippedProviderIds: stringArray(value.skippedProviderIds, "skippedProviderIds"),
+    catalogModelIds: stringArray(value.catalogModelIds, "catalogModelIds"),
+    ...(typeof value.lastError === "string" ? { lastError: value.lastError } : {}),
+  };
+}
+
+async function readStatus(info: ServerInfo): Promise<EngineV2PreviewStatus> {
+  const response = await fetch(`${info.baseUrl}/experimental/engine-v2-preview/status`, {
+    headers: authHeaders(info),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const value: unknown = await response.json();
+  if (response.status !== 200) throw new Error(`Engine v2 status returned ${response.status}: ${JSON.stringify(value)}`);
+  return parseStatus(value);
+}
+
+async function untilStatus(
+  info: ServerInfo,
+  predicate: (status: EngineV2PreviewStatus) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<EngineV2PreviewStatus> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await readStatus(info);
+  while (Date.now() < deadline) {
+    if (predicate(last)) return last;
+    await sleep(1_000);
+    last = await readStatus(info);
+  }
+  throw new Error(`Timed out waiting for ${label}; last status: ${JSON.stringify(last)}`);
+}
+
+async function engineSessionCount(info: ServerInfo, workspaceId: string, lane: "opencode" | "opencode2"): Promise<number> {
+  const path = lane === "opencode" ? "opencode/session?limit=100" : "opencode2/api/session";
+  const response = await fetch(`${info.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/${path}`, {
+    headers: authHeaders(info),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (lane === "opencode2" && response.status === 503) return -1;
+  const value: unknown = await response.json();
+  if (!response.ok) throw new Error(`${lane} session list returned ${response.status}: ${JSON.stringify(value)}`);
+  if (lane === "opencode") {
+    if (!Array.isArray(value)) throw new Error(`Unexpected v1 session list: ${JSON.stringify(value)}`);
+    return value.length;
+  }
+  if (!isRecord(value) || !Array.isArray(value.data)) {
+    throw new Error(`Unexpected v2 session list: ${JSON.stringify(value)}`);
+  }
+  return value.data.length;
+}
+
+async function clickSwitch(app: Surface, ariaLabel: string): Promise<void> {
+  const point = await evalIn(app, `(() => {
+    const control = [...document.querySelectorAll(${JSON.stringify(`[aria-label="${ariaLabel}"]`)})]
+      .find((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0
+          && candidate.getAttribute("aria-disabled") !== "true"
+          && !candidate.hasAttribute("data-disabled");
+      });
+    if (!(control instanceof HTMLElement)) return null;
+    control.scrollIntoView({ block: "center", behavior: "instant" });
+    const rect = control.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") {
+    throw new Error(`Could not resolve enabled switch ${ariaLabel}: ${JSON.stringify(point)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
+}
+
+async function closeModelPicker(app: Surface): Promise<void> {
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+}
+
+async function waitForModelInPicker(app: Surface, expected: string, timeoutMs = 45_000): Promise<void> {
+  await waitFor(app, `Boolean(document.querySelector('button[aria-label="Change model"]'))`, {
+    timeoutMs: 30_000,
+    label: "composer model picker",
+  });
+  const deadline = Date.now() + timeoutMs;
+  let lastItems: string[] = [];
+  while (Date.now() < deadline) {
+    const opened = await evalIn(app, `(() => {
+      if (document.querySelector('[data-slot="popover-content"]')) return true;
+      const trigger = document.querySelector('button[aria-label="Change model"]');
+      if (!(trigger instanceof HTMLButtonElement)) return false;
+      trigger.click();
+      return true;
+    })()`);
+    if (opened === true) {
+      await sleep(300);
+      await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return false;
+        if ([...popover.querySelectorAll('[data-slot="command-item"]')]
+          .some((item) => (item.textContent ?? "").includes(${JSON.stringify(expected)}))) return true;
+        const modelButton = [...popover.querySelectorAll('button')]
+          .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
+        if (!(modelButton instanceof HTMLButtonElement)) return false;
+        modelButton.click();
+        return true;
+      })()`);
+      await sleep(200);
+      const items = await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return [];
+        return [...popover.querySelectorAll('[data-slot="command-item"]')]
+          .map((item) => (item.textContent ?? "").trim());
+      })()`);
+      if (Array.isArray(items) && items.every((item) => typeof item === "string")) {
+        lastItems = items;
+        if (items.some((item) => item.includes(expected))) return;
+      }
+    }
+    await closeModelPicker(app);
+    await sleep(700);
+  }
+  throw new Error(`Timed out waiting for ${expected} in the model picker; last items: ${JSON.stringify(lastItems)}`);
+}
+
+async function selectModel(app: Surface, modelName: string): Promise<void> {
+  await waitForModelInPicker(app, modelName);
+  const picked = await evalIn(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+      .find((candidate) => (candidate.textContent ?? "").includes(${JSON.stringify(modelName)}));
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(picked).toBe(true);
+  await waitFor(app, `(document.querySelector('button[aria-label="Change model"]')?.textContent ?? "").includes(${JSON.stringify(modelName)})`, {
+    timeoutMs: 15_000,
+    label: `${modelName} selected`,
+  });
+}
+
+async function typeIntoComposer(app: Surface, text: string): Promise<void> {
+  await waitFor(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    return editor instanceof HTMLElement && (editor.innerText ?? "").trim() === "";
+  })()`, { timeoutMs: 30_000, label: "empty composer ready" });
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text });
+  await waitFor(app, `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === ${JSON.stringify(text)}`, {
+    timeoutMs: 10_000,
+    label: `composer contains ${text}`,
+  });
+}
+
+async function createNewSessionThroughSidebar(app: Surface): Promise<string> {
+  const previousValue = await evalIn(app, `document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""`);
+  const previous = typeof previousValue === "string" ? previousValue : "";
+  await waitFor(app, `(() => {
+    const button = document.querySelector('[data-sidebar-new-chat]');
+    return button instanceof HTMLButtonElement && !button.disabled;
+  })()`, { timeoutMs: 30_000, label: "enabled sidebar New task control" });
+  const clicked = await evalIn(app, `(() => {
+    const button = document.querySelector('[data-sidebar-new-chat]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+  await waitFor(app, `(() => {
+    const id = document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? "";
+    return id.startsWith("ses_") && id !== ${JSON.stringify(previous)}
+      && window.location.hash.includes("/session/" + id);
+  })()`, { timeoutMs: 60_000, label: "new session created by the active engine client" });
+  const value = await evalIn(app, `document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""`);
+  if (typeof value !== "string" || !value.startsWith("ses_")) throw new Error(`New session id was unavailable: ${String(value)}`);
+  return value;
+}
+
+async function waitForWitnessRequest(
+  requests: WitnessRequest[],
+  predicate: (request: WitnessRequest) => boolean,
+  label: string,
+): Promise<WitnessRequest> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const match = requests.find(predicate);
+    if (match) return match;
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${label}; requests: ${JSON.stringify(requests)}`);
+}
+
+async function sendAndWaitForNonce(
+  app: Surface,
+  requests: WitnessRequest[],
+  prompt: string,
+  auth: string,
+  model: string,
+  notBefore: number,
+  round: string,
+): Promise<{ request: WitnessRequest; latencyMs: number }> {
+  await typeIntoComposer(app, prompt);
+  const sentAt = Date.now();
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
+  const request = await waitForWitnessRequest(
+    requests,
+    (candidate) => candidate.stream && candidate.at >= sentAt && candidate.at >= notBefore
+      && candidate.auth === auth && candidate.model === model,
+    `${round} streamed witness request`,
+  );
+  await waitFor(app, `[...document.querySelectorAll('[data-message-role="assistant"]')]
+    .some((message) => message.textContent?.includes(${JSON.stringify(request.nonce)}))`, {
+    timeoutMs: 120_000,
+    label: `${round} transcript nonce ${request.nonce}`,
+  });
+  const latencyMs = Date.now() - sentAt;
+  console.info(`[opencode-v2-chat-routing] ${round} send-to-nonce latency: ${latencyMs}ms`);
+  return { request, latencyMs };
+}
+
+test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  const binPath = await resolveOpencodeV2Bin();
+  const witnessRequests: WitnessRequest[] = [];
+  const validAuth = new Set([`Bearer ${keyV1}`, `Bearer ${keyV2}`]);
+  const witness = createServer((request, response) => {
+    const url = request.url ?? "";
+    const auth = request.headers.authorization ?? "";
+    if (!validAuth.has(auth)) {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "invalid witness key" } }));
+      return;
+    }
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        object: "list",
+        data: [modelIdV1, modelIdV2].map((id) => ({ id, object: "model" })),
+      }));
+      return;
+    }
+    if (request.method !== "POST" || (url !== "/v1/chat/completions" && url !== "/chat/completions")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "not found" } }));
+      return;
+    }
+
+    request.setEncoding("utf8");
+    let rawBody = "";
+    request.on("data", (chunk: string) => {
+      rawBody += chunk;
+    });
+    request.on("end", () => {
+      let body: unknown;
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        body = null;
+      }
+      const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
+      const stream = isRecord(body) && body.stream === true;
+      const nonce = "OPENWORK-V2-ROUTING-NONCE";
+      witnessRequests.push({ at: Date.now(), auth, model, stream, nonce });
+      const id = `chatcmpl-opencode-v2-routing-${witnessRequests.length}`;
+      if (!stream) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          id,
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1_000),
+          model,
+          choices: [{ index: 0, message: { role: "assistant", content: "Witness title" }, finish_reason: "stop" }],
+        }));
+        return;
+      }
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      const chunk = (delta: Record<string, string>, finishReason: string | null): void => {
+        response.write(`data: ${JSON.stringify({
+          id,
+          object: "chat.completion.chunk",
+          model,
+          choices: [{ index: 0, delta, finish_reason: finishReason }],
+        })}\n\n`);
+      };
+      chunk({ role: "assistant" }, null);
+      chunk({ content: nonce }, null);
+      chunk({}, "stop");
+      response.end("data: [DONE]\n\n");
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    witness.once("error", reject);
+    witness.listen(0, "127.0.0.1", resolve);
+  });
+  const address = witness.address();
+  if (!address || typeof address === "string") throw new Error("Witness server did not bind a TCP port");
+  const witnessBaseUrl = `http://127.0.0.1:${address.port}/v1`;
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-v2-chat-routing-eval-"));
+  const workspacePath = join(profileDir, "workspace");
+  await mkdir(workspacePath, { recursive: true });
+  await writeFile(join(workspacePath, "opencode.json"), `${JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      "witness-v1": {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Witness V1",
+        options: { baseURL: witnessBaseUrl, apiKey: keyV1 },
+        models: { [modelIdV1]: { name: modelNameV1 } },
+      },
+    },
+  }, null, 2)}\n`);
+
+  await using host = localHost();
+  let app: Awaited<ReturnType<typeof desktop>> | undefined;
+  try {
+    app = await desktop({
+      name: "opencode-v2-chat-routing",
+      host,
+      profileDir,
+      env: {
+        OPENWORK_OPENCODE2_BIN: binPath,
+        ANTHROPIC_API_KEY: "",
+        OPENAI_API_KEY: "",
+        OPENROUTER_API_KEY: "",
+        GOOGLE_GENERATIVE_AI_API_KEY: "",
+        OPENWORK_API_KEY: "",
+        OPENWORK_INFERENCE_BASE_URL: "",
+      },
+    });
+    const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
+    const serverInfo = await readServerInfo(app);
+
+    await selectModel(app, modelNameV1);
+    const v2BeforeEnable = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(v2BeforeEnable).toBe(-1);
+    const r1 = await sendAndWaitForNonce(
+      app,
+      witnessRequests,
+      "hello r1",
+      `Bearer ${keyV1}`,
+      modelIdV1,
+      0,
+      "R1 v1",
+    );
+    expect(r1.request.auth).toBe(`Bearer ${keyV1}`);
+    expect(r1.request.model).toBe(modelIdV1);
+    expect(witnessRequests.some((request) => request.auth === `Bearer ${keyV2}`)).toBe(false);
+    evidence.recordAssertionEvidence(
+      "R1 chat stays on v1 before the preview is enabled",
+      `The transcript streamed ${r1.request.nonce} from ${modelIdV1} with Bearer ${keyV1} in ${r1.latencyMs}ms; the v2 proxy returned 503 and no request used Bearer ${keyV2}.`,
+      true,
+    );
+
+    await go(app, `/workspace/${workspaceId}/settings/advanced`);
+    await waitFor(app, `(() => {
+      const control = document.querySelector('[aria-label="OpenCode v2 engine preview"]');
+      return control?.getAttribute("aria-checked") === "false"
+        && control.getAttribute("aria-disabled") !== "true";
+    })()`, { timeoutMs: 60_000, label: "ready OpenCode v2 preview switch" });
+    await clickSwitch(app, "OpenCode v2 engine preview");
+    const runningStatus = await untilStatus(
+      serverInfo,
+      (status) => status.enabled && status.running && typeof status.pid === "number",
+      120_000,
+      "the OpenCode v2 sidecar to start",
+    );
+    const pid0 = runningStatus.pid;
+    if (pid0 === undefined) throw new Error("Running OpenCode v2 status did not contain a pid");
+
+    await waitFor(app, `(() => {
+      const control = document.querySelector('[aria-label="Route chat through OpenCode v2"]');
+      return control?.getAttribute("aria-checked") === "false"
+        && control.getAttribute("aria-disabled") !== "true";
+    })()`, { timeoutMs: 30_000, label: "ready OpenCode v2 chat routing switch" });
+    await clickSwitch(app, "Route chat through OpenCode v2");
+    await untilStatus(serverInfo, (status) => status.chatRouting, 30_000, "chat routing to be enabled");
+    const routedOnAt = Date.now();
+
+    const patchResponse = await fetch(`${serverInfo.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/config`, {
+      method: "PATCH",
+      headers: { ...authHeaders(serverInfo), "content-type": "application/json" },
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            "witness-v2": {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Witness V2",
+              options: { baseURL: witnessBaseUrl, apiKey: keyV2 },
+              models: { [modelIdV2]: { name: modelNameV2 } },
+            },
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    expect(patchResponse.status).toBe(200);
+    const mirroredStatus = await untilStatus(
+      serverInfo,
+      (status) => status.mirroredProviderIds.includes("witness-v2") && status.catalogModelIds.includes(modelIdV2),
+      60_000,
+      "the v2 witness provider to be mirrored",
+    );
+    expect(mirroredStatus.pid).toBe(pid0);
+
+    await go(app, `/workspace/${workspaceId}/session`);
+    await waitForModelInPicker(app, modelNameV2, 45_000);
+    await closeModelPicker(app);
+    const v1BeforeR2 = await engineSessionCount(serverInfo, workspaceId, "opencode");
+    const v2BeforeR2 = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(v2BeforeR2).toBeGreaterThanOrEqual(0);
+
+    // New task uses the selected workspace's currently swapped client. This
+    // avoids sending a v2 prompt to the pre-toggle v1 session id.
+    await createNewSessionThroughSidebar(app);
+    await selectModel(app, modelNameV2);
+    const r2 = await sendAndWaitForNonce(
+      app,
+      witnessRequests,
+      "hello r2",
+      `Bearer ${keyV2}`,
+      modelIdV2,
+      routedOnAt,
+      "R2 v2",
+    );
+    const v1AfterR2 = await engineSessionCount(serverInfo, workspaceId, "opencode");
+    const v2AfterR2 = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(v2AfterR2).toBeGreaterThan(v2BeforeR2);
+    expect(v1AfterR2).toBe(v1BeforeR2);
+    expect(r2.request.at).toBeGreaterThanOrEqual(routedOnAt);
+    expect(r2.request.auth).toBe(`Bearer ${keyV2}`);
+    expect(r2.request.model).toBe(modelIdV2);
+    evidence.recordAssertionEvidence(
+      "R2 routed chat creates and streams through v2 without touching v1",
+      `The v2 transcript streamed ${r2.request.nonce} from ${modelIdV2} with Bearer ${keyV2} in ${r2.latencyMs}ms; v2 sessions grew ${v2BeforeR2}→${v2AfterR2}, while v1 stayed frozen at ${v1BeforeR2}.`,
+      true,
+    );
+
+    const statusAfterR2 = await readStatus(serverInfo);
+    expect(statusAfterR2.running).toBe(true);
+    expect(statusAfterR2.pid).toBe(pid0);
+    evidence.recordAssertionEvidence(
+      "R3 routing chat does not restart the v2 sidecar",
+      `The routed send completed while the sidecar remained running at pid ${pid0}; no replacement pid appeared.`,
+      true,
+    );
+
+    await go(app, `/workspace/${workspaceId}/settings/advanced`);
+    await waitFor(app, `document.querySelector('[aria-label="Route chat through OpenCode v2"]')?.getAttribute("aria-checked") === "true"`, {
+      timeoutMs: 30_000,
+      label: "enabled chat routing switch before reversal",
+    });
+    await clickSwitch(app, "Route chat through OpenCode v2");
+    await untilStatus(serverInfo, (status) => !status.chatRouting, 30_000, "chat routing to be disabled");
+    const routedOffAt = Date.now();
+    await go(app, `/workspace/${workspaceId}/session`);
+    await waitForModelInPicker(app, modelNameV1, 45_000);
+    await closeModelPicker(app);
+    await createNewSessionThroughSidebar(app);
+    await selectModel(app, modelNameV1);
+    const r4 = await sendAndWaitForNonce(
+      app,
+      witnessRequests,
+      "hello r4",
+      `Bearer ${keyV1}`,
+      modelIdV1,
+      routedOffAt,
+      "R4 v1",
+    );
+    const v2AfterR4 = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(r4.request.at).toBeGreaterThanOrEqual(routedOffAt);
+    expect(r4.request.auth).toBe(`Bearer ${keyV1}`);
+    expect(r4.request.model).toBe(modelIdV1);
+    expect(v2AfterR4).toBe(v2AfterR2);
+    evidence.recordAssertionEvidence(
+      "R4 disabling routing returns new chat to v1 without mutating v2",
+      `After routing was disabled, the transcript streamed ${r4.request.nonce} from ${modelIdV1} with Bearer ${keyV1} in ${r4.latencyMs}ms; v2 sessions stayed frozen at ${v2AfterR2}.`,
+      true,
+    );
+  } finally {
+    if (app !== undefined) await app.stop();
+    witness.closeAllConnections();
+    await new Promise<void>((resolve, reject) => witness.close((error) => error ? reject(error) : resolve()));
+    await rm(profileDir, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/opencode-v2-provider-hot-inject.test.ts
+++ b/evals/specs/opencode-v2-provider-hot-inject.test.ts
@@ -1,0 +1,254 @@
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { eventually, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+import {
+  createManagedOpencodeV2Server,
+  type ManagedOpencodeV2Server,
+} from "../../apps/server/src/managed-opencode-v2";
+
+const execFileAsync = promisify(execFile);
+
+interface WitnessRequest {
+  at: number;
+  auth: string;
+  model: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOpencodeV2Bin(): Promise<string> {
+  const override = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const constants: unknown = JSON.parse(await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"));
+  if (!isRecord(constants) || typeof constants.opencodeV2Version !== "string") {
+    throw new Error("constants.json must define a string opencodeV2Version");
+  }
+  const cache = join(tmpdir(), "openwork-opencode-v2-cache", constants.opencodeV2Version);
+  const binary = join(cache, "node_modules", ".bin", "opencode2");
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, '{"private":true}\n');
+    await execFileAsync(
+      "npm",
+      ["install", "--no-fund", "--no-audit", "--no-save", `@opencode-ai/cli@${constants.opencodeV2Version}`],
+      { cwd: cache, timeout: 180_000 },
+    );
+  }
+  if (!(await exists(binary))) {
+    throw new Error(`OpenCode v2 binary was not installed at ${binary}; set OPENWORK_EVAL_OPENCODE2_BIN to a working opencode2 binary`);
+  }
+  return binary;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text === "" ? {} : JSON.parse(text);
+}
+
+function sessionId(payload: unknown): string | undefined {
+  if (!isRecord(payload) || !isRecord(payload.data)) return undefined;
+  return typeof payload.data.id === "string" ? payload.data.id : undefined;
+}
+
+test("opencode v2 injects providers at runtime without an engine reload", async ({ evidence }) => {
+  const binary = await resolveOpencodeV2Bin();
+  const nonce = `WITNESS-OK-${randomBytes(12).toString("hex")}`;
+  const requests: WitnessRequest[] = [];
+  const witness = createServer(async (request, response) => {
+    if (request.method !== "POST" || (request.url !== "/v1/chat/completions" && request.url !== "/chat/completions")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "not found" }));
+      return;
+    }
+
+    try {
+      const body = await readRequestBody(request);
+      const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
+      requests.push({ at: Date.now(), auth: request.headers.authorization ?? "", model });
+      const chunks = [
+        { id: "chatcmpl-w", object: "chat.completion.chunk", created: 1, model, choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+        { id: "chatcmpl-w", object: "chat.completion.chunk", created: 1, model, choices: [{ index: 0, delta: { content: nonce }, finish_reason: null }] },
+        { id: "chatcmpl-w", object: "chat.completion.chunk", created: 1, model, choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+      ];
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      response.end("data: [DONE]\n\n");
+    } catch (error) {
+      response.writeHead(400, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    witness.once("error", reject);
+    witness.listen(0, "127.0.0.1", resolve);
+  });
+  const witnessAddress = witness.address();
+  if (witnessAddress === null || typeof witnessAddress === "string") throw new Error("Witness failed to bind a TCP port");
+  const witnessUrl = `http://127.0.0.1:${witnessAddress.port}`;
+  const rootDir = await mkdtemp(join(tmpdir(), "oc2-hot-inject-"));
+  const directory = join(rootDir, "workspace");
+  await mkdir(directory);
+  let server: ManagedOpencodeV2Server | undefined;
+
+  try {
+    server = await createManagedOpencodeV2Server({ bin: binary, rootDir });
+    const initialHealth = await server.health();
+    const pid0 = initialHealth.pid;
+    expect(initialHealth.healthy).toBe(true);
+
+    const baseline = await server.fetchJson("/api/model", { directory });
+    const baselineText = JSON.stringify(baseline.json);
+    expect(baseline.status).toBe(200);
+    expect(baselineText).not.toContain("openwork-witness-a");
+    expect(baselineText).not.toContain("openwork-witness-b");
+    evidence.recordAssertionEvidence(
+      "C1 positive baseline and negative provider absence",
+      "The healthy v2 engine listed models while containing neither witness A nor witness B before injection.",
+      true,
+    );
+
+    const injectionStartedAt = Date.now();
+    await server.injectProvider({
+      id: "openwork-witness-a",
+      name: "Witness A",
+      baseUrl: `${witnessUrl}/v1`,
+      apiKey: "witness-key-a",
+      models: [{ id: "witness-model-a", name: "Witness Model A" }],
+    });
+    const modelsAfterA = await eventually(
+      () => server?.fetchJson("/api/model", { directory }),
+      {
+        within: 15_000,
+        intervalMs: 250,
+        label: "provider A to appear in the model list",
+        until: (result) => result !== undefined && JSON.stringify(result.json).includes("openwork-witness-a"),
+      },
+    );
+    const injectionLatencyMs = Date.now() - injectionStartedAt;
+    expect(JSON.stringify(modelsAfterA?.json)).toContain("openwork-witness-a");
+    console.info(`[opencode-v2-spec] provider A injection latency: ${injectionLatencyMs}ms`);
+    evidence.recordAssertionEvidence(
+      "C2 positive hot injection and negative bounded-wait failure",
+      `Witness A appeared through the watched config in ${injectionLatencyMs}ms, within the 15s bound and without a startup operation.`,
+      true,
+    );
+
+    const sessionA = await server.fetchJson("/api/session", {
+      method: "POST",
+      directory,
+      body: { model: { providerID: "openwork-witness-a", id: "witness-model-a" } },
+    });
+    expect(sessionA.status).toBe(200);
+    const idA = sessionId(sessionA.json);
+    expect(idA).toBeTypeOf("string");
+    if (idA === undefined) throw new Error("Provider A session response did not contain data.id");
+    const promptA = await server.fetchJson(`/api/session/${idA}/prompt`, {
+      method: "POST",
+      directory,
+      body: { text: "reply with anything" },
+    });
+    expect(promptA.status).toBe(200);
+    await eventually(
+      async () => JSON.stringify((await server?.fetchJson(`/api/session/${idA}/message`, { directory }))?.json),
+      { within: 60_000, intervalMs: 250, label: "provider A witness response", until: (text) => text.includes(nonce) },
+    );
+    expect(requests.some((entry) => entry.auth === "Bearer witness-key-a" && entry.model === "witness-model-a")).toBe(true);
+    expect(requests.some((entry) => entry.model === "witness-model-b")).toBe(false);
+    evidence.recordAssertionEvidence(
+      "C3 positive provider A execution and negative wrong-credential routing",
+      "The A session received the witness nonce, and the witness observed model A paired with only the expected Bearer key A assertion.",
+      true,
+    );
+    await server.injectProvider({
+      id: "openwork-witness-b",
+      name: "Witness B",
+      baseUrl: `${witnessUrl}/v1`,
+      apiKey: "witness-key-b",
+      models: [{ id: "witness-model-b", name: "Witness Model B" }],
+    });
+    let providerBFirstSeenAt: number | undefined;
+    const modelsAfterB = await eventually(
+      () => server?.fetchJson("/api/model", { directory }),
+      {
+        within: 15_000,
+        intervalMs: 250,
+        label: "provider B to appear in the model list",
+        until: (result) => {
+          if (result === undefined || !JSON.stringify(result.json).includes("openwork-witness-b")) {
+            providerBFirstSeenAt = undefined;
+            return false;
+          }
+          providerBFirstSeenAt ??= Date.now();
+          return Date.now() - providerBFirstSeenAt >= 2_000;
+        },
+      },
+    );
+    const modelsAfterBText = JSON.stringify(modelsAfterB?.json);
+    expect(modelsAfterBText).toContain("openwork-witness-a");
+    expect(modelsAfterBText).toContain("openwork-witness-b");
+
+    const sessionB = await server.fetchJson("/api/session", {
+      method: "POST",
+      directory,
+      body: { model: { providerID: "openwork-witness-b", id: "witness-model-b" } },
+    });
+    expect(sessionB.status).toBe(200);
+    const idB = sessionId(sessionB.json);
+    expect(idB).toBeTypeOf("string");
+    if (idB === undefined) throw new Error("Provider B session response did not contain data.id");
+    const promptB = await server.fetchJson(`/api/session/${idB}/prompt`, {
+      method: "POST",
+      directory,
+      body: { text: "reply with anything" },
+    });
+    expect(promptB.status).toBe(200);
+    await eventually(
+      async () => JSON.stringify((await server?.fetchJson(`/api/session/${idB}/message`, { directory }))?.json),
+      { within: 60_000, intervalMs: 250, label: "provider B witness response", until: (text) => text.includes(nonce) },
+    );
+    expect(requests.some((entry) => entry.auth === "Bearer witness-key-b" && entry.model === "witness-model-b")).toBe(true);
+    expect(requests.some((entry) => entry.auth === "Bearer witness-key-a" && entry.model === "witness-model-b")).toBe(false);
+    evidence.recordAssertionEvidence(
+      "C5 positive warm re-injection and negative clobbering or key leakage",
+      "Both providers remained listed; B produced the nonce with key B/model B, while no key A/model B request occurred.",
+      true,
+    );
+
+    const finalHealth = await server.health();
+    expect(finalHealth.pid).toBe(pid0);
+    expect(server.exitCode).toBeNull();
+    expect((server.stdout.match(/server listening on/g) ?? []).length).toBe(1);
+    evidence.recordAssertionEvidence(
+      "C4 positive same-process health and negative engine replacement",
+      `Health retained pid ${pid0}, the child remained live, and stdout contained exactly one server-listening boot line after both injections.`,
+      true,
+    );
+  } finally {
+    if (server !== undefined) await server.close();
+    await new Promise<void>((resolve, reject) => witness.close((error) => error ? reject(error) : resolve()));
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}, 240_000);


### PR DESCRIPTION
## What

Explores and lands a **parallel opencode v2 engine lane** (github.com/anomalyco/opencode branch `v2`), proving its headline property for OpenWork: **providers become usable at runtime with no engine reload** — the property that today forces `/instance/dispose` or a blue/green `EnginePool` rollover on every provider change.

- `docs/opencode-v2-parallel-lane.md` — full exploration: v1 integration map (four server→engine touchpoints), verified v2 architecture, why no reload is needed (rebuildable catalog, per-request credential resolution, content-keyed AI-SDK caches, watched config), full OpenWork-on-v2 lane design, rollout stages, parity risks.
- `apps/server/src/managed-opencode-v2.ts` — self-contained v2 lane manager: spawns `opencode2 serve` (Basic auth, isolated SQLite + always-watched config dir), health-based readiness, `injectProvider()`/`setProviders()` = atomic config writes. **The module contains no reload/dispose call — that absence is the point.**
- `apps/server/src/engine-v2-preview.ts` + Settings > Advanced toggle — **experimental feature flag "OpenCode v2 engine preview"** (default off): runs the v2 engine as a parallel sidecar and hot-mirrors every provider change from the runtime provider store into it (subscribes to `onRuntimeOpencodeConfigWrite`; no reload). Live status endpoint reports pid, mirrored/skipped providers, and sidecar-ingested model ids. The app keeps using the v1 engine; flag off constructs nothing.
- `constants.json` — pin `opencodeV2Version: 0.0.0-beta-18707` (npm `@opencode-ai/cli` beta dist-tag, ships the `opencode2` binary).

**Scope note**: the flag deliberately does not switch the app's primary engine — the renderer/proxy/credential paths still speak the v1 dialect. That adapter work is staged in the design doc; this flag is the dogfooding surface for the no-reload property while we test.

## Proof

- `evals/specs/opencode-v2-provider-hot-inject.test.ts` (app-less PR lane): C1 baseline absence → C2 hot injection listed in ~0.8–1.3s → C3 prompt round-trips through a local witness with the injected key (key isolation between two providers) → C4 **same engine pid, child never exited, exactly one boot line** → C5 warm second injection without clobbering.
- `evals/specs/engine-v2-preview-flag.e2e.test.ts` (app-driving): F1 default off (status + unchecked switch) → F2 enable via Settings boots the sidecar while v1 keeps serving → F3 provider added through the product config path is mirrored hot (sidecar catalog ingests the model id; baseURL-less record lands in skipped, never mirrored; **sidecar pid unchanged**) → F4 disable stops the sidecar and it stays stopped.
- `apps/server/src/engine-v2-preview.test.ts` (bun unit): v1→v2 provider mapping edge cases.

## Verification (local lane — Daytona credentials unavailable in this environment)

| Check | Command | Result |
| --- | --- | --- |
| App-less spec | `pnpm evals:pr specs/opencode-v2-provider-hot-inject.test.ts` | 1 passed / 0 failed / 0 skipped (10.7s) |
| E2E spec | `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/engine-v2-preview-flag.e2e.test.ts` | 1 passed / 0 failed / 0 skipped (78s) |
| Unit (mapping) | `pnpm --filter openwork-server exec bun test src/engine-v2-preview.test.ts` | 5 passed / 0 failed |
| Typecheck | `pnpm --filter openwork-server typecheck` · `pnpm --filter @openwork/app typecheck` | both green |

All runs executed on the PR head. Test evidence publication follows in the sticky comment.