### PR TITLE
fix(app): reconcile active session completion

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -6,6 +6,7 @@ import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
 import { createClient, unwrap } from "@/app/lib/opencode";
+import { perfNow, recordPerfLog } from "@/app/lib/perf-log";
 import { isGeneratedSessionTitle } from "@/app/lib/session-title";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
@@ -91,6 +92,11 @@ type SyncEntry = {
   deltaFlushBuffer: PendingDelta[];
   deltaFlushLane: DeltaFlushLane | null;
   cancelDeltaFlush: (() => void) | null;
+  liveSessionIds: Set<string>;
+  statusReconcileTimer: ReturnType<typeof setTimeout> | null;
+  statusReconcileAbort: AbortController | null;
+  runActiveObservedAt: Map<string, number>;
+  assistantMessageCompletedAt: Map<string, number>;
   titleRecovery: SessionTitleRecovery | null;
 };
 
@@ -106,6 +112,32 @@ const workspaceSyncDisposeGraceMs = 2_000;
 const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
 const backgroundDeltaFlushMs = 100;
+// OpenCode's own run client polls the authoritative status level every 250ms
+// because a transport can keep delivering message events after losing a
+// terminal status edge. This is a reconciliation cadence, not a completion
+// timeout: elapsed time never marks a task done.
+const activeSessionStatusReconcileIntervalMs = 250;
+
+type SessionStatusSource = "stream" | "connect-reconcile" | "active-reconcile";
+
+function developerDiagnosticsEnabled() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem("openwork.developerMode") === "1";
+  } catch {
+    return false;
+  }
+}
+
+function recordSessionCompletionMark(
+  event: string,
+  payload: Record<string, unknown>,
+) {
+  recordPerfLog(developerDiagnosticsEnabled(), "session.completion", event, {
+    monotonicMs: Math.round(perfNow() * 100) / 100,
+    ...payload,
+  });
+}
 
 function createListenerRegistry<Listener>(listener?: Listener) {
   const registry: ListenerRegistry<Listener> = new Map();
@@ -399,6 +431,13 @@ function disposeWorkspaceSync(key: string, entry: SyncEntry) {
   entry.cancelDeltaFlush?.();
   entry.deltaFlushLane = null;
   entry.cancelDeltaFlush = null;
+  if (entry.statusReconcileTimer) clearTimeout(entry.statusReconcileTimer);
+  entry.statusReconcileTimer = null;
+  entry.statusReconcileAbort?.abort();
+  entry.statusReconcileAbort = null;
+  entry.liveSessionIds.clear();
+  entry.runActiveObservedAt.clear();
+  entry.assistantMessageCompletedAt.clear();
   entry.titleRecovery?.dispose();
   entry.dispose();
   if (syncs.get(key) === entry) syncs.delete(key);
@@ -701,6 +740,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const sessionId = props.sessionID ?? props.info?.id ?? "";
     if (sessionId) entry.titleRecovery?.resolve(sessionId);
     if (sessionId) useSessionActivityStore.getState().removeSession(workspaceId, sessionId);
+    if (sessionId) stopTrackingLiveSession(entry, sessionId);
     if (sessionId) {
       for (const listener of entry.sessionDeletedListeners.keys()) listener(sessionId);
     }
@@ -722,6 +762,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       }
       notifyDesktopEvent({ type: "task.failed", sessionId, errorText });
       useSessionActivityStore.getState().setError(workspaceId, sessionId, errorText);
+      stopTrackingLiveSession(entry, sessionId);
       if (isTrackedSession(entry, sessionId)) {
         flushSessionDeltas(entry, workspaceId, sessionId);
         // The activity store treats session.error as terminal (setError
@@ -774,7 +815,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.status") {
     const props = (event.properties ?? {}) as { sessionID?: string; status?: SessionStatus };
     if (!props.sessionID || !props.status) return;
-    applySessionRunStatus(entry, workspaceId, props.sessionID, props.status);
+    applySessionRunStatus(entry, workspaceId, props.sessionID, props.status, { source: "stream" });
     return;
   }
 
@@ -883,6 +924,17 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       return;
     }
     useSessionActivityStore.getState().markMessageRole(workspaceId, info.sessionID, info.id, info.role);
+    if (info.role === "assistant" && typeof info.time?.completed === "number") {
+      const observedAt = perfNow();
+      entry.assistantMessageCompletedAt.set(info.sessionID, observedAt);
+      const runActiveAt = entry.runActiveObservedAt.get(info.sessionID);
+      recordSessionCompletionMark("assistant-message-completed", {
+        sessionID: info.sessionID,
+        ...(runActiveAt === undefined
+          ? {}
+          : { sinceRunActiveMs: Math.round((observedAt - runActiveAt) * 100) / 100 }),
+      });
+    }
     if (!isTrackedSession(entry, info.sessionID)) return;
     const created = info.time?.created;
     const completed = info.time?.completed;
@@ -1011,36 +1063,10 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.idle") {
     const props = (event.properties ?? {}) as { sessionID?: string };
     if (!props.sessionID) return;
