### PR TITLE
fix(app): show minutes in live Working counters past 60s

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -110,7 +110,7 @@ import {
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
 import type { SessionActivityStatus } from "@/react-app/domains/session/status/session-activity-store"
-import { formatToolCallDuration } from "@/lib/tool-call-duration"
+import { formatElapsedSeconds, formatToolCallDuration } from "@/lib/tool-call-duration"
 import { collectLatestAssistantToolParts } from "@/lib/latest-assistant-tool-parts"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
@@ -841,7 +841,7 @@ MessageComponent.displayName = "MessageComponent"
 const LoadingMessage = React.memo(({ elapsedSeconds }: { elapsedSeconds: number }) => (
     <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
       <div data-loading-message="working" className="py-1 text-sm text-muted-foreground">
-        <span className="ow-text-shimmer tabular-nums">Working {elapsedSeconds}s</span>
+        <span className="ow-text-shimmer tabular-nums">Working {formatElapsedSeconds(elapsedSeconds)}</span>
       </div>
     </Message>
 ))

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -11,7 +11,7 @@ import {
 import { useMessageList } from "@/components/chat/message-list-provider"
 import { taskChildSessionId, type TaskToolPart } from "@/lib/build-in-tools"
 import { isToolPartInFlight } from "@/lib/tool-activity"
-import { getToolCallStartedAt, trackToolCallDuration } from "@/lib/tool-call-duration"
+import { formatElapsedSeconds, getToolCallStartedAt, trackToolCallDuration } from "@/lib/tool-call-duration"
 import { cn } from "@/lib/utils"
 
 type SubagentRunLineProps = {
@@ -58,7 +58,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   const title = part.input?.description?.trim() || "Sub-agent task"
   const agent = agentName(part.input?.subagent_type ?? "")
   const status = inFlight
-    ? `Working ${elapsedSeconds}s`
+    ? `Working ${formatElapsedSeconds(elapsedSeconds)}`
     : isFailed
       ? part.errorText?.split("\n")[0]?.trim() || "Failed"
       : "Completed"

--- a/apps/app/src/lib/tool-call-duration.ts
+++ b/apps/app/src/lib/tool-call-duration.ts
@@ -1,6 +1,8 @@
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
 
-import { isToolPartInFlight } from "@/lib/tool-activity"
+// Relative so app-less evals specs can import this module without the app's
+// "@/" path alias.
+import { isToolPartInFlight } from "./tool-activity"
 
 type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
@@ -44,6 +46,17 @@ export function getToolCallStartedAt(part: AnyToolPart): number | null {
   const now = Date.now()
   startedAtByCallId.set(callId, now)
   return now
+}
+
+/**
+ * Live elapsed counters ("Working 12s") tick in whole seconds. Once a run
+ * crosses a minute, show minutes and seconds ("Working 6m 43s") instead of
+ * an ever-growing raw second count.
+ */
+export function formatElapsedSeconds(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  return `${minutes}m ${seconds % 60}s`
 }
 
 export function formatToolCallDuration(ms: number): string {

--- a/apps/app/tests/tool-call-duration.test.ts
+++ b/apps/app/tests/tool-call-duration.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatElapsedSeconds } from "../src/lib/tool-call-duration";
+
+describe("formatElapsedSeconds", () => {
+  test("shows whole seconds below a minute", () => {
+    expect(formatElapsedSeconds(0)).toBe("0s");
+    expect(formatElapsedSeconds(12)).toBe("12s");
+    expect(formatElapsedSeconds(59)).toBe("59s");
+  });
+
+  test("switches to minutes and seconds once a minute is crossed", () => {
+    expect(formatElapsedSeconds(60)).toBe("1m 0s");
+    expect(formatElapsedSeconds(115)).toBe("1m 55s");
+    expect(formatElapsedSeconds(403)).toBe("6m 43s");
+  });
+});

--- a/evals/specs/working-duration-format.test.ts
+++ b/evals/specs/working-duration-format.test.ts
@@ -1,0 +1,21 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { formatElapsedSeconds } from "../../apps/app/src/lib/tool-call-duration";
+
+test("live Working counters switch to minutes and seconds past one minute", () => {
+  // Claim: once a run crosses 60 seconds, the live "Working …" counter reads
+  // minutes and seconds (like the settled "Worked for 1m 55s" line), never a
+  // raw ever-growing second count such as "403s".
+  expect(formatElapsedSeconds(60)).toBe("1m 0s");
+  expect(formatElapsedSeconds(115)).toBe("1m 55s");
+  expect(formatElapsedSeconds(403)).toBe("6m 43s");
+  for (let seconds = 60; seconds <= 3600; seconds += 1) {
+    expect(formatElapsedSeconds(seconds)).not.toMatch(/^\d{2,}s$/);
+  }
+
+  // Negative half: below one minute the counter stays a plain second count,
+  // so short runs keep their familiar "Working 12s" ticking.
+  expect(formatElapsedSeconds(0)).toBe("0s");
+  expect(formatElapsedSeconds(12)).toBe("12s");
+  expect(formatElapsedSeconds(59)).toBe("59s");
+});


### PR DESCRIPTION
## What

Live "Working Ns" counters kept counting raw seconds forever — a long run reads `Working 403s` while the settled line already reads `Worked for 1m 55s`. Once a run crosses a minute, the live counter now reads minutes and seconds (`Working 6m 43s`); below a minute it keeps the familiar `Working 12s` tick.

Applies to both live counters:
- the main chat loading row (`message-list.tsx`)
- sub-agent task lines (`subagent-run-line.tsx`)

Both now share a `formatElapsedSeconds` helper next to the existing `formatToolCallDuration`. The helper module's internal import became relative so the app-less evals lane can import it without the `@/` alias.

## Proof

- `pnpm evals:pr specs/working-duration-format.test.ts` — 1 passed / 0 failed / 0 skipped, exit 0, on head `4aa70a4ad` (local lane; Daytona credentials unavailable in this environment). Claim + negative half: past 60s the counter is `Xm Ys` and never matches a raw `\d{2,}s` count up to an hour; below 60s it stays plain seconds.
- `apps/app`: `bun test --isolate tests/tool-call-duration.test.ts tests/message-list-loading.test.tsx tests/subagent-run-line.test.tsx tests/message-list-step-fold.test.tsx` — 11 pass / 0 fail. Existing `Working 0s` expectations still hold.
- `pnpm typecheck` in `apps/app` — clean.
- `pnpm evals:e2e chat-loading-shimmer --local`: the Working-row assertions pass with the new format; the run then fails on `expected 'Reading brief.md' to contain 'Now:'` in the later aggregate section. Pre-existing: the identical command fails at the identical assertion in a clean `origin/dev` control worktree at `64be5773a`.