### PR TITLE
ci(evals): add a bi-daily Daytona E2E singles lane for per-test topologies

### DIFF
--- a/.github/workflows/daytona-e2e-singles.yml
+++ b/.github/workflows/daytona-e2e-singles.yml
@@ -75,7 +75,7 @@ jobs:
             echo "$tests" | jq -r '.[] | "- `\(.)`"'
             echo
             echo "Denied from this lane:"
-            echo "- `capability-search-latency.e2e.test.ts`: its fault proxy is built on the driver machine's loopback in front of a driver-local mock MCP; a Daytona-hosted Den can never reach it, so it is local-placement-only."
+            echo "- \`capability-search-latency.e2e.test.ts\`: its fault proxy is built on the driver machine's loopback in front of a driver-local mock MCP; a Daytona-hosted Den can never reach it, so it is local-placement-only."
           } >> "$GITHUB_STEP_SUMMARY"
 
           echo "tests=$tests" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/daytona-e2e-singles.yml
+++ b/.github/workflows/daytona-e2e-singles.yml
@@ -1,0 +1,266 @@
+# Runs profile-excluded E2E specs standalone, with one Vitest invocation per
+# spec, so the testkit provisions each spec's own fresh Den + desktop topology.
+# This covers the fresh-den-url and fault-proxy profile categories.
+# per-test-den-env, local-placement, and secret/docker categories remain
+# follow-ups; per-test-den-env needs environment forwarding through
+# provisionDenSandbox -> test-server-on-daytona.sh.
+name: Daytona E2E Singles
+
+on:
+  schedule:
+    - cron: "30 6,18 * * *"
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Optional substring filter on E2E test filenames"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daytona-e2e-singles
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    if: github.repository == 'different-ai/openwork'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    outputs:
+      tests: ${{ steps.matrix.outputs.tests }}
+      has_tests: ${{ steps.matrix.outputs.has_tests }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Build E2E singles matrix
+        id: matrix
+        shell: bash
+        env:
+          ONLY_FILTER: ${{ inputs.only }}
+        run: |
+          set -euo pipefail
+
+          selected="$(node evals/scripts/list-singles-tests.mjs)"
+          tests="$(
+            printf '%s\n' "$selected" \
+              | jq -Rsc --arg only "$ONLY_FILTER" '
+                  split("\n")
+                  | map(select(length > 0))
+                  | map(select($only == "" or contains($only)))
+                '
+          )"
+
+          if [ "$(echo "$tests" | jq 'length')" -eq 0 ]; then
+            echo "::error::Daytona E2E singles selection is empty after applying the filter."
+            exit 1
+          fi
+
+          {
+            echo "### Daytona E2E singles plan"
+            echo
+            echo "Selected specs: $(echo "$tests" | jq 'length')"
+            echo "$tests" | jq -r '.[] | "- `\(.)`"'
+            echo
+            echo "Denied from this lane:"
+            echo "- `capability-search-latency.e2e.test.ts`: its fault proxy is built on the driver machine's loopback in front of a driver-local mock MCP; a Daytona-hosted Den can never reach it, so it is local-placement-only."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+          echo "has_tests=true" >> "$GITHUB_OUTPUT"
+          echo "Singles matrix: $tests"
+
+  run:
+    needs: plan
+    if: needs.plan.outputs.has_tests == 'true'
+    name: E2E (${{ matrix.test }})
+    environment: scheduled-e2e-singles
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        test: ${{ fromJSON(needs.plan.outputs.tests) }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.4.0
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+          pnpm --dir evals install --frozen-lockfile --ignore-scripts
+
+      # The opencode MCP OAuth spec (opencode-mcp-agent-oauth.e2e.test.ts)
+      # drives the real opencode CLI as an OAuth MCP client against the Den
+      # agent endpoint. Install the exact validated version without lifecycle
+      # scripts before Daytona credentials are provisioned on the runner, then
+      # run the package's one known postinstall deliberately — the bin shim
+      # refuses to start without it, and --ignore-scripts must not silently
+      # skip it for every transitive dependency's sake.
+      - name: Install opencode CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PNPM_HOME="$RUNNER_TEMP/pnpm-global"
+          export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
+          mkdir -p "$PNPM_HOME/bin"
+          pnpm add --global --ignore-scripts opencode-ai@1.18.18
+          package_dir=""
+          while IFS= read -r candidate; do
+            package_dir="$candidate"
+          done < <(pnpm list --global --parseable opencode-ai)
+          [ -n "$package_dir" ]
+          (cd "$package_dir" && node postinstall.mjs)
+          opencode --version
+          echo "$PNPM_HOME/bin" >> "$GITHUB_PATH"
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+
+      # The eval harness shells out to the daytona CLI (testkit daytonaAvailable
+      # gate and @openwork/hosts exec). The binary is pinned to a release tag
+      # and checksum-verified before it can run with CI secrets. When bumping,
+      # take the digest from GitHub's authoritative asset metadata, never from
+      # a local download (a truncating proxy once poisoned the pin):
+      #   gh api repos/daytona/clients/releases/tags/<tag> --jq '.assets[] | select(.name == "daytona-linux-amd64") | .digest'
+      - name: Install Daytona CLI
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_CLI_TAG: v0.204.0
+          DAYTONA_CLI_SHA256: 76701138c2ce93c14b30e7b10f51aa5ea2a9e156777bab933a4272237d81f14d
+        run: |
+          set -euo pipefail
+          gh release download "$DAYTONA_CLI_TAG" --repo daytona/clients --pattern daytona-linux-amd64 --output /tmp/daytona --clobber
+          echo "$DAYTONA_CLI_SHA256  /tmp/daytona" | sha256sum -c -
+          sudo install -m 0755 /tmp/daytona /usr/local/bin/daytona
+          daytona --version
+          # The CLI requires a stored profile; the env var alone is not enough.
+          daytona login --api-key "$DAYTONA_API_KEY"
+
+      - name: Run single test
+        id: run
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          NO_COLOR: "1"
+          MATRIX_TEST: ${{ matrix.test }}
+        run: |
+          set -euo pipefail
+
+          set +e
+          OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_E2E_TESTS=1 \
+          OPENWORK_EVAL_MAX_WORKERS=1 \
+          OPENWORK_EVAL_AUTOMATIONS_E2E_TEST=1 OPENWORK_EVAL_CONNECTOR_E2E_TEST=1 \
+          OPENWORK_EVAL_LOCAL_MANAGED_MCP=1 OPENWORK_EVAL_GENERATED_ARTIFACT_VIEWS_E2E_TEST=1 \
+          OPENWORK_EVAL_SAVED_SCRIPT_AUTOMATIONS_E2E_TEST=1 OPENWORK_EVAL_ENGINE_ROLLOVER_E2E_TEST=1 \
+          OPENWORK_EVAL_MODEL=big-pickle OPENWORK_EVAL_VISION=defer \
+          pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e "specs/${MATRIX_TEST}" \
+            2>&1 | tee /tmp/e2e-run.log
+          vitest_status="${PIPESTATUS[0]}"
+          set -e
+
+          sed -E 's/\x1B\[[0-9;]*m//g' /tmp/e2e-run.log > /tmp/e2e-run-plain.log
+          detail="1 E2E test"
+          if [ "$vitest_status" -ne 0 ]; then
+            result="failed"
+          elif grep -Eq "Tests[[:space:]].*skipped" /tmp/e2e-run-plain.log; then
+            result="failed"
+            detail="$detail; skipped (scheduled singles treat skips as failures)"
+          else
+            result="passed"
+          fi
+          needs_reasons="$(grep -o '\[needs:[^]]*\]' /tmp/e2e-run-plain.log | sort -u | paste -sd ';' - || true)"
+          if [ -n "$needs_reasons" ]; then
+            detail="$detail; $needs_reasons"
+          fi
+
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+          {
+            echo "### $MATRIX_TEST"
+            echo
+            echo "| Test | Result | Detail |"
+            echo "| --- | --- | --- |"
+            echo "| $MATRIX_TEST | $result | $detail |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Vitest exit code: $vitest_status"
+
+          if [ "$result" != "passed" ]; then
+            exit 1
+          fi
+
+      - name: Judge deferred vision claims
+        if: steps.run.outputs.result == 'passed'
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' test_run; do
+            pnpm --dir evals evidence:judge -- --test-run "$test_run"
+          done < <(find "$GITHUB_WORKSPACE/evals/results/test-runs" -mindepth 1 -maxdepth 1 -type d -print0)
+
+      - name: Upload E2E test artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-singles-artifacts-${{ strategy.job-index }}
+          path: evals/results/test-runs/
+          retention-days: 14
+          if-no-files-found: ignore
+
+  verdict:
+    needs:
+      - plan
+      - run
+    if: always() && needs.plan.result != 'failure'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+
+    steps:
+      - name: Report E2E singles verdict
+        shell: bash
+        env:
+          RUN_RESULT: ${{ needs.run.result }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Daytona E2E Singles"
+            echo
+            echo "Singles matrix result: **$RUN_RESULT**."
+            echo "Only a successful, non-skipped matrix passes this scheduled lane."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$RUN_RESULT" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/e2e-test-failure-alerts.yml
+++ b/.github/workflows/e2e-test-failure-alerts.yml
@@ -8,6 +8,7 @@ on:
     workflows:
       - Nightly Critical-Path E2E Journey
       - Daytona E2E Regression Suite
+      - Daytona E2E Singles
       - Nightly Flake Report
     types:
       - completed
@@ -47,6 +48,7 @@ jobs:
           case "$RUN_NAME" in
             "Nightly Critical-Path E2E Journey") issue_title="Nightly critical-path E2E journey failed" ;;
             "Daytona E2E Regression Suite") issue_title="Daytona E2E regression suite failed" ;;
+            "Daytona E2E Singles") issue_title="Daytona E2E singles lane failed" ;;
             "Nightly Flake Report") issue_title="Nightly flake report found unreliable specs" ;;
             *) echo "Unexpected workflow: $RUN_NAME" >&2; exit 1 ;;
           esac

