### PR TITLE
fix(app): stop errored runs from ticking Working forever

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -724,6 +724,12 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       useSessionActivityStore.getState().setError(workspaceId, sessionId, errorText);
       if (isTrackedSession(entry, sessionId)) {
         flushSessionDeltas(entry, workspaceId, sessionId);
+        // The activity store treats session.error as terminal (setError
+        // lowers runActive), but the chat surface derives its thread status
+        // from this react-query cache. An engine that errors without a
+        // following idle event otherwise leaves the transcript's "Working…"
+        // row ticking forever beside the error card. Mirror the idle write.
+        queryClient.setQueryData(statusKey(workspaceId, sessionId), idleStatus);
         queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId), (current = []) => {
           // Key the error to the latest assistant turn so it lands beside the
           // turn that failed and a later turn's error becomes its own message
@@ -745,6 +751,10 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
           exact: true,
         });
       }
+      // An errored run is over: give status listeners (like the queued-send
+      // drainer) the same idle edge session.idle would have delivered, so
+      // queued messages are not wedged behind a run that will never finish.
+      for (const listener of entry.sessionStatusListeners.keys()) listener({ sessionId, status: idleStatus });
     }
     return;
   }

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -180,6 +180,44 @@ describe("session run status ordering", () => {
     cleanup();
   });
 
+  test("clears the busy status cache when a run errors without a following idle", () => {
+    const statusUpdates: SessionStatus[] = [];
+    const input = {
+      workspaceId,
+      baseUrl: "https://run-status.example/opencode",
+      openworkToken: "token",
+      onSessionStatus: (update: { sessionId: string; status: SessionStatus }) => {
+        statusUpdates.push(update.status);
+      },
+    };
+    syncInputs.push(input);
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+
+    applyStatus(input, { type: "busy" });
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+
+    __applySessionSyncEventForTest(input, {
+      type: "session.error",
+      properties: {
+        sessionID: sessionId,
+        error: { name: "UnknownError", data: { message: "provider exploded" } },
+      },
+    });
+
+    // The chat surface derives its thread status from this cache: an errored
+    // run must stop reading busy, or the "Working…" row ticks forever beside
+    // the error card when the engine never sends a follow-up idle event.
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.status).toBe("error");
+    // Status listeners (like the queued-send drainer) get the same idle edge
+    // session.idle would have delivered, so queued sends are not wedged.
+    expect(statusUpdates.at(-1)).toEqual({ type: "idle" });
+
+    releaseSession();
+    cleanup();
+  });
+
   test("does not resurrect a finished run from a stale busy snapshot", () => {
     const { input, cleanup, releaseSession } = createTestSync();
     const snapshot = createSnapshot({ type: "busy" });


### PR DESCRIPTION
## What

Part of the "app shows Working when nothing is happening" report: a run that errors without a follow-up idle event left the transcript's "Working Ns" row counting forever beside the error card.

`session.error` lowered the run level in the activity store (so the **sidebar** showed error/idle), but never wrote the react-query status cache the **chat surface** derives its thread status from (`statusKey`), and never gave `sessionStatusListeners` an idle edge — so the queued-send drainer also stayed wedged behind a run that would never finish.

Fix: mirror the `session.idle` handling in the `session.error` handler — write `{ type: "idle" }` to the status cache for tracked sessions and notify status listeners. A later live `session.status busy` still re-raises the level through the existing ordered writers.

## Proof

- `apps/app`: `bun test --isolate tests/session-sync-run-status.test.ts tests/session-error-resilience.test.tsx` — 23 pass / 0 fail. New case: "clears the busy status cache when a run errors without a following idle" asserts the cache reads idle, the activity store reads error, and listeners receive the idle edge.
- Full `apps/app` unit suite: 1093 pass / 5 fail — the identical 5 failures (Connect capability inventory ×2, cloud workspace boot takeover, cloud provider sync wiring logout, Extensions sidebar destination) reproduce with the same command on a clean `origin/dev` control worktree at `64be5773a` (1092 pass / 5 fail), so they are pre-existing and unrelated.
- `pnpm typecheck` in `apps/app` — clean.

## Related

Remaining "Working forever" causes are tracked separately: a busy level pinned by a missed idle event on an otherwise-live stream (no periodic reconcile while connected), and engine-side wedges during rollover/drain.