-    // Only emits for runs this client instrumented (markTaskRunStart in the
-    // send path); also dedupes idle events from multiple workspace syncs.
-    const runStartedAt = takeTaskRunStart(props.sessionID);
-    if (runStartedAt !== null) {
-      captureAnalyticsEvent("task_run_completed", {
-        duration_ms: Date.now() - runStartedAt,
-      });
-      trackTaskCompleted(props.sessionID, Date.now() - runStartedAt);
-      notifyDesktopEvent({ type: "task.completed", sessionId: props.sessionID });
-      entry.titleRecovery?.observe(props.sessionID);
-    }
-    useSessionActivityStore.getState().setRunStatus(workspaceId, props.sessionID, idleStatus);
-    const tracked = isTrackedSession(entry, props.sessionID);
-    if (tracked) {
-      // Background deltas normally trade token-level freshness for lower
-      // notification frequency. A terminal event is the convergence point:
-      // commit its remaining text before the durable snapshot is refreshed.
-      flushSessionDeltas(entry, workspaceId, props.sessionID);
-      queryClient.setQueryData(statusKey(workspaceId, props.sessionID), idleStatus);
-      // A fast tool can complete and persist before its final part.updated SSE
-      // reaches the renderer. Reconcile successful turns from the durable
-      // snapshot just as failed turns do, so standard MCP App results mount
-      // without requiring an artificial provider delay or a page reload.
-      void queryClient.invalidateQueries({
-        queryKey: snapshotKey(workspaceId, props.sessionID),
-        exact: true,
-      });
-    }
-    for (const listener of entry.sessionStatusListeners.keys()) listener({ sessionId: props.sessionID, status: idleStatus });
-    if (input && tracked) releaseRetainedSessionSoon(input, entry, props.sessionID);
+    applySessionRunStatus(entry, workspaceId, props.sessionID, idleStatus, {
+      source: "stream",
+      terminalEvent: true,
+    });
   }
 }
 
