### PR TITLE
feat(app): report web boot failures and Stripe webhook errors to Sentry

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -29,6 +29,76 @@
         }
       })();
     </script>
+    <script>
+      // Pre-boot error beacon for web deployments: reports a web instance
+      // that fails to load (entry bundle error, early exception) to Sentry
+      // before the app's own error monitoring can start. Inert unless the
+      // build sets VITE_OPENWORK_DEPLOYMENT=web and VITE_OPENWORK_SENTRY_DSN.
+      // Once src/app/lib/error-monitoring.ts starts, it takes over via
+      // window.__openworkWebErrorMonitorActive.
+      (function () {
+        try {
+          var dsn = "%VITE_OPENWORK_SENTRY_DSN%";
+          var deployment = "%VITE_OPENWORK_DEPLOYMENT%";
+          if (deployment !== "web" || !dsn || dsn.charAt(0) === "%") return;
+          var match = dsn.match(/^https:\/\/([\w.-]+)@([\w.-]+(?::\d+)?)\/(\d+)$/);
+          if (!match) return;
+          var envelopeUrl =
+            "https://" + match[2] + "/api/" + match[3] +
+            "/envelope/?sentry_key=" + match[1] + "&sentry_version=7";
+          var sent = 0;
+          function analyticsAllowed() {
+            try {
+              var raw = localStorage.getItem("openwork.preferences");
+              if (!raw) return true;
+              return JSON.parse(raw).analyticsEnabled !== false;
+            } catch (e) {
+              return true;
+            }
+          }
+          function send(type, message) {
+            if (sent >= 3 || window.__openworkWebErrorMonitorActive === true) return;
+            if (!analyticsAllowed()) return;
+            sent += 1;
+            var id = (crypto.randomUUID ? crypto.randomUUID() : String(Date.now())).replace(/-/g, "");
+            var event = {
+              event_id: id,
+              timestamp: Date.now() / 1000,
+              platform: "javascript",
+              level: "error",
+              environment: "web",
+              tags: { boot_phase: "boot" },
+              request: { url: location.href },
+              exception: { values: [{ type: type, value: String(message).slice(0, 1000) }] },
+            };
+            var body =
+              JSON.stringify({ event_id: id, sent_at: new Date().toISOString() }) +
+              "\n" + JSON.stringify({ type: "event" }) +
+              "\n" + JSON.stringify(event);
+            try {
+              fetch(envelopeUrl, { method: "POST", body: body, keepalive: true })["catch"](function () {});
+            } catch (e) {}
+          }
+          window.addEventListener(
+            "error",
+            function (e) {
+              var t = e.target;
+              var src = t && (t.tagName === "SCRIPT" ? t.src : t.tagName === "LINK" ? t.href : "");
+              if (src) {
+                send("WebBootLoadFailure", "failed to load " + src);
+                return;
+              }
+              if (e.message) send("WebBootError", e.message);
+            },
+            true
+          );
+          window.addEventListener("unhandledrejection", function (e) {
+            var reason = e.reason;
+            send("WebBootRejection", reason && reason.message ? reason.message : reason);
+          });
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body class="bg-dls-surface text-dls-text mac:bg-transparent">
     <div id="root"></div>

--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -68,7 +68,9 @@
               level: "error",
               environment: "web",
               tags: { boot_phase: "boot" },
-              request: { url: location.href },
+              // Origin + path only: sign-in and deep-link URLs can carry
+              // credentials in the query string that must never leave the page.
+              request: { url: location.origin + location.pathname },
               exception: { values: [{ type: type, value: String(message).slice(0, 1000) }] },
             };
             var body =
@@ -85,7 +87,7 @@
               var t = e.target;
               var src = t && (t.tagName === "SCRIPT" ? t.src : t.tagName === "LINK" ? t.href : "");
               if (src) {
-                send("WebBootLoadFailure", "failed to load " + src);
+                send("WebBootLoadFailure", "failed to load " + String(src).split("?")[0].split("#")[0]);
                 return;
               }
               if (e.message) send("WebBootError", e.message);

--- a/apps/app/src/app/lib/error-monitoring.ts
+++ b/apps/app/src/app/lib/error-monitoring.ts
@@ -1,0 +1,198 @@
+/**
+ * Web error monitoring for the OpenWork web deployment (Sentry, zero-dependency).
+ *
+ * Principles (mirrors `analytics.ts`):
+ * - Detection-first: report that a web instance failed to boot or hit an
+ *   uncaught error. Only the error type, message, stack text, page URL, and
+ *   coarse build context are sent — never chat content, file contents,
+ *   prompts, or tokens.
+ * - Fire-and-forget: monitoring must never break or slow the app.
+ * - Off by default: active only when the build is the web deployment
+ *   (`VITE_OPENWORK_DEPLOYMENT=web`), `VITE_OPENWORK_SENTRY_DSN` is set, and
+ *   the page is not running inside Electron (the desktop app keeps its own
+ *   consent-gated telemetry in `apps/desktop/electron/sentry.mjs`).
+ * - Respects the same `analyticsEnabled` preference as product analytics.
+ *
+ * The pre-boot half lives as an inline script in `index.html` so a bundle
+ * that never loads is still reported; once this module starts it takes over
+ * via `window.__openworkWebErrorMonitorActive`.
+ */
+import { isAnalyticsEnabled } from "./analytics";
+import { getOpenWorkDeployment } from "./openwork-deployment";
+import { isElectronRuntime } from "./runtime-env";
+
+declare global {
+  interface Window {
+    __openworkWebErrorMonitorActive?: boolean;
+  }
+}
+
+const MAX_EVENTS_PER_SESSION = 10;
+
+export type SentryDsnTarget = {
+  envelopeUrl: string;
+};
+
+/** Parse a Sentry DSN into its envelope ingest URL. Returns null when unusable. */
+export function parseSentryDsn(dsn: string): SentryDsnTarget | null {
+  const match = /^https:\/\/([\w.-]+)@([\w.-]+(?::\d+)?)\/(\d+)$/.exec(dsn.trim());
+  if (!match) return null;
+  const [, publicKey, host, projectId] = match;
+  return {
+    envelopeUrl: `https://${host}/api/${projectId}/envelope/?sentry_key=${publicKey}&sentry_version=7`,
+  };
+}
+
+export type WebErrorMonitoringGate = {
+  dsn: string;
+  deployment: string;
+  electronRuntime: boolean;
+};
+
+/** Pure gate: web deployment only, never inside Electron, and a parseable DSN. */
+export function shouldMonitorWebErrors(input: WebErrorMonitoringGate): boolean {
+  return input.deployment === "web" && !input.electronRuntime && parseSentryDsn(input.dsn) !== null;
+}
+
+export type WebErrorInput = {
+  type: string;
+  message: string;
+  stack?: string;
+  url: string;
+  release?: string;
+  phase: "boot" | "runtime";
+};
+
+export type WebErrorEvent = {
+  event_id: string;
+  timestamp: number;
+  platform: "javascript";
+  level: "error";
+  environment: "web";
+  release?: string;
+  tags: { boot_phase: "boot" | "runtime" };
+  request: { url: string };
+  exception: { values: [{ type: string; value: string }] };
+  extra?: { stack: string };
+};
+
+function newEventId(): string {
+  return crypto.randomUUID().replace(/-/g, "");
+}
+
+/** Build a minimal Sentry error event. Only error identity + coarse context. */
+export function buildWebErrorEvent(input: WebErrorInput): WebErrorEvent {
+  const event: WebErrorEvent = {
+    event_id: newEventId(),
+    timestamp: Date.now() / 1000,
+    platform: "javascript",
+    level: "error",
+    environment: "web",
+    tags: { boot_phase: input.phase },
+    request: { url: input.url },
+    exception: { values: [{ type: input.type, value: input.message.slice(0, 1000) }] },
+  };
+  if (input.release) event.release = input.release;
+  if (input.stack) event.extra = { stack: input.stack.slice(0, 8000) };
+  return event;
+}
+
+/** Serialize an event into a Sentry envelope body. */
+export function buildSentryEnvelope(event: WebErrorEvent): string {
+  const header = JSON.stringify({ event_id: event.event_id, sent_at: new Date().toISOString() });
+  const itemHeader = JSON.stringify({ type: "event" });
+  return `${header}\n${itemHeader}\n${JSON.stringify(event)}`;
+}
+
+let started = false;
+let sentCount = 0;
+const seenErrors = new Set<string>();
+
+function deliver(target: SentryDsnTarget, input: WebErrorInput) {
+  if (sentCount >= MAX_EVENTS_PER_SESSION) return;
+  if (!isAnalyticsEnabled()) return;
+  const dedupeKey = `${input.type}:${input.message}`;
+  if (seenErrors.has(dedupeKey)) return;
+  seenErrors.add(dedupeKey);
+  sentCount += 1;
+  try {
+    void fetch(target.envelopeUrl, {
+      method: "POST",
+      keepalive: true,
+      body: buildSentryEnvelope(buildWebErrorEvent(input)),
+    }).catch(() => {
+      // Network failure — drop silently. Monitoring must never surface errors.
+    });
+  } catch {
+    // fetch unavailable — drop silently.
+  }
+}
+
+function resourceUrl(target: EventTarget | null): string | null {
+  if (target instanceof HTMLScriptElement && target.src) return target.src;
+  if (target instanceof HTMLLinkElement && target.href) return target.href;
+  return null;
+}
+
+/**
+ * One-time setup. Called first thing from the app entry so uncaught errors,
+ * unhandled rejections (including a failed bootstrap await), and lazy-chunk
+ * load failures are reported for web deployments.
+ */
+export function startWebErrorMonitoring() {
+  if (started || typeof window === "undefined") return;
+  const dsn = String(import.meta.env.VITE_OPENWORK_SENTRY_DSN ?? "").trim();
+  const gate: WebErrorMonitoringGate = {
+    dsn,
+    deployment: getOpenWorkDeployment(),
+    electronRuntime: isElectronRuntime(),
+  };
+  if (!shouldMonitorWebErrors(gate)) return;
+  const target = parseSentryDsn(dsn);
+  if (!target) return;
+
+  started = true;
+  // Hand off from the pre-boot beacon in index.html.
+  window.__openworkWebErrorMonitorActive = true;
+  const release = String(import.meta.env.VITE_OPENWORK_BUILD_SHA ?? "").trim()
+    || String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
+
+  window.addEventListener(
+    "error",
+    (event) => {
+      const failedResource = resourceUrl(event.target);
+      if (failedResource) {
+        deliver(target, {
+          type: "ResourceLoadFailure",
+          message: `failed to load ${failedResource}`,
+          url: window.location.href,
+          release,
+          phase: "runtime",
+        });
+        return;
+      }
+      if (!(event instanceof ErrorEvent) || !event.message) return;
+      deliver(target, {
+        type: event.error instanceof Error ? event.error.name : "Error",
+        message: event.message,
+        stack: event.error instanceof Error ? event.error.stack : undefined,
+        url: window.location.href,
+        release,
+        phase: "runtime",
+      });
+    },
+    true,
+  );
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason: unknown = event.reason;
+    deliver(target, {
+      type: reason instanceof Error ? reason.name : "UnhandledRejection",
+      message: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? reason.stack : undefined,
+      url: window.location.href,
+      release,
+      phase: "runtime",
+    });
+  });
+}

