### PR TITLE
Bound engine event-stream establishment and frame memory

### DIFF
--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  BoundedSseFrameBuffer,
   clearEnginePoolForConfig,
   EnginePool,
   computeEngineConfigFingerprint,
@@ -76,6 +77,15 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "    return Array.isArray(value) ? value : null;",
     "  } catch { return null; }",
     "};",
+    "const eventMode = (port) => {",
+    "  try {",
+    "    const state = JSON.parse(readFileSync(statePath, 'utf8'));",
+    "    const modes = state.__eventMode;",
+    "    if (!modes || typeof modes !== 'object') return null;",
+    "    const value = modes[String(port)];",
+    "    return typeof value === 'string' ? value : null;",
+    "  } catch { return null; }",
+    "};",
     "const server = Bun.serve({",
     "  hostname: '127.0.0.1',",
     "  port: requestedPort,",
@@ -91,6 +101,21 @@ async function writeFakeEngineBin(root: string): Promise<string> {
     "      if (owner && owner !== server.port) return Response.json([]);",
     "      const sessionID = url.searchParams.get('session') ?? busySessions(server.port, url.searchParams.get('directory'))[0] ?? `ses_${server.port}`;",
     "      return Response.json([{ id: url.searchParams.get('request') ?? `req_${server.port}`, sessionID }]);",
+    "    }",
+    "    if (url.pathname === '/event' || url.pathname === '/global/event') {",
+    "      const mode = eventMode(server.port);",
+    "      // stall: accept the socket but never answer with headers.",
+    "      if (mode === 'stall') return new Promise(() => {});",
+    "      // giant: one unterminated frame far above the cap on a stream that never closes.",
+    "      if (mode === 'giant') {",
+    "        const body = new ReadableStream({",
+    "          start(controller) {",
+    "            const chunk = new TextEncoder().encode('data: ' + 'x'.repeat(1024 * 1024));",
+    "            for (let i = 0; i < 6; i += 1) controller.enqueue(chunk);",
+    "          },",
+    "        });",
+    "        return new Response(body, { headers: { 'content-type': 'text/event-stream' } });",
+    "      }",
     "    }",
     "    if (url.pathname === '/global/event') {",
     "      const frame = (id) => `data: ${JSON.stringify({ directory: '/workspace', payload: { type: 'session.updated', properties: { sessionID: id } } })}\\n\\n`;",
@@ -157,6 +182,7 @@ type Fixture = {
   setBusy: (port: number, sessionIds: string[]) => Promise<void>;
   setBusyForDirectory: (port: number, directory: string, sessionIds: string[]) => Promise<void>;
   setEventSessions: (port: number, sessionIds: string[] | null) => Promise<void>;
+  setEventMode: (port: number, mode: "stall" | "giant" | null) => Promise<void>;
   logLines: () => Promise<string[]>;
   setRuntimeConfig: (content: string) => Promise<void>;
   spawnPrimary: () => Promise<ManagedOpencodeServer>;
@@ -271,6 +297,27 @@ async function createFixture(options?: { bin?: "ready" | "unready" }): Promise<F
     await writeFile(statePath, JSON.stringify(state));
   };
 
+  /**
+   * Force a misbehaving event endpoint on one engine: "stall" accepts the
+   * socket but never returns headers; "giant" streams one unterminated frame
+   * far above the frame cap; null restores normal behavior.
+   */
+  const setEventMode = async (port: number, mode: "stall" | "giant" | null): Promise<void> => {
+    const state = JSON.parse(await readFile(statePath, "utf8").catch(() => "{}")) as Record<string, unknown>;
+    const current = state.__eventMode;
+    const modes: Record<string, string> = {};
+    if (current !== undefined && typeof current === "object" && current !== null && !Array.isArray(current)) {
+      for (const [key, value] of Object.entries(current)) {
+        if (typeof value === "string") modes[key] = value;
+      }
+    }
+    if (mode === null) delete modes[String(port)];
+    else modes[String(port)] = mode;
+    if (Object.keys(modes).length === 0) delete state.__eventMode;
+    else state.__eventMode = modes;
+    await writeFile(statePath, JSON.stringify(state));
+  };
+
   const spawnPrimary = async (): Promise<ManagedOpencodeServer> => {
     const handle = await createManagedOpencodeServer({ bin, cwd: root, env: template.env });
     cleanups.push(() => handle.close().catch(() => undefined));
@@ -289,6 +336,7 @@ async function createFixture(options?: { bin?: "ready" | "unready" }): Promise<F
     setBusy,
     setBusyForDirectory,
     setEventSessions,
+    setEventMode,
     logLines: async () => (await readFile(logPath, "utf8").catch(() => "")).split("\n").filter(Boolean),
     setRuntimeConfig: (content: string) => writeFile(runtimeConfigPath, content),
     spawnPrimary,
@@ -855,5 +903,119 @@ describe("engine pool", () => {
     const lines = await fixture.logLines();
     expect(lines).toContain(`${portOf(primary.url)} SIGTERM`);
     expect(lines).toContain(`${portOf(replacementUrl ?? "http://127.0.0.1:0")} SIGTERM`);
+  });
+});
+
+describe("BoundedSseFrameBuffer", () => {
+  const encoder = new TextEncoder();
+
+  test("splits frames across chunk boundaries and both delimiter styles", () => {
+    const buffer = new BoundedSseFrameBuffer(64);
+    expect(buffer.push(encoder.encode("data: one\n\ndata: tw"))).toEqual({ frames: ["data: one"], overflow: false });
+    expect(buffer.push(encoder.encode("o\r\n\r\ndata: three"))).toEqual({ frames: ["data: two"], overflow: false });
+    expect(buffer.push(encoder.encode("\n\n"))).toEqual({ frames: ["data: three"], overflow: false });
+  });
+
+  test("keeps completed frames and flags overflow once the unterminated remainder exceeds the cap", () => {
+    const buffer = new BoundedSseFrameBuffer(8);
+    expect(buffer.push(encoder.encode("data: a\n\n0123456789"))).toEqual({ frames: ["data: a"], overflow: true });
+  });
+
+  test("never overflows while frames keep terminating", () => {
+    const buffer = new BoundedSseFrameBuffer(16);
+    for (let index = 0; index < 100; index += 1) {
+      expect(buffer.push(encoder.encode("data: abcdefgh\n\n"))).toEqual({ frames: ["data: abcdefgh"], overflow: false });
+    }
+  });
+});
+
+describe("engine event stream bounds", () => {
+  const proxyEvent = async (fixture: Fixture, path: string): Promise<Response> => {
+    const url = new URL(`http://127.0.0.1/opencode${path}`);
+    return proxyOpencodeRequest({
+      config: fixture.config,
+      request: new Request(url),
+      url,
+      workspace: fixture.workspace,
+      proxyPath: url.pathname.slice("/opencode".length),
+    });
+  };
+
+  test("a sibling that never returns headers does not stall the client event stream", async () => {
+    setEnv("OPENWORK_ENGINE_EVENT_ESTABLISH_TIMEOUT_MS", "300");
+    const fixture = await createFixture();
+    const { pool, primary } = await createPool(fixture);
+    const oldPort = portOf(primary.url);
+    await fixture.setBusy(oldPort, ["ses_live"]);
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+    expect((await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace })).action)
+      .toBe("rolled_over");
+    const newPort = portOf(pool.primaryUrl() ?? "http://127.0.0.1:0");
+    // The draining sibling accepts the socket but never answers with headers.
+    await fixture.setEventMode(oldPort, "stall");
+
+    const startedAt = Date.now();
+    const response = await proxyEvent(fixture, "/event");
+    const events = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(events).toContain(`"sessionID":"ses_${newPort}"`);
+  });
+
+  test("a quiet live event stream stays open past the establishment deadline", async () => {
+    setEnv("OPENWORK_ENGINE_EVENT_ESTABLISH_TIMEOUT_MS", "300");
+    const fixture = await createFixture();
+    await createPool(fixture);
+
+    // hold=1 sends one frame and then goes silent on an open stream.
+    const response = await proxyEvent(fixture, "/event?hold=1");
+    expect(response.status).toBe(200);
+    if (!response.body) throw new Error("expected a streaming body");
+    const reader = response.body.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+
+    // The establishment deadline is long past; only establishment is bounded,
+    // so the silent-but-live body must still be open.
+    const idle = await Promise.race([
+      reader.read().then((chunk) => (chunk.done ? "closed" : "data")),
+      new Promise<string>((resolve) => setTimeout(() => resolve("open"), 1_200)),
+    ]);
+    expect(idle).toBe("open");
+    await reader.cancel().catch(() => undefined);
+  });
+
+  test("closes an event connection whose frame never terminates instead of buffering it", async () => {
+    const fixture = await createFixture();
+    const { primary } = await createPool(fixture);
+    await fixture.setEventMode(portOf(primary.url), "giant");
+
+    const response = await proxyEvent(fixture, "/event");
+    expect(response.status).toBe(200);
+    // The runaway frame hits the cap: the connection is dropped and the
+    // merged stream closes instead of buffering the frame forever.
+    const events = await response.text();
+    expect(events).toBe("");
+  });
+
+  test("the drain activity watch drops a runaway frame stream and reconnects", async () => {
+    setEnv("OPENWORK_ENGINE_DRAIN_ACTIVITY_RECONNECT_MS", "100");
+    const fixture = await createFixture();
+    const { pool, primary } = await createPool(fixture);
+    const oldPort = portOf(primary.url);
+    await fixture.setBusy(oldPort, ["ses_stuck"]);
+    await fixture.setEventMode(oldPort, "giant");
+    await fixture.setRuntimeConfig(JSON.stringify({ generation: 2 }));
+    expect((await pool.requestRollover({ reason: "config_changed", workspace: fixture.workspace })).action)
+      .toBe("rolled_over");
+
+    // Every malformed stream is dropped at the frame cap and re-dialed;
+    // without the bound the first connection would buffer forever and a
+    // second dial would never happen.
+    expect(await waitUntil(async () => {
+      const lines = await fixture.logLines();
+      return lines.filter((line) => line === `${oldPort} GET /global/event`).length >= 2;
+    }, 10_000)).toBe(true);
   });
 });

