### PR TITLE
fix(app): fade sidebar titles only at hidden edges

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -266,11 +266,20 @@ body {
   mask-image: linear-gradient(to right, black calc(100% - 18px), transparent);
 }
 
-/* Session titles move once from their resting edge; the row and controls stay fixed. */
-.ow-session-title-moving {
+/* Fade only edges that still have hidden session-title text beyond them. */
+.ow-session-title-hidden-start {
+  mask-image: linear-gradient(to right, transparent, black 10px);
+}
+
+.ow-session-title-hidden-both {
   mask-image: linear-gradient(to right, transparent, black 10px, black calc(100% - 10px), transparent);
 }
 
+.ow-session-title-hidden-end {
+  mask-image: linear-gradient(to right, black calc(100% - 10px), transparent);
+}
+
+/* Session titles move once from their resting edge; the row and controls stay fixed. */
 .ow-session-title-moving > span {
   will-change: transform;
 }

--- a/apps/app/src/react-app/domains/session/sidebar/session-title.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/session-title.tsx
@@ -14,6 +14,22 @@ type SessionTitleProps = {
   tooltip: string;
 };
 
+export type SessionTitleHiddenEdges = "none" | "start" | "both" | "end";
+
+export function resolveSessionTitleHiddenEdges({
+  moving,
+  overflowing,
+  transitioning,
+}: {
+  moving: boolean;
+  overflowing: boolean;
+  transitioning: boolean;
+}): SessionTitleHiddenEdges {
+  if (!overflowing) return "none";
+  if (transitioning) return "both";
+  return moving ? "start" : "end";
+}
+
 const INITIAL_STATE: SessionTitleMarqueeState = {
   durationMs: 180,
   moving: false,
@@ -53,7 +69,9 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
   const reducedMotion = usePrefersReducedMotion();
   const reducedMotionRef = React.useRef(reducedMotion);
   const [state, setState] = React.useState(INITIAL_STATE);
+  const [transitioning, setTransitioning] = React.useState(false);
   const controllerRef = React.useRef<ReturnType<typeof createSessionTitleMarqueeController>>(null);
+  const targetOffsetRef = React.useRef(INITIAL_STATE.offsetPx);
   reducedMotionRef.current = reducedMotion;
 
   React.useLayoutEffect(() => {
@@ -80,6 +98,12 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
     controllerRef.current?.measure();
   }, [title, reducedMotion]);
 
+  React.useLayoutEffect(() => {
+    if (targetOffsetRef.current === state.offsetPx) return;
+    targetOffsetRef.current = state.offsetPx;
+    setTransitioning(true);
+  }, [state.offsetPx]);
+
   React.useEffect(() => {
     controllerRef.current?.setIntent(intent);
   }, [intent]);
@@ -89,6 +113,11 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
     reducedMotion,
     tooltip,
   });