--- a/evals/scripts/list-singles-tests.mjs
+++ b/evals/scripts/list-singles-tests.mjs
@@ -1,0 +1,91 @@
+import { access, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const specsDirectory = new URL("../specs/", import.meta.url);
+const profileUrl = new URL("../specs/daytona-e2e-regression-profile.json", import.meta.url);
+
+const SINGLES_CATEGORIES = ["fresh-den-url", "fault-proxy"];
+
+const SINGLES_DENYLIST = new Map([
+  [
+    "capability-search-latency.e2e.test.ts",
+    "its fault proxy is built on the driver machine's loopback in front of a driver-local mock MCP; a Daytona-hosted Den can never reach it, so it is local-placement-only",
+  ],
+]);
+
+function profileEntries(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("regression profile must be an object");
+  }
+
+  const excluded = Reflect.get(value, "excluded");
+  if (!Array.isArray(excluded) || excluded.length === 0) {
+    throw new Error("regression profile excluded must be a non-empty array");
+  }
+
+  return excluded.map((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new Error(`regression profile excluded[${index}] must be an object`);
+    }
+
+    const test = Reflect.get(entry, "test");
+    const category = Reflect.get(entry, "category");
+    if (typeof test !== "string" || test.length === 0) {
+      throw new Error(`regression profile excluded[${index}].test must be a non-empty string`);
+    }
+    if (typeof category !== "string" || category.length === 0) {
+      throw new Error(`regression profile excluded[${index}].category must be a non-empty string`);
+    }
+
+    return { test, category };
+  });
+}
+
+export async function listSinglesTests() {
+  let source;
+  try {
+    source = await readFile(profileUrl, "utf8");
+  } catch (error) {
+    throw new Error(`cannot read regression profile at ${fileURLToPath(profileUrl)}`, { cause: error });
+  }
+
+  let profile;
+  try {
+    profile = JSON.parse(source);
+  } catch (error) {
+    throw new Error(`regression profile is not valid JSON: ${fileURLToPath(profileUrl)}`, { cause: error });
+  }
+
+  const selected = profileEntries(profile)
+    .filter(({ category, test }) => SINGLES_CATEGORIES.includes(category) && !SINGLES_DENYLIST.has(test))
+    .map(({ test }) => test)
+    .sort();
+
+  if (selected.length === 0) {
+    throw new Error("Daytona E2E singles selection is empty");
+  }
+
+  for (const test of selected) {
+    try {
+      await access(new URL(test, specsDirectory));
+    } catch (error) {
+      throw new Error(`selected singles spec does not exist: evals/specs/${test}`, { cause: error });
+    }
+  }
+
+  return selected;
+}
+
+async function main() {
+  const selected = await listSinglesTests();
+  process.stdout.write(`${selected.join("\n")}\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to list Daytona E2E singles: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/evals/specs/daytona-e2e-singles-toolchain.test.ts
+++ b/evals/specs/daytona-e2e-singles-toolchain.test.ts
@@ -1,0 +1,117 @@
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { listSinglesTests } from "../scripts/list-singles-tests.mjs";
+
+const profilePath = fileURLToPath(
+  new URL("./daytona-e2e-regression-profile.json", import.meta.url),
+);
+const specsDirectory = new URL("./", import.meta.url);
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/daytona-e2e-singles.yml", import.meta.url),
+);
+const alertsWorkflowPath = fileURLToPath(
+  new URL("../../.github/workflows/e2e-test-failure-alerts.yml", import.meta.url),
+);
+
+const SINGLES_CATEGORIES = new Set(["fresh-den-url", "fault-proxy"]);
+const DISALLOWED_CATEGORIES = new Set([
+  "per-test-den-env",
+  "local-bun-world",
+  "raw-or-local-placement",
+  "unavailable-secret-or-docker",
+]);
+const DENIED_TEST = "capability-search-latency.e2e.test.ts";
+
+type ProfileEntry = {
+  test: string;
+  category: string;
+};
+
+function profileEntries(value: unknown): ProfileEntry[] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("profile must be an object");
+  }
+  const excluded = Reflect.get(value, "excluded");
+  if (!Array.isArray(excluded)) throw new Error("profile excluded must be an array");
+
+  return excluded.map((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new Error(`profile excluded[${index}] must be an object`);
+    }
+    const profileTest = Reflect.get(entry, "test");
+    const category = Reflect.get(entry, "category");
+    if (typeof profileTest !== "string" || typeof category !== "string") {
+      throw new Error(`profile excluded[${index}] must have test and category strings`);
+    }
+    return { test: profileTest, category };
+  });
+}
+
+test("the singles selection is exactly the standalone-runnable excluded categories", async ({ evidence }) => {
+  const [selected, profileSource] = await Promise.all([
+    listSinglesTests(),
+    readFile(profilePath, "utf8"),
+  ]);
+  const profile: unknown = JSON.parse(profileSource);
+  const entries = profileEntries(profile);
+  const expected = entries
+    .filter(({ category, test: profileTest }) => SINGLES_CATEGORIES.has(category) && profileTest !== DENIED_TEST)
+    .map(({ test: profileTest }) => profileTest);
+
+  expect(new Set(selected)).toEqual(new Set(expected));
+  expect(selected).toHaveLength(expected.length);
+  await Promise.all(selected.map((selectedTest) => access(new URL(selectedTest, specsDirectory))));
+
+  const selectedEntries = entries.filter(({ test: profileTest }) => selected.includes(profileTest));
+  expect(selectedEntries).toHaveLength(selected.length);
+  expect(selectedEntries.every(({ category }) => SINGLES_CATEGORIES.has(category))).toBe(true);
+  expect(selectedEntries.some(({ category }) => DISALLOWED_CATEGORIES.has(category))).toBe(false);
+  expect(selected).not.toContain(DENIED_TEST);
+
+  evidence.recordAssertionEvidence(
+    "The singles selector contains exactly the standalone-runnable profile exclusions",
+    "Selection equals the fresh-den-url and fault-proxy profile entries after the explicit local-placement denial; every selected spec exists and no incompatible category enters the lane.",
+    true,
+  );
+});
+
+test("the singles workflow runs one spec per vitest invocation on a bi-daily schedule", async ({ evidence }) => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const vitestInvocations = workflow
+    .split("\n")
+    .filter((line) => line.includes("pnpm --dir evals exec vitest run"));
+
+  expect(workflow).toContain('cron: "30 6,18 * * *"');
+  expect(workflow).toContain("node evals/scripts/list-singles-tests.mjs");
+  expect(vitestInvocations).toHaveLength(1);
+  expect(vitestInvocations[0]).toContain('--project e2e "specs/${MATRIX_TEST}"');
+  expect(vitestInvocations[0]).not.toMatch(/\*|\[@\]|TESTS_JSON|mapfile/);
+  expect(workflow).toMatch(
+    /elif grep -Eq "Tests\[\[:space:\]\]\.\*skipped"[^\n]*; then\n\s+result="failed"/,
+  );
+  expect(workflow).toContain("environment: scheduled-e2e-singles");
+  expect(workflow).not.toContain("pr-slow-specs");
+
+  evidence.recordAssertionEvidence(
+    "The scheduled singles workflow preserves per-spec topology isolation",
+    "The twice-daily lane derives its matrix from the selector, invokes Vitest once with one matrix file, fails skips, uses its dedicated environment, and never reuses the batched regression environment.",
+    true,
+  );
+});
+
+test("singles failures alert developers", async ({ evidence }) => {
+  const alertsWorkflow = await readFile(alertsWorkflowPath, "utf8");
+
+  expect(alertsWorkflow).toContain("      - Daytona E2E Singles");
+  expect(alertsWorkflow).toContain(
+    '"Daytona E2E Singles") issue_title="Daytona E2E singles lane failed" ;;',
+  );
+
+  evidence.recordAssertionEvidence(
+    "Daytona E2E singles failures reach the developer alert workflow",
+    "The failure-alert trigger watches the singles workflow and maps it to the dedicated Daytona E2E singles lane issue title.",
+    true,
+  );
+});


### PR DESCRIPTION
## What

131 of 150 E2E specs are excluded from the shared-stack Daytona regression suite. This adds the **Daytona E2E Singles** lane for the two categories that are standalone-runnable today, recovering 18 specs into scheduled CI:

- **Mechanism**: one vitest invocation per spec. The eval runner's one-explicit-file rule (`evals/runner/stack-suite.ts` `shouldPrepareSuite`) skips shared-stack prewarming, so the testkit provisions each spec's own fresh Den sandbox (stable baked preview URLs — what `fresh-den-url` needs) and per-spec sandbox exclusivity (what `fault-proxy`'s per-sandbox singleton proxy needs).
- **Selection**: `evals/scripts/list-singles-tests.mjs` derives the matrix from the checked-in regression profile (categories `fresh-den-url` + `fault-proxy`), with one explicit denial: `capability-search-latency.e2e.test.ts` builds its fault proxy on the driver's loopback in front of a driver-local mock MCP — unreachable from a Daytona-hosted Den, so it stays local-placement-only. The script fails loudly on empty selection or missing files.
- **Schedule**: `cron: "30 6,18 * * *"`, offset 30 min from the batched suite to stagger Daytona quota; `max-parallel: 3`; unprotected `scheduled-e2e-singles` environment; skips are classified as failures (a scheduled lane must never be vacuously green); deferred vision claims judged; artifacts uploaded; failures file issues via `E2E Test Failure Alerts` (registered here).

Remaining excluded categories and why they are follow-ups: `per-test-den-env` (11) needs env forwarding through `provisionDenSandbox` → `test-server-on-daytona.sh`; raw/local placement needs the in-sandbox vitest lane already noted in the batched workflow's header; secret/docker categories need credential provisioning.

## Verification

Lane: local hermetic pr lane (app-less; Daytona not applicable to the toolchain spec).

```
node evals/scripts/list-singles-tests.mjs   # 18 basenames, exit 0
pnpm evals:pr specs/daytona-e2e-singles-toolchain.test.ts
# Test Files  1 passed (1) · Tests  3 passed (3) · exit 0
```

Claims covered: selection set-equality against the profile with negatives (no disallowed category ever selected, denied spec absent, every selected file exists); single-file vitest invocation contract; skip-as-failure guard; dedicated environment with no `pr-slow-specs` reference; alerts registration.

Verdict: **Passed** (3/3 assertions, 0 skipped). The lane itself is observable post-merge: dispatch `Daytona E2E Singles` via workflow_dispatch (optionally with the `only` filter) or wait for the next 06:30/18:30 UTC run.

## Notes for reviewers

- Budget: 18 specs × 2/day, each provisioning its own Den + desktop sandbox pair — roughly comparable Daytona spend to one batched suite run; tune `max-parallel`/cron if quota contention shows up.
- This PR touches `.github/`, so the PR-triggered regression suite withholds itself (trusted review machinery guard) — expected.