### PR TITLE
Serialize and bound desktop automation lifecycle requests

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -174,9 +174,23 @@ export async function executeDesktopAutomation(assignment, options) {
   options.signal.addEventListener("abort", abort, { once: true })
   try {
     const startedAt = Date.now()
+    const deadlineAt = startedAt + assignment.timeoutMs
     while (true) {
-      if (Date.now() - startedAt > assignment.timeoutMs) throw new Error("Desktop Automation execution timed out")
-      const snapshot = await client.getThreadSnapshot(sessionId, { signal: options.signal, limit: 200 })
+      if (Date.now() > deadlineAt) throw new Error("Desktop Automation execution timed out")
+      // The wall-clock check above only runs between awaits. A machine that
+      // suspends mid-request can leave this socket half-open with no error,
+      // which would make the assignment timeout unreachable: bound each poll
+      // by the remaining execution budget so the deadline always fires.
+      let snapshot
+      try {
+        snapshot = await client.getThreadSnapshot(sessionId, {
+          signal: AbortSignal.any([options.signal, AbortSignal.timeout(Math.max(1, deadlineAt - Date.now()))]),
+          limit: 200,
+        })
+      } catch (error) {
+        if (!options.signal.aborted && Date.now() >= deadlineAt) throw new Error("Desktop Automation execution timed out")
+        throw error
+      }
       const output = assistantResult(snapshot)
       const snapshotError = assistantFailure(snapshot)
       if (snapshotError) {
@@ -300,7 +314,10 @@ export function createDesktopAutomationRunner(options) {
   const random = options.random ?? Math.random
   const waitBeforeReconnect = options.waitBeforeReconnect ?? sleep
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? 10_000
+  const heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? 8_000
+  const heartbeatMissLimit = options.heartbeatMissLimit ?? 3
   const workPollTimeoutMs = options.workPollTimeoutMs ?? 30_000
+  const lifecycleRequestTimeoutMs = options.lifecycleRequestTimeoutMs ?? 30_000
   const legacyBaseUrls = new Set((options.legacyBaseUrls ?? [])
     .map((value) => normalizeRunnerBaseUrl(value))
     .filter(Boolean))
@@ -369,13 +386,18 @@ export function createDesktopAutomationRunner(options) {
     }
   }
 
-  const heartbeat = async (state) => {
-    const active = state.active
-    if (!active || !isCurrent(state)) return
+  const heartbeat = async (state, active) => {
+    if (state.active !== active || !isCurrent(state)) return
     const response = await runnerRequest(
       state,
       `/v1/automation-runs/${encodeURIComponent(active.assignment.runId)}/heartbeat`,
-      { method: "POST", body: { attempt: active.assignment.attempt } },
+      {
+        method: "POST",
+        body: { attempt: active.assignment.attempt },
+        // Bounded below the interval so a hung probe settles before the next
+        // one is due instead of pinning the lease refresh on a dead socket.
+        signal: AbortSignal.timeout(heartbeatTimeoutMs),
+      },
     )
     if (state.active === active && (response.cancelRequested || response.leaseValid !== true)) {
       active.controller.abort(new Error("Automation run cancelled or lease lost"))
@@ -392,9 +414,37 @@ export function createDesktopAutomationRunner(options) {
     const event = (type, payload) => runnerRequest(
       state,
       `/v1/automation-runs/${encodeURIComponent(assignment.runId)}/events`,
-      { method: "POST", body: { attempt: assignment.attempt, sequence: ++sequence, type, payload, createdAt: Date.now() } },
+      {
+        method: "POST",
+        body: { attempt: assignment.attempt, sequence: ++sequence, type, payload, createdAt: Date.now() },
+        signal: AbortSignal.timeout(lifecycleRequestTimeoutMs),
+      },
     )
-    const heartbeatTimer = setInterval(() => void heartbeat(state).catch((error) => controller.abort(error)), heartbeatIntervalMs)
+    // Self-scheduling instead of setInterval: the next probe is armed only
+    // after the current one settles, so a slow heartbeat can never overlap
+    // the next tick. One transient failure must not kill a healthy run, so
+    // the run aborts only after consecutive misses outlast the lease.
+    let heartbeatTimer = null
+    let heartbeatStopped = false
+    let heartbeatMisses = 0
+    const heartbeatTick = async () => {
+      try {
+        await heartbeat(state, active)
+        heartbeatMisses = 0
+      } catch (error) {
+        heartbeatMisses += 1
+        if (heartbeatMisses >= heartbeatMissLimit) {
+          controller.abort(new Error(`Automation run heartbeat failed ${heartbeatMisses} times: ${serializedError(error)}`))
+          return
+        }
+        options.log?.(`runner heartbeat missed (${heartbeatMisses}/${heartbeatMissLimit}): ${serializedError(error)}`)
+      }
+      if (!heartbeatStopped && state.active === active && !controller.signal.aborted) scheduleHeartbeat()
+    }
+    const scheduleHeartbeat = () => {
+      heartbeatTimer = setTimeout(() => void heartbeatTick(), heartbeatIntervalMs)
+    }
+    scheduleHeartbeat()
     let result
     try {
       await event("user", { text: assignment.instructions, executionTarget: "desktop" })
@@ -428,14 +478,37 @@ export function createDesktopAutomationRunner(options) {
         },
       }
     } finally {
-      clearInterval(heartbeatTimer)
+      heartbeatStopped = true
+      clearTimeout(heartbeatTimer)
+    }
+    // Terminal delivery must terminate: reconcile (and with it the whole
+    // runner) waits on this step, so a hung or transiently failing request
+    // here would otherwise wedge the desktop until the app restarts. Each
+    // request gets its own deadline plus one retry, and a failed terminal
+    // event never skips the completion POST.
+    const deliver = async (label, send) => {
+      for (let attempt = 1; attempt <= 2; attempt += 1) {
+        try {
+          await send()
+          return
+        } catch (error) {
+          const retry = attempt === 1 && isCurrent(state)
+          options.log?.(`runner ${label} delivery failed${retry ? ", retrying" : ""}: ${serializedError(error)}`)
+          if (!retry) return
+        }
+      }
     }
     try {
-      await event("terminal", { status: result.status, executionTarget: "desktop", sessionId: result.sessionId })
-      await runnerRequest(state, `/v1/automation-runs/${encodeURIComponent(assignment.runId)}/complete`, {
+      await deliver("terminal event", () => event("terminal", {
+        status: result.status,
+        executionTarget: "desktop",
+        sessionId: result.sessionId,
+      }))
+      await deliver("completion", () => runnerRequest(state, `/v1/automation-runs/${encodeURIComponent(assignment.runId)}/complete`, {
         method: "POST",
         body: { ...result, attempt: assignment.attempt },
-      })
+        signal: AbortSignal.timeout(lifecycleRequestTimeoutMs),
+      }))
     } finally {
       if (state.active === active) state.active = null
       if (isCurrent(state) && pendingConfiguration) {
@@ -476,6 +549,7 @@ export function createDesktopAutomationRunner(options) {
       await runnerRequest(state, `/v1/remote-session-commands/${encodeURIComponent(assignment.commandId)}/complete`, {
         method: "POST",
         body: result,
+        signal: AbortSignal.timeout(lifecycleRequestTimeoutMs),
       })
     } finally {
       if (state.active === active) state.active = null
@@ -508,7 +582,7 @@ export function createDesktopAutomationRunner(options) {
             claimed = await runnerRequest(
               state,
               `/v1/remote-session-commands/${encodeURIComponent(item.commandId)}/claim`,
-              { method: "POST", body: {} },
+              { method: "POST", body: {}, signal: AbortSignal.timeout(lifecycleRequestTimeoutMs) },
             )
           } catch (error) {
             if (error?.status === 409) continue
@@ -524,7 +598,11 @@ export function createDesktopAutomationRunner(options) {
         state.claimInFlight = true
         let claimed
         try {
-          claimed = await runnerRequest(state, `/v1/automation-runs/${encodeURIComponent(item.runId)}/claim`, { method: "POST", body: {} })
+          claimed = await runnerRequest(state, `/v1/automation-runs/${encodeURIComponent(item.runId)}/claim`, {
+            method: "POST",
+            body: {},
+            signal: AbortSignal.timeout(lifecycleRequestTimeoutMs),
+          })
         } finally {
           state.claimInFlight = false
         }

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -1300,6 +1300,7 @@ test("cancellation during execution preserves the local thread and reaches a ter
   let offered = false
   let snapshotStarted = false
   const completions = []
+  const events = []
   let resolveCompleted
   const completed = new Promise((resolve) => { resolveCompleted = resolve })
   const sessionPaths = opencodeSessionPaths("workspace-1", "session-cancelled")
@@ -1342,7 +1343,10 @@ test("cancellation during execution preserves the local thread and reaches a ter
       if (parsed.pathname.endsWith("/heartbeat")) {
         return Response.json({ leaseValid: true, cancelRequested: snapshotStarted })
       }
-      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/events")) {
+        events.push(JSON.parse(options.body))
+        return Response.json({ ok: true })
+      }
       if (parsed.pathname.endsWith("/complete")) {
         completions.push(JSON.parse(options.body))
         resolveCompleted()
@@ -1366,6 +1370,7 @@ test("cancellation during execution preserves the local thread and reaches a ter
   assert.equal(completionBody.sessionId, "session-cancelled")
   assert.equal(completionBody.workspaceId, "workspace-1")
   assert.equal(completionBody.error.code, "cancelled")
+  assert.equal(events.find((entry) => entry.type === "terminal")?.payload.status, "cancelled")
   const abortRequest = localRequests.find((request) => request.path === sessionPaths.abort)
   assert.equal(abortRequest?.method, "POST")
   assert.equal(abortRequest?.authorization, "Bearer local-client-token")
@@ -1483,4 +1488,402 @@ test("desktop Automation execution surfaces a missing pinned model", async () =>
       && Reflect.get(error, "workspaceId") === "workspace-1"
       && /Choose a supported model/.test(error.message),
   )
+})
+
+function localExecutionRoutes(sessionPaths, snapshot) {
+  return async (parsed, options) => {
+    if (parsed.pathname === "/workspaces") {
+      return Response.json({ items: [{ id: "workspace-1" }], activeId: "workspace-1" })
+    }
+    if (parsed.pathname === sessionPaths.create && options.method === "POST") {
+      return Response.json({ id: "session-1" }, { status: 201 })
+    }
+    if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
+    if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+      return snapshot(parsed, options)
+    }
+    if (parsed.pathname === sessionPaths.abort) return Response.json(true)
+    throw new Error(`Unexpected local request ${parsed.pathname}`)
+  }
+}
+
+function finishedSnapshot(parsed, sessionPaths) {
+  return respondToSnapshotRequest(parsed, sessionPaths, {
+    status: { type: "idle" },
+    messages: [{
+      info: { id: "msg-done", role: "assistant", tokens: { input: 1, output: 1 } },
+      parts: [{ id: "part-done", type: "text", text: "done" }],
+    }],
+  })
+}
+
+test("a heartbeat slower than its interval never overlaps the next probe", async () => {
+  let inflight = 0
+  let maxInflight = 0
+  let settled = 0
+  let releaseSnapshot = () => {}
+  const snapshotGate = new Promise((resolve) => { releaseSnapshot = () => resolve(undefined) })
+  let resolveCompleted
+  const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  let offered = false
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  const local = localExecutionRoutes(sessionPaths, async (parsed) => {
+    await snapshotGate
+    return finishedSnapshot(parsed, sessionPaths)
+  })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") return local(parsed, options)
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/heartbeat")) {
+        inflight += 1
+        maxInflight = Math.max(maxInflight, inflight)
+        // Ten intervals long: a setInterval heartbeat would pile up here.
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        inflight -= 1
+        settled += 1
+        return Response.json({ leaseValid: true, cancelRequested: false })
+      }
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/complete")) {
+        resolveCompleted()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    heartbeatIntervalMs: 1,
+    waitBeforeReconnect: () => new Promise(() => {}),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await waitFor(() => settled >= 2, "two heartbeats did not settle")
+  releaseSnapshot()
+  await withTimeout(completed, "completion timed out")
+  runner.stop()
+  assert.ok(settled >= 2, "expected at least two settled heartbeats")
+  assert.equal(maxInflight, 1)
+})
+
+test("a hung completion request is bounded and the runner keeps claiming new work", async () => {
+  const completeSignals = []
+  const completions = []
+  let claims = 0
+  let resolveRunTwoComplete
+  const runTwoCompleted = new Promise((resolve) => { resolveRunTwoComplete = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  const local = localExecutionRoutes(sessionPaths, (parsed) => finishedSnapshot(parsed, sessionPaths))
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") return local(parsed, options)
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (claims === 0) return Response.json({ items: [{ runId: "run-1" }] })
+        if (claims === 1) return Response.json({ items: [{ runId: "run-2" }] })
+        return Response.json({ items: [] })
+      }
+      if (parsed.pathname.endsWith("/claim")) {
+        claims += 1
+        return Response.json({ assignment: { ...testAssignment(), runId: parsed.pathname.split("/").at(-2) } })
+      }
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname === "/v1/automation-runs/run-1/complete") {
+        completeSignals.push(options.signal)
+        // A suspended machine leaves the socket half-open: no response and no
+        // error until the request's own deadline aborts it.
+        return new Promise((_resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => reject(options.signal.reason ?? new Error("aborted")),
+            { once: true },
+          )
+        })
+      }
+      if (parsed.pathname === "/v1/automation-runs/run-2/complete") {
+        completions.push(JSON.parse(options.body))
+        resolveRunTwoComplete()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    lifecycleRequestTimeoutMs: 5,
+    waitBeforeReconnect: () => new Promise(() => {}),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await withTimeout(runTwoCompleted, "the runner never claimed new work after the hung completion")
+  runner.stop()
+  assert.equal(completeSignals.length, 2, "expected exactly one bounded retry of the hung completion")
+  assert.ok(completeSignals.every((signal) => signal?.aborted === true))
+  assert.equal(completions[0]?.status, "succeeded")
+})
+
+test("transient heartbeat failures below the miss threshold do not abort the run", async () => {
+  let heartbeats = 0
+  let releaseSnapshot = () => {}
+  const snapshotGate = new Promise((resolve) => { releaseSnapshot = () => resolve(undefined) })
+  const completions = []
+  let resolveCompleted
+  const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  let offered = false
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  // The gate is signal-aware so that an abort of the execution controller
+  // fails the run instead of being masked by the scripted response.
+  const local = localExecutionRoutes(sessionPaths, async (parsed, options) => {
+    await new Promise((resolve, reject) => {
+      const abort = () => reject(options.signal?.reason ?? new Error("aborted"))
+      if (options.signal?.aborted) return abort()
+      options.signal?.addEventListener("abort", abort, { once: true })
+      void snapshotGate.then(resolve)
+    })
+    return finishedSnapshot(parsed, sessionPaths)
+  })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") return local(parsed, options)
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/heartbeat")) {
+        heartbeats += 1
+        if (heartbeats <= 2) return Response.json({ message: "transient" }, { status: 500 })
+        return Response.json({ leaseValid: true, cancelRequested: false })
+      }
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/complete")) {
+        completions.push(JSON.parse(options.body))
+        resolveCompleted()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    heartbeatIntervalMs: 1,
+    heartbeatMissLimit: 3,
+    waitBeforeReconnect: () => new Promise(() => {}),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await waitFor(() => heartbeats >= 3, "the run did not survive to a third heartbeat")
+  releaseSnapshot()
+  await withTimeout(completed, "completion timed out")
+  runner.stop()
+  assert.equal(completions[0]?.status, "succeeded")
+})
+
+test("consecutive heartbeat misses abort the run and still deliver terminal and completion", async () => {
+  let heartbeats = 0
+  const events = []
+  const completions = []
+  let resolveCompleted
+  const completed = new Promise((resolve) => { resolveCompleted = resolve })
+  let offered = false
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  const local = localExecutionRoutes(sessionPaths, (parsed, options) => new Promise((_resolve, reject) => {
+    const abort = () => reject(options.signal?.reason ?? new Error("aborted"))
+    if (options.signal?.aborted) abort()
+    else options.signal?.addEventListener("abort", abort, { once: true })
+  }))
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") return local(parsed, options)
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/heartbeat")) {
+        heartbeats += 1
+        return Response.json({ message: "boom" }, { status: 500 })
+      }
+      if (parsed.pathname.endsWith("/events")) {
+        events.push(JSON.parse(options.body))
+        return Response.json({ ok: true })
+      }
+      if (parsed.pathname.endsWith("/complete")) {
+        completions.push(JSON.parse(options.body))
+        resolveCompleted()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    heartbeatIntervalMs: 1,
+    heartbeatMissLimit: 3,
+    waitBeforeReconnect: () => new Promise(() => {}),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await withTimeout(completed, "the failed run never reached completion")
+  runner.stop()
+  assert.equal(heartbeats, 3, "the run should survive exactly up to the miss threshold")
+  assert.equal(completions[0]?.status, "failed")
+  assert.match(completions[0]?.error.message, /heartbeat failed 3 times/)
+  assert.equal(events.find((entry) => entry.type === "terminal")?.payload.status, "failed")
+})
+
+test("a snapshot poll left hanging by a suspended machine still honors the assignment timeout", async () => {
+  const snapshotSignals = []
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  const local = localExecutionRoutes(sessionPaths, (parsed, options) => {
+    snapshotSignals.push(options.signal)
+    return new Promise((_resolve, reject) => {
+      options.signal?.addEventListener(
+        "abort",
+        () => reject(options.signal.reason ?? new Error("aborted")),
+        { once: true },
+      )
+    })
+  })
+  await assert.rejects(
+    executeDesktopAutomation({ ...testAssignment(), timeoutMs: 20 }, {
+      getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+      fetchImpl: async (url, options = {}) => local(new URL(url), options),
+      signal: new AbortController().signal,
+    }),
+    /Desktop Automation execution timed out/,
+  )
+  assert.equal(snapshotSignals[0]?.aborted, true)
+})
+
+test("a late heartbeat verdict for a finished run cannot cancel its successor", async () => {
+  const completions = []
+  let claims = 0
+  /** @type {((response: Response) => void) | null} */
+  let holdHeartbeat = null
+  let releaseRunOne = () => {}
+  const runOneGate = new Promise((resolve) => { releaseRunOne = () => resolve(undefined) })
+  let releaseRunTwo = () => {}
+  const runTwoGate = new Promise((resolve) => { releaseRunTwo = () => resolve(undefined) })
+  let resolveRunTwoComplete
+  const runTwoCompleted = new Promise((resolve) => { resolveRunTwoComplete = resolve })
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  const local = localExecutionRoutes(sessionPaths, async (parsed) => {
+    await (claims === 1 ? runOneGate : runTwoGate)
+    return finishedSnapshot(parsed, sessionPaths)
+  })
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") return local(parsed, options)
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (claims === 0) return Response.json({ items: [{ runId: "run-1" }] })
+        if (claims === 1) return Response.json({ items: [{ runId: "run-2" }] })
+        return Response.json({ items: [] })
+      }
+      if (parsed.pathname.endsWith("/claim")) {
+        claims += 1
+        return Response.json({ assignment: { ...testAssignment(), runId: parsed.pathname.split("/").at(-2) } })
+      }
+      if (parsed.pathname === "/v1/automation-runs/run-1/heartbeat") {
+        return new Promise((resolve) => { holdHeartbeat = resolve })
+      }
+      if (parsed.pathname === "/v1/automation-runs/run-2/heartbeat") {
+        return Response.json({ leaseValid: true, cancelRequested: false })
+      }
+      if (parsed.pathname.endsWith("/events")) return Response.json({ ok: true })
+      if (parsed.pathname.endsWith("/complete")) {
+        completions.push({ runId: parsed.pathname.split("/").at(-2), body: JSON.parse(options.body) })
+        if (parsed.pathname === "/v1/automation-runs/run-2/complete") resolveRunTwoComplete()
+        return Response.json({ ok: true })
+      }
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    heartbeatIntervalMs: 1,
+    waitBeforeReconnect: () => new Promise(() => {}),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await waitFor(() => holdHeartbeat !== null, "run-1's heartbeat did not start")
+  releaseRunOne()
+  await waitFor(() => claims === 2, "run-2 was not claimed")
+  // The stale probe answers with a cancellation verdict for the finished
+  // run-1: it must not touch the successor's execution.
+  holdHeartbeat?.(Response.json({ leaseValid: true, cancelRequested: true }))
+  await flushTasks()
+  releaseRunTwo()
+  await withTimeout(runTwoCompleted, "run-2 completion timed out")
+  runner.stop()
+  assert.equal(completions.find((entry) => entry.runId === "run-1")?.body.status, "succeeded")
+  assert.equal(completions.find((entry) => entry.runId === "run-2")?.body.status, "succeeded")
+})
+
+test("stopping the runner during terminal delivery aborts it without further requests", async () => {
+  const denPaths = []
+  /** @type {AbortSignal | null} */
+  let terminalSignal = null
+  let offered = false
+  const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
+  const local = localExecutionRoutes(sessionPaths, (parsed) => finishedSnapshot(parsed, sessionPaths))
+  const runner = createDesktopAutomationRunner({
+    getLocalRuntime: async () => ({ baseUrl: "http://127.0.0.1:3000", token: "local" }),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      if (parsed.origin === "http://127.0.0.1:3000") return local(parsed, options)
+      denPaths.push(parsed.pathname)
+      if (parsed.pathname === "/v1/automation-runner/work") {
+        if (offered) return Response.json({ items: [] })
+        offered = true
+        return Response.json({ items: [{ runId: "run-1" }] })
+      }
+      if (parsed.pathname.endsWith("/claim")) return Response.json({ assignment: testAssignment() })
+      if (parsed.pathname.endsWith("/events")) {
+        if (JSON.parse(options.body).type !== "terminal") return Response.json({ ok: true })
+        terminalSignal = options.signal
+        return new Promise((_resolve, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => reject(options.signal.reason ?? new Error("aborted")),
+            { once: true },
+          )
+        })
+      }
+      if (parsed.pathname.endsWith("/complete")) return Response.json({ ok: true })
+      throw new Error(`Unexpected Den request ${parsed.pathname}`)
+    },
+    lifecycleRequestTimeoutMs: 10_000,
+    waitBeforeReconnect: () => new Promise(() => {}),
+  })
+  runner.configure({
+    baseUrl: "https://den.example.com",
+    token: runnerTokenFor("https://den.example.com"),
+    runnerId: "runner-1",
+  })
+  await waitFor(() => terminalSignal !== null, "the terminal event did not start")
+  runner.stop()
+  await flushTasks()
+  assert.equal(terminalSignal?.aborted, true)
+  // user, assistant, and usage events plus exactly one terminal attempt: the
+  // retired generation never retries and never posts the completion.
+  assert.equal(denPaths.filter((path) => path.endsWith("/events")).length, 4)
+  assert.equal(denPaths.filter((path) => path.endsWith("/complete")).length, 0)
 })

--- a/evals/specs/automation-runner-reconnect-backoff.test.ts
+++ b/evals/specs/automation-runner-reconnect-backoff.test.ts
@@ -57,9 +57,16 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(unit.stdout).toContain("an unpinned assignment keeps the legacy active-workspace fallback");
   expect(unit.stdout).toContain("a pinned workspace missing locally fails instead of silently retargeting");
   expect(unit.stdout).toContain("desktop Automation execution runs in the assignment's pinned workspace");
+  expect(unit.stdout).toContain("a heartbeat slower than its interval never overlaps the next probe");
+  expect(unit.stdout).toContain("a hung completion request is bounded and the runner keeps claiming new work");
+  expect(unit.stdout).toContain("transient heartbeat failures below the miss threshold do not abort the run");
+  expect(unit.stdout).toContain("consecutive heartbeat misses abort the run and still deliver terminal and completion");
+  expect(unit.stdout).toContain("a snapshot poll left hanging by a suspended machine still honors the assignment timeout");
+  expect(unit.stdout).toContain("a late heartbeat verdict for a finished run cannot cancel its successor");
+  expect(unit.stdout).toContain("stopping the runner during terminal delivery aborts it without further requests");
   expect(unit.stdout).not.toContain("not ok");
-  expect(unit.stdout).toMatch(/# tests 38\b/);
-  expect(unit.stdout).toMatch(/# pass 38\b/);
+  expect(unit.stdout).toMatch(/# tests 45\b/);
+  expect(unit.stdout).toMatch(/# pass 45\b/);
   expect(unit.stdout).toMatch(/# fail 0\b/);
   expect(unit.stdout).toMatch(/# skipped 0\b/);
   expect(unit.stdout).toMatch(/# todo 0\b/);
@@ -81,7 +88,7 @@ test("desktop Automation runner retires rejected credentials without changing tr
   expect(bridgeOutput).toContain("0 fail");
   evidence.recordAssertionEvidence(
     "Rejected runner credentials stop and remint without disrupting valid work",
-    "The runner and bridge suites passed 45 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, remote-session delivery and failure receipts, and work-only polling.",
+    "The runner and bridge suites passed 57 tests covering one-shot 401/403 retirement on every runner route, fresh-token remint backoff, generation races, active assignments, in-flight claims, wake-time work polling, bounded idle polls, serialized bounded heartbeats with a consecutive-miss threshold, bounded terminal and completion delivery, cancellation, provider and workspace failures, durable failed-thread linkage, tool-only completion, remote-session delivery and failure receipts, and work-only polling.",
     true,
   );
 


### PR DESCRIPTION
## Problem

The desktop automation runner has no time limits on most of its Den control-plane requests, and its heartbeat can pile up. Verified against `dev` (`d939dd327`):

- The heartbeat ran on `setInterval` with an async handler and no in-flight guard, so a heartbeat slower than the 10s interval overlapped the next tick and requests piled up on a dead connection.
- The headless client is built with `requestTimeoutMs: 0`, disabling per-request deadlines; only the idle work poll was bounded (`AbortSignal.timeout`). A hung `getThreadSnapshot` made `assignment.timeoutMs` unreachable because the wall-clock check only runs between awaits.
- A hung `await event("terminal")` / `complete` POST blocked `runAssignment` → `reconcile` (deduped on `reconcilePromise`) → `wake()`, permanently wedging the runner until app restart, with no error surfaced.
- One transient heartbeat failure (e.g. a single 500) aborted the whole run and marked it failed.

Real-world trigger: a laptop suspends mid-request and leaves a half-open socket; on resume the request never resolves.

## Change

All in `apps/desktop/electron/automation-runner.mjs`:

- **Serialized heartbeat.** The `setInterval` is replaced with a self-scheduling `setTimeout` chain: the next probe is armed only after the current one settles, so at most one heartbeat is ever in flight.
- **Heartbeat deadline below the interval.** Each heartbeat carries `AbortSignal.timeout(8s)` (default interval 10s), combined with the generation signal inside `runnerRequest` via `AbortSignal.any`.
- **Consecutive-miss threshold.** Heartbeat failures are counted consecutively and reset on success; the run aborts only after 3 consecutive misses (~ the lease TTL) instead of on the first error. 401/403 still retire the credential immediately through the existing `rejectCredential` path.
- **Bounded lifecycle requests.** The `events`, `claim` (automation-run and remote-session), and `complete` (both) requests each get a 30s `AbortSignal.timeout`. The signal is passed to fetch, so response-body reading (`response.text()` in `requestJson`) is bounded by the same deadline.
- **Must-terminate terminal delivery.** The terminal event and the `complete` POST each get their own try block plus exactly one bounded retry. A failed or slow terminal event can no longer skip completion or wedge `reconcile`; failures are logged and the runner returns to claiming work.
- **Assignment timeout always fires.** Each execution snapshot poll is bounded by the remaining `assignment.timeoutMs` budget, so a hung `getThreadSnapshot` now surfaces "Desktop Automation execution timed out" at the deadline.

Deliberately unchanged, to preserve existing semantics:

- Lifecycle requests stay off `active.controller`, keeping the split where heartbeat-driven cancel aborts only execution — terminal/completion delivery still lands after a cancel.
- Deferred credential replacement mid-run is untouched.
- The signal-aware reconnect sleeps carry no deadlines.
- No changes to the Electron fetch bridge / `main.mjs`.

## Test evidence

New tests in `apps/desktop/electron/automation-runner.test.mjs`, using the existing scripted-fetch harness:

- a heartbeat slower than its interval never overlaps the next probe
- a hung completion request is bounded and the runner keeps claiming new work
- transient heartbeat failures below the miss threshold do not abort the run
- consecutive heartbeat misses abort the run and still deliver terminal and completion
- a snapshot poll left hanging by a suspended machine still honors the assignment timeout
- a late heartbeat verdict for a finished run cannot cancel its successor
- stopping the runner during terminal delivery aborts it without further requests
- the existing cancellation test now also asserts the terminal event is delivered alongside the completion

The eval drift-guard `evals/specs/automation-runner-reconnect-backoff.test.ts` pins this unit suite's size and names, so it now tracks the expanded 45-test suite (verified locally with `pnpm exec vitest run --project pr specs/automation-runner-reconnect-backoff.test.ts` — 1 passed).

Controls that keep passing unchanged: config replacement mid-run stays deferred ("routine credential rotation waits for the active assignment to complete" / "...an in-flight claim"), 401/403 retirement on every assignment route, reconnect-backoff behavior, and retire/stop cancelling waits.

Ran (macOS, Node v24.11.1, pnpm 11.4.0):

```
pnpm --filter @openwork/headless-threads build
node --test apps/desktop/electron/automation-runner.test.mjs
# tests 45  pass 45  fail 0

pnpm --filter @openwork/desktop test
# tests 295  pass 294  fail 0  skipped 1  (skip is the platform-conditional
# "is a no-op off macOS" ShipIt test, pre-existing)

pnpm --filter @openwork/desktop typecheck:electron
# clean
```

Demonstrated the defects by running the new tests against the previous runner (`git show origin/dev:apps/desktop/electron/automation-runner.mjs`):

```
✖ a heartbeat slower than its interval never overlaps the next probe
    AssertionError: Expected values to be strictly equal: actual: 10, expected: 1
    (ten heartbeats in flight at once)
✖ a hung completion request is bounded and the runner keeps claiming new work
    Error: the runner never claimed new work after the hung completion (wedged)
✖ transient heartbeat failures below the miss threshold do not abort the run
    AssertionError: the run did not survive to a third heartbeat
```

No video/fraimz: this is a main-process background lifecycle path with no UI surface, and the failure mode (half-open socket after machine suspend) is not reproducible on demand in a screen recording. The injected-fetch tests above assert the observable behavior directly; to reproduce, run the commands listed.

## Open questions

- **Heartbeat miss threshold.** I set the default to 3 consecutive misses (with an 8s per-probe deadline under a 10s interval, that tolerates roughly 30s of outage, in the ballpark of the lease TTL). If the Den lease TTL implies a different number, happy to adjust — it is a single constant (`heartbeatMissLimit`).
- **Headless client request timeout.** `createWorkspaceSessionClient` still passes `requestTimeoutMs: 0`, so local OpenCode requests other than the snapshot poll (e.g. `createThread`) remain unbounded. Restoring the client's 15s default would bound those too, but it changes behavior for slow local runtimes, so I left it as a separate decision rather than folding it in here.

