### PR TITLE
fix: wrap long unbroken text in queued follow-up drafts

### DIFF
--- a/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
+++ b/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
@@ -230,7 +230,7 @@ function QueuedDraftRow(props: {
               setDraftText(props.item.draft.text);
               setEditing(true);
             }}
-            className="w-full rounded-md px-0.5 text-left text-sm leading-5 text-gray-11 hover:text-gray-12 disabled:pointer-events-none"
+            className="w-full whitespace-pre-wrap break-words rounded-md px-0.5 text-left text-sm leading-5 text-gray-11 hover:text-gray-12 disabled:pointer-events-none"
             title={t("composer.queued_edit")}
           >
             <QueuedDraftContent draft={props.item.draft} />


### PR DESCRIPTION
## Problem

A queued follow-up message containing a long unbroken token (for example a `openwork://den-auth?...` deep link) overflows the queued-draft card horizontally instead of wrapping, pushing text past the card border in the composer queue panel.

## Fix

The read-only queued-draft button in `QueuedMessagesPanel` lost the `whitespace-pre-wrap break-words` treatment the previous panel body had. Restore both classes on the button so long URLs wrap within the card and user line breaks are preserved. The edit-mode textarea already wraps.

## Verification

- `pnpm --dir apps/app typecheck` — passed (exit 0).
- Styling-only one-class change; no behavior change.