### PR TITLE
docs(helm): surface Automations flags in every starter example

### DIFF
--- a/packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml
+++ b/packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml
@@ -39,6 +39,11 @@ config:
     webAppHosts: "pending-web-nlb"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "http://pending-web-nlb:3005"
+    # Automations are opt-in for self-hosted deployments and stay hidden until
+    # enabled. Set both values to "true" to turn them on. See the "Automations
+    # rollout" section in the chart README before changing either value.
+    automationsEnabled: "false"
+    automationsRuntimeEnabled: "true"
   provisioner:
     mode: stub
 

--- a/packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
+++ b/packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
@@ -39,6 +39,11 @@ config:
     webAppHosts: "REPLACE_WEB_HOST"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "https://REPLACE_WEB_HOST"
+    # Automations are opt-in for self-hosted deployments and stay hidden until
+    # enabled. Set both values to "true" to turn them on. See the "Automations
+    # rollout" section in the chart README before changing either value.
+    automationsEnabled: "false"
+    automationsRuntimeEnabled: "true"
   provisioner:
     mode: stub
 

--- a/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
@@ -41,6 +41,11 @@ config:
     webAppHosts: "REPLACE_WEB_HOST"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "https://REPLACE_WEB_HOST"
+    # Automations are opt-in for self-hosted deployments and stay hidden until
+    # enabled. Set both values to "true" to turn them on. See the "Automations
+    # rollout" section in the chart README before changing either value.
+    automationsEnabled: "false"
+    automationsRuntimeEnabled: "true"
   provisioner:
     mode: stub
 

--- a/packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml
@@ -39,6 +39,11 @@ config:
     webAppHosts: "REPLACE_WEB_HOST"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "https://REPLACE_WEB_HOST"
+    # Automations are opt-in for self-hosted deployments and stay hidden until
+    # enabled. Set both values to "true" to turn them on. See the "Automations
+    # rollout" section in the chart README before changing either value.
+    automationsEnabled: "false"
+    automationsRuntimeEnabled: "true"
   provisioner:
     mode: stub
 


### PR DESCRIPTION
## Why

Self-hosted Automations are opt-in and fail closed (`config.public.automationsEnabled: "false"`), but none of the starter example values files under `packaging/helm/openwork-ee/examples/` mention the flags. A customer trying to enable Automations guessed at nonexistent keys (a top-level `automation:` block with an `OPENWORK_AUTOMATION_ENABLED` env var), which Helm silently ignored because the chart has no values schema.

## What

Add `automationsEnabled` and `automationsRuntimeEnabled` to all four starter examples, set to the chart defaults (`"false"` / `"true"`), with a comment pointing to the **Automations rollout** section of the chart README. Behavior of every example is unchanged; the flags are now visible where operators actually copy values from.

## Proof

Config-only change to example values; no runtime-observable product behavior. Focused checks on this head:

- `helm template test . -f <example>` for each of the four examples renders `DEN_AUTOMATIONS_ENABLED: "false"` and `DEN_AUTOMATIONS_RUNTIME_ENABLED: "true"` — passed
- `bash tests/automations-enabled.sh` — passed (`automations-enabled chart checks passed`)