### PR TITLE
fix(den): harden Google Workspace retrieval

### DIFF
--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -69,6 +69,7 @@ type GmailBodyState = {
 
 const GMAIL_QUOTE_BODY_LIMIT = 10_000
 const GMAIL_HTML_INPUT_BYTE_LIMIT = 1_000_000
+const GMAIL_MESSAGE_BODY_LIMIT = 100_000
 const UTC_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 const UTC_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
@@ -277,7 +278,7 @@ export function extractGmailMessage(payloadJson: unknown): GoogleWorkspaceGmailM
   const state: GmailBodyState = { plain: null, html: null, attachments: [] }
   collectGmailPart(payload, state)
   const snippet = readString(message, "snippet")
-  const body = truncateText(state.plain ?? state.html ?? snippet, 100_000).text
+  const body = truncateText(state.plain ?? state.html ?? snippet, GMAIL_MESSAGE_BODY_LIMIT).text
 
   return {
     id: readString(message, "id"),

--- a/ee/apps/den-api/src/mcp/tool-content.ts
+++ b/ee/apps/den-api/src/mcp/tool-content.ts
@@ -6,6 +6,11 @@ export type AgentToolContentPart =
 
 const MAX_INLINE_IMAGE_BYTES = 1024 * 1024
 const MAX_IMAGE_DIMENSION = 1568
+const MAX_MODEL_VISIBLE_BINARY_BYTES = 64 * 1024
+const MAX_MODEL_VISIBLE_TEXT_CHARACTERS = 20_000
+const PRETTY_JSON_MAX_BYTES = 2 * 1024
+const BASE64_FIELD_PATTERN = /^(?:content|data)Base64$/i
+const TRUNCATION_MARKER = "\n[truncated]"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -19,6 +24,75 @@ function isImagePayload(value: unknown): value is Record<string, unknown> & {
     && typeof value.contentBase64 === "string"
     && typeof value.mimeType === "string"
     && value.mimeType.startsWith("image/")
+}
+
+function base64ByteSize(value: string): number {
+  return Buffer.byteLength(value, "base64")
+}
+
+function truncateModelString(value: string): string {
+  if (value.length <= MAX_MODEL_VISIBLE_TEXT_CHARACTERS) return value
+  return `${value.slice(0, MAX_MODEL_VISIBLE_TEXT_CHARACTERS - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`
+}
+
+function sanitizeModelPayload(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeModelPayload)
+  if (typeof value === "string") return truncateModelString(value)
+  if (!isRecord(value)) return value
+
+  const imagePayload = isImagePayload(value)
+  const omittedBase64 = new Map<string, number>()
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === "string" && BASE64_FIELD_PATTERN.test(key)) {
+      const byteSize = base64ByteSize(entry)
+      if (imagePayload || byteSize > MAX_MODEL_VISIBLE_BINARY_BYTES) omittedBase64.set(key, byteSize)
+    }
+  }
+
+  const reservedMetadata = new Set(
+    [...omittedBase64.keys()].flatMap((key) => [`${key}Omitted`, `${key}Bytes`]),
+  )
+  const sanitizedEntries: [string, unknown][] = []
+  for (const [key, entry] of Object.entries(value)) {
+    if (reservedMetadata.has(key)) continue
+    const byteSize = omittedBase64.get(key)
+    if (byteSize !== undefined) {
+      sanitizedEntries.push(
+        [key, `<${byteSize} binary bytes omitted from model-visible content>`],
+        [`${key}Omitted`, true],
+        [`${key}Bytes`, byteSize],
+      )
+      continue
+    }
+    if (typeof entry === "string" && BASE64_FIELD_PATTERN.test(key)) {
+      sanitizedEntries.push([key, entry])
+      continue
+    }
+    sanitizedEntries.push([key, sanitizeModelPayload(entry)])
+  }
+  return Object.fromEntries(sanitizedEntries)
+}
+
+function stringifyModelPayload(value: unknown): string {
+  const compact = JSON.stringify(value)
+  if (compact === undefined) return "null"
+  if (Buffer.byteLength(compact, "utf8") > PRETTY_JSON_MAX_BYTES) return compact
+  return JSON.stringify(value, null, 2)!
+}
+
+function findImagePayload(value: unknown, seen = new WeakSet<object>()): (Record<string, unknown> & {
+  contentBase64: string
+  mimeType: string
+}) | undefined {
+  if (isImagePayload(value)) return value
+  if (typeof value !== "object" || value === null || seen.has(value)) return undefined
+  seen.add(value)
+  const children = Array.isArray(value) ? value : Object.values(value)
+  for (const child of children) {
+    const image = findImagePayload(child, seen)
+    if (image) return image
+  }
+  return undefined
 }
 
 export function isKnownToolContentPart(value: unknown): value is AgentToolContentPart {
@@ -38,37 +112,17 @@ export function externalToolContent(result: unknown): AgentToolContentPart[] {
 }
 
 export async function buildRestToolContent(payload: unknown): Promise<AgentToolContentPart[]> {
-  if (typeof payload === "string") return [{ type: "text", text: payload }]
+  if (typeof payload === "string") return [{ type: "text", text: truncateModelString(payload) }]
 
-  const payloadRecord = isRecord(payload) ? payload : undefined
-  let imagePayload: (Record<string, unknown> & { contentBase64: string; mimeType: string }) | undefined
-  let imagePayloadKey: string | undefined
-  if (isImagePayload(payload)) {
-    imagePayload = payload
-  } else if (payloadRecord) {
-    for (const [key, value] of Object.entries(payloadRecord)) {
-      if (isImagePayload(value)) {
-        imagePayload = value
-        imagePayloadKey = key
-        break
-      }
-    }
-  }
+  const imagePayload = findImagePayload(payload)
 
-  if (!imagePayload) {
-    return [{ type: "text", text: JSON.stringify(payload, null, 2) }]
-  }
-
-  const byteSize = Buffer.byteLength(imagePayload.contentBase64, "base64")
-  const placeholder = `<${byteSize} bytes delivered as image content>`
-  const redactedImagePayload = { ...imagePayload, contentBase64: placeholder }
-  const redactedPayload = imagePayloadKey === undefined || payloadRecord === undefined
-    ? redactedImagePayload
-    : { ...payloadRecord, [imagePayloadKey]: redactedImagePayload }
   const textPart: AgentToolContentPart = {
     type: "text",
-    text: JSON.stringify(redactedPayload, null, 2),
+    text: stringifyModelPayload(sanitizeModelPayload(payload)),
   }
+  if (!imagePayload) return [textPart]
+
+  const byteSize = Buffer.byteLength(imagePayload.contentBase64, "base64")
 
   if (byteSize <= MAX_INLINE_IMAGE_BYTES) {
     return [textPart, {

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -40,12 +40,15 @@ const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
 const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
 const DRIVE_FULL_SCOPE = "https://www.googleapis.com/auth/drive"
+const DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000
-const MAX_DRIVE_FILE_CONTENT_BYTES = 10 * 1024 * 1024
+const MAX_DRIVE_FILE_CONTENT_BYTES = 64 * 1024
+const DRIVE_TEXT_CHARACTER_LIMIT = 200_000
 const DIRECT_UPLOAD_MAX_BYTES = 4 * 1024 * 1024
 const DIRECT_UPLOAD_BODY_MAX_BYTES = DIRECT_UPLOAD_MAX_BYTES + (256 * 1024)
 const DIRECT_UPLOAD_MAX_FILES = 10
 const GMAIL_REPLY_SUBJECT_RE = /^\s*(re|fwd?)\s*:/i
+const GMAIL_METADATA_CONCURRENCY = 4
 
 const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings > Connect and use Connect your account on the Google Workspace row, or connect from the OpenWork Cloud dashboard."
 
@@ -317,6 +320,8 @@ function driveApiBase(): string {
 export function missingScope(account: ConnectedAccountRow, anyOf: string[]): boolean {
   const scopes = account.scopes
   if (!Array.isArray(scopes) || scopes.length === 0) {
+    // Some legacy connections predate recorded scopes. Preserve their existing behavior;
+    // general Drive retrieval uses the stricter, fail-closed check below.
     return false
   }
   return !anyOf.some((scope) => scopes.includes(scope))
@@ -324,6 +329,25 @@ export function missingScope(account: ConnectedAccountRow, anyOf: string[]): boo
 
 function missingPermissionMessage(label: string): string {
   return `Your connected Google account is missing the ${label} permission. An admin can enable it on the Google Workspace connector in OpenWork Cloud -> Connectors; then reconnect your account in Settings -> Extensions.`
+}
+
+function driveReadPermissionMessage(account: ConnectedAccountRow): string | null {
+  const scopes = account.scopes
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    return "OpenWork could not verify the Google Drive permissions granted to this connection. An organization admin must enable Read all Drive files, then reconnect Google Workspace and grant Drive read access."
+  }
+  const grantedScopes = new Set(scopes)
+  if (grantedScopes.has(DRIVE_READ_SCOPE) || grantedScopes.has(DRIVE_FULL_SCOPE)) return null
+  return "Your connected Google account does not grant Read all Drive files. The selected-file Drive permission can upload or share files created through OpenWork, but it cannot search or read your general Drive. An organization admin must enable Read all Drive files, then reconnect Google Workspace and grant Drive read access."
+}
+
+function isDeclaredTextFile(mimeType: string): boolean {
+  return mimeType.startsWith("text/")
+    || mimeType === "application/json"
+    || mimeType === "application/xml"
+    || mimeType === "application/javascript"
+    || mimeType.endsWith("+json")
+    || mimeType.endsWith("+xml")
 }
 
 async function googleWorkspaceToken(input: {
@@ -376,14 +400,141 @@ async function googleWorkspaceToken(input: {
 
 async function googleApiError(operation: string, response: Response) {
   const text = await response.text()
-  return { error: "google_api_error", message: `${operation} failed: ${response.status} ${text.slice(0, 300)}` }
+  return { error: "google_api_error" as const, message: `${operation} failed: ${response.status} ${text.slice(0, 300)}` }
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function googleAuthorizationReasons(text: string): Set<string> {
+  const reasons = new Set<string>()
+  try {
+    const payload: unknown = JSON.parse(text)
+    if (!isRecordValue(payload) || !isRecordValue(payload.error)) return reasons
+    const errors = Array.isArray(payload.error.errors) ? payload.error.errors : []
+    const details = Array.isArray(payload.error.details) ? payload.error.details : []
+    for (const value of [...errors, ...details]) {
+      if (isRecordValue(value) && typeof value.reason === "string") reasons.add(value.reason)
+    }
+  } catch {
+    // Non-JSON provider errors retain the ordinary upstream-error path.
+  }
+  return reasons
+}
+
+function isGoogleAuthorizationFailure(status: number, text: string): boolean {
+  if (status === 401) return true
+  if (status !== 403) return false
+  const reasons = googleAuthorizationReasons(text)
+  return reasons.has("authError")
+    || reasons.has("insufficientPermissions")
+    || reasons.has("ACCESS_TOKEN_SCOPE_INSUFFICIENT")
+}
+
+async function googleDriveApiError(
+  operation: string,
+  response: Response,
+  options: { generalRead?: boolean } = {},
+): Promise<{
+  status: 409 | 502
+  body: { error: "needs_connection" | "google_api_error"; message: string }
+}> {
+  const text = await response.text()
+  const error = { error: "google_api_error" as const, message: `${operation} failed: ${response.status} ${text.slice(0, 300)}` }
+  const isFileReadOperation = operation === "Google Drive file metadata" || operation === "Google Drive file content"
+  if (response.status === 404 && isFileReadOperation) {
+    return {
+      status: 502,
+      body: {
+        error: "google_api_error",
+        message: `${operation} failed because Google Drive could not find the requested item. The connected account may not be able to see it, the file ID may be incorrect, or the item may have been deleted.`,
+      },
+    }
+  }
+  if (!isGoogleAuthorizationFailure(response.status, text)) return { status: 502, body: error }
+  return {
+    status: 409,
+    body: {
+      error: "needs_connection",
+      message: options.generalRead
+        ? "Google rejected this connection's Drive authorization. An organization admin must enable Read all Drive files, then reconnect Google Workspace and grant Drive read access."
+        : "Google rejected this connection's Drive authorization. Reconnect Google Workspace and grant the enabled Drive permissions, then retry.",
+    },
+  }
 }
 
 async function googleWorkspaceApiFetch(input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(GOOGLE_WORKSPACE_API_TIMEOUT_MS)
+  const signal = init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal
   return fetch(input, {
     ...init,
-    signal: AbortSignal.timeout(GOOGLE_WORKSPACE_API_TIMEOUT_MS),
+    signal,
   })
+}
+
+type GmailMetadataFetchResult =
+  | { ok: true; json: unknown }
+  | { ok: false; error: { error: "google_api_error"; message: string } }
+
+async function fetchGmailMetadata(
+  ids: readonly string[],
+  accessToken: string,
+  signal: AbortSignal,
+): Promise<
+  | { ok: true; json: unknown[] }
+  | { ok: false; error: { error: "google_api_error"; message: string } }
+> {
+  const results = new Array<unknown>(ids.length)
+  const controller = new AbortController()
+  const metadataSignal = AbortSignal.any([signal, controller.signal])
+  let nextIndex = 0
+  let stopped = false
+  let firstError: GmailMetadataFetchResult & { ok: false } | undefined
+  const stop = (error: GmailMetadataFetchResult & { ok: false }) => {
+    if (firstError) return
+    firstError = error
+    stopped = true
+    controller.abort()
+  }
+  const workerCount = Math.min(GMAIL_METADATA_CONCURRENCY, ids.length)
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (!stopped && nextIndex < ids.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const id = ids[index]
+      if (id === undefined) continue
+      try {
+        const messageUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages/${encodeURIComponent(id)}`)
+        messageUrl.searchParams.set("format", "metadata")
+        messageUrl.searchParams.append("metadataHeaders", "From")
+        messageUrl.searchParams.append("metadataHeaders", "To")
+        messageUrl.searchParams.append("metadataHeaders", "Bcc")
+        messageUrl.searchParams.append("metadataHeaders", "Subject")
+        messageUrl.searchParams.append("metadataHeaders", "Date")
+        const response = await googleWorkspaceApiFetch(messageUrl, {
+          headers: { authorization: `Bearer ${accessToken}` },
+          signal: metadataSignal,
+        })
+        if (!response.ok) {
+          stop({ ok: false, error: await googleApiError("Gmail message metadata", response) })
+          continue
+        }
+        results[index] = await readJson(response)
+      } catch {
+        stop({
+          ok: false,
+          error: {
+            error: "google_api_error",
+            message: "Gmail message metadata failed before Google returned a response.",
+          },
+        })
+      }
+    }
+  })
+  await Promise.all(workers)
+  if (firstError) return firstError
+  return { ok: true, json: results }
 }
 
 async function readJson(response: Response): Promise<unknown> {
@@ -609,6 +760,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       const boundary = `openwork-${randomUUID()}`
       const url = new URL(`${driveApiBase()}/upload/drive/v3/files`)
       url.searchParams.set("uploadType", "multipart")
+      url.searchParams.set("supportsAllDrives", "true")
       url.searchParams.set("fields", "id,name,mimeType,modifiedTime,webViewLink,size")
       const uploadBody = buildDriveMultipartUpload({
         metadata,
@@ -627,7 +779,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         body: uploadBodyBytes,
       })
       if (!response.ok) {
-        return c.json(await googleApiError("Google Drive file upload", response), 502)
+        const error = await googleDriveApiError("Google Drive file upload", response)
+        return error.status === 409 ? c.json(error.body, 409) : c.json(error.body, 502)
       }
       const uploadedFile = extractDriveFiles({ files: [await readJson(response)] })[0]
       if (!uploadedFile?.id) {
@@ -729,23 +882,13 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       }
 
       const ids = extractGmailMessageIds(await readJson(listResponse), 25)
-      const messages: z.infer<typeof gmailMessageSummarySchema>[] = []
-      for (const id of ids) {
-        const messageUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages/${encodeURIComponent(id)}`)
-        messageUrl.searchParams.set("format", "metadata")
-        messageUrl.searchParams.append("metadataHeaders", "From")
-        messageUrl.searchParams.append("metadataHeaders", "To")
-        messageUrl.searchParams.append("metadataHeaders", "Bcc")
-        messageUrl.searchParams.append("metadataHeaders", "Subject")
-        messageUrl.searchParams.append("metadataHeaders", "Date")
-        const messageResponse = await googleWorkspaceApiFetch(messageUrl, {
-          headers: { authorization: `Bearer ${token.accessToken}` },
-        })
-        if (!messageResponse.ok) {
-          return c.json(await googleApiError("Gmail message metadata", messageResponse), 502)
-        }
-        const message = extractGmailMessage(await readJson(messageResponse))
-        messages.push({
+      const metadata = await fetchGmailMetadata(ids, token.accessToken, c.req.raw.signal)
+      if (!metadata.ok) {
+        return c.json(metadata.error, 502)
+      }
+      const messages: z.infer<typeof gmailMessageSummarySchema>[] = metadata.json.map((json) => {
+        const message = extractGmailMessage(json)
+        return {
           id: message.id,
           threadId: message.threadId,
           from: message.from,
@@ -754,8 +897,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
           subject: message.subject,
           date: message.date,
           snippet: message.snippet,
-        })
-      }
+        }
+      })
 
       return c.json({ ok: true, messages })
     },
@@ -1065,21 +1208,27 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "needs_connection") {
         return c.json({ error: "needs_connection", message: token.message }, 409)
       }
-      if (missingScope(token.account, [DRIVE_READ_SCOPE, DRIVE_FULL_SCOPE, DRIVE_FILE_SCOPE])) {
-        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive read") }, 409)
+      const permissionMessage = driveReadPermissionMessage(token.account)
+      if (permissionMessage) {
+        return c.json({ error: "needs_connection", message: permissionMessage }, 409)
       }
 
       const query = c.req.valid("query")
       const url = new URL(`${driveApiBase()}/drive/v3/files`)
       url.searchParams.set("q", buildDriveSearchQuery(query.query))
       url.searchParams.set("pageSize", String(query.maxResults))
+      url.searchParams.set("corpora", "allDrives")
+      url.searchParams.set("spaces", "drive")
+      url.searchParams.set("supportsAllDrives", "true")
+      url.searchParams.set("includeItemsFromAllDrives", "true")
       url.searchParams.set("fields", "files(id,name,mimeType,modifiedTime,webViewLink,size)")
 
       const response = await googleWorkspaceApiFetch(url, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!response.ok) {
-        return c.json(await googleApiError("Google Drive files search", response), 502)
+        const error = await googleDriveApiError("Google Drive files search", response, { generalRead: true })
+        return error.status === 409 ? c.json(error.body, 409) : c.json(error.body, 502)
       }
 
       return c.json({ ok: true, files: extractDriveFiles(await readJson(response)) })
@@ -1091,9 +1240,10 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     describeRoute({
       tags: ["Capability Sources"],
       summary: "Read a Google Drive file's text or binary content as the calling member",
-      description: "Reads one Google Drive file, exporting Google Docs editors files as plain text. Downloaded files are content-sniffed with strict UTF-8 detection, so text is returned regardless of MIME type; binary content is returned as standard base64 up to 10 MiB.",
+      description: "Reads one Google Drive file, exporting Google Docs editors files as plain text. Downloaded files are content-sniffed with strict UTF-8 detection; declared text is bounded, and binary content is returned as standard base64 only up to the internal model-safety limit.",
       responses: {
         200: jsonResponse("Google Drive file returned.", driveFileResponseSchema),
+        400: jsonResponse("The Drive item is not a readable file.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
         502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
@@ -1113,27 +1263,41 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       if (token.kind === "needs_connection") {
         return c.json({ error: "needs_connection", message: token.message }, 409)
       }
-      if (missingScope(token.account, [DRIVE_READ_SCOPE, DRIVE_FULL_SCOPE, DRIVE_FILE_SCOPE])) {
-        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive read") }, 409)
+      const permissionMessage = driveReadPermissionMessage(token.account)
+      if (permissionMessage) {
+        return c.json({ error: "needs_connection", message: permissionMessage }, 409)
       }
 
       const { fileId } = c.req.valid("param")
       const metadataUrl = new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}`)
+      metadataUrl.searchParams.set("supportsAllDrives", "true")
       metadataUrl.searchParams.set("fields", "id,name,mimeType,modifiedTime,webViewLink,size")
       const metadataResponse = await googleWorkspaceApiFetch(metadataUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!metadataResponse.ok) {
-        return c.json(await googleApiError("Google Drive file metadata", metadataResponse), 502)
+        const error = await googleDriveApiError("Google Drive file metadata", metadataResponse, { generalRead: true })
+        return error.status === 409 ? c.json(error.body, 409) : c.json(error.body, 502)
       }
 
       const file = extractDriveFiles({ files: [await readJson(metadataResponse)] })[0]
       if (!file?.id) {
         return c.json({ error: "google_api_error", message: "Google Drive returned no file id." }, 502)
       }
+      if (file.mimeType === DRIVE_FOLDER_MIME_TYPE) {
+        return c.json({
+          error: "invalid_request",
+          details: [{ message: "The requested Drive item is a folder, not a readable file. Folder traversal is not supported by this file-read operation." }],
+        }, 400)
+      }
 
       const isGoogleAppsFile = file.mimeType.startsWith("application/vnd.google-apps")
-      if (!isGoogleAppsFile && file.size !== null && Number(file.size) > MAX_DRIVE_FILE_CONTENT_BYTES) {
+      if (
+        !isGoogleAppsFile
+        && !isDeclaredTextFile(file.mimeType)
+        && file.size !== null
+        && Number(file.size) > MAX_DRIVE_FILE_CONTENT_BYTES
+      ) {
         return c.json({
           ok: true,
           file: {
@@ -1154,17 +1318,19 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         contentUrl.searchParams.set("mimeType", "text/plain")
       } else {
         contentUrl.searchParams.set("alt", "media")
+        contentUrl.searchParams.set("supportsAllDrives", "true")
       }
 
       const contentResponse = await googleWorkspaceApiFetch(contentUrl, {
         headers: { authorization: `Bearer ${token.accessToken}` },
       })
       if (!contentResponse.ok) {
-        return c.json(await googleApiError("Google Drive file content", contentResponse), 502)
+        const error = await googleDriveApiError("Google Drive file content", contentResponse, { generalRead: true })
+        return error.status === 409 ? c.json(error.body, 409) : c.json(error.body, 502)
       }
 
       if (isGoogleAppsFile) {
-        const content = truncateText(await contentResponse.text(), 200_000)
+        const content = truncateText(await contentResponse.text(), DRIVE_TEXT_CHARACTER_LIMIT)
         return c.json({
           ok: true,
           file: {
@@ -1180,7 +1346,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
 
       const bytes = new Uint8Array(await contentResponse.arrayBuffer())
       const content = decodeFileContent(bytes, {
-        maxTextCharacters: 200_000,
+        maxTextCharacters: DRIVE_TEXT_CHARACTER_LIMIT,
         maxBinaryBytes: MAX_DRIVE_FILE_CONTENT_BYTES,
       })
       if (content.kind === "text") {
@@ -1269,6 +1435,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
 
       const url = new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}/permissions`)
       url.searchParams.set("sendNotificationEmail", String(input.sendNotificationEmail))
+      url.searchParams.set("supportsAllDrives", "true")
       url.searchParams.set("fields", "id,type,role")
       const response = await googleWorkspaceApiFetch(url, {
         method: "POST",
@@ -1279,7 +1446,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         body: JSON.stringify(permissionPayload),
       })
       if (!response.ok) {
-        return c.json(await googleApiError("Google Drive file share", response), 502)
+        const error = await googleDriveApiError("Google Drive file share", response)
+        return error.status === 409 ? c.json(error.body, 409) : c.json(error.body, 502)
       }
 
       const permission = extractDrivePermission(await readJson(response))

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -101,7 +101,17 @@ let calendarCreateCount = 0
 let lastDraftPayload: unknown = null
 let lastGmailThreadUrl: string | null = null
 let forceDriveUploadError = false
+let forceDriveAuthorizationError = false
+let forceDriveShareForbidden = false
 let largeDriveContentHitCount = 0
+let gmailListMessageIds = ["msg_1"]
+let gmailMetadataDelayMs = 0
+let gmailMetadataFailureId: string | null = null
+let activeGmailMetadataRequests = 0
+let maxActiveGmailMetadataRequests = 0
+let gmailMessageBody = "Plain Gmail body"
+let driveFileText = "Drive file text"
+let driveDocumentText = "Exported doc text"
 
 function resetFakeGoogle() {
   lastAuthorization = null
@@ -121,7 +131,17 @@ function resetFakeGoogle() {
   lastDraftPayload = null
   lastGmailThreadUrl = null
   forceDriveUploadError = false
+  forceDriveAuthorizationError = false
+  forceDriveShareForbidden = false
   largeDriveContentHitCount = 0
+  gmailListMessageIds = ["msg_1"]
+  gmailMetadataDelayMs = 0
+  gmailMetadataFailureId = null
+  activeGmailMetadataRequests = 0
+  maxActiveGmailMetadataRequests = 0
+  gmailMessageBody = "Plain Gmail body"
+  driveFileText = "Drive file text"
+  driveDocumentText = "Exported doc text"
 }
 
 // Trailing high bytes force base64url output ("-"/"_") to differ from standard base64 ("+"/"/").
@@ -129,11 +149,12 @@ const attachmentBytes = Buffer.concat([Buffer.from("%PDF-1.4 fake attachment", "
 const binaryDriveBytes = Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xfb, 0xef, 0xbe, 0xff]), Buffer.from("binary fixture", "utf8")])
 const dxfDriveText = "0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
 
-function gmailMessagePayload() {
+function gmailMessagePayload(id = "msg_1") {
+  const messageNumber = id.replace(/^msg_/, "")
   return {
-    id: "msg_1",
-    threadId: "thread_1",
-    snippet: "Gmail snippet",
+    id,
+    threadId: `thread_${messageNumber}`,
+    snippet: id === "msg_1" ? "Gmail snippet" : `Gmail snippet ${id}`,
     payload: {
       mimeType: "multipart/mixed",
       headers: [
@@ -144,7 +165,7 @@ function gmailMessagePayload() {
         { name: "Date", value: "Tue, 07 Jul 2026 10:00:00 +0000" },
       ],
       parts: [
-        { mimeType: "text/plain", body: { data: base64Url("Plain Gmail body") } },
+        { mimeType: "text/plain", body: { data: base64Url(gmailMessageBody) } },
         { filename: "plan.pdf", mimeType: "application/pdf", body: { attachmentId: "att_1", size: 123 } },
       ],
     },
@@ -170,10 +191,25 @@ const fakeGoogleServer = Bun.serve({
     }
 
     if (url.pathname === "/gmail/v1/users/me/messages") {
-      return json({ messages: [{ id: "msg_1", threadId: "thread_1" }] })
+      return json({ messages: gmailListMessageIds.map((id) => ({ id, threadId: `thread_${id.replace(/^msg_/, "")}` })) })
     }
-    if (url.pathname === "/gmail/v1/users/me/messages/msg_1") {
-      return json(gmailMessagePayload())
+    const gmailMessageMatch = url.pathname.match(/^\/gmail\/v1\/users\/me\/messages\/([^/]+)$/)
+    if (gmailMessageMatch?.[1]) {
+      if (url.searchParams.get("format") === "metadata") {
+        activeGmailMetadataRequests += 1
+        maxActiveGmailMetadataRequests = Math.max(maxActiveGmailMetadataRequests, activeGmailMetadataRequests)
+        try {
+          if (gmailMessageMatch[1] === gmailMetadataFailureId) {
+            return new Response("metadata exploded", { status: 500 })
+          }
+          if (gmailMetadataDelayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, gmailMetadataDelayMs))
+          }
+        } finally {
+          activeGmailMetadataRequests -= 1
+        }
+      }
+      return json(gmailMessagePayload(gmailMessageMatch[1]))
     }
     if (url.pathname === "/gmail/v1/users/me/messages/msg_1/attachments/att_1") {
       return json({ attachmentId: "att_1", size: attachmentBytes.byteLength, data: attachmentBytes.toString("base64url") })
@@ -270,6 +306,16 @@ const fakeGoogleServer = Bun.serve({
 
     if (url.pathname === "/drive/v3/files") {
       lastDriveQuery = url.searchParams.get("q")
+      if (forceDriveAuthorizationError) {
+        return json({
+          error: {
+            code: 403,
+            message: `${"x".repeat(400)} Insufficient Permission`,
+            status: "PERMISSION_DENIED",
+            errors: [{ reason: "insufficientPermissions" }],
+          },
+        }, 403)
+      }
       return json({
         files: [
           {
@@ -302,6 +348,9 @@ const fakeGoogleServer = Bun.serve({
       const body: unknown = await request.json()
       lastDriveSharePayload = body
       lastDriveShareUrl = request.url
+      if (forceDriveShareForbidden) {
+        return json({ error: { code: 403, message: "The target file cannot be shared.", status: "PERMISSION_DENIED" } }, 403)
+      }
       const payload = isRecord(body) ? body : {}
       return json({
         id: readString(payload, "type") === "domain" ? "perm_domain_1" : "perm_user_1",
@@ -310,7 +359,7 @@ const fakeGoogleServer = Bun.serve({
       })
     }
     if (url.pathname === "/drive/v3/files/file_1" && url.searchParams.get("alt") === "media") {
-      return new Response("Drive file text", { headers: { "content-type": "text/plain" } })
+      return new Response(driveFileText, { headers: { "content-type": "text/plain" } })
     }
     if (url.pathname === "/drive/v3/files/file_1") {
       return json({
@@ -320,6 +369,32 @@ const fakeGoogleServer = Bun.serve({
         modifiedTime: "2026-07-08T11:00:00Z",
         webViewLink: "https://drive.google.com/file/d/file_1/view",
         size: "42",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/user_created_file" && url.searchParams.get("alt") === "media") {
+      return new Response("Created directly in My Drive", { headers: { "content-type": "text/plain" } })
+    }
+    if (url.pathname === "/drive/v3/files/user_created_file") {
+      return json({
+        id: "user_created_file",
+        name: "Created in My Drive.txt",
+        mimeType: "text/plain",
+        modifiedTime: "2026-08-31T12:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/user_created_file/view",
+        size: "28",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/missing_file") {
+      return json({ error: { code: 404, message: "File not found: missing_file.", status: "NOT_FOUND" } }, 404)
+    }
+    if (url.pathname === "/drive/v3/files/folder_1") {
+      return json({
+        id: "folder_1",
+        name: "Planning folder",
+        mimeType: "application/vnd.google-apps.folder",
+        modifiedTime: "2026-08-31T12:00:00Z",
+        webViewLink: "https://drive.google.com/drive/folders/folder_1",
+        size: null,
       })
     }
     if (url.pathname === "/drive/v3/files/binary_file" && url.searchParams.get("alt") === "media") {
@@ -359,7 +434,7 @@ const fakeGoogleServer = Bun.serve({
         mimeType: "application/octet-stream",
         modifiedTime: "2026-07-08T11:00:00Z",
         webViewLink: "https://drive.google.com/file/d/large_file/view",
-        size: "20971520",
+        size: String(128 * 1024),
       })
     }
     if (url.pathname === "/drive/v3/files/doc_1") {
@@ -373,7 +448,7 @@ const fakeGoogleServer = Bun.serve({
       })
     }
     if (url.pathname === "/drive/v3/files/doc_1/export") {
-      return new Response("Exported doc text", { headers: { "content-type": "text/plain" } })
+      return new Response(driveDocumentText, { headers: { "content-type": "text/plain" } })
     }
 
     return new Response(`Unhandled fake Google route: ${url.pathname}`, { status: 404 })
@@ -442,6 +517,38 @@ function requestForm(path: string, form: FormData) {
   })
 }
 
+async function mcpToolCall(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const response = await app.request("http://den-api.local/mcp/agent", {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${directUploadMcpToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  })
+  expect(response.status).toBe(200)
+  const responseText = await response.text()
+  const dataLine = responseText.split("\n").find((line) => line.startsWith("data: "))
+  const payload: unknown = JSON.parse(dataLine?.slice("data: ".length) ?? responseText)
+  const envelope = expectRecord(payload, "MCP JSON-RPC response")
+  return expectRecord(envelope.result, "MCP tool result")
+}
+
+function mcpText(result: Record<string, unknown>): string {
+  const content = Array.isArray(result.content) ? result.content : []
+  for (const part of content) {
+    const record = isRecord(part) ? part : null
+    if (record?.type === "text" && typeof record.text === "string") return record.text
+  }
+  throw new Error("Expected MCP text result")
+}
+
 beforeAll(async () => {
   mock.restore()
   const realDb = (await import("@openwork-ee/den-db")).createDenDb({
@@ -492,13 +599,20 @@ beforeAll(async () => {
     token: authSessionToken,
     expiresAt: new Date(Date.now() + 60 * 60 * 1000),
   })
+  await credentialsMod.upsertOrgOAuthClient({
+    organizationId,
+    providerId: "google-workspace",
+    clientId: "gws-caps-client",
+    clientSecret: "gws-caps-secret",
+    createdByOrgMembershipId: memberId,
+  })
   const tokenResponse = await app.request("http://den-api.local/v1/mcp/token", {
     method: "POST",
     headers: {
       authorization: `Bearer ${authSessionToken}`,
       "content-type": "application/json",
     },
-    body: JSON.stringify({ scopes: ["mcp:write"] }),
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
   })
   expect(tokenResponse.status).toBe(200)
   const tokenBody: unknown = await tokenResponse.json()
@@ -513,6 +627,7 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
+  await db.delete(schema.OrgOAuthClientTable).where(drizzle.eq(schema.OrgOAuthClientTable.organizationId, organizationId))
   await db.delete(schema.OAuthAccessTokenTable).where(drizzle.eq(schema.OAuthAccessTokenTable.referenceId, organizationId))
   await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, authSessionId))
   await db.delete(schema.MemberTable).where(drizzle.eq(schema.MemberTable.organizationId, organizationId))
@@ -662,6 +777,42 @@ test("gmail list returns metadata-mapped messages", async () => {
       },
     ],
   })
+})
+
+test("gmail list overlaps metadata requests with bounded concurrency and preserves list order", async () => {
+  gmailListMessageIds = ["msg_1", "msg_2", "msg_3", "msg_4", "msg_5", "msg_6"]
+  gmailMetadataDelayMs = 40
+  const response = await request("/v1/capabilities/google-workspace/gmail-messages?maxResults=6")
+  expect(response.status).toBe(200)
+  const body = expectRecord(await response.json(), "concurrent Gmail response")
+  const messages = Array.isArray(body.messages) ? body.messages.map((message) => expectRecord(message, "Gmail message")) : []
+  expect(messages.map((message) => message.id)).toEqual(gmailListMessageIds)
+  expect(maxActiveGmailMetadataRequests).toBeGreaterThan(1)
+  expect(maxActiveGmailMetadataRequests).toBeLessThanOrEqual(4)
+})
+
+test("gmail metadata failure stops new work and returns the existing upstream error shape", async () => {
+  gmailListMessageIds = ["msg_1", "msg_2", "msg_3", "msg_4", "msg_5", "msg_6", "msg_7", "msg_8"]
+  gmailMetadataFailureId = "msg_2"
+  gmailMetadataDelayMs = 40
+  const response = await request("/v1/capabilities/google-workspace/gmail-messages?maxResults=8")
+  expect(response.status).toBe(502)
+  const metadataCalls = googleCallUrls.filter((value) => new URL(value).searchParams.get("format") === "metadata")
+  expect(metadataCalls).toHaveLength(4)
+  expect(metadataCalls.some((value) => value.includes("/msg_5"))).toBe(false)
+  expect(await response.json()).toEqual({
+    error: "google_api_error",
+    message: "Gmail message metadata failed: 500 metadata exploded",
+  })
+})
+
+test("gmail message body retains the existing retrieval limit before MCP serialization", async () => {
+  gmailMessageBody = "g".repeat(120_000)
+  const response = await request("/v1/capabilities/google-workspace/gmail-message/msg_1")
+  expect(response.status).toBe(200)
+  const body = expectRecord(await response.json(), "bounded Gmail response")
+  const message = expectRecord(body.message, "bounded Gmail message")
+  expect(expectString(message.body, "bounded Gmail body")).toHaveLength(100_000)
 })
 
 test("gmail attachment download returns standard base64 bytes and sends the member token", async () => {
@@ -920,6 +1071,119 @@ test("drive search returns mapped files", async () => {
       },
     ],
   })
+
+  const url = new URL(expectString(googleCallUrls.at(-1), "Drive search URL"))
+  expect(url.searchParams.get("pageSize")).toBe("3")
+  expect(url.searchParams.get("corpora")).toBe("allDrives")
+  expect(url.searchParams.get("spaces")).toBe("drive")
+  expect(url.searchParams.get("supportsAllDrives")).toBe("true")
+  expect(url.searchParams.get("includeItemsFromAllDrives")).toBe("true")
+  expect(url.searchParams.get("orderBy")).toBeNull()
+  expect(url.searchParams.get("fields")).toBe("files(id,name,mimeType,modifiedTime,webViewLink,size)")
+})
+
+test("Google Drive authorization failures become an actionable connector response", async () => {
+  forceDriveAuthorizationError = true
+  const response = await request("/v1/capabilities/google-workspace/drive-files?query=quarterly")
+  expect(response.status).toBe(409)
+  const body = expectRecord(await response.json(), "Google Drive authorization error")
+  expect(body.error).toBe("needs_connection")
+  expect(expectMessage(body)).toContain("enable Read all Drive files")
+  expect(expectMessage(body)).toContain("reconnect Google Workspace")
+})
+
+test("drive.file alone cannot execute general Drive search", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-files?query=quarterly&maxResults=3")
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectRecord(body, "Drive authorization response").error).toBe("needs_connection")
+  expect(expectMessage(body)).toContain("does not grant Read all Drive files")
+  expect(expectMessage(body)).toContain("reconnect Google Workspace")
+})
+
+test("drive.file alone cannot execute general Drive read", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-file/file_1")
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  expect(expectMessage(await response.json())).toContain("does not grant Read all Drive files")
+})
+
+test("Drive read scope matching rejects URL lookalikes", async () => {
+  await seedConnectedAccount([`${DRIVE_READ_SCOPE}.lookalike`, `prefix.${DRIVE_FULL_SCOPE}`])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-files?query=quarterly")
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  expect(expectMessage(await response.json())).toContain("does not grant Read all Drive files")
+})
+
+test("missing or empty recorded scopes fail closed for general Drive search and read", async () => {
+  for (const scopes of [null, []] as const) {
+    for (const path of [
+      "/v1/capabilities/google-workspace/drive-files?query=quarterly",
+      "/v1/capabilities/google-workspace/drive-file/user_created_file",
+    ]) {
+      await seedConnectedAccount(scopes)
+      resetFakeGoogle()
+      const response = await request(path)
+      expect(response.status).toBe(409)
+      expect(googleCallCount).toBe(0)
+      expect(expectMessage(await response.json())).toContain("could not verify the Google Drive permissions")
+    }
+  }
+})
+
+test("a file created directly in My Drive requires read-all scope for the same file id", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const denied = await request("/v1/capabilities/google-workspace/drive-file/user_created_file")
+  expect(denied.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  expect(expectMessage(await denied.json())).toContain("does not grant Read all Drive files")
+
+  for (const scope of [DRIVE_READ_SCOPE, DRIVE_FULL_SCOPE]) {
+    await seedConnectedAccount([scope])
+    resetFakeGoogle()
+    const allowed = await request("/v1/capabilities/google-workspace/drive-file/user_created_file")
+    expect(allowed.status).toBe(200)
+    expect(googleCallCount).toBe(2)
+    const file = expectRecord(expectRecord(await allowed.json(), "user-created Drive response").file, "user-created Drive file")
+    expect(file.id).toBe("user_created_file")
+    expect(file.content).toBe("Created directly in My Drive")
+  }
+})
+
+test("Drive 404 remains an ambiguous item error when full read access is recorded", async () => {
+  await seedConnectedAccount([DRIVE_FULL_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-file/missing_file")
+  expect(response.status).toBe(502)
+  expect(googleCallCount).toBe(1)
+  const body = expectRecord(await response.json(), "Drive not-found response")
+  expect(body.error).toBe("google_api_error")
+  const message = expectMessage(body)
+  expect(message).toContain("connected account may not be able to see it")
+  expect(message).toContain("file ID may be incorrect")
+  expect(message).toContain("item may have been deleted")
+  expect(message).not.toContain("Read all Drive files")
+  expect(message.length).toBeLessThan(300)
+})
+
+test("Drive file read rejects folders after metadata without attempting content download", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file/folder_1")
+  expect(response.status).toBe(400)
+  expect(googleCallCount).toBe(1)
+  const body = expectRecord(await response.json(), "Drive folder response")
+  expect(body.error).toBe("invalid_request")
+  const details = Array.isArray(body.details) ? body.details : []
+  const detail = expectRecord(details[0], "Drive folder diagnostic")
+  expect(detail.message).toContain("folder, not a readable file")
+  expect(detail.message).toContain("Folder traversal is not supported")
 })
 
 test("drive file read returns strict UTF-8 text metadata", async () => {
@@ -933,6 +1197,10 @@ test("drive file read returns strict UTF-8 text metadata", async () => {
   expect(file.encoding).toBe("text")
   expect(file.contentBase64).toBeNull()
   expect(file.contentUnavailableReason).toBeNull()
+  const metadataUrl = new URL(expectString(googleCallUrls[0], "Drive metadata URL"))
+  const contentUrl = new URL(expectString(googleCallUrls[1], "Drive content URL"))
+  expect(metadataUrl.searchParams.get("supportsAllDrives")).toBe("true")
+  expect(contentUrl.searchParams.get("supportsAllDrives")).toBe("true")
 })
 
 test("drive file read preserves binary bytes through standard base64", async () => {
@@ -978,6 +1246,16 @@ test("drive file read keeps the Google Apps text export branch", async () => {
   expect(file.content).toBe("Exported doc text")
 })
 
+test("drive text retains the existing retrieval limit before MCP serialization", async () => {
+  driveDocumentText = "d".repeat(210_000)
+  const response = await request("/v1/capabilities/google-workspace/drive-file/doc_1")
+  expect(response.status).toBe(200)
+  const body = expectRecord(await response.json(), "bounded Drive response")
+  const file = expectRecord(body.file, "bounded Drive file")
+  expect(expectString(file.content, "bounded Drive content")).toHaveLength(200_000)
+  expect(file.truncated).toBe(true)
+})
+
 test("direct Drive upload preserves exact multipart bytes and returns the user-facing link", async () => {
   await seedConnectedAccount([DRIVE_FILE_SCOPE])
   resetFakeGoogle()
@@ -988,6 +1266,8 @@ test("direct Drive upload preserves exact multipart bytes and returns the user-f
   const response = await requestForm("/v1/direct-uploads/google-workspace/drive-files", form)
   expect(response.status).toBe(200)
   expect(lastAuthorization).toBe("Bearer gws-token")
+  const uploadUrl = new URL(expectString(googleCallUrls[0], "Drive upload URL"))
+  expect(uploadUrl.searchParams.get("supportsAllDrives")).toBe("true")
   const contentType = expectString(lastDriveUploadContentType, "drive upload content type")
   const boundary = contentType.match(/boundary=(.+)$/)?.[1]
   if (!boundary) {
@@ -1038,6 +1318,7 @@ test("drive share grants user access and sends notification by default", async (
   const url = new URL(expectString(lastDriveShareUrl, "drive share URL"))
   expect(url.pathname).toBe("/drive/v3/files/file_1/permissions")
   expect(url.searchParams.get("sendNotificationEmail")).toBe("true")
+  expect(url.searchParams.get("supportsAllDrives")).toBe("true")
   expect(url.searchParams.get("fields")).toBe("id,type,role")
   const body: unknown = await response.json()
   expect(body).toEqual({ ok: true, fileId: "file_1", permissionId: "perm_user_1", type: "user", role: "reader" })
@@ -1069,6 +1350,21 @@ test("drive share validates user email before calling Google", async () => {
   expect(expectRecord(body, "invalid share response").error).toBe("invalid_request")
 })
 
+test("ordinary Drive share permission failures are not misclassified as missing OAuth scope", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  forceDriveShareForbidden = true
+  const response = await request("/v1/capabilities/google-workspace/drive-file-share/file_1", {
+    method: "POST",
+    body: { type: "user", emailAddress: "raghav@openworklabs.com" },
+  })
+  expect(response.status).toBe(502)
+  const body = expectRecord(await response.json(), "Drive share forbidden response")
+  expect(body.error).toBe("google_api_error")
+  expect(expectMessage(body)).toContain("target file cannot be shared")
+  expect(expectMessage(body)).not.toContain("Read all Drive files")
+})
+
 test("drive upload returns google_api_error when Google rejects the upload", async () => {
   await seedConnectedAccount([DRIVE_FILE_SCOPE])
   resetFakeGoogle()
@@ -1083,6 +1379,101 @@ test("drive upload returns google_api_error when Google rejects the upload", asy
     error: "google_api_error",
     message: "Google Drive file upload failed: 500 upload exploded",
   })
+})
+
+test("existing MCP search and execute path enforces Drive scope and bounds model-visible content", async () => {
+  const searchResult = await mcpToolCall("search_capabilities", { query: "drive files", limit: 10 })
+  const capabilityName = "native:google-workspace:getCapabilitiesGoogleWorkspaceDriveFiles"
+  expect(mcpText(searchResult)).toContain(capabilityName)
+
+  resetFakeGoogle()
+  const successfulSearch = await mcpToolCall("execute_capability", {
+    name: capabilityName,
+    query: { query: "quarterly", maxResults: 3 },
+  })
+  expect(successfulSearch.isError).not.toBe(true)
+  expect(mcpText(successfulSearch)).toContain("Quarterly Plan.txt")
+  const providerUrl = new URL(expectString(googleCallUrls[0], "MCP Drive search URL"))
+  expect(providerUrl.searchParams.get("supportsAllDrives")).toBe("true")
+  expect(providerUrl.searchParams.get("includeItemsFromAllDrives")).toBe("true")
+
+  resetFakeGoogle()
+  const rawBinary = binaryDriveBytes.toString("base64")
+  const binaryResult = await mcpToolCall("execute_capability", {
+    name: "native:google-workspace:getCapabilitiesGoogleWorkspaceDriveFile",
+    path: { fileId: "binary_file" },
+  })
+  const binaryText = mcpText(binaryResult)
+  expect(binaryText).toContain(rawBinary)
+  expect(binaryText).not.toContain("contentBase64Omitted")
+  expect(Buffer.byteLength(binaryText, "utf8")).toBeLessThan(2_000)
+
+  resetFakeGoogle()
+  const largeBinaryResult = await mcpToolCall("execute_capability", {
+    name: "native:google-workspace:getCapabilitiesGoogleWorkspaceDriveFile",
+    path: { fileId: "large_file" },
+  })
+  const largeBinaryText = mcpText(largeBinaryResult)
+  expect(largeBinaryText).toContain('"contentBase64": null')
+  expect(largeBinaryText).not.toContain("contentBase64Omitted")
+  expect(largeBinaryText).toContain("file_too_large")
+  expect(largeDriveContentHitCount).toBe(0)
+
+  resetFakeGoogle()
+  driveDocumentText = "d".repeat(25_000)
+  const textResult = await mcpToolCall("execute_capability", {
+    name: "native:google-workspace:getCapabilitiesGoogleWorkspaceDriveFile",
+    path: { fileId: "doc_1" },
+  })
+  const modelText = mcpText(textResult)
+  expect(modelText).toContain("[truncated]")
+  expect(modelText).not.toContain("d".repeat(20_001))
+  expect(Buffer.byteLength(modelText, "utf8")).toBeLessThan(22_000)
+
+  resetFakeGoogle()
+  gmailMessageBody = "g".repeat(25_000)
+  const gmailTextResult = await mcpToolCall("execute_capability", {
+    name: "native:google-workspace:getCapabilitiesGoogleWorkspaceGmailMessage",
+    path: { messageId: "msg_1" },
+  })
+  const gmailModelText = mcpText(gmailTextResult)
+  expect(gmailModelText).toContain("[truncated]")
+  expect(gmailModelText).not.toContain("g".repeat(20_001))
+  expect(Buffer.byteLength(gmailModelText, "utf8")).toBeLessThan(22_000)
+
+  resetFakeGoogle()
+  const attachmentResult = await mcpToolCall("execute_capability", {
+    name: "native:google-workspace:getCapabilitiesGoogleWorkspaceGmailAttachment",
+    path: { messageId: "msg_1", attachmentId: "att_1" },
+  })
+  expect(mcpText(attachmentResult)).toContain(attachmentBytes.toString("base64"))
+
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const deniedSearch = await mcpToolCall("execute_capability", {
+    name: capabilityName,
+    query: { query: "quarterly", maxResults: 3 },
+  })
+  expect(deniedSearch.isError).toBe(true)
+  expect(mcpText(deniedSearch)).toContain("does not grant Read all Drive files")
+  expect(googleCallCount).toBe(0)
+})
+
+test("legacy accounts without recorded scopes retain existing non-Drive behavior", async () => {
+  await seedConnectedAccount(null)
+  resetFakeGoogle()
+  const gmail = await request("/v1/capabilities/google-workspace/gmail-messages")
+  expect(gmail.status).toBe(200)
+  expect(googleCallCount).toBe(2)
+
+  await seedConnectedAccount(null)
+  resetFakeGoogle()
+  const share = await request("/v1/capabilities/google-workspace/drive-file-share/file_1", {
+    method: "POST",
+    body: { type: "user", emailAddress: "raghav@openworklabs.com" },
+  })
+  expect(share.status).toBe(200)
+  expect(googleCallCount).toBe(1)
 })
 
 test("no connected account returns needs_connection", async () => {

--- a/ee/apps/den-api/test/mcp-tool-content.test.ts
+++ b/ee/apps/den-api/test/mcp-tool-content.test.ts
@@ -23,7 +23,7 @@ test("buildRestToolContent emits a small image and redacts its base64 from text"
   expect(content).toHaveLength(2)
   expect(content[0]?.type).toBe("text")
   if (content[0]?.type === "text") {
-    expect(content[0].text).toContain("bytes delivered as image content")
+    expect(content[0].text).toContain("binary bytes omitted from model-visible content")
     expect(content[0].text).not.toContain(data)
   }
   expect(content[1]).toEqual({ type: "image", data, mimeType: "image/png" })
@@ -45,7 +45,7 @@ test("buildRestToolContent downscales large images to bounded JPEG content", asy
   const imagePart = content[1]
   expect(textPart?.type).toBe("text")
   if (textPart?.type === "text") {
-    expect(textPart.text).toContain("bytes delivered as image content")
+    expect(textPart.text).toContain("binary bytes omitted from model-visible content")
     expect(textPart.text).not.toContain(data)
   }
   expect(imagePart?.type).toBe("image")
@@ -57,12 +57,75 @@ test("buildRestToolContent downscales large images to bounded JPEG content", asy
   }
 })
 
-test("buildRestToolContent leaves non-image binary payloads unchanged", async () => {
-  const payload = { file: { dataBase64: "AAAA", mimeType: "application/pdf" } }
-  expect(await buildRestToolContent(payload)).toEqual([{
-    type: "text",
-    text: JSON.stringify(payload, null, 2),
-  }])
+test("buildRestToolContent omits non-image PDF and Office base64 from model-visible text", async () => {
+  const pdfBase64 = randomBytes(96 * 1024).toString("base64")
+  const officeBase64 = randomBytes(80 * 1024).toString("base64")
+  const content = await buildRestToolContent({
+    files: [
+      { dataBase64: pdfBase64, mimeType: "application/pdf", name: "report.pdf" },
+      { contentBase64: officeBase64, mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", name: "brief.docx" },
+    ],
+  })
+  expect(content).toHaveLength(1)
+  expect(content[0]?.type).toBe("text")
+  if (content[0]?.type === "text") {
+    expect(content[0].text).not.toContain(pdfBase64)
+    expect(content[0].text).not.toContain(officeBase64)
+    expect(content[0].text).toContain('"dataBase64Omitted": true')
+    expect(content[0].text).toContain('"contentBase64Omitted": true')
+  }
+})
+
+test("buildRestToolContent preserves small non-image bytes for existing attachment flows", async () => {
+  const dataBase64 = randomBytes(48 * 1024).toString("base64")
+  const content = await buildRestToolContent({
+    ok: true,
+    attachment: { dataBase64, mimeType: "application/pdf", name: "report.pdf" },
+  })
+  const text = content[0]?.type === "text" ? content[0].text : ""
+  expect(text).toContain(dataBase64)
+  expect(text).not.toContain("dataBase64Omitted")
+})
+
+test("buildRestToolContent bounds nested model-visible text", async () => {
+  const content = await buildRestToolContent({ ok: true, message: { body: "x".repeat(25_000) } })
+  const text = content[0]?.type === "text" ? content[0].text : ""
+  const parsed = JSON.parse(text) as { message: { body: string } }
+  expect(parsed.message.body).toHaveLength(20_000)
+  expect(parsed.message.body.endsWith("\n[truncated]")).toBe(true)
+  expect(text).not.toContain("x".repeat(20_001))
+})
+
+test("buildRestToolContent emits images nested inside arrays and objects", async () => {
+  const data = (await sharp({
+    create: { width: 2, height: 2, channels: 4, background: "blue" },
+  }).png().toBuffer()).toString("base64")
+  const content = await buildRestToolContent({ results: [{ nested: { contentBase64: data, mimeType: "image/png" } }] })
+  expect(content).toHaveLength(2)
+  expect(content[0]?.type === "text" ? content[0].text : "").not.toContain(data)
+  expect(content[1]).toEqual({ type: "image", data, mimeType: "image/png" })
+})
+
+test("buildRestToolContent owns omission metadata and safely serializes __proto__ keys", async () => {
+  const dataBase64 = randomBytes(96 * 1024).toString("base64")
+  const payload: unknown = JSON.parse(`{"dataBase64":${JSON.stringify(dataBase64)},"dataBase64Omitted":false,"dataBase64Bytes":1,"__proto__":{"polluted":true}}`)
+  const content = await buildRestToolContent(payload)
+  const text = content[0]?.type === "text" ? content[0].text : ""
+  const parsed = JSON.parse(text) as Record<string, unknown>
+  expect(parsed.dataBase64Omitted).toBe(true)
+  expect(parsed.dataBase64Bytes).toBe(96 * 1024)
+  expect(parsed).toHaveProperty("__proto__")
+  expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined()
+})
+
+test("buildRestToolContent compacts JSON only after the model-visible result grows beyond 2 KiB", async () => {
+  const small = await buildRestToolContent({ ok: true, value: "small" })
+  expect(small[0]?.type === "text" ? small[0].text : "").toContain("\n  \"ok\"")
+
+  const large = await buildRestToolContent({ ok: true, body: "x".repeat(3_000) })
+  const text = large[0]?.type === "text" ? large[0].text : ""
+  expect(text).not.toContain("\n")
+  expect(text).toBe(JSON.stringify({ ok: true, body: "x".repeat(3_000) }))
 })
 
 test("known content validation and external content passthrough preserve text and images", () => {

--- a/evals/specs/google-workspace-connector-retrieval.test.ts
+++ b/evals/specs/google-workspace-connector-retrieval.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { expect } from "vitest"
+import { localMysqlIsRunning, needs, test } from "@openwork/testkit"
+
+const repoRoot = resolve(import.meta.dirname, "../..")
+const mysqlOpen = await localMysqlIsRunning()
+
+test.skipIf(!mysqlOpen)("Google Workspace retrieval enforces Drive access and bounds model-visible output", ({ evidence }) => {
+  needs({})
+  const reportDir = mkdtempSync(join(tmpdir(), "google-workspace-retrieval-"))
+  const reportPath = join(reportDir, "junit.xml")
+  try {
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork-ee/den-api",
+      "exec",
+      "bun",
+      "test",
+      "test/mcp-tool-content.test.ts",
+      "test/google-workspace-capabilities.test.ts",
+      "--reporter=junit",
+      `--reporter-outfile=${reportPath}`,
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 180_000,
+      maxBuffer: 20 * 1024 * 1024,
+    })
+    const output = `${result.stdout}${result.stderr}`
+
+    expect(result.error, output).toBeUndefined()
+    expect(result.status, output).toBe(0)
+    const report = readFileSync(reportPath, "utf8")
+    expect(report).toContain('name="drive.file alone cannot execute general Drive search"')
+    expect(report).toContain('name="drive.file alone cannot execute general Drive read"')
+    expect(report).toContain('name="missing or empty recorded scopes fail closed for general Drive search and read"')
+    expect(report).toContain('name="a file created directly in My Drive requires read-all scope for the same file id"')
+    expect(report).toContain('name="Drive 404 remains an ambiguous item error when full read access is recorded"')
+    expect(report).toContain('name="Drive file read rejects folders after metadata without attempting content download"')
+    expect(report).toContain('name="Google Drive authorization failures become an actionable connector response"')
+    expect(report).toContain('name="gmail list overlaps metadata requests with bounded concurrency and preserves list order"')
+    expect(report).toContain('name="gmail metadata failure stops new work and returns the existing upstream error shape"')
+    expect(report).toContain('name="existing MCP search and execute path enforces Drive scope and bounds model-visible content"')
+    expect(report).toContain('name="drive text retains the existing retrieval limit before MCP serialization"')
+    expect(report).toContain('name="gmail message body retains the existing retrieval limit before MCP serialization"')
+    expect(report).not.toContain("<failure")
+    expect(report).not.toContain("<skipped")
+  } finally {
+    rmSync(reportDir, { recursive: true, force: true })
+  }
+
+  evidence.recordAssertionEvidence(
+    "General Drive retrieval requires a verified read grant",
+    "The focused connector suite proves selected-file access cannot call general Drive search or read, missing grants fail closed, and the same file created directly in My Drive succeeds with read-only or full Drive access. Provider authorization failures remain actionable, file-read 404s remain bounded and ambiguous, folders stop after metadata without traversal, and Shared Drive flags are sent as a separate compatibility correction.",
+    true,
+  )
+  evidence.recordAssertionEvidence(
+    "Gmail metadata retrieval overlaps bounded requests without reordering results",
+    "Six delayed metadata requests overlap with a maximum concurrency of four while the response remains in the original Gmail list order.",
+    true,
+  )
+  evidence.recordAssertionEvidence(
+    "The existing MCP path keeps model-visible connector output bounded",
+    "A real search_capabilities and execute_capability journey omits oversized non-image base64 before download where metadata permits, preserves existing small attachment bytes, compacts large JSON, and applies model-visible text limits to Drive and Gmail content without reducing their retrieval-layer limits.",
+    true,
+  )
+})


### PR DESCRIPTION
## Summary

- require an exact `drive.readonly` or full `drive` grant for general Drive search and file read, returning the existing actionable `needs_connection` response before any provider call when scopes are selected-file-only, missing, or unknown
- preserve legacy missing-scope behavior for Gmail, Calendar, Drive upload, and Drive share; `drive.file` remains valid only for the existing upload/share operations that support it
- search the `allDrives` corpus with the required Shared Drive flags and avoid the unsupported full-text `orderBy` combination
- classify authorization failures from structured Google error reasons, keep ordinary upload/share permission failures as upstream errors, and retain bounded, ambiguity-aware file-read 404 diagnostics
- reject Drive folders through the existing file-read route without downloading content or adding folder traversal
- retrieve Gmail metadata with bounded concurrency, stable ordering, failure-response consumption, transport-error mapping, and cancellation of outstanding siblings after the first failure
- apply the 20K text bound at MCP serialization while retaining the existing 100K Gmail and 200K Drive retrieval limits; compact large JSON, preserve supported small attachment bytes, emit nested image content, and omit oversized non-image binary content
- avoid downloading metadata-known oversized Drive binaries that cannot be returned safely

## Incident assessment

- Confirmed code defect: `drive.file` was accepted for general Drive search and read.
- Strong incident hypothesis: that scope mismatch caused the reported valid-link 404 for content created directly in My Drive.
- Confirmed secondary defect: Shared Drive requests were missing required compatibility parameters and the search corpus did not cover all member Shared Drives.
- Out of scope: folder traversal, a Drive browser, new Drive UI, new tools or capabilities, new configuration, and any additional product surface.

## Scope

This updates only the existing Google Workspace connector and existing MCP search/execute serialization path. It does not add a Drive app, custom results interface, companion launch tool, React component, HTML entry point, shared app payload, build registration, workflow, public option, or public API.

## Verification

- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit`
- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-tool-content.test.ts test/google-workspace-capabilities.test.ts test/google-workspace-api.test.ts` — 74 passed, 0 failed, 369 assertions
- `pnpm evals:pr specs/google-workspace-connector-retrieval.test.ts` — 1 passed, 0 failed, 0 skipped
- `drive.file`, missing scopes, empty scopes, and scope URL lookalikes reject general search/read with zero provider calls
- the same directly-created My Drive file ID succeeds with `drive.readonly` and full `drive`
- Shared Drive search sends `corpora=allDrives`, `supportsAllDrives=true`, and `includeItemsFromAllDrives=true`, with no incompatible `orderBy`
- structured scope failures become actionable connector responses while an ordinary share 403 remains a bounded upstream error
- Gmail metadata requests overlap at a maximum of four, preserve list order, and stop/cancel remaining work after failure
- the existing MCP search/execute path bounds Drive and Gmail text, blocks oversized binary downloads where metadata permits, preserves supported small attachment bytes, and strips oversized non-image base64
- nested images remain available as image content; omission metadata cannot be spoofed and `__proto__` keys do not mutate object prototypes
- exact-head diff check against `dev` is clean

## Operational follow-up

The organization administrator enables **Read all Drive files**, the affected member reconnects Google Workspace and grants Drive read access, support confirms the recorded scopes, and the same original file ID is retried. That live reconnect/retry is environment-dependent and separate from the code proof above.
