### PR TITLE
fix(app): drain queued composer messages while the session is not in view

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -76,6 +76,7 @@ import { interruptedTaskRecoveryPrompt } from "@/react-app/domains/session/sync/
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
+import { setQueuedSendContext } from "@/react-app/domains/session/sync/queued-send-context";
 import { useSessionScrollController } from "./scroll-controller";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
@@ -916,6 +917,32 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // session B when the route swaps the same surface component to another
   // session.
   const queuedItems = useComposerStateStore((state) => getComposerQueuedDrafts(state, props.sessionId));
+  useEffect(() => {
+    if (queuedItems.length === 0) return;
+    setQueuedSendContext(props.sessionId, {
+      workspaceId: props.workspaceId,
+      workspaceRoot: props.workspaceRoot,
+      opencodeBaseUrl: props.opencodeBaseUrl,
+      openworkToken: props.openworkToken,
+      client: props.client,
+      agent: props.selectedAgent,
+      variant: props.modelVariant,
+      model: props.selectedModel,
+      environmentRuntimeKey: props.environmentRuntimeKey ?? null,
+    });
+  }, [
+    props.client,
+    props.environmentRuntimeKey,
+    props.modelVariant,
+    props.opencodeBaseUrl,
+    props.openworkToken,
+    props.selectedAgent,
+    props.selectedModel,
+    props.sessionId,
+    props.workspaceId,
+    props.workspaceRoot,
+    queuedItems.length,
+  ]);
   const appendQueuedDraft = useComposerStateStore((state) => state.appendQueuedDraft);
   const removeQueuedDraftFromStore = useComposerStateStore((state) => state.removeQueuedDraft);
   const updateQueuedDraftInStore = useComposerStateStore((state) => state.updateQueuedDraft);

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -1,0 +1,178 @@
+import type {
+  AgentPartInput,
+  FilePartInput,
+  TextPartInput,
+} from "@opencode-ai/sdk/v2/client";
+
+import type { ComposerDraft, ComposerPart } from "@/app/types";
+import {
+  composerAttachmentsToWorkspaceFileParts,
+  type ChatAttachmentWorkspaceEndpoint,
+} from "./attachment-file-part";
+import {
+  firstLineLocalFileParts,
+  joinWorkspaceRelativePath,
+  toFileUrl,
+} from "./prompt-file-parts";
+import { appMentionInstruction } from "../surface/composer/app-mentions";
+import { connectSkillPrompt, parseConnectSkillToken } from "../surface/composer/connect-skill-token";
+import { decodeComposerMentionValue } from "../surface/composer/mention-encoding";
+
+// All workspace-scoped server URLs/clients/tokens come from
+// `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
+// Don't compose `<baseUrl>/workspace/<id>` here.
+export async function draftToParts(
+  draft: ComposerDraft,
+  workspaceRoot: string,
+  sessionId: string,
+  endpoint: ChatAttachmentWorkspaceEndpoint | null,
+) {
+  const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
+  const root = workspaceRoot.trim();
+
+  const toAbsolutePath = (path: string) => {
+    const trimmed = path.trim();
+    if (!trimmed) return "";
+    if (trimmed.startsWith("/")) return trimmed;
+    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed;
+    if (!root) return "";
+    return joinWorkspaceRelativePath(root, trimmed);
+  };
+
+  const filenameFromPath = (path: string) => {
+    const normalized = path.replace(/\\/g, "/");
+    const segments = normalized.split("/").filter(Boolean);
+    return segments[segments.length - 1] ?? "file";
+  };
+
+  const attachmentFileById = new Map<string, FilePartInput>();
+  if (draft.attachments.length > 0) {
+    if (!endpoint) {
+      throw new Error("Workspace endpoint is unavailable; attachments could not be copied for tool access.");
+    }
+    const uploaded = await composerAttachmentsToWorkspaceFileParts({
+      attachments: draft.attachments,
+      endpoint,
+      sessionId,
+      workspaceRoot: root,
+    });
+    for (const part of uploaded) {
+      if (part.type === "text") {
+        parts.push(part);
+        continue;
+      }
+    }
+    const fileParts = uploaded.filter((part): part is FilePartInput => part.type === "file");
+    for (const [index, attachment] of draft.attachments.entries()) {
+      const filePart = fileParts[index];
+      if (filePart) attachmentFileById.set(attachment.id, filePart);
+    }
+  }
+
+  // Prefer draft.text token order so attachment chips stay inline with surrounding text
+  // (same positions as the composer), instead of dumping every file part at the end.
+  const hasAttachmentTokens = /\[attachment [^\]]+\]/.test(draft.text);
+  if (hasAttachmentTokens || attachmentFileById.size > 0) {
+    const pasteByLabel = new Map(
+      draft.parts
+        .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
+        .map((part) => [part.label, part.text] as const),
+    );
+    for (const segment of draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/)) {
+      if (!segment) continue;
+      const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
+      if (attachmentMatch?.[1]) {
+        const filePart = attachmentFileById.get(attachmentMatch[1]);
+        if (filePart) {
+          parts.push(filePart);
+          attachmentFileById.delete(attachmentMatch[1]);
+        }
+        continue;
+      }
+      const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
+      if (pasteMatch?.[1]) {
+        const pasted = pasteByLabel.get(pasteMatch[1]);
+        if (pasted) parts.push({ type: "text", text: pasted });
+        continue;
+      }
+      const connectSkill = parseConnectSkillToken(segment);
+      if (connectSkill) {
+        parts.push({ type: "text", text: connectSkillPrompt(connectSkill) });
+        continue;
+      }
+      const skillMatch = segment.match(/^\[skill (.+)\]$/);
+      if (skillMatch?.[1]) {
+        parts.push({ type: "text", text: `Load [skill ${skillMatch[1]}] and follow its instructions.` });
+        continue;
+      }
+      if (segment.startsWith("@")) {
+        const value = decodeComposerMentionValue(segment.slice(1));
+        const mentionPart = draft.parts.find((part) =>
+          (part.type === "agent" && part.name === value)
+          || (part.type === "app" && part.name === value)
+          || (part.type === "file" && part.path === value),
+        );
+        if (mentionPart?.type === "agent") {
+          parts.push({ type: "agent", name: mentionPart.name });
+          continue;
+        }
+        if (mentionPart?.type === "app") {
+          parts.push({ type: "text", text: appMentionInstruction(mentionPart.name) });
+          continue;
+        }
+        if (mentionPart?.type === "file") {
+          const absolute = toAbsolutePath(mentionPart.path);
+          if (!absolute) continue;
+          parts.push({
+            type: "file",
+            mime: "text/plain",
+            url: toFileUrl(absolute),
+            filename: filenameFromPath(mentionPart.path),
+          });
+          continue;
+        }
+      }
+      parts.push({ type: "text", text: segment });
+    }
+    for (const filePart of attachmentFileById.values()) {
+      parts.push(filePart);
+    }
+  } else {
+    for (const part of draft.parts) {
+      if (part.type === "text") {
+        parts.push({ type: "text", text: part.text });
+        continue;
+      }
+      if (part.type === "paste") {
+        parts.push({ type: "text", text: part.text });
+        continue;
+      }
+      if (part.type === "agent") {
+        parts.push({ type: "agent", name: part.name });
+        continue;
+      }
+      if (part.type === "skill") {
+        parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
+        continue;
+      }
+      if (part.type === "app") {
+        parts.push({ type: "text", text: appMentionInstruction(part.name) });
+        continue;
+      }
+      if (part.type === "file") {
+        const absolute = toAbsolutePath(part.path);
+        if (!absolute) continue;
+        parts.push({
+          type: "file",
+          mime: "text/plain",
+          url: toFileUrl(absolute),
+          filename: filenameFromPath(part.path),
+        });
+      }
+    }
+  }
+
+  parts.push(...firstLineLocalFileParts(draft.resolvedText ?? draft.text, root));
+
+  return parts;
+}

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer-bridge.tsx
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer-bridge.tsx
@@ -1,0 +1,9 @@
+/** @jsxImportSource react */
+import { useEffect } from "react";
+
+import { startGlobalQueueDrainer } from "./global-queue-drainer";
+
+export function GlobalQueueDrainerBridge() {
+  useEffect(() => startGlobalQueueDrainer(), []);
+  return null;
+}

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -1,0 +1,377 @@
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+
+import { markTaskRunStart } from "@/app/lib/analytics";
+import { createClient } from "@/app/lib/opencode";
+import { shellInSession } from "@/app/lib/opencode-session";
+import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
+import type { ComposerDraft, ModelRef } from "@/app/types";
+import { readStoredDefaultModel } from "@/react-app/kernel/model-config";
+import { useSessionActivityStore } from "../status/session-activity-store";
+import {
+  getComposerQueuedDrafts,
+  useComposerStateStore,
+} from "../surface/composer-state-store";
+import {
+  canAdmitNextQueuedItem,
+  claimQueuedSend,
+  dispatchQueuedDrain,
+  getQueuedDrainState,
+  nextObservationProbeAt,
+  subscribeQueuedDrain,
+} from "../surface/queued-drain-machine";
+import { getSessionModelSelection, useSessionModelStore } from "../surface/session-model-store";
+import { draftToParts } from "./draft-parts";
+import { buildOpenworkEnvSystemContext } from "./env-context";
+import {
+  clearQueuedSendContext,
+  getQueuedSendContext,
+  subscribeQueuedSendContext,
+  type QueuedSendContext,
+} from "./queued-send-context";
+import { ensureWorkspaceSessionSync, trackWorkspaceSessionSync } from "./session-sync";
+
+type WatchedSession = {
+  sessionId: string;
+  context: QueuedSendContext;
+  releaseWorkspaceSync: () => void;
+  releaseSessionSync: () => void;
+  unsubscribeDrain: () => void;
+  initialStatusController: AbortController;
+  probeController: AbortController | null;
+  probeTimer: ReturnType<typeof setTimeout> | null;
+  lastObservedStatus: SessionStatus | null;
+  lastProbeAt: number | null;
+  probeInFlight: boolean;
+  sendInFlight: boolean;
+};
+
+const watchedSessions = new Map<string, WatchedSession>();
+let startRefs = 0;
+let unsubscribeComposerStore: (() => void) | null = null;
+let unsubscribeContexts: (() => void) | null = null;
+
+function sameContext(left: QueuedSendContext, right: QueuedSendContext) {
+  return left.workspaceId === right.workspaceId
+    && left.workspaceRoot === right.workspaceRoot
+    && left.opencodeBaseUrl === right.opencodeBaseUrl
+    && left.openworkToken === right.openworkToken
+    && left.client === right.client
+    && left.agent === right.agent
+    && left.variant === right.variant
+    && left.model?.providerID === right.model?.providerID
+    && left.model?.modelID === right.model?.modelID
+    && left.environmentRuntimeKey === right.environmentRuntimeKey;
+}
+
+function serializeSDKError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null) {
+    try {
+      const serialized = JSON.stringify(error);
+      if (serialized) return serialized;
+    } catch {
+      const message = Reflect.get(error, "message");
+      return typeof message === "string" ? message : String(error);
+    }
+  }
+  return String(error);
+}
+
+function readStoredDefaultModelSafely(): ModelRef | null {
+  try {
+    return readStoredDefaultModel();
+  } catch {
+    return null;
+  }
+}
+
+async function performQueuedDraftSend(
+  context: QueuedSendContext,
+  sessionId: string,
+  draft: ComposerDraft,
+) {
+  const text = draft.text.trim();
+  if (!text && draft.attachments.length === 0 && !draft.command) return;
+
+  const sessionModelSelection = getSessionModelSelection(sessionId);
+  const sendModel = sessionModelSelection?.model ?? readStoredDefaultModelSafely() ?? context.model;
+  const sendVariant = sessionModelSelection ? sessionModelSelection.variant : context.variant;
+  const opencodeClient = createClient(
+    context.opencodeBaseUrl,
+    context.workspaceRoot || undefined,
+    { token: context.openworkToken, mode: "openwork" },
+  );
+
+  if (draft.mode === "shell") {
+    await shellInSession(opencodeClient, sessionId, text);
+    return;
+  }
+
+  if (draft.command) {
+    const result = await opencodeClient.session.command({
+      sessionID: sessionId,
+      command: draft.command.name,
+      arguments: draft.command.arguments,
+    });
+    if (result.error) throw new Error(serializeSDKError(result.error));
+    return;
+  }
+
+  const parts = await draftToParts(draft, context.workspaceRoot, sessionId, {
+    client: context.client,
+    workspaceId: context.workspaceId,
+  });
+  const envSystemContext = await buildOpenworkEnvSystemContext(context.client, {
+    cacheKey: sessionId,
+    runtimeKey: context.environmentRuntimeKey,
+  });
+  const result = await opencodeClient.session.promptAsync({
+    sessionID: sessionId,
+    parts,
+    model: sendModel ?? undefined,
+    agent: context.agent ?? undefined,
+    ...(sendVariant ? { variant: sendVariant } : {}),
+    ...(envSystemContext ? { system: envSystemContext } : {}),
+  });
+  if (result.error) throw new Error(serializeSDKError(result.error));
+  if (sendModel) {
+    useSessionModelStore.getState().setModel(sessionId, sendModel, sendVariant ?? null);
+  }
+}
+
+// Mirrors withoutRevertTarget in ../surface/session-surface.tsx without
+// importing the component module.
+function withoutRevertTarget(draft: ComposerDraft): ComposerDraft {
+  if (!draft.revertMessageId) return draft;
+  return { ...draft, revertMessageId: undefined };
+}
+
+// Mirrors revokeAttachmentPreview in ../surface/session-surface.tsx, with a
+// guard for app-less/node execution.
+function revokeAttachmentPreview(attachment: { previewUrl?: string }) {
+  if (!attachment.previewUrl || typeof URL === "undefined" || typeof URL.revokeObjectURL !== "function") return;
+  URL.revokeObjectURL(attachment.previewUrl);
+}
+
+function armObservationProbe(watched: WatchedSession) {
+  if (watchedSessions.get(watched.sessionId) !== watched) return;
+  if (watched.probeTimer !== null) {
+    clearTimeout(watched.probeTimer);
+    watched.probeTimer = null;
+  }
+  if (watched.probeInFlight) return;
+
+  const probeAt = nextObservationProbeAt(
+    getQueuedDrainState(watched.sessionId),
+    watched.lastProbeAt,
+  );
+  if (probeAt === null) return;
+
+  watched.probeTimer = setTimeout(() => {
+    watched.probeTimer = null;
+    const startedAt = Date.now();
+    watched.lastProbeAt = startedAt;
+    watched.probeInFlight = true;
+    const controller = new AbortController();
+    watched.probeController = controller;
+    void composeNativeSessionSnapshot(
+      {
+        opencodeBaseUrl: watched.context.opencodeBaseUrl,
+        token: watched.context.openworkToken,
+      },
+      watched.sessionId,
+      { limit: 140, signal: controller.signal },
+    ).then((snapshot) => {
+      if (watchedSessions.get(watched.sessionId) !== watched) return;
+      watched.lastObservedStatus = snapshot.status;
+      if (snapshot.status.type === "idle") {
+        dispatchQueuedDrain(watched.sessionId, {
+          type: "idle_reconciled",
+          observedAt: startedAt,
+        });
+      } else {
+        dispatchQueuedDrain(watched.sessionId, { type: "busy_observed" });
+      }
+    }).catch(() => {
+      // A spaced retry is armed below from the machine's timing helper.
+    }).finally(() => {
+      if (watchedSessions.get(watched.sessionId) !== watched) return;
+      watched.probeInFlight = false;
+      watched.probeController = null;
+      armObservationProbe(watched);
+    });
+  }, Math.max(0, probeAt - Date.now()));
+}
+
+function handleObservedStatus(watched: WatchedSession, status: SessionStatus) {
+  if (watchedSessions.get(watched.sessionId) !== watched) return;
+  watched.lastObservedStatus = status;
+  if (status.type !== "idle") {
+    dispatchQueuedDrain(watched.sessionId, { type: "busy_observed" });
+    return;
+  }
+  if (getQueuedDrainState(watched.sessionId).phase.kind === "running") {
+    dispatchQueuedDrain(watched.sessionId, {
+      type: "idle_reconciled",
+      observedAt: Date.now(),
+    });
+  }
+  void attemptDrain(watched.sessionId);
+}
+
+function releaseWatchedSession(watched: WatchedSession, clearContext: boolean) {
+  if (watchedSessions.get(watched.sessionId) === watched) {
+    watchedSessions.delete(watched.sessionId);
+  }
+  if (watched.probeTimer !== null) clearTimeout(watched.probeTimer);
+  watched.initialStatusController.abort();
+  watched.probeController?.abort();
+  watched.unsubscribeDrain();
+  watched.releaseSessionSync();
+  watched.releaseWorkspaceSync();
+  if (clearContext) clearQueuedSendContext(watched.sessionId);
+}
+
+function watchSession(sessionId: string, context: QueuedSendContext) {
+  const initialStatusController = new AbortController();
+  const watched: WatchedSession = {
+    sessionId,
+    context,
+    releaseWorkspaceSync: () => {},
+    releaseSessionSync: () => {},
+    unsubscribeDrain: () => {},
+    initialStatusController,
+    probeController: null,
+    probeTimer: null,
+    lastObservedStatus: null,
+    lastProbeAt: null,
+    probeInFlight: false,
+    sendInFlight: false,
+  };
+  const input = {
+    workspaceId: context.workspaceId,
+    baseUrl: context.opencodeBaseUrl,
+    openworkToken: context.openworkToken,
+    onSessionStatus: (update: { sessionId: string; status: SessionStatus }) => {
+      if (update.sessionId === sessionId) handleObservedStatus(watched, update.status);
+    },
+  };
+  watched.releaseWorkspaceSync = ensureWorkspaceSessionSync(input);
+  watched.releaseSessionSync = trackWorkspaceSessionSync(input, sessionId);
+  watchedSessions.set(sessionId, watched);
+  watched.unsubscribeDrain = subscribeQueuedDrain(sessionId, () => {
+    armObservationProbe(watched);
+    if (watched.lastObservedStatus?.type === "idle") void attemptDrain(sessionId);
+  });
+  armObservationProbe(watched);
+
+  void composeNativeSessionSnapshot(
+    { opencodeBaseUrl: context.opencodeBaseUrl, token: context.openworkToken },
+    sessionId,
+    { limit: 140, signal: initialStatusController.signal },
+  ).then((snapshot) => {
+    handleObservedStatus(watched, snapshot.status);
+  }).catch(() => {
+    // The live workspace stream remains authoritative if this initial read fails.
+  });
+}
+
+function reconcileWatchedSessions() {
+  if (startRefs === 0) return;
+  const queuedDrafts = useComposerStateStore.getState().queuedDrafts;
+
+  for (const [sessionId, watched] of [...watchedSessions]) {
+    const queuedItems = queuedDrafts[sessionId] ?? [];
+    const context = getQueuedSendContext(sessionId);
+    if (watched.sendInFlight) continue;
+    if (queuedItems.length === 0 || !context) {
+      releaseWatchedSession(watched, queuedItems.length === 0);
+      continue;
+    }
+    if (!sameContext(watched.context, context)) {
+      releaseWatchedSession(watched, false);
+      watchSession(sessionId, context);
+    }
+  }
+
+  for (const [sessionId, queuedItems] of Object.entries(queuedDrafts)) {
+    if (queuedItems.length === 0 || watchedSessions.has(sessionId)) continue;
+    const context = getQueuedSendContext(sessionId);
+    if (context) watchSession(sessionId, context);
+  }
+
+  for (const [sessionId] of [...watchedSessions]) void attemptDrain(sessionId);
+}
+
+async function attemptDrain(sessionId: string) {
+  const watched = watchedSessions.get(sessionId);
+  if (!watched || watched.sendInFlight) return;
+  const context = getQueuedSendContext(sessionId);
+  const nextItem = getComposerQueuedDrafts(useComposerStateStore.getState(), sessionId)[0];
+  if (!context || !nextItem || watched.lastObservedStatus?.type !== "idle") return;
+  if (!canAdmitNextQueuedItem(getQueuedDrainState(sessionId))) return;
+
+  const draft = withoutRevertTarget(nextItem.draft);
+  // Claim synchronously before any await so a mounted surface cannot win the
+  // same item after this drainer observes it.
+  if (!claimQueuedSend(sessionId, nextItem.id)) return;
+  watched.sendInFlight = true;
+  useComposerStateStore.getState().removeQueuedDraft(sessionId, nextItem.id);
+
+  try {
+    await performQueuedDraftSend(context, sessionId, draft);
+    dispatchQueuedDrain(sessionId, {
+      type: "send_result",
+      itemId: nextItem.id,
+      outcome: "sent",
+      at: Date.now(),
+    });
+    draft.attachments.forEach(revokeAttachmentPreview);
+    useComposerStateStore.getState().appendHistory(sessionId, draft.text);
+    useSessionActivityStore.getState().setRunStatus(
+      context.workspaceId,
+      sessionId,
+      { type: "busy" },
+    );
+    markTaskRunStart(sessionId);
+  } catch {
+    dispatchQueuedDrain(sessionId, { type: "send_error", itemId: nextItem.id });
+    useComposerStateStore.getState().prependQueuedDrafts(sessionId, [{ id: nextItem.id, draft }]);
+  } finally {
+    watched.sendInFlight = false;
+    if (startRefs > 0) {
+      reconcileWatchedSessions();
+    }
+    if (getComposerQueuedDrafts(useComposerStateStore.getState(), sessionId).length === 0) {
+      clearQueuedSendContext(sessionId);
+    }
+  }
+}
+
+function stopGlobalQueueDrainer() {
+  unsubscribeComposerStore?.();
+  unsubscribeContexts?.();
+  unsubscribeComposerStore = null;
+  unsubscribeContexts = null;
+  for (const watched of [...watchedSessions.values()]) {
+    releaseWatchedSession(watched, false);
+  }
+}
+
+export function startGlobalQueueDrainer(): () => void {
+  startRefs += 1;
+  if (startRefs === 1) {
+    unsubscribeComposerStore = useComposerStateStore.subscribe(reconcileWatchedSessions);
+    unsubscribeContexts = subscribeQueuedSendContext(reconcileWatchedSessions);
+    reconcileWatchedSessions();
+  }
+
+  let stopped = false;
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    startRefs = Math.max(0, startRefs - 1);
+    if (startRefs === 0) stopGlobalQueueDrainer();
+  };
+}