@@ -1137,7 +1163,7 @@ function startSync(input: SyncOptions, entry: SyncEntry) {
     // cached idle: the server may have started or finished work while the
     // stream was down.
     onConnected: (signal) => {
-      void reconcileSessionRunStatuses(entry, input, signal);
+      void reconcileSessionRunStatuses(entry, input, signal, "connect-reconcile");
     },
     onPhaseChange: (phase) => {
       useWorkspaceSyncStreamStore.getState().publishPhase(streamKey, phase);
@@ -1165,24 +1191,93 @@ function applySessionRunStatus(
   workspaceId: string,
   sessionId: string,
   status: SessionStatus,
-  options: { snapshotStartedAt?: number } = {},
+  options: {
+    snapshotStartedAt?: number;
+    source?: SessionStatusSource;
+    terminalEvent?: boolean;
+  } = {},
 ) {
   const snapshotStartedAt = options.snapshotStartedAt;
   const store = useSessionActivityStore.getState();
+  const previousRecord = store.recordsByWorkspaceId[workspaceId]?.[sessionId];
+  const wasTrackedLive = entry.liveSessionIds.has(sessionId);
+  const wasLive = wasTrackedLive || previousRecord?.runActive === true;
   if (typeof snapshotStartedAt === "number") {
-    const record = store.recordsByWorkspaceId[workspaceId]?.[sessionId];
-    if (snapshotStartedAt < (record?.runStatusAt ?? 0)) return;
+    if (snapshotStartedAt < (previousRecord?.runStatusAt ?? 0)) return;
     store.seedSessionRun(workspaceId, sessionId, status, undefined, { snapshotStartedAt });
   } else {
     store.setRunStatus(workspaceId, sessionId, status);
   }
+
+  const live = isLiveStatus(status);
+  const observedAt = perfNow();
+  if (live) {
+    entry.liveSessionIds.add(sessionId);
+    if (!wasTrackedLive) {
+      entry.runActiveObservedAt.set(sessionId, observedAt);
+      recordSessionCompletionMark("run-active", {
+        sessionID: sessionId,
+        source: options.source ?? "stream",
+        status: status.type,
+      });
+    }
+    scheduleActiveSessionStatusReconciliation(entry);
+  } else {
+    entry.liveSessionIds.delete(sessionId);
+    clearActiveSessionStatusReconcileTimer(entry);
+  }
+
   const tracked = isTrackedSession(entry, sessionId);
   if (tracked) getReactQueryClient().setQueryData(statusKey(workspaceId, sessionId), status);
   for (const listener of entry.sessionStatusListeners.keys()) listener({ sessionId, status });
-  if (entry.input && tracked && !isLiveStatus(status)) releaseRetainedSessionSoon(entry.input, entry, sessionId);
+  if (!live) {
+    // A level-triggered idle response is as authoritative as the SSE edge.
+    // Converge through the same terminal path so a missed status event also
+    // flushes final deltas and refreshes any final persisted message parts.
+    const runStartedAt = takeTaskRunStart(sessionId);
+    if (runStartedAt !== null) {
+      captureAnalyticsEvent("task_run_completed", {
+        duration_ms: Date.now() - runStartedAt,
+      });
+      trackTaskCompleted(sessionId, Date.now() - runStartedAt);
+      notifyDesktopEvent({ type: "task.completed", sessionId });
+      entry.titleRecovery?.observe(sessionId);
+    }
+    const shouldRecordTerminal = wasLive || runStartedAt !== null;
+    const shouldConvergeTerminal = shouldRecordTerminal || options.terminalEvent === true;
+    if (tracked && shouldConvergeTerminal) {
+      flushSessionDeltas(entry, workspaceId, sessionId);
+      void getReactQueryClient().invalidateQueries({
+        queryKey: snapshotKey(workspaceId, sessionId),
+        exact: true,
+      });
+    }
+    if (shouldRecordTerminal) {
+      const assistantCompletedAt = entry.assistantMessageCompletedAt.get(sessionId);
+      const runActiveAt = entry.runActiveObservedAt.get(sessionId);
+      recordSessionCompletionMark("run-terminal", {
+        sessionID: sessionId,
+        source: options.source ?? "stream",
+        ...(assistantCompletedAt === undefined
+          ? {}
+          : { sinceAssistantMessageCompletedMs: Math.round((observedAt - assistantCompletedAt) * 100) / 100 }),
+        ...(runActiveAt === undefined
+          ? {}
+          : { sinceRunActiveMs: Math.round((observedAt - runActiveAt) * 100) / 100 }),
+      });
+    }
+    entry.runActiveObservedAt.delete(sessionId);
+    entry.assistantMessageCompletedAt.delete(sessionId);
+    if (entry.input && tracked) releaseRetainedSessionSoon(entry.input, entry, sessionId);
+  }
 }
 
-async function reconcileSessionRunStatuses(entry: SyncEntry, input: SyncOptions, signal: AbortSignal) {
+async function reconcileSessionRunStatuses(
+  entry: SyncEntry,
+  input: SyncOptions,
+  signal: AbortSignal,
+  source: Exclude<SessionStatusSource, "stream">,
+) {
   const startedAt = Date.now();
   let statuses: Record<string, SessionStatus>;
   try {
@@ -1198,12 +1293,55 @@ async function reconcileSessionRunStatuses(entry: SyncEntry, input: SyncOptions,
   // (heals a missed idle edge). Both flow through the same path a
   // session.status event uses so the status cache and listeners converge too.
   const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
-  const sessionIds = new Set([...Object.keys(statuses), ...Object.keys(records)]);
+  const sessionIds = new Set([
+    ...Object.keys(statuses),
+    ...Object.keys(records),
+    ...entry.liveSessionIds,
+  ]);
   for (const sessionId of sessionIds) {
     applySessionRunStatus(entry, input.workspaceId, sessionId, statuses[sessionId] ?? idleStatus, {
       snapshotStartedAt: startedAt,
+      source,
     });
   }
+}
+
+function clearActiveSessionStatusReconcileTimer(entry: SyncEntry) {
+  if (entry.liveSessionIds.size > 0 || !entry.statusReconcileTimer) return;
+  clearTimeout(entry.statusReconcileTimer);
+  entry.statusReconcileTimer = null;
+}
+
+function stopTrackingLiveSession(entry: SyncEntry, sessionId: string) {
+  entry.liveSessionIds.delete(sessionId);
+  entry.runActiveObservedAt.delete(sessionId);
+  entry.assistantMessageCompletedAt.delete(sessionId);
+  clearActiveSessionStatusReconcileTimer(entry);
+}
+
+function scheduleActiveSessionStatusReconciliation(entry: SyncEntry) {
+  if (
+    entry.liveSessionIds.size === 0
+    || entry.statusReconcileTimer
+    || entry.statusReconcileAbort
+  ) return;
+
+  entry.statusReconcileTimer = setTimeout(() => {
+    entry.statusReconcileTimer = null;
+    if (entry.liveSessionIds.size === 0) return;
+
+    const controller = new AbortController();
+    entry.statusReconcileAbort = controller;
+    void reconcileSessionRunStatuses(
+      entry,
+      entry.input,
+      controller.signal,
+      "active-reconcile",
+    ).finally(() => {
+      if (entry.statusReconcileAbort === controller) entry.statusReconcileAbort = null;
+      scheduleActiveSessionStatusReconciliation(entry);
+    });
+  }, activeSessionStatusReconcileIntervalMs);
 }
 
 export function ensureWorkspaceSessionSync(input: SyncOptions) {
@@ -1248,6 +1386,11 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     deltaFlushBuffer: [],
     deltaFlushLane: null,
     cancelDeltaFlush: null,
+    liveSessionIds: new Set(),
+    statusReconcileTimer: null,
+    statusReconcileAbort: null,
+    runActiveObservedAt: new Map(),
+    assistantMessageCompletedAt: new Map(),
     titleRecovery: null,
   };
   created.titleRecovery = createSessionTitleRecovery({
@@ -1443,12 +1586,19 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     deltaFlushBuffer: [],
     deltaFlushLane: null,
     cancelDeltaFlush: null,
+    liveSessionIds: new Set(),
+    statusReconcileTimer: null,
+    statusReconcileAbort: null,
+    runActiveObservedAt: new Map(),
+    assistantMessageCompletedAt: new Map(),
     titleRecovery: null,
   });
   return () => {
     const entry = syncs.get(key);
     if (entry) {
       for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
+      if (entry.statusReconcileTimer) clearTimeout(entry.statusReconcileTimer);
+      entry.statusReconcileAbort?.abort();
     }
     syncs.delete(key);
   };

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -15,6 +15,7 @@ import {
   snapshotKey,
   statusKey,
   trackWorkspaceSessionSync,
+  transcriptKey,
 } from "../src/react-app/domains/session/sync/session-sync";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 
@@ -98,6 +99,64 @@ function applyStatus(input: SyncInput, status: SessionStatus) {
     type: "session.status",
     properties: { sessionID: sessionId, status },
   });
+}
+
+function applyCompletedToolAndFinalAnswer(input: SyncInput) {
+  __applySessionSyncEventForTest(input, {
+    type: "message.updated",
+    properties: {
+      info: {
+        id: "assistant-tool",
+        role: "assistant",
+        sessionID: sessionId,
+        time: { created: 1, completed: 2 },
+      },
+    },
+  } as any);
+  __applySessionSyncEventForTest(input, {
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "part-tool",
+        sessionID: sessionId,
+        messageID: "assistant-tool",
+        type: "tool",
+        callID: "call-tool",
+        tool: "lookup",
+        state: {
+          status: "completed",
+          input: { query: "fixture" },
+          output: "fixture result",
+          title: "Lookup",
+          metadata: {},
+          time: { start: 1, end: 2 },
+        },
+      },
+    },
+  } as any);
+  __applySessionSyncEventForTest(input, {
+    type: "message.updated",
+    properties: {
+      info: {
+        id: "assistant-final",
+        role: "assistant",
+        sessionID: sessionId,
+        time: { created: 3, completed: 4 },
+      },
+    },
+  } as any);
+  __applySessionSyncEventForTest(input, {
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "part-final",
+        sessionID: sessionId,
+        messageID: "assistant-final",
+        type: "text",
+        text: "The final answer is visible.",
+      },
+    },
+  } as any);
 }
 
 afterEach(() => {
@@ -340,6 +399,32 @@ describe("session run status reconnect reconciliation", () => {
     releaseSession();
   });
 
+  test("does not resurrect an idle run from an older reconnect snapshot", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    let resolveStatuses: (statuses: Record<string, SessionStatus>) => void = () => {};
+    __setWorkspaceSessionSyncStatusFetcherForTest(() => new Promise((resolve) => {
+      resolveStatuses = resolve;
+    }));
+    setSystemTime(100);
+    const input = createSyncInput();
+    ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    setSystemTime(200);
+    applyStatus(input, { type: "busy" });
+    setSystemTime(300);
+    applyStatus(input, { type: "idle" });
+    resolveStatuses({ [sessionId]: { type: "busy" } });
+    await flushMicrotasks();
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(false);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+
+    releaseSession();
+  });
+
   test("heals an active record when a reconnect reports no active run", async () => {
     __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
@@ -383,5 +468,173 @@ describe("session run status reconnect reconciliation", () => {
     expect(subscriptions).toHaveLength(2);
     expect(subscriptions[1]?.signal.aborted).toBe(false);
     expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+  });
+});
+
+describe("active session status reconciliation", () => {
+  test("converges a missed terminal edge to idle without losing the completed tool or final answer", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    let statusFetches = 0;
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      statusFetches += 1;
+      return {};
+    });
+    const { input, cleanup, releaseSession } = createTestSync();
+    const queryClient = getReactQueryClient();
+    queryClient.setQueryData(snapshotKey(workspaceId, sessionId), createSnapshot({ type: "busy" }));
+
+    applyStatus(input, { type: "busy" });
+    applyCompletedToolAndFinalAnswer(input);
+
+    const before = queryClient.getQueryData<any[]>(transcriptKey(workspaceId, sessionId));
+    expect(before?.[0]?.parts[0]).toMatchObject({
+      type: "dynamic-tool",
+      state: "output-available",
+      output: "fixture result",
+    });
+    expect(before?.[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "The final answer is visible.",
+    });
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("responding");
+
+    // No session.status idle or session.idle event arrives. The long-lived
+    // stream remains open; only the authoritative status level reports that
+    // the run has ended.
+    setSystemTime(350);
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    expect(statusFetches).toBe(1);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+    expect(queryClient.getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "idle" });
+    expect(queryClient.getQueryState(snapshotKey(workspaceId, sessionId))?.isInvalidated).toBe(true);
+    const after = queryClient.getQueryData<any[]>(transcriptKey(workspaceId, sessionId));
+    expect(after?.[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "The final answer is visible.",
+    });
+
+    releaseSession();
+    cleanup();
+  });
+
+  test("keeps genuine tool, retry, waiting, and compaction work active until status is authoritatively idle", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    let status: Record<string, SessionStatus> = { [sessionId]: { type: "busy" } };
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => status);
+    const { input, cleanup, releaseSession } = createTestSync();
+
+    applyStatus(input, { type: "busy" });
+    useSessionActivityStore.getState().setWaitingRequest(
+      workspaceId,
+      sessionId,
+      "permission",
+      "permission-1",
+      true,
+    );
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("waiting");
+
+    useSessionActivityStore.getState().setWaitingRequest(
+      workspaceId,
+      sessionId,
+      "permission",
+      "permission-1",
+      false,
+    );
+    useSessionActivityStore.getState().setCompacting(workspaceId, sessionId, true);
+    status = {
+      [sessionId]: {
+        type: "retry",
+        attempt: 1,
+        message: "retrying",
+        next: 1_000,
+      },
+    };
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("compacting");
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+
+    status = {};
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+
+    releaseSession();
+    cleanup();
+  });
+
+  test("keeps a newer busy edge when an older idle poll resolves after a queued follow-up starts", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    let resolveStatuses: (statuses: Record<string, SessionStatus>) => void = () => {};
+    __setWorkspaceSessionSyncStatusFetcherForTest(() => new Promise((resolve) => {
+      resolveStatuses = resolve;
+    }));
+    const { input, cleanup, releaseSession } = createTestSync();
+
+    applyStatus(input, { type: "busy" });
+    setSystemTime(350);
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    // A queued follow-up starts while the older status request is in flight.
+    // Its live edge must win over the stale empty snapshot.
+    setSystemTime(Date.now() + 100);
+    applyStatus(input, { type: "busy" });
+    resolveStatuses({});
+    await flushMicrotasks();
+
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+
+    releaseSession();
+    cleanup();
+  });
+
+  test("accepts terminal-before-close, reordered final content, and duplicate terminal events", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+    setSystemTime(100);
+    const input = createSyncInput();
+    ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    applyStatus(input, { type: "busy" });
+    setSystemTime(200);
+    __applySessionSyncEventForTest(input, {
+      type: "session.idle",
+      properties: { sessionID: sessionId },
+    });
+
+    // The event transport is intentionally still open when terminal status
+    // arrives, and final content is delivered after it.
+    expect(subscriptions[0]?.signal.aborted).toBe(false);
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+    applyCompletedToolAndFinalAnswer(input);
+
+    // Duplicate modern and deprecated terminal events remain idempotent.
+    applyStatus(input, { type: "idle" });
+    __applySessionSyncEventForTest(input, {
+      type: "session.idle",
+      properties: { sessionID: sessionId },
+    });
+
+    const transcript = getReactQueryClient().getQueryData<any[]>(transcriptKey(workspaceId, sessionId));
+    expect(transcript?.[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "The final answer is visible.",
+    });
+    expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
+    expect(subscriptions[0]?.signal.aborted).toBe(false);
+
+    releaseSession();
   });
 });