+  const hiddenEdges = resolveSessionTitleHiddenEdges({
+    moving: state.moving,
+    overflowing: state.overflowing,
+    transitioning,
+  });
 
   return (
     <span
@@ -96,8 +125,12 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
       className={cn(
         "min-w-0 flex-1 overflow-hidden whitespace-nowrap",
         state.moving && "ow-session-title-moving",
+        hiddenEdges === "start" && "ow-session-title-hidden-start",
+        hiddenEdges === "both" && "ow-session-title-hidden-both",
+        hiddenEdges === "end" && "ow-session-title-hidden-end",
       )}
       data-session-title-slot
+      data-session-title-hidden-edges={hiddenEdges}
       data-session-title-moving={state.moving ? "true" : undefined}
       data-session-title-overflowing={state.overflowing ? "true" : undefined}
     >
@@ -106,6 +139,9 @@ export function SessionTitle({ intent, title, tooltip }: SessionTitleProps) {
         aria-hidden="true"
         className="inline-block"
         data-session-title-text
+        onTransitionEnd={(event) => {
+          if (event.propertyName === "transform") setTransitioning(false);
+        }}
         title={nativeTooltip}
         style={{
           transform: `translateX(-${state.offsetPx}px)`,

--- a/apps/app/tests/session-title-marquee.test.tsx
+++ b/apps/app/tests/session-title-marquee.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
+  resolveSessionTitleHiddenEdges,
   resolveSessionTitleTooltip,
   SessionTitle,
 } from "../src/react-app/domains/session/sidebar/session-title";
@@ -56,6 +57,29 @@ function setup(widths: { viewport: number; text: number }, reducedMotion = false
 }
 
 describe("session title marquee", () => {
+  test("fades only the edges with hidden title text", () => {
+    expect(resolveSessionTitleHiddenEdges({
+      moving: false,
+      overflowing: false,
+      transitioning: false,
+    })).toBe("none");
+    expect(resolveSessionTitleHiddenEdges({
+      moving: false,
+      overflowing: true,
+      transitioning: false,
+    })).toBe("end");
+    expect(resolveSessionTitleHiddenEdges({
+      moving: true,
+      overflowing: true,
+      transitioning: true,
+    })).toBe("both");
+    expect(resolveSessionTitleHiddenEdges({
+      moving: true,
+      overflowing: true,
+      transitioning: false,
+    })).toBe("start");
+  });
+
   test("never moves a fitting title", () => {
     const subject = setup({ viewport: 160, text: 140 });
     subject.controller.setIntent("focus");
@@ -141,6 +165,7 @@ describe("session title marquee", () => {
     );
 
     expect(markup).toContain('aria-label="A complete title, unread"');
+    expect(markup).toContain('data-session-title-hidden-edges="none"');
     expect(markup).toContain(
       'aria-hidden="true" class="inline-block" data-session-title-text="true" title="A complete title — Workspace"',
     );

--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -119,8 +119,8 @@ test("Daytona E2E regression profile excludes only audited shared-topology incom
   expect(categoryByTest.get("local-managed-mcp-oauth.e2e.test.ts")).toBe("raw-or-local-placement");
   expect(categoryByTest.get("slack-style-mcp-connector.e2e.test.ts")).toBe("raw-or-local-placement");
 
-  expect(inventory.all).toHaveLength(149);
-  expect(inventory.rawDesktop).toHaveLength(54);
+  expect(inventory.all).toHaveLength(150);
+  expect(inventory.rawDesktop).toHaveLength(55);
   expect(inventory.profile).toHaveLength(75);
   expect(inventory.eligible).toHaveLength(19);
   expect(inventory.rawDesktop).toContain("den-litellm-provider.e2e.test.ts");

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -1,0 +1,163 @@
+import { expect } from "vitest";
+import { createAndSelectWorkspace, evalIn, seedSessions, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { screenshot } from "@openwork/test-evidence";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "the sidebar title fade follows only the edges with hidden text"
+  : "sidebar title overflow fade skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+const longTitle = "Reading Google Drive documents for the quarterly workspace review";
+
+const titleStateExpression = `(() => {
+  const text = [...document.querySelectorAll("[data-session-title-text]")]
+    .find((node) => (node.textContent ?? "").trim() === ${JSON.stringify(longTitle)});
+  if (!(text instanceof HTMLElement) || !(text.parentElement instanceof HTMLElement)) return null;
+  const viewport = text.parentElement;
+  const rect = viewport.getBoundingClientRect();
+  return {
+    clientWidth: viewport.clientWidth,
+    hiddenEdges: viewport.dataset.sessionTitleHiddenEdges ?? "",
+    maskImage: getComputedStyle(viewport).maskImage,
+    scrollWidth: text.scrollWidth,
+    x: rect.left + Math.min(rect.width / 2, 80),
+    y: rect.top + rect.height / 2,
+  };
+})()`;
+
+const railPointExpression = `(() => {
+  const rail = document.querySelector('[data-sidebar="rail"]');
+  if (!(rail instanceof HTMLElement)) return null;
+  const rect = rail.getBoundingClientRect();
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+})()`;
+
+type TitleState = {
+  clientWidth: number;
+  hiddenEdges: string;
+  maskImage: string;
+  scrollWidth: number;
+  x: number;
+  y: number;
+};
+
+type Point = { x: number; y: number };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readTitleState(value: unknown): TitleState {
+  if (!isRecord(value)) throw new Error(`Could not read the sidebar title state: ${JSON.stringify(value)}`);
+  const { clientWidth, hiddenEdges, maskImage, scrollWidth, x, y } = value;
+  if (
+    typeof clientWidth !== "number" ||
+    typeof hiddenEdges !== "string" ||
+    typeof maskImage !== "string" ||
+    typeof scrollWidth !== "number" ||
+    typeof x !== "number" ||
+    typeof y !== "number"
+  ) {
+    throw new Error(`Sidebar title state had an unexpected shape: ${JSON.stringify(value)}`);
+  }
+  return { clientWidth, hiddenEdges, maskImage, scrollWidth, x, y };
+}
+
+function readPoint(value: unknown, label: string): Point {
+  if (!isRecord(value) || typeof value.x !== "number" || typeof value.y !== "number") {
+    throw new Error(`${label} had an unexpected shape: ${JSON.stringify(value)}`);
+  }
+  return { x: value.x, y: value.y };
+}
+
+test.skipIf(!e2eTestsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "sidebar-title-overflow-fade" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-sidebar-title-overflow-fade-${Date.now()}`,
+  });
+  await seedSessions(app, [longTitle]);
+
+  await waitFor(app, `${titleStateExpression}?.scrollWidth > ${titleStateExpression}?.clientWidth`, {
+    timeoutMs: 60_000,
+    label: "overflowing sidebar title",
+  });
+
+  const resting = readTitleState(await evalIn(app, titleStateExpression));
+  expect(resting.hiddenEdges).toBe("end");
+  expect(resting.maskImage).not.toBe("none");
+  evidence.recordAssertionEvidence(
+    "A resting clipped title fades only where more text is hidden on the right",
+    `The title measured ${resting.scrollWidth}px inside a ${resting.clientWidth}px viewport and reported only its end edge hidden.`,
+    true,
+  );
+
+  await app.client.send("Input.dispatchMouseEvent", {
+    type: "mouseMoved",
+    x: resting.x,
+    y: resting.y,
+  });
+  await waitFor(app, `${titleStateExpression}?.hiddenEdges === "both"`, {
+    timeoutMs: 10_000,
+    label: "title moving between clipped edges",
+  });
+  const moving = readTitleState(await evalIn(app, titleStateExpression));
+  expect(moving.maskImage).not.toBe("none");
+  evidence.recordAssertionEvidence(
+    "A moving title fades both edges while text is hidden on both sides",
+    `During the reveal transition the title reported ${JSON.stringify(moving.hiddenEdges)} hidden edges.`,
+    true,
+  );
+
+  await waitFor(app, `${titleStateExpression}?.hiddenEdges === "start"`, {
+    timeoutMs: 30_000,
+    label: "title reveal reached its final characters",
+  });
+  const revealed = readTitleState(await evalIn(app, titleStateExpression));
+  expect(revealed.maskImage).not.toBe("none");
+  evidence.recordAssertionEvidence(
+    "The final characters stay crisp once no text remains hidden on the right",
+    `At the end of the reveal the title reported only its start edge hidden, removing the right-edge fade from the final characters.`,
+    true,
+  );
+  await screenshot(app);
+
+  const rail = readPoint(await evalIn(app, railPointExpression), "sidebar resize rail");
+  await app.client.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: rail.x,
+    y: rail.y,
+    button: "left",
+    clickCount: 1,
+  });
+  await app.client.send("Input.dispatchMouseEvent", {
+    type: "mouseMoved",
+    x: rail.x + 340,
+    y: rail.y,
+    button: "left",
+  });
+  await app.client.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: rail.x + 340,
+    y: rail.y,
+    button: "left",
+    clickCount: 1,
+  });
+  await waitFor(app, `${titleStateExpression}?.hiddenEdges === "none"`, {
+    timeoutMs: 15_000,
+    label: "expanded sidebar exposes the full title",
+  });
+
+  const fitting = readTitleState(await evalIn(app, titleStateExpression));
+  expect(fitting.clientWidth).toBeGreaterThanOrEqual(fitting.scrollWidth);
+  expect(fitting.maskImage).toBe("none");
+  evidence.recordAssertionEvidence(
+    "Expanding the sidebar enough to show the full title removes every fade",
+    `After resizing, the ${fitting.scrollWidth}px title fits inside its ${fitting.clientWidth}px viewport, reports no hidden edges, and has no mask.`,
+    true,
+  );
+  await screenshot(app);
+});


### PR DESCRIPTION
## Summary

- apply the title fade only to edges that still hide text
- keep both-edge fading while the title marquee is moving
- remove the fade once an expanded sidebar fully fits the title
- cover the edge-state resolver and the complete Electron interaction
- keep the Daytona regression inventory in sync with the added desktop spec

## Verification

- `pnpm --dir apps/app exec bun test --isolate tests/session-title-marquee.test.tsx` — 9 passed
- `pnpm --dir apps/app typecheck` — passed
- `pnpm evals:pr specs/daytona-e2e-regression-concurrency.test.ts` — 3 passed
- `OPENWORK_EVAL_DAYTONA=1 pnpm evals:e2e sidebar-title-overflow-fade` — 1 passed, 0 failed, 0 skipped (Daytona Electron)
- GitHub OpenWork Tests — Linux and macOS matrix passed