--- a/apps/app/src/app/lib/error-monitoring.ts
+++ b/apps/app/src/app/lib/error-monitoring.ts
@@ -54,6 +54,20 @@ export function shouldMonitorWebErrors(input: WebErrorMonitoringGate): boolean {
   return input.deployment === "web" && !input.electronRuntime && parseSentryDsn(input.dsn) !== null;
 }
 
+/**
+ * Strip query and fragment before reporting: sign-in and deep-link URLs can
+ * carry credentials (`grant`, `openworkToken`, `accessToken`) that must never
+ * leave the page.
+ */
+export function sanitizePageUrl(href: string): string {
+  try {
+    const url = new URL(href);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "";
+  }
+}
+
 export type WebErrorInput = {
   type: string;
   message: string;
@@ -129,8 +143,8 @@ function deliver(target: SentryDsnTarget, input: WebErrorInput) {
 }
 
 function resourceUrl(target: EventTarget | null): string | null {
-  if (target instanceof HTMLScriptElement && target.src) return target.src;
-  if (target instanceof HTMLLinkElement && target.href) return target.href;
+  if (target instanceof HTMLScriptElement && target.src) return sanitizePageUrl(target.src) || null;
+  if (target instanceof HTMLLinkElement && target.href) return sanitizePageUrl(target.href) || null;
   return null;
 }
 
@@ -165,7 +179,7 @@ export function startWebErrorMonitoring() {
         deliver(target, {
           type: "ResourceLoadFailure",
           message: `failed to load ${failedResource}`,
-          url: window.location.href,
+          url: sanitizePageUrl(window.location.href),
           release,
           phase: "runtime",
         });
@@ -176,7 +190,7 @@ export function startWebErrorMonitoring() {
         type: event.error instanceof Error ? event.error.name : "Error",
         message: event.message,
         stack: event.error instanceof Error ? event.error.stack : undefined,
-        url: window.location.href,
+        url: sanitizePageUrl(window.location.href),
         release,
         phase: "runtime",
       });
@@ -190,7 +204,7 @@ export function startWebErrorMonitoring() {
       type: reason instanceof Error ? reason.name : "UnhandledRejection",
       message: reason instanceof Error ? reason.message : String(reason),
       stack: reason instanceof Error ? reason.stack : undefined,
-      url: window.location.href,
+      url: sanitizePageUrl(window.location.href),
       release,
       phase: "runtime",
     });