--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -119,9 +119,9 @@ test("Daytona E2E regression profile excludes only audited shared-topology incom
   expect(categoryByTest.get("local-managed-mcp-oauth.e2e.test.ts")).toBe("raw-or-local-placement");
   expect(categoryByTest.get("slack-style-mcp-connector.e2e.test.ts")).toBe("raw-or-local-placement");
 
-  expect(inventory.all).toHaveLength(148);
+  expect(inventory.all).toHaveLength(149);
   expect(inventory.rawDesktop).toHaveLength(54);
-  expect(inventory.profile).toHaveLength(74);
+  expect(inventory.profile).toHaveLength(75);
   expect(inventory.eligible).toHaveLength(19);
   expect(inventory.rawDesktop).toContain("den-litellm-provider.e2e.test.ts");
   expect(inventory.eligible).not.toContain("org-team-lifecycle-critical-path.e2e.test.ts");

--- a/evals/specs/daytona-e2e-regression-profile.json
+++ b/evals/specs/daytona-e2e-regression-profile.json
@@ -293,6 +293,11 @@
       "reason": "requires local self-hosted Den placement and local MySQL"
     },
     {
+      "test": "session-completion-reconciliation.e2e.test.ts",
+      "category": "raw-or-local-placement",
+      "reason": "requires local placement with an actual OpenCode process and a loopback deterministic provider"
+    },
+    {
       "test": "settings-visit-live-run-continuity.e2e.test.ts",
       "category": "unavailable-secret-or-docker",
       "reason": "requires ANTHROPIC_API_KEY, which is unavailable to this lane"

--- a/evals/specs/session-completion-reconciliation.e2e.test.ts
+++ b/evals/specs/session-completion-reconciliation.e2e.test.ts
@@ -1,0 +1,429 @@
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+import type { UIMessage } from "ai";
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+import { expect } from "vitest";
+import { briefTest, claim, needs, testBrief } from "@openwork/testkit";
+
+import {
+  findFreePort,
+  makeClient,
+  normalizeEvent,
+  spawnOpencodeServe,
+  waitForHealthy,
+} from "../../apps/app/scripts/_util.mjs";
+import { getReactQueryClient } from "../../apps/app/src/react-app/infra/query-client";
+import { useSessionActivityStore } from "../../apps/app/src/react-app/domains/session/status/session-activity-store";
+import {
+  __disposeWorkspaceSessionSyncForTest,
+  __setWorkspaceSessionSyncStatusFetcherForTest,
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest,
+  ensureWorkspaceSessionSync,
+  snapshotKey,
+  statusKey,
+  trackWorkspaceSessionSync,
+  transcriptKey,
+} from "../../apps/app/src/react-app/domains/session/sync/session-sync";
+
+type TimelineEntry = {
+  boundary: string;
+  atMs: number;
+  detail?: Record<string, string | number | boolean | null>;
+};
+
+const modelId = "session-completion-reconciliation";
+const providerId = "session-completion-provider";
+const finalAnswer = "The fixture capability completed successfully.";
+const finalToTerminalDelayMs = 800;
+const terminalToProviderEndDelayMs = 600;
+
+function streamChunk(id: string, delta: Record<string, unknown>, finishReason: string | null = null) {
+  return {
+    id,
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+function writeFrame(response: ServerResponse, value: unknown) {
+  response.write(`data: ${JSON.stringify(value)}\n\n`);
+}
+
+function eventSessionId(event: ReturnType<typeof normalizeEvent>): string {
+  if (!event) return "";
+  const properties = (event.properties ?? {}) as {
+    sessionID?: unknown;
+    part?: { sessionID?: unknown };
+    info?: { sessionID?: unknown };
+  };
+  const value = properties.sessionID ?? properties.part?.sessionID ?? properties.info?.sessionID;
+  return typeof value === "string" ? value : "";
+}
+
+function messageParts(messages: UIMessage[]) {
+  return messages.flatMap((message) => message.parts);
+}
+
+function sleep(durationMs: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number) {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(20);
+  }
+  return predicate();
+}
+
+briefTest(testBrief({
+  behavior: "A completed OpenCode turn converges promptly to idle even when a live event transport loses its terminal edge, without treating final text or elapsed time as completion.",
+  claims: {
+    providerAndEngine: claim("a deterministic OpenAI-compatible provider drives a real tool call and final response through OpenCode, whose ordinary completion path emits terminal session state promptly", {
+      never: "attribute provider inference or tool execution time to renderer completion convergence",
+    }),
+    genuineWorkStaysActive: claim("final text delivered before the provider terminal marker does not stop a genuinely active run", {
+      never: "treat visible assistant text or a timer as proof that work finished",
+    }),
+    missedTerminalConverges: claim("when terminal events are removed from an otherwise-open transport, the authoritative session status level moves the tracked task to idle within one bounded reconciliation cycle", {
+      never: "wait for stream closure, reconnect, or an arbitrary completion timeout",
+    }),
+    finalStatePreserved: claim("the completed tool result and final assistant answer remain visible after level-triggered idle reconciliation", {
+      never: "clear or hide the final response while stopping the activity state",
+    }),
+  },
+}), async ({ prove, evidence }) => {
+  needs({
+    commands: ["opencode"],
+    optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+    placement: "local",
+  });
+
+  const startedAt = performance.now();
+  const timeline: TimelineEntry[] = [];
+  const stamp = (
+    boundary: string,
+    detail?: Record<string, string | number | boolean | null>,
+  ) => {
+    timeline.push({
+      boundary,
+      atMs: Math.round((performance.now() - startedAt) * 100) / 100,
+      ...(detail ? { detail } : {}),
+    });
+  };
+  const timeOf = (boundary: string) => timeline.find((entry) => entry.boundary === boundary)?.atMs;
+
+  const workspace = await mkdtemp(join(tmpdir(), "openwork-session-completion-reconciliation-"));
+  await mkdir(join(workspace, ".opencode"), { recursive: true });
+  const workspaceId = "workspace-session-completion-reconciliation";
+  const syncInput = {
+    workspaceId,
+    baseUrl: "http://session-completion-reconciliation.invalid/opencode",
+    openworkToken: "fixture-token",
+  };
+
+  let provider: Server | null = null;
+  let engine: Awaited<ReturnType<typeof spawnOpencodeServe>> | null = null;
+  let releaseWorkspaceSync: (() => void) | null = null;
+  let releaseTrackedSession: (() => void) | null = null;
+  let sessionId = "";
+  let providerRequests = 0;
+  let providerFinalContentWritten = false;
+  let providerTerminalSent = false;
+  let providerEndCalled = false;
+  let resolveFinalContent: () => void = () => {};
+  const finalContentWritten = new Promise<void>((resolve) => {
+    resolveFinalContent = resolve;
+  });
+  let sawBusyEvent = false;
+  let sawBusyStatusAfterFinalContent = false;
+  let sawAuthoritativeIdle = false;
+  let filteredTerminalEvents = 0;
+  let eventStreamEnded = false;
+
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+  getReactQueryClient().clear();
+
+  try {
+    const providerPort = await findFreePort();
+    provider = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "127.0.0.1"}`);
+      if (request.method === "GET" && url.pathname.endsWith("/models")) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+        return;
+      }
+      if (request.method !== "POST" || !url.pathname.endsWith("/chat/completions")) {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: { message: "not found" } }));
+        return;
+      }
+
+      request.resume();
+      request.on("end", () => {
+        providerRequests += 1;
+        const turn = providerRequests;
+        stamp("provider.request", { turn });
+        response.writeHead(200, {
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+          "content-type": "text/event-stream",
+        });
+        const responseId = `chatcmpl-session-completion-${turn}`;
+        writeFrame(response, streamChunk(responseId, { role: "assistant" }));
+
+        if (turn === 1) {
+          writeFrame(response, streamChunk(responseId, {
+            tool_calls: [{
+              index: 0,
+              id: "call_fixture_capability",
+              type: "function",
+              function: {
+                name: "bash",
+                arguments: JSON.stringify({ command: "printf 'fixture capability result\\n'" }),
+              },
+            }],
+          }));
+          stamp("provider.tool-call", { turn });
+          writeFrame(response, streamChunk(responseId, {}, "tool_calls"));
+          response.write("data: [DONE]\n\n");
+          response.end();
+          return;
+        }
+
+        writeFrame(response, streamChunk(responseId, { content: finalAnswer }));
+        providerFinalContentWritten = true;
+        stamp("provider.final-content", { bytes: Buffer.byteLength(finalAnswer) });
+        resolveFinalContent();
+
+        void (async () => {
+          await sleep(finalToTerminalDelayMs);
+          writeFrame(response, streamChunk(responseId, {}, "stop"));
+          response.write("data: [DONE]\n\n");
+          providerTerminalSent = true;
+          stamp("provider.terminal-marker", { reason: "stop" });
+          await sleep(terminalToProviderEndDelayMs);
+          providerEndCalled = true;
+          stamp("provider.response-end-called");
+          response.end();
+        })();
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      provider?.once("error", reject);
+      provider?.listen(providerPort, "127.0.0.1", resolve);
+    });
+    stamp("provider.listening");
+
+    await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      permission: { bash: "allow" },
+      provider: {
+        [providerId]: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Session completion fixture",
+          options: {
+            apiKey: "fixture-key",
+            baseURL: `http://127.0.0.1:${providerPort}/v1`,
+          },
+          models: { [modelId]: { name: "Session completion fixture" } },
+        },
+      },
+    }, null, 2));
+
+    const enginePort = await findFreePort();
+    engine = await spawnOpencodeServe({ directory: workspace, port: enginePort });
+    const client = makeClient({ baseUrl: engine.baseUrl, directory: workspace });
+    await waitForHealthy(client);
+    stamp("opencode.healthy");
+
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(async (_baseUrl, _token, signal) => {
+      const subscription = await client.event.subscribe({ directory: workspace }, { signal });
+      stamp("sync.event-stream-connected");
+      return (async function* filteredStream() {
+        try {
+          for await (const raw of subscription.stream) {
+            const event = normalizeEvent(raw);
+            if (!event) continue;
+            const matchesSession = Boolean(sessionId) && eventSessionId(event) === sessionId;
+            if (matchesSession && event.type === "session.status") {
+              const properties = (event.properties ?? {}) as { status?: SessionStatus };
+              if (properties.status?.type === "busy") {
+                sawBusyEvent = true;
+                stamp("opencode.event-busy");
+              }
+              if (properties.status?.type === "idle") {
+                filteredTerminalEvents += 1;
+                stamp("opencode.event-terminal-filtered", { event: "session.status" });
+                continue;
+              }
+            }
+            if (matchesSession && event.type === "session.idle") {
+              filteredTerminalEvents += 1;
+              stamp("opencode.event-terminal-filtered", { event: "session.idle" });
+              continue;
+            }
+            if (matchesSession && event.type === "message.part.updated") {
+              const properties = (event.properties ?? {}) as {
+                part?: { type?: string; text?: string; state?: { status?: string } };
+              };
+              if (properties.part?.type === "tool" && properties.part.state?.status === "completed") {
+                stamp("opencode.tool-completed");
+              }
+              if (properties.part?.type === "text" && properties.part.text) {
+                stamp("opencode.final-message-part", {
+                  bytes: Buffer.byteLength(properties.part.text),
+                });
+              }
+            }
+            yield raw;
+          }
+        } finally {
+          eventStreamEnded = true;
+          stamp("sync.event-stream-ended");
+        }
+      })();
+    });
+
+    let lastStatus = "";
+    __setWorkspaceSessionSyncStatusFetcherForTest(async (_baseUrl, _token, signal) => {
+      const statuses = await client.session.status(undefined, { signal }) as Record<string, SessionStatus>;
+      if (sessionId) {
+        const status = statuses[sessionId]?.type ?? "idle";
+        if (status !== lastStatus) {
+          lastStatus = status;
+          stamp("opencode.status-level", { status });
+        }
+        if (providerFinalContentWritten && !providerTerminalSent && status !== "idle") {
+          sawBusyStatusAfterFinalContent = true;
+        }
+        if (sawBusyEvent && status === "idle" && !sawAuthoritativeIdle) {
+          sawAuthoritativeIdle = true;
+          stamp("opencode.status-authoritative-idle");
+        }
+      }
+      return statuses;
+    });
+
+    releaseWorkspaceSync = ensureWorkspaceSessionSync(syncInput);
+    const session = await client.session.create({ title: "Session completion reconciliation" });
+    sessionId = session.id;
+    releaseTrackedSession = trackWorkspaceSessionSync(syncInput, sessionId);
+    getReactQueryClient().setQueryData(snapshotKey(workspaceId, sessionId), { fixture: true });
+    stamp("opencode.session-created");
+
+    await client.session.promptAsync({
+      sessionID: sessionId,
+      model: { providerID: providerId, modelID: modelId },
+      parts: [{ type: "text", text: "Run the fixture capability and report its result." }],
+    });
+    stamp("opencode.prompt-accepted");
+
+    await finalContentWritten;
+    const respondingBeforeTerminal = await waitUntil(
+      () => useSessionActivityStore.getState().getStatus(workspaceId, sessionId) === "responding",
+      500,
+    );
+    const statusRemainedBusyAfterFinalContent = await waitUntil(
+      () => sawBusyStatusAfterFinalContent,
+      600,
+    );
+    expect(providerTerminalSent).toBe(false);
+    expect(respondingBeforeTerminal).toBe(true);
+    expect(statusRemainedBusyAfterFinalContent).toBe(true);
+    stamp("sync.still-active-after-final-content");
+
+    const converged = await waitUntil(
+      () => useSessionActivityStore.getState().getStatus(workspaceId, sessionId) === "idle",
+      5_000,
+    );
+    expect(converged).toBe(true);
+    stamp("sync.authoritative-idle-applied", { providerEndCalled });
+
+    const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey(workspaceId, sessionId)) ?? [];
+    const parts = messageParts(transcript);
+    const completedTool = parts.find((part) =>
+      part.type === "dynamic-tool"
+      && "state" in part
+      && part.state === "output-available"
+    );
+    const visibleFinalAnswer = parts.some((part) =>
+      part.type === "text"
+      && "text" in part
+      && part.text.includes(finalAnswer)
+    );
+
+    const providerTerminalAt = timeOf("provider.terminal-marker");
+    const engineTerminalAt = timeOf("opencode.event-terminal-filtered");
+    const authoritativeIdleAt = timeOf("opencode.status-authoritative-idle");
+    const syncIdleAt = timeOf("sync.authoritative-idle-applied");
+    expect(providerTerminalAt).toBeTypeOf("number");
+    expect(engineTerminalAt).toBeTypeOf("number");
+    expect(authoritativeIdleAt).toBeTypeOf("number");
+    expect(syncIdleAt).toBeTypeOf("number");
+    const providerToEngineTerminalMs = (engineTerminalAt ?? Infinity) - (providerTerminalAt ?? 0);
+    const providerToAuthoritativeIdleMs = (authoritativeIdleAt ?? Infinity) - (providerTerminalAt ?? 0);
+    const providerToSyncIdleMs = (syncIdleAt ?? Infinity) - (providerTerminalAt ?? 0);
+    const authoritativeIdleToSyncIdleMs = (syncIdleAt ?? Infinity) - (authoritativeIdleAt ?? 0);
+
+    prove.providerAndEngine(
+      providerRequests === 2
+      && sawBusyEvent
+      && filteredTerminalEvents >= 1
+      && providerToEngineTerminalMs >= 0
+      && providerToEngineTerminalMs < 1_000,
+      `The real OpenCode engine made ${providerRequests} provider turns (tool then final), emitted busy, and produced its terminal event ${providerToEngineTerminalMs.toFixed(2)}ms after the provider terminal marker.`,
+    );
+    prove.genuineWorkStaysActive(
+      respondingBeforeTerminal && sawBusyStatusAfterFinalContent,
+      `During the ${finalToTerminalDelayMs}ms final-text-to-terminal gap, authoritative status remained busy and the activity store remained responding.`,
+    );
+    prove.missedTerminalConverges(
+      filteredTerminalEvents >= 1
+      && sawAuthoritativeIdle
+      && providerToAuthoritativeIdleMs >= 0
+      && providerToSyncIdleMs >= 0
+      && authoritativeIdleToSyncIdleMs >= 0
+      && authoritativeIdleToSyncIdleMs < 500
+      && !eventStreamEnded,
+      `${filteredTerminalEvents} terminal event(s) were withheld while the event stream stayed open; authoritative status became idle ${providerToAuthoritativeIdleMs.toFixed(2)}ms after the provider marker and workspace sync applied idle ${authoritativeIdleToSyncIdleMs.toFixed(2)}ms after that authoritative observation.`,
+    );
+    prove.finalStatePreserved(
+      Boolean(completedTool)
+      && visibleFinalAnswer
+      && getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))?.type === "idle"
+      && getReactQueryClient().getQueryState(snapshotKey(workspaceId, sessionId))?.isInvalidated === true,
+      `After idle convergence, the transcript retained ${transcript.length} assistant message(s), including the completed tool and ${Buffer.byteLength(finalAnswer)}-byte final answer; status cache was idle and the durable snapshot was invalidated.`,
+    );
+
+    evidence.recordJsonArtifact("session completion phase timeline", {
+      schemaVersion: 1,
+      timings: timeline,
+      counters: {
+        providerRequests,
+        filteredTerminalEvents,
+      },
+    });
+
+    expect(await waitUntil(() => providerEndCalled, 2_000)).toBe(true);
+  } finally {
+    releaseTrackedSession?.();
+    releaseWorkspaceSync?.();
+    __disposeWorkspaceSessionSyncForTest(syncInput);
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
+    __setWorkspaceSessionSyncStatusFetcherForTest(null);
+    useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+    getReactQueryClient().clear();
+    await engine?.close();
+    if (provider) {
+      provider.closeAllConnections();
+      await new Promise<void>((resolve) => provider?.close(() => resolve()));
+    }
+    await rm(workspace, { recursive: true, force: true });
+  }
+});

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 import { shouldPrepareSuite, suiteWorkerCount } from "./runner/stack-suite.ts";
 
 const common = {
   environment: "node",
   testTimeout: 120_000,
+};
+const appSource = fileURLToPath(new URL("../apps/app/src/", import.meta.url));
+const appResolve = {
+  alias: [{ find: /^@\//, replacement: appSource }],
 };
 
 const prepareSuite = shouldPrepareSuite(process.argv);
@@ -28,6 +33,7 @@ export default defineConfig({
         },
       },
       {
+        resolve: appResolve,
         test: {
           ...common,
           name: "e2e",


### PR DESCRIPTION
## Incident symptom

A capability-backed request completed capability search in about 0.3 seconds and capability execution in about 0.9 seconds, while the session continued to display as working after roughly 72 seconds. The focused case is final assistant content that is already available while terminal session state does not converge in the client.

## Confirmed root cause and boundary

Workspace session sync treated `session.status` / `session.idle` as edge-only completion signals. It queried the authoritative `/session/status` level when the event stream connected or reconnected, but not while an otherwise-healthy stream had a known live run. If that long-lived stream continued delivering message events but missed its terminal status edge, final output could be visible while the activity store stayed busy indefinitely, until a later reconnect happened for another reason.

The first confirmed broken boundary is workspace session reconciliation between global event delivery and the session activity/status store. Provider completion, ordinary OpenCode completion recognition, and the normal OpenCode terminal event path completed promptly in the deterministic control; the unbounded state appears when the client loses a terminal edge but never rechecks the authoritative status level.

The fix is placed at that boundary. One workspace-level loop reconciles `/session/status` only while at least one run is known live. The 250 ms cadence matches the resilience pattern used by OpenCode's own run client and is not a success timeout: only an authoritative idle level can end a run. Fetch-start ordering prevents an older response from stopping a newer queued follow-up.

## Control timeline

Monotonic local control against OpenCode 1.18.15, with a deterministic tool call and ordinary terminal delivery:

- provider final content, terminal marker, `[DONE]`, and response close: 1820.5–1820.7 ms from process start
- OpenCode final message part: 1834.3 ms, about 13.6 ms later
- OpenCode `session.status: idle` / `session.idle`: 1834.3 ms, about 13.6 ms later
- authoritative `/session/status` first reported idle: 1844.2 ms, about 23.5 ms later

That control rules out a built-in 72-second wait in provider completion recognition or ordinary OpenCode terminal emission. In the pre-change missed-edge control, the final message could be delivered while both terminal session events were absent; workspace sync then made no further status request until reconnect, so `T_client_terminal` and `T_ui_idle` were unbounded by the completion path.

## Candidate timeline

Exact-head testkit run at `3fdb56cd3a689864f8d49f3dea0ddd58ae29f62f`:

- `T_final`, provider final content: 1673.82 ms
- run remained authoritatively busy through the controlled 800 ms final-text-to-terminal gap
- provider terminal marker: 2474.88 ms
- provider response end called: 3075.46 ms
- `T_server_terminal`, OpenCode final part and terminal session events: 3088.41–3088.63 ms
- both terminal session events were deliberately withheld from the otherwise-live client event stream
- authoritative `/session/status` idle observation: 3254.41 ms
- `T_ui_idle`, workspace activity store/cache idle: 3263.15 ms, 8.74 ms after the authoritative idle observation

This isolates provider/protocol completion from client reconciliation. The candidate does not claim to improve model, LiteLLM, Vertex, or provider latency.

## Correctness invariants

- final text is never treated as completion; the run stayed responding during the controlled final-text delay
- completed tool and final assistant content remain visible after idle convergence
- final message and idle may arrive in either valid order
- duplicate idle status and `session.idle` events are harmless
- stale reconnect or snapshot state cannot resurrect a completed run
- older status polls cannot stop a newer queued follow-up
- retry, permission-waiting, question-waiting, compaction, and genuinely busy states remain active until authoritative idle
- error handling remains distinct from successful completion
- polling is aggregated per workspace and stops when no live runs remain
- the same workspace sync path serves local and OpenWork-server transports

## Verification

Proof verdict: **Passed**. Lane: local, because this incident brief explicitly requires a deterministic local provider/test witness with a real OpenCode tool-call continuation and no private provider or Calendar account.

- `corepack pnpm --filter @openwork/app exec bun test --isolate tests/session-sync-run-status.test.ts` — exit 0; 18 passed, 0 failed, 0 skipped; 56 assertions
- `corepack pnpm --filter @openwork/app typecheck` — exit 0
- `corepack pnpm --dir evals run test:pr` — exit 0; 88 files passed, 2 skipped; 118 tests passed, 2 skipped
- `corepack pnpm evals:e2e session-completion-reconciliation --local` — exit 0; 1 passed, 0 failed, 0 skipped; exact head `3fdb56cd3a689864f8d49f3dea0ddd58ae29f62f`

The real-engine witness is intentionally in the explicit E2E lane and excluded from the shared Daytona regression topology because it owns a local OpenCode process and loopback provider. The published testkit evidence contains four passed claims and the safe monotonic phase timeline. Developer Mode now records only the correlated session ID, status category/source, monotonic timestamp, and phase durations for `run-active`, `assistant-message-completed`, and `run-terminal`; it does not record prompts, tool results, raw provider responses, credentials, headers, or private URLs.

Google Workspace connector execution, OAuth, capability search, MCP Apps, model selection, and reasoning effort were not changed.