--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -289,6 +289,40 @@ function eventIdentifiers(payload: unknown): { sessionIds: Set<string>; requestI
   return { sessionIds, requestIds };
 }
 
+/**
+ * Cap on the text one unterminated SSE frame may buffer before the stream is
+ * treated as malformed. Sized well above any legitimate single engine event
+ * (large tool outputs included) so real frames are never truncated; only a
+ * stream that stops terminating frames hits it.
+ */
+export const ENGINE_SSE_FRAME_MAX_CHARS = 4 * 1024 * 1024;
+
+/**
+ * Incremental SSE frame splitter shared by the client event fan-in and the
+ * drain activity watch. It bounds the memory a single unterminated frame can
+ * hold: completed frames are always returned, and `overflow` turns true once
+ * the pending remainder exceeds the cap so the caller can drop that
+ * connection instead of buffering it forever.
+ */
+export class BoundedSseFrameBuffer {
+  private readonly decoder = new TextDecoder();
+  private buffered = "";
+
+  constructor(private readonly maxFrameChars = ENGINE_SSE_FRAME_MAX_CHARS) {}
+
+  push(chunk: Uint8Array): { frames: string[]; overflow: boolean } {
+    this.buffered += this.decoder.decode(chunk, { stream: true });
+    const frames: string[] = [];
+    while (true) {
+      const delimiter = this.buffered.match(/\r?\n\r?\n/);
+      if (!delimiter || delimiter.index === undefined) break;
+      frames.push(this.buffered.slice(0, delimiter.index));
+      this.buffered = this.buffered.slice(delimiter.index + delimiter[0].length);
+    }
+    return { frames, overflow: this.buffered.length > this.maxFrameChars };
+  }
+}
+
 /** Decode one SSE frame's `data:` payload; null when the frame carries none. */
 function sseFramePayload(frame: string): unknown {
   const data = frame
@@ -855,23 +889,22 @@ export class EnginePool {
     signal: AbortSignal,
   ): Promise<void> {
     const reader = body.getReader();
-    const decoder = new TextDecoder();
-    let buffered = "";
+    const frameBuffer = new BoundedSseFrameBuffer();
     try {
       while (!signal.aborted && generation.status === "draining") {
         const chunk = await reader.read();
         if (chunk.done) return;
-        buffered += decoder.decode(chunk.value, { stream: true });
-        while (true) {
-          const delimiter = buffered.match(/\r?\n\r?\n/);
-          if (!delimiter || delimiter.index === undefined) break;
-          const frame = buffered.slice(0, delimiter.index);
-          buffered = buffered.slice(delimiter.index + delimiter[0].length);
+        const parsed = frameBuffer.push(chunk.value);
+        for (const frame of parsed.frames) {
           this.noteDrainActivity(generation, sseFramePayload(frame));
         }
+        // A frame that never terminates would buffer without bound; drop the
+        // stream and let the watch loop reconnect.
+        if (parsed.overflow) return;
       }
     } finally {
       await reader.cancel().catch(() => undefined);
+      reader.releaseLock();
     }
   }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -7,6 +7,7 @@ import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor,
 import { agentContextDiagnosticsRequestSchema } from "./agent-context-diagnostics-schema.js";
 import { ApprovalService } from "./approvals.js";
 import {
+  BoundedSseFrameBuffer,
   EnginePool,
   enginePoolForConfig,
   isEngineConnectionFailure,
@@ -1656,27 +1657,29 @@ function mergedEventBody(input: {
         close();
       };
       const pump = async (entry: typeof readers[number]) => {
-        const decoder = new TextDecoder();
-        let buffered = "";
+        const frameBuffer = new BoundedSseFrameBuffer();
         try {
           while (!cancelled) {
             const chunk = await entry.reader.read();
             if (chunk.done) break;
-            buffered += decoder.decode(chunk.value, { stream: true });
-            while (true) {
-              const delimiter = buffered.match(/\r?\n\r?\n/);
-              if (!delimiter || delimiter.index === undefined) break;
-              const frame = buffered.slice(0, delimiter.index);
-              buffered = buffered.slice(delimiter.index + delimiter[0].length);
+            const parsed = frameBuffer.push(chunk.value);
+            for (const frame of parsed.frames) {
               if (input.pool.shouldForwardEvent(entry.connection.generationId, parseSsePayload(frame))) {
                 controller.enqueue(encoder.encode(`${frame}\n\n`));
               }
+            }
+            if (parsed.overflow) {
+              // A frame that never terminates would buffer without bound;
+              // drop this connection and let the client reconnect.
+              await entry.reader.cancel(new Error("SSE frame exceeded the size limit")).catch(() => undefined);
+              break;
             }
           }
         } catch {
           // A generation flip intentionally aborts these readers. The client
           // reconnects and the next stream fans in every live generation.
         } finally {
+          entry.reader.releaseLock();
           finish();
         }
       };
@@ -1697,6 +1700,13 @@ function mergedEventBody(input: {
   });
 }
 
+// Read lazily so tests can shrink the deadline at runtime. Matches the 5s
+// bound proxyEngineAggregateRead puts on its per-connection fan-out.
+function engineEventStreamEstablishTimeoutMs(): number {
+  const parsed = Number(process.env.OPENWORK_ENGINE_EVENT_ESTABLISH_TIMEOUT_MS ?? "5000");
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5_000;
+}
+
 async function proxyEngineEventStreams(input: {
   pool: EnginePool;
   connections: EnginePoolConnection[];
@@ -1707,30 +1717,57 @@ async function proxyEngineEventStreams(input: {
 }): Promise<Response> {
   const lease = input.pool.openEventProxy(input.clientSignal);
   const settled = await Promise.allSettled(input.connections.map(async (connection) => {
-    const response = await loopbackFetch(buildOpencodeProxyUrl(connection.baseUrl, input.proxyPath, input.search), {
-      method: "GET",
-      headers: headersForEngineConnection(input.headers, connection),
-      signal: lease.signal,
-    });
-    return { connection, response };
+    // Bound establishment (headers) only: a connection that accepts the
+    // socket but never answers must not stall the whole fan-out. The timer is
+    // cleared as soon as the response resolves so the long-lived body stream
+    // itself is never put on a deadline; lease aborts tear the body down
+    // through the merged-stream reader cancellation instead.
+    const establish = new AbortController();
+    const onLeaseAbort = () => establish.abort(lease.signal.reason);
+    lease.signal.addEventListener("abort", onLeaseAbort, { once: true });
+    if (lease.signal.aborted) onLeaseAbort();
+    const timer = setTimeout(
+      () => establish.abort(new Error("OpenCode event stream establishment timed out")),
+      engineEventStreamEstablishTimeoutMs(),
+    );
+    timer.unref?.();
+    try {
+      const response = await loopbackFetch(buildOpencodeProxyUrl(connection.baseUrl, input.proxyPath, input.search), {
+        method: "GET",
+        headers: headersForEngineConnection(input.headers, connection),
+        signal: establish.signal,
+      });
+      return { connection, response };
+    } finally {
+      clearTimeout(timer);
+      lease.signal.removeEventListener("abort", onLeaseAbort);
+    }
   }));
   const successful = settled
     .filter((entry): entry is PromiseFulfilledResult<{ connection: EnginePoolConnection; response: Response }> =>
       entry.status === "fulfilled")
     .map((entry) => entry.value);
+  // Established fetches are no longer tied to any abort signal, so bodies the
+  // merged stream will not own must be cancelled here instead of leaking.
+  const discard = (entries: Array<{ response: Response }>) => {
+    for (const entry of entries) void entry.response.body?.cancel().catch(() => undefined);
+  };
   const primary = successful.find((entry) => entry.connection.role === "primary");
   if (!primary) {
     lease.release();
+    discard(successful);
     throw new ApiError(502, "opencode_unreachable", "The primary OpenCode event stream is unavailable");
   }
   if (!primary.response.ok || !primary.response.body) {
     lease.release();
+    discard(successful.filter((entry) => entry !== primary));
     return sanitizeProxyResponse(primary.response);
   }
   const streams = successful
     .flatMap((entry) => entry.response.ok && entry.response.body
       ? [{ connection: entry.connection, body: entry.response.body }]
       : []);
+  discard(successful.filter((entry) => entry !== primary && !(entry.response.ok && entry.response.body)));
   const headers = new Headers(primary.response.headers);
   headers.delete("content-length");
   headers.delete("content-encoding");


### PR DESCRIPTION
## Problem

The server proxies live agent activity from the local engine pool with no deadline on establishing those connections, and both SSE frame parsers buffer without bound:

- `proxyEngineEventStreams` (apps/server/src/server.ts) fans out to every pool connection during a generation rollover and awaited `Promise.allSettled(...)` with only `lease.signal`. If one sibling connection accepts the socket but never returns headers, `allSettled` can never settle and the client's live feed never starts — even when the primary connection is healthy — until the client disconnects. The analogous fan-out in `proxyEngineAggregateRead` already bounds each connection with `AbortSignal.timeout(5_000)`; this route was missing that pattern.
- `mergedEventBody` (server.ts) grows an in-memory `buffered` string on every chunk and only shrinks it on a `\r?\n\r?\n` frame delimiter, so a frame that never terminates grows without bound.
- The drain watch `consumeDrainActivityEvents` (apps/server/src/engine-pool.ts) had the identical unbounded buffer loop.

## Change

- **Establishment deadline, not a stream deadline.** Each event-stream fetch in `proxyEngineEventStreams` now uses a per-connection `AbortController` with a 5s timer (matching `proxyEngineAggregateRead`, env-tunable via `OPENWORK_ENGINE_EVENT_ESTABLISH_TIMEOUT_MS` so tests can shrink it) that is **cleared the moment the response resolves**. The long-lived body is never put on a timer: lease aborts still tear bodies down through the merged-stream reader cancellation, and the existing 30s ping keep-alive is untouched. Because established fetches are no longer tied to an abort signal, response bodies the merged stream will not own are explicitly cancelled instead of leaking.
- **Shared bounded SSE frame splitter.** New `BoundedSseFrameBuffer` (exported from engine-pool.ts, modeled on the bounded reader pattern of `readBoundedEngineMcpRegistrationResponse`) is used by both `mergedEventBody` and `consumeDrainActivityEvents`. Completed frames are always delivered; once the unterminated remainder exceeds the cap the connection is dropped — the client fan-in cancels that reader (client reconnects), the drain watch returns and its loop re-dials.
- **Reader lock hygiene.** `releaseLock()` added in the finally paths where readers are cancelled, consistent with `readBoundedEngineMcpRegistrationResponse`.

Not changed, deliberately: no absolute duration or idle-between-events timeout on the merged live stream (legitimate quiet sessions stay open indefinitely; a test asserts this), and no change to the drain monitor's overall deadline behavior.

## Open question for review

The max-frame cap is `ENGINE_SSE_FRAME_MAX_CHARS = 4 MiB` (per connection, roughly bytes for ASCII payloads; a JS string cap so worst-case resident memory is ~2x that). It is sized well above any single engine event I could find in practice (large tool outputs included) so a legitimate frame is never truncated, but the exact bound is a judgment call — happy to raise/lower it.

## Test evidence

Environment: local macOS (darwin arm64), bun 1.3.4, fresh worktree off `dev` @ d939dd327.

```
$ pnpm --filter openwork-server typecheck
  → passed (tsc -p tsconfig.json --noEmit, no output)

$ cd apps/server && bun --conditions=development test src/engine-pool.test.ts
  → 26 pass, 0 fail, 226 expect() calls
```

New tests and what they observe:

- **Positive — stalled sibling doesn't block the feed:** after a rollover, the draining sibling's `/event` accepts the socket and never returns headers (`setEventMode(port, "stall")`); the proxied `/event` response still returns HTTP 200 with the primary's frames in < 2s (establishment deadline shrunk to 300ms via env).
- **Positive — quiet-but-live stream stays open:** with the establishment deadline at 300ms, a held stream that sends one frame then goes silent is still open at 1.2s (a second `read()` neither errors nor reports done). This also proves the timer is cleared at header time rather than aborting the body.
- **Negative — runaway unterminated frame (client fan-in):** an engine that streams a 6 MiB frame with no delimiter on a never-closing stream (`setEventMode(port, "giant")`): the connection is dropped at the cap and the merged response ends (`response.text()` resolves to `""`) instead of buffering forever.
- **Negative — runaway frame (drain watch):** during a drain, the old engine serves the same 6 MiB unterminated frame on `/global/event`; the watch drops the stream at the cap and re-dials (≥ 2 `GET /global/event` lines observed in the fake engine's log).
- **Unit — `BoundedSseFrameBuffer`:** frame splits across chunk boundaries and both `\n\n`/`\r\n\r\n` delimiters; completed frames survive an overflow signal; no overflow while frames keep terminating.

Counterfactuals (each bound reverted one at a time; observed before restoring):

- `signal: establish.signal` → `signal: lease.signal`: the stalled-sibling test hangs (bun 5s test timeout).
- `new BoundedSseFrameBuffer()` → `new BoundedSseFrameBuffer(Infinity)` in `mergedEventBody`: the runaway-frame test hangs.
- drop `if (parsed.overflow) return;` in `consumeDrainActivityEvents`: the drain re-dial test fails (no second dial within 10s).

Full package suite:

```
$ cd apps/server && bun --conditions=development test
  → 817 pass, 8 skip, 1 fail (826 tests, 103 files)
```

The single failure is `src/workspace-kv-store.node.test.ts`, which fails identically on clean `dev` (verified with the diff stashed): Bun cannot resolve `node:sqlite` (it's a Node-runtime test). Unrelated to this change.

Related engine/proxy suites: `bun --conditions=development test src/opencode-proxy.e2e.test.ts src/engine-instance-eviction.e2e.test.ts src/engine-instance-reaper.test.ts src/engine-self-heal.test.ts` → 29 pass, 0 fail.

No fraimz run: this is a server-internal hardening with no new UI-observable experience; the runtime behavior is proven by the coded proxy/engine tests above (each claim backed by an observed assertion, plus counterfactual failures). To reproduce everything locally: `pnpm install`, then the commands above from `apps/server/`.
