### PR TITLE
docs(skills): refresh stale repo skill references

### DIFF
--- a/.opencode/skills/browser-automation/SKILL.md
+++ b/.opencode/skills/browser-automation/SKILL.md
@@ -48,7 +48,7 @@ OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=0 pnpm dev
 Use a detached launch when the user wants the app running in the background:
 
 ```sh
-nohup pnpm dev > /var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/opencode/openwork-dev.log 2>&1 &
+nohup pnpm dev > /tmp/openwork-dev.log 2>&1 &
 ```
 
 Then wait for the CDP port:

--- a/.opencode/skills/build-a-witness/SKILL.md
+++ b/.opencode/skills/build-a-witness/SKILL.md
@@ -5,7 +5,7 @@ description: Mock a provider, add a mock, fake the API for tests. Use when build
 
 # Skill: Build a Witness
 
-Follow the pattern established by `labs/mock-mcp` and the Google fixtures.
+Follow the pattern established by `@openwork/labs` (`evals/packages/labs/src/mock-mcp.ts`) and the Google fixtures (`evals/packages/labs/src/mock-google.ts`).
 
 ## Witness contracts
 

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: release
+description: Cut an OpenWork release, release the app, publish a new version, rerun or recover a release tag, verify release assets. Tag-driven GitHub Actions release that makes zero commits to the repo.
+---
+
 # Skill: release
 
 Cut an OpenWork release. The "Release App" workflow


### PR DESCRIPTION
## What

Small best-practice refresh of the repo agent skills in `.opencode/skills/`:

- **release**: adds the standard YAML frontmatter (`name` + `description`). It was the only skill without frontmatter, which hurts skill discovery/triggering.
- **build-a-witness**: the referenced `labs/mock-mcp` path no longer exists; points at the current sources `evals/packages/labs/src/mock-mcp.ts` and `evals/packages/labs/src/mock-google.ts` (`@openwork/labs`).
- **browser-automation**: replaces a machine-specific macOS temp path (`/var/folders/d9/xqhkv.../openwork-dev.log`) with a portable `/tmp/openwork-dev.log`.

## Why

Skills are the paved onboarding path for agents working on this repo; stale paths and missing frontmatter send new contributors (and agents) to files that no longer exist.

## Verification

Docs/inert agent config only; per `AGENTS.md`, runtime proof is skipped. Both replacement paths verified to exist at the PR base; frontmatter shape matches every other skill in `.opencode/skills/`.