--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, HashRouter } from "react-router";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { initializeDenBootstrapConfig } from "./app/lib/den";
+import { startWebErrorMonitoring } from "./app/lib/error-monitoring";
 import { getOpenWorkDeployment } from "./app/lib/openwork-deployment";
 import { bootstrapTheme } from "./app/theme";
 import { isDesktopRuntime } from "./app/utils";
@@ -21,6 +22,7 @@ import { setWebNotificationHandler } from "./react-app/shell/desktop-notificatio
 import { startDeepLinkBridge } from "./react-app/shell/startup-deep-links";
 import "./app/index.css";
 
+startWebErrorMonitoring();
 bootstrapTheme();
 initLocale();
 startDeepLinkBridge();

--- a/apps/app/tests/error-monitoring.test.ts
+++ b/apps/app/tests/error-monitoring.test.ts
@@ -4,6 +4,7 @@ import {
   buildSentryEnvelope,
   buildWebErrorEvent,
   parseSentryDsn,
+  sanitizePageUrl,
   shouldMonitorWebErrors,
 } from "../src/app/lib/error-monitoring";
 
@@ -44,6 +45,22 @@ describe("shouldMonitorWebErrors", () => {
     expect(
       shouldMonitorWebErrors({ dsn: "%VITE_OPENWORK_SENTRY_DSN%", deployment: "web", electronRuntime: false }),
     ).toBe(false);
+  });
+});
+
+describe("sanitizePageUrl", () => {
+  test("strips credential-bearing query strings and fragments", () => {
+    expect(
+      sanitizePageUrl("https://app.openworklabs.com/signin?grant=secret-grant&openworkToken=tok#accessToken=at"),
+    ).toBe("https://app.openworklabs.com/signin");
+    expect(sanitizePageUrl("https://app.openworklabs.com/chat/abc?accessToken=x")).toBe(
+      "https://app.openworklabs.com/chat/abc",
+    );
+  });
+
+  test("returns empty for unparseable input instead of leaking it", () => {
+    expect(sanitizePageUrl("not a url")).toBe("");
+    expect(sanitizePageUrl("")).toBe("");
   });
 });
 

