### PR TITLE
feat(world): stage-isolated receipts, plan, and idempotent up for script worlds

### DIFF
--- a/evals/packages/env/src/index.ts
+++ b/evals/packages/env/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./place.ts";
+export * from "./recipe.ts";
 export * from "./needs.ts";
 export * from "./mock.ts";
 export * from "./den.ts";

--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -272,7 +272,9 @@ class DaytonaPlace implements Place {
 
 /** Resolve placement once; resources never inspect placement environment again. */
 export function resolvePlace(env: NodeJS.ProcessEnv = process.env): Place {
-  const useDaytona = env.OPENWORK_EVAL_DAYTONA?.trim() === "1";
+  const worldPlace = env.OPENWORK_WORLD_PLACE?.trim() || undefined;
+  const useDaytona = worldPlace === "daytona"
+    || (worldPlace === undefined && env.OPENWORK_EVAL_DAYTONA?.trim() === "1");
   if (useDaytona) {
     const ref = env.OPENWORK_EVAL_REF?.trim() || env.GITHUB_SHA?.trim() || "dev";
     return new DaytonaPlace(ref, env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim());

--- a/evals/packages/env/src/recipe.ts
+++ b/evals/packages/env/src/recipe.ts
@@ -1,0 +1,36 @@
+import { assertWorldName, defaultDisplayStage, hold, resolveStage } from "@openwork/world";
+import { resolvePlace, type Place } from "./place.ts";
+
+export interface RecipeTools {
+  stack: AsyncDisposableStack;
+  place: Place;
+  stage: string;
+  stageName(base: string): string;
+}
+
+export interface WorldRecipe<O extends Record<string, string> = Record<string, string>> {
+  kind: "recipe";
+  name: string;
+  build(tools: RecipeTools): Promise<O>;
+}
+
+export function recipe<O extends Record<string, string>>(
+  name: string,
+  build: (tools: RecipeTools) => Promise<O>,
+): WorldRecipe<O> {
+  assertWorldName(name);
+  return { kind: "recipe", name, build };
+}
+
+export async function runRecipe(def: WorldRecipe): Promise<void> {
+  await using stack = new AsyncDisposableStack();
+  const stage = resolveStage(process.env) ?? defaultDisplayStage(process.env);
+  const place = resolvePlace();
+  const outputs = await def.build({
+    stack,
+    place,
+    stage,
+    stageName: (base) => `${base} (${stage})`,
+  });
+  await hold({ name: def.name, outputs });
+}

--- a/evals/specs/script-world-lifecycle.test.ts
+++ b/evals/specs/script-world-lifecycle.test.ts
@@ -119,8 +119,8 @@ if (import.meta.main) await main();
     assert.equal(await probe(snapshot.outputs.url), 200);
 
     const duplicate = await run(upCommand);
-    assert.equal(duplicate.code, 1);
-    assert.match(duplicate.lines.join("\n"), /already running.*world down healthy-world.*first/is);
+    assert.equal(duplicate.code, 0, duplicate.lines.join("\n"));
+    assert.match(duplicate.lines.join("\n"), /World "healthy-world" is already running \(pid \d+\); adopted\./);
     const afterDuplicate = await readScriptWorldSnapshot(snapshotPath);
     assert.ok(afterDuplicate);
     assert.equal(afterDuplicate.pid, launchedPid);
@@ -173,7 +173,7 @@ if (import.meta.main) await main();
     );
     evidence.recordAssertionEvidence(
       "Duplicate launch and unknown teardown are isolated",
-      "Both operations failed without replacing the pid, duplicating snapshots, stopping the original probe, or running disposal.",
+      "Duplicate launch adopted the existing pid, while unknown teardown failed without duplicating snapshots, stopping the original probe, or running disposal.",
       true,
     );
     evidence.recordAssertionEvidence(

--- a/evals/specs/world-plan-idempotent-up.test.ts
+++ b/evals/specs/world-plan-idempotent-up.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { access, appendFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { eventually, test } from "@openwork/testkit";
+import {
+  isProcessAlive,
+  main,
+  readScriptWorldSnapshot,
+  type WorldCliOptions,
+} from "@openwork/world";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+interface ProbeResult {
+  status: number;
+  body: string;
+}
+
+async function probe(url: string): Promise<ProbeResult | "rejected"> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+    return { status: response.status, body: await response.text() };
+  } catch {
+    return "rejected";
+  }
+}
+
+async function exitedNodePid(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", ""]);
+  if (child.pid === undefined) throw new Error("Expected the dead-pid helper to have a pid.");
+  const pid = child.pid;
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", () => resolve());
+  });
+  return pid;
+}
+
+test("plan classifies and up adopts without duplicating worlds", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-plan-idempotent-"));
+  const worldsDirectory = join(root, "worlds");
+  const scriptsDirectory = join(root, ".worlds", "scripts");
+  const fixtureName = "idempotent-world";
+  const fixturePath = join(worldsDirectory, `${fixtureName}.ts`);
+  const snapshotPath = join(scriptsDirectory, `${fixtureName}.json`);
+  const logPath = join(scriptsDirectory, `${fixtureName}.log`);
+  const holdUrl = pathToFileURL(join(REPO_ROOT, "packages", "world", "src", "hold.ts")).href;
+  const previousSnapshotDirectory = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  const previousStage = process.env.OPENWORK_WORLD_STAGE;
+  const launchedPids = new Set<number>();
+  let printedLines: string[] = [];
+
+  const options: WorldCliOptions = {
+    cwd: root,
+    worldsDirectory,
+    print(line) {
+      printedLines.push(line);
+    },
+  };
+  const run = async (argv: string[]): Promise<{ code: number; lines: string[] }> => {
+    printedLines = [];
+    const code = await main(argv, options);
+    return { code, lines: [...printedLines] };
+  };
+
+  try {
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR = scriptsDirectory;
+    delete process.env.OPENWORK_WORLD_STAGE;
+    await mkdir(worldsDirectory);
+    await mkdir(scriptsDirectory, { recursive: true });
+    const fixtureSource = `
+import { createServer } from "node:http";
+import { hold } from ${JSON.stringify(holdUrl)};
+
+export async function main(): Promise<void> {
+  await using stack = new AsyncDisposableStack();
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.end("ok");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  stack.use({
+    async [Symbol.asyncDispose](): Promise<void> {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    },
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("Expected an assigned TCP address.");
+  await hold({ outputs: { url: \`http://127.0.0.1:\${address.port}\` } });
+}
+
+if (import.meta.main) await main();
+`;
+    await writeFile(fixturePath, fixtureSource, "utf8");
+
+    const initialPlan = await run(["plan", fixturePath]);
+    assert.equal(initialPlan.code, 0, initialPlan.lines.join("\n"));
+    assert.deepEqual(initialPlan.lines, ["+ create", `receipt  ${snapshotPath}`]);
+    assert.equal(await exists(snapshotPath), false);
+    assert.deepEqual(await readdir(scriptsDirectory), []);
+    evidence.recordAssertionEvidence(
+      "Plan reports create without mutating snapshots",
+      "Before launch, plan printed the exact create classification and receipt path while leaving the receipt absent and snapshot directory empty.",
+      true,
+    );
+
+    const firstUp = await run(["up", fixturePath, "--detach", "--timeout", "10000"]);
+    assert.equal(firstUp.code, 0, firstUp.lines.join("\n"));
+    const first = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(first);
+    launchedPids.add(first.pid);
+    assert.equal(first.version, 2);
+    assert.match(first.recipeHash ?? "", /^sha256:[0-9a-f]{64}$/);
+    const firstProbe = await probe(first.outputs.url);
+    assert.deepEqual(firstProbe, { status: 200, body: "ok" });
+    evidence.recordAssertionEvidence(
+      "First up records a hashed live recipe",
+      "The first detached launch wrote a version-2 receipt with a sha256 recipe hash and exposed an HTTP 200 endpoint.",
+      true,
+    );
+
+    const runningPlan = await run(["plan", fixturePath]);
+    assert.equal(runningPlan.code, 0, runningPlan.lines.join("\n"));
+    assert.deepEqual(runningPlan.lines, [
+      "• running (attachable)",
+      `receipt  ${snapshotPath}`,
+      `url  ${first.outputs.url}`,
+    ]);
+    evidence.recordAssertionEvidence(
+      "Plan identifies an attachable matching runtime",
+      "With the hashed process alive, plan printed the exact running classification, receipt path, and URL output line.",
+      true,
+    );
+
+    const secondUp = await run(["up", fixturePath, "--detach", "--timeout", "10000"]);
+    assert.equal(secondUp.code, 0, secondUp.lines.join("\n"));
+    assert.match(secondUp.lines.join("\n"), /World ".*" is already running \(pid \d+\); adopted\./);
+    const adopted = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(adopted);
+    assert.equal(adopted.pid, first.pid);
+    assert.equal(adopted.outputs.url, first.outputs.url);
+    assert.deepEqual(await probe(adopted.outputs.url), firstProbe);
+    assert.deepEqual((await readdir(scriptsDirectory)).sort(), [
+      `${fixtureName}.json`,
+      `${fixtureName}.log`,
+    ]);
+    assert.equal(await exists(logPath), true);
+    evidence.recordAssertionEvidence(
+      "Identical up adopts without duplication",
+      "A second identical up printed the adopted message, retained the original pid, URL, body, and port, and left exactly the original receipt/log pair.",
+      true,
+    );
+
+    await appendFile(fixturePath, "\n// recipe hash change\n", "utf8");
+    const stalePlan = await run(["plan", fixturePath]);
+    assert.equal(stalePlan.code, 0, stalePlan.lines.join("\n"));
+    assert.deepEqual(stalePlan.lines, [
+      "~ stale (recipe changed)",
+      `receipt  ${snapshotPath}`,
+      `url  ${first.outputs.url}`,
+    ]);
+    const changedUp = await run(["up", fixturePath, "--detach", "--timeout", "10000"]);
+    assert.equal(changedUp.code, 1, changedUp.lines.join("\n"));
+    assert.deepEqual(changedUp.lines, [
+      `World "${fixtureName}" is running but its recipe changed; run pnpm world down ${fixtureName} first.`,
+    ]);
+    assert.equal(isProcessAlive(first.pid), true);
+    assert.deepEqual(await probe(first.outputs.url), { status: 200, body: "ok" });
+    evidence.recordAssertionEvidence(
+      "Recipe changes are reported without replacing the runtime",
+      "Plan printed the exact stale classification and up rejected with the exact recipe-changed message while the original pid and HTTP endpoint remained live.",
+      true,
+    );
+
+    const firstDown = await run(["down", fixtureName]);
+    assert.equal(firstDown.code, 0, firstDown.lines.join("\n"));
+    assert.deepEqual(firstDown.lines, [`World "${fixtureName}" torn down.`]);
+    await eventually(async () => !isProcessAlive(first.pid) && await probe(first.outputs.url) === "rejected", {
+      within: 10_000,
+      intervalMs: 50,
+      label: "original idempotent fixture stops",
+    });
+    const deadPid = await exitedNodePid();
+    assert.equal(isProcessAlive(deadPid), false);
+    await writeFile(snapshotPath, `${JSON.stringify({
+      version: 2,
+      kind: "script",
+      name: fixtureName,
+      createdAt: new Date().toISOString(),
+      pid: deadPid,
+      sourcePath: fixturePath,
+      outputs: { url: first.outputs.url },
+      recipeHash: first.recipeHash,
+    }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    const orphanPlan = await run(["plan", fixturePath]);
+    assert.equal(orphanPlan.code, 0, orphanPlan.lines.join("\n"));
+    assert.deepEqual(orphanPlan.lines, [
+      "- orphaned (stale receipt, will recreate)",
+      `receipt  ${snapshotPath}`,
+      `url  ${first.outputs.url}`,
+    ]);
+    assert.equal(await exists(snapshotPath), true);
+
+    await writeFile(fixturePath, fixtureSource, "utf8");
+    const recreatedUp = await run(["up", fixturePath, "--detach", "--timeout", "10000"]);
+    assert.equal(recreatedUp.code, 0, recreatedUp.lines.join("\n"));
+    assert.equal(recreatedUp.lines[0], `Removed stale world receipt "${fixtureName}" (pid ${deadPid}); recreating.`);
+    const recreated = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(recreated);
+    launchedPids.add(recreated.pid);
+    assert.notEqual(recreated.pid, first.pid);
+    assert.notEqual(recreated.pid, deadPid);
+    assert.equal(isProcessAlive(recreated.pid), true);
+    assert.deepEqual(await probe(recreated.outputs.url), { status: 200, body: "ok" });
+    evidence.recordAssertionEvidence(
+      "Orphan planning is read-only and up recreates stale state",
+      "After teardown, plan classified a hand-written dead-pid receipt as orphaned without removing it; restored-source up printed stale removal and launched a distinct live pid.",
+      true,
+    );
+
+    const finalDown = await run(["down", fixtureName]);
+    assert.equal(finalDown.code, 0, finalDown.lines.join("\n"));
+    assert.deepEqual(finalDown.lines, [`World "${fixtureName}" torn down.`]);
+    const missingDown = await run(["down", fixtureName]);
+    assert.equal(missingDown.code, 1, missingDown.lines.join("\n"));
+    assert.deepEqual(missingDown.lines, [`World receipt "${fixtureName}" does not exist.`]);
+    evidence.recordAssertionEvidence(
+      "Final teardown is idempotently observable",
+      "The recreated world tore down successfully, and a second down returned exit 1 with the exact missing-receipt message.",
+      true,
+    );
+  } finally {
+    delete process.env.OPENWORK_WORLD_STAGE;
+    try {
+      const snapshot = await readScriptWorldSnapshot(snapshotPath);
+      if (snapshot && isProcessAlive(snapshot.pid)) {
+        await main(["down", fixtureName], { ...options, print: () => {} });
+      }
+    } catch {}
+    for (const pid of launchedPids) {
+      if (!isProcessAlive(pid)) continue;
+      try { process.kill(pid, "SIGKILL"); } catch {}
+      try {
+        await eventually(() => !isProcessAlive(pid), {
+          within: 2_000,
+          intervalMs: 25,
+          label: "idempotent fixture cleanup",
+        });
+      } catch {}
+    }
+    if (previousSnapshotDirectory === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previousSnapshotDirectory;
+    if (previousStage === undefined) delete process.env.OPENWORK_WORLD_STAGE;
+    else process.env.OPENWORK_WORLD_STAGE = previousStage;
+    await rm(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/evals/specs/world-stage-isolation.test.ts
+++ b/evals/specs/world-stage-isolation.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { eventually, test } from "@openwork/testkit";
+import {
+  isProcessAlive,
+  main,
+  readScriptWorldSnapshot,
+  type WorldCliOptions,
+} from "@openwork/world";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+async function probe(url: string): Promise<number | "rejected"> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+    await response.text();
+    return response.status;
+  } catch {
+    return "rejected";
+  }
+}
+
+test("staged worlds run side by side without touching each other", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-stage-isolation-"));
+  const worldsDirectory = join(root, "worlds");
+  const scriptsDirectory = join(root, ".worlds", "scripts");
+  const fixtureName = "staged-recipe-world";
+  const fixturePath = join(worldsDirectory, `${fixtureName}.ts`);
+  const bareSnapshotPath = join(scriptsDirectory, `${fixtureName}.json`);
+  const stageAPath = join(scriptsDirectory, `${fixtureName}--a.json`);
+  const stageBPath = join(scriptsDirectory, `${fixtureName}--b.json`);
+  const stageCPath = join(scriptsDirectory, `${fixtureName}--c.json`);
+  const recipeUrl = pathToFileURL(join(REPO_ROOT, "evals", "packages", "env", "src", "recipe.ts")).href;
+  const previousSnapshotDirectory = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  const previousStage = process.env.OPENWORK_WORLD_STAGE;
+  const launchedPids = new Set<number>();
+  let printedLines: string[] = [];
+
+  const options: WorldCliOptions = {
+    cwd: root,
+    worldsDirectory,
+    print(line) {
+      printedLines.push(line);
+    },
+  };
+  const run = async (argv: string[]): Promise<{ code: number; lines: string[] }> => {
+    printedLines = [];
+    const code = await main(argv, options);
+    return { code, lines: [...printedLines] };
+  };
+
+  try {
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR = scriptsDirectory;
+    delete process.env.OPENWORK_WORLD_STAGE;
+    await mkdir(worldsDirectory);
+    await writeFile(fixturePath, `
+import { createServer } from "node:http";
+import { recipe, runRecipe } from ${JSON.stringify(recipeUrl)};
+
+const world = recipe(${JSON.stringify(fixtureName)}, async (tools) => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.end("ok");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  tools.stack.use({
+    async [Symbol.asyncDispose](): Promise<void> {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    },
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("Expected an assigned TCP address.");
+  return { url: \`http://127.0.0.1:\${address.port}\`, orgLabel: tools.stageName("Org") };
+});
+
+export default world;
+if (import.meta.main) await runRecipe(world);
+`, "utf8");
+
+    const stageAUp = await run(["up", fixturePath, "--detach", "--stage", "a", "--timeout", "10000"]);
+    assert.equal(stageAUp.code, 0, stageAUp.lines.join("\n"));
+    const stageBUp = await run(["up", fixturePath, "--detach", "--stage", "b", "--timeout", "10000"]);
+    assert.equal(stageBUp.code, 0, stageBUp.lines.join("\n"));
+    const stageA = await readScriptWorldSnapshot(stageAPath);
+    const stageB = await readScriptWorldSnapshot(stageBPath);
+    assert.ok(stageA);
+    assert.ok(stageB);
+    launchedPids.add(stageA.pid);
+    launchedPids.add(stageB.pid);
+    assert.notEqual(stageAPath, stageBPath);
+    assert.equal(stageA.version, 2);
+    assert.equal(stageB.version, 2);
+    assert.equal(stageA.stage, "a");
+    assert.equal(stageB.stage, "b");
+    assert.notEqual(stageA.pid, stageB.pid);
+    assert.equal(isProcessAlive(stageA.pid), true);
+    assert.equal(isProcessAlive(stageB.pid), true);
+    assert.notEqual(stageA.outputs.url, stageB.outputs.url);
+    assert.equal(await probe(stageA.outputs.url), 200);
+    assert.equal(await probe(stageB.outputs.url), 200);
+    const stageAAfterBoth = await readScriptWorldSnapshot(stageAPath);
+    const stageBAfterBoth = await readScriptWorldSnapshot(stageBPath);
+    assert.ok(stageAAfterBoth);
+    assert.ok(stageBAfterBoth);
+    assert.equal(stageAAfterBoth.pid, stageA.pid);
+    assert.equal(stageBAfterBoth.pid, stageB.pid);
+    evidence.recordAssertionEvidence(
+      "Staged launches have isolated receipts and runtimes",
+      "Stages a and b launched with distinct receipt paths, live pids, and responding URLs; parsing both after both launches proved neither receipt overwrote the other.",
+      true,
+    );
+
+    const downA = await run(["down", fixtureName, "--stage", "a"]);
+    assert.equal(downA.code, 0, downA.lines.join("\n"));
+    assert.deepEqual(downA.lines, [`World "${fixtureName}--a" torn down.`]);
+    await eventually(async () => !isProcessAlive(stageA.pid) && await probe(stageA.outputs.url) === "rejected", {
+      within: 10_000,
+      intervalMs: 50,
+      label: "stage a stops while stage b remains available",
+    });
+    assert.equal(await probe(stageA.outputs.url), "rejected");
+    assert.equal(await probe(stageB.outputs.url), 200);
+    assert.equal(await exists(stageAPath), false);
+    const stageBAfterDownA = await readScriptWorldSnapshot(stageBPath);
+    assert.ok(stageBAfterDownA);
+    assert.equal(stageBAfterDownA.pid, stageB.pid);
+    assert.equal(isProcessAlive(stageBAfterDownA.pid), true);
+    evidence.recordAssertionEvidence(
+      "Teardown targets only the selected stage",
+      "Down for stage a stopped its URL and removed only its receipt while stage b kept the same live pid, responding URL, and parseable receipt.",
+      true,
+    );
+    const downB = await run(["down", fixtureName, "--stage", "b"]);
+    assert.equal(downB.code, 0, downB.lines.join("\n"));
+
+    process.env.OPENWORK_WORLD_STAGE = "c";
+    const stageCUp = await run(["up", fixturePath, "--detach", "--timeout", "10000"]);
+    assert.equal(stageCUp.code, 0, stageCUp.lines.join("\n"));
+    const stageC = await readScriptWorldSnapshot(stageCPath);
+    assert.ok(stageC);
+    launchedPids.add(stageC.pid);
+    assert.equal(stageC.version, 2);
+    assert.equal(stageC.stage, "c");
+    assert.equal(stageC.outputs.orgLabel, "Org (c)");
+    assert.equal(await exists(bareSnapshotPath), false);
+    evidence.recordAssertionEvidence(
+      "Environment stage reaches receipt and recipe display naming",
+      "OPENWORK_WORLD_STAGE=c without a CLI stage produced only the c-suffixed receipt and the recipe output Org (c), with no unstaged receipt.",
+      true,
+    );
+    const downC = await run(["down", fixtureName, "--stage", "c"]);
+    assert.equal(downC.code, 0, downC.lines.join("\n"));
+
+    delete process.env.OPENWORK_WORLD_STAGE;
+    const bareUp = await run(["up", fixturePath, "--detach", "--timeout", "10000"]);
+    assert.equal(bareUp.code, 0, bareUp.lines.join("\n"));
+    const bare = await readScriptWorldSnapshot(bareSnapshotPath);
+    assert.ok(bare);
+    launchedPids.add(bare.pid);
+    assert.equal(bare.version, 2);
+    assert.equal("stage" in bare, false);
+    assert.deepEqual(
+      (await readdir(scriptsDirectory)).filter((name) => name.endsWith(".json")),
+      [`${fixtureName}.json`],
+    );
+    const bareDown = await run(["down", fixtureName]);
+    assert.equal(bareDown.code, 0, bareDown.lines.join("\n"));
+    assert.deepEqual(bareDown.lines, [`World "${fixtureName}" torn down.`]);
+    evidence.recordAssertionEvidence(
+      "Unstaged launches retain legacy receipt naming",
+      "With no stage flag or environment value, up wrote only the unsuffixed version-2 receipt without a stage field and bare-name down succeeded.",
+      true,
+    );
+  } finally {
+    delete process.env.OPENWORK_WORLD_STAGE;
+    for (const stage of ["a", "b", "c"]) {
+      try { await main(["down", fixtureName, "--stage", stage], { ...options, print: () => {} }); } catch {}
+    }
+    try { await main(["down", fixtureName], { ...options, print: () => {} }); } catch {}
+    for (const pid of launchedPids) {
+      if (!isProcessAlive(pid)) continue;
+      try { process.kill(pid, "SIGKILL"); } catch {}
+      try {
+        await eventually(() => !isProcessAlive(pid), {
+          within: 2_000,
+          intervalMs: 25,
+          label: "staged recipe fixture cleanup",
+        });
+      } catch {}
+    }
+    if (previousSnapshotDirectory === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previousSnapshotDirectory;
+    if (previousStage === undefined) delete process.env.OPENWORK_WORLD_STAGE;
+    else process.env.OPENWORK_WORLD_STAGE = previousStage;
+    await rm(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/packages/world/src/cli.ts
+++ b/packages/world/src/cli.ts
@@ -1,7 +1,10 @@
-import { join, resolve } from "node:path";
+import { access, rm } from "node:fs/promises";
+import { basename, extname, join, resolve } from "node:path";
 import { discoverWorlds, displayWorldPath, resolveWorldScript } from "./loader.ts";
+import { receiptName, resolveStage, sanitizeStage } from "./stage.ts";
 import { WorldStateStore } from "./store.ts";
 import {
+  computeRecipeHash,
   downScriptWorld,
   isProcessAlive,
   launchScriptWorld,
@@ -16,9 +19,12 @@ export type WorldCommand =
       source: string;
       detach?: boolean;
       timeoutMs?: number;
+      stage?: string;
+      place?: "local" | "daytona";
       args: string[];
     }
-  | { kind: "down"; name: string }
+  | { kind: "down"; name: string; stage?: string }
+  | { kind: "plan"; source: string; stage?: string }
   | { kind: "list" }
   | { kind: "forget"; name: string }
   | { kind: "help"; error?: string };
@@ -31,6 +37,25 @@ export interface WorldCliOptions {
 
 function helpError(message: string): WorldCommand {
   return { kind: "help", error: message };
+}
+
+function parseStageOptions(options: string[]): { stage?: string; error?: string } {
+  let stage: string | undefined;
+  for (let index = 0; index < options.length; index += 1) {
+    const option = options[index];
+    if (option === "--stage" && stage === undefined) {
+      const value = options[index + 1];
+      try {
+        stage = sanitizeStage(value ?? "");
+      } catch {
+        return { error: "Use --stage followed by a non-empty stage value." };
+      }
+      index += 1;
+      continue;
+    }
+    return { error: `Unknown world CLI option ${JSON.stringify(option)}.` };
+  }
+  return stage === undefined ? {} : { stage };
 }
 
 export function parseWorldArgs(argv: string[]): WorldCommand {
@@ -48,6 +73,8 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
     const scriptArgs = separator === -1 ? [] : rest.slice(separator + 1);
     let detach = false;
     let timeoutMs: number | undefined;
+    let stage: string | undefined;
+    let place: "local" | "daytona" | undefined;
     for (let index = 0; index < options.length; index += 1) {
       const option = options[index];
       if (option === "--detach" && !detach) {
@@ -64,6 +91,25 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
         index += 1;
         continue;
       }
+      if (option === "--stage" && stage === undefined) {
+        const value = options[index + 1];
+        try {
+          stage = sanitizeStage(value ?? "");
+        } catch {
+          return helpError("Use --stage followed by a non-empty stage value.");
+        }
+        index += 1;
+        continue;
+      }
+      if (option === "--place" && place === undefined) {
+        const value = options[index + 1];
+        if (value !== "local" && value !== "daytona") {
+          return helpError("Use --place followed by local or daytona.");
+        }
+        place = value;
+        index += 1;
+        continue;
+      }
       return helpError(`Unknown world CLI option ${JSON.stringify(option)}. Pass script arguments after --.`);
     }
     if (timeoutMs !== undefined && !detach) return helpError("Use --timeout only with --detach.");
@@ -72,23 +118,38 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
       source,
       ...(detach ? { detach: true } : {}),
       ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      ...(stage === undefined ? {} : { stage }),
+      ...(place === undefined ? {} : { place }),
       args: scriptArgs,
     };
+  }
+  if (command === "plan") {
+    const [source, ...options] = args;
+    if (!source || source === "--" || source.startsWith("--")) {
+      return helpError("The plan command needs a script path or world name.");
+    }
+    const parsed = parseStageOptions(options);
+    if (parsed.error) return helpError(parsed.error);
+    return { kind: "plan", source, ...(parsed.stage === undefined ? {} : { stage: parsed.stage }) };
   }
   if (command === "list") {
     return args.length === 0 ? { kind: "list" } : helpError("The list command does not take arguments.");
   }
   if (command === "down") {
-    return args.length === 1 && args[0]
-      ? { kind: "down", name: args[0] }
-      : helpError("The down command needs exactly one world name.");
+    const [name, ...options] = args;
+    if (!name || name === "--" || name.startsWith("--")) {
+      return helpError("The down command needs exactly one world name.");
+    }
+    const parsed = parseStageOptions(options);
+    if (parsed.error) return helpError(parsed.error);
+    return { kind: "down", name, ...(parsed.stage === undefined ? {} : { stage: parsed.stage }) };
   }
   if (command === "forget") {
     return args.length === 1 && args[0]
       ? { kind: "forget", name: args[0] }
       : helpError("The forget command needs exactly one world name.");
   }
-  return helpError(`Unknown command ${JSON.stringify(command)}. Script worlds support up, down, list, forget, and help.`);
+  return helpError(`Unknown command ${JSON.stringify(command)}. Script worlds support up, plan, down, list, forget, and help.`);
 }
 
 function messageText(error: unknown): string {
@@ -99,14 +160,39 @@ async function helpText(options: WorldCliOptions): Promise<string> {
   const discovered = await discoverWorlds(options.worldsDirectory);
   const sources = discovered.map((world) => displayWorldPath(world.path, options.cwd));
   return `Usage:
-  pnpm world up <script-path-or-name> [--detach] [--timeout <ms>] [-- <script args...>]
-  pnpm world down <name>
+  pnpm world up <script-path-or-name> [--detach] [--timeout <ms>] [--stage <value>] [--place <local|daytona>] [-- <script args...>]
+  pnpm world plan <script-path-or-name> [--stage <value>]
+  pnpm world down <name> [--stage <value>]
   pnpm world list
   pnpm world forget <name>
   pnpm world help
 
 World scripts run in the foreground by default; use --detach for background lifecycle receipts.
 Available world scripts: ${sources.join(", ") || "(none)"}`;
+}
+
+type ScriptReceiptState =
+  | { kind: "create" }
+  | { kind: "running" | "changed" | "orphaned"; snapshot: NonNullable<Awaited<ReturnType<typeof readScriptWorldSnapshot>>> };
+
+async function classifyScriptReceipt(path: string, recipeHash: string): Promise<ScriptReceiptState> {
+  const snapshot = await readScriptWorldSnapshot(path);
+  if (!snapshot) return { kind: "create" };
+  if (!isProcessAlive(snapshot.pid)) return { kind: "orphaned", snapshot };
+  return snapshot.recipeHash === undefined || snapshot.recipeHash === recipeHash
+    ? { kind: "running", snapshot }
+    : { kind: "changed", snapshot };
+}
+
+function printOutputs(
+  snapshot: NonNullable<Awaited<ReturnType<typeof readScriptWorldSnapshot>>>,
+  print: (line: string) => void,
+): void {
+  for (const [key, value] of Object.entries(snapshot.outputs)) print(`${key}  ${value}`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
 }
 
 export async function main(argv: string[], options: WorldCliOptions): Promise<number> {
@@ -120,13 +206,35 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
   if (command.kind === "up") {
     try {
       const script = await resolveWorldScript(command.source, options);
+      const stage = resolveStage(process.env, command.stage);
+      const recipeHash = await computeRecipeHash(script.path);
+      const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
+      const stagedName = receiptName(script.name, stage);
+      const snapshotPath = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
+      const state = await classifyScriptReceipt(snapshotPath, recipeHash);
+      if (state.kind === "running") {
+        printOutputs(state.snapshot, print);
+        print(`World ${JSON.stringify(stagedName)} is already running (pid ${state.snapshot.pid}); adopted.`);
+        return 0;
+      }
+      if (state.kind === "changed") {
+        print(`World ${JSON.stringify(stagedName)} is running but its recipe changed; run pnpm world down ${script.name}${stage ? ` --stage ${stage}` : ""} first.`);
+        return 1;
+      }
+      if (state.kind === "orphaned") {
+        await rm(snapshotPath, { force: true });
+        print(`Removed stale world receipt ${JSON.stringify(stagedName)} (pid ${state.snapshot.pid}); recreating.`);
+      }
       return await launchScriptWorld({
         path: script.path,
         name: script.name,
         args: command.args,
-        snapshotDirectory: scriptWorldSnapshotDirectory(options.cwd),
+        snapshotDirectory,
         detach: command.detach === true,
         ...(command.timeoutMs === undefined ? {} : { timeoutMs: command.timeoutMs }),
+        ...(stage === undefined ? {} : { stage }),
+        recipeHash,
+        ...(command.place === undefined ? {} : { place: command.place }),
         print,
       });
     } catch (error) {
@@ -134,18 +242,60 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       return 1;
     }
   }
+  if (command.kind === "plan") {
+    try {
+      const script = await resolveWorldScript(command.source, options);
+      const stage = resolveStage(process.env, command.stage);
+      const recipeHash = await computeRecipeHash(script.path);
+      const snapshotPath = scriptWorldSnapshotPath(
+        scriptWorldSnapshotDirectory(options.cwd),
+        receiptName(script.name, stage),
+      );
+      const state = await classifyScriptReceipt(snapshotPath, recipeHash);
+      const labels = {
+        create: "+ create",
+        running: "• running (attachable)",
+        changed: "~ stale (recipe changed)",
+        orphaned: "- orphaned (stale receipt, will recreate)",
+      };
+      print(labels[state.kind]);
+      print(`receipt  ${snapshotPath}`);
+      if (state.kind !== "create") printOutputs(state.snapshot, print);
+      return 0;
+    } catch (error) {
+      print(messageText(error));
+      return 1;
+    }
+  }
   if (command.kind === "down") {
     try {
-      const path = scriptWorldSnapshotPath(scriptWorldSnapshotDirectory(options.cwd), command.name);
+      const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
+      let stagedName = receiptName(command.name, command.stage);
+      let path = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
+      if (command.stage === undefined && !await pathExists(path)) {
+        const prefix = `${command.name}--`;
+        const candidates = (await new WorldStateStore(snapshotDirectory).list())
+          .map((candidatePath) => basename(candidatePath, extname(candidatePath)))
+          .filter((candidate) => candidate.startsWith(prefix));
+        if (candidates.length > 1) {
+          print(`Multiple staged world receipts match ${JSON.stringify(command.name)}:`);
+          for (const candidate of candidates) print(`  ${candidate}`);
+          return 1;
+        }
+        if (candidates[0]) {
+          stagedName = candidates[0];
+          path = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
+        }
+      }
       const result = await downScriptWorld(path);
       if (!result.found) {
-        print(`World receipt ${JSON.stringify(command.name)} does not exist.`);
+        print(`World receipt ${JSON.stringify(stagedName)} does not exist.`);
         return 1;
       }
       if (result.forced) {
-        print(`World ${JSON.stringify(command.name)} teardown was forced (pid ${result.pid}).`);
+        print(`World ${JSON.stringify(stagedName)} teardown was forced (pid ${result.pid}).`);
       } else {
-        print(`World ${JSON.stringify(command.name)} torn down.`);
+        print(`World ${JSON.stringify(stagedName)} torn down.`);
       }
       return 0;
     } catch (error) {

--- a/packages/world/src/hold.ts
+++ b/packages/world/src/hold.ts
@@ -1,18 +1,22 @@
 import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { receiptName, resolveStage } from "./stage.ts";
+import { assertWorldName } from "./store.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
-const SAFE_WORLD_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export interface ScriptWorldSnapshot {
-  version: 1;
+  version: 1 | 2;
   kind: "script";
   name: string;
   createdAt: string;
   pid: number;
   sourcePath: string;
   outputs: Record<string, string>;
+  stage?: string;
+  recipeHash?: string;
+  place?: string;
 }
 
 export interface HoldOptions {
@@ -51,39 +55,45 @@ async function aliveSnapshotPid(path: string): Promise<number | undefined> {
 export async function hold(options: HoldOptions = {}): Promise<void> {
   const sourcePath = process.argv[1];
   const name = options.name ?? basename(sourcePath, extname(sourcePath));
-  if (!SAFE_WORLD_NAME.test(name)) {
-    throw new Error("World names must use only letters, numbers, dots, underscores, and hyphens.");
-  }
+  assertWorldName(name);
+  const stage = resolveStage(process.env);
+  const recipeHash = process.env.OPENWORK_WORLD_RECIPE_HASH;
+  const place = process.env.OPENWORK_WORLD_PLACE;
+  const stagedName = receiptName(name, stage);
 
   const snapshotDirectory = resolve(
     options.snapshotDir
       ?? process.env.OPENWORK_WORLD_SNAPSHOT_DIR
       ?? join(REPO_ROOT, "evals", "results", ".worlds", "scripts"),
   );
-  const snapshotPath = join(snapshotDirectory, `${name}.json`);
+  const snapshotPath = join(snapshotDirectory, `${stagedName}.json`);
   const existingPid = await aliveSnapshotPid(snapshotPath);
   if (existingPid !== undefined) {
     throw new Error(
-      `Script world ${JSON.stringify(name)} is already running (pid ${existingPid}); run \`pnpm world down ${name}\` first.`,
+      `Script world ${JSON.stringify(stagedName)} is already running (pid ${existingPid}); run \`pnpm world down ${name}${stage ? ` --stage ${stage}` : ""}\` first.`,
     );
   }
 
   const outputs = options.outputs ?? {};
+  const version = stage !== undefined || recipeHash !== undefined || place !== undefined ? 2 : 1;
   const snapshot: ScriptWorldSnapshot = {
-    version: 1,
+    version,
     kind: "script",
-    name,
+    name: stagedName,
     createdAt: new Date().toISOString(),
     pid: process.pid,
     sourcePath,
     outputs,
+    ...(stage === undefined ? {} : { stage }),
+    ...(recipeHash === undefined ? {} : { recipeHash }),
+    ...(place === undefined ? {} : { place }),
   };
   await mkdir(dirname(snapshotPath), { recursive: true });
   await writeFile(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   await chmod(snapshotPath, 0o600);
 
   for (const [key, value] of Object.entries(outputs)) console.log(`${key}  ${value}`);
-  console.log(`World ${JSON.stringify(name)} is up. Ctrl-C (or pnpm world down ${name}) tears it down.`);
+  console.log(`World ${JSON.stringify(stagedName)} is up. Ctrl-C (or pnpm world down ${name}${stage ? ` --stage ${stage}` : ""}) tears it down.`);
 
   await new Promise<void>((done) => {
     let stopping = false;

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./loader.ts";
 export * from "./store.ts";
+export * from "./stage.ts";
 export * from "./hold.ts";
 export * from "./script-world.ts";
 export * from "./cli.ts";

--- a/packages/world/src/script-world.ts
+++ b/packages/world/src/script-world.ts
@@ -1,7 +1,9 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { access, chmod, mkdir, open, readFile, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { receiptName } from "./stage.ts";
 import { assertWorldName } from "./store.ts";
 import type { ScriptWorldSnapshot } from "./hold.ts";
 
@@ -29,7 +31,7 @@ export function parseScriptWorldSnapshot(text: string): ScriptWorldSnapshot {
   const value: unknown = JSON.parse(text);
   if (
     !isRecord(value)
-    || value.version !== 1
+    || (value.version !== 1 && value.version !== 2)
     || value.kind !== "script"
     || typeof value.name !== "string"
     || typeof value.createdAt !== "string"
@@ -38,18 +40,30 @@ export function parseScriptWorldSnapshot(text: string): ScriptWorldSnapshot {
     || value.pid <= 0
     || typeof value.sourcePath !== "string"
     || !isStringRecord(value.outputs)
+    || (value.version === 2 && "stage" in value && value.stage !== undefined && typeof value.stage !== "string")
+    || (value.version === 2 && "recipeHash" in value && value.recipeHash !== undefined && typeof value.recipeHash !== "string")
+    || (value.version === 2 && "place" in value && value.place !== undefined && typeof value.place !== "string")
   ) {
     throw new Error("The file is not a valid script world snapshot.");
   }
   return {
-    version: 1,
+    version: value.version,
     kind: "script",
     name: value.name,
     createdAt: value.createdAt,
     pid: value.pid,
     sourcePath: value.sourcePath,
     outputs: value.outputs,
+    ...(value.version === 2 && typeof value.stage === "string" ? { stage: value.stage } : {}),
+    ...(value.version === 2 && typeof value.recipeHash === "string" ? { recipeHash: value.recipeHash } : {}),
+    ...(value.version === 2 && typeof value.place === "string" ? { place: value.place } : {}),
   };
+}
+
+/** Hashes only the recipe file bytes; imported files are not included. */
+export async function computeRecipeHash(filePath: string): Promise<string> {
+  const bytes = await readFile(filePath);
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 }
 
 export function isProcessAlive(pid: number): boolean {
@@ -151,18 +165,28 @@ export interface LaunchScriptWorldOptions {
   snapshotDirectory: string;
   detach: boolean;
   timeoutMs?: number;
+  stage?: string;
+  recipeHash?: string;
+  place?: string;
   print: (line: string) => void;
 }
 
 export async function launchScriptWorld(options: LaunchScriptWorldOptions): Promise<number> {
   const path = resolve(options.path);
-  const snapshotPath = scriptWorldSnapshotPath(options.snapshotDirectory, options.name);
-  const env = { ...process.env, OPENWORK_WORLD_SNAPSHOT_DIR: options.snapshotDirectory };
-  await assertNoRunningSnapshot(snapshotPath, options.name);
+  const stagedName = receiptName(options.name, options.stage);
+  const snapshotPath = scriptWorldSnapshotPath(options.snapshotDirectory, stagedName);
+  const env: NodeJS.ProcessEnv = { ...process.env, OPENWORK_WORLD_SNAPSHOT_DIR: options.snapshotDirectory };
+  if (options.stage === undefined) delete env.OPENWORK_WORLD_STAGE;
+  else env.OPENWORK_WORLD_STAGE = options.stage;
+  if (options.recipeHash === undefined) delete env.OPENWORK_WORLD_RECIPE_HASH;
+  else env.OPENWORK_WORLD_RECIPE_HASH = options.recipeHash;
+  if (options.place === undefined) delete env.OPENWORK_WORLD_PLACE;
+  else env.OPENWORK_WORLD_PLACE = options.place;
+  await assertNoRunningSnapshot(snapshotPath, stagedName);
 
   if (!options.detach) return waitForChild(path, options.args, env);
 
-  const logPath = scriptWorldLogPath(options.snapshotDirectory, options.name);
+  const logPath = scriptWorldLogPath(options.snapshotDirectory, stagedName);
   await mkdir(options.snapshotDirectory, { recursive: true });
   const log = await open(logPath, "w", 0o600);
   await chmod(logPath, 0o600);
@@ -193,7 +217,7 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
     }
     if (child.exitCode !== null || child.signalCode !== null) {
       await removeDeadSnapshot(snapshotPath);
-      options.print(`Script world ${JSON.stringify(options.name)} exited before creating its snapshot.`);
+      options.print(`Script world ${JSON.stringify(stagedName)} exited before creating its snapshot.`);
       for (const line of await lastLogLines(logPath)) options.print(line);
       return 1;
     }
@@ -205,7 +229,7 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
     try { process.kill(child.pid, "SIGTERM"); } catch {}
   }
   await removeDeadSnapshot(snapshotPath);
-  options.print(`Timed out after ${options.timeoutMs ?? DEFAULT_START_TIMEOUT_MS}ms waiting for script world ${JSON.stringify(options.name)}.`);
+  options.print(`Timed out after ${options.timeoutMs ?? DEFAULT_START_TIMEOUT_MS}ms waiting for script world ${JSON.stringify(stagedName)}.`);
   for (const line of await lastLogLines(logPath)) options.print(line);
   return 1;
 }

--- a/packages/world/src/stage.ts
+++ b/packages/world/src/stage.ts
@@ -2,13 +2,18 @@ import { userInfo } from "node:os";
 import { assertWorldName } from "./store.ts";
 
 export function sanitizeStage(raw: string): string {
-  const stage = raw
+  let stage = raw
     .trim()
     .replace(/[^A-Za-z0-9._-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^[._-]+|[._-]+$/g, "")
-    .slice(0, 32)
-    .replace(/[._-]+$/g, "");
+    .replace(/-+/g, "-");
+  let start = 0;
+  while (start < stage.length && "._-".includes(stage[start])) start += 1;
+  let end = stage.length;
+  while (end > start && "._-".includes(stage[end - 1])) end -= 1;
+  stage = stage.slice(start, end).slice(0, 32);
+  end = stage.length;
+  while (end > 0 && "._-".includes(stage[end - 1])) end -= 1;
+  stage = stage.slice(0, end);
   if (!stage) throw new Error("World stages must contain at least one letter or number.");
   return stage;
 }

--- a/packages/world/src/stage.ts
+++ b/packages/world/src/stage.ts
@@ -1,0 +1,31 @@
+import { userInfo } from "node:os";
+import { assertWorldName } from "./store.ts";
+
+export function sanitizeStage(raw: string): string {
+  const stage = raw
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "")
+    .slice(0, 32)
+    .replace(/[._-]+$/g, "");
+  if (!stage) throw new Error("World stages must contain at least one letter or number.");
+  return stage;
+}
+
+export function resolveStage(env: NodeJS.ProcessEnv, explicit?: string): string | undefined {
+  if (explicit !== undefined) return sanitizeStage(explicit);
+  const configured = env.OPENWORK_WORLD_STAGE?.trim();
+  return configured ? sanitizeStage(configured) : undefined;
+}
+
+export function defaultDisplayStage(_env: NodeJS.ProcessEnv): string {
+  return `dev_${sanitizeStage(userInfo().username)}`;
+}
+
+export function receiptName(worldName: string, stage: string | undefined): string {
+  assertWorldName(worldName);
+  const name = stage ? `${worldName}--${stage}` : worldName;
+  assertWorldName(name);
+  return name;
+}

--- a/packages/world/test/cli.test.ts
+++ b/packages/world/test/cli.test.ts
@@ -14,6 +14,10 @@ test("world arguments expose only script lifecycle flags and forward arguments a
       "--detach",
       "--timeout",
       "5000",
+      "--stage",
+      "feature one",
+      "--place",
+      "daytona",
       "--",
       "--replace",
       "value",
@@ -23,6 +27,8 @@ test("world arguments expose only script lifecycle flags and forward arguments a
       source: "./worlds/dev-headless.ts",
       detach: true,
       timeoutMs: 5000,
+      stage: "feature-one",
+      place: "daytona",
       args: ["--replace", "value"],
     },
   );
@@ -41,6 +47,32 @@ test("world arguments expose only script lifecycle flags and forward arguments a
   assert.equal(oldCommand.kind, "help");
   if (oldCommand.kind !== "help") throw new Error("expected help");
   assert.match(oldCommand.error ?? "", /Unknown command "resume"/);
+
+  assert.deepEqual(parseWorldArgs(["plan", "dev-headless", "--stage", "preview"]), {
+    kind: "plan",
+    source: "dev-headless",
+    stage: "preview",
+  });
+  assert.deepEqual(parseWorldArgs(["down", "dev-headless", "--stage", "preview"]), {
+    kind: "down",
+    name: "dev-headless",
+    stage: "preview",
+  });
+
+  const invalidPlace = parseWorldArgs(["up", "dev-headless", "--place", "remote"]);
+  assert.equal(invalidPlace.kind, "help");
+  if (invalidPlace.kind !== "help") throw new Error("expected help");
+  assert.match(invalidPlace.error ?? "", /local or daytona/);
+
+  const emptyStage = parseWorldArgs(["up", "dev-headless", "--stage", "---"]);
+  assert.equal(emptyStage.kind, "help");
+  if (emptyStage.kind !== "help") throw new Error("expected help");
+  assert.match(emptyStage.error ?? "", /non-empty stage value/);
+
+  const unknownPlanFlag = parseWorldArgs(["plan", "dev-headless", "--detach"]);
+  assert.equal(unknownPlanFlag.kind, "help");
+  if (unknownPlanFlag.kind !== "help") throw new Error("expected help");
+  assert.match(unknownPlanFlag.error ?? "", /Unknown world CLI option "--detach"/);
 });
 
 test("discovery, resolution, list, and help classify scripts without importing them", async () => {

--- a/packages/world/test/stage.test.ts
+++ b/packages/world/test/stage.test.ts
@@ -11,8 +11,15 @@ test("sanitizeStage produces bounded world-name-safe segments", () => {
   assert.equal(sanitizeStage("  feature / one  "), "feature-one");
   assert.equal(sanitizeStage("...alpha!!!beta___"), "alpha-beta");
   assert.equal(sanitizeStage("a---b"), "a-b");
+  assert.equal(sanitizeStage("---alpha_beta---"), "alpha_beta");
   assert.equal(sanitizeStage("abcdefghijklmnopqrstuvwxyz0123456789"), "abcdefghijklmnopqrstuvwxyz012345");
   assert.throws(() => sanitizeStage(" ._- "), /at least one letter or number/);
+});
+
+test("sanitizeStage trims long separator runs in linear time", () => {
+  const startedAt = Date.now();
+  assert.equal(sanitizeStage(`${"-".repeat(10_000)}a${"-".repeat(10_000)}`), "a");
+  assert.ok(Date.now() - startedAt < 200, "expected stage sanitization to finish within 200ms");
 });
 
 test("resolveStage gives an explicit stage precedence over environment configuration", () => {

--- a/packages/world/test/stage.test.ts
+++ b/packages/world/test/stage.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  defaultDisplayStage,
+  receiptName,
+  resolveStage,
+  sanitizeStage,
+} from "../src/stage.ts";
+
+test("sanitizeStage produces bounded world-name-safe segments", () => {
+  assert.equal(sanitizeStage("  feature / one  "), "feature-one");
+  assert.equal(sanitizeStage("...alpha!!!beta___"), "alpha-beta");
+  assert.equal(sanitizeStage("a---b"), "a-b");
+  assert.equal(sanitizeStage("abcdefghijklmnopqrstuvwxyz0123456789"), "abcdefghijklmnopqrstuvwxyz012345");
+  assert.throws(() => sanitizeStage(" ._- "), /at least one letter or number/);
+});
+
+test("resolveStage gives an explicit stage precedence over environment configuration", () => {
+  assert.equal(resolveStage({ OPENWORK_WORLD_STAGE: "environment" }, "flag stage"), "flag-stage");
+  assert.equal(resolveStage({ OPENWORK_WORLD_STAGE: " environment stage " }), "environment-stage");
+  assert.equal(resolveStage({ OPENWORK_WORLD_STAGE: "  " }), undefined);
+  assert.equal(resolveStage({}), undefined);
+});
+
+test("receiptName joins valid world and stage names within SAFE_WORLD_NAME", () => {
+  assert.equal(receiptName("demo", undefined), "demo");
+  assert.equal(receiptName("demo", "feature-1"), "demo--feature-1");
+  assert.match(receiptName("demo", "feature-1"), /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/);
+  assert.throws(() => receiptName("x".repeat(120), "stage-name"), /World names must use/);
+});
+
+test("defaultDisplayStage identifies the local OS user", () => {
+  assert.match(defaultDisplayStage({}), /^dev_[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/);
+});

--- a/packages/world/test/store.test.ts
+++ b/packages/world/test/store.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { parseScriptWorldSnapshot } from "../src/script-world.ts";
 import { WorldStateStore } from "../src/store.ts";
 
 test("local world state is owner-only and addressable by world name", async () => {
@@ -18,4 +19,39 @@ test("local world state is owner-only and addressable by world name", async () =
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("script world snapshots parse v1 and strict v2 receipts", () => {
+  const base = {
+    kind: "script",
+    name: "demo",
+    createdAt: "2026-09-01T00:00:00.000Z",
+    pid: 123,
+    sourcePath: "/tmp/demo.ts",
+    outputs: { url: "http://127.0.0.1:1234" },
+  };
+  assert.deepEqual(parseScriptWorldSnapshot(JSON.stringify({ version: 1, ...base })), {
+    version: 1,
+    ...base,
+  });
+  assert.deepEqual(parseScriptWorldSnapshot(JSON.stringify({
+    version: 2,
+    ...base,
+    name: "demo--preview",
+    stage: "preview",
+    recipeHash: "sha256:abc",
+    place: "local",
+  })), {
+    version: 2,
+    ...base,
+    name: "demo--preview",
+    stage: "preview",
+    recipeHash: "sha256:abc",
+    place: "local",
+  });
+  assert.throws(
+    () => parseScriptWorldSnapshot(JSON.stringify({ version: 2, ...base, stage: 1 })),
+    /not a valid script world snapshot/,
+  );
+  assert.throws(() => parseScriptWorldSnapshot("{}"), /not a valid script world snapshot/);
 });

--- a/worlds/litellm-per-member.ts
+++ b/worlds/litellm-per-member.ts
@@ -5,9 +5,8 @@ import type { Den, DenOrgHandle } from "../evals/packages/env/src/den.ts";
 import { liteLlmPerMemberProvider } from "../evals/packages/env/src/litellm-provider.ts";
 import { liteLlm } from "../evals/packages/env/src/litellm.ts";
 import type { LiteLlmHandle } from "../evals/packages/env/src/litellm.ts";
-import { resolvePlace } from "../evals/packages/env/src/place.ts";
 import type { Place } from "../evals/packages/env/src/place.ts";
-import { hold } from "../packages/world/src/hold.ts";
+import { recipe, runRecipe } from "../evals/packages/env/src/recipe.ts";
 
 export const LITELLM_WORLD_ORG = "LiteLLM Per-Member World";
 export const LITELLM_WORLD_PROVIDER = "openwork-litellm-per-member";
@@ -31,11 +30,12 @@ export interface LiteLlmPerMemberWorld {
  * the complete per-member example. The LiteLLM gateway talks to a deterministic
  * local OpenAI-compatible witness; it never reads or requires OPENAI_API_KEY.
  *
- * Launch: `pnpm world up ./worlds/litellm-per-member.ts`
+ * Launch: `pnpm world up litellm-per-member [--stage <s>]`
  */
 export async function bootLiteLlmPerMember(
   stack: AsyncDisposableStack,
   place: Place,
+  naming?: { stage: string; stageName(base: string): string },
 ): Promise<LiteLlmPerMemberWorld> {
   const gateway = stack.use(await liteLlm({
     place,
@@ -51,7 +51,10 @@ export async function bootLiteLlmPerMember(
     email: "litellm-admin@openwork.test",
     password: LITELLM_WORLD_PASSWORD,
   });
-  const org = stack.use(await createOrg(den, LITELLM_WORLD_ORG));
+  const org = stack.use(await createOrg(
+    den,
+    naming ? naming.stageName(LITELLM_WORLD_ORG) : LITELLM_WORLD_ORG,
+  ));
   const alice = await inviteMember(den, "alice", {
     name: "Alice LiteLLM",
     email: "alice-litellm@openwork.test",
@@ -70,26 +73,24 @@ export async function bootLiteLlmPerMember(
     den,
     place,
     as: "admin",
-    workspacePath: "/tmp/openwork-litellm-per-member-world",
+    workspacePath: naming
+      ? `/tmp/openwork-litellm-per-member-world-${naming.stage}`
+      : "/tmp/openwork-litellm-per-member-world",
     model: `${LITELLM_WORLD_PROVIDER}/${LITELLM_WORLD_MODEL}`,
   }));
   return { gateway, den, org, admin, alice, provider, desktop };
 }
 
-async function main(): Promise<void> {
-  await using stack = new AsyncDisposableStack();
-  const place = resolvePlace();
-  const { gateway, den, desktop } = await bootLiteLlmPerMember(stack, place);
-  await hold({
-    outputs: {
-      denWeb: den.ref.webUrl,
-      denApi: den.ref.apiUrl,
-      litellm: gateway.baseUrl,
-      cdp: desktop.handle.cdpUrl,
-    },
-  });
-}
+export const litellmPerMember = recipe("litellm-per-member", async (tools) => {
+  const world = await bootLiteLlmPerMember(tools.stack, tools.place, tools);
+  return {
+    denWeb: world.den.ref.webUrl,
+    denApi: world.den.ref.apiUrl,
+    litellm: world.gateway.baseUrl,
+    cdp: world.desktop.handle.cdpUrl,
+  };
+});
 
-if (import.meta.main) {
-  await main();
-}
+export default litellmPerMember;
+
+if (import.meta.main) await runRecipe(litellmPerMember);


### PR DESCRIPTION
Phase 1 of the world-engine plan: make script worlds stage-isolated, planable, and idempotent, and introduce the `recipe()` authoring API so worlds and specs can share one environment definition.

## What changed

**Engine (`packages/world`)**
- Receipt schema v2 — optional `stage`, `recipeHash`, `place`; v1 receipts remain readable; staged receipts are keyed `<world>--<stage>` and only exist when a stage is provided (legacy behavior is byte-identical otherwise).
- `world plan <src> [--stage]` — read-only classification: `+ create` / `• running (attachable)` / `~ stale (recipe changed)` / `- orphaned (stale receipt, will recreate)`, plus receipt path and outputs.
- `world up` — computes a sha256 recipe-file hash, then adopts a live matching world (exit 0, no respawn), refuses a live mismatched one, or clears an orphaned receipt and boots. New `--stage` / `--place local|daytona` flags; `down --stage`, with single-candidate fallback for bare names.
- `hold()` is the single authority for staged receipt naming via pinned child env.

**Authoring (`@openwork/env`)**
- `recipe(name, build)` + `runRecipe()`: builds into an `AsyncDisposableStack`, resolves stage (`OPENWORK_WORLD_STAGE` else `dev_<user>`) and place, and writes outputs to the receipt. `--place local` now explicitly overrides `OPENWORK_EVAL_DAYTONA=1` in `resolvePlace`.

**Pilot port**
- `worlds/litellm-per-member.ts` is now a recipe world (`pnpm world up litellm-per-member [--stage s]`); `bootLiteLlmPerMember(stack, place)` stays 2-arg compatible, org name and workspace path get stage-suffixed only when staged.

**Deliberate semantic change**
- Duplicate `up` of an unchanged live world now **adopts** (exit 0) instead of rejecting; `evals/specs/script-world-lifecycle.test.ts` was updated for exactly this.

## Verification (all on PR head, local lane — Daytona API credentials unavailable in this environment; local fallback per run-tests policy; Daytona is not exercised by these app-less engine specs)

| Check | Command | Result |
|---|---|---|
| World unit tests | `pnpm --filter @openwork/world test` | 14 pass, 0 fail |
| New: stage isolation | `pnpm evals:pr specs/world-stage-isolation.test.ts` | 1/1 passed |
| New: plan + idempotent up | `pnpm evals:pr specs/world-plan-idempotent-up.test.ts` | 1/1 passed |
| Updated lifecycle | `pnpm evals:pr specs/script-world-lifecycle.test.ts` | 1/1 passed |
| Import-safety guard | `pnpm evals:pr specs/shared-world-engine.test.ts` | 3/3 passed |
| World port runtime proof | `node evals/bin/evals.mjs litellm-per-member-world --local` | 1/1 passed (83s) |

Pre-existing reds, classified against clean `origin/dev` with identical commands: `pnpm evals:typecheck` fails with the same 579 errors on baseline and branch (0 introduced); `specs/google-workspace-connector-retrieval.test.ts` and `specs/sso-super-admin-registration.test.ts` fail identically on baseline; `specs/sso-saml-acs-delivery.test.ts` is green solo on both baseline and branch and failed only under full-lane parallelism.

Test evidence for each spec above is published as sticky-comment sections below.