### PR TITLE
ci(evals): run the Daytona E2E regression suite bi-daily and fix matched-test selection

### DIFF
--- a/.github/workflows/daytona-e2e-regression-suite.yml
+++ b/.github/workflows/daytona-e2e-regression-suite.yml
@@ -3,6 +3,7 @@
 # The checked-in lane profile removes only topology/dependency skips before the
 # matrix is built; compatible product regressions remain in the matrix.
 # The critical-path journey remains owned by its dedicated nightly workflow.
+# A bi-daily schedule runs the full eligible suite unattended.
 # Tests that drive raw desktop() from @openwork/hosts are excluded dynamically:
 # they spawn Electron on the caller's machine (correct inside a VNC sandbox or
 # on a dev workstation, impossible on a headless runner) and need a follow-up
@@ -10,6 +11,8 @@
 name: Daytona E2E Regression Suite
 
 on:
+  schedule:
+    - cron: "0 6,18 * * *"
   workflow_run:
     workflows: [Warden]
     types: [completed]
@@ -34,6 +37,7 @@ jobs:
     if: >-
       github.repository == 'different-ai/openwork' &&
       (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository))
@@ -87,9 +91,14 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: echo "authorized=true" >> "$GITHUB_OUTPUT"
 
+      - name: Authorize scheduled E2E regression
+        id: authorize-scheduled
+        if: github.event_name == 'schedule'
+        run: echo "authorized=true" >> "$GITHUB_OUTPUT"
+
       - name: Check E2E regression configuration
         id: config
-        if: steps.authorize.outputs.authorized == 'true' || steps.authorize-manual.outputs.authorized == 'true'
+        if: steps.authorize.outputs.authorized == 'true' || steps.authorize-manual.outputs.authorized == 'true' || steps.authorize-scheduled.outputs.authorized == 'true'
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -159,7 +168,8 @@ jobs:
           )"
 
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            matched_tests="$(node evals/scripts/spec-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --matched-tests)"
+            # spec-impact emits evals/specs/… paths; the matrix speaks basenames.
+            matched_tests="$(node evals/scripts/spec-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --matched-tests | jq -c 'map(sub("^evals/specs/"; ""))')"
             only_filter=""
           else
             matched_tests='[]'
@@ -227,8 +237,8 @@ jobs:
     needs: plan
     if: needs.plan.outputs.enabled == 'true' && needs.plan.outputs.has_tests == 'true'
     name: E2E (${{ matrix.batch.name }})
-    # Existing GitHub environment name retained for approval compatibility.
-    environment: pr-slow-specs
+    # Existing GitHub environment name retained for approval compatibility; scheduled runs use the unprotected scheduled-e2e-regression environment so they run unattended.
+    environment: ${{ github.event_name == 'schedule' && 'scheduled-e2e-regression' || 'pr-slow-specs' }}
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/evals/specs/daytona-e2e-regression-schedule.test.ts
+++ b/evals/specs/daytona-e2e-regression-schedule.test.ts
@@ -1,0 +1,50 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/daytona-e2e-regression-suite.yml", import.meta.url),
+);
+
+test("the regression suite runs the full eligible suite bi-daily without manual approval", async ({ evidence }) => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const wardenAuthorization = workflow.indexOf("- name: Authorize Warden-cleared pull request");
+  const guardedPathCheck = workflow.indexOf("E2E regression withheld: PR changes trusted review machinery.");
+
+  expect(workflow).toContain('cron: "0 6,18 * * *"');
+  expect(workflow).toContain(
+    "id: authorize-scheduled\n        if: github.event_name == 'schedule'",
+  );
+  expect(workflow).toContain("steps.authorize-scheduled.outputs.authorized");
+  expect(workflow).toContain("github.event_name == 'schedule'");
+  expect(workflow).toContain(
+    "environment: ${{ github.event_name == 'schedule' && 'scheduled-e2e-regression' || 'pr-slow-specs' }}",
+  );
+  expect(wardenAuthorization).toBeGreaterThan(-1);
+  expect(guardedPathCheck).toBeGreaterThan(wardenAuthorization);
+
+  evidence.recordAssertionEvidence(
+    "The Daytona E2E regression suite runs the full eligible suite bi-daily without manual approval",
+    "The workflow schedules 06:00 and 18:00 UTC runs, authorizes and configures schedule events, routes them to an unprotected environment, and preserves Warden plus trusted-review-machinery guards for pull requests.",
+    true,
+  );
+});
+
+test("PR-triggered selection intersects matched tests as basenames", async ({ evidence }) => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const rawMatchedAssignment =
+    'matched_tests="$(node evals/scripts/spec-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --matched-tests)"';
+
+  expect(workflow).toContain(
+    'matched_tests="$(node evals/scripts/spec-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --matched-tests | jq -c \'map(sub("^evals/specs/"; ""))\')"',
+  );
+  expect(workflow).toContain("| sed 's#^evals/specs/##' \\");
+  expect(workflow).not.toContain(rawMatchedAssignment);
+
+  evidence.recordAssertionEvidence(
+    "PR-triggered Daytona E2E selection compares matched and eligible test basenames",
+    "The workflow strips the evals/specs/ prefix from spec-impact output before intersecting it with the basename inventory, and the former raw assignment is absent.",
+    true,
+  );
+});


### PR DESCRIPTION
## What

1. **Bi-daily scheduled full run** — `cron: "0 6,18 * * *"` now runs the entire eligible E2E matrix unattended on the dev tip. Scheduled runs authorize through a dedicated `authorize-scheduled` step and route to the unprotected `scheduled-e2e-regression` environment (auto-created on first reference), while PR-triggered runs keep the `pr-slow-specs` required-reviewer gate, Warden clearance, and the trusted-review-machinery withholding untouched.
2. **Selection bugfix** — `spec-impact.mjs --matched-tests` emits full paths (`evals/specs/foo.e2e.test.ts`) but the matrix builder intersects basenames, so any PR with a non-empty contract match selected **zero** tests and the verdict job failed as Incomplete. Matched output is now normalized to basenames before the intersection.

## Verification

Lane: local hermetic pr lane (app-less toolchain spec; Daytona is not applicable to this spec kind).

```
pnpm evals:pr specs/daytona-e2e-regression-schedule.test.ts
# Test Files  1 passed (1) · Tests  2 passed (2) · exit 0
```

Claims covered: bi-daily cron present; schedule events authorized and configured; environment expression routes schedule → `scheduled-e2e-regression` and PRs → `pr-slow-specs`; Warden authorization + guarded-path withholding still present (negative); matched tests normalized to basenames with the raw un-normalized assignment gone (negative).

Verdict: **Passed** (2/2 assertions, 0 skipped). GitHub-side cron execution and environment auto-creation are observable only post-merge: the first scheduled run lands at the next 06:00/18:00 UTC and failures file issues through the existing `E2E Test Failure Alerts` workflow.

## Notes for reviewers

- This PR touches `.github/`, so the PR-triggered regression suite deliberately withholds itself (trusted review machinery guard) — expected.
- The soft spec-impact snapshot will flag `evals.daytona-e2e-regression-suite` as needing attention (its mapped specs did not change); advisory-only. Follow-up: map the new toolchain spec into that contract once the contract-coverage PR (test/spec-impact-contract-coverage) merges.