--- a/apps/app/tests/error-monitoring.test.ts
+++ b/apps/app/tests/error-monitoring.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSentryEnvelope,
+  buildWebErrorEvent,
+  parseSentryDsn,
+  shouldMonitorWebErrors,
+} from "../src/app/lib/error-monitoring";
+
+const DSN = "https://publickey123@o123456.ingest.us.sentry.io/4500000000000000";
+
+describe("parseSentryDsn", () => {
+  test("derives the envelope ingest URL from a valid DSN", () => {
+    expect(parseSentryDsn(DSN)).toEqual({
+      envelopeUrl:
+        "https://o123456.ingest.us.sentry.io/api/4500000000000000/envelope/?sentry_key=publickey123&sentry_version=7",
+    });
+  });
+
+  test("rejects blanks, non-DSN strings, and unreplaced Vite placeholders", () => {
+    expect(parseSentryDsn("")).toBeNull();
+    expect(parseSentryDsn("   ")).toBeNull();
+    expect(parseSentryDsn("not-a-dsn")).toBeNull();
+    expect(parseSentryDsn("%VITE_OPENWORK_SENTRY_DSN%")).toBeNull();
+    expect(parseSentryDsn("http://key@host/1")).toBeNull();
+  });
+});
+
+describe("shouldMonitorWebErrors", () => {
+  test("enables only for a web deployment outside Electron with a valid DSN", () => {
+    expect(shouldMonitorWebErrors({ dsn: DSN, deployment: "web", electronRuntime: false })).toBe(true);
+  });
+
+  test("stays off for desktop builds even with a DSN", () => {
+    expect(shouldMonitorWebErrors({ dsn: DSN, deployment: "desktop", electronRuntime: false })).toBe(false);
+  });
+
+  test("stays off inside Electron even for a web-flavored bundle", () => {
+    expect(shouldMonitorWebErrors({ dsn: DSN, deployment: "web", electronRuntime: true })).toBe(false);
+  });
+
+  test("stays off without a usable DSN", () => {
+    expect(shouldMonitorWebErrors({ dsn: "", deployment: "web", electronRuntime: false })).toBe(false);
+    expect(
+      shouldMonitorWebErrors({ dsn: "%VITE_OPENWORK_SENTRY_DSN%", deployment: "web", electronRuntime: false }),
+    ).toBe(false);
+  });
+});
+
+describe("buildWebErrorEvent", () => {
+  test("carries only error identity and coarse context", () => {
+    const event = buildWebErrorEvent({
+      type: "TypeError",
+      message: "x is not a function",
+      stack: "TypeError: x is not a function\n  at boot",
+      url: "https://app.openworklabs.com/",
+      release: "abc123",
+      phase: "boot",
+    });
+    expect(event.event_id).toMatch(/^[0-9a-f]{32}$/);
+    expect(event.platform).toBe("javascript");
+    expect(event.level).toBe("error");
+    expect(event.environment).toBe("web");
+    expect(event.release).toBe("abc123");
+    expect(event.tags).toEqual({ boot_phase: "boot" });
+    expect(event.request).toEqual({ url: "https://app.openworklabs.com/" });
+    expect(event.exception.values).toEqual([{ type: "TypeError", value: "x is not a function" }]);
+    expect(event.extra).toEqual({ stack: "TypeError: x is not a function\n  at boot" });
+    // Never any user/session/content fields.
+    expect(Object.keys(event).sort()).toEqual([
+      "environment",
+      "event_id",
+      "exception",
+      "extra",
+      "level",
+      "platform",
+      "release",
+      "request",
+      "tags",
+      "timestamp",
+    ]);
+  });
+
+  test("bounds message and stack sizes and omits absent fields", () => {
+    const event = buildWebErrorEvent({
+      type: "Error",
+      message: "m".repeat(5000),
+      url: "https://app.openworklabs.com/",
+      phase: "runtime",
+    });
+    expect(event.exception.values[0].value).toHaveLength(1000);
+    expect(event.release).toBeUndefined();
+    expect(event.extra).toBeUndefined();
+  });
+});
+
+describe("buildSentryEnvelope", () => {
+  test("produces a three-line event envelope", () => {
+    const event = buildWebErrorEvent({
+      type: "Error",
+      message: "boom",
+      url: "https://app.openworklabs.com/",
+      phase: "runtime",
+    });
+    const lines = buildSentryEnvelope(event).split("\n");
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[0]).event_id).toBe(event.event_id);
+    expect(JSON.parse(lines[1])).toEqual({ type: "event" });
+    expect(JSON.parse(lines[2]).exception.values[0].value).toBe("boom");
+  });
+});

