### PR TITLE
feat: per-member credential lifecycle — self-serve keys, probe/stale routes, provisioner daemon

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -335,11 +335,17 @@ export type DenOrgLlmProvider = {
   providerId: string;
   name: string;
   providerConfig: Record<string, unknown>;
+  credentialMode?: "shared" | "per_member";
   hasApiKey: boolean;
+  hasMyCredential?: boolean;
   models: DenOrgLlmProviderModel[];
   createdAt: string | null;
   updatedAt: string | null;
 };
+
+export type DenLlmProviderMyCredentialInput =
+  | { apiKey: string; apiKeys?: never }
+  | { apiKey?: never; apiKeys: Record<string, string> };
 
 export type DenExternalMcpConnection = {
   id: string;
@@ -2053,7 +2059,13 @@ function parseDenOrgLlmProvider(value: unknown): DenOrgLlmProvider | null {
     providerId: value.providerId,
     name: value.name,
     providerConfig: parseJsonRecord(value.providerConfig),
+    ...(value.credentialMode === "shared" || value.credentialMode === "per_member"
+      ? { credentialMode: value.credentialMode }
+      : {}),
     hasApiKey: value.hasApiKey === true,
+    ...(typeof value.hasMyCredential === "boolean"
+      ? { hasMyCredential: value.hasMyCredential }
+      : {}),
     models: Array.isArray(value.models)
       ? value.models.flatMap((model) => {
           const parsed = parseDenOrgLlmProviderModel(model);
@@ -3363,6 +3375,23 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         throw new DenApiError(500, "invalid_llm_provider_payload", "LLM provider response was missing connection details.");
       }
       return provider;
+    },
+
+    async putMyLlmProviderCredential(
+      orgId: string,
+      llmProviderId: string,
+      credential: DenLlmProviderMyCredentialInput,
+    ): Promise<void> {
+      await requestJson<unknown>(
+        baseUrls,
+        `/v1/llm-providers/${encodeURIComponent(llmProviderId)}/my-credential`,
+        {
+          method: "PUT",
+          token,
+          organizationId: orgId,
+          body: credential,
+        },
+      );
     },
 
     async listMcpConnections(orgId: string, scope: "usable" | "manageable" = "usable"): Promise<DenExternalMcpConnection[]> {

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -9,6 +9,7 @@ import type {
 import { t } from "../../../../i18n";
 import {
   createDenClient,
+  DenApiError,
   readDenSettings,
   resolveDenBaseUrls,
   type DenOrgLlmProvider,
@@ -317,6 +318,7 @@ function providerListModelEntitlementOptions(
 }
 
 export type ProviderAuthStore = ReturnType<typeof createProviderAuthStore>;
+export type CloudProviderMemberCredentialResult = "saved" | "blocked";
 
 export function createProviderAuthStore(options: CreateProviderAuthStoreOptions) {
   const listeners = new Set<() => void>();
@@ -1799,6 +1801,50 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   }
 
+  async function saveCloudProviderMemberCredential(
+    cloudProviderId: string,
+    apiKey: string,
+  ): Promise<CloudProviderMemberCredentialResult> {
+    const trimmed = apiKey.trim();
+    if (!trimmed) throw new Error(t("providers.api_key_required"));
+
+    const provider = state.cloudOrgProviders.find((entry) => entry.id === cloudProviderId);
+    if (!provider) throw new Error("This organization provider is no longer available.");
+    assertProviderAllowedByDesktopPolicy(getCloudManagedProviderId(provider));
+
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    if (!token || !orgId) {
+      throw new Error("Sign in to OpenWork Cloud and choose an organization first.");
+    }
+
+    const den = createDenClient({ baseUrl: settings.baseUrl, token });
+    try {
+      await den.putMyLlmProviderCredential(orgId, cloudProviderId, { apiKey: trimmed });
+    } catch (error) {
+      if (
+        error instanceof DenApiError &&
+        error.status === 409 &&
+        error.code === "credential_blocked"
+      ) {
+        return "blocked";
+      }
+      throw error;
+    }
+
+    await runCloudProviderSync("manual");
+    await Promise.all([
+      refreshCloudOrgProviders({ force: true }),
+      refreshImportedCloudProviders({ strict: true }),
+    ]);
+    if (state.cloudProviderServerSync?.skippedProviders[cloudProviderId]?.reason === "needs_key") {
+      await runCloudProviderSync("manual");
+      await refreshImportedCloudProviders({ strict: true });
+    }
+    return "saved";
+  }
+
   async function removeCloudProviderInternal(
     cloudProviderId: string,
     optionsArg?: { silent?: boolean },
@@ -2519,6 +2565,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     completeProviderAuthOAuth,
     submitProviderApiKey,
     connectCloudProvider,
+    saveCloudProviderMemberCredential,
     removeCloudProvider,
     disconnectProvider,
     ensureProjectProviderDisabledState,

--- a/apps/app/src/react-app/domains/settings/cloud/sections.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/sections.tsx
@@ -11,6 +11,7 @@ import fuzzysort from "fuzzysort";
 import * as React from "react";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   RefreshButton,
@@ -43,6 +44,7 @@ export type CloudProviderRowStatus =
   | "error"
   | "conflict"
   | "blocked"
+  | "needs_key"
   | "needs_credential"
   | "needs_server"
   | "unavailable";
@@ -100,6 +102,7 @@ function cloudProviderStatusTone(status: CloudProviderRowStatus) {
     case "conflict":
       return "error" as const;
     case "blocked":
+    case "needs_key":
     case "needs_credential":
     case "needs_server":
     case "unavailable":
@@ -121,6 +124,8 @@ function cloudProviderStatusLabel(status: CloudProviderRowStatus) {
       return t("den.cloud_provider_conflict");
     case "blocked":
       return t("den.cloud_provider_blocked");
+    case "needs_key":
+      return "Needs your key";
     case "needs_credential":
       return t("den.cloud_provider_needs_credential");
     case "needs_server":
@@ -201,15 +206,38 @@ interface CloudProviderListItemProps {
   actionId: string | null;
   row: CloudProviderRow;
   onRetry: (cloudProviderId: string) => void | Promise<void>;
+  onSaveMemberCredential: (cloudProviderId: string, apiKey: string) => Promise<"saved" | "blocked">;
 }
 
-function CloudProviderListItem({ actionId, row, onRetry }: CloudProviderListItemProps) {
+function CloudProviderListItem({ actionId, row, onRetry, onSaveMemberCredential }: CloudProviderListItemProps) {
   const actionBusy = actionId === row.cloudProviderId;
   const status = actionBusy ? "syncing" : row.status;
+  const [apiKey, setApiKey] = React.useState("");
+  const [credentialError, setCredentialError] = React.useState<string | null>(null);
+  const [credentialBusy, setCredentialBusy] = React.useState(false);
+
+  const submitMemberCredential = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const credential = apiKey.trim();
+    if (!credential || credentialBusy) return;
+    setApiKey("");
+    setCredentialError(null);
+    setCredentialBusy(true);
+    try {
+      const result = await onSaveMemberCredential(row.cloudProviderId, credential);
+      if (result === "blocked") {
+        setCredentialError("An admin manages this credential. Ask them to update it.");
+      }
+    } catch (error) {
+      setCredentialError(error instanceof Error ? error.message : "We couldn't save your key. Try again.");
+    } finally {
+      setCredentialBusy(false);
+    }
+  };
 
   return (
     <SettingsListItem>
-      <SettingsListItemContent>
+      <SettingsListItemContent className="flex-1">
         <SettingsListTitle>
           <SettingsListItemTitle>{row.name}</SettingsListItemTitle>
           <SettingsPill className={statusBadgeVariants({ tone: cloudProviderStatusTone(status) })}>
@@ -219,10 +247,33 @@ function CloudProviderListItem({ actionId, row, onRetry }: CloudProviderListItem
         <SettingsListItemDescription>
           {[
             row.provider?.providerId ?? row.imported?.providerId,
-            row.provider?.hasApiKey ? t("den.credentials_ready_badge") : null,
+            row.provider?.hasApiKey || row.provider?.hasMyCredential ? t("den.credentials_ready_badge") : null,
             row.detail,
           ].filter(Boolean).join(" · ")}
         </SettingsListItemDescription>
+        {row.status === "needs_key" ? (
+          <form className="mt-2 flex max-w-xl flex-col gap-2 sm:flex-row sm:items-start" onSubmit={submitMemberCredential}>
+            <div className="min-w-0 flex-1">
+              <Input
+                type="password"
+                aria-label={`API key for ${row.name}`}
+                aria-invalid={Boolean(credentialError)}
+                autoComplete="new-password"
+                placeholder="Paste your provider key"
+                spellCheck={false}
+                value={apiKey}
+                onChange={(event) => setApiKey(event.currentTarget.value)}
+                disabled={credentialBusy}
+              />
+              {credentialError ? (
+                <p className="mt-1 text-xs text-destructive" role="alert">{credentialError}</p>
+              ) : null}
+            </div>
+            <Button type="submit" size="sm" disabled={credentialBusy || !apiKey.trim()}>
+              {credentialBusy ? "Saving…" : "Save key"}
+            </Button>
+          </form>
+        ) : null}
       </SettingsListItemContent>
       {row.status === "error" && row.provider ? (
         <SettingsListItemActions>
@@ -386,6 +437,7 @@ export interface CloudProvidersSectionProps {
   rows: CloudProviderRow[];
   onRefresh: () => void | Promise<void>;
   onRetry: (cloudProviderId: string) => void | Promise<void>;
+  onSaveMemberCredential: (cloudProviderId: string, apiKey: string) => Promise<"saved" | "blocked">;
 }
 
 export function CloudProvidersSection({
@@ -395,6 +447,7 @@ export function CloudProvidersSection({
   rows,
   onRefresh,
   onRetry,
+  onSaveMemberCredential,
 }: CloudProvidersSectionProps) {
   const { hasActiveOrg } = useCloudSession();
   const [searchQuery, setSearchQuery] = React.useState("");
@@ -405,6 +458,7 @@ export function CloudProvidersSection({
     "error",
     "conflict",
     "blocked",
+    "needs_key",
     "needs_credential",
     "needs_server",
     "unavailable",
@@ -476,6 +530,7 @@ export function CloudProvidersSection({
                           actionId={actionId}
                           row={row}
                           onRetry={onRetry}
+                          onSaveMemberCredential={onSaveMemberCredential}
                         />
                       ))}
                     </SettingsList>

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -31,6 +31,7 @@ export type CloudProviderRowStateInput = {
   allowed: boolean;
   importsUnavailable: boolean;
   needsCredential: boolean;
+  needsMemberCredential?: boolean;
   needsServer: boolean;
   syncError: CloudProviderSyncError | null;
   /**
@@ -51,6 +52,7 @@ export function resolveCloudProviderRowStatus(
 ): CloudProviderRowStatus {
   if (input.importsUnavailable) return "unavailable";
   if (!input.allowed) return "blocked";
+  if (input.needsMemberCredential) return "needs_key";
   if (input.syncError) return input.syncError.kind;
   if (input.needsCredential || input.skippedByServer === true) return "needs_credential";
   if (input.needsServer) return "needs_server";
@@ -75,6 +77,7 @@ export type CloudProvidersViewProps = {
   onOpenAccount: () => void;
   refreshCloudOrgProviders: (options?: { force?: boolean }) => Promise<DenOrgLlmProvider[]>;
   runCloudProviderSync: (reason: "manual") => Promise<unknown>;
+  saveCloudProviderMemberCredential: (cloudProviderId: string, apiKey: string) => Promise<"saved" | "blocked">;
   /** Server-side sync facts (reload pending, skips); null on the legacy renderer-import path. */
   serverSync: CloudProviderServerSyncState | null;
 };
@@ -91,6 +94,7 @@ export function CloudProvidersView({
   onOpenAccount,
   refreshCloudOrgProviders,
   runCloudProviderSync,
+  saveCloudProviderMemberCredential,
   serverSync,
 }: CloudProvidersViewProps) {
   const { activeOrganization, isSignedIn } = useCloudSession();
@@ -110,15 +114,21 @@ export function CloudProvidersView({
       });
       const syncError = lastSyncError[provider.id] ?? null;
       const env = getCloudProviderEnv(provider.providerConfig);
+      const skippedProvider = serverSync?.skippedProviders[provider.id];
+      const needsMemberCredential = skippedProvider?.reason === "needs_key";
+      const hasCredential = provider.credentialMode === "per_member"
+        ? provider.hasMyCredential === true
+        : provider.hasApiKey;
       const status = resolveCloudProviderRowStatus({
         imported: Boolean(imported),
         outOfSync,
         allowed,
         importsUnavailable,
-        needsCredential: !provider.hasApiKey && env.length > 0,
-        needsServer: provider.hasApiKey && env.length > 1 && !openworkServerAvailable,
+        needsCredential: !needsMemberCredential && !hasCredential && env.length > 0,
+        needsMemberCredential,
+        needsServer: hasCredential && env.length > 1 && !openworkServerAvailable,
         syncError,
-        skippedByServer: Boolean(serverSync?.skippedProviders[provider.id]),
+        skippedByServer: Boolean(skippedProvider),
         reloadPending: serverSync?.reloadPending === true,
       });
       const source = provider.source === "custom" ? "custom" : "managed";
@@ -130,11 +140,13 @@ export function CloudProvidersView({
         ? t("den.cloud_provider_blocked")
         : status === "unavailable"
           ? t("den.cloud_provider_imports_unavailable")
-          : status === "needs_credential"
-            ? syncError?.message ?? t("den.cloud_provider_needs_credential")
-            : status === "needs_server"
-              ? syncError?.message ?? t("den.cloud_provider_needs_server")
-              : syncError?.message ?? providerDetail;
+          : status === "needs_key"
+            ? "Paste your provider key to connect."
+            : status === "needs_credential"
+              ? syncError?.message ?? t("den.cloud_provider_needs_credential")
+              : status === "needs_server"
+                ? syncError?.message ?? t("den.cloud_provider_needs_server")
+                : syncError?.message ?? providerDetail;
 
       return {
         key: `live:${provider.id}`,
@@ -214,6 +226,7 @@ export function CloudProvidersView({
       rows={rows}
       onRefresh={syncNow}
       onRetry={retryProvider}
+      onSaveMemberCredential={saveCloudProviderMemberCredential}
     />
   );
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2435,6 +2435,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 onOpenAccount={openCloudAccountSettings}
                 refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
                 runCloudProviderSync={providerAuthStore.runCloudProviderSync}
+                saveCloudProviderMemberCredential={providerAuthStore.saveCloudProviderMemberCredential}
                 serverSync={providerAuthSnapshot.cloudProviderServerSync}
               />
             }
@@ -2590,6 +2591,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             onOpenAccount={openCloudAccountSettings}
             refreshCloudOrgProviders={providerAuthStore.refreshCloudOrgProviders}
             runCloudProviderSync={providerAuthStore.runCloudProviderSync}
+            saveCloudProviderMemberCredential={providerAuthStore.saveCloudProviderMemberCredential}
             serverSync={providerAuthSnapshot.cloudProviderServerSync}
           />
         );

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -22,6 +22,7 @@ import {
   listConfiguredEnvKeys,
   readProviderEnvNames,
   resolveProviderCredential,
+  selectPrimaryCredentialEnvName,
 } from "../../llm/provider-credentials.js"
 import {
   jsonValidator,
@@ -144,6 +145,17 @@ const adminMemberCredentialWriteSchema = z.object({
   externalCredentialId: z.string().trim().min(1).max(255).optional(),
   expectedVersion: z.number().int().positive().optional(),
 }).superRefine(requireExactlyOneCredential)
+
+const providerProbeRequestSchema = z.object({
+  orgMembershipId: denTypeIdSchema("member").optional(),
+})
+
+const providerProbeResponseSchema = z.object({
+  status: z.enum(["ok", "unauthorized", "unreachable", "model_missing", "no_credential"]),
+  latencyMs: z.number().int().nonnegative().optional(),
+  models: z.number().int().nonnegative().optional(),
+  missingModelIds: z.array(z.string()).optional(),
+}).meta({ ref: "LlmProviderProbeResponse" })
 
 const endpointProbeRequestSchema = z.object({
   api: z.string().trim().min(1).max(2048),
@@ -391,6 +403,26 @@ function memberCredentialSummary(credential: LlmProviderMemberCredentialRow) {
     version: credential.version,
     updatedAt: credential.updatedAt.toISOString(),
   }
+}
+
+function probeBearerCredential(provider: Pick<LlmProviderRow, "providerConfig">, secret: string | null) {
+  const credential = decodeProviderCredential(secret)
+  if (credential.apiKey) return credential.apiKey
+  if (!credential.apiKeys) return null
+  const envName = selectPrimaryCredentialEnvName(
+    readProviderEnvNames(provider.providerConfig),
+    Object.keys(credential.apiKeys),
+  )
+  return envName ? credential.apiKeys[envName] ?? null : null
+}
+
+function readGatewayModelIds(value: unknown) {
+  if (typeof value !== "object" || value === null || !("data" in value) || !Array.isArray(value.data)) return []
+  return value.data.flatMap((entry) =>
+    typeof entry === "object" && entry !== null && "id" in entry && typeof entry.id === "string"
+      ? [entry.id]
+      : [],
+  )
 }
 
 type MemberCredentialWriteResult = {
@@ -1028,6 +1060,136 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
     },
   )
 
+  app.post(
+    "/v1/llm-providers/:llmProviderId/probe",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Probe an LLM provider with a resolved credential",
+      description: "Tests the provider's models endpoint with the calling member's resolved credential. Owners and admins may select another granted member's per-member binding. Credential material and upstream response bodies are never returned.",
+      responses: {
+        200: jsonResponse("Provider probe completed.", providerProbeResponseSchema),
+        400: jsonResponse("The provider id or target binding was invalid.", z.union([invalidRequestSchema, notPerMemberSchema])),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        403: jsonResponse("The caller cannot access the provider or selected member binding.", forbiddenSchema),
+        404: jsonResponse("The provider or selected member could not be found.", notFoundSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(orgLlmProviderParamsSchema),
+    jsonValidator(providerProbeRequestSchema),
+    resolveMemberTeamsMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const memberTeams = c.get("memberTeams") ?? []
+      const params = c.req.valid("param")
+      const input = c.req.valid("json")
+      const llmProviderId = parseLlmProviderId(params.llmProviderId)
+      const provider = await getLlmProvider({ organizationId: payload.organization.id, llmProviderId })
+      if (!provider) return c.json({ error: "llm_provider_not_found" }, 404)
+
+      const accessible = await canAccessLlmProvider({
+        organizationId: payload.organization.id,
+        llmProviderId,
+        currentMemberId: payload.currentMember.id,
+        memberTeams,
+      })
+      if (!accessible) {
+        return c.json({ error: "forbidden", message: "You do not have access to this provider." }, 403)
+      }
+
+      let targetMemberId = payload.currentMember.id
+      if (input.orgMembershipId) {
+        targetMemberId = parseMemberId(input.orgMembershipId)
+        if (targetMemberId !== payload.currentMember.id && !isOrganizationAdmin(payload)) {
+          return c.json({ error: "forbidden", message: "Only workspace owners and admins can probe another member's credential." }, 403)
+        }
+        if (provider.credentialMode !== "per_member") {
+          return c.json({ error: "not_per_member" }, 400)
+        }
+        const targetRows = await db
+          .select({ id: MemberTable.id })
+          .from(MemberTable)
+          .where(and(
+            eq(MemberTable.organizationId, payload.organization.id),
+            eq(MemberTable.id, targetMemberId),
+            isNull(MemberTable.removedAt),
+          ))
+          .limit(1)
+        if (!targetRows[0]) return c.json({ error: "member_not_found" }, 404)
+        const grantedMemberIds = await listGrantedLlmProviderMemberIds({
+          organizationId: payload.organization.id,
+          llmProviderId,
+        })
+        if (!grantedMemberIds.includes(targetMemberId)) {
+          return c.json({ error: "forbidden", message: "The selected member does not have access to this provider." }, 403)
+        }
+      }
+
+      let secret = provider.apiKey
+      if (provider.credentialMode === "per_member") {
+        const bindingRows = await db
+          .select({ secret: LlmProviderMemberCredentialTable.secret, state: LlmProviderMemberCredentialTable.state })
+          .from(LlmProviderMemberCredentialTable)
+          .where(and(
+            eq(LlmProviderMemberCredentialTable.organizationId, payload.organization.id),
+            eq(LlmProviderMemberCredentialTable.llmProviderId, llmProviderId),
+            eq(LlmProviderMemberCredentialTable.orgMembershipId, targetMemberId),
+          ))
+          .limit(1)
+        const binding = bindingRows[0]
+        secret = binding?.state === "active" ? binding.secret : null
+      }
+      const apiKey = probeBearerCredential(provider, secret)
+      if (!apiKey) return c.json({ status: "no_credential" })
+
+      const api = typeof provider.providerConfig.api === "string"
+        ? provider.providerConfig.api.replace(/\/+$/, "")
+        : ""
+      const startedAt = Date.now()
+      let response: Response
+      try {
+        response = await fetch(`${api}/models`, {
+          headers: { authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(5_000),
+        })
+      } catch {
+        return c.json({ status: "unreachable", latencyMs: Date.now() - startedAt })
+      }
+      const latencyMs = Date.now() - startedAt
+      if (response.status === 401 || response.status === 403) {
+        return c.json({ status: "unauthorized", latencyMs })
+      }
+      if (!response.ok) {
+        return c.json({ status: "unreachable", latencyMs })
+      }
+
+      let body: unknown = null
+      try {
+        body = await response.json()
+      } catch {
+        body = null
+      }
+      const gatewayModelIds = readGatewayModelIds(body)
+      const configuredModels = await db
+        .select({ id: LlmProviderModelTable.modelId })
+        .from(LlmProviderModelTable)
+        .where(eq(LlmProviderModelTable.llmProviderId, llmProviderId))
+      const availableModels = new Set(gatewayModelIds)
+      const missingModelIds = configuredModels
+        .map((model) => model.id)
+        .filter((id) => !availableModels.has(id))
+      if (missingModelIds.length > 0) {
+        return c.json({
+          status: "model_missing",
+          latencyMs,
+          models: gatewayModelIds.length,
+          missingModelIds,
+        })
+      }
+      return c.json({ status: "ok", latencyMs, models: gatewayModelIds.length })
+    },
+  )
+
   app.put(
     "/v1/llm-providers/:llmProviderId/my-credential",
     describeRoute({
@@ -1329,6 +1491,58 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       const credential: LlmProviderMemberCredentialRow = {
         ...existing,
         state: "blocked",
+        version: existing.version + 1,
+        updatedAt: new Date(),
+      }
+      await db
+        .update(LlmProviderMemberCredentialTable)
+        .set({ state: credential.state, version: credential.version, updatedAt: credential.updatedAt })
+        .where(eq(LlmProviderMemberCredentialTable.id, existing.id))
+      return c.json(memberCredentialSummary(credential))
+    },
+  )
+
+  app.post(
+    "/v1/llm-providers/:llmProviderId/member-credentials/:orgMembershipId/stale",
+    describeRoute({
+      tags: ["LLM Providers"],
+      summary: "Mark one member's LLM provider credential stale",
+      responses: {
+        200: jsonResponse("Member credential marked stale.", memberCredentialSummarySchema),
+        400: jsonResponse("The provider or member id is invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can mark member credentials stale.", forbiddenSchema),
+        404: jsonResponse("The provider or member credential could not be found.", notFoundSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(orgLlmProviderMemberCredentialParamsSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const admin = ensureOrganizationAdminRole(c, "Only workspace owners and admins can mark member credentials stale.")
+      if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+
+      const params = c.req.valid("param")
+      const llmProviderId = parseLlmProviderId(params.llmProviderId)
+      const orgMembershipId = parseMemberId(params.orgMembershipId)
+      const provider = await getLlmProvider({ organizationId: payload.organization.id, llmProviderId })
+      if (!provider) return c.json({ error: "llm_provider_not_found" }, 404)
+
+      const rows = await db
+        .select()
+        .from(LlmProviderMemberCredentialTable)
+        .where(and(
+          eq(LlmProviderMemberCredentialTable.organizationId, payload.organization.id),
+          eq(LlmProviderMemberCredentialTable.llmProviderId, llmProviderId),
+          eq(LlmProviderMemberCredentialTable.orgMembershipId, orgMembershipId),
+        ))
+        .limit(1)
+      const existing = rows[0]
+      if (!existing) return c.json({ error: "member_credential_not_found" }, 404)
+
+      const credential: LlmProviderMemberCredentialRow = {
+        ...existing,
+        state: "stale",
         version: existing.version + 1,
         updatedAt: new Date(),
       }

--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -119,10 +119,11 @@ test("Daytona E2E regression profile excludes only audited shared-topology incom
   expect(categoryByTest.get("local-managed-mcp-oauth.e2e.test.ts")).toBe("raw-or-local-placement");
   expect(categoryByTest.get("slack-style-mcp-connector.e2e.test.ts")).toBe("raw-or-local-placement");
 
-  expect(inventory.all).toHaveLength(150);
+  expect(inventory.all).toHaveLength(151);
   expect(inventory.rawDesktop).toHaveLength(55);
   expect(inventory.profile).toHaveLength(75);
-  expect(inventory.eligible).toHaveLength(19);
+  expect(inventory.eligible).toHaveLength(20);
+  expect(inventory.eligible).toContain("per-member-credential-self-serve.e2e.test.ts");
   expect(inventory.rawDesktop).toContain("den-litellm-provider.e2e.test.ts");
   expect(inventory.eligible).not.toContain("org-team-lifecycle-critical-path.e2e.test.ts");
   expect(inventory.eligible).not.toContain("library-mcp-connect-error.e2e.test.ts");

--- a/evals/specs/litellm-per-member-credentials.e2e.test.ts
+++ b/evals/specs/litellm-per-member-credentials.e2e.test.ts
@@ -1,8 +1,11 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
 import {
   liteLlm,
+  inviteMember,
   needs,
   server,
   SkipError,
@@ -33,22 +36,42 @@ interface ProvisionerConfig {
   liteLlmBaseUrl: string;
   liteLlmMasterKey: string;
   models: string[];
+  dryRun?: boolean;
+  keyDuration?: string;
+  renewBeforeSeconds?: number;
 }
 
 interface ProvisionerModule {
   syncProviderModelMetadata(input: ProvisionerConfig): Promise<ModelMetadataResult>;
   reconcileMemberKeys(input: ProvisionerConfig): Promise<ReconcileResult>;
   offboardMember(input: ProvisionerConfig & { orgMembershipId: string }): Promise<unknown>;
+  markStale(input: ProvisionerConfig & { orgMembershipId: string }): Promise<unknown>;
 }
 
 interface ModelMetadataResult {
-  action: "unchanged" | "updated";
+  action: "unchanged" | "updated" | "planned";
   models: Array<{ id: string; maxInputTokens: number; maxOutputTokens: number }>;
 }
 
 interface ReconcileResult {
   modelMetadata: ModelMetadataResult;
-  memberCredentials: unknown[];
+  memberCredentials: MemberCredentialAction[];
+  failures: number;
+  planned: number;
+  writes: { den: number; liteLlm: number };
+}
+
+interface MemberCredentialAction {
+  orgMembershipId: string;
+  action: string;
+  outcome: string;
+  externalCredentialId?: string;
+  detail?: string;
+}
+
+interface UpstreamKey {
+  key: string;
+  tokenId: string;
 }
 
 interface LiveModelMetadata {
@@ -70,7 +93,8 @@ function isProvisionerModule(value: unknown): value is ProvisionerModule {
   return isRecord(value)
     && typeof value.syncProviderModelMetadata === "function"
     && typeof value.reconcileMemberKeys === "function"
-    && typeof value.offboardMember === "function";
+    && typeof value.offboardMember === "function"
+    && typeof value.markStale === "function";
 }
 
 function auth(session: DenSession): Record<string, string> {
@@ -181,6 +205,166 @@ function memberCredentials(value: unknown): Record<string, unknown>[] {
   return value.memberCredentials.filter(isRecord);
 }
 
+async function listedMemberCredentials(
+  admin: DenSession,
+  orgId: string,
+  providerId: string,
+): Promise<Record<string, unknown>[]> {
+  const result = await denFetch(admin, `/v1/llm-providers/${encodeURIComponent(providerId)}/member-credentials`, {
+    headers: orgHeaders(admin, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!result.response.ok) {
+    throw new Error(`Listing member credentials failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return memberCredentials(result.body);
+}
+
+function liteLlmAdminUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
+async function upstreamKeys(baseUrl: string, apiKey: string): Promise<Record<string, unknown>[]> {
+  const response = await fetch(`${liteLlmAdminUrl(baseUrl)}/key/list?return_full_object=true&size=100`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body: unknown = await response.json();
+  const keys = isRecord(body) && Array.isArray(body.keys) ? body.keys.filter(isRecord) : [];
+  if (!response.ok) throw new Error(`Listing LiteLLM keys failed with HTTP ${response.status}.`);
+  return keys;
+}
+
+function upstreamKeyId(value: Record<string, unknown>): string {
+  if (typeof value.token !== "string" || !value.token) throw new Error("LiteLLM key list entry did not include token.");
+  return value.token;
+}
+
+async function generateUpstreamKey(
+  baseUrl: string,
+  apiKey: string,
+  input: { alias: string; orgMembershipId: string; email: string; duration?: string },
+): Promise<UpstreamKey> {
+  const response = await fetch(`${liteLlmAdminUrl(baseUrl)}/key/generate`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      models: [MODEL_ID],
+      key_alias: input.alias,
+      metadata: { openwork_org_membership_id: input.orgMembershipId, email: input.email },
+      ...(input.duration ? { duration: input.duration } : {}),
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body: unknown = await response.json();
+  if (!response.ok
+    || !isRecord(body)
+    || typeof body.key !== "string"
+    || typeof body.token_id !== "string") {
+    throw new Error(`Generating a LiteLLM key failed with HTTP ${response.status}.`);
+  }
+  return { key: body.key, tokenId: body.token_id };
+}
+
+async function upstreamKeyInfo(baseUrl: string, apiKey: string, tokenId: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`${liteLlmAdminUrl(baseUrl)}/key/info?key=${encodeURIComponent(tokenId)}`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body: unknown = await response.json();
+  if (!response.ok || !isRecord(body) || !isRecord(body.info)) {
+    throw new Error(`Reading LiteLLM key info failed with HTTP ${response.status}.`);
+  }
+  return body.info;
+}
+
+async function deleteUpstreamKey(baseUrl: string, apiKey: string, tokenId: string): Promise<void> {
+  const response = await fetch(`${liteLlmAdminUrl(baseUrl)}/key/delete`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+    body: JSON.stringify({ keys: [tokenId] }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Deleting a LiteLLM key failed with HTTP ${response.status}.`);
+}
+
+async function setProviderMemberAccess(
+  admin: DenSession,
+  orgId: string,
+  providerId: string,
+  memberIds: string[],
+): Promise<void> {
+  const provider = await manageableProvider(admin, orgId, providerId);
+  if (typeof provider.name !== "string" || !isRecord(provider.providerConfig) || !Array.isArray(provider.models)) {
+    throw new Error("Manageable provider did not include the fields needed for access replacement.");
+  }
+  const models = provider.models.map((entry) => {
+    if (!isRecord(entry) || !isRecord(entry.config)) throw new Error("Manageable provider included an invalid model.");
+    return entry.config;
+  });
+  const result = await denFetch(admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+    method: "PATCH",
+    headers: orgHeaders(admin, orgId),
+    body: JSON.stringify({
+      name: provider.name,
+      source: "custom",
+      customConfig: { ...provider.providerConfig, models },
+      credentialMode: "per_member",
+      allMembers: false,
+      memberIds,
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!result.response.ok) {
+    throw new Error(`Replacing provider access failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+}
+
+async function runProvisionerCli(
+  args: string[],
+  config: ProvisionerConfig,
+): Promise<{ stdout: string; stderr: string }> {
+  const provisionerPath = fileURLToPath(new URL(
+    "../../examples/litellm-per-member-keys/provision.mjs",
+    import.meta.url,
+  ));
+  return new Promise((resolve, reject) => {
+    execFile(process.execPath, [provisionerPath, ...args], {
+      encoding: "utf8",
+      timeout: 120_000,
+      maxBuffer: 1024 * 1024,
+      env: {
+        ...process.env,
+        OPENWORK_DEN_API_URL: config.denApiUrl,
+        OPENWORK_DEN_TOKEN: config.denToken,
+        OPENWORK_ORG_ID: config.orgId,
+        OPENWORK_LLM_PROVIDER_ID: config.providerId,
+        LITELLM_BASE_URL: config.liteLlmBaseUrl,
+        LITELLM_MASTER_KEY: config.liteLlmMasterKey,
+        LITELLM_MODELS: config.models.join(","),
+        OPENWORK_DRY_RUN: "",
+        OPENWORK_KEY_DURATION: "",
+        OPENWORK_RENEW_BEFORE_SECONDS: "",
+      },
+    }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`Provisioner CLI failed: ${error.message}\n${stderr.slice(0, 1_000)}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function structuredLines(stdout: string): Record<string, unknown>[] {
+  return stdout.trim().split("\n").filter(Boolean).map((line) => {
+    const value: unknown = JSON.parse(line);
+    if (!isRecord(value)) throw new Error("Provisioner emitted a non-object JSON line.");
+    return value;
+  });
+}
+
 async function manageableProvider(admin: DenSession, orgId: string, providerId: string): Promise<Record<string, unknown>> {
   const result = await denFetch(admin, "/v1/llm-providers?scope=manageable", {
     headers: orgHeaders(admin, orgId),
@@ -282,7 +466,8 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   const bob = den.members.bob;
   if (!alice || !bob) throw new Error("The cold managed Den did not provision both members.");
   const orgId = await organizationId(den.admin);
-  const [aliceMemberId, bobMemberId] = await Promise.all([
+  const [adminMemberId, aliceMemberId, bobMemberId] = await Promise.all([
+    memberIdByEmail(den.admin, orgId, den.admin.email),
     memberIdByEmail(den.admin, orgId, alice.email),
     memberIdByEmail(den.admin, orgId, bob.email),
   ]);
@@ -475,5 +660,343 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
       && bobSelfWrite.body.error === "credential_blocked"
       && aliceStillWorks.status === 200
       && aliceStillWorks.reply.includes(REPLY),
+  );
+
+  const charlie = await inviteMember(den, "charlie", {
+    email: `charlie-lifecycle-${Date.now()}@openwork.test`,
+    name: "Charlie Credential Member",
+    password: "OpenWorkEval123!",
+  });
+  const charlieMemberId = await memberIdByEmail(den.admin, orgId, charlie.email);
+  const credentialsBeforeDryRun = await listedMemberCredentials(den.admin, orgId, providerId);
+  const keysBeforeDryRun = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const dryRun = await runProvisionerCli(["reconcile", "--dry-run"], provisionerConfig);
+  const dryRunLines = structuredLines(dryRun.stdout);
+  const credentialsAfterDryRun = await listedMemberCredentials(den.admin, orgId, providerId);
+  const keysAfterDryRun = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const dryRunSummary = dryRunLines.find((line) => line.action === "reconcile.summary");
+  expect(dryRun.stderr).toBe("");
+  expect(credentialsAfterDryRun).toEqual(credentialsBeforeDryRun);
+  expect(keysAfterDryRun.map(upstreamKeyId).sort()).toEqual(keysBeforeDryRun.map(upstreamKeyId).sort());
+  expect(dryRunLines).toEqual(expect.arrayContaining([
+    expect.objectContaining({ action: "member.provision", orgMembershipId: charlieMemberId, outcome: "planned" }),
+  ]));
+  expect(dryRunSummary).toMatchObject({ outcome: "planned" });
+  expect(dryRunSummary?.detail).toContain("denWrites=0 liteLlmWrites=0");
+  expect(dryRun.stdout).not.toContain(provisionerConfig.denToken);
+  expect(dryRun.stdout).not.toContain(provisionerConfig.liteLlmMasterKey);
+  evidence.recordAssertionEvidence(
+    "Dry-run computes a missing-member plan without writing to Den or LiteLLM",
+    "The CLI emitted JSON plan lines for Charlie, while the complete Den binding list and LiteLLM key identifiers stayed byte-for-byte equivalent and neither admin secret appeared in output.",
+    JSON.stringify(credentialsAfterDryRun) === JSON.stringify(credentialsBeforeDryRun)
+      && keysAfterDryRun.map(upstreamKeyId).sort().join(",") === keysBeforeDryRun.map(upstreamKeyId).sort().join(",")
+      && dryRunLines.some((line) => line.action === "member.provision" && line.orgMembershipId === charlieMemberId && line.outcome === "planned")
+      && dryRunSummary?.outcome === "planned"
+      && typeof dryRunSummary.detail === "string"
+      && dryRunSummary.detail.includes("denWrites=0 liteLlmWrites=0")
+      && !dryRun.stdout.includes(provisionerConfig.denToken)
+      && !dryRun.stdout.includes(provisionerConfig.liteLlmMasterKey),
+  );
+
+  const preexistingCharlieKey = await generateUpstreamKey(gateway.baseUrl, gateway.apiKey, {
+    alias: `openwork-${charlieMemberId}`,
+    orgMembershipId: charlieMemberId,
+    email: charlie.email,
+  });
+  const keysBeforeAdoption = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const adoption = await imported.reconcileMemberKeys(provisionerConfig);
+  const credentialsAfterAdoption = await listedMemberCredentials(den.admin, orgId, providerId);
+  const charlieBinding = credentialsAfterAdoption.find((entry) => entry.orgMembershipId === charlieMemberId);
+  const adoptedCredentialId = typeof charlieBinding?.externalCredentialId === "string"
+    ? charlieBinding.externalCredentialId
+    : "";
+  const keysAfterAdoption = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const adoptedUpstream = keysAfterAdoption.find((entry) => upstreamKeyId(entry) === adoptedCredentialId);
+  expect(adoption.failures).toBe(0);
+  expect(adoption.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: charlieMemberId, action: "adopted", outcome: "succeeded" }),
+  ]));
+  expect(charlieBinding?.state).toBe("active");
+  expect(adoptedCredentialId).not.toBe("");
+  expect(adoptedCredentialId).not.toBe(preexistingCharlieKey.tokenId);
+  expect(keysAfterAdoption).toHaveLength(keysBeforeAdoption.length);
+  expect(keysAfterAdoption.some((entry) => upstreamKeyId(entry) === preexistingCharlieKey.tokenId)).toBe(false);
+  expect(adoptedUpstream?.key_alias).toBe(`openwork-${charlieMemberId}`);
+  evidence.recordAssertionEvidence(
+    "A pre-existing LiteLLM identity is adopted without leaving a second upstream key",
+    "LiteLLM Community could not return Charlie's plaintext key, so reconciliation alias-swapped one replacement into Den, deleted the old hash, retained the stable alias, and left the total key count unchanged.",
+    charlieBinding?.state === "active"
+      && adoptedCredentialId.length > 0
+      && adoptedCredentialId !== preexistingCharlieKey.tokenId
+      && keysAfterAdoption.length === keysBeforeAdoption.length
+      && !keysAfterAdoption.some((entry) => upstreamKeyId(entry) === preexistingCharlieKey.tokenId)
+      && adoptedUpstream?.key_alias === `openwork-${charlieMemberId}`,
+  );
+
+  const credentialsBeforeIdempotence = await listedMemberCredentials(den.admin, orgId, providerId);
+  const keysBeforeIdempotence = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const adoptionIdempotence = await imported.reconcileMemberKeys(provisionerConfig);
+  const credentialsAfterIdempotence = await listedMemberCredentials(den.admin, orgId, providerId);
+  const keysAfterIdempotence = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  expect(adoptionIdempotence.failures).toBe(0);
+  expect(adoptionIdempotence.memberCredentials).toEqual([]);
+  expect(adoptionIdempotence.writes).toEqual({ den: 0, liteLlm: 0 });
+  expect(credentialsAfterIdempotence).toEqual(credentialsBeforeIdempotence);
+  expect(keysAfterIdempotence.map(upstreamKeyId).sort()).toEqual(keysBeforeIdempotence.map(upstreamKeyId).sort());
+  evidence.recordAssertionEvidence(
+    "Reconciliation is idempotent after adoption",
+    "The next pass reported zero Den writes, zero LiteLLM writes, and no member actions; both inventories remained unchanged.",
+    adoptionIdempotence.memberCredentials.length === 0
+      && adoptionIdempotence.writes.den === 0
+      && adoptionIdempotence.writes.liteLlm === 0
+      && JSON.stringify(credentialsAfterIdempotence) === JSON.stringify(credentialsBeforeIdempotence)
+      && keysAfterIdempotence.map(upstreamKeyId).sort().join(",") === keysBeforeIdempotence.map(upstreamKeyId).sort().join(","),
+  );
+
+  const dana = await inviteMember(den, "dana", {
+    email: `dana-lifecycle-${Date.now()}@openwork.test`,
+    name: "Dana Credential Member",
+    password: "OpenWorkEval123!",
+  });
+  const danaMemberId = await memberIdByEmail(den.admin, orgId, dana.email);
+  const keysBeforeDurationMint = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const durationMint = await runProvisionerCli([
+    "reconcile",
+    "--key-duration",
+    "1h",
+    "--renew-before",
+    "0",
+  ], provisionerConfig);
+  const durationLines = structuredLines(durationMint.stdout);
+  const credentialsAfterDurationMint = await listedMemberCredentials(den.admin, orgId, providerId);
+  const danaInitialBinding = credentialsAfterDurationMint.find((entry) => entry.orgMembershipId === danaMemberId);
+  const danaInitialCredentialId = typeof danaInitialBinding?.externalCredentialId === "string"
+    ? danaInitialBinding.externalCredentialId
+    : "";
+  const danaInitialVersion = typeof danaInitialBinding?.version === "number" ? danaInitialBinding.version : 0;
+  const danaInitialInfo = await upstreamKeyInfo(gateway.baseUrl, gateway.apiKey, danaInitialCredentialId);
+  const keysAfterDurationMint = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  expect(durationMint.stderr).toBe("");
+  expect(durationLines).toEqual(expect.arrayContaining([
+    expect.objectContaining({ action: "member.provision", orgMembershipId: danaMemberId, outcome: "succeeded" }),
+  ]));
+  expect(keysAfterDurationMint).toHaveLength(keysBeforeDurationMint.length + 1);
+  expect(typeof danaInitialInfo.expires).toBe("string");
+  expect(Date.parse(String(danaInitialInfo.expires))).toBeGreaterThan(Date.now());
+
+  const renewal = await imported.reconcileMemberKeys({
+    ...provisionerConfig,
+    keyDuration: "1h",
+    renewBeforeSeconds: 7_200,
+  });
+  const credentialsAfterRenewal = await listedMemberCredentials(den.admin, orgId, providerId);
+  const danaRenewedBinding = credentialsAfterRenewal.find((entry) => entry.orgMembershipId === danaMemberId);
+  const danaRenewedCredentialId = typeof danaRenewedBinding?.externalCredentialId === "string"
+    ? danaRenewedBinding.externalCredentialId
+    : "";
+  expect(renewal.failures).toBe(0);
+  expect(renewal.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: danaMemberId, action: "renewed", outcome: "succeeded" }),
+  ]));
+  expect(danaRenewedCredentialId).not.toBe(danaInitialCredentialId);
+  expect(danaRenewedBinding?.version).toBe(danaInitialVersion + 1);
+  expect((await upstreamKeys(gateway.baseUrl, gateway.apiKey)).length).toBe(keysAfterDurationMint.length);
+  evidence.recordAssertionEvidence(
+    "Expiring keys are minted with a duration and replaced inside the renewal window",
+    "Dana's first key had a future LiteLLM expiry; a 7200-second threshold re-minted it, changed the external key identifier, incremented Den's optimistic version exactly once, and did not grow the key inventory.",
+    typeof danaInitialInfo.expires === "string"
+      && Date.parse(danaInitialInfo.expires) > Date.now()
+      && danaRenewedCredentialId.length > 0
+      && danaRenewedCredentialId !== danaInitialCredentialId
+      && danaRenewedBinding?.version === danaInitialVersion + 1
+      && (await upstreamKeys(gateway.baseUrl, gateway.apiKey)).length === keysAfterDurationMint.length,
+  );
+
+  const everyMemberId = [adminMemberId, aliceMemberId, bobMemberId, charlieMemberId, danaMemberId];
+  await setProviderMemberAccess(
+    den.admin,
+    orgId,
+    providerId,
+    everyMemberId.filter((memberId) => memberId !== charlieMemberId),
+  );
+  const autoOffboard = await imported.reconcileMemberKeys(provisionerConfig);
+  expect(autoOffboard.failures).toBe(0);
+  expect(autoOffboard.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: charlieMemberId, action: "offboarded", outcome: "succeeded" }),
+  ]));
+  const charlieUpstreamAfterOffboard = await upstreamKeyInfo(gateway.baseUrl, gateway.apiKey, adoptedCredentialId);
+  expect(charlieUpstreamAfterOffboard.blocked).toBe(true);
+  await setProviderMemberAccess(den.admin, orgId, providerId, everyMemberId);
+  const charlieBlockedConnect = await connect(charlie, orgId, providerId);
+  const charlieBlockedBinding = (await listedMemberCredentials(den.admin, orgId, providerId))
+    .find((entry) => entry.orgMembershipId === charlieMemberId);
+  expect(charlieBlockedBinding?.state).toBe("blocked");
+  expect(charlieBlockedConnect.response.status).toBe(200);
+  expect(connectCredentialState(charlieBlockedConnect.body)).toBe("blocked");
+  evidence.recordAssertionEvidence(
+    "Reconciliation automatically offboards a removed provider grant in upstream-first order",
+    "After Charlie's grant disappeared, LiteLLM reported blocked=true and Den persisted blocked; re-granting access exposed HTTP 200 with null material and memberCredential.state=blocked.",
+    charlieUpstreamAfterOffboard.blocked === true
+      && charlieBlockedBinding?.state === "blocked"
+      && charlieBlockedConnect.response.status === 200
+      && connectCredentialState(charlieBlockedConnect.body) === "blocked",
+  );
+
+  const danaBeforeSyntheticFailure = await connect(dana, orgId, providerId);
+  const danaCurrentKey = connectKey(danaBeforeSyntheticFailure.body);
+  const danaBindingBeforeSyntheticFailure = (await listedMemberCredentials(den.admin, orgId, providerId))
+    .find((entry) => entry.orgMembershipId === danaMemberId);
+  const danaVersionBeforeSyntheticFailure = typeof danaBindingBeforeSyntheticFailure?.version === "number"
+    ? danaBindingBeforeSyntheticFailure.version
+    : 0;
+  const nonexistentCredentialId = `missing-upstream-${danaMemberId}`;
+  const syntheticBinding = await denFetch(
+    den.admin,
+    `/v1/llm-providers/${encodeURIComponent(providerId)}/member-credentials/${encodeURIComponent(danaMemberId)}`,
+    {
+      method: "PUT",
+      headers: orgHeaders(den.admin, orgId),
+      body: JSON.stringify({
+        apiKey: danaCurrentKey,
+        externalCredentialId: nonexistentCredentialId,
+        expectedVersion: danaVersionBeforeSyntheticFailure,
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
+  expect(syntheticBinding.response.status).toBe(200);
+  const syntheticInventoryPass = await imported.reconcileMemberKeys(provisionerConfig);
+  expect(syntheticInventoryPass.failures).toBe(0);
+  expect(syntheticInventoryPass.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: danaMemberId, action: "stale", outcome: "succeeded" }),
+  ]));
+  const danaSelfRepair = await denFetch(dana, `/v1/llm-providers/${encodeURIComponent(providerId)}/my-credential`, {
+    method: "PUT",
+    headers: orgHeaders(dana, orgId),
+    body: JSON.stringify({ apiKey: danaCurrentKey }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(danaSelfRepair.response.status).toBe(200);
+  expect(danaSelfRepair.body).toMatchObject({ state: "active" });
+
+  await setProviderMemberAccess(
+    den.admin,
+    orgId,
+    providerId,
+    everyMemberId.filter((memberId) => memberId !== danaMemberId),
+  );
+  const failedAutoOffboard = await imported.reconcileMemberKeys(provisionerConfig);
+  expect(failedAutoOffboard.failures).toBeGreaterThan(0);
+  expect(failedAutoOffboard.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: danaMemberId, action: "failed", outcome: "failed" }),
+  ]));
+  const danaActualUpstreamAfterFailure = await upstreamKeyInfo(gateway.baseUrl, gateway.apiKey, danaRenewedCredentialId);
+  expect(danaActualUpstreamAfterFailure.blocked).not.toBe(true);
+  await setProviderMemberAccess(den.admin, orgId, providerId, everyMemberId);
+  const danaBindingAfterFailure = (await listedMemberCredentials(den.admin, orgId, providerId))
+    .find((entry) => entry.orgMembershipId === danaMemberId);
+  const danaConnectAfterFailure = await connect(dana, orgId, providerId);
+  expect(danaBindingAfterFailure).toMatchObject({ state: "active", externalCredentialId: nonexistentCredentialId });
+  expect(danaConnectAfterFailure.response.status).toBe(200);
+  expect(connectCredentialState(danaConnectAfterFailure.body)).toBe("active");
+  expect(connectKey(danaConnectAfterFailure.body)).toBe(danaCurrentKey);
+  evidence.recordAssertionEvidence(
+    "An upstream auto-offboard failure leaves the Den binding active and reports a nonzero failure summary",
+    "Dana's synthetic missing LiteLLM identifier made the upstream-first block fail; the summary reported failure, the real upstream key stayed unblocked, and re-granted Den access still returned the unchanged active credential.",
+    failedAutoOffboard.failures > 0
+      && failedAutoOffboard.memberCredentials.some((action) => action.orgMembershipId === danaMemberId && action.outcome === "failed")
+      && danaActualUpstreamAfterFailure.blocked !== true
+      && danaBindingAfterFailure?.state === "active"
+      && danaBindingAfterFailure.externalCredentialId === nonexistentCredentialId
+      && danaConnectAfterFailure.response.status === 200
+      && connectCredentialState(danaConnectAfterFailure.body) === "active"
+      && connectKey(danaConnectAfterFailure.body) === danaCurrentKey,
+  );
+
+  const danaVersionAfterFailure = typeof danaBindingAfterFailure?.version === "number"
+    ? danaBindingAfterFailure.version
+    : 0;
+  const restoreDanaIdentifier = await denFetch(
+    den.admin,
+    `/v1/llm-providers/${encodeURIComponent(providerId)}/member-credentials/${encodeURIComponent(danaMemberId)}`,
+    {
+      method: "PUT",
+      headers: orgHeaders(den.admin, orgId),
+      body: JSON.stringify({
+        apiKey: danaCurrentKey,
+        externalCredentialId: danaRenewedCredentialId,
+        expectedVersion: danaVersionAfterFailure,
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
+  expect(restoreDanaIdentifier.response.status).toBe(200);
+
+  const credentialsBeforeStale = await listedMemberCredentials(den.admin, orgId, providerId);
+  const aliceBeforeStale = credentialsBeforeStale.find((entry) => entry.orgMembershipId === aliceMemberId);
+  const danaBeforeStale = credentialsBeforeStale.find((entry) => entry.orgMembershipId === danaMemberId);
+  const aliceCredentialId = typeof aliceBeforeStale?.externalCredentialId === "string"
+    ? aliceBeforeStale.externalCredentialId
+    : "";
+  const aliceVersionBeforeStale = typeof aliceBeforeStale?.version === "number" ? aliceBeforeStale.version : 0;
+  const danaVersionBeforeStale = typeof danaBeforeStale?.version === "number" ? danaBeforeStale.version : 0;
+  await deleteUpstreamKey(gateway.baseUrl, gateway.apiKey, aliceCredentialId);
+
+  const brokenKeysBeforeDryRun = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  const staleDryRun = await imported.reconcileMemberKeys({ ...provisionerConfig, dryRun: true });
+  const credentialsAfterStaleDryRun = await listedMemberCredentials(den.admin, orgId, providerId);
+  const brokenKeysAfterDryRun = await upstreamKeys(gateway.baseUrl, gateway.apiKey);
+  expect(staleDryRun.failures).toBe(0);
+  expect(staleDryRun.writes).toEqual({ den: 0, liteLlm: 0 });
+  expect(staleDryRun.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: aliceMemberId, action: "planned", outcome: "planned", detail: "mark stale" }),
+  ]));
+  expect(credentialsAfterStaleDryRun).toEqual(credentialsBeforeStale);
+  expect(brokenKeysAfterDryRun.map(upstreamKeyId).sort()).toEqual(brokenKeysBeforeDryRun.map(upstreamKeyId).sort());
+
+  const staleReconcile = await imported.reconcileMemberKeys(provisionerConfig);
+  const credentialsAfterStale = await listedMemberCredentials(den.admin, orgId, providerId);
+  const aliceAfterStale = credentialsAfterStale.find((entry) => entry.orgMembershipId === aliceMemberId);
+  const danaAfterStale = credentialsAfterStale.find((entry) => entry.orgMembershipId === danaMemberId);
+  const aliceStaleConnect = await connect(alice, orgId, providerId);
+  expect(staleReconcile.failures).toBe(0);
+  expect(staleReconcile.memberCredentials).toEqual(expect.arrayContaining([
+    expect.objectContaining({ orgMembershipId: aliceMemberId, action: "stale", outcome: "succeeded" }),
+  ]));
+  expect(aliceAfterStale).toMatchObject({ state: "stale", version: aliceVersionBeforeStale + 1 });
+  expect(aliceStaleConnect.response.status).toBe(200);
+  expect(aliceStaleConnect.body).toMatchObject({
+    llmProvider: { apiKey: null, apiKeys: null, memberCredential: { state: "stale" } },
+  });
+  expect(danaAfterStale).toMatchObject({ state: "active", version: danaVersionBeforeStale });
+
+  const staleIdempotence = await imported.reconcileMemberKeys(provisionerConfig);
+  const aliceAfterStaleIdempotence = (await listedMemberCredentials(den.admin, orgId, providerId))
+    .find((entry) => entry.orgMembershipId === aliceMemberId);
+  expect(staleIdempotence.failures).toBe(0);
+  expect(staleIdempotence.memberCredentials).toEqual([]);
+  expect(staleIdempotence.writes).toEqual({ den: 0, liteLlm: 0 });
+  expect(aliceAfterStaleIdempotence?.version).toBe(aliceVersionBeforeStale + 1);
+  evidence.recordAssertionEvidence(
+    "A missing upstream key becomes stale without automatic re-minting or collateral writes",
+    "Dry-run planned Alice's stale transition with zero Den or LiteLLM writes. The real pass incremented only Alice's binding version, connect returned null credentials with state=stale, Dana stayed active at the same version, and a later pass performed no re-mint or repeat stale write.",
+    staleDryRun.writes.den === 0
+      && staleDryRun.writes.liteLlm === 0
+      && JSON.stringify(credentialsAfterStaleDryRun) === JSON.stringify(credentialsBeforeStale)
+      && brokenKeysAfterDryRun.map(upstreamKeyId).sort().join(",") === brokenKeysBeforeDryRun.map(upstreamKeyId).sort().join(",")
+      && aliceAfterStale?.state === "stale"
+      && aliceAfterStale.version === aliceVersionBeforeStale + 1
+      && aliceStaleConnect.response.status === 200
+      && connectCredentialState(aliceStaleConnect.body) === "stale"
+      && isRecord(aliceStaleConnect.body)
+      && isRecord(aliceStaleConnect.body.llmProvider)
+      && aliceStaleConnect.body.llmProvider.apiKey === null
+      && aliceStaleConnect.body.llmProvider.apiKeys === null
+      && danaAfterStale?.state === "active"
+      && danaAfterStale.version === danaVersionBeforeStale
+      && staleIdempotence.memberCredentials.length === 0
+      && staleIdempotence.writes.den === 0
+      && staleIdempotence.writes.liteLlm === 0
+      && aliceAfterStaleIdempotence?.version === aliceVersionBeforeStale + 1,
   );
 });

--- a/evals/specs/llm-provider-probe.test.ts
+++ b/evals/specs/llm-provider-probe.test.ts
@@ -1,0 +1,271 @@
+import { createServer, type Server } from "node:http";
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { inviteMember, server, test } from "@openwork/testkit";
+
+const REQUEST_TIMEOUT_MS = 15_000;
+const MODEL_ID = "team-model";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession, orgId: string): Record<string, string> {
+  return { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId };
+}
+
+async function organizationId(admin: DenSession, name: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${admin.token}` },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = orgs.find((org) => org.name === name)?.id;
+  if (!result.response.ok || typeof id !== "string") throw new Error(`Could not find test organization: ${result.text}`);
+  return id;
+}
+
+async function membershipId(admin: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/org", {
+    headers: auth(admin, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members) ? result.body.members.filter(isRecord) : [];
+  const id = members.find((member) => isRecord(member.user) && member.user.email === email)?.id;
+  if (!result.response.ok || typeof id !== "string") throw new Error(`Could not find membership for ${email}: ${result.text}`);
+  return id;
+}
+
+interface GatewayWitness extends AsyncDisposable {
+  url: string;
+  acceptedKey: string;
+  modelIds: string[];
+  authorizations: string[];
+}
+
+async function listen(httpServer: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
+  const address = httpServer.address();
+  if (address === null || typeof address === "string") throw new Error("Gateway witness did not receive a TCP port.");
+  return address.port;
+}
+
+async function close(httpServer: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    httpServer.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function gatewayWitness(acceptedKey: string): Promise<GatewayWitness> {
+  const state: { acceptedKey: string; modelIds: string[]; authorizations: string[] } = {
+    acceptedKey,
+    modelIds: [MODEL_ID],
+    authorizations: [],
+  };
+  const httpServer = createServer((request, response) => {
+    const authorization = request.headers.authorization ?? "";
+    state.authorizations.push(authorization);
+    if (request.method !== "GET" || request.url !== "/v1/models") {
+      response.writeHead(404).end();
+      return;
+    }
+    if (authorization !== `Bearer ${state.acceptedKey}`) {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "upstream body must not escape" }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ data: state.modelIds.map((id) => ({ id })) }));
+  });
+  const port = await listen(httpServer);
+  return {
+    url: `http://127.0.0.1:${port}/v1`,
+    get acceptedKey() { return state.acceptedKey; },
+    set acceptedKey(value: string) { state.acceptedKey = value; },
+    get modelIds() { return state.modelIds; },
+    set modelIds(value: string[]) { state.modelIds = value; },
+    get authorizations() { return state.authorizations; },
+    async [Symbol.asyncDispose]() { await close(httpServer); },
+  };
+}
+
+async function closedPortUrl(): Promise<string> {
+  const httpServer = createServer();
+  const port = await listen(httpServer);
+  await close(httpServer);
+  return `http://127.0.0.1:${port}/v1`;
+}
+
+function providerConfig(api: string) {
+  return {
+    id: "probe-gateway",
+    name: "Probe gateway",
+    npm: "@ai-sdk/openai-compatible",
+    env: ["GATEWAY_API_KEY"],
+    api,
+    models: [{ id: MODEL_ID, name: "Team model" }],
+  };
+}
+
+async function writeProviderApi(admin: DenSession, orgId: string, providerId: string, api: string) {
+  const result = await denFetch(admin, `/v1/llm-providers/${providerId}`, {
+    method: "PATCH",
+    headers: auth(admin, orgId),
+    body: JSON.stringify({
+      name: "Probe gateway",
+      source: "custom",
+      customConfig: providerConfig(api),
+      credentialMode: "per_member",
+      allMembers: true,
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  expect(result.response.status, result.text).toBe(200);
+}
+
+async function request(session: DenSession, orgId: string, path: string, method = "GET", body?: object) {
+  return denFetch(session, path, {
+    method,
+    headers: auth(session, orgId),
+    ...(body ? { body: JSON.stringify(body) } : {}),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}
+
+function memberBinding(body: unknown, memberId: string): Record<string, unknown> {
+  const bindings = isRecord(body) && Array.isArray(body.memberCredentials) ? body.memberCredentials.filter(isRecord) : [];
+  const binding = bindings.find((entry) => entry.orgMembershipId === memberId);
+  if (!binding) throw new Error(`Missing member credential binding ${memberId}.`);
+  return binding;
+}
+
+test("organization provider probes classify resolved credentials and stale bindings remain repairable", { timeout: 300_000 }, async ({ evidence, place }) => {
+  const runId = `${Date.now().toString(36)}-${process.pid}`;
+  const organizationName = `Provider probe ${runId}`;
+  const originalKey = `probe-original-${runId}`;
+  const rotatedKey = `probe-rotated-${runId}`;
+  const repairedKey = `probe-repaired-${runId}`;
+  await using witness = await gatewayWitness(originalKey);
+  await using den = await server({ place, org: { name: organizationName, members: {} } });
+  const memberA = await inviteMember(den, "memberA", {
+    email: `probe-a-${runId}@example.com`,
+    name: "Probe Member A",
+    password: "OpenWorkEval123!",
+  });
+  const memberB = await inviteMember(den, "memberB", {
+    email: `probe-b-${runId}@example.com`,
+    name: "Probe Member B",
+    password: "OpenWorkEval123!",
+  });
+  const orgId = await organizationId(den.admin, organizationName);
+  const [memberAId, memberBId] = await Promise.all([
+    membershipId(den.admin, orgId, memberA.email),
+    membershipId(den.admin, orgId, memberB.email),
+  ]);
+
+  const created = await request(den.admin, orgId, "/v1/llm-providers", "POST", {
+    name: "Probe gateway",
+    source: "custom",
+    customConfig: providerConfig(witness.url),
+    credentialMode: "per_member",
+    allMembers: true,
+  });
+  expect(created.response.status, created.text).toBe(201);
+  const providerId = isRecord(created.body) && isRecord(created.body.llmProvider) ? created.body.llmProvider.id : null;
+  if (typeof providerId !== "string") throw new Error("Created provider did not return an id.");
+
+  const initialWrite = await request(
+    den.admin,
+    orgId,
+    `/v1/llm-providers/${providerId}/member-credentials/${memberAId}`,
+    "PUT",
+    { apiKey: originalKey },
+  );
+  expect(initialWrite.body).toMatchObject({ state: "active", version: 1 });
+
+  const okProbe = await request(memberA, orgId, `/v1/llm-providers/${providerId}/probe`, "POST", {});
+  expect(okProbe.response.status, okProbe.text).toBe(200);
+  expect(okProbe.body).toMatchObject({ status: "ok", models: 1 });
+  expect(isRecord(okProbe.body) && typeof okProbe.body.latencyMs === "number").toBe(true);
+  expect(witness.authorizations.at(-1)).toBe(`Bearer ${originalKey}`);
+  expect(okProbe.text).not.toContain(originalKey);
+
+  const rotated = await request(
+    den.admin,
+    orgId,
+    `/v1/llm-providers/${providerId}/member-credentials/${memberAId}`,
+    "PUT",
+    { apiKey: rotatedKey, expectedVersion: 1 },
+  );
+  expect(rotated.body).toMatchObject({ state: "active", version: 2 });
+  const unauthorized = await request(memberA, orgId, `/v1/llm-providers/${providerId}/probe`, "POST", {});
+  expect(unauthorized.body).toMatchObject({ status: "unauthorized" });
+  expect(unauthorized.text).not.toContain(rotatedKey);
+  expect(unauthorized.text).not.toContain("upstream body must not escape");
+
+  const noCredential = await request(memberB, orgId, `/v1/llm-providers/${providerId}/probe`, "POST", {});
+  expect(noCredential.response.status).toBe(200);
+  expect(noCredential.body).toEqual({ status: "no_credential" });
+  const forbidden = await request(memberB, orgId, `/v1/llm-providers/${providerId}/probe`, "POST", { orgMembershipId: memberAId });
+  expect(forbidden.response.status).toBe(403);
+
+  const afterForbidden = await request(den.admin, orgId, `/v1/llm-providers/${providerId}/member-credentials`);
+  expect(memberBinding(afterForbidden.body, memberAId)).toMatchObject({ state: "active", version: 2 });
+  expect(memberBinding(afterForbidden.body, memberBId)).toMatchObject({ state: "missing", version: null });
+
+  const closedUrl = await closedPortUrl();
+  await writeProviderApi(den.admin, orgId, providerId, closedUrl);
+  const unreachableStartedAt = Date.now();
+  const unreachable = await request(memberA, orgId, `/v1/llm-providers/${providerId}/probe`, "POST", {});
+  const unreachableElapsedMs = Date.now() - unreachableStartedAt;
+  expect(unreachable.body).toMatchObject({ status: "unreachable" });
+  expect(unreachableElapsedMs).toBeLessThan(10_000);
+
+  await writeProviderApi(den.admin, orgId, providerId, witness.url);
+  witness.acceptedKey = rotatedKey;
+  witness.modelIds = [];
+  const modelMissing = await request(memberA, orgId, `/v1/llm-providers/${providerId}/probe`, "POST", {});
+  expect(modelMissing.body).toMatchObject({ status: "model_missing", models: 0, missingModelIds: [MODEL_ID] });
+  expect(modelMissing.text).not.toContain(rotatedKey);
+
+  const stale = await request(
+    den.admin,
+    orgId,
+    `/v1/llm-providers/${providerId}/member-credentials/${memberAId}/stale`,
+    "POST",
+  );
+  expect(stale.body).toMatchObject({ state: "stale", version: 3 });
+  const staleConnect = await request(memberA, orgId, `/v1/llm-providers/${providerId}/connect`);
+  expect(staleConnect.body).toMatchObject({
+    llmProvider: { apiKey: null, apiKeys: null, memberCredential: { state: "stale" } },
+  });
+  const repaired = await request(memberA, orgId, `/v1/llm-providers/${providerId}/my-credential`, "PUT", { apiKey: repairedKey });
+  expect(repaired.body).toMatchObject({ state: "active", version: 4 });
+
+  const blocked = await request(
+    den.admin,
+    orgId,
+    `/v1/llm-providers/${providerId}/member-credentials/${memberAId}/block`,
+    "POST",
+  );
+  expect(blocked.body).toMatchObject({ state: "blocked", version: 5 });
+  const blockedWrite = await request(memberA, orgId, `/v1/llm-providers/${providerId}/my-credential`, "PUT", { apiKey: "must-not-unblock" });
+  expect(blockedWrite.response.status).toBe(409);
+  expect(blockedWrite.body).toEqual({ error: "credential_blocked" });
+
+  evidence.recordAssertionEvidence(
+    "Provider probes resolve member credentials without disclosure and stale remains distinct from blocked",
+    "The gateway observed member A's bearer key; responses disclosed no key or upstream body, all five probe classifications were exercised, stale was self-repaired, and blocked rejected self-repair.",
+    okProbe.response.status === 200
+      && witness.authorizations.includes(`Bearer ${originalKey}`)
+      && !okProbe.text.includes(originalKey)
+      && forbidden.response.status === 403
+      && unreachableElapsedMs < 10_000
+      && repaired.response.status === 200
+      && blockedWrite.response.status === 409,
+  );
+});

--- a/evals/specs/llm-provider-probe.test.ts
+++ b/evals/specs/llm-provider-probe.test.ts
@@ -2,10 +2,15 @@ import { createServer, type Server } from "node:http";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
-import { inviteMember, server, test } from "@openwork/testkit";
+import { inviteMember, localMysqlIsRunning, server, test } from "@openwork/testkit";
 
 const REQUEST_TIMEOUT_MS = 15_000;
 const MODEL_ID = "team-model";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = localPlacement && !mysqlOpen
+  ? "provider probe classification skipped — needs MySQL on 127.0.0.1:3306"
+  : "organization provider probes classify resolved credentials and stale bindings remain repairable";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -143,7 +148,7 @@ function memberBinding(body: unknown, memberId: string): Record<string, unknown>
   return binding;
 }
 
-test("organization provider probes classify resolved credentials and stale bindings remain repairable", { timeout: 300_000 }, async ({ evidence, place }) => {
+test.skipIf(localPlacement && !mysqlOpen)(title, { timeout: 300_000 }, async ({ evidence, place }) => {
   const runId = `${Date.now().toString(36)}-${process.pid}`;
   const organizationName = `Provider probe ${runId}`;
   const originalKey = `probe-original-${runId}`;

--- a/evals/specs/per-member-credential-self-serve.e2e.test.ts
+++ b/evals/specs/per-member-credential-self-serve.e2e.test.ts
@@ -1,0 +1,346 @@
+import { expect, onTestFinished } from "vitest";
+import { denFetch, evalIn, fill, go, readAvailableModels, waitFor, clickButton } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { app, eventually, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const RUN_ID = `${Date.now().toString(36)}-${process.pid}`;
+const ORGANIZATION_NAME = `Per-member self-serve ${RUN_ID}`;
+const PROVIDER_NAME = "Member Key Provider";
+const PROVIDER_KEY = "member-key-provider";
+const PROVIDER_ENV = "MEMBER_KEY_PROVIDER_API_KEY";
+const MODEL_ID = "member-key-model";
+const MEMBER_A_EMAIL = `member-a+${RUN_ID}@example.com`;
+const MEMBER_B_EMAIL = `member-b+${RUN_ID}@example.com`;
+const MEMBER_A_KEY = "sk-member-a-self-serve-eval";
+const BLOCKED_REPLACEMENT_KEY = "sk-member-a-blocked-replacement-eval";
+const REQUEST_TIMEOUT_MS = 10_000;
+const requirements: TestNeeds = { optIn: ["OPENWORK_EVAL_E2E_TESTS"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `per-member credential self-serve skipped — needs: ${missingRequirements.join(", ")}`
+  : "a member can self-serve only their own cloud provider credential from Desktop";
+
+interface MemberCredentialFacts {
+  state: string;
+  version: number | null;
+}
+
+interface ProviderSyncFacts {
+  materialized: boolean;
+  skippedReason: string | null;
+  raw: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+function orgHeaders(session: DenSession, orgId: string): Record<string, string> {
+  return { ...auth(session), "x-openwork-org-id": orgId };
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === ORGANIZATION_NAME);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function membershipId(admin: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/org", {
+    headers: orgHeaders(admin, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members)
+    ? result.body.members.filter(isRecord)
+    : [];
+  const member = members.find((entry) => isRecord(entry.user) && entry.user.email === email);
+  const id = member && typeof member.id === "string" ? member.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding membership for ${email} failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function createProvider(
+  admin: DenSession,
+  orgId: string,
+  memberIds: string[],
+): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: orgHeaders(admin, orgId),
+    body: JSON.stringify({
+      name: PROVIDER_NAME,
+      source: "custom",
+      customConfig: {
+        id: PROVIDER_KEY,
+        name: PROVIDER_NAME,
+        npm: "@ai-sdk/openai-compatible",
+        env: [PROVIDER_ENV],
+        api: "https://gateway.example.com/v1",
+        models: [{ id: MODEL_ID, name: "Member Key Model" }],
+      },
+      credentialMode: "per_member",
+      allMembers: false,
+      memberIds,
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider)
+    ? result.body.llmProvider
+    : null;
+  const id = provider && typeof provider.id === "string" ? provider.id : "";
+  if (result.response.status !== 201 || !id) {
+    throw new Error(`Creating the per-member provider failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function deleteProvider(admin: DenSession, orgId: string, providerId: string): Promise<void> {
+  await denFetch(admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+    method: "DELETE",
+    headers: orgHeaders(admin, orgId),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}
+
+async function memberCredential(
+  admin: DenSession,
+  orgId: string,
+  providerId: string,
+  orgMembershipId: string,
+): Promise<MemberCredentialFacts> {
+  const result = await denFetch(
+    admin,
+    `/v1/llm-providers/${encodeURIComponent(providerId)}/member-credentials`,
+    {
+      headers: orgHeaders(admin, orgId),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
+  const credentials = isRecord(result.body) && Array.isArray(result.body.memberCredentials)
+    ? result.body.memberCredentials.filter(isRecord)
+    : [];
+  const credential = credentials.find((entry) => entry.orgMembershipId === orgMembershipId);
+  if (!result.response.ok || !credential || typeof credential.state !== "string") {
+    throw new Error(`Reading member credential failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return {
+    state: credential.state,
+    version: typeof credential.version === "number" ? credential.version : null,
+  };
+}
+
+async function readProviderSync(
+  surface: Parameters<typeof evalIn>[0],
+  providerId: string,
+): Promise<ProviderSyncFacts> {
+  const value = await evalIn(surface, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { specError: "local server unavailable" };
+    const token = String(info.ownerToken ?? info.clientToken ?? "");
+    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + "/cloud-provider-sync/status", {
+      headers: { Authorization: "Bearer " + token },
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!response.ok) return { specError: "HTTP " + response.status + " " + (await response.text()).slice(0, 200) };
+    return await response.json();
+  })()`, { awaitPromise: true, timeoutMs: 40_000 });
+  if (!isRecord(value) || typeof value.specError === "string") {
+    throw new Error(`Reading desktop provider sync failed: ${isRecord(value) ? value.specError : "invalid response"}`);
+  }
+  const providers = Array.isArray(value.providers) ? value.providers.filter(isRecord) : [];
+  const skipped = Array.isArray(value.skippedProviders) ? value.skippedProviders.filter(isRecord) : [];
+  const skippedProvider = skipped.find((entry) => entry.cloudProviderId === providerId);
+  return {
+    materialized: providers.some((entry) => entry.cloudProviderId === providerId),
+    skippedReason: skippedProvider && typeof skippedProvider.reason === "string" ? skippedProvider.reason : null,
+    raw: value,
+  };
+}
+
+function providerRowStateExpression(status: "Needs your key" | "Connected"): string {
+  return `(() => {
+    const title = [...document.querySelectorAll("span")]
+      .find((element) => (element.textContent ?? "").trim() === ${JSON.stringify(PROVIDER_NAME)});
+    const row = title?.parentElement?.parentElement?.parentElement;
+    return Boolean(row
+      && (row.textContent ?? "").includes(${JSON.stringify(status)})
+      && ${status === "Needs your key"
+        ? `row.querySelector(${JSON.stringify(`input[aria-label="API key for ${PROVIDER_NAME}"]`)})`
+        : `!row.querySelector(${JSON.stringify(`input[aria-label="API key for ${PROVIDER_NAME}"]`)})`});
+  })()`;
+}
+
+test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+  await using den = await server({
+    place,
+    org: {
+      name: ORGANIZATION_NAME,
+      admin: { name: "Credential Admin", email: `admin+${RUN_ID}@example.com` },
+      members: {
+        a: { name: "Member A", email: MEMBER_A_EMAIL },
+        b: { name: "Member B", email: MEMBER_B_EMAIL },
+      },
+    },
+  });
+  const memberA = den.members.a;
+  const memberB = den.members.b;
+  if (!memberA || !memberB) throw new Error("The test organization did not provision both members.");
+
+  const orgId = await organizationId(den.admin);
+  const [memberAId, memberBId] = await Promise.all([
+    membershipId(den.admin, orgId, MEMBER_A_EMAIL),
+    membershipId(den.admin, orgId, MEMBER_B_EMAIL),
+  ]);
+  const providerId = await createProvider(den.admin, orgId, [memberAId, memberBId]);
+  onTestFinished(async () => {
+    await deleteProvider(den.admin, orgId, providerId).catch(() => undefined);
+  });
+
+  await using desktop = await app({ den, as: "a", place });
+  const initialSync = await eventually(
+    () => readProviderSync(desktop, providerId),
+    {
+      within: 120_000,
+      intervalMs: 2_000,
+      label: "member provider skipped for needs_key",
+      until: (facts) => facts.skippedReason === "needs_key" && !facts.materialized,
+    },
+  );
+  const settingsRoute = `/workspace/${desktop.workspaceId}/settings/cloud-providers`;
+  await go(desktop, settingsRoute);
+  await waitFor(desktop, providerRowStateExpression("Needs your key"), {
+    timeoutMs: 60_000,
+    label: "per-member provider needs-key row",
+  });
+  expect(initialSync.skippedReason).toBe("needs_key");
+  evidence.recordAssertionEvidence(
+    "A granted per-member provider without a binding asks this member for their key",
+    `Desktop sync skipped only provider ${providerId} with reason needs_key, and Settings rendered its masked key form.`,
+    initialSync.skippedReason === "needs_key" && !initialSync.materialized,
+  );
+
+  const keyInput = `input[aria-label="API key for ${PROVIDER_NAME}"]`;
+  await fill(desktop, keyInput, MEMBER_A_KEY);
+  await clickButton(desktop, "Save key");
+
+  const [activeA, materialized] = await Promise.all([
+    eventually(
+      () => memberCredential(den.admin, orgId, providerId, memberAId),
+      { within: 60_000, intervalMs: 1_000, label: "member A credential active", until: (facts) => facts.state === "active" },
+    ),
+    eventually(
+      () => readProviderSync(desktop, providerId),
+      {
+        within: 120_000,
+        intervalMs: 2_000,
+        label: "member provider materialized after self-serve key",
+        until: (facts) => facts.materialized && facts.skippedReason === null,
+      },
+    ),
+  ]);
+  const stillMissingB = await memberCredential(den.admin, orgId, providerId, memberBId);
+  await waitFor(desktop, providerRowStateExpression("Connected"), {
+    timeoutMs: 60_000,
+    label: "per-member provider connected row",
+  });
+  expect(activeA.state).toBe("active");
+  expect(materialized.materialized).toBe(true);
+  expect(stillMissingB).toEqual({ state: "missing", version: null });
+  evidence.recordAssertionEvidence(
+    "Saving a member key activates and materializes the provider for that desktop",
+    `Member A reached credential state active/version ${activeA.version}; sync status listed ${providerId}, and Settings showed Connected.`,
+    activeA.state === "active" && materialized.materialized && materialized.skippedReason === null,
+  );
+  evidence.recordAssertionEvidence(
+    "Member A's self-serve key does not activate Member B",
+    "The admin credential-state API still reported Member B as missing with no version.",
+    stillMissingB.state === "missing" && stillMissingB.version === null,
+  );
+
+  await go(desktop, `/workspace/${desktop.workspaceId}/session`);
+  const models = await readAvailableModels(desktop);
+  const modelMaterialized = models.some((model) => model.id === MODEL_ID && model.selectable);
+  expect(modelMaterialized).toBe(true);
+  evidence.recordAssertionEvidence(
+    "The materialized provider contributes its model to the running engine",
+    `The model picker exposed selectable model ${MODEL_ID}.`,
+    modelMaterialized,
+  );
+  await evalIn(desktop, `(() => {
+    const close = document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]');
+    if (close instanceof HTMLElement) close.click();
+    return true;
+  })()`);
+  await go(desktop, settingsRoute);
+  await waitFor(desktop, providerRowStateExpression("Connected"), {
+    timeoutMs: 60_000,
+    label: "connected provider before admin block",
+  });
+
+  const block = await denFetch(
+    den.admin,
+    `/v1/llm-providers/${encodeURIComponent(providerId)}/member-credentials/${encodeURIComponent(memberAId)}/block`,
+    {
+      method: "POST",
+      headers: orgHeaders(den.admin, orgId),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
+  expect(block.response.status).toBe(200);
+  const blockedPayload = isRecord(block.body) ? block.body : {};
+  const blockedVersion = typeof blockedPayload.version === "number" ? blockedPayload.version : null;
+  expect(blockedPayload.state).toBe("blocked");
+  expect(blockedVersion).not.toBeNull();
+
+  await clickButton(desktop, "Sync now");
+  await eventually(
+    () => readProviderSync(desktop, providerId),
+    {
+      within: 120_000,
+      intervalMs: 2_000,
+      label: "blocked member provider returns to needs_key",
+      until: (facts) => facts.skippedReason === "needs_key" && !facts.materialized,
+    },
+  );
+  await waitFor(desktop, providerRowStateExpression("Needs your key"), {
+    timeoutMs: 60_000,
+    label: "blocked provider key form",
+  });
+  await fill(desktop, keyInput, BLOCKED_REPLACEMENT_KEY);
+  await clickButton(desktop, "Save key");
+  await waitFor(desktop, `(() => {
+    const alert = document.querySelector('[role="alert"]');
+    const input = document.querySelector(${JSON.stringify(keyInput)});
+    return Boolean(alert?.textContent?.includes("An admin manages this credential")
+      && input instanceof HTMLInputElement
+      && input.value === ""
+      && !document.body.innerText.includes(${JSON.stringify(BLOCKED_REPLACEMENT_KEY)}));
+  })()`, { timeoutMs: 30_000, label: "admin-managed blocked credential error" });
+
+  const stillBlockedA = await memberCredential(den.admin, orgId, providerId, memberAId);
+  expect(stillBlockedA).toEqual({ state: "blocked", version: blockedVersion });
+  evidence.recordAssertionEvidence(
+    "An admin block stays authoritative when the member tries another key",
+    `Settings showed the inline admin-managed error, cleared the masked input, and Den kept state blocked/version ${blockedVersion}.`,
+    stillBlockedA.state === "blocked" && stillBlockedA.version === blockedVersion,
+  );
+});

--- a/examples/litellm-per-member-keys/Dockerfile
+++ b/examples/litellm-per-member-keys/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:24-alpine
+
+WORKDIR /app
+COPY provision.mjs ./provision.mjs
+
+USER node
+ENTRYPOINT ["node", "provision.mjs"]
+CMD ["reconcile", "--watch"]

--- a/examples/litellm-per-member-keys/README.md
+++ b/examples/litellm-per-member-keys/README.md
@@ -1,47 +1,91 @@
 # LiteLLM per-member keys
 
-This zero-dependency Node.js example reconciles OpenWork Cloud per-member LLM credential bindings with LiteLLM virtual keys. It is an example provisioner, not a native LiteLLM integration in Den.
+This dependency-free Node.js example owns the lifecycle of OpenWork Cloud per-member LLM credential bindings backed by LiteLLM virtual keys. It is an example provisioner, not a native LiteLLM integration in Den.
 
 ## Configure
 
-Set these environment variables:
+| Environment variable | Required | Purpose |
+| --- | --- | --- |
+| `OPENWORK_DEN_API_URL` | Yes | Den API base URL |
+| `OPENWORK_DEN_TOKEN` | Yes | Organization owner or admin bearer token |
+| `OPENWORK_ORG_ID` | Yes | Organization ID sent as `x-openwork-org-id` |
+| `OPENWORK_LLM_PROVIDER_ID` | Yes | Custom `per_member` provider record ID |
+| `LITELLM_BASE_URL` | Yes | LiteLLM base URL, with or without `/v1` |
+| `LITELLM_MASTER_KEY` | Yes | LiteLLM proxy admin key |
+| `LITELLM_MODELS` | Yes | Comma-separated model groups assigned to each key |
+| `OPENWORK_KEY_DURATION` | No | LiteLLM duration such as `30d` for newly minted keys |
+| `OPENWORK_RENEW_BEFORE_SECONDS` | No | Renewal window; default `0` only renews expired keys |
+| `OPENWORK_DRY_RUN` | No | Set to `1` or `true` to prohibit writes |
+| `OPENWORK_WATCH_SECONDS` | No | Daemon interval used by bare `--watch`; default `300` |
 
-- `OPENWORK_DEN_API_URL`: Den API base URL
-- `OPENWORK_DEN_TOKEN`: organization owner or admin bearer token
-- `OPENWORK_ORG_ID`: organization ID sent as `x-openwork-org-id`
-- `OPENWORK_LLM_PROVIDER_ID`: the per-member LLM provider ID
-- `LITELLM_BASE_URL`: LiteLLM base URL, with or without `/v1`
-- `LITELLM_MASTER_KEY`: LiteLLM master key
-- `LITELLM_MODELS`: comma-separated model IDs assigned to each virtual key
+## Run
 
-Run reconciliation after granting provider access:
-
-```bash
-node provision.mjs reconcile
-```
-
-Before provisioning keys, the script reads the existing custom, `per_member` provider from Den and reconciles its configured model metadata from LiteLLM `GET /model_group/info` using master-key authentication. It preserves the provider config, model names and unknown model fields, and current member/team access while updating token limits. When LiteLLM supplies the corresponding facts, it also maps function calling, reasoning, vision, response schemas, and temperature support to Den's `tool_call`, `reasoning`, `attachment`, `structured_output`, and `temperature` model fields. It only PATCHes Den when those values changed.
-
-Every model in `LITELLM_MODELS` must have an exact `model_group` match with finite, positive `max_input_tokens` and `max_output_tokens`. Reconciliation fails closed before creating member keys if LiteLLM omits a requested model or either limit. The example never guesses token limits or falls back to a generic value.
-
-After metadata is synchronized, the script lists Den member credential states, mints a LiteLLM virtual key for each `missing` member, and writes the key to Den with LiteLLM's `token_id` as `externalCredentialId`. Summaries report the metadata action and safe model limits but never contain member keys.
-
-## Run the complete local world
-
-From the repository root, launch a signed-in Desktop, an isolated Den organization, and a database-backed LiteLLM gateway with the provider and member keys already reconciled:
+One reconciliation adopts or provisions missing bindings, renews keys inside the expiry window, and offboards members whose provider grant disappeared:
 
 ```bash
-pnpm world up ./worlds/litellm-per-member.ts
+node provision.mjs reconcile --key-duration 30d --renew-before 86400
 ```
 
-The command prints the Den URLs, LiteLLM URL, synchronized model limits, Den provider record ID, and Desktop CDP URL. Keep it running while testing and press Ctrl-C to tear down the world. Docker, local MySQL, and local Redis are required. The gateway uses a deterministic local OpenAI-compatible witness and does not read or require `OPENAI_API_KEY`.
+Preview the complete computation without writing to Den or LiteLLM:
 
-Offboard a member by organization membership ID:
+```bash
+node provision.mjs reconcile --dry-run
+```
+
+Run continuously. Reconciliations are single-flight, intervals have jitter, and `SIGINT`/`SIGTERM` stop cleanly:
+
+```bash
+node provision.mjs reconcile --watch
+node provision.mjs reconcile --watch 60
+```
+
+Explicitly offboard one membership when it is still in Den's granted-member list:
 
 ```bash
 node provision.mjs offboard member_...
 ```
 
-**Ordering rule:** block the upstream LiteLLM key first, then mark the Den binding blocked. LiteLLM v1.97 accepts its generated `token_id` in `POST /key/block`, so offboarding does not need the plaintext member key.
+Every action is one JSON line with `ts`, `action`, `outcome`, and optional safe detail. Credential material is redacted and is never included in summaries.
+
+## Reconciliation behavior
+
+The provisioner first verifies the exact Den provider and synchronizes configured model limits and capability facts from LiteLLM `GET /model_group/info`. Missing metadata fails closed before any key lifecycle write.
+
+For a missing binding it searches paginated LiteLLM `GET /key/list` results for the stable alias `openwork-<orgMembershipId>` or matching member email metadata. LiteLLM v1.97 Community returns only a key hash and gates `/key/regenerate` behind Enterprise, so plaintext material cannot be adopted directly. The honest Community variant is a mint-and-alias-swap: move the old alias aside, mint replacement material under the stable alias, PUT that material and its new `token_id` into Den, then delete the old key. The final upstream key count does not increase. A failed Den PUT compensates by deleting the replacement and restoring the old alias.
+
+`--key-duration` is sent as LiteLLM's `duration`. Active binding expiry is read through `GET /key/info`; a key whose expiry is within `--renew-before` is replaced and written with Den's current `expectedVersion`.
+
+Automatic offboarding discovers removed grants from the previous lifecycle pass and from provisioner-owned LiteLLM key metadata. It calls LiteLLM `POST /key/block` first and Den's block route second. If any upstream block fails, Den remains active and the reconciliation summary reports a failure.
+
+Every non-missing, non-blocked binding is also checked through LiteLLM `GET /key/info`. If its external key identifier no longer resolves, the provisioner calls Den's stale route; dry-run reports the same action without writing. Stale bindings are deliberately **not** re-minted automatically. They stay stale until the member supplies replacement material through `PUT my-credential`, which keeps unexpected upstream deletion visible and leaves recovery under member control. Later passes verify them but do not increment the stale version again.
+
+## Enterprise security data flow
+
+```text
+Member -> Den connect route -> member-specific provider configuration + write-only key
+Admin/provisioner -> Den admin routes -> member IDs, state, version, external IDs (no key material)
+Admin/provisioner -> LiteLLM admin routes -> key metadata, expiry, block/generate operations
+LiteLLM -> provisioner -> Den PUT -> newly minted plaintext key (transient in process memory)
+Den -> member -> LiteLLM gateway -> configured upstream model
+```
+
+The Den admin token and LiteLLM master key stay only in the provisioner. Den stores member key material write-only and returns only safe external identifiers to admin list calls. LiteLLM receives the membership ID and, when available, the member email as key metadata for deterministic reconciliation. Offboarding never reports a local block before the upstream key is blocked.
+
+## Local proof world
+
+From the repository root, launch the isolated Den and database-backed LiteLLM proof world:
+
+```bash
+pnpm world up ./worlds/litellm-per-member.ts
+```
+
+Docker, local MySQL, and local Redis are required. The gateway uses a deterministic local OpenAI-compatible witness and does not require a model-provider API key.
+
+Build and run the minimal daemon image with the environment variables above:
+
+```bash
+docker build -t litellm-member-reconciler examples/litellm-per-member-keys
+docker run --rm --env-file provisioner.env litellm-member-reconciler
+```
 
 See [Per-member LLM credentials](../../packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx) for the API contract. The executable proof is [`litellm-per-member-credentials.e2e.test.ts`](../../evals/specs/litellm-per-member-credentials.e2e.test.ts).

--- a/examples/litellm-per-member-keys/provision.mjs
+++ b/examples/litellm-per-member-keys/provision.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
 
 /**
  * @typedef {object} ProvisionerConfig
@@ -11,13 +12,18 @@ import { pathToFileURL } from "node:url";
  * @property {string} liteLlmBaseUrl
  * @property {string} liteLlmMasterKey
  * @property {string[]} models
+ * @property {boolean} [dryRun]
+ * @property {string} [keyDuration]
+ * @property {number} [renewBeforeSeconds]
  */
 
 /**
  * @typedef {object} MemberCredentialSummary
  * @property {string} orgMembershipId
- * @property {"provisioned"} action
- * @property {string} externalCredentialId
+ * @property {"provisioned" | "adopted" | "renewed" | "offboarded" | "stale" | "failed" | "planned"} action
+ * @property {"succeeded" | "failed" | "planned"} outcome
+ * @property {string} [externalCredentialId]
+ * @property {string} [detail]
  */
 
 /**
@@ -29,7 +35,7 @@ import { pathToFileURL } from "node:url";
 
 /**
  * @typedef {object} ModelMetadataResult
- * @property {"unchanged" | "updated"} action
+ * @property {"unchanged" | "updated" | "planned"} action
  * @property {ModelMetadataSummary[]} models
  */
 
@@ -37,7 +43,21 @@ import { pathToFileURL } from "node:url";
  * @typedef {object} ReconcileResult
  * @property {ModelMetadataResult} modelMetadata
  * @property {MemberCredentialSummary[]} memberCredentials
+ * @property {number} failures
+ * @property {number} planned
+ * @property {{den: number, liteLlm: number}} writes
  */
+
+/**
+ * @typedef {object} LiteLlmKey
+ * @property {string} id
+ * @property {string | null} alias
+ * @property {Record<string, unknown>} metadata
+ * @property {boolean} blocked
+ */
+
+/** @type {Map<string, Map<string, {externalCredentialId: string, state: string}>>} */
+const knownBindingsByProvider = new Map();
 
 /**
  * @typedef {object} CurrentProviderModel
@@ -106,6 +126,27 @@ function redact(text, secrets) {
 }
 
 /**
+ * @param {string} action
+ * @param {"succeeded" | "failed" | "planned" | "skipped" | "started" | "stopped"} outcome
+ * @param {string | undefined} [orgMembershipId]
+ * @param {string | undefined} [detail]
+ */
+function logAction(action, outcome, orgMembershipId, detail) {
+  console.log(JSON.stringify({
+    ts: new Date().toISOString(),
+    action,
+    ...(orgMembershipId ? { orgMembershipId } : {}),
+    outcome,
+    ...(detail ? { detail } : {}),
+  }));
+}
+
+/** @param {unknown} error @param {string[]} secrets */
+function safeError(error, secrets) {
+  return redact(error instanceof Error ? error.message : String(error), secrets).slice(0, 1_000);
+}
+
+/**
  * @param {unknown} body
  * @param {string} text
  */
@@ -116,6 +157,14 @@ function responseErrorText(body, text) {
     if (isRecord(body.error) && typeof body.error.message === "string") return body.error.message;
   }
   return text || "empty response";
+}
+
+class HttpResponseError extends Error {
+  /** @param {string} message @param {number} status */
+  constructor(message, status) {
+    super(message);
+    this.status = status;
+  }
 }
 
 /**
@@ -137,7 +186,10 @@ async function requestJson(url, init, secrets) {
   if (!response.ok) {
     const method = init.method ?? "GET";
     const pathname = new URL(url).pathname;
-    throw new Error(redact(`${method} ${pathname} failed with HTTP ${response.status}: ${responseErrorText(body, text).slice(0, 1_000)}`, secrets));
+    throw new HttpResponseError(
+      redact(`${method} ${pathname} failed with HTTP ${response.status}: ${responseErrorText(body, text).slice(0, 1_000)}`, secrets),
+      response.status,
+    );
   }
   return body;
 }
@@ -362,7 +414,12 @@ export async function syncProviderModelMetadata(input) {
     maxOutputTokens: entry.maxOutputTokens,
   }));
   if (JSON.stringify(canonicalJson(current)) === JSON.stringify(canonicalJson(desired))) {
+    logAction("model_metadata.sync", "skipped", undefined, "already synchronized");
     return { action: "unchanged", models: summaries };
+  }
+  if (input.dryRun) {
+    logAction("model_metadata.sync", "planned", undefined, "Den provider metadata update");
+    return { action: "planned", models: summaries };
   }
   await requestJson(
     `${denApiUrl}/v1/llm-providers/${providerId}`,
@@ -373,6 +430,7 @@ export async function syncProviderModelMetadata(input) {
     },
     secrets,
   );
+  logAction("model_metadata.sync", "succeeded", undefined, "Den provider metadata updated");
   return { action: "updated", models: summaries };
 }
 
@@ -404,7 +462,317 @@ function externalCredentialId(value) {
 }
 
 /**
- * Mint a LiteLLM virtual key for every granted Den member whose binding is missing.
+ * @param {ProvisionerConfig} input
+ */
+function liteLlmHeaders(input) {
+  return {
+    authorization: `Bearer ${input.liteLlmMasterKey}`,
+    "content-type": "application/json",
+  };
+}
+
+/** @param {unknown} value */
+function parsedMetadata(value) {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** @param {unknown} value @returns {LiteLlmKey} */
+function liteLlmKey(value) {
+  if (!isRecord(value) || typeof value.token !== "string" || !value.token) {
+    throw new Error("LiteLLM /key/list returned a key without a safe token identifier.");
+  }
+  return {
+    id: value.token,
+    alias: typeof value.key_alias === "string" && value.key_alias ? value.key_alias : null,
+    metadata: parsedMetadata(value.metadata),
+    blocked: value.blocked === true,
+  };
+}
+
+/** @param {ProvisionerConfig} input */
+async function listLiteLlmKeys(input) {
+  const baseUrl = liteLlmAdminBaseUrl(input.liteLlmBaseUrl);
+  const secrets = [input.denToken, input.liteLlmMasterKey];
+  /** @type {LiteLlmKey[]} */
+  const keys = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const value = await requestJson(
+      `${baseUrl}/key/list?return_full_object=true&size=100&page=${page}`,
+      { headers: liteLlmHeaders(input) },
+      secrets,
+    );
+    if (!isRecord(value) || !Array.isArray(value.keys)) {
+      throw new Error("LiteLLM /key/list response had an invalid shape.");
+    }
+    keys.push(...value.keys.map(liteLlmKey));
+    totalPages = typeof value.total_pages === "number" && Number.isInteger(value.total_pages)
+      ? Math.max(1, value.total_pages)
+      : 1;
+    page += 1;
+  } while (page <= totalPages);
+  return keys;
+}
+
+/** @param {ProvisionerConfig} input */
+async function listOrgMemberEmails(input) {
+  const denApiUrl = cleanBaseUrl(input.denApiUrl);
+  const secrets = [input.denToken, input.liteLlmMasterKey];
+  const value = await requestJson(
+    `${denApiUrl}/v1/org`,
+    { headers: denHeaders(input) },
+    secrets,
+  );
+  if (!isRecord(value) || !Array.isArray(value.members)) {
+    throw new Error("Den organization response had an invalid member list.");
+  }
+  return new Map(value.members.flatMap((member) => {
+    if (!isRecord(member)
+      || typeof member.id !== "string"
+      || !isRecord(member.user)
+      || typeof member.user.email !== "string") return [];
+    return [[member.id, member.user.email.toLowerCase()]];
+  }));
+}
+
+/** @param {LiteLlmKey} key */
+function managedOrgMembershipId(key) {
+  const metadataId = key.metadata.openwork_org_membership_id;
+  if (typeof metadataId === "string" && metadataId) return metadataId;
+  if (key.alias?.startsWith("openwork-") && !key.alias.includes("-replaced-")) {
+    return key.alias.slice("openwork-".length);
+  }
+  return null;
+}
+
+/** @param {LiteLlmKey} key */
+function keyMetadataEmail(key) {
+  for (const field of ["email", "user_email", "openwork_member_email"]) {
+    const value = key.metadata[field];
+    if (typeof value === "string" && value) return value.toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * @param {LiteLlmKey[]} keys
+ * @param {string} orgMembershipId
+ * @param {string | undefined} email
+ */
+function adoptionCandidate(keys, orgMembershipId, email) {
+  const alias = `openwork-${orgMembershipId}`;
+  const aliasMatches = keys.filter((key) => !key.blocked && key.alias === alias);
+  if (aliasMatches.length > 1) throw new Error(`LiteLLM returned multiple active keys for alias ${alias}.`);
+  if (aliasMatches[0]) return aliasMatches[0];
+  if (!email) return null;
+  const emailMatches = keys.filter((key) => {
+    const metadataId = managedOrgMembershipId(key);
+    return !key.blocked && keyMetadataEmail(key) === email && (!metadataId || metadataId === orgMembershipId);
+  });
+  if (emailMatches.length > 1) throw new Error(`LiteLLM returned multiple active keys for the member email metadata.`);
+  return emailMatches[0] ?? null;
+}
+
+/** @param {ProvisionerConfig} input @param {string} credentialId */
+async function keyInfo(input, credentialId) {
+  const value = await requestJson(
+    `${liteLlmAdminBaseUrl(input.liteLlmBaseUrl)}/key/info?key=${encodeURIComponent(credentialId)}`,
+    { headers: liteLlmHeaders(input) },
+    [input.denToken, input.liteLlmMasterKey],
+  );
+  if (!isRecord(value) || !isRecord(value.info)) {
+    throw new Error("LiteLLM /key/info response had an invalid shape.");
+  }
+  return value.info;
+}
+
+/** @param {unknown} error */
+function isUnresolvableKey(error) {
+  return error instanceof HttpResponseError && (error.status === 400 || error.status === 404);
+}
+
+/**
+ * @param {ProvisionerConfig} input
+ * @param {string} orgMembershipId
+ * @param {string | undefined} email
+ * @param {{den: number, liteLlm: number}} writes
+ */
+async function mintLiteLlmKey(input, orgMembershipId, email, writes) {
+  const models = configuredModels(input);
+  const value = await requestJson(
+    `${liteLlmAdminBaseUrl(input.liteLlmBaseUrl)}/key/generate`,
+    {
+      method: "POST",
+      headers: liteLlmHeaders(input),
+      body: JSON.stringify({
+        models,
+        key_alias: `openwork-${orgMembershipId}`,
+        metadata: {
+          openwork_org_membership_id: orgMembershipId,
+          ...(email ? { email } : {}),
+        },
+        ...(input.keyDuration ? { duration: requireString(input.keyDuration, "keyDuration") } : {}),
+      }),
+    },
+    [input.denToken, input.liteLlmMasterKey],
+  );
+  writes.liteLlm += 1;
+  return {
+    apiKey: generatedKey(value),
+    credentialId: externalCredentialId(value),
+    userId: isRecord(value) && typeof value.user_id === "string" && value.user_id ? value.user_id : null,
+  };
+}
+
+/**
+ * @param {ProvisionerConfig} input
+ * @param {string} orgMembershipId
+ * @param {{apiKey: string, credentialId: string, userId: string | null}} minted
+ * @param {number | null} expectedVersion
+ * @param {{den: number, liteLlm: number}} writes
+ */
+async function putDenBinding(input, orgMembershipId, minted, expectedVersion, writes) {
+  const providerId = encodeURIComponent(requireString(input.providerId, "providerId"));
+  await requestJson(
+    `${cleanBaseUrl(input.denApiUrl)}/v1/llm-providers/${providerId}/member-credentials/${encodeURIComponent(orgMembershipId)}`,
+    {
+      method: "PUT",
+      headers: denHeaders(input),
+      body: JSON.stringify({
+        apiKey: minted.apiKey,
+        externalCredentialId: minted.credentialId,
+        ...(minted.userId ? { externalPrincipalId: minted.userId } : {}),
+        ...(expectedVersion === null ? {} : { expectedVersion }),
+      }),
+    },
+    [input.denToken, input.liteLlmMasterKey, minted.apiKey],
+  );
+  writes.den += 1;
+}
+
+/** @param {ProvisionerConfig} input @param {string} credentialId @param {string} alias @param {{den: number, liteLlm: number}} writes */
+async function updateLiteLlmAlias(input, credentialId, alias, writes) {
+  await requestJson(
+    `${liteLlmAdminBaseUrl(input.liteLlmBaseUrl)}/key/update`,
+    {
+      method: "POST",
+      headers: liteLlmHeaders(input),
+      body: JSON.stringify({ key: credentialId, key_alias: alias }),
+    },
+    [input.denToken, input.liteLlmMasterKey],
+  );
+  writes.liteLlm += 1;
+}
+
+/** @param {ProvisionerConfig} input @param {string} credentialId @param {{den: number, liteLlm: number}} writes */
+async function deleteLiteLlmKey(input, credentialId, writes) {
+  await requestJson(
+    `${liteLlmAdminBaseUrl(input.liteLlmBaseUrl)}/key/delete`,
+    {
+      method: "POST",
+      headers: liteLlmHeaders(input),
+      body: JSON.stringify({ keys: [credentialId] }),
+    },
+    [input.denToken, input.liteLlmMasterKey],
+  );
+  writes.liteLlm += 1;
+}
+
+/**
+ * LiteLLM v1.97 Community does not expose plaintext virtual keys and gates
+ * /key/regenerate behind Enterprise. Preserve the stable alias by moving the
+ * old key aside, minting replacement material, switching Den, then deleting
+ * the old key. The final upstream key count is unchanged.
+ *
+ * @param {ProvisionerConfig} input
+ * @param {string} orgMembershipId
+ * @param {string | undefined} email
+ * @param {string} oldCredentialId
+ * @param {number | null} expectedVersion
+ * @param {{den: number, liteLlm: number}} writes
+ */
+async function replaceLiteLlmKey(input, orgMembershipId, email, oldCredentialId, expectedVersion, writes) {
+  const stableAlias = `openwork-${orgMembershipId}`;
+  const replacementAlias = `${stableAlias}-replaced-${randomUUID()}`;
+  await updateLiteLlmAlias(input, oldCredentialId, replacementAlias, writes);
+  let minted;
+  try {
+    minted = await mintLiteLlmKey(input, orgMembershipId, email, writes);
+  } catch (error) {
+    await updateLiteLlmAlias(input, oldCredentialId, stableAlias, writes).catch(() => undefined);
+    throw error;
+  }
+  try {
+    await putDenBinding(input, orgMembershipId, minted, expectedVersion, writes);
+  } catch (error) {
+    await deleteLiteLlmKey(input, minted.credentialId, writes).catch(() => undefined);
+    await updateLiteLlmAlias(input, oldCredentialId, stableAlias, writes).catch(() => undefined);
+    throw error;
+  }
+  await deleteLiteLlmKey(input, oldCredentialId, writes);
+  return minted;
+}
+
+/**
+ * @param {ProvisionerConfig} input
+ * @param {string} orgMembershipId
+ * @param {string | undefined} email
+ * @param {{den: number, liteLlm: number}} writes
+ */
+async function provisionLiteLlmKey(input, orgMembershipId, email, writes) {
+  const minted = await mintLiteLlmKey(input, orgMembershipId, email, writes);
+  try {
+    await putDenBinding(input, orgMembershipId, minted, null, writes);
+  } catch (error) {
+    await deleteLiteLlmKey(input, minted.credentialId, writes).catch(() => undefined);
+    throw error;
+  }
+  return minted;
+}
+
+/** @param {ProvisionerConfig} input */
+function providerScope(input) {
+  return `${cleanBaseUrl(input.denApiUrl)}|${input.orgId}|${input.providerId}`;
+}
+
+/**
+ * @param {ProvisionerConfig} input
+ * @param {string} orgMembershipId
+ * @param {string[]} credentialIds
+ * @param {{den: number, liteLlm: number}} writes
+ */
+async function blockMemberBinding(input, orgMembershipId, credentialIds, writes) {
+  for (const credentialId of [...new Set(credentialIds)]) {
+    await requestJson(
+      `${liteLlmAdminBaseUrl(input.liteLlmBaseUrl)}/key/block`,
+      {
+        method: "POST",
+        headers: liteLlmHeaders(input),
+        body: JSON.stringify({ key: credentialId }),
+      },
+      [input.denToken, input.liteLlmMasterKey],
+    );
+    writes.liteLlm += 1;
+  }
+  await requestJson(
+    `${cleanBaseUrl(input.denApiUrl)}/v1/llm-providers/${encodeURIComponent(input.providerId)}/member-credentials/${encodeURIComponent(orgMembershipId)}/block`,
+    { method: "POST", headers: denHeaders(input), body: JSON.stringify({}) },
+    [input.denToken, input.liteLlmMasterKey],
+  );
+  writes.den += 1;
+}
+
+/**
+ * Reconcile model metadata, missing bindings, stale upstream references,
+ * expiring keys, and members whose provider grant was removed.
  *
  * @param {ProvisionerConfig} input
  * @returns {Promise<ReconcileResult>}
@@ -412,104 +780,209 @@ function externalCredentialId(value) {
 export async function reconcileMemberKeys(input) {
   const modelMetadata = await syncProviderModelMetadata(input);
   const denApiUrl = cleanBaseUrl(input.denApiUrl);
-  const liteLlmBaseUrl = liteLlmAdminBaseUrl(input.liteLlmBaseUrl);
   const providerId = encodeURIComponent(requireString(input.providerId, "providerId"));
-  const models = configuredModels(input);
   const secrets = [input.denToken, input.liteLlmMasterKey];
-  const listed = await requestJson(
-    `${denApiUrl}/v1/llm-providers/${providerId}/member-credentials`,
-    { headers: denHeaders(input) },
-    secrets,
-  );
+  const renewBeforeSeconds = input.renewBeforeSeconds ?? 0;
+  if (!Number.isFinite(renewBeforeSeconds) || renewBeforeSeconds < 0) {
+    throw new Error("renewBeforeSeconds must be a finite non-negative number.");
+  }
+  const [listed, emailsByMemberId, upstreamKeys] = await Promise.all([
+    requestJson(
+      `${denApiUrl}/v1/llm-providers/${providerId}/member-credentials`,
+      { headers: denHeaders(input) },
+      secrets,
+    ),
+    listOrgMemberEmails(input),
+    listLiteLlmKeys(input),
+  ]);
+  const entries = memberCredentials(listed).filter((entry) => typeof entry.orgMembershipId === "string");
+  const grantedMemberIds = new Set(entries.map((entry) => entry.orgMembershipId));
+  const scope = providerScope(input);
+  const knownBindings = new Map(knownBindingsByProvider.get(scope) ?? []);
+  for (const entry of entries) {
+    if (typeof entry.orgMembershipId === "string" && typeof entry.externalCredentialId === "string" && entry.externalCredentialId) {
+      knownBindings.set(entry.orgMembershipId, {
+        externalCredentialId: entry.externalCredentialId,
+        state: typeof entry.state === "string" ? entry.state : "unknown",
+      });
+    }
+  }
+  knownBindingsByProvider.set(scope, knownBindings);
+
   /** @type {MemberCredentialSummary[]} */
   const summary = [];
+  const writes = { den: modelMetadata.action === "updated" ? 1 : 0, liteLlm: 0 };
+  let failures = 0;
+  let planned = modelMetadata.action === "planned" ? 1 : 0;
 
-  for (const entry of memberCredentials(listed)) {
-    if (entry.state !== "missing" || typeof entry.orgMembershipId !== "string") continue;
-    const orgMembershipId = entry.orgMembershipId;
-    const keyAlias = `openwork-${orgMembershipId}`;
-    const generated = await requestJson(
-      `${liteLlmBaseUrl}/key/generate`,
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${input.liteLlmMasterKey}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          models,
-          key_alias: keyAlias,
-          metadata: { openwork_org_membership_id: orgMembershipId },
-        }),
-      },
-      secrets,
-    );
-    const apiKey = generatedKey(generated);
-    const credentialId = externalCredentialId(generated);
-    const userId = isRecord(generated) && typeof generated.user_id === "string" && generated.user_id
-      ? generated.user_id
-      : null;
-    const body = {
-      apiKey,
-      externalCredentialId: credentialId,
-      ...(userId ? { externalPrincipalId: userId } : {}),
-    };
-    await requestJson(
-      `${denApiUrl}/v1/llm-providers/${providerId}/member-credentials/${encodeURIComponent(orgMembershipId)}`,
-      { method: "PUT", headers: denHeaders(input), body: JSON.stringify(body) },
-      [...secrets, apiKey],
-    );
-    summary.push({ orgMembershipId, action: "provisioned", externalCredentialId: credentialId });
+  /** @type {Map<string, string[]>} */
+  const offboardCandidates = new Map();
+  for (const [orgMembershipId, binding] of knownBindings) {
+    if (!grantedMemberIds.has(orgMembershipId) && binding.state !== "blocked") {
+      offboardCandidates.set(orgMembershipId, [binding.externalCredentialId]);
+    }
+  }
+  for (const key of upstreamKeys) {
+    const orgMembershipId = managedOrgMembershipId(key);
+    if (!orgMembershipId || grantedMemberIds.has(orgMembershipId) || key.blocked) continue;
+    const identifiers = offboardCandidates.get(orgMembershipId) ?? [];
+    if (!identifiers.includes(key.id)) identifiers.push(key.id);
+    offboardCandidates.set(orgMembershipId, identifiers);
   }
 
-  return { modelMetadata, memberCredentials: summary };
+  for (const [orgMembershipId, credentialIds] of [...offboardCandidates].sort(([left], [right]) => left.localeCompare(right))) {
+    if (input.dryRun) {
+      planned += 1;
+      summary.push({ orgMembershipId, action: "planned", outcome: "planned", detail: "offboard" });
+      logAction("member.offboard", "planned", orgMembershipId, "block LiteLLM before Den");
+      continue;
+    }
+    try {
+      await blockMemberBinding(input, orgMembershipId, credentialIds, writes);
+      knownBindings.set(orgMembershipId, { externalCredentialId: credentialIds[0], state: "blocked" });
+      summary.push({ orgMembershipId, action: "offboarded", outcome: "succeeded", externalCredentialId: credentialIds[0] });
+      logAction("member.offboard", "succeeded", orgMembershipId, "LiteLLM blocked before Den");
+    } catch (error) {
+      failures += 1;
+      const detail = safeError(error, secrets);
+      summary.push({ orgMembershipId, action: "failed", outcome: "failed", detail });
+      logAction("member.offboard", "failed", orgMembershipId, `${detail}; Den binding left active`);
+    }
+  }
+
+  for (const entry of entries) {
+    const orgMembershipId = /** @type {string} */ (entry.orgMembershipId);
+    const email = emailsByMemberId.get(orgMembershipId);
+    try {
+      if (entry.state === "missing") {
+        const candidate = adoptionCandidate(upstreamKeys, orgMembershipId, email);
+        if (input.dryRun) {
+          planned += 1;
+          const detail = candidate ? "adopt by alias swap" : "mint missing key";
+          summary.push({ orgMembershipId, action: "planned", outcome: "planned", detail });
+          logAction(candidate ? "member.adopt" : "member.provision", "planned", orgMembershipId, detail);
+          continue;
+        }
+        const minted = candidate
+          ? await replaceLiteLlmKey(input, orgMembershipId, email, candidate.id, null, writes)
+          : await provisionLiteLlmKey(input, orgMembershipId, email, writes);
+        knownBindings.set(orgMembershipId, { externalCredentialId: minted.credentialId, state: "active" });
+        const action = candidate ? "adopted" : "provisioned";
+        summary.push({ orgMembershipId, action, outcome: "succeeded", externalCredentialId: minted.credentialId });
+        logAction(candidate ? "member.adopt" : "member.provision", "succeeded", orgMembershipId, candidate ? "alias swapped without increasing upstream key count" : "key minted and bound");
+        continue;
+      }
+      if (entry.state === "blocked") continue;
+      if (typeof entry.externalCredentialId !== "string" || !entry.externalCredentialId) {
+        throw new Error("Den binding did not include externalCredentialId.");
+      }
+      let info;
+      try {
+        info = await keyInfo(input, entry.externalCredentialId);
+      } catch (error) {
+        if (!isUnresolvableKey(error)) throw error;
+        if (entry.state === "stale") {
+          logAction("member.stale", "skipped", orgMembershipId, "already stale; member self-repair required");
+          continue;
+        }
+        await markStale({ ...input, orgMembershipId });
+        if (input.dryRun) {
+          planned += 1;
+          summary.push({ orgMembershipId, action: "planned", outcome: "planned", detail: "mark stale" });
+        } else {
+          writes.den += 1;
+          knownBindings.set(orgMembershipId, { externalCredentialId: entry.externalCredentialId, state: "stale" });
+          summary.push({ orgMembershipId, action: "stale", outcome: "succeeded", externalCredentialId: entry.externalCredentialId });
+        }
+        // Stale bindings are member-repaired, never automatically re-minted
+        // in the same reconciliation pass.
+        continue;
+      }
+      if (entry.state !== "active") continue;
+      if (info.expires === null || info.expires === undefined) continue;
+      if (typeof info.expires !== "string") throw new Error("LiteLLM /key/info returned an invalid expires value.");
+      const expiresAt = Date.parse(info.expires);
+      if (!Number.isFinite(expiresAt)) throw new Error("LiteLLM /key/info returned an unparseable expires value.");
+      if (expiresAt - Date.now() > renewBeforeSeconds * 1_000) continue;
+      if (input.dryRun) {
+        planned += 1;
+        summary.push({ orgMembershipId, action: "planned", outcome: "planned", detail: "renew expiring key" });
+        logAction("member.renew", "planned", orgMembershipId, "key is inside renewal window");
+        continue;
+      }
+      if (typeof entry.version !== "number") throw new Error("Active Den binding did not include a numeric version for renewal.");
+      const minted = await replaceLiteLlmKey(
+        input,
+        orgMembershipId,
+        email,
+        entry.externalCredentialId,
+        entry.version,
+        writes,
+      );
+      knownBindings.set(orgMembershipId, { externalCredentialId: minted.credentialId, state: "active" });
+      summary.push({ orgMembershipId, action: "renewed", outcome: "succeeded", externalCredentialId: minted.credentialId });
+      logAction("member.renew", "succeeded", orgMembershipId, "replacement stored with expectedVersion");
+    } catch (error) {
+      failures += 1;
+      const detail = safeError(error, secrets);
+      summary.push({ orgMembershipId, action: "failed", outcome: "failed", detail });
+      logAction("member.reconcile", "failed", orgMembershipId, detail);
+    }
+  }
+
+  logAction(
+    "reconcile.summary",
+    failures > 0 ? "failed" : input.dryRun ? "planned" : "succeeded",
+    undefined,
+    `failures=${failures} planned=${planned} denWrites=${writes.den} liteLlmWrites=${writes.liteLlm}`,
+  );
+  return { modelMetadata, memberCredentials: summary, failures, planned, writes };
 }
 
 /**
  * Block a member's LiteLLM virtual key before marking its Den binding blocked.
- * LiteLLM v1.97 accepts the generated token_id in POST /key/block, so plaintext
- * member keys are not needed after reconciliation.
  *
  * @param {ProvisionerConfig & { orgMembershipId: string }} input
- * @returns {Promise<{ orgMembershipId: string, action: "blocked", externalCredentialId: string }>}
+ * @returns {Promise<{ orgMembershipId: string, action: "blocked" | "planned", externalCredentialId: string }>}
  */
 export async function offboardMember(input) {
-  const denApiUrl = cleanBaseUrl(input.denApiUrl);
-  const liteLlmBaseUrl = liteLlmAdminBaseUrl(input.liteLlmBaseUrl);
   const providerId = encodeURIComponent(requireString(input.providerId, "providerId"));
   const orgMembershipId = requireString(input.orgMembershipId, "orgMembershipId");
   const secrets = [input.denToken, input.liteLlmMasterKey];
   const listed = await requestJson(
-    `${denApiUrl}/v1/llm-providers/${providerId}/member-credentials`,
+    `${cleanBaseUrl(input.denApiUrl)}/v1/llm-providers/${providerId}/member-credentials`,
     { headers: denHeaders(input) },
     secrets,
   );
   const binding = memberCredentials(listed).find((entry) => entry.orgMembershipId === orgMembershipId);
-  const credentialId = binding && typeof binding.externalCredentialId === "string"
-    ? binding.externalCredentialId
-    : "";
-  if (!credentialId) {
-    throw new Error(`Member ${orgMembershipId} does not have an externalCredentialId to block.`);
+  const credentialId = binding && typeof binding.externalCredentialId === "string" ? binding.externalCredentialId : "";
+  if (!credentialId) throw new Error(`Member ${orgMembershipId} does not have an externalCredentialId to block.`);
+  if (input.dryRun) {
+    logAction("member.offboard", "planned", orgMembershipId, "block LiteLLM before Den");
+    return { orgMembershipId, action: "planned", externalCredentialId: credentialId };
   }
-
-  await requestJson(
-    `${liteLlmBaseUrl}/key/block`,
-    {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${input.liteLlmMasterKey}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ key: credentialId }),
-    },
-    secrets,
-  );
-  await requestJson(
-    `${denApiUrl}/v1/llm-providers/${providerId}/member-credentials/${encodeURIComponent(orgMembershipId)}/block`,
-    { method: "POST", headers: denHeaders(input), body: JSON.stringify({}) },
-    secrets,
-  );
+  await blockMemberBinding(input, orgMembershipId, [credentialId], { den: 0, liteLlm: 0 });
+  logAction("member.offboard", "succeeded", orgMembershipId, "LiteLLM blocked before Den");
   return { orgMembershipId, action: "blocked", externalCredentialId: credentialId };
+}
+
+/**
+ * @param {ProvisionerConfig & {orgMembershipId: string}} input
+ * @returns {Promise<{orgMembershipId: string, action: "stale" | "planned"}>}
+ */
+export async function markStale(input) {
+  const orgMembershipId = requireString(input.orgMembershipId, "orgMembershipId");
+  if (input.dryRun) {
+    logAction("member.stale", "planned", orgMembershipId, "upstream key no longer resolves");
+    return { orgMembershipId, action: "planned" };
+  }
+  await requestJson(
+    `${cleanBaseUrl(input.denApiUrl)}/v1/llm-providers/${encodeURIComponent(input.providerId)}/member-credentials/${encodeURIComponent(orgMembershipId)}/stale`,
+    { method: "POST", headers: denHeaders(input), body: JSON.stringify({}) },
+    [input.denToken, input.liteLlmMasterKey],
+  );
+  logAction("member.stale", "succeeded", orgMembershipId, "upstream key no longer resolves");
+  return { orgMembershipId, action: "stale" };
 }
 
 /** @param {string} name */
@@ -517,8 +990,82 @@ function env(name) {
   return requireString(process.env[name], name);
 }
 
-/** @returns {ProvisionerConfig} */
-function configFromEnv() {
+/** @param {string} name */
+function optionalEnv(name) {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** @param {unknown} value @param {string} label */
+function nonNegativeNumber(value, label) {
+  const number = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(number) || number < 0) throw new Error(`${label} must be a finite non-negative number.`);
+  return number;
+}
+
+/** @param {unknown} value @param {string} label */
+function positiveNumber(value, label) {
+  const number = nonNegativeNumber(value, label);
+  if (number === 0) throw new Error(`${label} must be greater than zero.`);
+  return number;
+}
+
+/** @param {string | undefined} value */
+function booleanValue(value) {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+/**
+ * @typedef {object} CliOptions
+ * @property {"reconcile" | "offboard"} command
+ * @property {string} [orgMembershipId]
+ * @property {boolean} dryRun
+ * @property {string} [keyDuration]
+ * @property {number} renewBeforeSeconds
+ * @property {number} [watchSeconds]
+ */
+
+/** @param {string[]} argv @returns {CliOptions} */
+function parseCli(argv) {
+  const args = [...argv];
+  const first = args[0];
+  const command = first === "reconcile" || first === "offboard" ? args.shift() : "reconcile";
+  if (command !== "reconcile" && command !== "offboard") throw new Error("Unknown command.");
+  const orgMembershipId = command === "offboard" ? requireString(args.shift(), "orgMembershipId") : undefined;
+  let dryRun = booleanValue(optionalEnv("OPENWORK_DRY_RUN"));
+  let keyDuration = optionalEnv("OPENWORK_KEY_DURATION");
+  let renewBeforeSeconds = nonNegativeNumber(optionalEnv("OPENWORK_RENEW_BEFORE_SECONDS") ?? 0, "OPENWORK_RENEW_BEFORE_SECONDS");
+  /** @type {number | undefined} */
+  let watchSeconds;
+  while (args.length > 0) {
+    const option = args.shift();
+    if (option === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (option === "--key-duration") {
+      keyDuration = requireString(args.shift(), "--key-duration");
+      continue;
+    }
+    if (option === "--renew-before") {
+      renewBeforeSeconds = nonNegativeNumber(args.shift(), "--renew-before");
+      continue;
+    }
+    if (option === "--watch") {
+      if (command !== "reconcile") throw new Error("--watch is only valid with reconcile.");
+      const next = args[0];
+      watchSeconds = next && !next.startsWith("--")
+        ? positiveNumber(args.shift(), "--watch")
+        : positiveNumber(optionalEnv("OPENWORK_WATCH_SECONDS") ?? 300, "OPENWORK_WATCH_SECONDS");
+      continue;
+    }
+    throw new Error(`Unknown option ${String(option)}.`);
+  }
+  return { command, ...(orgMembershipId ? { orgMembershipId } : {}), dryRun, ...(keyDuration ? { keyDuration } : {}), renewBeforeSeconds, ...(watchSeconds ? { watchSeconds } : {}) };
+}
+
+/** @param {CliOptions} options @returns {ProvisionerConfig} */
+function configFromEnv(options) {
   return {
     denApiUrl: env("OPENWORK_DEN_API_URL"),
     denToken: env("OPENWORK_DEN_TOKEN"),
@@ -527,28 +1074,86 @@ function configFromEnv() {
     liteLlmBaseUrl: env("LITELLM_BASE_URL"),
     liteLlmMasterKey: env("LITELLM_MASTER_KEY"),
     models: env("LITELLM_MODELS").split(",").map((model) => model.trim()).filter(Boolean),
+    dryRun: options.dryRun,
+    ...(options.keyDuration ? { keyDuration: options.keyDuration } : {}),
+    renewBeforeSeconds: options.renewBeforeSeconds,
   };
+}
+
+/** @param {number} milliseconds @param {() => boolean} stopped */
+function waitForWatchDelay(milliseconds, stopped) {
+  return new Promise((resolve) => {
+    if (stopped()) {
+      resolve(undefined);
+      return;
+    }
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearInterval(poll);
+      resolve(undefined);
+    };
+    const timer = setTimeout(finish, milliseconds);
+    const poll = setInterval(() => {
+      if (stopped()) finish();
+    }, 100);
+  });
+}
+
+/** @param {ProvisionerConfig} config @param {number} watchSeconds */
+async function watch(config, watchSeconds) {
+  let stopping = false;
+  const stop = () => {
+    if (stopping) return;
+    stopping = true;
+    logAction("watch.lifecycle", "stopped", undefined, "shutdown requested");
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  logAction("watch.lifecycle", "started", undefined, `intervalSeconds=${watchSeconds}`);
+  try {
+    while (!stopping) {
+      try {
+        await reconcileMemberKeys(config);
+      } catch (error) {
+        logAction("watch.reconcile", "failed", undefined, safeError(error, [config.denToken, config.liteLlmMasterKey]));
+      }
+      if (stopping) break;
+      const jitteredMilliseconds = watchSeconds * 1_000 * (0.9 + Math.random() * 0.2);
+      await waitForWatchDelay(jitteredMilliseconds, () => stopping);
+    }
+  } finally {
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+  }
 }
 
 /** @returns {Promise<void>} */
 async function main() {
-  const command = process.argv[2];
-  const config = configFromEnv();
-  if (command === "reconcile") {
-    console.log(JSON.stringify(await reconcileMemberKeys(config), null, 2));
+  const options = parseCli(process.argv.slice(2));
+  const config = configFromEnv(options);
+  if (options.command === "reconcile" && options.watchSeconds) {
+    await watch(config, options.watchSeconds);
     return;
   }
-  if (command === "offboard") {
-    const orgMembershipId = requireString(process.argv[3], "orgMembershipId");
-    console.log(JSON.stringify(await offboardMember({ ...config, orgMembershipId }), null, 2));
+  if (options.command === "reconcile") {
+    const result = await reconcileMemberKeys(config);
+    if (result.failures > 0) process.exitCode = 1;
     return;
   }
-  throw new Error("Usage: node provision.mjs reconcile | node provision.mjs offboard <orgMembershipId>");
+  await offboardMember({ ...config, orgMembershipId: requireString(options.orgMembershipId, "orgMembershipId") });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
-    console.error(error instanceof Error ? error.message : String(error));
+    console.error(JSON.stringify({
+      ts: new Date().toISOString(),
+      action: "provisioner.fatal",
+      outcome: "failed",
+      detail: safeError(error, [process.env.OPENWORK_DEN_TOKEN ?? "", process.env.LITELLM_MASTER_KEY ?? ""]),
+    }));
     process.exitCode = 1;
   });
 }

--- a/packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx
+++ b/packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx
@@ -64,10 +64,17 @@ Organization owners and admins can operate a central provisioner with these rout
 - `GET /v1/llm-providers/:id/member-credentials` lists every granted membership's state, version, and external identifiers. It never returns credential material.
 - `PUT /v1/llm-providers/:id/member-credentials/:orgMembershipId` stores one member's credential. The body accepts `apiKey` or `apiKeys`, plus optional `externalPrincipalId`, `externalCredentialId`, and `expectedVersion`.
 - `POST /v1/llm-providers/:id/member-credentials/:orgMembershipId/block` marks an existing binding blocked.
+- `POST /v1/llm-providers/:id/member-credentials/:orgMembershipId/stale` marks an existing binding stale after its upstream credential is rotated or deleted.
 
 Use `expectedVersion` when multiple provisioner workers may update the same binding. A mismatch returns HTTP `409` with `{ "error": "version_conflict" }`.
 
 A blocked binding is admin-owned. A member cannot overwrite or delete it: member writes and deletes return HTTP `409` with `{ "error": "credential_blocked" }`. An admin `PUT` is the explicit unblock and replacement path.
+
+A stale binding returns null credentials from the connect route but remains member-repairable. Either a member `PUT .../my-credential` or an admin credential `PUT` replaces it and returns the binding to `active`.
+
+## Probe a provider
+
+Any granted member can call `POST /v1/llm-providers/:id/probe` with `{}` to test `GET <provider api>/models` using their resolved credential. Owners and admins can pass `{ "orgMembershipId": "..." }` for a granted member of a `per_member` provider. The response classifies the result as `ok`, `unauthorized`, `unreachable`, `model_missing`, or `no_credential`; it can report latency, model count, and missing configured model IDs, but never credential material or upstream error bodies.
 
 ## LiteLLM example
 


### PR DESCRIPTION
## Summary

Closes the loop on per-member gateway credentials (for example LiteLLM virtual keys) across all three surfaces:

- **Desktop (apps/app):** a granted `per_member` provider with no binding shows a **Needs your key** row in Settings with a masked input. Saving calls `PUT /v1/llm-providers/:id/my-credential`, triggers a provider sync pass, and the provider materializes. A `409 credential_blocked` renders an inline admin-managed error and never clears other state.
- **Den API (ee/apps/den-api):** `POST /v1/llm-providers/:id/probe` classifies a live gateway check with the caller's resolved credential — `ok | unauthorized | unreachable | model_missing | no_credential` — returning latency and missing model ids but never credential material or upstream bodies. Admins may target a granted member's binding. `POST .../member-credentials/:orgMembershipId/stale` marks a binding stale after upstream rotation; unlike `blocked`, stale stays member-repairable.
- **Provisioner example (examples/litellm-per-member-keys):** `reconcile` now adopts pre-existing upstream keys (mint-and-alias-swap; upstream key count unchanged), auto-offboards removed grants upstream-first with fail-visible semantics, marks bindings stale when the upstream key no longer resolves (never auto-re-mints), renews expiring keys (`--key-duration`/`--renew-before`), supports `--dry-run` (zero writes), runs as a `--watch` daemon with jittered single-flight passes and structured JSON logs, and ships a Dockerfile. README documents the data flow for security review.

Docs updated: `packages/docs/cloud/share-with-your-team/per-member-llm-credentials.mdx` (stale route + probe).

Deliberately out of scope: Helm chart packaging, a desktop "Test connection" button wired to the probe route, managed minting / JWT identity mode.

## Verification

Node 24, local lane (Daytona credentials unavailable in this environment — expected OSS fallback). All runs on PR head `acc1a797a` (rebased onto current dev), cold-booted through `server()` with no Den reuse override:

- `pnpm evals:pr specs/llm-provider-probe.test.ts` — exit 0, **1 passed, 0 failed, 0 skipped** (33.6s). In CI's MySQL-less PR lane this spec skips with an explicit needs title, gated like sibling local-placement Den specs
- `pnpm evals:e2e per-member-credential-self-serve` — exit 0, **1 passed, 0 failed, 0 skipped** (87.5s)
- `pnpm evals:e2e litellm-per-member-credentials` — exit 0, **1 passed, 0 failed, 0 skipped** (56.4s, real LiteLLM database via Docker)
- `pnpm --dir evals run test` — **209 passed, 0 failed, 0 skipped**
- `pnpm evals:pr specs/daytona-e2e-regression-concurrency.test.ts` — exit 0, **3 passed** (the new e2e spec is registered as eligible in the Daytona regression audit)
- `pnpm --dir apps/app run typecheck` — exit 0; `tsc --noEmit` in `ee/apps/den-api` — exit 0

One earlier red run of the self-serve spec was an environment-specific `app()` readiness timeout (desktop stuck at "Preparing workspace" for 180s on a host running six concurrent Electron instances); it failed before any spec claim and the identical command passed on re-run and in a prior run of the same tree.

Head-matching test evidence is published in the sticky PR comment.

## Verdict

**Passed** — every claim in the three specs has an observable assertion in the runs above.

## Notes for review

- New UI strings in the needs-key form are literal English rather than `t()` keys — flagged as a follow-up to wire into the i18n catalogs alongside the other `den.cloud_provider_*` labels.
- `hasMyCredential`/`credentialMode` on the provider list are pre-existing Den API fields; the renderer now consumes them.