--- a/apps/app/src/react-app/domains/session/sync/queued-send-context.ts
+++ b/apps/app/src/react-app/domains/session/sync/queued-send-context.ts
@@ -1,0 +1,38 @@
+import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+import type { ModelRef } from "@/app/types";
+
+export type QueuedSendContext = {
+  workspaceId: string;
+  workspaceRoot: string;
+  opencodeBaseUrl: string;
+  openworkToken: string;
+  client: OpenworkServerClient;
+  agent: string | null;
+  variant: string | null;
+  model: ModelRef | null;
+  environmentRuntimeKey: string | null;
+};
+
+// Context is registered by the mounted surface (enqueueing only happens there)
+// and consumed by the global drainer after the surface unmounts.
+const queuedSendContexts = new Map<string, QueuedSendContext>();
+const listeners = new Set<() => void>();
+
+export function setQueuedSendContext(sessionId: string, context: QueuedSendContext) {
+  queuedSendContexts.set(sessionId, context);
+  for (const listener of listeners) listener();
+}
+
+export function getQueuedSendContext(sessionId: string) {
+  return queuedSendContexts.get(sessionId);
+}
+
+export function clearQueuedSendContext(sessionId: string) {
+  if (!queuedSendContexts.delete(sessionId)) return;
+  for (const listener of listeners) listener();
+}
+
+export function subscribeQueuedSendContext(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -9,6 +9,7 @@ import { isDesktopRuntime } from "@/app/utils";
 import { ConnectLinkProvider } from "@/react-app/domains/cloud/connect-link-provider";
 import { DenAuthProvider } from "@/react-app/domains/cloud/den-auth-provider";
 import { AutomationRunnerBridge } from "@/react-app/domains/automations/automation-runner-bridge";
+import { GlobalQueueDrainerBridge } from "@/react-app/domains/session/sync/global-queue-drainer-bridge";
 import { BrandThemeProvider } from "@/react-app/domains/cloud/brand-theme";
 import { DesktopConfigProvider } from "@/react-app/domains/cloud/desktop-config-provider";
 import { RestrictionNoticeProvider } from "@/react-app/domains/cloud/restriction-notice-provider";
@@ -62,6 +63,7 @@ function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
             <RestrictionNoticeProvider>
               <LocalProvider>
                 <AutomationRunnerBridge />
+                <GlobalQueueDrainerBridge />
                 <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
                 <Toaster />
               </LocalProvider>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -9,12 +9,7 @@ import {
 } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "@/components/ui/sonner";
-import type {
-  AgentPartInput,
-  FilePartInput,
-  ProviderListResponse,
-  TextPartInput,
-} from "@opencode-ai/sdk/v2/client";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 
 import { captureAnalyticsEvent, markTaskRunStart } from "@/app/lib/analytics";
 import { trackSessionActive, trackTaskStarted } from "@/app/lib/den-telemetry";
@@ -52,7 +47,6 @@ import {
 import type {
   ComposerAttachment,
   ComposerDraft,
-  ComposerPart,
   ModelOption,
   ModelRef,
   SlashCommandOption,
@@ -114,8 +108,7 @@ import {
   applySessionRevert,
   applySessionUnrevert,
 } from "@/react-app/domains/session/sync/session-sync";
-import { firstLineLocalFileParts, joinWorkspaceRelativePath, toFileUrl } from "@/react-app/domains/session/sync/prompt-file-parts";
-import { composerAttachmentsToWorkspaceFileParts } from "@/react-app/domains/session/sync/attachment-file-part";
+import { draftToParts } from "@/react-app/domains/session/sync/draft-parts";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { getModelBehaviorSummary, nextModelBehaviorValue, previousModelBehaviorValue } from "@/app/lib/model-behavior";
@@ -130,9 +123,6 @@ import {
   useModelCollectionsStore,
 } from "@/react-app/domains/session/models/model-collections-store";
 import { openModelPickerEvent, openProviderAuthEvent } from "@/react-app/shell/new-providers-listener";
-import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
-import { decodeComposerMentionValue } from "@/react-app/domains/session/surface/composer/mention-encoding";
-import { connectSkillPrompt, parseConnectSkillToken } from "@/react-app/domains/session/surface/composer/connect-skill-token";
 import { markComposerAutoSend } from "@/react-app/domains/session/surface/composer-auto-send";
 import { sendWithRevertRollback } from "@/react-app/domains/session/surface/safe-edit-resend";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
@@ -338,166 +328,6 @@ function nextEvalUnavailableModel(current: ModelRef | null | undefined) {
       ? "eval-unavailable-model-b"
       : "eval-unavailable-model-a",
   } satisfies ModelRef;
-}
-
-// All workspace-scoped server URLs/clients/tokens come from
-// `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
-// Don't compose `<baseUrl>/workspace/<id>` here.
-
-async function draftToParts(
-  draft: ComposerDraft,
-  workspaceRoot: string,
-  sessionId: string,
-  endpoint: ResolvedWorkspaceEndpoint | null,
-) {
-  const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
-  const root = workspaceRoot.trim();
-
-  const toAbsolutePath = (path: string) => {
-    const trimmed = path.trim();
-    if (!trimmed) return "";
-    if (trimmed.startsWith("/")) return trimmed;
-    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed;
-    if (!root) return "";
-    return joinWorkspaceRelativePath(root, trimmed);
-  };
-
-  const filenameFromPath = (path: string) => {
-    const normalized = path.replace(/\\/g, "/");
-    const segments = normalized.split("/").filter(Boolean);
-    return segments[segments.length - 1] ?? "file";
-  };
-
-  const attachmentFileById = new Map<string, FilePartInput>();
-  if (draft.attachments.length > 0) {
-    if (!endpoint) {
-      throw new Error("Workspace endpoint is unavailable; attachments could not be copied for tool access.");
-    }
-    const uploaded = await composerAttachmentsToWorkspaceFileParts({
-      attachments: draft.attachments,
-      endpoint,
-      sessionId,
-      workspaceRoot: root,
-    });
-    for (const part of uploaded) {
-      if (part.type === "text") {
-        parts.push(part);
-        continue;
-      }
-    }
-    const fileParts = uploaded.filter((part): part is FilePartInput => part.type === "file");
-    for (const [index, attachment] of draft.attachments.entries()) {
-      const filePart = fileParts[index];
-      if (filePart) attachmentFileById.set(attachment.id, filePart);
-    }
-  }
-
-  // Prefer draft.text token order so attachment chips stay inline with surrounding text
-  // (same positions as the composer), instead of dumping every file part at the end.
-  const hasAttachmentTokens = /\[attachment [^\]]+\]/.test(draft.text);
-  if (hasAttachmentTokens || attachmentFileById.size > 0) {
-    const pasteByLabel = new Map(
-      draft.parts
-        .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
-        .map((part) => [part.label, part.text] as const),
-    );
-    for (const segment of draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/)) {
-      if (!segment) continue;
-      const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
-      if (attachmentMatch?.[1]) {
-        const filePart = attachmentFileById.get(attachmentMatch[1]);
-        if (filePart) {
-          parts.push(filePart);
-          attachmentFileById.delete(attachmentMatch[1]);
-        }
-        continue;
-      }
-      const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
-      if (pasteMatch?.[1]) {
-        const pasted = pasteByLabel.get(pasteMatch[1]);
-        if (pasted) parts.push({ type: "text", text: pasted });
-        continue;
-      }
-      const connectSkill = parseConnectSkillToken(segment);
-      if (connectSkill) {
-        parts.push({ type: "text", text: connectSkillPrompt(connectSkill) });
-        continue;
-      }
-      const skillMatch = segment.match(/^\[skill (.+)\]$/);
-      if (skillMatch?.[1]) {
-        parts.push({ type: "text", text: `Load [skill ${skillMatch[1]}] and follow its instructions.` });
-        continue;
-      }
-      if (segment.startsWith("@")) {
-        const value = decodeComposerMentionValue(segment.slice(1));
-        const mentionPart = draft.parts.find((part) =>
-          (part.type === "agent" && part.name === value)
-          || (part.type === "app" && part.name === value)
-          || (part.type === "file" && part.path === value),
-        );
-        if (mentionPart?.type === "agent") {
-          parts.push({ type: "agent", name: mentionPart.name });
-          continue;
-        }
-        if (mentionPart?.type === "app") {
-          parts.push({ type: "text", text: appMentionInstruction(mentionPart.name) });
-          continue;
-        }
-        if (mentionPart?.type === "file") {
-          const absolute = toAbsolutePath(mentionPart.path);
-          if (!absolute) continue;
-          parts.push({
-            type: "file",
-            mime: "text/plain",
-            url: toFileUrl(absolute),
-            filename: filenameFromPath(mentionPart.path),
-          });
-          continue;
-        }
-      }
-      parts.push({ type: "text", text: segment });
-    }
-    for (const filePart of attachmentFileById.values()) {
-      parts.push(filePart);
-    }
-  } else {
-    for (const part of draft.parts) {
-      if (part.type === "text") {
-        parts.push({ type: "text", text: part.text });
-        continue;
-      }
-      if (part.type === "paste") {
-        parts.push({ type: "text", text: part.text });
-        continue;
-      }
-      if (part.type === "agent") {
-        parts.push({ type: "agent", name: part.name });
-        continue;
-      }
-      if (part.type === "skill") {
-        parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
-        continue;
-      }
-      if (part.type === "app") {
-        parts.push({ type: "text", text: appMentionInstruction(part.name) });
-        continue;
-      }
-      if (part.type === "file") {
-        const absolute = toAbsolutePath(part.path);
-        if (!absolute) continue;
-        parts.push({
-          type: "file",
-          mime: "text/plain",
-          url: toFileUrl(absolute),
-          filename: filenameFromPath(part.path),
-        });
-      }
-    }
-  }
-
-  parts.push(...firstLineLocalFileParts(draft.resolvedText ?? draft.text, root));
-
-  return parts;
 }
 
 function singlePickedDirectory(selection: string | string[] | null) {

--- a/evals/specs/composer-queued-drain-while-away.e2e.test.ts
+++ b/evals/specs/composer-queued-drain-while-away.e2e.test.ts
@@ -1,0 +1,518 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clickButton, control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { desktop } from "@openwork/hosts";
+import { screenshot, validate } from "@openwork/test-evidence";
+import { eventually, needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+import { expect, onTestFinished } from "vitest";
+
+const requirements: TestNeeds = {
+  optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `queued composer drain while away skipped — needs: ${missingRequirements.join(", ")}`
+  : "a queued composer message drains exactly once while another workspace stays visible";
+
+const providerId = "away-drain-mock";
+const modelId = "away-drain-model";
+const modelName = "Away drain model";
+const firstPrompt = "away-drain first task";
+const queuedPrompt = "away-drain queued follow-up";
+const firstReply = "away-drain first reply";
+const queuedReply = "away-drain queued reply";
+
+type RuntimeCredentials = { port: string; token: string };
+type EngineMessage = { id: string; role: string; text: string };
+type MainRequest = { rawBody: string; lastUserText: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRuntimeCredentials(raw: unknown): RuntimeCredentials {
+  if (typeof raw !== "string") throw new Error(`Local server credentials were not serialized: ${String(raw)}`);
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed) || typeof parsed.port !== "string" || typeof parsed.token !== "string") {
+    throw new Error(`Invalid local server credentials: ${raw}`);
+  }
+  return { port: parsed.port, token: parsed.token };
+}
+
+function parseEngineMessages(payload: unknown): EngineMessage[] {
+  if (!Array.isArray(payload)) throw new Error(`Engine message response is malformed: ${JSON.stringify(payload)}`);
+  const messages: EngineMessage[] = [];
+  for (const entry of payload) {
+    if (!isRecord(entry) || !isRecord(entry.info) || typeof entry.info.id !== "string") continue;
+    const parts = Array.isArray(entry.parts) ? entry.parts : [];
+    messages.push({
+      id: entry.info.id,
+      role: typeof entry.info.role === "string" ? entry.info.role : "",
+      text: parts.flatMap((part) => (
+        isRecord(part) && part.type === "text" && typeof part.text === "string" ? [part.text] : []
+      )).join(""),
+    });
+  }
+  return messages;
+}
+
+async function readEngineMessages(
+  credentials: RuntimeCredentials,
+  workspaceId: string,
+  sessionId: string,
+): Promise<EngineMessage[]> {
+  const response = await fetch(
+    `http://127.0.0.1:${credentials.port}/workspace/${encodeURIComponent(workspaceId)}/opencode/session/${encodeURIComponent(sessionId)}/message`,
+    {
+      headers: { Authorization: `Bearer ${credentials.token}` },
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+  if (!response.ok) throw new Error(`Engine messages failed: ${response.status} ${(await response.text()).slice(0, 500)}`);
+  return parseEngineMessages(await response.json());
+}
+
+async function waitForEngineReady(credentials: RuntimeCredentials, workspaceId: string): Promise<void> {
+  await eventually(async () => {
+    const response = await fetch(
+      `http://127.0.0.1:${credentials.port}/workspace/${encodeURIComponent(workspaceId)}/opencode/session`,
+      {
+        headers: { Authorization: `Bearer ${credentials.token}` },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    return response.ok;
+  }, {
+    within: 60_000,
+    intervalMs: 500,
+    label: `workspace ${workspaceId} engine ready`,
+    until: (ready) => ready,
+  });
+}
+
+async function activeSessionId(app: Surface): Promise<string> {
+  await waitFor(app, `(document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "").startsWith("ses_")`, {
+    timeoutMs: 30_000,
+    label: "active session surface",
+  });
+  const value = await evalIn(app, `document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""`);
+  if (typeof value !== "string" || !value.startsWith("ses_")) throw new Error(`Active session id was unavailable: ${String(value)}`);
+  return value;
+}
+
+async function createSession(app: Surface): Promise<string> {
+  const deadline = Date.now() + 30_000;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      await control(app, "session.create_task");
+      return await activeSessionId(app);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  throw new Error(`session.create_task kept failing: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}
+
+async function selectMockModel(app: Surface): Promise<void> {
+  await waitFor(app, `Boolean(document.querySelector('button[aria-label="Change model"]'))`, {
+    timeoutMs: 60_000,
+    label: "composer model selector",
+  });
+  const opened = await evalIn(app, `(() => {
+    const trigger = document.querySelector('button[aria-label="Change model"]');
+    if (!(trigger instanceof HTMLButtonElement)) return false;
+    trigger.click();
+    return true;
+  })()`);
+  expect(opened).toBe(true);
+  await waitFor(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    return popover instanceof HTMLElement
+      && popover.querySelector('[data-slot="model-select-root"]') instanceof HTMLElement;
+  })()`, { timeoutMs: 60_000, label: "model picker root pane" });
+  const modelPaneOpened = await evalIn(app, `(() => {
+    const root = document.querySelector('[data-slot="popover-content"] [data-slot="model-select-root"]');
+    const button = [...(root?.querySelectorAll("button") ?? [])]
+      .find((candidate) => candidate.querySelector("span")?.textContent?.trim() === "Model");
+    if (!(button instanceof HTMLButtonElement)) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(modelPaneOpened).toBe(true);
+  await waitFor(app, `(() => {
+    const input = document.querySelector('[data-slot="popover-content"] input[placeholder="Search models..."]');
+    return input instanceof HTMLInputElement;
+  })()`, { timeoutMs: 60_000, label: "model picker search input" });
+  const searchFocused = await evalIn(app, `(() => {
+    const input = document.querySelector('[data-slot="popover-content"] input[placeholder="Search models..."]');
+    if (!(input instanceof HTMLInputElement)) return false;
+    input.focus();
+    return true;
+  })()`);
+  expect(searchFocused).toBe(true);
+  await app.client.send("Input.insertText", { text: modelName });
+  await waitFor(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    const input = popover?.querySelector('input[placeholder="Search models..."]');
+    return input instanceof HTMLInputElement
+      && input.value === ${JSON.stringify(modelName)}
+      && [...popover.querySelectorAll('[data-slot="command-item"]')]
+        .some((item) => (item.textContent ?? "").includes(${JSON.stringify(modelName)}));
+  })()`, { timeoutMs: 60_000, label: "away drain mock model listed after search" });
+  const picked = await evalIn(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+      .find((candidate) => (candidate.textContent ?? "").includes(${JSON.stringify(modelName)}));
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(picked).toBe(true);
+  await waitFor(app, `(document.querySelector('button[aria-label="Change model"]')?.textContent ?? "").includes(${JSON.stringify(modelName)})`, {
+    timeoutMs: 15_000,
+    label: "away drain mock model selected",
+  });
+}
+
+async function typeIntoComposer(app: Surface, text: string): Promise<void> {
+  await waitFor(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    return editor instanceof HTMLElement && (editor.innerText ?? "").trim() === "";
+  })()`, { timeoutMs: 30_000, label: "empty composer ready" });
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text });
+  await waitFor(app, `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === ${JSON.stringify(text)}`, {
+    timeoutMs: 10_000,
+    label: `composer contains ${text}`,
+  });
+}
+
+async function pressEnter(app: Surface): Promise<void> {
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Enter",
+    code: "Enter",
+    windowsVirtualKeyCode: 13,
+    nativeVirtualKeyCode: 13,
+    text: "\r",
+    unmodifiedText: "\r",
+  });
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Enter",
+    code: "Enter",
+    windowsVirtualKeyCode: 13,
+    nativeVirtualKeyCode: 13,
+  });
+}
+
+async function clickSessionRow(app: Surface, workspaceId: string, sessionId: string): Promise<void> {
+  const clicked = await evalIn(app, `(() => {
+    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`)});
+    const tab = row?.querySelector(${JSON.stringify(`[data-session-tab-id="${sessionId}"]`)});
+    if (!(row instanceof HTMLElement) || !(tab instanceof HTMLElement)) return false;
+    row.scrollIntoView({ block: "center" });
+    tab.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+  await waitFor(app, `(() => {
+    const surface = document.querySelector("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(sessionId)}
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(workspaceId)};
+  })()`, { timeoutMs: 60_000, label: `workspace ${workspaceId} session ${sessionId} visible` });
+}
+
+function lastUserTextFromBody(rawBody: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return "";
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) return "";
+  for (let index = parsed.messages.length - 1; index >= 0; index -= 1) {
+    const message: unknown = parsed.messages[index];
+    if (!isRecord(message) || message.role !== "user") continue;
+    if (typeof message.content === "string") return message.content;
+    if (Array.isArray(message.content)) {
+      return message.content.flatMap((part) => (
+        isRecord(part) && part.type === "text" && typeof part.text === "string" ? [part.text] : []
+      )).join("");
+    }
+    return "";
+  }
+  return "";
+}
+
+async function writeWorkspaceConfig(workspacePath: string, baseUrl: string): Promise<void> {
+  await writeFile(join(workspacePath, "opencode.json"), `${JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Away drain mock",
+        options: { baseURL: baseUrl, apiKey: "sk-away-drain" },
+        models: { [modelId]: { name: modelName } },
+      },
+    },
+  }, null, 2)}\n`);
+}
+
+test(title, async ({ evidence }) => {
+  needs(requirements);
+
+  const mainRequests: MainRequest[] = [];
+  let releaseFirst: () => void = () => undefined;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const mock = createServer((request, response) => {
+    const url = request.url ?? "";
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+    if (request.method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
+      request.setEncoding("utf8");
+      let rawBody = "";
+      request.on("data", (chunk: string) => {
+        rawBody += chunk;
+      });
+      request.on("end", () => {
+        let parsedBody: unknown;
+        try {
+          parsedBody = JSON.parse(rawBody);
+        } catch {
+          parsedBody = null;
+        }
+        const tools = isRecord(parsedBody) ? parsedBody.tools : undefined;
+        const isMain = Array.isArray(tools) && tools.length > 0;
+        if (isMain) mainRequests.push({ rawBody, lastUserText: lastUserTextFromBody(rawBody) });
+        const reply = !isMain ? "Away drain session title" : rawBody.includes(queuedPrompt) ? queuedReply : firstReply;
+        const id = `chatcmpl-away-drain-${mainRequests.length}`;
+        response.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const write = (chunk: unknown): void => {
+          if (!response.writableEnded) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        };
+        write({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] });
+        const finish = (): void => {
+          write({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: reply }, finish_reason: null }] });
+          setTimeout(() => {
+            write({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+            setTimeout(() => {
+              if (!response.writableEnded) response.end("data: [DONE]\n\n");
+            }, 200);
+          }, 200);
+        };
+        if (isMain && !rawBody.includes(queuedPrompt)) {
+          void firstGate.then(finish);
+          return;
+        }
+        setTimeout(finish, 200);
+      });
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    mock.once("error", reject);
+    mock.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    releaseFirst();
+    mock.closeAllConnections();
+    await new Promise<void>((resolve, reject) => mock.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = mock.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  await using app = await desktop({
+    name: "queued-drain-while-away",
+    mode: process.env.OPENWORK_EVAL_CDP_URL?.trim() ? "attach" : "spawn",
+    env: {
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      OPENROUTER_API_KEY: "",
+      GOOGLE_GENERATIVE_AI_API_KEY: "",
+      OPENWORK_API_KEY: "",
+      OPENWORK_INFERENCE_BASE_URL: "",
+    },
+  });
+
+  const workspacePathA = await mkdtemp(join(tmpdir(), "openwork-away-drain-a-"));
+  const workspacePathB = await mkdtemp(join(tmpdir(), "openwork-away-drain-b-"));
+  await Promise.all([
+    writeWorkspaceConfig(workspacePathA, baseUrl),
+    writeWorkspaceConfig(workspacePathB, baseUrl),
+  ]);
+
+  const workspaceA = await createAndSelectWorkspace(app, { path: workspacePathA });
+  const credentials = parseRuntimeCredentials(await evalIn(app, `JSON.stringify({
+    port: localStorage.getItem("openwork.server.port") ?? "",
+    token: localStorage.getItem("openwork.server.token") ?? "",
+  })`));
+  await waitForEngineReady(credentials, workspaceA.workspaceId);
+  const sessionA = await createSession(app);
+  await selectMockModel(app);
+  await typeIntoComposer(app, firstPrompt);
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
+  const firstRequestCount = await eventually(() => mainRequests.length, {
+    within: 60_000,
+    intervalMs: 200,
+    label: "first gated completion reached mock",
+    until: (count) => count === 1,
+  });
+  expect(firstRequestCount).toBe(1);
+  expect(mainRequests[0]?.lastUserText).toContain(firstPrompt);
+  await waitFor(app, `Boolean(document.querySelector('button[aria-label="Stop"]'))`, {
+    timeoutMs: 60_000,
+    label: "session A is busy",
+  });
+
+  await typeIntoComposer(app, queuedPrompt);
+  expect(await evalIn(app, `Boolean(document.querySelector('button[aria-label="Stop"]'))`)).toBe(true);
+  await pressEnter(app);
+  await waitFor(app, `document.body.innerText.includes("1 queued")`, {
+    timeoutMs: 15_000,
+    label: "follow-up queued in session A",
+  });
+  const queuedUiState = await evalIn(app, `(() => ({
+    badge: document.body.innerText.includes("1 queued"),
+    queuedUserBubble: [...document.querySelectorAll('[data-message-role="user"]')]
+      .some((bubble) => (bubble.textContent ?? "").includes(${JSON.stringify(queuedPrompt)})),
+  }))()`);
+  expect(queuedUiState).toEqual({ badge: true, queuedUserBubble: false });
+  const engineWhileBusy = await readEngineMessages(credentials, workspaceA.workspaceId, sessionA);
+  expect(engineWhileBusy.some((message) => message.text.includes(queuedPrompt))).toBe(false);
+  expect(mainRequests.filter((request) => request.rawBody.includes(queuedPrompt))).toHaveLength(0);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "The busy conversation shows a queued messages panel headed '1 queued'",
+      "The queued follow-up is not rendered as a user conversation bubble",
+      "No error dialog or crash is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+  evidence.recordAssertionEvidence(
+    "A follow-up remains queued and unsent while session A is busy",
+    `Session ${sessionA} showed "1 queued" with no queued-text user bubble; its engine had ${engineWhileBusy.length} messages, none containing the queued marker, and the mock had zero requests containing it.`,
+    true,
+  );
+
+  const workspaceB = await createAndSelectWorkspace(app, { path: workspacePathB });
+  await waitForEngineReady(credentials, workspaceB.workspaceId);
+  const sessionB = await createSession(app);
+  expect(sessionB).not.toBe(sessionA);
+  const awayState = await evalIn(app, `(() => ({
+    active: document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "",
+    sessionASurfacePresent: Boolean(document.querySelector(${JSON.stringify(`[data-session-surface-id="${sessionA}"]`)})),
+    workspace: localStorage.getItem("openwork.react.activeWorkspace") ?? "",
+  }))()`);
+  expect(awayState).toEqual({ active: sessionB, sessionASurfacePresent: false, workspace: workspaceB.workspaceId });
+  const bBeforeDrain = await readEngineMessages(credentials, workspaceB.workspaceId, sessionB);
+  expect(bBeforeDrain.some((message) => message.text.includes(queuedPrompt))).toBe(false);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "An empty session with no conversation messages is visible",
+      "The text '1 queued' is not visible anywhere",
+      "No message bubble contains 'away-drain queued follow-up'",
+      "No error dialog or crash is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+
+  releaseFirst();
+  const drained = await eventually(async () => {
+    const [aMessages, bMessages] = await Promise.all([
+      readEngineMessages(credentials, workspaceA.workspaceId, sessionA),
+      readEngineMessages(credentials, workspaceB.workspaceId, sessionB),
+    ]);
+    const visibleSession = await evalIn(app, `document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""`);
+    return { aMessages, bMessages, visibleSession };
+  }, {
+    within: 60_000,
+    intervalMs: 250,
+    label: "session A queued follow-up drains while session B remains visible",
+    until: ({ aMessages, bMessages, visibleSession }) => aMessages.length === 4
+      && aMessages.some((message) => message.role === "assistant" && message.text === queuedReply)
+      && !bMessages.some((message) => message.text.includes(queuedPrompt))
+      && visibleSession === sessionB,
+  });
+  expect(drained.visibleSession).toBe(sessionB);
+  expect(drained.bMessages.some((message) => message.text.includes(queuedPrompt))).toBe(false);
+  expect(drained.aMessages.map((message) => message.role)).toEqual(["user", "assistant", "user", "assistant"]);
+  expect(drained.aMessages[0]?.text).toContain(firstPrompt);
+  expect(drained.aMessages[1]?.text).toBe(firstReply);
+  expect(drained.aMessages[2]?.text.trim()).toBe(queuedPrompt);
+  expect(drained.aMessages[3]?.text).toBe(queuedReply);
+  const queuedRequestsAfterDrain = mainRequests.filter((request) => request.rawBody.includes(queuedPrompt));
+  expect(queuedRequestsAfterDrain).toHaveLength(1);
+  expect(queuedRequestsAfterDrain[0]?.lastUserText.trim()).toBe(queuedPrompt);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "An empty conversation with no message bubbles is visible",
+      "The text '1 queued' is not visible anywhere",
+      "No message bubble contains 'away-drain queued follow-up'",
+      "No error dialog or crash is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+  evidence.recordAssertionEvidence(
+    "Session A drains the queued follow-up exactly once while session B stays visible and clean",
+    `While visible session remained ${sessionB}, session A gained a separate user turn after its first assistant reply; session B had ${drained.bMessages.length} messages containing no queued marker, and exactly ${queuedRequestsAfterDrain.length} main provider request contained it.`,
+    true,
+  );
+
+  await clickSessionRow(app, workspaceA.workspaceId, sessionA);
+  await waitFor(app, `(() => {
+    const bubbles = [...document.querySelectorAll('[data-message-role="user"]')];
+    return bubbles.some((bubble) => (bubble.textContent ?? "").includes(${JSON.stringify(queuedPrompt)}))
+      && !document.body.innerText.includes("1 queued");
+  })()`, { timeoutMs: 30_000, label: "drained follow-up reconciled after returning to session A" });
+  const returnUi = await evalIn(app, `(() => ({
+    queuedBadge: document.body.innerText.includes("1 queued"),
+    queuedBubbleCount: [...document.querySelectorAll('[data-message-role="user"]')]
+      .filter((bubble) => (bubble.textContent ?? "").includes(${JSON.stringify(queuedPrompt)})).length,
+  }))()`);
+  expect(returnUi).toEqual({ queuedBadge: false, queuedBubbleCount: 1 });
+  expect(mainRequests.filter((request) => request.rawBody.includes(queuedPrompt))).toHaveLength(1);
+  const bAfterReturn = await readEngineMessages(credentials, workspaceB.workspaceId, sessionB);
+  expect(bAfterReturn.some((message) => message.text.includes(queuedPrompt))).toBe(false);
+  {
+    const shot = await screenshot(app);
+    const seen = await validate(shot, [
+      "A user message bubble containing 'away-drain queued follow-up' is visible",
+      "The text '1 queued' is not visible anywhere",
+      "No error dialog or crash is visible",
+    ]);
+    expect(seen.ok, seen.why).toBe(true);
+  }
+  evidence.recordAssertionEvidence(
+    "Returning to session A reconciles the drained turn without sending it again",
+    `The queued badge was absent, exactly one rendered user bubble contained the queued marker, the mock still had exactly one matching main request after remount, and session B remained clean.`,
+    true,
+  );
+});

--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -119,8 +119,8 @@ test("Daytona E2E regression profile excludes only audited shared-topology incom
   expect(categoryByTest.get("local-managed-mcp-oauth.e2e.test.ts")).toBe("raw-or-local-placement");
   expect(categoryByTest.get("slack-style-mcp-connector.e2e.test.ts")).toBe("raw-or-local-placement");
 
-  expect(inventory.all).toHaveLength(146);
-  expect(inventory.rawDesktop).toHaveLength(52);
+  expect(inventory.all).toHaveLength(147);
+  expect(inventory.rawDesktop).toHaveLength(53);
   expect(inventory.profile).toHaveLength(74);
   expect(inventory.eligible).toHaveLength(19);
   expect(inventory.rawDesktop).toContain("den-litellm-provider.e2e.test.ts");


### PR DESCRIPTION
## Problem

A queued composer message is only sent while its session's surface stays mounted. Navigate to another session and the queue sits forever; navigate to another workspace and the workspace's SSE stream is disposed after its retention TTL, so the busy→idle edge is never even observed.

Queued drafts (`composer-state-store.ts`) and the admission machine (`queued-drain-machine.ts`) are module-level and survive navigation by design — but the only driver feeding status into the machine and performing sends was a trio of `useEffect`s in `SessionSurface` (view-scoped).

## Fix

Add a global, non-component drainer that coexists race-free with the mounted surface:

- **`queued-send-context.ts`** — per-session send context (endpoint, tokens, workspace root, model/agent snapshot) registered by the mounted surface while queued items exist; enqueueing only ever happens from a mounted surface, so the context is always capturable.
- **`global-queue-drainer.ts`** — watches the composer store; for each session with queued drafts it holds `ensureWorkspaceSessionSync` + `trackWorkspaceSessionSync` refs (keeps the away workspace's stream alive), feeds `busy_observed`/`idle_reconciled` into the existing machine, runs the observation-probe parity, and on observed idle performs the same admission protocol as the surface: `claimQueuedSend` **before any await** → remove → send → `send_result`/`send_error` → requeue on failure. The atomic per-session claim makes surface/drainer races single-winner.
- **`draft-parts.ts`** — `draftToParts` moved verbatim out of `session-route.tsx` (endpoint param narrowed to `ChatAttachmentWorkspaceEndpoint`) so sends work outside React; both route call sites now import it.
- **`global-queue-drainer-bridge.tsx`** — starts the drainer once beside `AutomationRunnerBridge` (StrictMode-safe start/stop).
- Send parity with the route supplier: shell mode, slash commands, per-session model resolution (`getSessionModelSelection` → stored default → context snapshot), env system context, `promptAsync` error unwrapping, model memory, `markTaskRunStart`. The cloud submission gate is skipped — both route call sites already pass `skipGate: true`.

## Verification (local lane — Daytona credentials unavailable in this environment)

New spec `evals/specs/composer-queued-drain-while-away.e2e.test.ts` (single scenario): a gated OpenAI-compatible mock keeps session A busy; a follow-up is queued; the user switches to workspace B / session B1; the gate is released **without navigating back**.

- Sent-while-away: session A's engine message list gains the queued user turn + its assistant reply while the visible surface remains B1 (engine REST assertions).
- Not before idle: while A is busy, the queued text is absent from A's engine list, the provider log, and user bubbles.
- Wrong-session negative: B1's engine list never contains the queued text (asserted at three points).
- Exactly-once: the mock's main-request log contains the queued text in exactly one completion — re-asserted after navigating back (no double-send on remount).
- UI reconciliation: on return, the queued badge is gone and exactly one user bubble shows the queued text.

Commands on PR head `ab962b3fb`:

```
OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/composer-queued-drain-while-away.e2e.test.ts   # 1 passed
pnpm --filter @openwork/app run typecheck                                                                                                                # green
pnpm --filter @openwork/app exec bun test tests/composer-state-store.test.ts                                                                             # 6 pass
pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/queued-drain-admission-wedge.test.ts                                       # 6 passed
```

**Negative control:** the same spec with the app changes stashed (base behavior) fails exactly at the drain wait — session A stuck at 2 messages, queue never sent — so the spec discriminates this fix.

## Notes

- Queued drafts remain in-memory only (attachments hold live `File` objects); app restart drops them — pre-existing behavior, unchanged.
- Pre-existing (not touched here): `composer-queued-follow-ups-sequential.e2e.test.ts` fails on clean dev — the model picker became multi-pane and its selectors drifted. The new spec navigates the current picker (root pane → Model → search).
- `pnpm evals:typecheck` has ~300 pre-existing errors on clean dev (identical modulo paths); zero reference the new spec.