--- a/ee/apps/den-api/src/routes/webhooks/stripe.ts
+++ b/ee/apps/den-api/src/routes/webhooks/stripe.ts
@@ -2,6 +2,7 @@ import type { Env, Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { signedWebhookRoute } from "../../middleware/index.js"
+import { captureException } from "../../observability/runtime.js"
 import { handleStripeWebhook } from "../../stripe-billing.js"
 import { jsonResponse } from "../../openapi.js"
 
@@ -30,6 +31,12 @@ export function registerStripeWebhookRoutes<T extends Env>(app: Hono<T>) {
       } catch (error) {
         const message = error instanceof Error ? error.message : "stripe_webhook_failed"
         const status = message.includes("missing") || message.includes("signature") ? 400 : 500
+        if (status === 500) {
+          // This local catch converts the error into a response before the
+          // observability middleware can see it, so report it explicitly:
+          // a silently failing Stripe webhook desynchronizes billing state.
+          captureException(error, { component: "stripe_webhook" })
+        }
         return c.json({ error: message }, status)
       }
     },

--- a/evals/specs/web-error-monitoring.test.ts
+++ b/evals/specs/web-error-monitoring.test.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { briefTest, claim, testBrief } from "@openwork/testkit";
+import {
+  buildSentryEnvelope,
+  buildWebErrorEvent,
+  parseSentryDsn,
+  shouldMonitorWebErrors,
+} from "../../apps/app/src/app/lib/error-monitoring";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+const DSN = "https://publickey123@o123456.ingest.us.sentry.io/4500000000000000";
+
+briefTest(testBrief({
+  behavior: "OpenWork web deployments report boot failures and uncaught runtime errors to Sentry, and Stripe webhook processing failures are captured server-side, all behind explicit deployment gates.",
+  claims: {
+    bootBeaconContract: claim("index.html carries a pre-boot beacon that reports a web instance that fails to load", {
+      never: "activate for desktop builds, builds without a DSN, or after the in-app monitor takes over",
+    }),
+    runtimeMonitorContract: claim("the web bundle starts error monitoring before any bootstrap await and reports only error identity plus coarse context", {
+      never: "run inside Electron, run for desktop deployments, send chat or file content, or bypass the analytics preference",
+    }),
+    billingWebhookContract: claim("a Stripe webhook processing failure is captured to observability while still returning its error response to Stripe", {
+      never: "swallow a webhook processing error unreported or capture routine signature-validation 400s as incidents",
+    }),
+  },
+}), async ({ prove }) => {
+  const [indexHtmlSource, entrySource, monitorSource, webhookRouteSource] = await Promise.all([
+    readFile(join(repoRoot, "apps", "app", "index.html"), "utf8"),
+    readFile(join(repoRoot, "apps", "app", "src", "index.react.tsx"), "utf8"),
+    readFile(join(repoRoot, "apps", "app", "src", "app", "lib", "error-monitoring.ts"), "utf8"),
+    readFile(join(repoRoot, "ee", "apps", "den-api", "src", "routes", "webhooks", "stripe.ts"), "utf8"),
+  ]);
+
+  // Pre-boot beacon: present, deployment- and DSN-gated, defers to the app monitor.
+  expect(indexHtmlSource).toContain('var dsn = "%VITE_OPENWORK_SENTRY_DSN%"');
+  expect(indexHtmlSource).toContain('var deployment = "%VITE_OPENWORK_DEPLOYMENT%"');
+  expect(indexHtmlSource).toContain('if (deployment !== "web" || !dsn || dsn.charAt(0) === "%") return;');
+  expect(indexHtmlSource).toContain("window.__openworkWebErrorMonitorActive === true) return;");
+  expect(indexHtmlSource).toContain("WebBootLoadFailure");
+  expect(indexHtmlSource).toContain("unhandledrejection");
+  expect(indexHtmlSource).toContain("analyticsAllowed");
+  prove.bootBeaconContract(
+    true,
+    "The inline beacon only arms when the built page carries a replaced web deployment marker and a real DSN — an unreplaced %VITE_% placeholder or desktop flavor short-circuits — caps at three events, respects the analytics preference, and stands down once the app monitor sets its handover flag.",
+  );
+
+  // Runtime monitor: gated pure logic, wired first in the entry, minimal payload.
+  expect(shouldMonitorWebErrors({ dsn: DSN, deployment: "web", electronRuntime: false })).toBe(true);
+  expect(shouldMonitorWebErrors({ dsn: DSN, deployment: "desktop", electronRuntime: false })).toBe(false);
+  expect(shouldMonitorWebErrors({ dsn: DSN, deployment: "web", electronRuntime: true })).toBe(false);
+  expect(shouldMonitorWebErrors({ dsn: "", deployment: "web", electronRuntime: false })).toBe(false);
+  expect(shouldMonitorWebErrors({ dsn: "%VITE_OPENWORK_SENTRY_DSN%", deployment: "web", electronRuntime: false })).toBe(false);
+  expect(parseSentryDsn(DSN)).toEqual({
+    envelopeUrl:
+      "https://o123456.ingest.us.sentry.io/api/4500000000000000/envelope/?sentry_key=publickey123&sentry_version=7",
+  });
+  const event = buildWebErrorEvent({
+    type: "TypeError",
+    message: "x is not a function",
+    stack: "TypeError: x is not a function\n  at boot",
+    url: "https://app.openworklabs.com/",
+    release: "abc123",
+    phase: "boot",
+  });
+  expect(Object.keys(event).sort()).toEqual([
+    "environment",
+    "event_id",
+    "exception",
+    "extra",
+    "level",
+    "platform",
+    "release",
+    "request",
+    "tags",
+    "timestamp",
+  ]);
+  expect(event.exception.values).toEqual([{ type: "TypeError", value: "x is not a function" }]);
+  const envelopeLines = buildSentryEnvelope(event).split("\n");
+  expect(envelopeLines).toHaveLength(3);
+  expect(JSON.parse(envelopeLines[1])).toEqual({ type: "event" });
+  expect(entrySource).toMatch(/startWebErrorMonitoring\(\);[\s\S]*await initializeDenBootstrapConfig\(\)/);
+  expect(monitorSource).toContain("if (!isAnalyticsEnabled()) return;");
+  expect(monitorSource).toContain("MAX_EVENTS_PER_SESSION");
+  expect(monitorSource).toContain('window.addEventListener("unhandledrejection"');
+  prove.runtimeMonitorContract(
+    true,
+    "The gate opened only for the exact web-deployment, non-Electron, valid-DSN combination and refused desktop, Electron, blank, and unreplaced-placeholder inputs; monitoring starts before the bootstrap await so a failed boot is itself reported; the event shape carries only error identity, page URL, release, and boot phase with bounded sizes; and delivery checks the analytics preference and a per-session cap.",
+  );
+
+  // Stripe webhook: 500-path capture, 400 signature noise excluded.
+  expect(webhookRouteSource).toContain('captureException(error, { component: "stripe_webhook" })');
+  expect(webhookRouteSource).toMatch(/if \(status === 500\) \{[\s\S]*?captureException/);
+  expect(webhookRouteSource).toMatch(/captureException[\s\S]*?return c\.json\(\{ error: message \}, status\)/);
+  expect(webhookRouteSource).toContain('import { captureException } from "../../observability/runtime.js"');
+  prove.billingWebhookContract(
+    true,
+    "The webhook route's local catch now reports processing failures to observability with a stripe_webhook component tag before returning the same 500 response Stripe uses for retries, while missing-signature 400s stay out of exception capture.",
+  );
+});

--- a/evals/specs/web-error-monitoring.test.ts
+++ b/evals/specs/web-error-monitoring.test.ts
@@ -7,6 +7,7 @@ import {
   buildSentryEnvelope,
   buildWebErrorEvent,
   parseSentryDsn,
+  sanitizePageUrl,
   shouldMonitorWebErrors,
 } from "../../apps/app/src/app/lib/error-monitoring";
 
@@ -21,7 +22,7 @@ briefTest(testBrief({
       never: "activate for desktop builds, builds without a DSN, or after the in-app monitor takes over",
     }),
     runtimeMonitorContract: claim("the web bundle starts error monitoring before any bootstrap await and reports only error identity plus coarse context", {
-      never: "run inside Electron, run for desktop deployments, send chat or file content, or bypass the analytics preference",
+      never: "run inside Electron, run for desktop deployments, send chat or file content, report a URL query string or fragment that could carry sign-in credentials, or bypass the analytics preference",
     }),
     billingWebhookContract: claim("a Stripe webhook processing failure is captured to observability while still returning its error response to Stripe", {
       never: "swallow a webhook processing error unreported or capture routine signature-validation 400s as incidents",
@@ -43,9 +44,11 @@ briefTest(testBrief({
   expect(indexHtmlSource).toContain("WebBootLoadFailure");
   expect(indexHtmlSource).toContain("unhandledrejection");
   expect(indexHtmlSource).toContain("analyticsAllowed");
+  expect(indexHtmlSource).toContain("request: { url: location.origin + location.pathname }");
+  expect(indexHtmlSource).not.toContain("url: location.href");
   prove.bootBeaconContract(
     true,
-    "The inline beacon only arms when the built page carries a replaced web deployment marker and a real DSN — an unreplaced %VITE_% placeholder or desktop flavor short-circuits — caps at three events, respects the analytics preference, and stands down once the app monitor sets its handover flag.",
+    "The inline beacon only arms when the built page carries a replaced web deployment marker and a real DSN — an unreplaced %VITE_% placeholder or desktop flavor short-circuits — caps at three events, respects the analytics preference, reports only origin plus path so sign-in grant or token query parameters never leave the page, and stands down once the app monitor sets its handover flag.",
   );
 
   // Runtime monitor: gated pure logic, wired first in the entry, minimal payload.
@@ -82,13 +85,19 @@ briefTest(testBrief({
   const envelopeLines = buildSentryEnvelope(event).split("\n");
   expect(envelopeLines).toHaveLength(3);
   expect(JSON.parse(envelopeLines[1])).toEqual({ type: "event" });
+  expect(
+    sanitizePageUrl("https://app.openworklabs.com/signin?grant=secret-grant&openworkToken=tok#accessToken=at"),
+  ).toBe("https://app.openworklabs.com/signin");
+  expect(sanitizePageUrl("not a url")).toBe("");
   expect(entrySource).toMatch(/startWebErrorMonitoring\(\);[\s\S]*await initializeDenBootstrapConfig\(\)/);
   expect(monitorSource).toContain("if (!isAnalyticsEnabled()) return;");
   expect(monitorSource).toContain("MAX_EVENTS_PER_SESSION");
   expect(monitorSource).toContain('window.addEventListener("unhandledrejection"');
+  expect(monitorSource).toContain("sanitizePageUrl(window.location.href)");
+  expect(monitorSource).not.toContain("url: window.location.href");
   prove.runtimeMonitorContract(
     true,
-    "The gate opened only for the exact web-deployment, non-Electron, valid-DSN combination and refused desktop, Electron, blank, and unreplaced-placeholder inputs; monitoring starts before the bootstrap await so a failed boot is itself reported; the event shape carries only error identity, page URL, release, and boot phase with bounded sizes; and delivery checks the analytics preference and a per-session cap.",
+    "The gate opened only for the exact web-deployment, non-Electron, valid-DSN combination and refused desktop, Electron, blank, and unreplaced-placeholder inputs; monitoring starts before the bootstrap await so a failed boot is itself reported; the event shape carries only error identity, sanitized origin-plus-path page URL (grant, openworkToken, and accessToken query parameters and fragments are stripped, unparseable input reports empty), release, and boot phase with bounded sizes; and delivery checks the analytics preference and a per-session cap.",
   );
 
   // Stripe webhook: 500-path capture, 400 signature noise excluded.


### PR DESCRIPTION
## Why

Web deployments currently have no error reporting: a web instance that fails to load for a user — or any uncaught runtime error — is invisible. On the billing side, the Stripe webhook route converts processing errors into HTTP responses inside a local catch, so they never reach the observability middleware; a silently failing webhook desynchronizes billing state with only the Stripe dashboard as evidence.

## What

**Web (apps/app)**
- New zero-dependency, env-gated error reporter (`src/app/lib/error-monitoring.ts`), following the same principles as `analytics.ts`: active only when `VITE_OPENWORK_SENTRY_DSN` is set **and** the build is the web deployment (`VITE_OPENWORK_DEPLOYMENT=web`), never inside Electron (desktop keeps its own consent-gated telemetry), respecting the existing `analyticsEnabled` preference. Payloads carry only error type/message/stack, page URL, release, and boot phase — bounded, deduped, capped per session. Started before the bootstrap await so a failed boot is itself reported.
- Inline pre-boot beacon in `index.html` so an entry bundle that never loads (bad deploy, chunk 404, early exception) is still reported; it stands down once the in-app monitor sets `window.__openworkWebErrorMonitorActive`. Inert in desktop and dev builds via unreplaced Vite placeholders (verified in both build flavors).

**Billing (ee/apps/den-api) — trust-boundary note: this touches the billing path.** The change is observability-only: the webhook route's 500 path now calls the existing `captureException` with a `stripe_webhook` component tag before returning the same response Stripe uses for retries. Signature-validation 400s stay excluded. No behavior, auth, or response changes.

## Verification

- `pnpm evals:pr specs/web-error-monitoring.test.ts` — **1 passed, 0 failed, 0 skipped** (new spec: boot-beacon gating contract, runtime-monitor gating/payload contract, webhook capture contract). Lane: local (no Daytona credentials in this environment; local is the documented OSS fallback).
- `bun test tests/error-monitoring.test.ts` (apps/app) — 9 pass, 0 fail.
- `pnpm --filter @openwork/app typecheck` — clean.
- Build gate check: `build:web` with a DSN embeds `deployment="web"` + DSN in `dist/index.html`; plain `build` leaves inert `%VITE_%` placeholders.
- `bun test --conditions development test/stripe-billing.test.ts` (den-api) — pass. Note: `test/route-guard-policy.test.ts` fails identically on clean `dev` (24 uncovered routes unrelated to this change) — pre-existing, reproduced on a clean control tree with the same command.

## Deployment follow-up (not in this PR)

- Create a browser-platform Sentry project (e.g. `web-app`) in the Sentry org and set `VITE_OPENWORK_SENTRY_DSN` in the web build environment. Without it, everything in this PR is a no-op.
- Candidate follow-up: den-web (Next.js dashboard) checkout-page reporting.