### PR TITLE
fix(app,server): stop Working timers from ticking unvalidated when the engine is unreachable

### DIFF
--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -18,6 +18,11 @@ interface MessageListContextValue {
   displaySuggestions: boolean
   providerConnectedCount: number
   connectorIdentities: ConnectorToolIdentity[]
+  /**
+   * True while the workspace sync layer cannot validate live run status
+   * (failed status revalidation). Working indicators must stop ticking.
+   */
+  syncDegraded: boolean
   dispatchAction: (action: DispatchAction) => void
   setPrompt: (prompt: string) => void
   onRevertToUserMessage: (messageId: string) => void
@@ -58,6 +63,7 @@ interface MessageListProviderProps {
   displaySuggestions: boolean
   providerConnectedCount: number
   connectorIdentities?: ConnectorToolIdentity[]
+  syncDegraded?: boolean
   dispatchAction: (action: DispatchAction) => void
   setPrompt: (prompt: string) => void
 }
@@ -78,6 +84,7 @@ export function MessageListProvider({
   displaySuggestions,
   providerConnectedCount,
   connectorIdentities = [],
+  syncDegraded = false,
   dispatchAction,
   setPrompt,
   onRevertToUserMessage,
@@ -155,6 +162,7 @@ export function MessageListProvider({
       displaySuggestions,
       providerConnectedCount,
       connectorIdentities,
+      syncDegraded,
       ...stableHandlers,
       onOpenSubagentSession: canOpenSubagentSession
         ? stableHandlers.onOpenSubagentSession
@@ -172,6 +180,7 @@ export function MessageListProvider({
       displaySuggestions,
       providerConnectedCount,
       connectorIdentities,
+      syncDegraded,
       stableHandlers,
       canOpenSubagentSession,
       canResumeInterrupted,

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -15,6 +15,7 @@ import {
   Pencil,
   Split,
   Undo2,
+  WifiOff,
 } from "lucide-react"
 import {
   DynamicToolUIPart,
@@ -848,6 +849,53 @@ const LoadingMessage = React.memo(({ elapsedSeconds }: { elapsedSeconds: number 
 
 LoadingMessage.displayName = "LoadingMessage"
 
+// Show when the run was last validated once the gap is long enough to matter;
+// a short blip needs no timestamp archaeology.
+const RECONNECTING_LAST_CONFIRMED_AFTER_MS = 120_000
+
+export function reconnectingLastConfirmedLabel(
+  lastConfirmedAt: number | null,
+  now: number,
+): string | null {
+  if (lastConfirmedAt === null) return null
+  if (now - lastConfirmedAt < RECONNECTING_LAST_CONFIRMED_AFTER_MS) return null
+  return new Date(lastConfirmedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+}
+
+/**
+ * The honest replacement for the ticking "Working" row while a live run can
+ * no longer be validated: the engine may still be working, but nothing has
+ * confirmed it recently, so the timer stops instead of counting unverified
+ * time. Recovery is automatic — the sync layer keeps revalidating and the
+ * row settles from authoritative status, never from elapsed time.
+ */
+const ReconnectingMessage = React.memo(({ lastConfirmedAt }: { lastConfirmedAt: number | null }) => {
+  const [now, setNow] = React.useState(() => Date.now())
+  React.useEffect(() => {
+    // The health store stops changing once its failure counter caps, so keep
+    // a slow local tick to let the "last update" hint appear over time.
+    const interval = window.setInterval(() => setNow(Date.now()), 30_000)
+    return () => window.clearInterval(interval)
+  }, [])
+  const lastConfirmedLabel = reconnectingLastConfirmedLabel(lastConfirmedAt, now)
+  return (
+    <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
+      <div
+        data-loading-message="reconnecting"
+        className="flex min-w-0 items-center gap-2 py-1 text-sm text-muted-foreground"
+      >
+        <WifiOff aria-hidden="true" className="size-4 shrink-0" />
+        <span className="min-w-0 truncate">
+          Connection lost — reconnecting…
+          {lastConfirmedLabel ? ` · last update ${lastConfirmedLabel}` : ""}
+        </span>
+      </div>
+    </Message>
+  )
+})
+
+ReconnectingMessage.displayName = "ReconnectingMessage"
+
 interface ErrorMessageProps {
   error: string | null
   /** Set only for interrupted runs (aborted / provider timeout) that can resume. */
@@ -1266,11 +1314,22 @@ const StandaloneMessage = React.memo(function StandaloneMessage(props: Standalon
   return <MessageComponent {...props} />
 })
 
+/**
+ * Liveness of the run behind this transcript, derived from the workspace
+ * sync layer's continuous status revalidation. While `degraded` is true the
+ * busy state cannot be confirmed, so working indicators must stop ticking.
+ */
+export interface RunSyncHealth {
+  degraded: boolean
+  lastConfirmedAt: number | null
+}
+
 interface MessageListProps {
   messages: UIMessage[]
   status: ThreadStatus
   activityStatus: SessionActivityStatus
   retryStatus?: RetryStatus | null
+  syncHealth?: RunSyncHealth
 }
 
 export function shouldShowMessageListLoading(
@@ -1282,9 +1341,15 @@ export function shouldShowMessageListLoading(
   return status === "streaming" || (status === "submitted" && messageCount > 0)
 }
 
-export function MessageList({ messages, status, activityStatus, retryStatus }: MessageListProps) {
+export function shouldShowRunReconnecting(status: ThreadStatus, syncDegraded: boolean) {
+  if (!syncDegraded) return false
+  return status === "submitted" || status === "streaming" || status === "retrying"
+}
+
+export function MessageList({ messages, status, activityStatus, retryStatus, syncHealth }: MessageListProps) {
   const isStreaming = status === "streaming" || status === "retrying"
   const runActive = status === "submitted" || status === "streaming" || status === "retrying"
+  const syncDegraded = syncHealth?.degraded === true
   const runStartedAtRef = React.useRef<number | null>(null)
   const [runElapsedSeconds, setRunElapsedSeconds] = React.useState(0)
   // Anchor the counter to the user message that started the run (server
@@ -1307,6 +1372,11 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
     }
     if (runStartedAt !== null) runStartedAtRef.current = runStartedAt
     else if (runStartedAtRef.current === null) runStartedAtRef.current = Date.now()
+    // While liveness is unconfirmed the counter must not tick: elapsed time
+    // is only presented as work while something is validating that work is
+    // still happening. The anchor is kept, so a confirmed recovery resumes
+    // the true task age instead of restarting at zero.
+    if (syncDegraded) return
     const updateElapsed = () => {
       const startedAt = runStartedAtRef.current
       if (startedAt !== null) setRunElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)))
@@ -1314,7 +1384,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
     updateElapsed()
     const interval = window.setInterval(updateElapsed, 1000)
     return () => window.clearInterval(interval)
-  }, [runActive, runStartedAt])
+  }, [runActive, runStartedAt, syncDegraded])
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
   const hasSessionErrorMessage = React.useMemo(() => messages.some(isSessionErrorMessage), [messages])
@@ -1323,7 +1393,8 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
     [messages],
   )
   const hasVisibleToolActivity = latestAssistantToolParts.some(isToolPartInFlight)
-  const showLoading = shouldShowMessageListLoading(status, messages.length, hasVisibleToolActivity)
+  const showReconnecting = shouldShowRunReconnecting(status, syncDegraded)
+  const showLoading = !showReconnecting && shouldShowMessageListLoading(status, messages.length, hasVisibleToolActivity)
   const currentToolCallIds = React.useMemo(
     () => new Set(latestAssistantToolParts.map((part) => part.toolCallId)),
     [latestAssistantToolParts],
@@ -1365,6 +1436,7 @@ export function MessageList({ messages, status, activityStatus, retryStatus }: M
         })}
 
         {showLoading && <LoadingMessage elapsedSeconds={runElapsedSeconds} />}
+        {showReconnecting && <ReconnectingMessage lastConfirmedAt={syncHealth?.lastConfirmedAt ?? null} />}
         {retryStatus ? <RetryMessage status={retryStatus} /> : null}
         {error && !hasSessionErrorMessage ? <ErrorMessage error={error} /> : null}
       </div>

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -37,7 +37,7 @@ function agentName(slug: string): string {
  */
 export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   const [open, setOpen] = useState(false)
-  const { onOpenSubagentSession } = useMessageList()
+  const { onOpenSubagentSession, syncDegraded } = useMessageList()
   const childSessionId = taskChildSessionId(part)
   const inFlight = isToolPartInFlight(part)
   const isFailed = part.state === "output-error"
@@ -47,18 +47,22 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   // switching sessions and back) resumes the counter instead of restarting.
   const startedAt = getToolCallStartedAt(part)
   useEffect(() => {
-    if (!inFlight || startedAt === null) return
+    // While run liveness is unconfirmed the counter must not tick; the
+    // module-scoped anchor resumes the true elapsed time on recovery.
+    if (!inFlight || startedAt === null || syncDegraded) return
     const update = () => {
       setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)))
     }
     update()
     const interval = window.setInterval(update, 1000)
     return () => window.clearInterval(interval)
-  }, [inFlight, startedAt, part.toolCallId])
+  }, [inFlight, startedAt, part.toolCallId, syncDegraded])
   const title = part.input?.description?.trim() || "Sub-agent task"
   const agent = agentName(part.input?.subagent_type ?? "")
   const status = inFlight
-    ? `Working ${formatElapsedSeconds(elapsedSeconds)}`
+    ? syncDegraded
+      ? "Connection lost — reconnecting…"
+      : `Working ${formatElapsedSeconds(elapsedSeconds)}`
     : isFailed
       ? part.errorText?.split("\n")[0]?.trim() || "Failed"
       : "Completed"
@@ -66,7 +70,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   const lines = (
     <>
       <span className="flex min-w-0 items-center gap-2">
-        <span className={cn("min-w-0 truncate", inFlight && "ow-text-shimmer")}>
+        <span className={cn("min-w-0 truncate", inFlight && !syncDegraded && "ow-text-shimmer")}>
           {title}
           <span className="text-muted-foreground/70"> · {agent} agent</span>
         </span>
@@ -89,7 +93,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
       <div
         data-subagent-run={part.toolCallId}
         data-subagent-session-id={childSessionId}
-        data-subagent-activity={inFlight ? "shimmer" : isFailed ? "failed" : "completed"}
+        data-subagent-activity={inFlight ? (syncDegraded ? "reconnecting" : "shimmer") : isFailed ? "failed" : "completed"}
         className={className}
       >
         <button
@@ -107,7 +111,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
   return (
     <Collapsible
       data-subagent-run={part.toolCallId}
-      data-subagent-activity={inFlight ? "shimmer" : isFailed ? "failed" : "completed"}
+      data-subagent-activity={inFlight ? (syncDegraded ? "reconnecting" : "shimmer") : isFailed ? "failed" : "completed"}
       open={open}
       onOpenChange={setOpen}
       className={className}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -89,10 +89,13 @@ import { deriveOpenTargets, sameOpenTargets, selectAutoOpenTarget, type OpenTarg
 import { usePanelTabStore } from "@/react-app/domains/session/panel/panel-tab-store";
 import {
   markSessionSnapshotFetchStart,
+  reconcileFailureDegradedThreshold,
   seedSessionState,
   snapshotKey as reactSnapshotKey,
   statusKey as reactStatusKey,
   transcriptKey as reactTranscriptKey,
+  useWorkspaceSyncStreamStore,
+  workspaceSyncStreamKey,
 } from "@/react-app/domains/session/sync/session-sync";
 import { resolveForkBoundaryId } from "@/react-app/domains/session/sync/transcript-reconcile";
 import {
@@ -1178,6 +1181,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const preparingCloudTools = props.cloudMcpSubmissionState.status === "checking" ||
     props.cloudMcpSubmissionState.status === "repairing";
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
+  // A busy status is a claim that decays: the sync layer revalidates it
+  // continuously against /session/status, and once that validation keeps
+  // failing (network drop, sleep, dead engine) the transcript must present
+  // "reconnecting" instead of a confidently ticking Working row.
+  const syncStreamKey = workspaceSyncStreamKey({ workspaceId: props.workspaceId, baseUrl: props.opencodeBaseUrl });
+  const syncReconcileHealth = useWorkspaceSyncStreamStore(
+    (state) => state.reconcileHealthByKey[syncStreamKey],
+  );
+  const runSyncHealth = useMemo(() => ({
+    degraded: (syncReconcileHealth?.consecutiveFailures ?? 0) >= reconcileFailureDegradedThreshold,
+    lastConfirmedAt: syncReconcileHealth?.lastSuccessAt ?? null,
+  }), [syncReconcileHealth]);
 
   useEffect(() => {
     if (!chatStreaming) setSteering(false);
@@ -2652,6 +2667,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       displaySuggestions={shellConfig.starterCards}
                       providerConnectedCount={props.providerConnectedCount ?? 0}
                       connectorIdentities={connectorIdentities}
+                      syncDegraded={runSyncHealth.degraded}
                       dispatchAction={handleMessageListDispatchAction}
                       setPrompt={handleMessageListSetPrompt}
                       onRevertToUserMessage={handleRevertToUserMessage}
@@ -2668,6 +2684,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                         status={status}
                         activityStatus={effectiveActivityStatus}
                         retryStatus={liveStatus.type === "retry" ? liveStatus : null}
+                        syncHealth={runSyncHealth}
                       />
                     </MessageListProvider>
                   </EnvironmentVariableProvider>

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -238,9 +238,43 @@ function syncKey(input: SyncOptions) {
   return `${input.workspaceId}:${input.baseUrl}`;
 }
 
+/**
+ * Freshness of the `/session/status` reconcile loop for one workspace stream.
+ * While any session is believed live that loop polls continuously, so it is
+ * the strongest liveness signal the renderer has: a run status is only as
+ * trustworthy as its latest successful validation. `lastSuccessAt` freezes at
+ * the moment validation started failing so surfaces can say when the run was
+ * last confirmed.
+ */
+export type WorkspaceSyncReconcileHealth = {
+  consecutiveFailures: number;
+  lastSuccessAt: number | null;
+};
+
+/**
+ * A busy status whose validation keeps failing must stop being presented as
+ * confident progress. Three consecutive failures tolerate a single transient
+ * blip while flagging a refused connection within about a second and a
+ * blackholed one within roughly three request timeouts (~30s).
+ */
+export const reconcileFailureDegradedThreshold = 3;
+
+// Cap the stored counter so an extended outage stops producing store updates
+// (and re-renders) once the degraded threshold is long past.
+const reconcileFailureCountCap = 99;
+
+// Non-reactive success times: healthy reconciles land every 250ms while a
+// run is live, and publishing each one through the store would notify
+// subscribers at that cadence for no visible change. The store is only
+// stamped on health transitions.
+const lastReconcileSuccessAtByKey = new Map<string, number>();
+
 type WorkspaceSyncStreamStore = {
   phasesByKey: Record<string, SyncStreamPhase>;
+  reconcileHealthByKey: Record<string, WorkspaceSyncReconcileHealth>;
   publishPhase: (key: string, phase: SyncStreamPhase) => void;
+  publishReconcileSuccess: (key: string, at: number) => void;
+  publishReconcileFailure: (key: string) => void;
   removePhase: (key: string) => void;
 };
 
@@ -252,21 +286,61 @@ type WorkspaceSyncStreamStore = {
  */
 export const useWorkspaceSyncStreamStore = create<WorkspaceSyncStreamStore>((set) => ({
   phasesByKey: {},
+  reconcileHealthByKey: {},
   publishPhase: (key, phase) => set((state) => ({
     phasesByKey: { ...state.phasesByKey, [key]: phase },
   })),
-  removePhase: (key) => set((state) => {
-    if (!(key in state.phasesByKey)) return state;
-    const next = { ...state.phasesByKey };
-    delete next[key];
-    return { phasesByKey: next };
+  publishReconcileSuccess: (key, at) => {
+    lastReconcileSuccessAtByKey.set(key, at);
+    set((state) => {
+      const current = state.reconcileHealthByKey[key];
+      if (!current || current.consecutiveFailures === 0) return state;
+      return {
+        reconcileHealthByKey: {
+          ...state.reconcileHealthByKey,
+          [key]: { consecutiveFailures: 0, lastSuccessAt: at },
+        },
+      };
+    });
+  },
+  publishReconcileFailure: (key) => set((state) => {
+    const current = state.reconcileHealthByKey[key] ?? { consecutiveFailures: 0, lastSuccessAt: null };
+    if (current.consecutiveFailures >= reconcileFailureCountCap) return state;
+    return {
+      reconcileHealthByKey: {
+        ...state.reconcileHealthByKey,
+        [key]: {
+          consecutiveFailures: current.consecutiveFailures + 1,
+          lastSuccessAt: current.consecutiveFailures === 0
+            ? lastReconcileSuccessAtByKey.get(key) ?? current.lastSuccessAt
+            : current.lastSuccessAt,
+        },
+      },
+    };
   }),
+  removePhase: (key) => {
+    lastReconcileSuccessAtByKey.delete(key);
+    set((state) => {
+      if (!(key in state.phasesByKey) && !(key in state.reconcileHealthByKey)) return state;
+      const nextPhases = { ...state.phasesByKey };
+      delete nextPhases[key];
+      const nextHealth = { ...state.reconcileHealthByKey };
+      delete nextHealth[key];
+      return { phasesByKey: nextPhases, reconcileHealthByKey: nextHealth };
+    });
+  },
 }));
+
+export function workspaceSyncStreamKey(
+  input: Pick<SyncOptions, "workspaceId" | "baseUrl">,
+): string {
+  return `${input.workspaceId}:${input.baseUrl}`;
+}
 
 export function getWorkspaceSessionSyncStreamPhase(
   input: Pick<SyncOptions, "workspaceId" | "baseUrl">,
 ): SyncStreamPhase | null {
-  return useWorkspaceSyncStreamStore.getState().phasesByKey[`${input.workspaceId}:${input.baseUrl}`] ?? null;
+  return useWorkspaceSyncStreamStore.getState().phasesByKey[workspaceSyncStreamKey(input)] ?? null;
 }
 
 function getErrorStatus(error: unknown) {
@@ -1283,9 +1357,18 @@ async function reconcileSessionRunStatuses(
   try {
     statuses = await sessionStatusFetcher(input.baseUrl, entry.openworkToken, signal);
   } catch {
+    // The run state itself is deliberately left untouched: a failed fetch is
+    // not evidence that work stopped. It is evidence that the busy state can
+    // no longer be validated, so record it where surfaces can stop
+    // presenting a confident ticking "Working" row. Aborted fetches are
+    // lifecycle noise (dispose, generation rotation), not failures.
+    if (!signal.aborted) {
+      useWorkspaceSyncStreamStore.getState().publishReconcileFailure(syncKey(input));
+    }
     return;
   }
   if (signal.aborted) return;
+  useWorkspaceSyncStreamStore.getState().publishReconcileSuccess(syncKey(input), startedAt);
 
   // Level-triggered convergence on every SSE (re)connect: sessions the fetch
   // reports live are seeded busy (heals a subscriber that missed the busy
@@ -1342,6 +1425,33 @@ function scheduleActiveSessionStatusReconciliation(entry: SyncEntry) {
       scheduleActiveSessionStatusReconciliation(entry);
     });
   }, activeSessionStatusReconcileIntervalMs);
+}
+
+/**
+ * A restored network (or a wake that brings it back) should not wait out
+ * retry backoff or the next watchdog tick: reconnect any parked stream with
+ * fresh backoff and revalidate run statuses immediately, so a run that ended
+ * or kept working while the machine was offline settles within one fetch.
+ */
+function revalidateWorkspaceSyncs() {
+  for (const entry of syncs.values()) {
+    entry.notifyStreamGenerationChanged?.();
+    const controller = new AbortController();
+    void reconcileSessionRunStatuses(entry, entry.input, controller.signal, "connect-reconcile");
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("online", revalidateWorkspaceSyncs);
+}
+
+export function __revalidateWorkspaceSyncsForTest() {
+  revalidateWorkspaceSyncs();
+}
+
+export function __resetWorkspaceSyncReconcileHealthForTest() {
+  lastReconcileSuccessAtByKey.clear();
+  useWorkspaceSyncStreamStore.setState({ reconcileHealthByKey: {} });
 }
 
 export function ensureWorkspaceSessionSync(input: SyncOptions) {

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -5,7 +5,10 @@ import type { UIMessage } from "ai";
 
 import {
   MessageList,
+  reconnectingLastConfirmedLabel,
   shouldShowMessageListLoading,
+  shouldShowRunReconnecting,
+  type RunSyncHealth,
 } from "../src/components/chat/message-list";
 import { MessageListProvider } from "../src/components/chat/message-list-provider";
 import type { ThreadStatus } from "../src/lib/messages";
@@ -16,7 +19,7 @@ const userMessage: UIMessage = {
   parts: [{ type: "text", text: "Send this", state: "done" }],
 };
 
-function renderList(messages: UIMessage[], status: ThreadStatus) {
+function renderList(messages: UIMessage[], status: ThreadStatus, syncHealth?: RunSyncHealth) {
   return renderToStaticMarkup(
     <MessageListProvider
       workspaceId="ws"
@@ -25,6 +28,7 @@ function renderList(messages: UIMessage[], status: ThreadStatus) {
       developerMode={false}
       displaySuggestions={false}
       providerConnectedCount={1}
+      syncDegraded={syncHealth?.degraded ?? false}
       dispatchAction={() => {}}
       setPrompt={() => {}}
       onRevertToUserMessage={() => {}}
@@ -34,7 +38,7 @@ function renderList(messages: UIMessage[], status: ThreadStatus) {
       onMcpReopenAuthorization={() => Promise.resolve()}
       onMcpRetry={() => {}}
     >
-      <MessageList messages={messages} status={status} />
+      <MessageList messages={messages} status={status} syncHealth={syncHealth} />
     </MessageListProvider>,
   );
 }
@@ -64,5 +68,53 @@ describe("message-list loading feedback", () => {
 
   test("does not duplicate working feedback when a tool row is visible", () => {
     expect(shouldShowMessageListLoading("streaming", 2, true)).toBe(false);
+  });
+});
+
+describe("message-list reconnecting feedback", () => {
+  test("replaces the ticking working row when run liveness cannot be validated", () => {
+    const markup = renderList([userMessage], "streaming", {
+      degraded: true,
+      lastConfirmedAt: Date.now() - 1_000,
+    });
+
+    expect(markup).toContain('data-loading-message="reconnecting"');
+    expect(markup).toContain("Connection lost — reconnecting…");
+    expect(markup).not.toContain("Working");
+    expect(markup).not.toContain("ow-text-shimmer");
+  });
+
+  test("keeps the confident working row while liveness is confirmed", () => {
+    const markup = renderList([userMessage], "streaming", {
+      degraded: false,
+      lastConfirmedAt: Date.now(),
+    });
+
+    expect(markup).toContain('data-loading-message="working"');
+    expect(markup).not.toContain('data-loading-message="reconnecting"');
+  });
+
+  test("names the last confirmed time once the outage is prolonged", () => {
+    const markup = renderList([userMessage], "streaming", {
+      degraded: true,
+      lastConfirmedAt: Date.now() - 3 * 60_000,
+    });
+
+    expect(markup).toContain("last update");
+  });
+
+  test("stays quiet without an active run even when the stream is degraded", () => {
+    expect(shouldShowRunReconnecting("ready", true)).toBe(false);
+    expect(shouldShowRunReconnecting("submitted", true)).toBe(true);
+    expect(shouldShowRunReconnecting("streaming", true)).toBe(true);
+    expect(shouldShowRunReconnecting("retrying", true)).toBe(true);
+    expect(shouldShowRunReconnecting("streaming", false)).toBe(false);
+  });
+
+  test("only surfaces the last confirmed hint after a meaningful gap", () => {
+    const now = 10 * 60_000;
+    expect(reconnectingLastConfirmedLabel(null, now)).toBeNull();
+    expect(reconnectingLastConfirmedLabel(now - 30_000, now)).toBeNull();
+    expect(reconnectingLastConfirmedLabel(now - 3 * 60_000, now)).not.toBeNull();
   });
 });

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -7,15 +7,20 @@ import {
   __applySessionSyncEventForTest,
   __createWorkspaceSessionSyncForTest,
   __disposeWorkspaceSessionSyncForTest,
+  __resetWorkspaceSyncReconcileHealthForTest,
+  __revalidateWorkspaceSyncsForTest,
   __setWorkspaceSessionSyncStatusFetcherForTest,
   __setWorkspaceSessionSyncSubscriptionFactoryForTest,
   ensureWorkspaceSessionSync,
   markSessionSnapshotFetchStart,
+  reconcileFailureDegradedThreshold,
   seedSessionState,
   snapshotKey,
   statusKey,
   trackWorkspaceSessionSync,
   transcriptKey,
+  useWorkspaceSyncStreamStore,
+  workspaceSyncStreamKey,
 } from "../src/react-app/domains/session/sync/session-sync";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 
@@ -167,6 +172,8 @@ afterEach(() => {
   __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
   __setWorkspaceSessionSyncStatusFetcherForTest(null);
   useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+  useWorkspaceSyncStreamStore.setState({ phasesByKey: {} });
+  __resetWorkspaceSyncReconcileHealthForTest();
   getReactQueryClient().clear();
   setSystemTime();
 });
@@ -634,6 +641,141 @@ describe("active session status reconciliation", () => {
     });
     expect(useSessionActivityStore.getState().getStatus(workspaceId, sessionId)).toBe("idle");
     expect(subscriptions[0]?.signal.aborted).toBe(false);
+
+    releaseSession();
+  });
+});
+
+describe("run status reconcile liveness health", () => {
+  // Distinct per-test stream keys: liveness health is keyed by
+  // workspace+baseUrl, and these assertions must not observe residue from
+  // other tests that share the default sync input.
+  function createHealthTestSync(label: string) {
+    const input = {
+      workspaceId,
+      baseUrl: `https://run-status-health-${label}.example/opencode`,
+      openworkToken: "token",
+    };
+    syncInputs.push(input);
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    return { input, cleanup, releaseSession };
+  }
+
+  test("records consecutive failed revalidations without fabricating idle", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      throw new Error("status unreachable");
+    });
+    const { input, cleanup, releaseSession } = createHealthTestSync("failures");
+
+    applyStatus(input, { type: "busy" });
+    for (let attempt = 0; attempt < reconcileFailureDegradedThreshold; attempt += 1) {
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+    }
+
+    const health = useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)];
+    expect(health?.consecutiveFailures).toBeGreaterThanOrEqual(reconcileFailureDegradedThreshold);
+    // A failed validation is evidence the busy state cannot be confirmed,
+    // never evidence that work stopped: the run state must stay busy.
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+    expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+
+    releaseSession();
+    cleanup();
+  });
+
+  test("freezes the last confirmed time at the first failure and resets on recovery", () => {
+    const key = "workspace-run-status:https://run-status-health-store.example/opencode";
+    const store = useWorkspaceSyncStreamStore.getState();
+
+    // Healthy validations do not create store records (they would notify
+    // subscribers every 250ms for no visible change); the success time is
+    // remembered so the first failure can freeze it.
+    store.publishReconcileSuccess(key, 200);
+    expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[key]).toBeUndefined();
+
+    store.publishReconcileFailure(key);
+    expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[key]).toEqual({
+      consecutiveFailures: 1,
+      lastSuccessAt: 200,
+    });
+
+    store.publishReconcileFailure(key);
+    expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[key]).toEqual({
+      consecutiveFailures: 2,
+      lastSuccessAt: 200,
+    });
+
+    store.publishReconcileSuccess(key, 400);
+    expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[key]).toEqual({
+      consecutiveFailures: 0,
+      lastSuccessAt: 400,
+    });
+  });
+
+  test("does not count aborted revalidations as failures", async () => {
+    jest.useFakeTimers();
+    setSystemTime(100);
+    __setWorkspaceSessionSyncStatusFetcherForTest(
+      (_baseUrl, _token, signal) => new Promise((_, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      }),
+    );
+    const { input, cleanup, releaseSession } = createHealthTestSync("aborted");
+
+    applyStatus(input, { type: "busy" });
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    // Dispose while the revalidation is in flight: the abort is lifecycle
+    // noise, not evidence of an unreachable engine.
+    releaseSession();
+    cleanup();
+    await flushMicrotasks();
+
+    expect(useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)]).toBeUndefined();
+  });
+
+  test("revalidates parked run state immediately when the network returns", async () => {
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
+    let failing = true;
+    let fetches = 0;
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => {
+      fetches += 1;
+      if (failing) throw new Error("status unreachable");
+      return {};
+    });
+    setSystemTime(100);
+    const input = {
+      workspaceId,
+      baseUrl: "https://run-status-health-online.example/opencode",
+      openworkToken: "token",
+    };
+    syncInputs.push(input);
+    ensureWorkspaceSessionSync(input);
+    const releaseSession = trackWorkspaceSessionSync(input, sessionId);
+    await waitForSubscriptions(1);
+    await flushMicrotasks();
+
+    setSystemTime(200);
+    applyStatus(input, { type: "busy" });
+    const fetchesBeforeOnline = fetches;
+
+    // The network comes back: revalidation must not wait for retry backoff
+    // or the next reconcile tick, and the authoritative answer (no live
+    // sessions) settles the run without a stream event.
+    failing = false;
+    setSystemTime(300);
+    __revalidateWorkspaceSyncsForTest();
+    await flushMicrotasks();
+
+    expect(fetches).toBeGreaterThan(fetchesBeforeOnline);
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(false);
+    const health = useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[workspaceSyncStreamKey(input)];
+    expect(health?.consecutiveFailures ?? 0).toBe(0);
 
     releaseSession();
   });

--- a/apps/server/src/engine-event-heartbeat.e2e.test.ts
+++ b/apps/server/src/engine-event-heartbeat.e2e.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { clearEnginePoolForConfig, computeEngineConfigFingerprint, type EngineSpawnTemplate } from "./engine-pool.js";
+import type { ManagedOpencodeServer } from "./managed-opencode.js";
+import { createEnginePoolForConfig, registerTrustedOpencodeProcess, startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+/**
+ * The merged engine event stream must keep quiet-but-healthy connections
+ * attestable: SSE comments are invisible to SSE parsers (they only yield
+ * frames with data lines), so the keepalive has to be a data-bearing
+ * heartbeat event. Otherwise the renderer's stale-stream watchdog cannot
+ * tell a healthy silent stream from a dead socket and churns reconnects.
+ */
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+const savedEnv = new Map<string, string | undefined>();
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  for (const [name, value] of savedEnv) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  savedEnv.clear();
+});
+
+function setEnv(name: string, value: string): void {
+  if (!savedEnv.has(name)) savedEnv.set(name, process.env[name]);
+  process.env[name] = value;
+}
+
+function startMockEngine() {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/event") {
+        // Held open and silent like a real engine between task events; ends
+        // when the proxy aborts it after its client disconnects.
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: {}\n\n"));
+          },
+        });
+        return new Response(body, { headers: { "content-type": "text/event-stream" } });
+      }
+      if (url.pathname === "/session/status") return Response.json({});
+      if (url.pathname === "/session") return Response.json([]);
+      if (url.pathname === "/mcp") return Response.json({});
+      if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
+    },
+  }) as Served & { port: number };
+  stops.push(() => server.stop(true));
+  return { url: `http://127.0.0.1:${server.port}` };
+}
+
+function syntheticManagedHandle(url: string): ManagedOpencodeServer {
+  return {
+    url,
+    username: "event-heartbeat-user",
+    password: "event-heartbeat-pass",
+    pid: null,
+    execution: { command: "opencode", args: [], cwd: "/", env: [] },
+    isAlive: () => true,
+    close: async () => undefined,
+  };
+}
+
+async function startPooledOpenworkServer(input: { root: string; engineUrl: string }) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_heartbeat",
+      name: "Heartbeat",
+      path: input.root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: input.engineUrl,
+    }],
+    authorizedRoots: [input.root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  registerTrustedOpencodeProcess(config, {
+    baseUrl: input.engineUrl,
+    identity: "test-event-heartbeat",
+    isAlive: () => true,
+  });
+  const runtimeConfigPath = join(input.root, ".opencode", "runtime-config.json");
+  await writeFile(runtimeConfigPath, "{}\n", "utf8");
+  const template: EngineSpawnTemplate = {
+    cwd: input.root,
+    runtimeConfigPath,
+    env: {},
+    reservedPorts: () => [],
+  };
+  const pool = createEnginePoolForConfig({
+    config,
+    template,
+    handle: syntheticManagedHandle(input.engineUrl),
+    fingerprint: await computeEngineConfigFingerprint(template),
+    registryId: null,
+    trustedIdentity: null,
+  });
+  stops.push(async () => {
+    clearEnginePoolForConfig(config);
+    await pool.disposeAll();
+  });
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+describe("engine event stream heartbeat", () => {
+  test("emits data-bearing heartbeats on a quiet stream instead of SSE comments", async () => {
+    setEnv("OPENWORK_ENGINE_EVENT_HEARTBEAT_MS", "50");
+    const root = await mkdtemp(join(tmpdir(), "openwork-event-heartbeat-"));
+    roots.push(root);
+    await mkdir(join(root, ".opencode"), { recursive: true });
+    const engine = startMockEngine();
+    const openwork = await startPooledOpenworkServer({ root, engineUrl: engine.url });
+
+    const controller = new AbortController();
+    const response = await fetch(`${openwork.base}/workspace/ws_heartbeat/opencode/event`, {
+      headers: { Authorization: `Bearer ${openwork.token}`, Accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    const deadline = Date.now() + 3_000;
+    let heartbeats = 0;
+    while (Date.now() < deadline && heartbeats < 2) {
+      const chunk = await Promise.race([
+        reader.read(),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 250)),
+      ]);
+      if (chunk === null) continue;
+      if (chunk.done) break;
+      buffered += decoder.decode(chunk.value, { stream: true });
+      heartbeats = (buffered.match(/data: \{"type":"server\.heartbeat"\}/g) ?? []).length;
+    }
+    controller.abort();
+    await reader.cancel().catch(() => undefined);
+
+    // Two heartbeats prove a periodic signal, not a one-shot frame. Comment
+    // keepalives would be dropped by SSE parsers before any liveness
+    // tracking, so none may remain.
+    expect(heartbeats).toBeGreaterThanOrEqual(2);
+    expect(buffered).not.toContain(": ping");
+  }, 20_000);
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1684,9 +1684,15 @@ function mergedEventBody(input: {
         }
       };
       for (const entry of readers) void pump(entry);
+      // A data-bearing heartbeat, not an SSE comment: SSE parsers only yield
+      // frames with data lines, so a `: ping` comment can keep middleboxes
+      // happy but is invisible to the client's stream-staleness tracking. The
+      // heartbeat lets a quiet-but-healthy stream attest liveness instead of
+      // being aborted as stale, and makes a silent half-open socket
+      // detectable within one stale window.
       pingTimer = setInterval(() => {
-        if (!closed && !cancelled) controller.enqueue(encoder.encode(": ping\n\n"));
-      }, 30_000);
+        if (!closed && !cancelled) controller.enqueue(encoder.encode(`data: {"type":"server.heartbeat"}\n\n`));
+      }, engineEventStreamHeartbeatIntervalMs());
       pingTimer.unref?.();
       input.lease.signal.addEventListener("abort", abort, { once: true });
       if (input.lease.signal.aborted) abort();
@@ -1705,6 +1711,14 @@ function mergedEventBody(input: {
 function engineEventStreamEstablishTimeoutMs(): number {
   const parsed = Number(process.env.OPENWORK_ENGINE_EVENT_ESTABLISH_TIMEOUT_MS ?? "5000");
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 5_000;
+}
+
+// 15s keeps two heartbeats inside the renderer's 30s stale-stream window, so
+// one lost beat never churns a healthy connection. Read lazily so tests can
+// shrink the interval at runtime.
+function engineEventStreamHeartbeatIntervalMs(): number {
+  const parsed = Number(process.env.OPENWORK_ENGINE_EVENT_HEARTBEAT_MS ?? "15000");
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15_000;
 }
 
 async function proxyEngineEventStreams(input: {

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -463,7 +463,8 @@
         "evals/specs/session-title-failure-warning.e2e.test.ts",
         "evals/specs/settings-visit-live-run-continuity.e2e.test.ts",
         "evals/specs/task-activity-shimmer.e2e.test.ts",
-        "evals/specs/unfinished-tool-lifecycle.e2e.test.ts"
+        "evals/specs/unfinished-tool-lifecycle.e2e.test.ts",
+        "evals/specs/working-status-liveness.e2e.test.ts"
       ]
     },
     {

--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -119,9 +119,9 @@ test("Daytona E2E regression profile excludes only audited shared-topology incom
   expect(categoryByTest.get("local-managed-mcp-oauth.e2e.test.ts")).toBe("raw-or-local-placement");
   expect(categoryByTest.get("slack-style-mcp-connector.e2e.test.ts")).toBe("raw-or-local-placement");
 
-  expect(inventory.all).toHaveLength(150);
+  expect(inventory.all).toHaveLength(151);
   expect(inventory.rawDesktop).toHaveLength(55);
-  expect(inventory.profile).toHaveLength(75);
+  expect(inventory.profile).toHaveLength(76);
   expect(inventory.eligible).toHaveLength(19);
   expect(inventory.rawDesktop).toContain("den-litellm-provider.e2e.test.ts");
   expect(inventory.eligible).not.toContain("org-team-lifecycle-critical-path.e2e.test.ts");

--- a/evals/specs/daytona-e2e-regression-profile.json
+++ b/evals/specs/daytona-e2e-regression-profile.json
@@ -358,6 +358,11 @@
       "reason": "requires a freshly booted Den Web/API origin for its Workflow dashboard assertions"
     },
     {
+      "test": "working-status-liveness.e2e.test.ts",
+      "category": "raw-or-local-placement",
+      "reason": "requires local placement with an actual OpenCode process it kills and restarts on one port"
+    },
+    {
       "test": "workspace-storm-auth-coherence.e2e.test.ts",
       "category": "fault-proxy",
       "reason": "requires all desktop Den traffic to traverse per-test latency and 401 fault proxies"

--- a/evals/specs/working-status-liveness.e2e.test.ts
+++ b/evals/specs/working-status-liveness.e2e.test.ts
@@ -1,0 +1,319 @@
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+import { expect } from "vitest";
+import { briefTest, claim, needs, testBrief } from "@openwork/testkit";
+
+import {
+  findFreePort,
+  makeClient,
+  spawnOpencodeServe,
+  waitForHealthy,
+} from "../../apps/app/scripts/_util.mjs";
+import { getReactQueryClient } from "../../apps/app/src/react-app/infra/query-client";
+import { useSessionActivityStore } from "../../apps/app/src/react-app/domains/session/status/session-activity-store";
+import {
+  __disposeWorkspaceSessionSyncForTest,
+  __resetWorkspaceSyncReconcileHealthForTest,
+  __setWorkspaceSessionSyncStatusFetcherForTest,
+  __setWorkspaceSessionSyncSubscriptionFactoryForTest,
+  ensureWorkspaceSessionSync,
+  reconcileFailureDegradedThreshold,
+  statusKey,
+  trackWorkspaceSessionSync,
+  useWorkspaceSyncStreamStore,
+  workspaceSyncStreamKey,
+} from "../../apps/app/src/react-app/domains/session/sync/session-sync";
+
+type TimelineEntry = {
+  boundary: string;
+  atMs: number;
+  detail?: Record<string, string | number | boolean | null>;
+};
+
+const modelId = "working-status-liveness";
+const providerId = "working-status-liveness-provider";
+
+function streamChunk(id: string, delta: Record<string, unknown>, finishReason: string | null = null) {
+  return {
+    id,
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+function writeFrame(response: ServerResponse, value: unknown) {
+  response.write(`data: ${JSON.stringify(value)}\n\n`);
+}
+
+function sleep(durationMs: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number) {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(20);
+  }
+  return predicate();
+}
+
+briefTest(testBrief({
+  behavior: "A live run whose engine becomes unreachable (network drop, sleep, dead process) is continuously revalidated: the failure is recorded within seconds so the transcript can stop presenting a confident ticking Working row, the busy state is never fabricated into idle, and reachability alone settles the run from authoritative status.",
+  claims: {
+    continuousValidation: claim("while a run is believed live, the sync layer keeps revalidating against /session/status and records consecutive failures once the engine is unreachable, crossing the degraded threshold within seconds", {
+      never: "swallow failed revalidations silently while a Working indicator keeps ticking",
+    }),
+    noFabricatedIdle: claim("an unreachable engine leaves the busy run state and status cache untouched", {
+      never: "invent idle or completion from elapsed time or from failed validation",
+    }),
+    degradedPresentation: claim("the recorded failure count crosses the exported threshold that flips the transcript from the ticking Working row to its reconnecting presentation, and the frozen last-confirmed time predates the outage", {
+      never: "present unvalidated elapsed time as confident progress",
+    }),
+    authoritativeRecovery: claim("once an engine answers on the same endpoint again, one revalidation settles the run from authoritative status and clears the degradation without a reload or timer expiry", {
+      never: "require user action or stream reconnect backoff to settle a reachable run",
+    }),
+  },
+}), async ({ prove, evidence }) => {
+  needs({
+    commands: ["opencode"],
+    optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+    placement: "local",
+  });
+
+  const startedAt = performance.now();
+  const timeline: TimelineEntry[] = [];
+  const stamp = (
+    boundary: string,
+    detail?: Record<string, string | number | boolean | null>,
+  ) => {
+    timeline.push({
+      boundary,
+      atMs: Math.round((performance.now() - startedAt) * 100) / 100,
+      ...(detail ? { detail } : {}),
+    });
+  };
+  const timeOf = (boundary: string) => timeline.find((entry) => entry.boundary === boundary)?.atMs;
+
+  const workspace = await mkdtemp(join(tmpdir(), "openwork-working-status-liveness-"));
+  await mkdir(join(workspace, ".opencode"), { recursive: true });
+  const workspaceId = "workspace-working-status-liveness";
+  let engineBaseUrl = "";
+
+  let provider: Server | null = null;
+  const heldProviderResponses: ServerResponse[] = [];
+  let engine: Awaited<ReturnType<typeof spawnOpencodeServe>> | null = null;
+  let restartedEngine: Awaited<ReturnType<typeof spawnOpencodeServe>> | null = null;
+  let releaseWorkspaceSync: (() => void) | null = null;
+  let releaseTrackedSession: (() => void) | null = null;
+  let syncInput: { workspaceId: string; baseUrl: string; openworkToken: string } | null = null;
+  let sessionId = "";
+  let statusFetchAttempts = 0;
+  let statusFetchAttemptsAtKill = 0;
+
+  useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+  __resetWorkspaceSyncReconcileHealthForTest();
+  getReactQueryClient().clear();
+
+  try {
+    const providerPort = await findFreePort();
+    provider = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "127.0.0.1"}`);
+      if (request.method === "GET" && url.pathname.endsWith("/models")) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+        return;
+      }
+      if (request.method !== "POST" || !url.pathname.endsWith("/chat/completions")) {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: { message: "not found" } }));
+        return;
+      }
+      request.resume();
+      request.on("end", () => {
+        response.writeHead(200, {
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+          "content-type": "text/event-stream",
+        });
+        // Emit a role chunk, then hold the stream open without a terminal
+        // marker: the engine's run stays genuinely busy for as long as this
+        // spec needs it to be.
+        writeFrame(response, streamChunk("chatcmpl-working-status-liveness", { role: "assistant" }));
+        heldProviderResponses.push(response);
+        stamp("provider.holding-run-open");
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      provider?.once("error", reject);
+      provider?.listen(providerPort, "127.0.0.1", resolve);
+    });
+    stamp("provider.listening");
+
+    await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      provider: {
+        [providerId]: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Working status liveness fixture",
+          options: {
+            apiKey: "fixture-key",
+            baseURL: `http://127.0.0.1:${providerPort}/v1`,
+          },
+          models: { [modelId]: { name: "Working status liveness fixture" } },
+        },
+      },
+    }, null, 2));
+
+    const enginePort = await findFreePort();
+    engine = await spawnOpencodeServe({ directory: workspace, port: enginePort });
+    engineBaseUrl = engine.baseUrl;
+    const client = makeClient({ baseUrl: engineBaseUrl, directory: workspace });
+    await waitForHealthy(client);
+    stamp("opencode.healthy");
+
+    syncInput = {
+      workspaceId,
+      baseUrl: engineBaseUrl,
+      openworkToken: "fixture-token",
+    };
+    const healthKey = workspaceSyncStreamKey(syncInput);
+    const reconcileHealth = () => useWorkspaceSyncStreamStore.getState().reconcileHealthByKey[healthKey];
+
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(async (_baseUrl, _token, signal) => {
+      const subscription = await client.event.subscribe({ directory: workspace }, { signal });
+      stamp("sync.event-stream-connected");
+      return subscription.stream;
+    });
+    __setWorkspaceSessionSyncStatusFetcherForTest(async (_baseUrl, _token, signal) => {
+      statusFetchAttempts += 1;
+      return await client.session.status(undefined, { signal }) as Record<string, SessionStatus>;
+    });
+
+    releaseWorkspaceSync = ensureWorkspaceSessionSync(syncInput);
+    const session = await client.session.create({ title: "Working status liveness" });
+    sessionId = session.id;
+    releaseTrackedSession = trackWorkspaceSessionSync(syncInput, sessionId);
+    stamp("opencode.session-created");
+
+    await client.session.promptAsync({
+      sessionID: sessionId,
+      model: { providerID: providerId, modelID: modelId },
+      parts: [{ type: "text", text: "Hold this run open." }],
+    });
+    stamp("opencode.prompt-accepted");
+
+    const runObservedBusy = await waitUntil(() => (
+      useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive === true
+      && heldProviderResponses.length > 0
+    ), 15_000);
+    expect(runObservedBusy).toBe(true);
+    const validatedWhileHealthy = await waitUntil(() => statusFetchAttempts >= 2, 5_000);
+    expect(validatedWhileHealthy).toBe(true);
+    expect(reconcileHealth()?.consecutiveFailures ?? 0).toBe(0);
+    stamp("sync.run-busy-and-validated", { statusFetchAttempts });
+
+    // The engine dies abruptly mid-run — the local stand-in for a network
+    // drop, a laptop sleep that severed connections, or a crashed engine.
+    statusFetchAttemptsAtKill = statusFetchAttempts;
+    engine.child.kill("SIGKILL");
+    stamp("engine.killed");
+
+    const degraded = await waitUntil(
+      () => (reconcileHealth()?.consecutiveFailures ?? 0) >= reconcileFailureDegradedThreshold,
+      10_000,
+    );
+    stamp("sync.degraded-threshold-crossed", {
+      consecutiveFailures: reconcileHealth()?.consecutiveFailures ?? 0,
+      attemptsSinceKill: statusFetchAttempts - statusFetchAttemptsAtKill,
+    });
+    const runStillBusyWhileUnreachable =
+      useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive === true;
+    const statusCacheStillBusy =
+      (getReactQueryClient().getQueryData<SessionStatus>(statusKey(workspaceId, sessionId)))?.type === "busy";
+    const lastConfirmedAt = reconcileHealth()?.lastSuccessAt ?? null;
+
+    const killAt = timeOf("engine.killed");
+    const degradedAt = timeOf("sync.degraded-threshold-crossed");
+    const killToDegradedMs = (degradedAt ?? Infinity) - (killAt ?? 0);
+
+    prove.continuousValidation(
+      degraded
+      && statusFetchAttempts - statusFetchAttemptsAtKill >= reconcileFailureDegradedThreshold
+      && killToDegradedMs < 10_000,
+      `After the engine was killed mid-run, the live reconcile loop kept attempting /session/status (${statusFetchAttempts - statusFetchAttemptsAtKill} attempts) and recorded ${reconcileHealth()?.consecutiveFailures ?? 0} consecutive failures, crossing the degraded threshold ${killToDegradedMs.toFixed(0)}ms after the kill.`,
+    );
+    prove.noFabricatedIdle(
+      runStillBusyWhileUnreachable && statusCacheStillBusy,
+      "While the engine was unreachable, the activity record stayed runActive and the status cache stayed busy: failed validation was recorded as degraded health, never converted into a fabricated idle.",
+    );
+    prove.degradedPresentation(
+      (reconcileHealth()?.consecutiveFailures ?? 0) >= reconcileFailureDegradedThreshold
+      && lastConfirmedAt !== null
+      && lastConfirmedAt <= Date.now(),
+      `The recorded failure count (${reconcileHealth()?.consecutiveFailures}) meets reconcileFailureDegradedThreshold (${reconcileFailureDegradedThreshold}) — the exact store input the session surface maps to the reconnecting row with its timer frozen — and the frozen last-confirmed time (${lastConfirmedAt}) predates the outage.`,
+    );
+
+    // The engine returns on the same endpoint. A fresh engine has no busy
+    // session, so authoritative status settles the stale busy run to idle and
+    // the recorded degradation clears — with no reload and no reliance on
+    // stream reconnect backoff.
+    restartedEngine = await spawnOpencodeServe({ directory: workspace, port: enginePort });
+    stamp("engine.restarted");
+    const recovered = await waitUntil(() => (
+      useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive === false
+      && (reconcileHealth()?.consecutiveFailures ?? 0) === 0
+    ), 10_000);
+    stamp("sync.recovered", {
+      consecutiveFailures: reconcileHealth()?.consecutiveFailures ?? 0,
+    });
+    const restartAt = timeOf("engine.restarted");
+    const recoveredAt = timeOf("sync.recovered");
+    const restartToRecoveredMs = (recoveredAt ?? Infinity) - (restartAt ?? 0);
+    const statusCacheIdleAfterRecovery =
+      (getReactQueryClient().getQueryData<SessionStatus>(statusKey(workspaceId, sessionId)))?.type === "idle";
+
+    prove.authoritativeRecovery(
+      recovered && statusCacheIdleAfterRecovery && restartToRecoveredMs < 10_000,
+      `After an engine answered on the same endpoint again, the run settled from authoritative status within ${restartToRecoveredMs.toFixed(0)}ms: runActive cleared, the status cache read idle, and consecutive failures reset to ${reconcileHealth()?.consecutiveFailures ?? 0}.`,
+    );
+
+    evidence.recordJsonArtifact("working status liveness timeline", {
+      schemaVersion: 1,
+      timings: timeline,
+      counters: {
+        statusFetchAttempts,
+        attemptsSinceKill: statusFetchAttempts - statusFetchAttemptsAtKill,
+        degradedThreshold: reconcileFailureDegradedThreshold,
+      },
+    });
+  } finally {
+    releaseTrackedSession?.();
+    releaseWorkspaceSync?.();
+    if (syncInput) __disposeWorkspaceSessionSyncForTest(syncInput);
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(null);
+    __setWorkspaceSessionSyncStatusFetcherForTest(null);
+    useSessionActivityStore.setState({ recordsByWorkspaceId: {}, statusesByWorkspaceId: {} });
+    __resetWorkspaceSyncReconcileHealthForTest();
+    getReactQueryClient().clear();
+    for (const held of heldProviderResponses) {
+      try {
+        held.end();
+      } catch {
+        // Already closed with its engine.
+      }
+    }
+    await engine?.close();
+    await restartedEngine?.close();
+    if (provider) {
+      provider.closeAllConnections();
+      await new Promise<void>((resolve) => provider?.close(() => resolve()));
+    }
+    await rm(workspace, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

A network drop, laptop sleep, or dead engine leaves the transcript's live **"Working Xm Ys"** row ticking forever (users have watched it pass 38 minutes with nothing behind it). Four verified gaps compound:

- Busy status is latched on positive evidence only: `session.status`/`session.idle`/`session.error` edges or a **successful** `/session/status` reconcile. No layer downgrades confidence when evidence stops arriving.
- Failed reconciles are swallowed (`catch { return; }`) and rescheduled forever, invisibly.
- The engine event-stream keepalive is an SSE **comment** (`: ping`), which SSE parsers drop before liveness tracking — so the renderer's 30s stale-stream watchdog can't tell a healthy quiet stream from a dead socket and churns healthy connections through reconnects.
- Nothing revalidates immediately when connectivity returns; the first paint after sleep shows the whole gap as confident "worked" time.

## Change

Treat busy as a **validated lease**, reusing the machinery that already exists (the 250ms active-status reconcile loop is the continuous health check — it was just blind and unconsumed):

- **Failure ledger:** consecutive failed status revalidations (and the frozen last-confirmed time) are recorded per workspace stream in the existing sync stream store. Aborted fetches don't count. A failure never touches run state itself — absence of evidence never fabricates idle, so legitimately long runs are safe.
- **Honest transcript state:** past `reconcileFailureDegradedThreshold` (3 — ~1s for refused connections, ~3 request timeouts for blackholes), the ticking Working row is replaced by `Connection lost — reconnecting…` with the timer frozen (`data-loading-message="reconnecting"`), plus a "last update HH:MM" hint once the outage exceeds two minutes. The sub-agent Working line freezes the same way. Recovery settles only from authoritative status and resumes the true task age.
- **Visible heartbeat:** the merged engine event stream now emits `data: {"type":"server.heartbeat"}` (default 15s, env-tunable) instead of the `: ping` comment, so two beats fit inside the renderer's 30s stale window; quiet-but-healthy streams stop being aborted as stale, and real half-open sockets become detectable.
- **Online nudge:** on the window `online` event every workspace sync reconnects parked streams with fresh backoff and revalidates run statuses immediately, so post-sleep/offline state converges within one fetch instead of waiting out backoff.

## Proof

- `pnpm evals:e2e working-status-liveness --local` at this exact head — **passed (1/0/0)**: a real OpenCode engine runs a genuinely busy session (held-open provider stream), is SIGKILLed mid-run, the failure ledger crosses the degraded threshold in bounded time while run state stays busy (no fabricated idle), then an engine restarted on the same endpoint settles the run to idle and clears degradation within one revalidation. Runs cold-boot per invocation; also passed twice pre-rebase. Daytona credentials are unavailable in this environment and the spec family (like `session-completion-reconciliation`) declares `placement: "local"`, so local is the eligible lane.
- New spec registered under the `desktop.sessions-engine` contract; `vitest run specs/spec-impact.test.ts` — passed (6/6).
- `bun test --isolate` on the six owning app suites (message-list loading/reconnecting, session-sync run-status/lifecycle/token-rotation/permissions/tool-parts) — **71 pass, 0 fail** (three consecutive runs).
- `bun --conditions=development test src/engine-event-heartbeat.e2e.test.ts` — passed: a quiet proxied stream emits ≥2 data-bearing heartbeats and no comment frames (through the real server + engine pool with a mock engine).
- `apps/app` and `apps/server` `tsc --noEmit` — clean. `git diff --check` — clean.
- Full `apps/app` suite: 1121 pass, 5 fail — the identical five failures reproduce with the same command on a clean `dev` control worktree at the same base (all five pass in isolation in both trees), so they are pre-existing full-suite ordering flakes unrelated to this change (`connect-capability-inventory`, `cloud-workspace-overlay`, `session-provider-auth-server-sync`, `extensions-sidebar-header`).

## Notes for review

- Store updates are transition-only (healthy validations don't notify subscribers every 250ms; the failure counter caps at 99), so there is no render churn from the ledger.
- UI strings follow the existing hardcoded-English pattern of the Working row itself.
- The `evals` workspace `tsc -p .` lane is broadly red on clean `dev` (582 errors on a control worktree, same import-resolution classes on the sibling spec); the new spec matches sibling conventions and runs green under the Vitest transform.
