### PR TITLE
feat: route OpenWork chat through opencode v2 behind the preview flag (stage-3 renderer slice)

### DIFF
--- a/apps/app/src/app/lib/opencode-session-native.ts
+++ b/apps/app/src/app/lib/opencode-session-native.ts
@@ -1,6 +1,7 @@
 import type { Message, Part, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, unwrap, type FieldsResult } from "./opencode";
+import { createClientV2, isOpencodeV2BaseUrl } from "./opencode-v2-adapter";
 import type { OpenworkSessionSnapshot } from "./openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "./workspace-endpoint";
 
@@ -20,7 +21,9 @@ export type NativeSessionDependencies = {
 };
 
 function createNativeOperations(endpoint: NativeSessionEndpoint): NativeSessionOperations {
-  const client = createClient(endpoint.opencodeBaseUrl, undefined, { mode: "openwork", token: endpoint.token });
+  const client = isOpencodeV2BaseUrl(endpoint.opencodeBaseUrl)
+    ? createClientV2(endpoint.opencodeBaseUrl, undefined, { token: endpoint.token })
+    : createClient(endpoint.opencodeBaseUrl, undefined, { mode: "openwork", token: endpoint.token });
   return {
     get: (sessionId, options) => client.session.get({ sessionID: sessionId }, options),
     messages: (sessionId, limit, options) => client.session.messages({ sessionID: sessionId, limit }, options),

--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -741,7 +741,7 @@ export function createClientV2(
       const modelResult = await request(
         "POST",
         `/api/session/${encodeURIComponent(parameters.sessionID)}/model`,
-        { providerID: parameters.model.providerID, id: parameters.model.modelID },
+        { model: { providerID: parameters.model.providerID, id: parameters.model.modelID } },
         options?.signal,
       );
       if (!modelResult.response.ok) return failedResult(modelResult);

--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1,0 +1,923 @@
+import type {
+  Model,
+  Provider,
+  ProviderListResponse,
+  Session,
+  TextPart,
+} from "@opencode-ai/sdk/v2/client";
+
+import { createClient, createDesktopFetch, type FieldsResult } from "./opencode";
+import { isDesktopRuntime } from "./runtime-env";
+import type { OpencodeEvent } from "../types";
+
+type RequestOptions = {
+  signal?: AbortSignal;
+  throwOnError?: boolean;
+};
+
+type DirectoryParameters = {
+  directory?: string;
+  workspace?: string;
+};
+
+type SessionParameters = DirectoryParameters & {
+  sessionID: string;
+};
+
+type ModelBinding = {
+  providerID: string;
+  modelID?: string;
+  id?: string;
+};
+
+type PromptPart = {
+  type?: unknown;
+  text?: unknown;
+};
+
+type PromptParameters = SessionParameters & {
+  model?: { providerID: string; modelID: string };
+  parts?: PromptPart[];
+  messageID?: string;
+  agent?: string;
+  noReply?: boolean;
+  tools?: Record<string, boolean>;
+  system?: string;
+  variant?: string;
+  reasoning_effort?: string;
+};
+
+type SessionCreateParameters = DirectoryParameters & {
+  model?: ModelBinding;
+};
+
+type SessionUpdateParameters = SessionParameters & {
+  title?: string;
+  time?: { archived?: number };
+};
+
+type V2MessageRole = "user" | "assistant" | "system";
+
+export type V2MappedMessage = {
+  info: {
+    id: string;
+    sessionID: string;
+    role: V2MessageRole;
+    time: {
+      created: number;
+      completed?: number;
+    };
+  };
+  parts: TextPart[];
+};
+
+type TextStream = {
+  sessionID: string;
+  messageID: string;
+  partID: string;
+  ordinal: number;
+  text: string;
+};
+
+export type V2EventTranslationState = {
+  streams: Map<string, TextStream>;
+  latestStreamKeyBySession: Map<string, string>;
+  nextOrdinalByMessage: Map<string, number>;
+  unknownTypes: Set<string>;
+};
+
+type TransportResult = {
+  payload: unknown;
+  request: Request;
+  response: Response;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRecord(value: unknown, key: string): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const nested = value[key];
+  return isRecord(nested) ? nested : null;
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" ? field : undefined;
+}
+
+function readNumber(value: unknown, key: string): number | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function responseData(value: unknown): unknown {
+  return isRecord(value) && "data" in value ? value.data : value;
+}
+
+function responseItems(value: unknown): unknown[] {
+  const data = responseData(value);
+  return Array.isArray(data) ? data : [];
+}
+
+function eventProperties(value: Record<string, unknown>): Record<string, unknown> {
+  const data = readRecord(value, "data");
+  if (data) return data;
+  const properties = readRecord(value, "properties");
+  return properties ?? value;
+}
+
+function readSessionID(value: Record<string, unknown>): string {
+  return readString(value, "sessionID") ?? readString(value, "sessionId") ?? "";
+}
+
+function readMessageID(value: Record<string, unknown>): string {
+  return readString(value, "assistantMessageID") ?? readString(value, "messageID") ?? readString(value, "messageId") ?? "";
+}
+
+function readTimestamp(value: Record<string, unknown>): number {
+  return readNumber(value, "timestamp") ?? Date.now();
+}
+
+function mapV2Session(value: unknown, directory: string | undefined): Session | null {
+  const data = responseData(value);
+  if (!isRecord(data)) return null;
+  const source = readRecord(data, "info") ?? data;
+  const id = readString(source, "id") ?? readString(source, "sessionID");
+  if (!id) return null;
+  const time = readRecord(source, "time");
+  const location = readRecord(source, "location");
+  const created = readNumber(time, "created") ?? readNumber(source, "created") ?? 0;
+  const updated = readNumber(time, "updated") ?? readNumber(source, "updated") ?? created;
+  const archived = readNumber(time, "archived");
+  const parentID = readString(source, "parentID");
+  const mapped: Session = {
+    id,
+    slug: readString(source, "slug") ?? id,
+    projectID: readString(source, "projectID") ?? "v2",
+    directory: readString(source, "directory") ?? readString(location, "directory") ?? directory ?? "",
+    title: readString(source, "title") ?? "Untitled session",
+    version: readString(source, "version") ?? "v2",
+    time: {
+      created,
+      updated,
+      ...(archived === undefined ? {} : { archived }),
+    },
+    ...(parentID ? { parentID } : {}),
+  };
+  return mapped;
+}
+
+function messageRole(value: Record<string, unknown>): V2MessageRole {
+  const raw = readString(value, "role") ?? readString(value, "type");
+  if (raw === "user") return "user";
+  if (raw === "system" || raw === "synthetic" || raw === "compaction") return "system";
+  return "assistant";
+}
+
+function messageTextEntries(value: Record<string, unknown>): string[] {
+  const content = value.content;
+  if (Array.isArray(content)) {
+    return content.flatMap((entry) => {
+      if (!isRecord(entry) || readString(entry, "type") !== "text") return [];
+      const text = readString(entry, "text");
+      return text === undefined ? [] : [text];
+    });
+  }
+  const text = readString(value, "text");
+  return text === undefined ? [] : [text];
+}
+
+function mapV2Message(value: unknown, sessionID: string): V2MappedMessage | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value, "id") ?? readString(value, "messageID");
+  if (!id) return null;
+  const time = readRecord(value, "time");
+  const created = readNumber(time, "created") ?? readNumber(value, "timestamp") ?? 0;
+  const completed = readNumber(time, "completed");
+  const resolvedSessionID = readString(value, "sessionID") ?? sessionID;
+  const parts = messageTextEntries(value).map<TextPart>((text, ordinal) => ({
+    id: `${id}:${ordinal}`,
+    messageID: id,
+    sessionID: resolvedSessionID,
+    type: "text",
+    text,
+  }));
+  return {
+    info: {
+      id,
+      sessionID: resolvedSessionID,
+      role: messageRole(value),
+      time: {
+        created,
+        ...(completed === undefined ? {} : { completed }),
+      },
+    },
+    parts,
+  };
+}
+
+function modelStatus(value: unknown): Model["status"] {
+  return value === "alpha" || value === "beta" || value === "deprecated" || value === "active"
+    ? value
+    : "active";
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function mapV2Model(value: unknown): Model | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value, "id");
+  const providerID = readString(value, "providerID");
+  if (!id || !providerID) return null;
+  const rawApi = readRecord(value, "api");
+  const rawCapabilities = readRecord(value, "capabilities");
+  const rawLimit = readRecord(value, "limit");
+  const rawTime = readRecord(value, "time");
+  const rawCosts = value.cost;
+  const firstCost = Array.isArray(rawCosts) && rawCosts.length > 0 && isRecord(rawCosts[0])
+    ? rawCosts[0]
+    : isRecord(rawCosts)
+      ? rawCosts
+      : null;
+  const rawCacheCost = readRecord(firstCost, "cache");
+  const inputCapabilities = stringArray(rawCapabilities?.input);
+  const outputCapabilities = stringArray(rawCapabilities?.output);
+  const toolcall = rawCapabilities?.tools === true;
+  const released = readNumber(rawTime, "released");
+  return {
+    id,
+    providerID,
+    api: {
+      id: readString(rawApi, "id") ?? id,
+      url: readString(rawApi, "url") ?? "",
+      npm: readString(rawApi, "npm") ?? readString(rawApi, "package") ?? "",
+    },
+    name: readString(value, "name") ?? id,
+    capabilities: {
+      temperature: false,
+      reasoning: outputCapabilities.includes("reasoning"),
+      attachment: inputCapabilities.some((kind) => kind !== "text"),
+      toolcall,
+      input: {
+        text: inputCapabilities.length === 0 || inputCapabilities.includes("text"),
+        audio: inputCapabilities.includes("audio"),
+        image: inputCapabilities.includes("image"),
+        video: inputCapabilities.includes("video"),
+        pdf: inputCapabilities.includes("pdf"),
+      },
+      output: {
+        text: outputCapabilities.length === 0 || outputCapabilities.includes("text"),
+        audio: outputCapabilities.includes("audio"),
+        image: outputCapabilities.includes("image"),
+        video: outputCapabilities.includes("video"),
+        pdf: outputCapabilities.includes("pdf"),
+      },
+      interleaved: false,
+    },
+    cost: {
+      input: readNumber(firstCost, "input") ?? 0,
+      output: readNumber(firstCost, "output") ?? 0,
+      cache: {
+        read: readNumber(rawCacheCost, "read") ?? 0,
+        write: readNumber(rawCacheCost, "write") ?? 0,
+      },
+    },
+    limit: {
+      context: readNumber(rawLimit, "context") ?? 0,
+      output: readNumber(rawLimit, "output") ?? 0,
+      ...(readNumber(rawLimit, "input") === undefined ? {} : { input: readNumber(rawLimit, "input") }),
+    },
+    status: modelStatus(value.status),
+    options: {},
+    headers: {},
+    release_date: released === undefined ? "" : new Date(released).toISOString(),
+  };
+}
+
+function mapDefaultModels(value: unknown): Record<string, string> {
+  const data = responseData(value);
+  const defaults: Record<string, string> = {};
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      if (!isRecord(item)) continue;
+      const providerID = readString(item, "providerID");
+      const modelID = readString(item, "modelID") ?? readString(item, "id");
+      if (providerID && modelID) defaults[providerID] = modelID;
+    }
+    return defaults;
+  }
+  if (!isRecord(data)) return defaults;
+  const providerID = readString(data, "providerID");
+  const modelID = readString(data, "modelID") ?? readString(data, "id");
+  if (providerID && modelID) defaults[providerID] = modelID;
+  for (const [key, item] of Object.entries(data)) {
+    if (typeof item === "string") defaults[key] = item;
+  }
+  return defaults;
+}
+
+function errorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  if (isRecord(value)) {
+    const direct = readString(value, "message");
+    if (direct) return direct;
+    if ("error" in value) return errorMessage(value.error);
+  }
+  try {
+    return JSON.stringify(value) || "OpenCode v2 execution failed.";
+  } catch {
+    return "OpenCode v2 execution failed.";
+  }
+}
+
+function streamKey(properties: Record<string, unknown>, sessionID: string, messageID: string): string {
+  const explicit = readString(properties, "textID") ?? readString(properties, "textId");
+  if (explicit) return explicit;
+  const ordinal = readNumber(properties, "ordinal");
+  // v2 emits one text stream per (assistantMessageID, ordinal); keying on the
+  // event-provided ordinal keeps multi-part messages from merging into one part.
+  return ordinal === undefined ? `${sessionID}:${messageID}` : `${messageID}:${ordinal}`;
+}
+
+function resolveTextStream(
+  properties: Record<string, unknown>,
+  state: V2EventTranslationState,
+): TextStream | null {
+  const sessionID = readSessionID(properties);
+  const messageID = readMessageID(properties);
+  const explicitKey = streamKey(properties, sessionID, messageID);
+  const byExplicitKey = state.streams.get(explicitKey);
+  if (byExplicitKey) return byExplicitKey;
+  const latestKey = sessionID ? state.latestStreamKeyBySession.get(sessionID) : undefined;
+  if (latestKey) return state.streams.get(latestKey) ?? null;
+  return null;
+}
+
+function terminalEvents(sessionID: string, error?: unknown): OpencodeEvent[] {
+  const events: OpencodeEvent[] = [];
+  if (error !== undefined) {
+    events.push({
+      type: "session.error",
+      properties: {
+        sessionID,
+        error: { name: "UnknownError", data: { message: errorMessage(error) } },
+      },
+    });
+  }
+  events.push(
+    { type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+    { type: "session.idle", properties: { sessionID } },
+  );
+  return events;
+}
+
+export function createV2EventTranslationState(): V2EventTranslationState {
+  return {
+    streams: new Map(),
+    latestStreamKeyBySession: new Map(),
+    nextOrdinalByMessage: new Map(),
+    unknownTypes: new Set(),
+  };
+}
+
+export function translateV2Event(
+  value: unknown,
+  state: V2EventTranslationState,
+): OpencodeEvent[] | null {
+  if (!isRecord(value)) return null;
+  const type = readString(value, "type");
+  if (!type) return null;
+  const properties = eventProperties(value);
+  const sessionID = readSessionID(properties);
+
+  if (type === "session.execution.started") {
+    if (!sessionID) return null;
+    return [{ type: "session.status", properties: { sessionID, status: { type: "busy" } } }];
+  }
+
+  if (type === "session.text.started" || type === "session.next.text.started") {
+    const messageID = readMessageID(properties);
+    if (!sessionID || !messageID) return null;
+    const key = streamKey(properties, sessionID, messageID);
+    const existing = state.streams.get(key);
+    const ordinal = readNumber(properties, "ordinal")
+      ?? existing?.ordinal
+      ?? state.nextOrdinalByMessage.get(messageID)
+      ?? 0;
+    const stream = existing ?? {
+      sessionID,
+      messageID,
+      partID: `${messageID}:${ordinal}`,
+      ordinal,
+      text: "",
+    };
+    state.streams.set(key, stream);
+    state.latestStreamKeyBySession.set(sessionID, key);
+    if (!existing) state.nextOrdinalByMessage.set(messageID, ordinal + 1);
+    const part: TextPart = {
+      id: stream.partID,
+      messageID,
+      sessionID,
+      type: "text",
+      text: "",
+    };
+    return [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: messageID,
+            sessionID,
+            role: "assistant",
+            time: { created: readTimestamp(properties) },
+          },
+        },
+      },
+      { type: "message.part.updated", properties: { part } },
+    ];
+  }
+
+  if (type === "session.text.delta" || type === "session.next.text.delta") {
+    const stream = resolveTextStream(properties, state);
+    const delta = readString(properties, "delta");
+    if (!stream || delta === undefined) return null;
+    stream.text += delta;
+    return [{
+      type: "message.part.delta",
+      properties: {
+        sessionID: stream.sessionID,
+        messageID: stream.messageID,
+        partID: stream.partID,
+        field: "text",
+        delta,
+      },
+    }];
+  }
+
+  if (type === "session.text.ended" || type === "session.next.text.ended") {
+    const stream = resolveTextStream(properties, state);
+    if (!stream) return null;
+    const fullText = readString(properties, "text");
+    if (fullText !== undefined) stream.text = fullText;
+    const part: TextPart = {
+      id: stream.partID,
+      messageID: stream.messageID,
+      sessionID: stream.sessionID,
+      type: "text",
+      text: stream.text,
+    };
+    return [{ type: "message.part.updated", properties: { part } }];
+  }
+
+  if (
+    type === "session.execution.succeeded" ||
+    type === "session.execution.interrupted"
+  ) {
+    return sessionID ? terminalEvents(sessionID) : null;
+  }
+
+  if (type === "session.execution.failed") {
+    return sessionID ? terminalEvents(sessionID, properties.error ?? properties) : null;
+  }
+
+  if (type === "session.status") {
+    if (!sessionID || !isRecord(properties.status)) return null;
+    return [{ type: "session.status", properties: { sessionID, status: properties.status } }];
+  }
+
+  if (type === "session.idle") {
+    return sessionID ? [{ type: "session.idle", properties: { sessionID } }] : null;
+  }
+
+  if (type === "session.created" || type === "session.renamed") {
+    const info = mapV2Session(properties, undefined);
+    if (!info) return null;
+    return [{
+      type: type === "session.created" ? "session.created" : "session.updated",
+      properties: { info },
+    }];
+  }
+
+  if (type === "session.deleted") {
+    const info = mapV2Session(properties, undefined);
+    const deletedSessionID = sessionID || info?.id || "";
+    if (!deletedSessionID) return null;
+    return [{
+      type: "session.deleted",
+      properties: { sessionID: deletedSessionID, ...(info ? { info } : {}) },
+    }];
+  }
+
+  if (!state.unknownTypes.has(type)) {
+    state.unknownTypes.add(type);
+    console.debug(`[opencode-v2] skipping unsupported event type: ${type}`);
+  }
+  return null;
+}
+
+async function* translateV2Events(
+  response: Response,
+  signal: AbortSignal | undefined,
+): AsyncGenerator<OpencodeEvent> {
+  if (!response.body) return;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const state = createV2EventTranslationState();
+  let buffer = "";
+  try {
+    while (!signal?.aborted) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data:")) continue;
+        const text = line.slice("data:".length).trim();
+        if (!text) continue;
+        let event: unknown;
+        try {
+          event = JSON.parse(text);
+        } catch {
+          continue;
+        }
+        const translated = translateV2Event(event, state);
+        if (!translated) continue;
+        for (const item of translated) yield item;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function createWebFetch(auth: { token?: string }): typeof globalThis.fetch {
+  return (input, init) => {
+    const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+    if (auth.token && !headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${auth.token}`);
+    }
+    if (input instanceof Request) {
+      return globalThis.fetch(new Request(input, { headers }), init);
+    }
+    return globalThis.fetch(input, { ...init, headers });
+  };
+}
+
+function createV2Fetch(auth: { token?: string }): typeof globalThis.fetch {
+  return isDesktopRuntime()
+    ? createDesktopFetch({ mode: "openwork", token: auth.token })
+    : createWebFetch(auth);
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+  if (response.status === 204) return null;
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function successfulResult<T>(transport: TransportResult, data: T): FieldsResult<T> {
+  return { data, request: transport.request, response: transport.response };
+}
+
+function failedResult<T>(transport: TransportResult): FieldsResult<T> {
+  return {
+    error: transport.payload ?? { name: "OpenCodeV2RequestFailed" },
+    request: transport.request,
+    response: transport.response,
+  };
+}
+
+function localResult<T>(baseUrl: string, path: string, data: T): FieldsResult<T> {
+  return {
+    data,
+    request: new Request(`${baseUrl}${path}`),
+    response: new Response(null, { status: 200 }),
+  };
+}
+
+function unsupportedResult<T>(baseUrl: string, operation: string): FieldsResult<T> {
+  return {
+    error: { name: "UnsupportedInV2Preview", operation },
+    request: new Request(`${baseUrl}/unsupported/${encodeURIComponent(operation)}`),
+    response: new Response(null, { status: 501, statusText: "Unsupported in OpenCode v2 preview" }),
+  };
+}
+
+export function isOpencodeV2BaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).pathname.replace(/\/+$/, "").endsWith("/opencode2");
+  } catch {
+    return baseUrl.replace(/\/+$/, "").endsWith("/opencode2");
+  }
+}
+
+export function createClientV2(
+  opencode2BaseUrl: string,
+  directory: string | undefined,
+  auth: { token?: string },
+): ReturnType<typeof createClient> {
+  const baseUrl = opencode2BaseUrl.replace(/\/+$/, "");
+  const fetchImpl = createV2Fetch(auth);
+  const compatibilityClient = createClient(baseUrl, directory, { mode: "openwork", token: auth.token });
+
+  const request = async (
+    method: string,
+    path: string,
+    body?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<TransportResult> => {
+    const headers = new Headers();
+    if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
+    if (body) headers.set("Content-Type", "application/json");
+    const transportRequest = new Request(`${baseUrl}${path}`, {
+      method,
+      headers,
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      ...(signal ? { signal } : {}),
+    });
+    const response = await fetchImpl(transportRequest);
+    return { payload: await readPayload(response), request: transportRequest, response };
+  };
+
+  const getSession = async (
+    parameters: SessionParameters,
+    options?: RequestOptions,
+  ): Promise<FieldsResult<Session>> => {
+    const result = await request("GET", `/api/session/${encodeURIComponent(parameters.sessionID)}`, undefined, options?.signal);
+    if (!result.response.ok) return failedResult(result);
+    const session = mapV2Session(result.payload, directory);
+    if (session) return successfulResult(result, session);
+    return failedResult({ ...result, payload: { name: "InvalidV2SessionResponse" } });
+  };
+
+  const createSession = async (
+    parameters: SessionCreateParameters = {},
+    options?: RequestOptions,
+  ): Promise<FieldsResult<Session>> => {
+    const modelID = parameters.model?.id ?? parameters.model?.modelID;
+    const model = parameters.model && modelID
+      ? { providerID: parameters.model.providerID, id: modelID }
+      : undefined;
+    // v2 binds a session's location through the create BODY; the query-param
+    // location middleware does not apply to session.create (verified against
+    // the running engine: query-only creates land in the engine cwd project).
+    const location = parameters.directory ?? directory;
+    const result = await request("POST", "/api/session", {
+      ...(model ? { model } : {}),
+      ...(location ? { location: { directory: location } } : {}),
+    }, options?.signal);
+    if (!result.response.ok) return failedResult(result);
+    const session = mapV2Session(result.payload, directory);
+    if (session) return successfulResult(result, session);
+    return failedResult({ ...result, payload: { name: "InvalidV2SessionResponse" } });
+  };
+
+  const session = {
+    list: async (
+      parameters: DirectoryParameters & { limit?: number } = {},
+      options?: RequestOptions,
+    ): Promise<FieldsResult<Session[]>> => {
+      const query = new URLSearchParams();
+      if (parameters.limit !== undefined) query.set("limit", String(parameters.limit));
+      const suffix = query.size ? `?${query.toString()}` : "";
+      const result = await request("GET", `/api/session${suffix}`, undefined, options?.signal);
+      if (!result.response.ok) return failedResult(result);
+      const data = responseItems(result.payload).flatMap((item) => {
+        const mapped = mapV2Session(item, directory);
+        return mapped ? [mapped] : [];
+      });
+      return successfulResult(result, data);
+    },
+    create: createSession,
+    get: getSession,
+    messages: async (
+      parameters: SessionParameters & { limit?: number; before?: string },
+      options?: RequestOptions,
+    ): Promise<FieldsResult<V2MappedMessage[]>> => {
+      const query = new URLSearchParams();
+      if (parameters.limit !== undefined) query.set("limit", String(parameters.limit));
+      const suffix = query.size ? `?${query.toString()}` : "";
+      const result = await request(
+        "GET",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/message${suffix}`,
+        undefined,
+        options?.signal,
+      );
+      if (!result.response.ok) return failedResult(result);
+      const data = responseItems(result.payload).flatMap((item) => {
+        const mapped = mapV2Message(item, parameters.sessionID);
+        return mapped ? [mapped] : [];
+      });
+      return successfulResult(result, data);
+    },
+    todo: async (parameters: SessionParameters): Promise<FieldsResult<never[]>> =>
+      localResult(baseUrl, `/api/session/${encodeURIComponent(parameters.sessionID)}/todo`, []),
+    status: async (): Promise<FieldsResult<Record<string, never>>> =>
+      localResult(baseUrl, "/api/session/status", {}),
+    promptAsync: async (
+      parameters: PromptParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<Record<string, never>>> => {
+      if (!parameters.model) {
+        return {
+          error: { name: "ModelRequiredInV2Preview" },
+          request: new Request(`${baseUrl}/api/session/${encodeURIComponent(parameters.sessionID)}/model`),
+          response: new Response(null, { status: 400 }),
+        };
+      }
+      const modelResult = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/model`,
+        { providerID: parameters.model.providerID, id: parameters.model.modelID },
+        options?.signal,
+      );
+      if (!modelResult.response.ok) return failedResult(modelResult);
+      const text = (parameters.parts ?? [])
+        .filter((part) => part.type === "text" && typeof part.text === "string")
+        .map((part) => typeof part.text === "string" ? part.text : "")
+        .join("");
+      const promptResult = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/prompt`,
+        { text },
+        options?.signal,
+      );
+      if (!promptResult.response.ok) return failedResult(promptResult);
+      return successfulResult(promptResult, {});
+    },
+    abort: async (
+      parameters: SessionParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<boolean>> => {
+      const result = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/interrupt`,
+        {},
+        options?.signal,
+      );
+      return result.response.ok ? successfulResult(result, true) : failedResult(result);
+    },
+    update: async (
+      parameters: SessionUpdateParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<Session>> => {
+      if (!parameters.title) return getSession(parameters, options);
+      const result = await request(
+        "POST",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/rename`,
+        { title: parameters.title },
+        options?.signal,
+      );
+      if (!result.response.ok) return failedResult(result);
+      const mapped = mapV2Session(result.payload, directory);
+      return mapped ? successfulResult(result, mapped) : getSession(parameters, options);
+    },
+    delete: async (
+      parameters: SessionParameters,
+      options?: RequestOptions,
+    ): Promise<FieldsResult<boolean>> => {
+      const result = await request(
+        "DELETE",
+        `/api/session/${encodeURIComponent(parameters.sessionID)}`,
+        undefined,
+        options?.signal,
+      );
+      return result.response.ok ? successfulResult(result, true) : failedResult(result);
+    },
+    fork: async (): Promise<FieldsResult<Session>> => unsupportedResult(baseUrl, "session.fork"),
+    revert: async (): Promise<FieldsResult<Session>> => unsupportedResult(baseUrl, "session.revert"),
+    unrevert: async (): Promise<FieldsResult<Session>> => unsupportedResult(baseUrl, "session.unrevert"),
+    summarize: async (): Promise<FieldsResult<boolean>> => unsupportedResult(baseUrl, "session.summarize"),
+    shell: async (): Promise<FieldsResult<Record<string, never>>> => unsupportedResult(baseUrl, "session.shell"),
+    command: async (): Promise<FieldsResult<Record<string, never>>> => unsupportedResult(baseUrl, "session.command"),
+  };
+
+  const adapter = {
+    global: {
+      health: async (options?: RequestOptions): Promise<FieldsResult<{ healthy: boolean; version: string }>> => {
+        const result = await request("GET", "/api/health", undefined, options?.signal);
+        if (!result.response.ok) return failedResult(result);
+        const data = responseData(result.payload);
+        return successfulResult(result, {
+          healthy: isRecord(data) && data.healthy === true,
+          version: readString(data, "version") ?? "v2",
+        });
+      },
+    },
+    session,
+    config: {
+      get: async (): Promise<FieldsResult<Record<string, never>>> => localResult(baseUrl, "/api/config", {}),
+    },
+    provider: {
+      list: async (
+        _parameters: DirectoryParameters = {},
+        options?: RequestOptions,
+      ): Promise<FieldsResult<ProviderListResponse>> => {
+        const modelsResult = await request("GET", "/api/model", undefined, options?.signal);
+        if (!modelsResult.response.ok) return failedResult(modelsResult);
+        const defaultsResult = await request("GET", "/api/model/default", undefined, options?.signal);
+        const models = responseItems(modelsResult.payload).flatMap((item) => {
+          const mapped = mapV2Model(item);
+          return mapped ? [mapped] : [];
+        });
+        const providersByID = new Map<string, Provider>();
+        for (const model of models) {
+          const current = providersByID.get(model.providerID);
+          if (current) {
+            current.models[model.id] = model;
+            continue;
+          }
+          providersByID.set(model.providerID, {
+            id: model.providerID,
+            name: model.providerID,
+            source: "config",
+            env: [],
+            options: {},
+            models: { [model.id]: model },
+          });
+        }
+        const all = [...providersByID.values()];
+        return successfulResult(modelsResult, {
+          all,
+          connected: all.map((provider) => provider.id),
+          default: defaultsResult.response.ok ? mapDefaultModels(defaultsResult.payload) : {},
+        });
+      },
+    },
+    app: {
+      agents: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/agent", []),
+    },
+    command: {
+      list: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/command", []),
+    },
+    permission: {
+      list: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/permission", []),
+    },
+    question: {
+      list: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/question", []),
+    },
+    v2: {
+      session: {
+        permission: {
+          list: async (): Promise<FieldsResult<{ data: never[] }>> =>
+            localResult(baseUrl, "/api/session/permission", { data: [] }),
+        },
+      },
+    },
+    find: {
+      files: async (): Promise<FieldsResult<never[]>> => localResult(baseUrl, "/api/fs/find", []),
+    },
+    mcp: {
+      status: async (): Promise<FieldsResult<Record<string, never>>> => localResult(baseUrl, "/api/mcp", {}),
+    },
+    event: {
+      subscribe: async (
+        _parameters?: DirectoryParameters,
+        options?: RequestOptions,
+      ): Promise<{ stream: AsyncGenerator<OpencodeEvent> }> => {
+        const headers = new Headers({ Accept: "text/event-stream" });
+        if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
+        const eventRequest = new Request(`${baseUrl}/api/event`, {
+          headers,
+          ...(options?.signal ? { signal: options.signal } : {}),
+        });
+        const response = await fetchImpl(eventRequest);
+        if (!response.ok) {
+          const error = new Error(errorMessage(await readPayload(response)));
+          Object.assign(error, { status: response.status, response });
+          throw error;
+        }
+        return { stream: translateV2Events(response, options?.signal) };
+      },
+    },
+  };
+
+  Object.assign(compatibilityClient.global, adapter.global);
+  Object.assign(compatibilityClient.session, adapter.session);
+  Object.assign(compatibilityClient.config, adapter.config);
+  Object.assign(compatibilityClient.provider, adapter.provider);
+  Object.assign(compatibilityClient.app, adapter.app);
+  Object.assign(compatibilityClient.command, adapter.command);
+  Object.assign(compatibilityClient.permission, adapter.permission);
+  Object.assign(compatibilityClient.question, adapter.question);
+  Object.assign(compatibilityClient.v2.session.permission, adapter.v2.session.permission);
+  Object.assign(compatibilityClient.find, adapter.find);
+  Object.assign(compatibilityClient.mcp, adapter.mcp);
+  Object.assign(compatibilityClient.event, adapter.event);
+  return compatibilityClient;
+}
+
+export type OpencodeV2Client = ReturnType<typeof createClientV2>;

--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -217,7 +217,7 @@ function nativeFetchRef(): typeof globalThis.fetch {
   return globalThis.fetch as typeof globalThis.fetch;
 }
 
-const createDesktopFetch = (auth?: OpencodeAuth) => {
+export const createDesktopFetch = (auth?: OpencodeAuth) => {
   const authHeader = resolveAuthHeader(auth);
   const addAuth = (headers: Headers) => {
     if (!authHeader || headers.has("Authorization")) return;

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -69,6 +69,7 @@ export type OpenworkCloudProviderSyncStatus = {
 export interface EngineV2PreviewStatus {
   enabled: boolean;
   running: boolean;
+  chatRouting: boolean;
   version?: string;
   pid?: number;
   binSource?: string;
@@ -93,6 +94,7 @@ function parseEngineV2PreviewStatus(value: unknown): EngineV2PreviewStatus {
   return {
     enabled: value.enabled,
     running: value.running,
+    chatRouting: "chatRouting" in value && typeof value.chatRouting === "boolean" ? value.chatRouting : false,
     version: "version" in value && typeof value.version === "string" ? value.version : undefined,
     pid: "pid" in value && typeof value.pid === "number" ? value.pid : undefined,
     binSource: "binSource" in value && typeof value.binSource === "string" ? value.binSource : undefined,
@@ -1568,6 +1570,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         token,
         method: "PUT",
         body: { enabled },
+        timeoutMs: timeouts.config,
+      })),
+    setEngineV2PreviewChatRouting: async (chatRouting: boolean): Promise<EngineV2PreviewStatus> =>
+      parseEngineV2PreviewStatus(await requestJson<unknown>(baseUrl, "/experimental/engine-v2-preview", {
+        token,
+        method: "PUT",
+        body: { chatRouting },
         timeoutMs: timeouts.config,
       })),
     setConnectState: (connectEnabled: boolean) => requestJson<OpenworkConnectState>(baseUrl, "/experimental/connect/state", { token, hostToken, method: "PUT", body: { connectEnabled }, timeoutMs: timeouts.config }),

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -6,6 +6,7 @@ import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
+import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { isGeneratedSessionTitle } from "@/app/lib/session-title";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
@@ -144,14 +145,20 @@ type SessionStatusFetcher = (
   signal: AbortSignal,
 ) => Promise<Record<string, SessionStatus>>;
 
+function createSyncClient(baseUrl: string, openworkToken: string) {
+  return isOpencodeV2BaseUrl(baseUrl)
+    ? createClientV2(baseUrl, undefined, { token: openworkToken })
+    : createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+}
+
 const defaultSyncSubscriptionFactory: SyncSubscriptionFactory = async (baseUrl, openworkToken, signal) => {
-  const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+  const client = createSyncClient(baseUrl, openworkToken);
   const subscription = await client.event.subscribe(undefined, { signal });
   return subscription.stream;
 };
 
 const defaultSessionStatusFetcher: SessionStatusFetcher = async (baseUrl, openworkToken, signal) => {
-  const client = createClient(baseUrl, undefined, { token: openworkToken, mode: "openwork" });
+  const client = createSyncClient(baseUrl, openworkToken);
   const result = await client.session.status(undefined, { signal });
   if (result.data !== undefined) return result.data;
   throw result.error;
@@ -1242,7 +1249,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   };
   created.titleRecovery = createSessionTitleRecovery({
     fetch: async (sessionId) => {
-      const client = createClient(input.baseUrl, undefined, { token: created.openworkToken, mode: "openwork" });
+      const client = createSyncClient(input.baseUrl, created.openworkToken);
       const [session, messages] = await Promise.all([
         client.session.get({ sessionID: sessionId }).then(unwrap),
         client.session.messages({ sessionID: sessionId, limit: 20 }).then(unwrap),

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -774,6 +774,7 @@ export function AdvancedFeatureFlagsSection(props: AdvancedFeatureFlagsSectionPr
 interface AdvancedEngineV2PreviewSectionProps {
   getStatus: () => Promise<EngineV2PreviewStatus>;
   setEnabled: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
+  setChatRouting: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
 }
 
 export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSectionProps) {
@@ -822,9 +823,21 @@ export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSec
     }
   };
 
+  const setChatRouting = async (enabled: boolean) => {
+    setBusy(true);
+    setLoadError(null);
+    try {
+      setStatus(await props.setChatRouting(enabled));
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : "Failed to update OpenCode v2 chat routing.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const skippedCount = status?.skippedProviderIds.length ?? 0;
   const runningStatus = status?.enabled && status.running
-    ? `Running v${status.version ?? "unknown"} (pid ${status.pid ?? "unknown"}) — ${status.mirroredProviderIds.length} providers mirrored, ${status.catalogModelIds.length} models${skippedCount ? `, ${skippedCount} skipped` : ""}`
+    ? `Running v${status.version ?? "unknown"} (pid ${status.pid ?? "unknown"}) — ${status.mirroredProviderIds.length} providers mirrored, ${status.catalogModelIds.length} models${skippedCount ? `, ${skippedCount} skipped` : ""}${status.chatRouting ? " — chat routed to v2" : ""}`
     : null;
   const error = (status?.enabled && !status.running ? status.lastError : null) ?? loadError;
   const starting = status?.enabled && !status.running && !error ? "Starting the OpenCode v2 sidecar…" : null;
@@ -839,7 +852,7 @@ export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSec
         <LayoutSectionItemHeader>
           <LayoutSectionItemTitle>OpenCode v2 engine preview</LayoutSectionItemTitle>
           <LayoutSectionItemDescription>
-            Experimental: runs the OpenCode v2 engine as a parallel sidecar and mirrors provider changes into it live — no engine reload. The app keeps using the current engine.
+            Experimental: runs the OpenCode v2 engine as a parallel sidecar and mirrors provider changes into it live — no engine reload.
           </LayoutSectionItemDescription>
           <LayoutSectionItemHeaderActions>
             <Switch
@@ -854,6 +867,25 @@ export function AdvancedEngineV2PreviewSection(props: AdvancedEngineV2PreviewSec
         {starting ? <div className="text-xs text-gray-11">{starting}</div> : null}
         {error ? <div className="text-xs text-red-11">{error}</div> : null}
       </LayoutSectionItem>
+
+      {status?.enabled ? (
+        <LayoutSectionItem>
+          <LayoutSectionItemHeader>
+            <LayoutSectionItemTitle>Route chat through OpenCode v2</LayoutSectionItemTitle>
+            <LayoutSectionItemDescription>
+              Text chat uses the preview sidecar. Unsupported commands, tools, permissions, and file search remain unavailable in this preview.
+            </LayoutSectionItemDescription>
+            <LayoutSectionItemHeaderActions>
+              <Switch
+                aria-label="Route chat through OpenCode v2"
+                checked={status.chatRouting}
+                disabled={!status.running || busy}
+                onCheckedChange={(enabled) => { void setChatRouting(enabled); }}
+              />
+            </LayoutSectionItemHeaderActions>
+          </LayoutSectionItemHeader>
+        </LayoutSectionItem>
+      ) : null}
     </LayoutSection>
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -50,6 +50,7 @@ export type AdvancedViewProps = {
   refreshCloudMcpHealth: () => Promise<OpenworkCloudMcpHealth | null>;
   getEngineV2PreviewStatus: () => Promise<EngineV2PreviewStatus>;
   setEngineV2PreviewEnabled: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
+  setEngineV2PreviewChatRouting: (enabled: boolean) => Promise<EngineV2PreviewStatus>;
 };
 
 type AdvancedStatusTone = "ready" | "warning" | "error" | "neutral";
@@ -199,6 +200,7 @@ export function AdvancedView(props: AdvancedViewProps) {
       <AdvancedEngineV2PreviewSection
         getStatus={props.getEngineV2PreviewStatus}
         setEnabled={props.setEngineV2PreviewEnabled}
+        setChatRouting={props.setEngineV2PreviewChatRouting}
       />
 
       <AdvancedDeveloperSection

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2210,11 +2210,13 @@ export function SessionRoute() {
     if (!endpoint || !endpoint.token) {
       return null;
     }
-    const workspaceClient = createClient(
-      endpoint.opencodeBaseUrl,
-      workspace.path?.trim() || undefined,
-      { token: endpoint.token, mode: "openwork" },
-    );
+    const workspaceClient = workspaceId === selectedWorkspaceId && opencodeClient
+      ? opencodeClient
+      : createClient(
+          endpoint.opencodeBaseUrl,
+          workspace.path?.trim() || undefined,
+          { token: endpoint.token, mode: "openwork" },
+        );
     try {
       setErrorsByWorkspaceId((current) => ({ ...current, [workspaceId]: null }));
       setRouteError(null);
@@ -2271,7 +2273,7 @@ export function SessionRoute() {
       }
       return null;
     }
-  }, [applyLastUsedModelToSession, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
+  }, [applyLastUsedModelToSession, endpointForWorkspace, loading, navigateToWorkspaceSession, opencodeClient, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2623,6 +2623,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               if (!openworkClient) throw new Error("OpenWork server is not connected.");
               return openworkClient.setEngineV2PreviewEnabled(enabled);
             }}
+            setEngineV2PreviewChatRouting={async (enabled) => {
+              if (!openworkClient) throw new Error("OpenWork server is not connected.");
+              return openworkClient.setEngineV2PreviewChatRouting(enabled);
+            }}
             organizationServer={denSession}
           />
         );

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -23,6 +23,7 @@ import {
   type WorkspaceList,
 } from "@/app/lib/desktop";
 import { createClient } from "@/app/lib/opencode";
+import { createClientV2 } from "@/app/lib/opencode-v2-adapter";
 import { getNativeSession } from "@/app/lib/opencode-session-native";
 import { createOpenworkServerClient, type OpenworkServerClient } from "@/app/lib/openwork-server";
 import { readDenBootstrapConfig } from "@/app/lib/den";
@@ -179,6 +180,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const [client, setClient] = useState<OpenworkServerClient | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
   const [token, setToken] = useState("");
+  const [engineV2ChatRouting, setEngineV2ChatRouting] = useState(false);
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
   const [workspaceOrderIds, setWorkspaceOrderIds] = useState<string[]>(() => readWorkspaceOrderIds());
   const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, RouteSession[]>>({});
@@ -995,7 +997,34 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   // local workspaces it's the user's local OpenWork server.
   const selectedWorkspaceEndpoint = useWorkspaceServerClient(selectedWorkspace, { baseUrl, token });
   const selectedWorkspaceServerToken = selectedWorkspaceEndpoint?.token ?? "";
-  const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
+  const defaultOpencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
+  const opencode2BaseUrl = selectedWorkspaceEndpoint ? `${selectedWorkspaceEndpoint.mountedBaseUrl}/opencode2` : "";
+  useEffect(() => {
+    const openworkClient = selectedWorkspaceEndpoint?.client;
+    if (!openworkClient) {
+      setEngineV2ChatRouting(false);
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const status = await openworkClient.getEngineV2PreviewStatus();
+        if (!cancelled) setEngineV2ChatRouting(status.enabled && status.running && status.chatRouting);
+      } catch (error) {
+        if (cancelled) return;
+        setEngineV2ChatRouting(false);
+        console.warn("[opencode-v2] failed to read chat routing status; retaining the current engine", error);
+      }
+    };
+    setEngineV2ChatRouting(false);
+    void refresh();
+    const interval = window.setInterval(() => { void refresh(); }, 15_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [selectedWorkspaceEndpoint?.baseUrl, selectedWorkspaceEndpoint?.client, selectedWorkspaceEndpoint?.workspaceId]);
+  const opencodeBaseUrl = engineV2ChatRouting ? opencode2BaseUrl : defaultOpencodeBaseUrl;
   const selectedWorkspaceError = errorsByWorkspaceId[selectedWorkspaceId] ?? null;
   const selectedSessionKnown = Boolean(
     selectedSessionId &&
@@ -1125,12 +1154,16 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const opencodeClient = useMemo(
     () =>
       opencodeBaseUrl && selectedWorkspaceServerToken && !selectedWorkspaceError
-        ? createClient(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
-            token: selectedWorkspaceServerToken,
-            mode: "openwork",
-          })
+        ? engineV2ChatRouting
+          ? createClientV2(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
+              token: selectedWorkspaceServerToken,
+            })
+          : createClient(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
+              token: selectedWorkspaceServerToken,
+              mode: "openwork",
+            })
         : null,
-    [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
+    [engineV2ChatRouting, opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
   useEffect(() => {
     if (!developerMode || !opencodeClient) return;

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createV2EventTranslationState,
+  translateV2Event,
+} from "../src/app/lib/opencode-v2-adapter";
+
+describe("OpenCode v2 event translation", () => {
+  test("uses one stable text part id from start through the cumulative end update", () => {
+    const state = createV2EventTranslationState();
+
+    expect(translateV2Event({
+      type: "session.text.started",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_1",
+        textID: "txt_1",
+        timestamp: 10,
+      },
+    }, state)).toEqual([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "msg_1",
+            sessionID: "ses_1",
+            role: "assistant",
+            time: { created: 10 },
+          },
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "msg_1:0",
+            messageID: "msg_1",
+            sessionID: "ses_1",
+            type: "text",
+            text: "",
+          },
+        },
+      },
+    ]);
+
+    expect(translateV2Event({
+      type: "session.text.delta",
+      data: { sessionID: "ses_1", textID: "txt_1", delta: "Hello " },
+    }, state)).toEqual([{
+      type: "message.part.delta",
+      properties: {
+        sessionID: "ses_1",
+        messageID: "msg_1",
+        partID: "msg_1:0",
+        field: "text",
+        delta: "Hello ",
+      },
+    }]);
+    translateV2Event({
+      type: "session.text.delta",
+      data: { sessionID: "ses_1", textID: "txt_1", delta: "world" },
+    }, state);
+
+    expect(translateV2Event({
+      type: "session.text.ended",
+      data: { sessionID: "ses_1", textID: "txt_1" },
+    }, state)).toEqual([{
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "msg_1:0",
+          messageID: "msg_1",
+          sessionID: "ses_1",
+          type: "text",
+          text: "Hello world",
+        },
+      },
+    }]);
+  });
+
+  test("emits an error before terminal idle events for failed execution", () => {
+    const state = createV2EventTranslationState();
+    expect(translateV2Event({
+      type: "session.execution.failed",
+      properties: { sessionID: "ses_2", error: { message: "provider failed" } },
+    }, state)).toEqual([
+      {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_2",
+          error: { name: "UnknownError", data: { message: "provider failed" } },
+        },
+      },
+      { type: "session.status", properties: { sessionID: "ses_2", status: { type: "idle" } } },
+      { type: "session.idle", properties: { sessionID: "ses_2" } },
+    ]);
+  });
+});

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -78,6 +78,95 @@ describe("OpenCode v2 event translation", () => {
     }]);
   });
 
+  test("uses event-provided ordinals to keep same-message text parts distinct", () => {
+    const state = createV2EventTranslationState();
+
+    const firstStarted = translateV2Event({
+      type: "session.text.started",
+      data: { sessionID: "ses_ordinal", assistantMessageID: "msg_ordinal", ordinal: 0 },
+    }, state);
+    const secondStarted = translateV2Event({
+      type: "session.text.started",
+      data: { sessionID: "ses_ordinal", assistantMessageID: "msg_ordinal", ordinal: 1 },
+    }, state);
+
+    expect(firstStarted?.[1]).toMatchObject({
+      type: "message.part.updated",
+      properties: { part: { id: "msg_ordinal:0" } },
+    });
+    expect(secondStarted?.[1]).toMatchObject({
+      type: "message.part.updated",
+      properties: { part: { id: "msg_ordinal:1" } },
+    });
+
+    const delta = translateV2Event({
+      type: "session.text.delta",
+      data: { sessionID: "ses_ordinal", assistantMessageID: "msg_ordinal", ordinal: 1, delta: "second" },
+    }, state);
+    expect(delta).toEqual([{
+      type: "message.part.delta",
+      properties: {
+        sessionID: "ses_ordinal",
+        messageID: "msg_ordinal",
+        partID: "msg_ordinal:1",
+        field: "text",
+        delta: "second",
+      },
+    }]);
+    expect(delta).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ properties: expect.objectContaining({ partID: "msg_ordinal:0" }) }),
+    ]));
+  });
+
+  test("translates captured v2 text lifecycle events through terminal idle", () => {
+    const state = createV2EventTranslationState();
+    const captured = [
+      { type: "session.text.started", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0 } },
+      { type: "session.text.delta", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, delta: "hello world" } },
+      { type: "session.text.ended", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0, text: "hello world" } },
+      { type: "session.execution.succeeded", data: { sessionID: "s" } },
+    ];
+    const translated = captured.flatMap((event) => translateV2Event(event, state) ?? []);
+
+    expect(translated).toEqual([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "m",
+            sessionID: "s",
+            role: "assistant",
+            time: { created: expect.any(Number) },
+          },
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: { id: "m:0", messageID: "m", sessionID: "s", type: "text", text: "" },
+        },
+      },
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "s",
+          messageID: "m",
+          partID: "m:0",
+          field: "text",
+          delta: "hello world",
+        },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: { id: "m:0", messageID: "m", sessionID: "s", type: "text", text: "hello world" },
+        },
+      },
+      { type: "session.status", properties: { sessionID: "s", status: { type: "idle" } } },
+      { type: "session.idle", properties: { sessionID: "s" } },
+    ]);
+  });
+
   test("emits an error before terminal idle events for failed execution", () => {
     const state = createV2EventTranslationState();
     expect(translateV2Event({

--- a/apps/server/src/engine-v2-preview.test.ts
+++ b/apps/server/src/engine-v2-preview.test.ts
@@ -1,6 +1,67 @@
 import { expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { mapRuntimeProvidersToV2Specs } from "./engine-v2-preview.js";
+import {
+  createEngineV2Preview,
+  mapRuntimeProvidersToV2Specs,
+  readEngineV2PreviewState,
+  writeEngineV2PreviewState,
+} from "./engine-v2-preview.js";
+import type { ServerConfig } from "./types.js";
+
+function testConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "client-token",
+    hostToken: "host-token",
+    configPath: join(root, "openwork-server.json"),
+    approval: { mode: "manual", timeoutMs: 1_000 },
+    corsOrigins: [],
+    workspaces: [],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+test("round trips enabled and chat routing state and defaults corrupt state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-engine-v2-preview-"));
+  const config = testConfig(root);
+  try {
+    await writeEngineV2PreviewState(config, { enabled: true, chatRouting: true });
+    expect(readEngineV2PreviewState(config)).toEqual({ enabled: true, chatRouting: true });
+
+    await writeFile(join(root, "engine-v2-preview.json"), "{invalid", "utf8");
+    expect(readEngineV2PreviewState(config)).toEqual({ enabled: false, chatRouting: false });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("persists chat routing and includes it in preview status without starting the engine", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-engine-v2-preview-"));
+  const config = testConfig(root);
+  const preview = createEngineV2Preview({ config });
+  try {
+    expect(preview.status().chatRouting).toBe(false);
+    const status = await preview.setChatRouting(true);
+    expect(status.chatRouting).toBe(true);
+    expect(status.enabled).toBe(false);
+    expect(status.running).toBe(false);
+    expect(preview.connection()).toBeUndefined();
+    expect(readEngineV2PreviewState(config)).toEqual({ enabled: false, chatRouting: true });
+  } finally {
+    await preview.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("maps runtime provider fields and models to an OpenCode v2 spec", () => {
   expect(mapRuntimeProvidersToV2Specs({

--- a/apps/server/src/engine-v2-preview.ts
+++ b/apps/server/src/engine-v2-preview.ts
@@ -24,6 +24,7 @@ const UNSET_API_KEY = "openwork-engine-v2-preview-unset";
 
 export interface EngineV2PreviewStatus {
   enabled: boolean;
+  chatRouting: boolean;
   running: boolean;
   version?: string;
   pid?: number;
@@ -48,7 +49,14 @@ export interface RuntimeProviderRecordLike {
 export interface EngineV2Preview {
   status(): EngineV2PreviewStatus;
   setEnabled(enabled: boolean): Promise<EngineV2PreviewStatus>;
+  setChatRouting(chatRouting: boolean): Promise<EngineV2PreviewStatus>;
+  connection(): { url: string; username: string; password: string } | undefined;
   stop(): Promise<void>;
+}
+
+export interface EngineV2PreviewState {
+  enabled: boolean;
+  chatRouting?: boolean;
 }
 
 interface ResolvedBinary {
@@ -68,18 +76,28 @@ function statePath(config: ServerConfig): string {
   return join(runtimeStorageDir(config), PREVIEW_STATE_FILE);
 }
 
-function readEnabled(config: ServerConfig): boolean {
+export function readEngineV2PreviewState(config: ServerConfig): EngineV2PreviewState {
   try {
     const parsed: unknown = JSON.parse(readFileSync(statePath(config), "utf8"));
-    return isRecord(parsed) && parsed.enabled === true;
+    if (
+      !isRecord(parsed)
+      || typeof parsed.enabled !== "boolean"
+      || (parsed.chatRouting !== undefined && typeof parsed.chatRouting !== "boolean")
+    ) {
+      return { enabled: false, chatRouting: false };
+    }
+    return { enabled: parsed.enabled, chatRouting: parsed.chatRouting === true };
   } catch {
-    return false;
+    return { enabled: false, chatRouting: false };
   }
 }
 
-async function persistEnabled(config: ServerConfig, enabled: boolean): Promise<void> {
+export async function writeEngineV2PreviewState(
+  config: ServerConfig,
+  state: EngineV2PreviewState,
+): Promise<void> {
   await mkdir(runtimeStorageDir(config), { recursive: true });
-  await writeFile(statePath(config), `${JSON.stringify({ enabled }, null, 2)}\n`, "utf8");
+  await writeFile(statePath(config), `${JSON.stringify(state, null, 2)}\n`, "utf8");
 }
 
 function exec(file: string, args: string[], options: { cwd?: string; timeout?: number } = {}): Promise<void> {
@@ -209,7 +227,9 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
   const { config } = options;
   const rootDir = join(runtimeStorageDir(config), "opencode-v2", "state");
   const workspaceDir = join(rootDir, "workspace");
-  let enabled = readEnabled(config);
+  const persistedState = readEngineV2PreviewState(config);
+  let enabled = persistedState.enabled;
+  let chatRouting = persistedState.chatRouting === true;
   let allowRunning = true;
   let running = false;
   let version: string | undefined;
@@ -229,6 +249,7 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
   function status(): EngineV2PreviewStatus {
     return {
       enabled,
+      chatRouting,
       running,
       ...(version === undefined ? {} : { version }),
       ...(pid === undefined ? {} : { pid }),
@@ -363,7 +384,7 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
 
   async function setEnabled(nextEnabled: boolean): Promise<EngineV2PreviewStatus> {
     if (nextEnabled && enabled && running) return status();
-    await persistEnabled(config, nextEnabled);
+    await writeEngineV2PreviewState(config, { enabled: nextEnabled, chatRouting });
     enabled = nextEnabled;
     if (!enabled) {
       await stopRuntime();
@@ -378,10 +399,21 @@ export function createEngineV2Preview(options: { config: ServerConfig }): Engine
     return status();
   }
 
+  async function setChatRouting(nextChatRouting: boolean): Promise<EngineV2PreviewStatus> {
+    await writeEngineV2PreviewState(config, { enabled, chatRouting: nextChatRouting });
+    chatRouting = nextChatRouting;
+    return status();
+  }
+
+  function connection(): { url: string; username: string; password: string } | undefined {
+    if (!running || !sidecar) return undefined;
+    return { url: sidecar.url, username: sidecar.username, password: sidecar.password };
+  }
+
   async function stop(): Promise<void> {
     await stopRuntime();
   }
 
   if (enabled) void start().catch(recordStartError);
-  return { status, setEnabled, stop };
+  return { status, setEnabled, setChatRouting, connection, stop };
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -796,6 +796,19 @@ function parseWorkspaceOpencodeMount(pathname: string): { workspaceId: string; r
   return { workspaceId: decodeURIComponent(workspaceId), restPath };
 }
 
+function parseWorkspaceOpencodeV2Mount(pathname: string): { workspaceId: string; restPath: string } | null {
+  if (!pathname.startsWith("/workspace/")) return null;
+  const remainder = pathname.slice("/workspace/".length);
+  if (!remainder) return null;
+  const slash = remainder.indexOf("/");
+  if (slash === -1) return null;
+  const workspaceId = remainder.slice(0, slash);
+  const restPath = remainder.slice(slash) || "/";
+  if (!workspaceId.trim()) return null;
+  if (restPath !== "/opencode2" && !restPath.startsWith("/opencode2/")) return null;
+  return { workspaceId: decodeURIComponent(workspaceId), restPath };
+}
+
 function normalizeOpencodeProxyPath(proxyPath: string): string {
   const raw = (proxyPath ?? "").trim() || "/";
   const withoutPrefix = raw.startsWith("/opencode") ? raw.slice("/opencode".length) : raw;
@@ -1007,6 +1020,42 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
         }
       };
 
+      const proxyWorkspaceOpencodeV2Mount = async (mount: { workspaceId: string; restPath: string }) => {
+        authMode = "client";
+        try {
+          const actor = await requireClient(request, config, tokens);
+          assertOpencodeProxyAllowed(actor, request.method, mount.restPath);
+          const workspace = await resolveWorkspaceWithoutBootstrap(config, mount.workspaceId);
+          const connection = engineV2Preview.connection();
+          if (!connection) {
+            return finalize(jsonResponse({ error: "engine_v2_preview_not_running" }, 503));
+          }
+          proxyService = "opencode";
+          proxyBaseUrl = connection.url;
+          const response = await proxyOpencodeV2Request({
+            config,
+            request,
+            url,
+            workspace,
+            proxyPath: mount.restPath,
+            connection,
+          });
+          return finalize(response);
+        } catch (error) {
+          const requestCanceled = isExpectedRequestCancellation(error, request.signal);
+          if (!(error instanceof ApiError) && !requestCanceled) {
+            captureServerException(error, { method: request.method, route: "/workspace/:id/opencode2/*", requestSignal: request.signal });
+          }
+          const apiError = error instanceof ApiError
+            ? error
+            : requestCanceled
+              ? new ApiError(499, "request_aborted", "Request was canceled")
+              : new ApiError(500, "internal_error", "Unexpected server error");
+          recordApiError(apiError);
+          return finalize(jsonResponse(formatError(apiError), apiError.status));
+        }
+      };
+
       if (request.method === "OPTIONS") {
         return finalize(new Response(null, { status: 204 }));
       }
@@ -1014,6 +1063,11 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
       const canonicalOpencodeMount = parseWorkspaceOpencodeMount(url.pathname);
       if (canonicalOpencodeMount) {
         return proxyWorkspaceOpencodeMount(canonicalOpencodeMount);
+      }
+
+      const canonicalOpencodeV2Mount = parseWorkspaceOpencodeV2Mount(url.pathname);
+      if (canonicalOpencodeV2Mount) {
+        return proxyWorkspaceOpencodeV2Mount(canonicalOpencodeV2Mount);
       }
 
       const mount = parseWorkspaceMount(url.pathname);
@@ -1191,6 +1245,43 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   target.pathname = trimmedPath.startsWith("/") ? trimmedPath : `/${trimmedPath}`;
   target.search = search;
   return target.toString();
+}
+
+async function proxyOpencodeV2Request(input: {
+  config: ServerConfig;
+  request: Request;
+  url: URL;
+  workspace: WorkspaceInfo;
+  proxyPath: string;
+  connection: { url: string; username: string; password: string };
+}): Promise<Response> {
+  const method = input.request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") ensureWritable(input.config);
+
+  const withoutPrefix = input.proxyPath.slice("/opencode2".length);
+  const forwardedPath = withoutPrefix || "/";
+  const target = new URL(input.connection.url);
+  target.pathname = forwardedPath;
+  target.search = input.url.search;
+  if (forwardedPath.startsWith("/api/")) {
+    const hasLocation = [...target.searchParams.keys()]
+      .some((key) => key === "location" || key.startsWith("location["));
+    if (!hasLocation) target.searchParams.append("location[directory]", input.workspace.path);
+  }
+
+  const headers = new Headers(input.request.headers);
+  headers.delete("authorization");
+  headers.delete("x-openwork-host-token");
+  headers.delete("x-openwork-client-id");
+  headers.delete("host");
+  headers.delete("origin");
+  headers.set("authorization", `Basic ${Buffer.from(`opencode:${input.connection.password}`).toString("base64")}`);
+
+  const body = method === "GET" || method === "HEAD"
+    ? undefined
+    : await input.request.arrayBuffer().then((buffer) => buffer.byteLength > 0 ? buffer : undefined);
+  const response = await loopbackFetch(target.toString(), { method, headers, body });
+  return sanitizeProxyResponse(response);
 }
 
 function opencodeUnreachableError(error: unknown, path: string): ApiError {
@@ -2577,10 +2668,19 @@ function createRoutes(
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
     const body = await readJsonBody(ctx.request);
-    if (!isRecord(body) || typeof body.enabled !== "boolean") {
+    if (!isRecord(body) || (body.enabled === undefined && body.chatRouting === undefined)) {
+      throw new ApiError(400, "invalid_payload", "enabled or chatRouting must be provided");
+    }
+    if (body.enabled !== undefined && typeof body.enabled !== "boolean") {
       throw new ApiError(400, "invalid_payload", "enabled must be a boolean");
     }
-    return jsonResponse(await engineV2Preview.setEnabled(body.enabled));
+    if (body.chatRouting !== undefined && typeof body.chatRouting !== "boolean") {
+      throw new ApiError(400, "invalid_payload", "chatRouting must be a boolean");
+    }
+    let status = engineV2Preview.status();
+    if (typeof body.enabled === "boolean") status = await engineV2Preview.setEnabled(body.enabled);
+    if (typeof body.chatRouting === "boolean") status = await engineV2Preview.setChatRouting(body.chatRouting);
+    return jsonResponse(status);
   });
 
   addRoute(routes, "PATCH", "/runtime-config/providers", "host-token", async (ctx) => {

--- a/docs/opencode-v1-v2-benchmarks.md
+++ b/docs/opencode-v1-v2-benchmarks.md
@@ -6,6 +6,7 @@ ranges below are calculated directly from the sample arrays in:
 
 - `evals/bench/results/2026-08-31-m3max-engines.json`
 - `evals/bench/results/2026-08-31-m3max-app-v1.json`
+- `evals/bench/results/2026-09-01-m3max-app-v2.json`
 
 ## What was asked and what each lane answers
 
@@ -40,15 +41,15 @@ witness.
 
 This isolates the engine boundary from OpenWork renderer and Electron costs.
 
-### Why there is no pure-CDP v2 app lane
+### Why the pure-CDP v2 app lane arrived through the adapter
 
-OpenWork's UI cannot run on v2 until the server-to-engine dialect adapter lands.
-That adapter is stage 3 in
-[`docs/opencode-v2-parallel-lane.md`](opencode-v2-parallel-lane.md#3-server-to-engine-dialect)
-and is not part of the current parallel sidecar.
+OpenWork's UI now routes chat through v2 behind the preview flag and the
+**Route chat through OpenCode v2** toggle from
+`feat/opencode-v2-chat-routing`. Lane A was rerun in that mode with
+`OPENWORK_BENCH_ENGINE=v2`, using the server-to-engine dialect adapter.
 
-The v2 stack's own drivable surface is not a substitute. Its web UI, bundled
-in the `opencode2` binary, crashes on `/new-session` with:
+Historically, the v2 stack's own drivable surface was not a substitute. Its web
+UI, bundled in the `opencode2` binary, crashed on `/new-session` with:
 
 ```text
 Error: TitlebarRight must be used within TitlebarRightProvider
@@ -58,10 +59,9 @@ That failure was reproduced through CDP in Chrome 152 on 2026-08-30 with both
 0.0.0-beta-18707 and 0.0.0-dev-18710. A narrow-viewport layout crashed the same
 way. The older 0.0.0-beta-17823 home screen never opened a session view.
 
-Building the v2 desktop app from source would benchmark a different app, not
-the proposed engine swap inside OpenWork. Lane B is therefore the fair engine
-comparison available today. Lane A should be rerun on both engines after the
-adapter lands.
+Building the v2 desktop app from source would have benchmarked a different app,
+not the proposed engine swap inside OpenWork. That is why the app lane arrived
+through OpenWork's adapter rather than through the v2 web or desktop UI.
 
 ## Method
 
@@ -257,29 +257,79 @@ deltas stated above.
 `uiCompactionAvailable=false`: OpenWork has no user-facing compact or summarize
 control in this UI today. Engine-side compaction is covered in Lane B.
 
+## Lane A results: OpenWork app on v2 (adapter preview), pure CDP (medians, N=5)
+
+Delta is app on v2 minus app on v1. Negative means v2 completed this boundary
+sooner.
+
+| Metric | App on v1 median (min-max) | App on v2 median (min-max) | Delta |
+| --- | ---: | ---: | ---: |
+| `cold_boot_to_composer.appInteractive` | 27089 (27022-36513) | 20100 (19217-22136) | -6989 |
+| `cold_boot_to_composer.workspaceReady` | 38536 (38489-51020) | 31499 (26839-35337) | -7037 |
+| `cold_boot_to_composer.composerReady` | 38537 (38490-51020) | 31499 (26840-35338) | -7038 |
+| `cold_boot_to_composer.appReadinessMs` | 7025 (6821-7690) | 5075 (4284-6456) | -1950 |
+| `first_send_cold.complete` | 2885 (2325-3583) | 602 (581-649) | -2283 |
+| `new_session_ready` | 355 (335-403) | 291 (183-396) | -64 |
+| `message_rtt.userRendered` | 76 (75-83) | 588 (568-636) | +512 |
+| `message_rtt.firstToken` | 92 (88-133) | 589 (569-640) | +497 |
+| `message_rtt.complete` | 506 (490-523) | 589 (569-641) | +83 |
+| `workspace_switch.aToB` | 107 (97-133) | 170 (151-438) | +63 |
+| `workspace_switch.bToA` | 93 (89-132) | 127 (98-142) | +34 |
+| `long_message.insertMs` | 43 (42-50) | 57 (55-118) | +14 |
+| `long_message.userRendered` | 108 (94-124) | 589 (570-716) | +481 |
+| `long_message.firstToken` | 167 (131-167) | 592 (571-718) | +425 |
+| `long_message.complete` | 540 (524-552) | 593 (572-718) | +53 |
+
+### Interpretation
+
+- **First send cold:** v2 takes 602 ms versus v1's 2885 ms, about 4.8x
+  faster to the first-ever reply. V2 needs no runtime npm provider install;
+  v1 installs `@ai-sdk/openai-compatible` on first use.
+- **New session ready:** v2 takes 291 ms versus v1's 355 ms.
+- **Streaming gap (v0 finding):** on v2, `userRendered`, `firstToken`, and
+  `complete` are approximately equal in every iteration, at roughly 570-640
+  ms. The adapter currently renders complete turns rather than incremental
+  tokens. V1 renders the user message at about 76 ms, the first token at about
+  92 ms, and completion at about 506 ms. **Hypothesis:** the adapter's
+  `promptAsync` performs a model-switch round trip before the prompt POST,
+  delaying the optimistic user render. **Hypothesis:** delta events lack an
+  established part anchor until the cumulative `part.updated` at `text.ended`,
+  so token deltas do not paint incrementally. This is the top adapter follow-up;
+  engine-side completion is equivalent (Lane B: 452 ms versus 517 ms over a
+  400 ms pacing floor).
+- **Workspace switch:** v2 takes about 170 ms A→B and 127 ms B→A versus v1's
+  107 ms and 93 ms, respectively. It is slightly slower. **Hypothesis:** extra
+  preview-status and lane checks account for part of the difference.
+- **Cold boot:** the lanes are comparable and dev-build-dominated. The dev-build
+  warning above applies to both; these values do not predict packaged startup.
+- **Setup asymmetry:** v2 mode provisions the witness through the runtime
+  provider path, mirrored to the sidecar, and enables the preview flag through
+  the API as untimed scaffolding. All measured interactions remain pure CDP in
+  both app lanes.
+
 ## Answers to the five questions
 
-| Question | Metric today: v1 app and engine | V2 engine equivalent | Likely user-visible change after adoption |
+| Question | Metric today: v1 app and engine | V2 preview app and engine | Likely user-visible change after adoption |
 | --- | --- | --- | --- |
-| First session, load, and send | DEV composer ready 38537 ms; cold first send 2885 ms; engine API usable 683 ms | API usable 520 ms; cold first prompt 4502 ms | Packaged app must be measured separately; provider changes no longer require reload |
-| Ready session | App ready 355 ms; engine create 7 ms | Engine create 55 ms | About +48 ms engine-side, likely hidden by current UI work |
-| Workspace switch | 107 ms A→B and 93 ms B→A; unseen-directory engine touch 13 ms | Unseen-directory touch 49 ms | About +36 ms on first directory touch; revisits need an app-lane rerun |
-| Message response | Visible first token 92 ms, complete 506 ms; engine complete 452 ms | Engine complete 517 ms | Warm flow is broadly equivalent; UI streaming cannot be claimed until Lane A runs on v2 |
-| Long message and compaction | Exact 200000 chars complete in 540 ms; no UI compaction control; engine summarize 469 ms | Exact long prompt complete 525 ms; compact 452 ms | Long sends and witness-backed compaction are equivalent at this pacing floor |
+| First session, load, and send | DEV composer ready 38537 ms; cold first send 2885 ms; engine API usable 683 ms | DEV composer ready 31499 ms; cold first send 602 ms; API usable 520 ms; cold first engine prompt 4502 ms | Packaged startup must be measured separately; first send is about 4.8x faster because v2 avoids the runtime provider install |
+| Ready session | App ready 355 ms; engine create 7 ms | App ready 291 ms; engine create 55 ms | The measured v2 preview is 64 ms faster at the app boundary |
+| Workspace switch | 107 ms A→B and 93 ms B→A; unseen-directory engine touch 13 ms | 170 ms A→B and 127 ms B→A; unseen-directory touch 49 ms | Preview app revisits are slightly slower, as is first directory touch |
+| Message response | User visible 76 ms, first token 92 ms, complete 506 ms; engine complete 452 ms | User visible 588 ms, first token 589 ms, complete 589 ms; engine complete 517 ms | Completion remains close, but the preview adapter currently paints complete turns instead of streaming incrementally |
+| Long message and compaction | Exact 200000 chars insert in 43 ms and complete in 540 ms; no UI compaction control; engine summarize 469 ms | Exact 200000 chars insert in 57 ms and complete in 593 ms; engine compact 452 ms; compaction unsupported in the preview adapter because it has no UI control | Long-message completion is close at this pacing floor; compaction remains engine-only |
 
-The strongest expected UX difference is not a benchmark-table win. V2 can
-apply provider changes without reloading the engine. Session create adds about
-50 ms engine-side and first directory touch adds about 35 ms, both small beside
-today's UI boundaries. Message flows are equivalent for practical purposes in
-this sample.
+V2 can apply provider changes without reloading the engine, reflected in the
+much faster cold first send. Warm engine completion remains broadly equivalent,
+but the preview adapter's lack of incremental painting is a clear user-visible
+regression. Session create adds about 50 ms engine-side while the app's new-task
+boundary is 64 ms faster; workspace revisits are slightly slower.
 
 ## Follow-ups
 
-- Rerun Lane A against v2 after the stage 3 OpenWork adapter in
-  [`docs/opencode-v2-parallel-lane.md`](opencode-v2-parallel-lane.md#rollout-stages)
-  exists. That will produce the true v2 app-perspective comparison.
+- Fix incremental streaming in the v2 adapter, including part anchoring and
+  optimistic user render, then re-measure `message_rtt`.
 - Report the `/new-session` web UI crash upstream against the anomalyco/opencode
   v2 branch, including the exact provider error and affected builds above.
+- Per-engine app numbers still need to be rerun on packaged builds.
 - N=5 on one machine is directional evidence, not a population study. Treat
   single-digit-millisecond deltas as noise. The 400 ms pacing floor dominates
   completion metrics by design.

--- a/evals/bench/results/2026-09-01-m3max-app-v2.json
+++ b/evals/bench/results/2026-09-01-m3max-app-v2.json
@@ -1,0 +1,158 @@
+{
+  "lane": "app-v2",
+  "createdAt": "2026-08-31T22:16:37.442Z",
+  "machine": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpus": 16,
+    "cpuModel": "Apple M3 Max",
+    "memGB": 48,
+    "node": "v24.15.0"
+  },
+  "appCommit": "6bf01c58dc0aae18ab3e6bd479610a324b3d0ece",
+  "iterations": 5,
+  "pacingMs": 20,
+  "tokens": 20,
+  "pollResolutionMs": 50,
+  "executionPlan": {
+    "coldInstances": 5,
+    "warmIterations": 5,
+    "warmScenariosRunIn": "last cold instance only"
+  },
+  "modelReselectedPerSession": false,
+  "uiCompactionAvailable": false,
+  "results": {
+    "cold_boot_to_composer": [
+      {
+        "appInteractive": 21054,
+        "workspaceReady": 32987,
+        "composerReady": 32988,
+        "desktopTotalMs": 21054,
+        "appReadinessMs": 4284
+      },
+      {
+        "appInteractive": 22136,
+        "workspaceReady": 35337,
+        "composerReady": 35338,
+        "desktopTotalMs": 22136,
+        "appReadinessMs": 6456
+      },
+      {
+        "appInteractive": 19746,
+        "workspaceReady": 31093,
+        "composerReady": 31096,
+        "desktopTotalMs": 19746,
+        "appReadinessMs": 5123
+      },
+      {
+        "appInteractive": 19217,
+        "workspaceReady": 26839,
+        "composerReady": 26840,
+        "desktopTotalMs": 19217,
+        "appReadinessMs": 4827
+      },
+      {
+        "appInteractive": 20100,
+        "workspaceReady": 31499,
+        "composerReady": 31499,
+        "desktopTotalMs": 20100,
+        "appReadinessMs": 5075
+      }
+    ],
+    "first_send_cold": [
+      581,
+      649,
+      587,
+      628,
+      602
+    ],
+    "new_session_ready": [
+      396,
+      304,
+      291,
+      183,
+      258
+    ],
+    "message_rtt": [
+      {
+        "userRendered": 636,
+        "firstToken": 640,
+        "complete": 641
+      },
+      {
+        "userRendered": 627,
+        "firstToken": 628,
+        "complete": 630
+      },
+      {
+        "userRendered": 577,
+        "firstToken": 578,
+        "complete": 578
+      },
+      {
+        "userRendered": 568,
+        "firstToken": 569,
+        "complete": 569
+      },
+      {
+        "userRendered": 588,
+        "firstToken": 589,
+        "complete": 589
+      }
+    ],
+    "workspace_switch": [
+      {
+        "aToB": 151,
+        "bToA": 142
+      },
+      {
+        "aToB": 202,
+        "bToA": 99
+      },
+      {
+        "aToB": 438,
+        "bToA": 142
+      },
+      {
+        "aToB": 166,
+        "bToA": 98
+      },
+      {
+        "aToB": 170,
+        "bToA": 127
+      }
+    ],
+    "long_message": [
+      {
+        "insertMs": 78,
+        "userRendered": 631,
+        "firstToken": 632,
+        "complete": 633
+      },
+      {
+        "insertMs": 118,
+        "userRendered": 716,
+        "firstToken": 718,
+        "complete": 718
+      },
+      {
+        "insertMs": 57,
+        "userRendered": 571,
+        "firstToken": 572,
+        "complete": 572
+      },
+      {
+        "insertMs": 57,
+        "userRendered": 589,
+        "firstToken": 592,
+        "complete": 593
+      },
+      {
+        "insertMs": 55,
+        "userRendered": 570,
+        "firstToken": 571,
+        "complete": 572
+      }
+    ]
+  }
+}

--- a/evals/specs/bench-openwork-app-v1.e2e.test.ts
+++ b/evals/specs/bench-openwork-app-v1.e2e.test.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
-import { writeFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { access, writeFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { ServerResponse } from "node:http";
 import { arch, cpus, platform, tmpdir, totalmem } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { clickButton, createAndSelectWorkspace, evalIn, readComposerState } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
 import { desktop, localHost } from "@openwork/hosts";
@@ -12,16 +13,19 @@ import { eventually, needs, test } from "@openwork/testkit";
 import { timeline } from "../packages/timeline/src/index.ts";
 import { expect } from "vitest";
 
+const execFileAsync = promisify(execFile);
 const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const benchEngine = process.env.OPENWORK_BENCH_ENGINE === "v2" ? "v2" : "v1";
 const title = enabled
-  ? "OpenWork Electron v1 engine completes the CDP benchmark with faithful witness traffic"
-  : "OpenWork Electron v1 benchmark skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+  ? `OpenWork Electron ${benchEngine} engine completes the CDP benchmark with faithful witness traffic`
+  : `OpenWork Electron ${benchEngine} benchmark skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1`;
 const providerId = "bench-witness";
 const modelId = "bench-model";
 const modelName = "Bench Model";
 const pacingMs = 20;
 const tokenCount = 20;
 const pollResolutionMs = 50;
+const rendererRoutingPollMs = 15_500;
 const longMessageChars = 200_000;
 
 interface WitnessRequest {
@@ -82,11 +86,65 @@ interface Chat {
   title: string;
 }
 
+interface ServerInfo {
+  baseUrl: string;
+  token: string;
+}
+
+interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  chatRouting: boolean;
+  mirroredProviderIds: string[];
+  catalogModelIds: string[];
+}
+
+interface V1SessionFreezeCheck {
+  workspaceId: string;
+  before: number;
+  after: number;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOpencodeV2Bin(): Promise<string> {
+  const override = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const constants: unknown = JSON.parse(await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"));
+  if (!isRecord(constants) || typeof constants.opencodeV2Version !== "string") {
+    throw new Error("constants.json must define a string opencodeV2Version");
+  }
+  const cache = join(tmpdir(), "openwork-opencode-v2-cache", constants.opencodeV2Version);
+  const binary = join(cache, "node_modules", ".bin", "opencode2");
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, '{"private":true}\n');
+    await execFileAsync(
+      "pnpm",
+      ["add", "--ignore-workspace", "--save-exact", `@opencode-ai/cli@${constants.opencodeV2Version}`],
+      { cwd: cache, timeout: 180_000 },
+    );
+  }
+  if (!(await exists(binary))) {
+    throw new Error(`OpenCode v2 binary was not installed at ${binary}; set OPENWORK_EVAL_OPENCODE2_BIN to a working opencode2 binary`);
+  }
+  return binary;
+}
 
 function bodyFromJson(raw: string): unknown {
   try {
@@ -246,6 +304,144 @@ async function writeProviderConfig(workspacePath: string, witnessUrl: string): P
   }, null, 2)}\n`);
 }
 
+async function readServerInfo(app: Surface): Promise<ServerInfo> {
+  const value = await evalIn(app, `(async () => {
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    return { baseUrl, token };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.baseUrl !== "string" || !value.baseUrl || typeof value.token !== "string" || !value.token) {
+    throw new Error(`Local server credentials are unavailable: ${JSON.stringify(value)}`);
+  }
+  return { baseUrl: value.baseUrl, token: value.token };
+}
+
+function authHeaders(info: ServerInfo): { Authorization: string } {
+  return { Authorization: `Bearer ${info.token}` };
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`Engine v2 status ${field} was not a string array: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseStatus(value: unknown): EngineV2PreviewStatus {
+  if (
+    !isRecord(value)
+    || typeof value.enabled !== "boolean"
+    || typeof value.running !== "boolean"
+    || typeof value.chatRouting !== "boolean"
+  ) {
+    throw new Error(`Unexpected engine v2 preview status: ${JSON.stringify(value)}`);
+  }
+  return {
+    enabled: value.enabled,
+    running: value.running,
+    chatRouting: value.chatRouting,
+    mirroredProviderIds: stringArray(value.mirroredProviderIds, "mirroredProviderIds"),
+    catalogModelIds: stringArray(value.catalogModelIds, "catalogModelIds"),
+  };
+}
+
+async function readStatus(info: ServerInfo): Promise<EngineV2PreviewStatus> {
+  const response = await fetch(`${info.baseUrl}/experimental/engine-v2-preview/status`, {
+    headers: authHeaders(info),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const value: unknown = await response.json();
+  if (response.status !== 200) throw new Error(`Engine v2 status returned ${response.status}: ${JSON.stringify(value)}`);
+  return parseStatus(value);
+}
+
+async function untilStatus(
+  info: ServerInfo,
+  predicate: (status: EngineV2PreviewStatus) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<EngineV2PreviewStatus> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await readStatus(info);
+  while (Date.now() < deadline) {
+    if (predicate(last)) return last;
+    await sleep(1_000);
+    last = await readStatus(info);
+  }
+  throw new Error(`Timed out waiting for ${label}; last status: ${JSON.stringify(last)}`);
+}
+
+async function setupV2Routing(app: Surface, workspaceId: string, witnessUrl: string): Promise<ServerInfo> {
+  const info = await readServerInfo(app);
+  const enableResponse = await fetch(`${info.baseUrl}/experimental/engine-v2-preview`, {
+    method: "PUT",
+    headers: { ...authHeaders(info), "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true, chatRouting: true }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const enableValue: unknown = await enableResponse.json();
+  if (enableResponse.status !== 200) {
+    throw new Error(`Enabling engine v2 routing returned ${enableResponse.status}: ${JSON.stringify(enableValue)}`);
+  }
+  parseStatus(enableValue);
+  await untilStatus(info, (status) => status.running && status.chatRouting, 120_000, "engine v2 routed lane to start");
+
+  const patchResponse = await fetch(`${info.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/config`, {
+    method: "PATCH",
+    headers: { ...authHeaders(info), "content-type": "application/json" },
+    body: JSON.stringify({
+      opencode: {
+        provider: {
+          [providerId]: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "Bench Witness",
+            options: { baseURL: `${witnessUrl}/v1`, apiKey: "bench-key-app" },
+            models: { [modelId]: { name: modelName } },
+          },
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const patchValue: unknown = await patchResponse.json();
+  if (patchResponse.status !== 200) {
+    throw new Error(`Provisioning the v2 benchmark provider returned ${patchResponse.status}: ${JSON.stringify(patchValue)}`);
+  }
+  await untilStatus(
+    info,
+    (status) => status.mirroredProviderIds.includes(providerId),
+    60_000,
+    "the benchmark provider to be mirrored into v2",
+  );
+  return info;
+}
+
+async function v1EngineSessionCount(info: ServerInfo, workspaceId: string): Promise<number> {
+  const response = await fetch(
+    `${info.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/opencode/session`,
+    { headers: authHeaders(info), signal: AbortSignal.timeout(15_000) },
+  );
+  const value: unknown = await response.json();
+  if (!response.ok) throw new Error(`v1 session list returned ${response.status}: ${JSON.stringify(value)}`);
+  if (!Array.isArray(value)) throw new Error(`Unexpected v1 session list: ${JSON.stringify(value)}`);
+  return value.length;
+}
+
 async function pollExpression(
   app: Surface,
   expression: string,
@@ -323,11 +519,109 @@ async function selectBenchModel(app: Surface): Promise<void> {
   );
 }
 
+async function closeModelPicker(app: Surface): Promise<void> {
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+}
+
+async function selectBenchModelV2(app: Surface): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  await pollExpression(
+    app,
+    `Boolean(document.querySelector('button[aria-label="Change model"]'))`,
+    "v2 bench model picker trigger",
+    60_000,
+  );
+  let lastItems: string[] = [];
+  while (Date.now() < deadline) {
+    const opened = await evalIn(app, `(() => {
+      if (document.querySelector('[data-slot="popover-content"]')) return true;
+      const trigger = document.querySelector('button[aria-label="Change model"]');
+      if (!(trigger instanceof HTMLButtonElement)) return false;
+      trigger.click();
+      return true;
+    })()`);
+    if (opened === true) {
+      await sleep(300);
+      await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return false;
+        const matches = (text) => text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+        if ([...popover.querySelectorAll('[data-slot="command-item"]')]
+          .some((item) => matches(item.textContent ?? ""))) return true;
+        const modelButton = [...popover.querySelectorAll('button')]
+          .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
+        if (!(modelButton instanceof HTMLButtonElement)) return false;
+        modelButton.click();
+        return true;
+      })()`);
+      await sleep(200);
+      const items = await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return [];
+        return [...popover.querySelectorAll('[data-slot="command-item"]')]
+          .map((item) => (item.textContent ?? "").trim());
+      })()`);
+      if (Array.isArray(items) && items.every((item) => typeof item === "string")) {
+        lastItems = items;
+        if (items.some((item) => item.includes(modelName) || item.includes(modelId))) {
+          const picked = await evalIn(app, `(() => {
+            const popover = document.querySelector('[data-slot="popover-content"]');
+            const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+              .find((candidate) => {
+                const text = candidate.textContent ?? "";
+                return text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+              });
+            if (!(item instanceof HTMLElement)) return false;
+            item.click();
+            return true;
+          })()`);
+          expect(picked).toBe(true);
+          const remaining = Math.max(1, deadline - Date.now());
+          await pollExpression(
+            app,
+            `(() => {
+              const text = document.querySelector('button[aria-label="Change model"]')?.textContent ?? "";
+              return text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+            })()`,
+            "v2 Bench Model selected",
+            remaining,
+          );
+          return;
+        }
+      }
+    }
+    await closeModelPicker(app);
+    await sleep(700);
+  }
+  throw new Error(`Timed out waiting for the v2 bench model in the picker; last items: ${JSON.stringify(lastItems)}`);
+}
+
 async function ensureBenchModel(app: Surface): Promise<boolean> {
   await waitForComposerReady(app, "composer before checking persisted model");
   const state = await readComposerState(app);
   if (state.selectedModelLabel.includes(modelName)) return false;
   await selectBenchModel(app);
+  return true;
+}
+
+async function ensureBenchModelV2(app: Surface): Promise<boolean> {
+  await waitForComposerReady(app, "composer before checking persisted v2 model");
+  const state = await readComposerState(app);
+  if (state.selectedModelLabel.includes(modelName) || state.selectedModelLabel.includes(modelId)) return false;
+  await selectBenchModelV2(app);
   return true;
 }
 
@@ -634,6 +928,7 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
   needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
   const iterations = Number(process.env.OPENWORK_BENCH_ITERATIONS ?? "1");
   expect(Number.isInteger(iterations) && iterations > 0, "OPENWORK_BENCH_ITERATIONS must be a positive integer").toBe(true);
+  const opencodeV2Bin = benchEngine === "v2" ? await resolveOpencodeV2Bin() : undefined;
   const runNonce = `${Date.now().toString(36)}-${process.pid}`;
   const results: BenchmarkResults = {
     cold_boot_to_composer: [],
@@ -651,6 +946,7 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
   const switchTargetChecks: boolean[] = [];
   const switchIsolationChecks: boolean[] = [];
   const longMessageChecks: boolean[] = [];
+  const v1SessionFreezeChecks: V1SessionFreezeCheck[] = [];
   let modelReselectedPerSession = false;
   let uiCompactionAvailable = false;
   const host = localHost();
@@ -659,17 +955,22 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
     for (let coldIndex = 0; coldIndex < iterations; coldIndex += 1) {
       const witnessNonce = `${runNonce}-cold-${coldIndex}`;
       const witness = await startWitness(witnessNonce);
-      const profileDir = await mkdtemp(join(tmpdir(), "openwork-bench-v1-profile-"));
-      const workspaceAPath = await mkdtemp(join(tmpdir(), "openwork-bench-v1-workspace-a-"));
+      const profileDir = await mkdtemp(join(tmpdir(), `openwork-bench-${benchEngine}-profile-`));
+      const workspaceAPath = await mkdtemp(join(tmpdir(), `openwork-bench-${benchEngine}-workspace-a-`));
       const workspaceBPath = coldIndex === iterations - 1
-        ? await mkdtemp(join(tmpdir(), "openwork-bench-v1-workspace-b-"))
+        ? await mkdtemp(join(tmpdir(), `openwork-bench-${benchEngine}-workspace-b-`))
         : null;
+      // Keep the project provider file in both modes so workspace setup stays
+      // symmetric and the v1 picker remains deterministic. The v2 routed lane
+      // receives the identical provider separately through the runtime PATCH.
       await writeProviderConfig(workspaceAPath, witness.url);
       if (workspaceBPath) await writeProviderConfig(workspaceBPath, witness.url);
       let app: DesktopHandle | undefined;
+      let serverInfo: ServerInfo | undefined;
+      const v1SessionSnapshots = new Map<string, number>();
 
       try {
-        const appName = `bench-openwork-app-v1-${coldIndex}`;
+        const appName = `bench-openwork-app-${benchEngine}-${coldIndex}`;
         const timelineStart = timeline().length;
         const coldStartedAt = Date.now();
         app = await desktop({
@@ -683,6 +984,7 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
             GOOGLE_GENERATIVE_AI_API_KEY: "",
             OPENWORK_API_KEY: "",
             OPENWORK_INFERENCE_BASE_URL: "",
+            ...(opencodeV2Bin === undefined ? {} : { OPENWORK_OPENCODE2_BIN: opencodeV2Bin }),
           },
         });
         const appInteractive = Date.now() - coldStartedAt;
@@ -704,7 +1006,19 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
         if (appReadinessMs !== undefined) coldTiming.appReadinessMs = appReadinessMs;
         results.cold_boot_to_composer.push(coldTiming);
 
-        await selectBenchModel(app);
+        if (benchEngine === "v2") {
+          serverInfo = await setupV2Routing(app, workspaceA.workspaceId, witness.url);
+          await sleep(rendererRoutingPollMs);
+          await selectBenchModelV2(app);
+          v1SessionSnapshots.set(
+            workspaceA.workspaceId,
+            await v1EngineSessionCount(serverInfo, workspaceA.workspaceId),
+          );
+          await createNewSession(app);
+          if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+        } else {
+          await selectBenchModel(app);
+        }
         const warmupPrompt = `bench first send cold ${coldIndex} ${witnessNonce}`;
         const warmup = await sendMessage(app, warmupPrompt, witnessNonce);
         results.first_send_cold.push(warmup.timing.complete);
@@ -717,7 +1031,19 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
           if (!workspaceBPath) throw new Error("Last cold instance has no second workspace directory.");
           const workspaceBId = await createSecondWorkspaceViaUi(app, workspaceA.workspaceId, workspaceBPath);
           expect(workspaceBId).not.toBe(workspaceA.workspaceId);
-          await selectBenchModel(app);
+          if (benchEngine === "v2") {
+            if (!serverInfo) throw new Error("The v2 benchmark server connection was not initialized.");
+            await sleep(rendererRoutingPollMs);
+            await selectBenchModelV2(app);
+            v1SessionSnapshots.set(workspaceBId, await v1EngineSessionCount(serverInfo, workspaceBId));
+            // The workspace switch can leave the pre-flip v1 session selected.
+            // Create the routed session after the untimed switch boundary, then
+            // reselect the v2 model before any workspace B send is measured.
+            await createNewSession(app);
+            if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+          } else {
+            await selectBenchModel(app);
+          }
           const bNonces: string[] = [];
           const setupNonce = `bench-b-setup-${witnessNonce}`;
           bNonces.push(setupNonce);
@@ -730,7 +1056,11 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
             const created = await createNewSession(app);
             results.new_session_ready.push(created.ms);
             newSessionIds.push(created.sessionId);
-            if (await ensureBenchModel(app)) modelReselectedPerSession = true;
+            if (benchEngine === "v2") {
+              if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+            } else if (await ensureBenchModel(app)) {
+              modelReselectedPerSession = true;
+            }
 
             const messageNonce = `${witnessNonce}-message-${warmIndex}`;
             const message = `bench message ${warmIndex} ${messageNonce}`;
@@ -744,7 +1074,11 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
             expect(messageComplete).toBe(true);
 
             await createNewSession(app);
-            if (await ensureBenchModel(app)) modelReselectedPerSession = true;
+            if (benchEngine === "v2") {
+              if (await ensureBenchModelV2(app)) modelReselectedPerSession = true;
+            } else if (await ensureBenchModel(app)) {
+              modelReselectedPerSession = true;
+            }
             const longMessage = deterministicLongMessage(warmIndex, witnessNonce);
             bNonces.push(longMessage.marker);
             const beforeLong = await readComposerState(app);
@@ -772,13 +1106,25 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
             title: "workspace A warmup",
           };
           await switchAndMeasure(app, workspaceAChat);
+          if (benchEngine === "v2") {
+            await sleep(rendererRoutingPollMs);
+            await selectBenchModelV2(app);
+          }
           for (let switchIndex = 0; switchIndex < iterations; switchIndex += 1) {
             const aToB = await switchAndMeasure(app, latestBChat);
             const bTexts = await visibleUserTexts(app);
             const bTargetVisible = bTexts.some((text) => text.includes(latestBMarker));
+            if (benchEngine === "v2") {
+              await sleep(rendererRoutingPollMs);
+              await selectBenchModelV2(app);
+            }
             const bToA = await switchAndMeasure(app, workspaceAChat);
             const aTexts = await visibleUserTexts(app);
             const aIsolated = bNonces.every((nonce) => aTexts.every((text) => !text.includes(nonce)));
+            if (benchEngine === "v2") {
+              await sleep(rendererRoutingPollMs);
+              await selectBenchModelV2(app);
+            }
             results.workspace_switch.push({ aToB, bToA });
             switchTargetChecks.push(bTargetVisible);
             switchIsolationChecks.push(aIsolated);
@@ -799,6 +1145,15 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
           })()`);
           uiCompactionAvailable = compactionProbe === true;
         }
+
+        if (benchEngine === "v2") {
+          if (!serverInfo) throw new Error("The v2 benchmark server connection was not initialized.");
+          for (const [workspaceId, before] of v1SessionSnapshots) {
+            const after = await v1EngineSessionCount(serverInfo, workspaceId);
+            v1SessionFreezeChecks.push({ workspaceId, before, after });
+            expect(after, `v1 sessions stayed frozen for ${workspaceId}`).toBe(before);
+          }
+        }
       } finally {
         try {
           if (app) await app.stop();
@@ -818,13 +1173,13 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
     expect(warmupCompletions).toHaveLength(iterations);
     expect(warmupCompletions.every(Boolean)).toBe(true);
     evidence.recordAssertionEvidence(
-      "Each cold v1 desktop reaches a ready composer from a fresh profile and workspace",
+      `Each cold ${benchEngine} desktop reaches a ready composer from a fresh profile and workspace`,
       `${iterations} unique workspaces reached appInteractive, workspaceReady and composerReady. No profile or workspace was reused.`,
       results.cold_boot_to_composer.length === iterations
         && new Set(coldWorkspaceIds).size === iterations,
     );
     evidence.recordAssertionEvidence(
-      "Each cold v1 engine's first send completes after the untimed model selection",
+      `Each cold ${benchEngine} engine's first send completes after the untimed model selection`,
       `${iterations} first sends rendered exact user messages and the final token-20 witness nonce; completion ms=${JSON.stringify(results.first_send_cold)}. No first send was incomplete.`,
       results.first_send_cold.length === iterations && warmupCompletions.every(Boolean),
     );
@@ -877,14 +1232,25 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
     ));
     expect(unfaithfulRequests).toEqual([]);
     evidence.recordAssertionEvidence(
-      "All v1 app completions use only the file-provisioned Bench Witness model and key",
+      `All ${benchEngine} app completions use only the Bench Witness model and key`,
       `${allWitnessRequests.length} completion requests all carried Bearer bench-key-app and model bench-model; mismatches=${JSON.stringify(unfaithfulRequests)}. No request escaped to another configured provider.`,
       allWitnessRequests.length > 0 && unfaithfulRequests.length === 0,
     );
 
+    if (benchEngine === "v2") {
+      expect(v1SessionFreezeChecks).toHaveLength(iterations + 1);
+      expect(v1SessionFreezeChecks.every((check) => check.after === check.before)).toBe(true);
+      evidence.recordAssertionEvidence(
+        "Routed v2 benchmark scenarios never create a session in the v1 engine",
+        `${v1SessionFreezeChecks.length} workspace snapshots remained unchanged after their routed scenarios: ${JSON.stringify(v1SessionFreezeChecks)}.`,
+        v1SessionFreezeChecks.length === iterations + 1
+          && v1SessionFreezeChecks.every((check) => check.after === check.before),
+      );
+    }
+
     const cpuList = cpus();
     const report = {
-      lane: "app-v1",
+      lane: `app-${benchEngine}`,
       createdAt: new Date().toISOString(),
       machine: {
         platform: platform(),
@@ -910,10 +1276,10 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
     };
     const resultsDir = process.env.OPENWORK_BENCH_RESULTS_DIR ?? tmpdir();
     await mkdir(resultsDir, { recursive: true });
-    const resultsPath = join(resultsDir, `bench-openwork-app-v1-${Date.now()}.json`);
+    const resultsPath = join(resultsDir, `bench-openwork-app-${benchEngine}-${Date.now()}.json`);
     await writeFile(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
-    console.info(`[bench-openwork-app-v1] medians\n${medianTable(results)}`);
-    console.info(`[bench-openwork-app-v1] results=${resultsPath} uiCompactionAvailable=${uiCompactionAvailable}`);
+    console.info(`[bench-openwork-app-${benchEngine}] medians\n${medianTable(results)}`);
+    console.info(`[bench-openwork-app-${benchEngine}] results=${resultsPath} uiCompactionAvailable=${uiCompactionAvailable}`);
   } finally {
     await host.stop();
   }

--- a/evals/specs/opencode-v2-chat-routing.e2e.test.ts
+++ b/evals/specs/opencode-v2-chat-routing.e2e.test.ts
@@ -1,0 +1,654 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { clickButton, createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { desktop, localHost } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "chat routing switches live between OpenCode v1 and the v2 preview sidecar"
+  : "OpenCode v2 chat routing skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+const keyV1 = "key-v1";
+const keyV2 = "key-v2";
+const modelIdV1 = "witness-model-v1";
+const modelIdV2 = "witness-model-v2";
+const modelNameV1 = "Witness Model V1";
+const modelNameV2 = "Witness Model V2";
+
+interface ServerInfo {
+  baseUrl: string;
+  token: string;
+}
+
+interface EngineV2PreviewStatus {
+  enabled: boolean;
+  running: boolean;
+  chatRouting: boolean;
+  pid?: number;
+  mirroredProviderIds: string[];
+  skippedProviderIds: string[];
+  catalogModelIds: string[];
+  lastError?: string;
+}
+
+interface WitnessRequest {
+  at: number;
+  auth: string;
+  model: string;
+  stream: boolean;
+  nonce: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOpencodeV2Bin(): Promise<string> {
+  const override = process.env.OPENWORK_EVAL_OPENCODE2_BIN;
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const constants: unknown = JSON.parse(await readFile(join(import.meta.dirname, "../../constants.json"), "utf8"));
+  if (!isRecord(constants) || typeof constants.opencodeV2Version !== "string") {
+    throw new Error("constants.json must define a string opencodeV2Version");
+  }
+  const cache = join(tmpdir(), "openwork-opencode-v2-cache", constants.opencodeV2Version);
+  const binary = join(cache, "node_modules", ".bin", "opencode2");
+  if (!(await exists(binary))) {
+    await mkdir(cache, { recursive: true });
+    const packageJson = join(cache, "package.json");
+    if (!(await exists(packageJson))) await writeFile(packageJson, '{"private":true}\n');
+    await execFileAsync(
+      "pnpm",
+      ["add", "--ignore-workspace", "--save-exact", `@opencode-ai/cli@${constants.opencodeV2Version}`],
+      { cwd: cache, timeout: 180_000 },
+    );
+  }
+  if (!(await exists(binary))) {
+    throw new Error(`OpenCode v2 binary was not installed at ${binary}; set OPENWORK_EVAL_OPENCODE2_BIN to a working opencode2 binary`);
+  }
+  return binary;
+}
+
+async function readServerInfo(app: Surface): Promise<ServerInfo> {
+  const value = await evalIn(app, `(async () => {
+    let baseUrl = "";
+    let token = "";
+    try {
+      const invokeDesktop = window.__OPENWORK_ELECTRON__ && window.__OPENWORK_ELECTRON__.invokeDesktop;
+      if (invokeDesktop) {
+        const info = await invokeDesktop("openworkServerInfo");
+        if (info && info.running === true) {
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\\/+$/, "");
+          token = String(info.ownerToken ?? info.clientToken ?? "").trim();
+        }
+      }
+    } catch {}
+    if (!baseUrl || !token) {
+      const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
+      baseUrl = port ? "http://127.0.0.1:" + port : baseUrl;
+      token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
+    }
+    return { baseUrl, token };
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  if (!isRecord(value) || typeof value.baseUrl !== "string" || !value.baseUrl || typeof value.token !== "string" || !value.token) {
+    throw new Error(`Local server credentials are unavailable: ${JSON.stringify(value)}`);
+  }
+  return { baseUrl: value.baseUrl, token: value.token };
+}
+
+function authHeaders(info: ServerInfo): { Authorization: string } {
+  return { Authorization: `Bearer ${info.token}` };
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`Engine v2 status ${field} was not a string array: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseStatus(value: unknown): EngineV2PreviewStatus {
+  if (
+    !isRecord(value)
+    || typeof value.enabled !== "boolean"
+    || typeof value.running !== "boolean"
+    || typeof value.chatRouting !== "boolean"
+  ) {
+    throw new Error(`Unexpected engine v2 preview status: ${JSON.stringify(value)}`);
+  }
+  if (value.pid !== undefined && typeof value.pid !== "number") {
+    throw new Error(`Unexpected engine v2 pid: ${JSON.stringify(value.pid)}`);
+  }
+  return {
+    enabled: value.enabled,
+    running: value.running,
+    chatRouting: value.chatRouting,
+    ...(typeof value.pid === "number" ? { pid: value.pid } : {}),
+    mirroredProviderIds: stringArray(value.mirroredProviderIds, "mirroredProviderIds"),
+    skippedProviderIds: stringArray(value.skippedProviderIds, "skippedProviderIds"),
+    catalogModelIds: stringArray(value.catalogModelIds, "catalogModelIds"),
+    ...(typeof value.lastError === "string" ? { lastError: value.lastError } : {}),
+  };
+}
+
+async function readStatus(info: ServerInfo): Promise<EngineV2PreviewStatus> {
+  const response = await fetch(`${info.baseUrl}/experimental/engine-v2-preview/status`, {
+    headers: authHeaders(info),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const value: unknown = await response.json();
+  if (response.status !== 200) throw new Error(`Engine v2 status returned ${response.status}: ${JSON.stringify(value)}`);
+  return parseStatus(value);
+}
+
+async function untilStatus(
+  info: ServerInfo,
+  predicate: (status: EngineV2PreviewStatus) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<EngineV2PreviewStatus> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await readStatus(info);
+  while (Date.now() < deadline) {
+    if (predicate(last)) return last;
+    await sleep(1_000);
+    last = await readStatus(info);
+  }
+  throw new Error(`Timed out waiting for ${label}; last status: ${JSON.stringify(last)}`);
+}
+
+async function engineSessionCount(info: ServerInfo, workspaceId: string, lane: "opencode" | "opencode2"): Promise<number> {
+  const path = lane === "opencode" ? "opencode/session?limit=100" : "opencode2/api/session";
+  const response = await fetch(`${info.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/${path}`, {
+    headers: authHeaders(info),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (lane === "opencode2" && response.status === 503) return -1;
+  const value: unknown = await response.json();
+  if (!response.ok) throw new Error(`${lane} session list returned ${response.status}: ${JSON.stringify(value)}`);
+  if (lane === "opencode") {
+    if (!Array.isArray(value)) throw new Error(`Unexpected v1 session list: ${JSON.stringify(value)}`);
+    return value.length;
+  }
+  if (!isRecord(value) || !Array.isArray(value.data)) {
+    throw new Error(`Unexpected v2 session list: ${JSON.stringify(value)}`);
+  }
+  return value.data.length;
+}
+
+async function clickSwitch(app: Surface, ariaLabel: string): Promise<void> {
+  const point = await evalIn(app, `(() => {
+    const control = [...document.querySelectorAll(${JSON.stringify(`[aria-label="${ariaLabel}"]`)})]
+      .find((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0
+          && candidate.getAttribute("aria-disabled") !== "true"
+          && !candidate.hasAttribute("data-disabled");
+      });
+    if (!(control instanceof HTMLElement)) return null;
+    control.scrollIntoView({ block: "center", behavior: "instant" });
+    const rect = control.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") {
+    throw new Error(`Could not resolve enabled switch ${ariaLabel}: ${JSON.stringify(point)}`);
+  }
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
+  await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
+}
+
+async function closeModelPicker(app: Surface): Promise<void> {
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+  await app.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+    nativeVirtualKeyCode: 27,
+  });
+}
+
+async function waitForModelInPicker(app: Surface, expected: string, timeoutMs = 45_000): Promise<void> {
+  await waitFor(app, `Boolean(document.querySelector('button[aria-label="Change model"]'))`, {
+    timeoutMs: 30_000,
+    label: "composer model picker",
+  });
+  const deadline = Date.now() + timeoutMs;
+  let lastItems: string[] = [];
+  while (Date.now() < deadline) {
+    const opened = await evalIn(app, `(() => {
+      if (document.querySelector('[data-slot="popover-content"]')) return true;
+      const trigger = document.querySelector('button[aria-label="Change model"]');
+      if (!(trigger instanceof HTMLButtonElement)) return false;
+      trigger.click();
+      return true;
+    })()`);
+    if (opened === true) {
+      await sleep(300);
+      await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return false;
+        if ([...popover.querySelectorAll('[data-slot="command-item"]')]
+          .some((item) => (item.textContent ?? "").includes(${JSON.stringify(expected)}))) return true;
+        const modelButton = [...popover.querySelectorAll('button')]
+          .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
+        if (!(modelButton instanceof HTMLButtonElement)) return false;
+        modelButton.click();
+        return true;
+      })()`);
+      await sleep(200);
+      const items = await evalIn(app, `(() => {
+        const popover = document.querySelector('[data-slot="popover-content"]');
+        if (!(popover instanceof HTMLElement)) return [];
+        return [...popover.querySelectorAll('[data-slot="command-item"]')]
+          .map((item) => (item.textContent ?? "").trim());
+      })()`);
+      if (Array.isArray(items) && items.every((item) => typeof item === "string")) {
+        lastItems = items;
+        if (items.some((item) => item.includes(expected))) return;
+      }
+    }
+    await closeModelPicker(app);
+    await sleep(700);
+  }
+  throw new Error(`Timed out waiting for ${expected} in the model picker; last items: ${JSON.stringify(lastItems)}`);
+}
+
+async function selectModel(app: Surface, modelName: string): Promise<void> {
+  await waitForModelInPicker(app, modelName);
+  const picked = await evalIn(app, `(() => {
+    const popover = document.querySelector('[data-slot="popover-content"]');
+    const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+      .find((candidate) => (candidate.textContent ?? "").includes(${JSON.stringify(modelName)}));
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(picked).toBe(true);
+  await waitFor(app, `(document.querySelector('button[aria-label="Change model"]')?.textContent ?? "").includes(${JSON.stringify(modelName)})`, {
+    timeoutMs: 15_000,
+    label: `${modelName} selected`,
+  });
+}
+
+async function typeIntoComposer(app: Surface, text: string): Promise<void> {
+  await waitFor(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    return editor instanceof HTMLElement && (editor.innerText ?? "").trim() === "";
+  })()`, { timeoutMs: 30_000, label: "empty composer ready" });
+  const focused = await evalIn(app, `(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!(editor instanceof HTMLElement)) return false;
+    editor.focus();
+    return true;
+  })()`);
+  expect(focused).toBe(true);
+  await app.client.send("Input.insertText", { text });
+  await waitFor(app, `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === ${JSON.stringify(text)}`, {
+    timeoutMs: 10_000,
+    label: `composer contains ${text}`,
+  });
+}
+
+async function createNewSessionThroughSidebar(app: Surface): Promise<string> {
+  const previousValue = await evalIn(app, `document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""`);
+  const previous = typeof previousValue === "string" ? previousValue : "";
+  await waitFor(app, `(() => {
+    const button = document.querySelector('[data-sidebar-new-chat]');
+    return button instanceof HTMLButtonElement && !button.disabled;
+  })()`, { timeoutMs: 30_000, label: "enabled sidebar New task control" });
+  const clicked = await evalIn(app, `(() => {
+    const button = document.querySelector('[data-sidebar-new-chat]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+  await waitFor(app, `(() => {
+    const id = document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? "";
+    return id.startsWith("ses_") && id !== ${JSON.stringify(previous)}
+      && window.location.hash.includes("/session/" + id);
+  })()`, { timeoutMs: 60_000, label: "new session created by the active engine client" });
+  const value = await evalIn(app, `document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""`);
+  if (typeof value !== "string" || !value.startsWith("ses_")) throw new Error(`New session id was unavailable: ${String(value)}`);
+  return value;
+}
+
+async function waitForWitnessRequest(
+  requests: WitnessRequest[],
+  predicate: (request: WitnessRequest) => boolean,
+  label: string,
+): Promise<WitnessRequest> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const match = requests.find(predicate);
+    if (match) return match;
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${label}; requests: ${JSON.stringify(requests)}`);
+}
+
+async function sendAndWaitForNonce(
+  app: Surface,
+  requests: WitnessRequest[],
+  prompt: string,
+  auth: string,
+  model: string,
+  notBefore: number,
+  round: string,
+): Promise<{ request: WitnessRequest; latencyMs: number }> {
+  await typeIntoComposer(app, prompt);
+  const sentAt = Date.now();
+  await clickButton(app, "Run task", { timeoutMs: 30_000 });
+  const request = await waitForWitnessRequest(
+    requests,
+    (candidate) => candidate.stream && candidate.at >= sentAt && candidate.at >= notBefore
+      && candidate.auth === auth && candidate.model === model,
+    `${round} streamed witness request`,
+  );
+  await waitFor(app, `[...document.querySelectorAll('[data-message-role="assistant"]')]
+    .some((message) => message.textContent?.includes(${JSON.stringify(request.nonce)}))`, {
+    timeoutMs: 120_000,
+    label: `${round} transcript nonce ${request.nonce}`,
+  });
+  const latencyMs = Date.now() - sentAt;
+  console.info(`[opencode-v2-chat-routing] ${round} send-to-nonce latency: ${latencyMs}ms`);
+  return { request, latencyMs };
+}
+
+test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  const binPath = await resolveOpencodeV2Bin();
+  const witnessRequests: WitnessRequest[] = [];
+  const validAuth = new Set([`Bearer ${keyV1}`, `Bearer ${keyV2}`]);
+  const witness = createServer((request, response) => {
+    const url = request.url ?? "";
+    const auth = request.headers.authorization ?? "";
+    if (!validAuth.has(auth)) {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "invalid witness key" } }));
+      return;
+    }
+    if (request.method === "GET" && url.startsWith("/v1/models")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        object: "list",
+        data: [modelIdV1, modelIdV2].map((id) => ({ id, object: "model" })),
+      }));
+      return;
+    }
+    if (request.method !== "POST" || (url !== "/v1/chat/completions" && url !== "/chat/completions")) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "not found" } }));
+      return;
+    }
+
+    request.setEncoding("utf8");
+    let rawBody = "";
+    request.on("data", (chunk: string) => {
+      rawBody += chunk;
+    });
+    request.on("end", () => {
+      let body: unknown;
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        body = null;
+      }
+      const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
+      const stream = isRecord(body) && body.stream === true;
+      const nonce = "OPENWORK-V2-ROUTING-NONCE";
+      witnessRequests.push({ at: Date.now(), auth, model, stream, nonce });
+      const id = `chatcmpl-opencode-v2-routing-${witnessRequests.length}`;
+      if (!stream) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          id,
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1_000),
+          model,
+          choices: [{ index: 0, message: { role: "assistant", content: "Witness title" }, finish_reason: "stop" }],
+        }));
+        return;
+      }
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      const chunk = (delta: Record<string, string>, finishReason: string | null): void => {
+        response.write(`data: ${JSON.stringify({
+          id,
+          object: "chat.completion.chunk",
+          model,
+          choices: [{ index: 0, delta, finish_reason: finishReason }],
+        })}\n\n`);
+      };
+      chunk({ role: "assistant" }, null);
+      chunk({ content: nonce }, null);
+      chunk({}, "stop");
+      response.end("data: [DONE]\n\n");
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    witness.once("error", reject);
+    witness.listen(0, "127.0.0.1", resolve);
+  });
+  const address = witness.address();
+  if (!address || typeof address === "string") throw new Error("Witness server did not bind a TCP port");
+  const witnessBaseUrl = `http://127.0.0.1:${address.port}/v1`;
+  const profileDir = await mkdtemp(join(tmpdir(), "openwork-v2-chat-routing-eval-"));
+  const workspacePath = join(profileDir, "workspace");
+  await mkdir(workspacePath, { recursive: true });
+  await writeFile(join(workspacePath, "opencode.json"), `${JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      "witness-v1": {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Witness V1",
+        options: { baseURL: witnessBaseUrl, apiKey: keyV1 },
+        models: { [modelIdV1]: { name: modelNameV1 } },
+      },
+    },
+  }, null, 2)}\n`);
+
+  await using host = localHost();
+  let app: Awaited<ReturnType<typeof desktop>> | undefined;
+  try {
+    app = await desktop({
+      name: "opencode-v2-chat-routing",
+      host,
+      profileDir,
+      env: {
+        OPENWORK_OPENCODE2_BIN: binPath,
+        ANTHROPIC_API_KEY: "",
+        OPENAI_API_KEY: "",
+        OPENROUTER_API_KEY: "",
+        GOOGLE_GENERATIVE_AI_API_KEY: "",
+        OPENWORK_API_KEY: "",
+        OPENWORK_INFERENCE_BASE_URL: "",
+      },
+    });
+    const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
+    const serverInfo = await readServerInfo(app);
+
+    await selectModel(app, modelNameV1);
+    const v2BeforeEnable = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(v2BeforeEnable).toBe(-1);
+    const r1 = await sendAndWaitForNonce(
+      app,
+      witnessRequests,
+      "hello r1",
+      `Bearer ${keyV1}`,
+      modelIdV1,
+      0,
+      "R1 v1",
+    );
+    expect(r1.request.auth).toBe(`Bearer ${keyV1}`);
+    expect(r1.request.model).toBe(modelIdV1);
+    expect(witnessRequests.some((request) => request.auth === `Bearer ${keyV2}`)).toBe(false);
+    evidence.recordAssertionEvidence(
+      "R1 chat stays on v1 before the preview is enabled",
+      `The transcript streamed ${r1.request.nonce} from ${modelIdV1} with Bearer ${keyV1} in ${r1.latencyMs}ms; the v2 proxy returned 503 and no request used Bearer ${keyV2}.`,
+      true,
+    );
+
+    await go(app, `/workspace/${workspaceId}/settings/advanced`);
+    await waitFor(app, `(() => {
+      const control = document.querySelector('[aria-label="OpenCode v2 engine preview"]');
+      return control?.getAttribute("aria-checked") === "false"
+        && control.getAttribute("aria-disabled") !== "true";
+    })()`, { timeoutMs: 60_000, label: "ready OpenCode v2 preview switch" });
+    await clickSwitch(app, "OpenCode v2 engine preview");
+    const runningStatus = await untilStatus(
+      serverInfo,
+      (status) => status.enabled && status.running && typeof status.pid === "number",
+      120_000,
+      "the OpenCode v2 sidecar to start",
+    );
+    const pid0 = runningStatus.pid;
+    if (pid0 === undefined) throw new Error("Running OpenCode v2 status did not contain a pid");
+
+    await waitFor(app, `(() => {
+      const control = document.querySelector('[aria-label="Route chat through OpenCode v2"]');
+      return control?.getAttribute("aria-checked") === "false"
+        && control.getAttribute("aria-disabled") !== "true";
+    })()`, { timeoutMs: 30_000, label: "ready OpenCode v2 chat routing switch" });
+    await clickSwitch(app, "Route chat through OpenCode v2");
+    await untilStatus(serverInfo, (status) => status.chatRouting, 30_000, "chat routing to be enabled");
+    const routedOnAt = Date.now();
+
+    const patchResponse = await fetch(`${serverInfo.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/config`, {
+      method: "PATCH",
+      headers: { ...authHeaders(serverInfo), "content-type": "application/json" },
+      body: JSON.stringify({
+        opencode: {
+          provider: {
+            "witness-v2": {
+              npm: "@ai-sdk/openai-compatible",
+              name: "Witness V2",
+              options: { baseURL: witnessBaseUrl, apiKey: keyV2 },
+              models: { [modelIdV2]: { name: modelNameV2 } },
+            },
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    expect(patchResponse.status).toBe(200);
+    const mirroredStatus = await untilStatus(
+      serverInfo,
+      (status) => status.mirroredProviderIds.includes("witness-v2") && status.catalogModelIds.includes(modelIdV2),
+      60_000,
+      "the v2 witness provider to be mirrored",
+    );
+    expect(mirroredStatus.pid).toBe(pid0);
+
+    await go(app, `/workspace/${workspaceId}/session`);
+    await waitForModelInPicker(app, modelNameV2, 45_000);
+    await closeModelPicker(app);
+    const v1BeforeR2 = await engineSessionCount(serverInfo, workspaceId, "opencode");
+    const v2BeforeR2 = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(v2BeforeR2).toBeGreaterThanOrEqual(0);
+
+    // New task uses the selected workspace's currently swapped client. This
+    // avoids sending a v2 prompt to the pre-toggle v1 session id.
+    await createNewSessionThroughSidebar(app);
+    await selectModel(app, modelNameV2);
+    const r2 = await sendAndWaitForNonce(
+      app,
+      witnessRequests,
+      "hello r2",
+      `Bearer ${keyV2}`,
+      modelIdV2,
+      routedOnAt,
+      "R2 v2",
+    );
+    const v1AfterR2 = await engineSessionCount(serverInfo, workspaceId, "opencode");
+    const v2AfterR2 = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(v2AfterR2).toBeGreaterThan(v2BeforeR2);
+    expect(v1AfterR2).toBe(v1BeforeR2);
+    expect(r2.request.at).toBeGreaterThanOrEqual(routedOnAt);
+    expect(r2.request.auth).toBe(`Bearer ${keyV2}`);
+    expect(r2.request.model).toBe(modelIdV2);
+    evidence.recordAssertionEvidence(
+      "R2 routed chat creates and streams through v2 without touching v1",
+      `The v2 transcript streamed ${r2.request.nonce} from ${modelIdV2} with Bearer ${keyV2} in ${r2.latencyMs}ms; v2 sessions grew ${v2BeforeR2}→${v2AfterR2}, while v1 stayed frozen at ${v1BeforeR2}.`,
+      true,
+    );
+
+    const statusAfterR2 = await readStatus(serverInfo);
+    expect(statusAfterR2.running).toBe(true);
+    expect(statusAfterR2.pid).toBe(pid0);
+    evidence.recordAssertionEvidence(
+      "R3 routing chat does not restart the v2 sidecar",
+      `The routed send completed while the sidecar remained running at pid ${pid0}; no replacement pid appeared.`,
+      true,
+    );
+
+    await go(app, `/workspace/${workspaceId}/settings/advanced`);
+    await waitFor(app, `document.querySelector('[aria-label="Route chat through OpenCode v2"]')?.getAttribute("aria-checked") === "true"`, {
+      timeoutMs: 30_000,
+      label: "enabled chat routing switch before reversal",
+    });
+    await clickSwitch(app, "Route chat through OpenCode v2");
+    await untilStatus(serverInfo, (status) => !status.chatRouting, 30_000, "chat routing to be disabled");
+    const routedOffAt = Date.now();
+    await go(app, `/workspace/${workspaceId}/session`);
+    await waitForModelInPicker(app, modelNameV1, 45_000);
+    await closeModelPicker(app);
+    await createNewSessionThroughSidebar(app);
+    await selectModel(app, modelNameV1);
+    const r4 = await sendAndWaitForNonce(
+      app,
+      witnessRequests,
+      "hello r4",
+      `Bearer ${keyV1}`,
+      modelIdV1,
+      routedOffAt,
+      "R4 v1",
+    );
+    const v2AfterR4 = await engineSessionCount(serverInfo, workspaceId, "opencode2");
+    expect(r4.request.at).toBeGreaterThanOrEqual(routedOffAt);
+    expect(r4.request.auth).toBe(`Bearer ${keyV1}`);
+    expect(r4.request.model).toBe(modelIdV1);
+    expect(v2AfterR4).toBe(v2AfterR2);
+    evidence.recordAssertionEvidence(
+      "R4 disabling routing returns new chat to v1 without mutating v2",
+      `After routing was disabled, the transcript streamed ${r4.request.nonce} from ${modelIdV1} with Bearer ${keyV1} in ${r4.latencyMs}ms; v2 sessions stayed frozen at ${v2AfterR2}.`,
+      true,
+    );
+  } finally {
+    if (app !== undefined) await app.stop();
+    witness.closeAllConnections();
+    await new Promise<void>((resolve, reject) => witness.close((error) => error ? reject(error) : resolve()));
+    await rm(profileDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Stacked on #4248 (which stacks on #4247).

## What

**OpenWork chat now runs on the opencode v2 engine** — behind the existing "OpenCode v2 engine preview" flag plus a new sub-toggle **"Route chat through OpenCode v2"** (Settings > Advanced, default off). This is the stage-3 renderer slice from the design doc, done at the standard seam with no new protocols invented:

- `apps/app/src/app/lib/opencode-v2-adapter.ts` — implements the same thin-client interface the renderer already consumes (all ~60 call sites unchanged), hand-rolled v2 transport per repo precedent. Builds a real v1 client and overlays the v2-backed namespaces, so untouched surfaces keep graceful SDK behavior with full type compatibility (zero casts). Event translation maps v2 `session.text.started/delta/ended` + `execution.*` into the v1 `message.updated` / `message.part.updated` / `message.part.delta` / `session.idle` shapes the sync layer reduces — parts keyed by the event-supplied `(assistantMessageID, ordinal)`, verified against captured live engine streams.
- Lane selection: the workspace client memo picks the adapter when preview status reports `enabled && running && chatRouting`; the opencode base URL becomes `<mounted>/opencode2`, and the URL itself is the lane marker for session-sync and native-snapshot paths.
- `apps/server` — sibling proxy mount `ALL /workspace/:id/opencode2/*` (bearer auth in, Basic auth out, `location[directory]` injected, SSE streamed, same conventions as the v1 mount) + persisted `chatRouting` on the preview state and `PUT /experimental/engine-v2-preview {enabled?, chatRouting?}`.
- Fixes found by driving the real UI: v2 session location binds via the create **body** (query middleware doesn't apply to create), nested `{model:{providerID,id}}` switch-model payload, New-task flow reuses the swapped client, native snapshot path lane-dispatches.

**Scope (deliberate)**: text-only chat v0. Tools, permissions, attachments, fork/revert/compaction return explicit `UnsupportedInV2Preview` results; unknown v2 event types are skipped with a one-time debug log. Flag off = zero behavior change; v1 remains the default engine everywhere.

## Proof

`evals/specs/opencode-v2-chat-routing.e2e.test.ts` — app-driving, engine attribution via per-engine session counts through the product proxies (the provider mirror is faithful, so witness traffic alone cannot attribute an engine):
- **R1** routing off: UI send is served by v1 (witness hit with key-1) while the v2 proxy reports the sidecar not running (503).
- **R2** flag + routing enabled through real Settings clicks: the picker shows the v2 catalog, a routed send streams the witness nonce into the real transcript, **the sidecar gains the session while the v1 engine's count stays frozen**, witness sees `Bearer key-2`.
- **R3** sidecar pid unchanged across the routed send (no restart).
- **R4** routing off again: the next UI send lands on v1, sidecar count frozen.

Adapter unit tests cover ordinal-keyed part identity (two streams on one message stay distinct) and the captured live event lifecycle end-to-end.

Observed routed-send latency in the spec runs: **v2 ~136–356 ms send→reply** vs v1 ~1.2 s cold first send / ~130 ms warm.

## Verification (local lane — Daytona credentials unavailable; all runs on this head's tree)

| Check | Result |
| --- | --- |
| `opencode-v2-chat-routing.e2e` | 1 passed / 0 skipped ×3 (two executor runs + my rerun, 48–50 s) |
| `engine-v2-preview-flag.e2e` (regression: section gained a switch) | 1 passed / 0 skipped |
| Adapter unit tests (`apps/app tests/`) | 4 passed |
| `pnpm --filter openwork-server test` | greens except 4 machine-local flakes (2 sidecar-gated MCP tests fail identically on clean origin/dev; 2 pass in isolation, flake only under full parallel load) |
| `pnpm --filter @openwork/app test` | greens except the 5 failures also present on clean origin/dev |
| Typechecks (server + app) | green |

Test evidence follows in comments. Next on this stack: app-perspective benchmark numbers on the v2 lane (same Lane A harness, routing enabled).