### PR TITLE
ci: prune tagged release Daytona snapshots with a 20-newest retention window

### DIFF
--- a/.github/workflows/dev-daytona-snapshot.yml
+++ b/.github/workflows/dev-daytona-snapshot.yml
@@ -248,8 +248,10 @@ jobs:
       # Per-push dev snapshots accumulate forever. Keep the pinned snapshot plus
       # the 5 newest and skip snapshots referenced by active sandboxes. Old
       # stopped/archived sandboxes do not block pruning because they keep their own disks.
-      # This also runs nightly as a pruning backstop when the snapshot already exists.
-      - name: Prune old dev snapshots
+      # This also runs nightly as a pruning backstop when the snapshot already exists,
+      # and additionally prunes tagged release snapshots (keep 20) so old releases
+      # drain even when no new release is published.
+      - name: Prune old dev and release snapshots
         if: steps.channel.outputs.enabled == 'true' && steps.resolve.outcome == 'success'
         shell: bash
         env:
@@ -290,5 +292,20 @@ jobs:
             echo
             echo '```'
             echo "$result"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          release_result="$(node scripts/prune-daytona-dev-snapshots.mjs \
+            ${DAYTONA_API_URL:+--api-url "$DAYTONA_API_URL"} \
+            --channel release \
+            --name-base "${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}" \
+            --keep "$current_pin" \
+            --keep-count 20)"
+          echo "$release_result"
+          {
+            echo "### Daytona release snapshot prune"
+            echo
+            echo '```'
+            echo "$release_result"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -242,3 +242,65 @@ jobs:
             echo
             echo "Triggered a den-api deploy so the new pin takes effect."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Tagged release snapshots accumulate forever without this: nothing else
+      # deletes them and the dev pruner is scoped to `<base>-dev-*` names only.
+      # Keep the just-published snapshot, the current production pin, the 20
+      # newest releases, in-flight builds, and anything an active sandbox still
+      # references. Checked out at the workflow SHA (not the release tag) so
+      # older tags without release-channel support still get pruned.
+      - name: Checkout snapshot prune automation
+        if: steps.publish.outcome == 'success'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          path: .snapshot-prune-automation
+          sparse-checkout: |
+            scripts/prune-daytona-dev-snapshots.mjs
+            scripts/update-daytona-snapshot-pin.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Prune old release snapshots
+        if: steps.publish.outcome == 'success'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_URL: ${{ vars.DAYTONA_API_URL }}
+          DAYTONA_CLOUD_ENV_GROUP_ID: ${{ vars.DAYTONA_CLOUD_ENV_GROUP_ID }}
+          DAYTONA_PIN_CHANNEL: ${{ vars.DAYTONA_PIN_CHANNEL }}
+          DAYTONA_SNAPSHOT_NAME_BASE: ${{ vars.DAYTONA_SNAPSHOT_NAME_BASE }}
+          DAYTONA_SNAPSHOT_NAME: ${{ steps.resolve.outputs.snapshot_name }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          keep_args=(--keep "$DAYTONA_SNAPSHOT_NAME")
+          current_pin=""
+          if [ -n "${DAYTONA_CLOUD_ENV_GROUP_ID:-}" ] && [ -n "${RENDER_API_KEY:-}" ]; then
+            current_pin="$(node .snapshot-prune-automation/scripts/update-daytona-snapshot-pin.mjs \
+              --env-group-id "$DAYTONA_CLOUD_ENV_GROUP_ID" --read || true)"
+          fi
+          if [ -n "$current_pin" ]; then
+            keep_args+=(--keep "$current_pin")
+          elif [ "${DAYTONA_PIN_CHANNEL:-}" != "dev" ]; then
+            # The production pin may be a release snapshot on this channel;
+            # never prune blind to it.
+            echo "::warning::release snapshot prune skipped: current production pin unknown while the engine channel pins releases"
+            echo "release snapshot prune skipped: current production pin unknown" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          result="$(node .snapshot-prune-automation/scripts/prune-daytona-dev-snapshots.mjs \
+            ${DAYTONA_API_URL:+--api-url "$DAYTONA_API_URL"} \
+            --channel release \
+            --name-base "${DAYTONA_SNAPSHOT_NAME_BASE:-openwork}" \
+            "${keep_args[@]}" \
+            --keep-count 20)"
+          echo "$result"
+          {
+            echo "### Daytona release snapshot prune"
+            echo
+            echo '```'
+            echo "$result"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/prune-daytona-dev-snapshots.mjs
+++ b/scripts/prune-daytona-dev-snapshots.mjs
@@ -94,15 +94,28 @@ function compareOldest(left, right) {
   return created || left.name.localeCompare(right.name)
 }
 
-export function selectDevSnapshotPrunes({
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+// Release snapshots are named `<base>-<version>` from validated release tags
+// (see release-daytona-snapshot.yml), so scope on that exact shape. Per-push
+// dev snapshots (`<base>-dev-<sha>`) can never match because "dev" is not a
+// version number.
+function releaseSnapshotPattern(nameBase) {
+  return new RegExp(
+    `^${escapeRegExp(nameBase)}-\\d+\\.\\d+\\.\\d+([.-][0-9A-Za-z.-]+)?$`,
+  )
+}
+
+function selectSnapshotPrunes({
   snapshots,
   sandboxes,
-  nameBase,
+  inScope,
   keepNames,
   keepCount,
 }) {
-  const prefix = `${nameBase}-dev-`
-  const scoped = snapshots.filter((snapshot) => snapshot.name.startsWith(prefix))
+  const scoped = snapshots.filter((snapshot) => inScope(snapshot.name))
   const recentNames = new Set(
     [...scoped].sort(compareNewest).slice(0, keepCount).map((snapshot) => snapshot.name),
   )
@@ -136,6 +149,53 @@ export function selectDevSnapshotPrunes({
   }
 
   return { prune, keep }
+}
+
+export function selectDevSnapshotPrunes({
+  snapshots,
+  sandboxes,
+  nameBase,
+  keepNames,
+  keepCount,
+}) {
+  const prefix = `${nameBase}-dev-`
+  return selectSnapshotPrunes({
+    snapshots,
+    sandboxes,
+    keepNames,
+    keepCount,
+    inScope: (name) => name.startsWith(prefix),
+  })
+}
+
+export function selectReleaseSnapshotPrunes({
+  snapshots,
+  sandboxes,
+  nameBase,
+  keepNames,
+  keepCount,
+}) {
+  const pattern = releaseSnapshotPattern(nameBase)
+  return selectSnapshotPrunes({
+    snapshots,
+    sandboxes,
+    keepNames,
+    keepCount,
+    inScope: (name) => pattern.test(name),
+  })
+}
+
+const CHANNELS = {
+  dev: { select: selectDevSnapshotPrunes, defaultKeepCount: 5 },
+  release: { select: selectReleaseSnapshotPrunes, defaultKeepCount: 20 },
+}
+
+function validateChannel(channel) {
+  if (!Object.hasOwn(CHANNELS, channel)) {
+    throw new Error(`Invalid channel ${JSON.stringify(channel)}. Use dev or release.`)
+  }
+
+  return channel
 }
 
 async function readSnapshots({ apiUrl, apiKey, fetchImpl }) {
@@ -204,25 +264,27 @@ async function readSandboxes({ apiUrl, apiKey, fetchImpl }) {
   throw new Error("Daytona API sandbox pagination exceeded 100 pages.")
 }
 
-export async function pruneDaytonaDevSnapshots({
+export async function pruneDaytonaSnapshots({
   apiUrl = DEFAULT_API_URL,
+  channel = "dev",
   nameBase = "openwork",
   keepNames,
-  keepCount = 5,
+  keepCount,
   dryRun = false,
   apiKey,
   fetchImpl = globalThis.fetch,
   log = console.log,
 }) {
   const baseUrl = requiredValue(apiUrl, "Missing Daytona API URL.").replace(/\/+$/, "")
+  const scope = CHANNELS[validateChannel(channel)]
   const base = requiredValue(nameBase, "Missing snapshot name base.")
   const protectedNames = keepNames.map(validateSnapshotName)
-  const recentCount = validateKeepCount(keepCount)
+  const recentCount = validateKeepCount(keepCount ?? scope.defaultKeepCount)
   authorizationHeaders(apiKey)
 
   const snapshots = await readSnapshots({ apiUrl: baseUrl, apiKey, fetchImpl })
   const sandboxes = await readSandboxes({ apiUrl: baseUrl, apiKey, fetchImpl })
-  const selection = selectDevSnapshotPrunes({
+  const selection = scope.select({
     snapshots,
     sandboxes,
     nameBase: base,
@@ -272,6 +334,9 @@ export async function pruneDaytonaDevSnapshots({
   return result
 }
 
+// Compatibility alias for callers that predate the release channel.
+export const pruneDaytonaDevSnapshots = pruneDaytonaSnapshots
+
 function optionValue(args, index, option) {
   const value = args[index + 1]
   if (!value || value.startsWith("--")) {
@@ -280,16 +345,20 @@ function optionValue(args, index, option) {
   return value
 }
 
-export const USAGE = `Prune old per-push Daytona dev snapshots.
+export const USAGE = `Prune old Daytona engine snapshots.
 
 Usage:
-  node scripts/prune-daytona-dev-snapshots.mjs [--api-url <url>] [--name-base <base>] --keep <name> [--keep <name> ...] [--keep-count <n>] [--dry-run]
+  node scripts/prune-daytona-dev-snapshots.mjs [--api-url <url>] [--channel dev|release] [--name-base <base>] --keep <name> [--keep <name> ...] [--keep-count <n>] [--dry-run]
 
 Options:
   --api-url <url>       Daytona API base URL (default: https://app.daytona.io/api).
+  --channel <channel>   Snapshot family to prune: dev scopes to per-push
+                        <base>-dev-* snapshots, release scopes to tagged
+                        <base>-<version> snapshots (default: dev).
   --name-base <base>    Snapshot name base (default: openwork).
   --keep <name>         Snapshot name to protect; may be repeated.
-  --keep-count <n>      Protect the newest n dev snapshots (default: 5).
+  --keep-count <n>      Protect the newest n in-scope snapshots
+                        (default: 5 for dev, 20 for release).
   --dry-run             Fetch and report without deleting snapshots.
   -h, --help            Show this help.
 
@@ -299,9 +368,10 @@ Environment:
 export function parseArgs(args) {
   const options = {
     apiUrl: DEFAULT_API_URL,
+    channel: "dev",
     nameBase: "openwork",
     keepNames: [],
-    keepCount: 5,
+    keepCount: undefined,
     dryRun: false,
     help: false,
   }
@@ -310,6 +380,9 @@ export function parseArgs(args) {
     const argument = args[index]
     if (argument === "--api-url") {
       options.apiUrl = optionValue(args, index, argument)
+      index += 1
+    } else if (argument === "--channel") {
+      options.channel = validateChannel(optionValue(args, index, argument))
       index += 1
     } else if (argument === "--name-base") {
       options.nameBase = optionValue(args, index, argument)
@@ -350,7 +423,7 @@ export async function main(args, environment = process.env) {
     return { status: "help" }
   }
 
-  return pruneDaytonaDevSnapshots({
+  return pruneDaytonaSnapshots({
     ...options,
     apiKey: environment.DAYTONA_API_KEY,
   })

--- a/scripts/prune-daytona-dev-snapshots.test.mjs
+++ b/scripts/prune-daytona-dev-snapshots.test.mjs
@@ -2,8 +2,11 @@ import assert from "node:assert/strict"
 import test from "node:test"
 
 import {
+  parseArgs,
   pruneDaytonaDevSnapshots,
+  pruneDaytonaSnapshots,
   selectDevSnapshotPrunes,
+  selectReleaseSnapshotPrunes,
 } from "./prune-daytona-dev-snapshots.mjs"
 
 const apiKey = "test-daytona-api-key"
@@ -71,6 +74,115 @@ test("selection prunes only unprotected dev snapshots", () => {
     ["openwork-dev-recent-2", "recent"],
   ])
   assert.equal(result.prune.some((item) => !item.name.startsWith("openwork-dev-")), false)
+})
+
+test("release selection prunes only unprotected release snapshots", () => {
+  const snapshots = [
+    snapshot("old", "openwork-0.18.1", "2026-01-01T00:00:00Z"),
+    snapshot("rc", "openwork-0.18.2-rc.1", "2026-01-02T00:00:00Z"),
+    snapshot("explicit", "openwork-0.18.3", "2026-01-03T00:00:00Z"),
+    snapshot("pulling", "openwork-0.18.4", "2026-01-04T00:00:00Z", "pulling"),
+    snapshot("active", "openwork-0.18.5", "2026-01-05T00:00:00Z"),
+    snapshot("recent-1", "openwork-0.18.6", "2026-01-06T00:00:00Z"),
+    snapshot("recent-2", "openwork-0.18.7", "2026-01-07T00:00:00Z"),
+    snapshot("dev", "openwork-dev-abc1234", "2026-01-08T00:00:00Z"),
+    snapshot("base", "daytonaio/sandbox:0.8.0", "2026-01-09T00:00:00Z"),
+    snapshot("windows", "windows-small", "2026-01-10T00:00:00Z"),
+  ]
+  const sandboxes = [
+    { id: "started", state: "started", snapshot: "openwork-0.18.5" },
+    { id: "stopped", state: "stopped", snapshot: "openwork-0.18.1" },
+  ]
+
+  const result = selectReleaseSnapshotPrunes({
+    snapshots,
+    sandboxes,
+    nameBase: "openwork",
+    keepNames: ["openwork-0.18.3"],
+    keepCount: 2,
+  })
+
+  assert.deepEqual(result.prune.map((item) => item.name), [
+    "openwork-0.18.1",
+    "openwork-0.18.2-rc.1",
+  ])
+  assert.deepEqual(result.keep.map((item) => [item.name, item.reason]), [
+    ["openwork-0.18.3", "explicit"],
+    ["openwork-0.18.4", "in-flight"],
+    ["openwork-0.18.5", "active-ref"],
+    ["openwork-0.18.6", "recent"],
+    ["openwork-0.18.7", "recent"],
+  ])
+  assert.equal(
+    result.prune.concat(result.keep).some((item) => item.name.includes("-dev-")),
+    false,
+  )
+})
+
+test("release channel defaults to keeping the 20 newest release snapshots", async () => {
+  const snapshots = Array.from({ length: 21 }, (_, index) =>
+    snapshot(
+      `release-${index}`,
+      `openwork-0.18.${index}`,
+      `2026-01-${String(index + 1).padStart(2, "0")}T00:00:00Z`,
+    ),
+  )
+  const { calls, fetchImpl } = inventoryFetch(snapshots)
+
+  const result = await pruneDaytonaSnapshots({
+    apiKey,
+    channel: "release",
+    keepNames: ["openwork-0.18.20"],
+    fetchImpl,
+    log: () => {},
+  })
+
+  assert.deepEqual(result.prune.map((item) => item.name), ["openwork-0.18.0"])
+  assert.equal(result.keep.length, 20)
+  assert.deepEqual(
+    calls.filter((call) => call.options.method === "DELETE").map((call) => call.url),
+    [`${apiUrl}/snapshots/release-0`],
+  )
+})
+
+test("release channel never deletes dev snapshots even when unprotected", async () => {
+  const snapshots = [
+    snapshot("dev-old", "openwork-dev-old", "2026-01-01T00:00:00Z"),
+    snapshot("release-old", "openwork-0.18.1", "2026-01-02T00:00:00Z"),
+    snapshot("release-new", "openwork-0.18.2", "2026-01-03T00:00:00Z"),
+  ]
+  const { calls, fetchImpl } = inventoryFetch(snapshots)
+
+  await pruneDaytonaSnapshots({
+    apiKey,
+    channel: "release",
+    keepNames: ["openwork-0.18.2"],
+    keepCount: 1,
+    fetchImpl,
+    log: () => {},
+  })
+
+  assert.deepEqual(
+    calls.filter((call) => call.options.method === "DELETE").map((call) => call.url),
+    [`${apiUrl}/snapshots/release-old`],
+  )
+})
+
+test("parseArgs resolves channel and rejects unknown channels", () => {
+  const options = parseArgs([
+    "--channel",
+    "release",
+    "--keep",
+    "openwork-0.18.2",
+  ])
+  assert.equal(options.channel, "release")
+  assert.equal(options.keepCount, undefined)
+
+  assert.equal(parseArgs(["--keep", "openwork-dev-a"]).channel, "dev")
+  assert.throws(
+    () => parseArgs(["--channel", "nightly", "--keep", "openwork-dev-a"]),
+    /Invalid channel/,
+  )
 })
 
 test("exactly keepCount in-scope snapshots prunes nothing", () => {


### PR DESCRIPTION
## Problem

Release-tagged engine snapshots (`openwork-<version>`, published by `release-daytona-snapshot.yml`) have no retention. The existing pruner in `dev-daytona-snapshot.yml` deliberately scopes to `<base>-dev-*` names, so every tagged release accumulates against Daytona's active-snapshot ceiling forever. The org already runs close to that ceiling, and a quota-exhausted snapshot publish blocks the next release's provisioning and recycles fleet-wide.

## Change

- **`scripts/prune-daytona-dev-snapshots.mjs`**: add a `--channel dev|release` scope. The release scope matches only `<base>-<semver>` names (release-candidate suffixes included, `-dev-` builds never) and defaults to keeping the **20 newest**. All existing protections carry over unchanged: explicit `--keep` names, the current production pin, in-flight builds, and snapshots still referenced by an active sandbox. `pruneDaytonaDevSnapshots` remains exported as a compatibility alias; dev-channel behavior and its keep-5 default are unchanged.
- **`release-daytona-snapshot.yml`**: after a successful publish, prune the release family keeping the just-published snapshot plus the current pin. The prune scripts are checked out at the workflow SHA (same pattern as the pin automation) so older tags prune correctly. If the engine channel pins releases and the pin cannot be read, the prune **skips with a visible `::warning`** rather than running blind.
- **`dev-daytona-snapshot.yml`**: the nightly backstop also prunes the release family, so the already-accumulated release backlog drains without waiting for the next tagged release. On the dev channel the pin is a `-dev-` name and out of release scope, so passing it as an explicit keep is safe in both channel configurations.

## Verification

- `node --test scripts/prune-daytona-dev-snapshots.test.mjs` — **10/10 passed**, including new coverage: release scoping (semver and rc-suffix names in scope; dev/base/windows names out of scope), the 20-newest default via `--channel release`, proof that the release channel never deletes a `-dev-` snapshot even when unprotected, and `parseArgs` channel validation.
- Both workflow files parse as valid YAML; `--help` and invalid-channel CLI paths exercised.
- CI-tooling-only change: no app or Den runtime behavior is touched, so no `evals/specs` run applies. The first live release/nightly run will exercise the workflow steps; both are dry-run-capable via the script's `--dry-run` flag if a manual check is wanted first.