### PR TITLE
feat(world): resource ledger and reaper so crashed worlds never leak or duplicate

### DIFF
--- a/evals/packages/env/src/cli.ts
+++ b/evals/packages/env/src/cli.ts
@@ -1,14 +1,51 @@
 import { fileURLToPath } from "node:url";
-import { main as runWorldCli, parseWorldArgs } from "@openwork/world";
+import { createConnection } from "mysql2/promise";
+import { main as runWorldCli, parseWorldArgs, type Reaper } from "@openwork/world";
+import { DEFAULT_MYSQL_URL } from "./place.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const WORLDS_DIRECTORY = fileURLToPath(new URL("../../../../worlds", import.meta.url));
 
 export { parseWorldArgs };
 
+function isEphemeralDatabaseName(name: string): boolean {
+  const prefix = "openwork_eval_";
+  if (!name.startsWith(prefix)) return false;
+  const suffix = name.slice(prefix.length);
+  if (suffix.length < 1 || suffix.length > 60) return false;
+  for (const character of suffix) {
+    const code = character.charCodeAt(0);
+    const lower = code >= 97 && code <= 122;
+    const digit = code >= 48 && code <= 57;
+    if (!lower && !digit && character !== "_") return false;
+  }
+  return true;
+}
+
+const dropEphemeralDatabase: Reaper = async (entry) => {
+  if (!isEphemeralDatabaseName(entry.id)) {
+    return { status: "skipped", reason: "outside allowed names" };
+  }
+  try {
+    const url = new URL(process.env.OPENWORK_EVAL_MYSQL_URL?.trim() || DEFAULT_MYSQL_URL);
+    url.pathname = "/";
+    const connection = await createConnection(url.toString());
+    try {
+      await connection.query(`DROP DATABASE IF EXISTS \`${entry.id}\``);
+    } finally {
+      await connection.end();
+    }
+    return { status: "reaped" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "skipped", reason: `mysql unavailable: ${message}` };
+  }
+};
+
 export function main(argv = process.argv.slice(2)): Promise<number> {
   return runWorldCli(argv, {
     cwd: REPO_ROOT,
     worldsDirectory: WORLDS_DIRECTORY,
+    reapers: { "mysql-db": dropEphemeralDatabase },
   });
 }

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -16,6 +16,7 @@ import {
   startMockOnSandbox,
 } from "@openwork/hosts";
 import { denFetch, ensureMemberSession, freshSession, signIn } from "@openwork/behaviors";
+import { trackResource } from "@openwork/world";
 import { createConnection } from "mysql2/promise";
 import type { ChildProcess } from "node:child_process";
 import type { DenRef, DenSession } from "@openwork/behaviors";
@@ -756,6 +757,7 @@ export async function server(options: ServerOptions): Promise<Den> {
   let database: DbHandle | undefined;
   try {
     database = await options.place.db(ephemeralDatabaseName());
+    await trackResource({ kind: "mysql-db", id: database.name, label: "den-mysql" });
     await runDbPush(database.url);
     let apiPort: number;
     let webPort: number;
@@ -781,7 +783,8 @@ export async function server(options: ServerOptions): Promise<Den> {
     };
     const logsDir = join(REPO_ROOT, "evals", "results", ".testkit", database.name);
     await mkdir(logsDir, { recursive: true });
-    if (process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED !== "1" && options.web !== false) {
+    const prepared = process.env.OPENWORK_EVAL_DEN_RUNTIME_PREPARED === "1";
+    if (!prepared && options.web !== false) {
       // Every ephemeral next dev process otherwise reuses the same Turbopack
       // graph. A stale missing-module node can break /api/den even though
       // /api/ready is healthy.
@@ -826,6 +829,7 @@ export async function server(options: ServerOptions): Promise<Den> {
       };
     const api = spawnService("den-api", "dev:den:api", apiPort, { ...commonEnv, DEN_BIND_HOST: "127.0.0.1" }, join(logsDir, "api.log"));
     services.push(api);
+    await trackResource({ kind: "process", id: String(api.pid), label: "den-api", match: prepared ? "@openwork-ee/den-api" : "dev:den:api" });
     const web = options.web === false
       ? null
       : spawnService("den-web", "dev:den:web", webPort, {
@@ -836,7 +840,10 @@ export async function server(options: ServerOptions): Promise<Den> {
           DEN_AUTH_ORIGIN: `http://localhost:${webPort}`,
           DEN_AUTH_FALLBACK_BASE: `http://127.0.0.1:${apiPort}`,
         }, join(logsDir, "web.log"));
-    if (web) services.push(web);
+    if (web) {
+      services.push(web);
+      await trackResource({ kind: "process", id: String(web.pid), label: "den-web", match: prepared ? "@openwork-ee/den-web" : "dev:den:web" });
+    }
     await waitForHttp(`${ref.apiUrl}/health`, api, (response) => response.ok);
     if (web) {
       await waitForHttp(`${ref.webUrl}/api/ready`, web, (response) => response.ok);

--- a/evals/packages/env/src/desktop-app.ts
+++ b/evals/packages/env/src/desktop-app.ts
@@ -3,6 +3,7 @@ import { attachSurface, evaluateOnSurface, isInteractive, probeAppStateOnSurface
 import type { Surface } from "@openwork/cdp";
 import { desktop } from "@openwork/hosts";
 import { liveSharedProductionStateEnv } from "@openwork/hosts";
+import { trackResource } from "@openwork/world";
 import type { AppReadiness, DesktopHandle, Host, InstalledProductionDesktopState } from "@openwork/hosts";
 import type { Den } from "./den.ts";
 import type { Place } from "./place.ts";
@@ -151,6 +152,12 @@ export async function app(options: AppOptions): Promise<App> {
       },
       env: Object.keys(env).length > 0 ? env : undefined,
     });
+    if (surface.handle.pid !== undefined) {
+      await trackResource({ kind: "process", id: String(surface.handle.pid), label: "electron", match: process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim() || "dev:electron" });
+    }
+    if (surface.handle.meta?.profileOwner !== "caller" && typeof surface.handle.profileDir === "string") {
+      await trackResource({ kind: "tmpdir", id: surface.handle.profileDir, label: "electron-profile" });
+    }
     try {
       const path = options.workspacePath ?? `/tmp/openwork-fresh-${Date.now()}`;
       const { workspaceId } = await createAndSelectWorkspace(surface, { path });
@@ -189,6 +196,12 @@ export async function app(options: AppOptions): Promise<App> {
     },
     env: Object.keys(env).length > 0 ? env : undefined,
   });
+  if (surface.handle.pid !== undefined) {
+    await trackResource({ kind: "process", id: String(surface.handle.pid), label: "electron", match: process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim() || "dev:electron" });
+  }
+  if (surface.handle.meta?.profileOwner !== "caller" && typeof surface.handle.profileDir === "string") {
+    await trackResource({ kind: "tmpdir", id: surface.handle.profileDir, label: "electron-profile" });
+  }
   try {
     // Workspace first, then the org sign-in: the signed-in org shell offers no
     // Add workspace entry, so a member's workspace exists before they connect.

--- a/evals/packages/env/src/litellm.ts
+++ b/evals/packages/env/src/litellm.ts
@@ -11,6 +11,7 @@ import {
   deleteSandboxes,
   execInSandbox,
 } from "@openwork/hosts";
+import { trackResource } from "@openwork/world";
 import type { Server, ServerResponse } from "node:http";
 import { SkipError } from "./needs.ts";
 import type { Place } from "./place.ts";
@@ -654,6 +655,7 @@ async function startLocalLiteLlm(
     );
     witness = startedWitness.server;
     root = await realpath(await mkdtemp(join(tmpdir(), "openwork-litellm-")));
+    await trackResource({ kind: "tmpdir", id: root, label: "litellm-config" });
     const configPath = join(root, "config.json");
     await writeFile(
       configPath,
@@ -676,6 +678,7 @@ async function startLocalLiteLlm(
         "--publish", "127.0.0.1::5432",
         POSTGRES_IMAGE,
       ]);
+      await trackResource({ kind: "docker", id: postgresContainer, label: "litellm-postgres" });
       await run("docker", ["start", postgresContainer], 30_000);
       postgresPort = await mappedPostgresPort(postgresContainer);
       await waitForPostgres(postgresContainer);
@@ -695,6 +698,7 @@ async function startLocalLiteLlm(
           IMAGE, "--config", "/app/config.json", "--port", "4000",
         ];
     await run("docker", createArgs);
+    await trackResource({ kind: "docker", id: container, label: "litellm" });
     await run("docker", ["cp", configPath, `${container}:/app/config.json`], 30_000);
     await run("docker", ["start", container], 30_000);
     const port = input.database
@@ -709,9 +713,9 @@ async function startLocalLiteLlm(
       redactedSecrets: input.database ? [postgresPassword] : undefined,
       async dispose(): Promise<void> {
         if (placementDisposed) return;
-        await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
+        await run("docker", ["rm", "--force", "--volumes", container], 20_000).catch(() => undefined);
         if (input.database) {
-          await run("docker", ["rm", "--force", postgresContainer], 20_000).catch(() => undefined);
+          await run("docker", ["rm", "--force", "--volumes", postgresContainer], 20_000).catch(() => undefined);
         }
         await Promise.all([
           rm(root, { recursive: true, force: true }),
@@ -725,9 +729,9 @@ async function startLocalLiteLlm(
     const postgresLogs = input.database
       ? await run("docker", ["logs", postgresContainer], 10_000).then((result) => result.stdout + result.stderr, () => "")
       : "";
-    await run("docker", ["rm", "--force", container], 20_000).catch(() => undefined);
+    await run("docker", ["rm", "--force", "--volumes", container], 20_000).catch(() => undefined);
     if (input.database) {
-      await run("docker", ["rm", "--force", postgresContainer], 20_000).catch(() => undefined);
+      await run("docker", ["rm", "--force", "--volumes", postgresContainer], 20_000).catch(() => undefined);
     }
     if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
     if (witness) await closeServer(witness).catch(() => undefined);

--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -10,7 +10,7 @@ import type {
   SurfaceHandle,
 } from "@openwork/hosts";
 
-const DEFAULT_MYSQL_URL = "mysql://root:password@127.0.0.1:3306";
+export const DEFAULT_MYSQL_URL = "mysql://root:password@127.0.0.1:3306";
 
 export interface DbHandle extends AsyncDisposable {
   name: string;

--- a/evals/packages/env/src/recipe.ts
+++ b/evals/packages/env/src/recipe.ts
@@ -1,4 +1,17 @@
-import { assertWorldName, defaultDisplayStage, hold, resolveStage } from "@openwork/world";
+import {
+  assertWorldName,
+  defaultDisplayStage,
+  defaultScriptWorldSnapshotDirectory,
+  hold,
+  LEDGER_ENV,
+  ledgerPath,
+  readLedger,
+  receiptName,
+  resolveStage,
+  rewriteLedger,
+  trackResource,
+  type LedgerEntry,
+} from "@openwork/world";
 import { resolvePlace, type Place } from "./place.ts";
 
 export interface RecipeTools {
@@ -6,6 +19,7 @@ export interface RecipeTools {
   place: Place;
   stage: string;
   stageName(base: string): string;
+  track(entry: Omit<LedgerEntry, "at">): Promise<void>;
 }
 
 export interface WorldRecipe<O extends Record<string, string> = Record<string, string>> {
@@ -23,14 +37,30 @@ export function recipe<O extends Record<string, string>>(
 }
 
 export async function runRecipe(def: WorldRecipe): Promise<void> {
-  await using stack = new AsyncDisposableStack();
-  const stage = resolveStage(process.env) ?? defaultDisplayStage(process.env);
-  const place = resolvePlace();
-  const outputs = await def.build({
-    stack,
-    place,
-    stage,
-    stageName: (base) => `${base} (${stage})`,
-  });
-  await hold({ name: def.name, outputs });
+  const worldStage = resolveStage(process.env);
+  const path = process.env[LEDGER_ENV]
+    ?? ledgerPath(defaultScriptWorldSnapshotDirectory(), receiptName(def.name, worldStage));
+  process.env[LEDGER_ENV] = path;
+  let completed = false;
+  try {
+    {
+      await using stack = new AsyncDisposableStack();
+      const stage = worldStage ?? defaultDisplayStage(process.env);
+      const place = resolvePlace();
+      const outputs = await def.build({
+        stack,
+        place,
+        stage,
+        stageName: (base) => `${base} (${stage})`,
+        track: trackResource,
+      });
+      await hold({ name: def.name, outputs });
+    }
+    completed = true;
+  } finally {
+    if (completed) {
+      const retained = (await readLedger(path)).filter((entry) => entry.retain === true);
+      await rewriteLedger(path, retained);
+    }
+  }
 }

--- a/evals/specs/world-crash-reap.test.ts
+++ b/evals/specs/world-crash-reap.test.ts
@@ -1,0 +1,362 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { access, appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { eventually, test } from "@openwork/testkit";
+import {
+  isProcessAlive,
+  main,
+  readLedger,
+  readScriptWorldSnapshot,
+  rewriteLedger,
+  type WorldCliOptions,
+} from "@openwork/world";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+async function stopPid(pid: number, label: string): Promise<void> {
+  if (!isProcessAlive(pid)) return;
+  try { process.kill(pid, "SIGKILL"); } catch {}
+  await eventually(() => !isProcessAlive(pid), {
+    within: 5_000,
+    intervalMs: 25,
+    label,
+  });
+}
+
+test("a crashed world is reaped and recreated without leaking or duplicating resources", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-crash-reap-"));
+  const worldsDirectory = join(root, "worlds");
+  const scriptsDirectory = join(root, ".worlds", "scripts");
+  const fixtureName = "reap-world";
+  const stage = "crash";
+  const stagedName = `${fixtureName}--${stage}`;
+  const fixturePath = join(worldsDirectory, `${fixtureName}.ts`);
+  const snapshotPath = join(scriptsDirectory, `${stagedName}.json`);
+  const ledgerPath = join(scriptsDirectory, `${stagedName}.ledger.jsonl`);
+  const recipeUrl = pathToFileURL(join(REPO_ROOT, "evals", "packages", "env", "src", "recipe.ts")).href;
+  const previousSnapshotDirectory = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  const previousStubCrash = process.env.OPENWORK_WORLD_STUB_CRASH;
+  const launchedPids = new Set<number>();
+  const sleeperPids = new Set<number>();
+  let unrelatedPid: number | undefined;
+  let printedLines: string[] = [];
+
+  const options: WorldCliOptions = {
+    cwd: root,
+    worldsDirectory,
+    print(line) {
+      printedLines.push(line);
+    },
+  };
+  const run = async (argv: string[]): Promise<{ code: number; lines: string[] }> => {
+    printedLines = [];
+    const code = await main(argv, options);
+    return { code, lines: [...printedLines] };
+  };
+  const up = (): Promise<{ code: number; lines: string[] }> => run([
+    "up", fixturePath, "--detach", "--stage", stage, "--timeout", "10000",
+  ]);
+  const retainedLine = (count: number): string =>
+    `Retained ${count} resources for "${stagedName}"; run pnpm world down ${fixtureName} --stage ${stage} --purge to remove them.`;
+
+  try {
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR = scriptsDirectory;
+    delete process.env.OPENWORK_WORLD_STUB_CRASH;
+    await mkdir(worldsDirectory);
+    await writeFile(fixturePath, `
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recipe, runRecipe } from ${JSON.stringify(recipeUrl)};
+
+const world = recipe(${JSON.stringify(fixtureName)}, async (tools) => {
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });
+  if (child.pid === undefined) throw new Error("Expected sleeper child pid.");
+  child.unref();
+  await tools.track({ kind: "process", id: String(child.pid), label: "sleeper", match: "setInterval" });
+  const dir = await mkdtemp(join(tmpdir(), "openwork-reap-"));
+  await tools.track({ kind: "tmpdir", id: dir, label: "scratch" });
+  const kept = await mkdtemp(join(tmpdir(), "openwork-reap-kept-"));
+  await tools.track({ kind: "tmpdir", id: kept, label: "kept", retain: true });
+  if (process.env.OPENWORK_WORLD_STUB_CRASH === "1") process.kill(process.pid, "SIGKILL");
+  tools.stack.use({
+    async [Symbol.asyncDispose](): Promise<void> {
+      try { process.kill(child.pid, "SIGKILL"); } catch {}
+      await rm(dir, { recursive: true, force: true });
+    },
+  });
+  return { child: String(child.pid), dir, kept };
+});
+
+export default world;
+if (import.meta.main) await runRecipe(world);
+`, "utf8");
+
+    const initialUp = await up();
+    assert.equal(initialUp.code, 0, initialUp.lines.join("\n"));
+    const initial = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(initial);
+    launchedPids.add(initial.pid);
+    assert.equal(isProcessAlive(initial.pid), true, await readFile(join(scriptsDirectory, `${stagedName}.log`), "utf8"));
+    const oldChildPid = Number(initial.outputs.child);
+    sleeperPids.add(oldChildPid);
+    const initialLedger = await readLedger(ledgerPath);
+    assert.equal(initialLedger.length, 3);
+    assert.deepEqual(initialLedger.map((entry) => entry.kind), ["process", "tmpdir", "tmpdir"]);
+    assert.equal(initialLedger[0]?.match, "setInterval");
+    assert.equal(initialLedger.find((entry) => entry.id === initial.outputs.kept)?.retain, true);
+    assert.equal(isProcessAlive(oldChildPid), true);
+    assert.equal(await exists(initial.outputs.dir), true);
+    assert.equal(await exists(initial.outputs.kept), true);
+    evidence.recordAssertionEvidence(
+      "World startup records every reapable and retained resource",
+      "Up succeeded with exactly one matched process, one temporary directory, and one retained temporary directory; all three resources were live or present.",
+      true,
+    );
+
+    process.kill(initial.pid, "SIGKILL");
+    await eventually(() => !isProcessAlive(initial.pid), {
+      within: 5_000,
+      intervalMs: 25,
+      label: "crashed world exits",
+    });
+    assert.equal(isProcessAlive(oldChildPid), true);
+    assert.equal(await exists(initial.outputs.dir), true);
+    const orphanPlan = await run(["plan", fixturePath, "--stage", stage]);
+    assert.equal(orphanPlan.code, 0, orphanPlan.lines.join("\n"));
+    assert.deepEqual(orphanPlan.lines, [
+      "- orphaned (stale receipt, will recreate)",
+      `receipt  ${snapshotPath}`,
+      `child  ${initial.outputs.child}`,
+      `dir  ${initial.outputs.dir}`,
+      `kept  ${initial.outputs.kept}`,
+      "leaked  2 resources",
+      "retained  1 resources",
+    ]);
+    assert.equal(isProcessAlive(oldChildPid), true);
+    assert.equal((await readLedger(ledgerPath)).length, 3);
+    evidence.recordAssertionEvidence(
+      "Plan reports orphan leaks without reaping them",
+      "After SIGKILL left the sleeper and scratch directory behind, plan printed the exact orphan, outputs, leaked, and retained lines while leaving the child and all three ledger entries untouched.",
+      true,
+    );
+
+    const recreatedUp = await up();
+    assert.equal(recreatedUp.code, 0, recreatedUp.lines.join("\n"));
+    assert.equal(recreatedUp.lines[0], `Reaped 2 leaked resources from "${stagedName}".`);
+    assert.equal(recreatedUp.lines[1], retainedLine(1));
+    assert.equal(recreatedUp.lines[2], `Removed stale world receipt "${stagedName}" (pid ${initial.pid}); recreating.`);
+    await eventually(() => !isProcessAlive(oldChildPid), {
+      within: 5_000,
+      intervalMs: 25,
+      label: "old sleeper is reaped",
+    });
+    assert.equal(await exists(initial.outputs.dir), false);
+    assert.equal(await exists(initial.outputs.kept), true);
+    const recreated = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(recreated);
+    launchedPids.add(recreated.pid);
+    const recreatedChildPid = Number(recreated.outputs.child);
+    sleeperPids.add(recreatedChildPid);
+    assert.notEqual(recreated.pid, initial.pid);
+    assert.notEqual(recreated.outputs.child, initial.outputs.child);
+    assert.equal(isProcessAlive(recreatedChildPid), true);
+    const recreatedLedger = await readLedger(ledgerPath);
+    assert.equal(recreatedLedger.length, 4);
+    const recreatedProcesses = recreatedLedger.filter((entry) => entry.kind === "process");
+    assert.equal(recreatedProcesses.length, 1);
+    assert.equal(isProcessAlive(Number(recreatedProcesses[0]?.id)), true);
+    evidence.recordAssertionEvidence(
+      "Up reaps an orphan before recreating it",
+      "Recreation printed reap, retain, and stale-receipt messages in order, removed only old non-retained resources, preserved the kept directory, and left exactly one new live sleeper.",
+      true,
+    );
+
+    const gracefulDown = await run(["down", fixtureName, "--stage", stage]);
+    assert.equal(gracefulDown.code, 0, gracefulDown.lines.join("\n"));
+    assert.deepEqual(gracefulDown.lines, [
+      `World "${stagedName}" torn down.`,
+      retainedLine(2),
+    ]);
+    await eventually(async () =>
+      !isProcessAlive(recreatedChildPid)
+      && !await exists(snapshotPath)
+      && !await exists(recreated.outputs.dir), {
+      within: 10_000,
+      intervalMs: 50,
+      label: "graceful world disposal",
+    });
+    assert.equal(await exists(initial.outputs.kept), true);
+    assert.equal(await exists(recreated.outputs.kept), true);
+    const gracefulLedger = await readLedger(ledgerPath);
+    assert.equal(gracefulLedger.length, 2);
+    assert.equal(gracefulLedger.every((entry) => entry.kind === "tmpdir" && entry.retain === true), true);
+    evidence.recordAssertionEvidence(
+      "Graceful down disposes active resources but preserves retained entries",
+      "Down printed teardown before the retained count, stopped the new sleeper, removed its receipt and scratch directory, and kept exactly the two retained directories in the ledger.",
+      true,
+    );
+
+    const crashDownUp = await up();
+    assert.equal(crashDownUp.code, 0, crashDownUp.lines.join("\n"));
+    const crashDownSnapshot = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(crashDownSnapshot);
+    launchedPids.add(crashDownSnapshot.pid);
+    const crashDownChildPid = Number(crashDownSnapshot.outputs.child);
+    sleeperPids.add(crashDownChildPid);
+    assert.equal(isProcessAlive(crashDownChildPid), true);
+    process.kill(crashDownSnapshot.pid, "SIGKILL");
+    await eventually(() => !isProcessAlive(crashDownSnapshot.pid), {
+      within: 5_000,
+      intervalMs: 25,
+      label: "second crashed world exits",
+    });
+    const crashDown = await run(["down", fixtureName, "--stage", stage]);
+    assert.equal(crashDown.code, 0, crashDown.lines.join("\n"));
+    assert.equal(crashDown.lines[0], `World "${stagedName}" torn down.`);
+    assert.equal(crashDown.lines[1], `Reaped 2 leaked resources from "${stagedName}".`);
+    assert.equal(crashDown.lines[2], retainedLine(3));
+    await eventually(() => !isProcessAlive(crashDownChildPid), {
+      within: 5_000,
+      intervalMs: 25,
+      label: "crash-then-down sleeper is reaped",
+    });
+    assert.equal(await exists(crashDownSnapshot.outputs.dir), false);
+    const keptDirectories = [initial.outputs.kept, recreated.outputs.kept, crashDownSnapshot.outputs.kept];
+    assert.equal((await Promise.all(keptDirectories.map(exists))).every(Boolean), true);
+    assert.equal(await exists(snapshotPath), false);
+    const crashDownLedger = await readLedger(ledgerPath);
+    assert.equal(crashDownLedger.length, 3);
+    assert.equal(crashDownLedger.every((entry) => entry.kind === "tmpdir" && entry.retain === true), true);
+    evidence.recordAssertionEvidence(
+      "Down reaps resources from a crashed receipt",
+      "Crash-then-down printed teardown, reaped two leaks, retained three directories, removed the receipt and latest scratch directory, and left only retained entries.",
+      true,
+    );
+
+    const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    if (unrelated.pid === undefined) throw new Error("Expected unrelated child pid.");
+    unrelatedPid = unrelated.pid;
+    unrelated.unref();
+    await appendFile(ledgerPath, `${JSON.stringify({
+      kind: "process",
+      id: String(unrelatedPid),
+      match: "definitely-not-this-marker",
+      at: new Date().toISOString(),
+    })}\n`, "utf8");
+    const identityDown = await run(["down", fixtureName, "--stage", stage]);
+    assert.equal(identityDown.code, 0, identityDown.lines.join("\n"));
+    assert.equal(identityDown.lines.includes(`Skipped process ${unrelatedPid}: identity mismatch.`), true);
+    assert.equal(identityDown.lines.at(-1), `World "${stagedName}" has no receipt; reaped its ledger.`);
+    assert.equal(isProcessAlive(unrelatedPid), true);
+    const guardedLedger = await readLedger(ledgerPath);
+    assert.equal(guardedLedger.length, 4);
+    assert.ok(guardedLedger.find((entry) => entry.kind === "process" && entry.id === String(unrelatedPid)));
+    await rewriteLedger(ledgerPath, guardedLedger.filter((entry) => entry.id !== String(unrelatedPid)));
+    await stopPid(unrelatedPid, "unrelated identity-guard child cleanup");
+    unrelatedPid = undefined;
+    evidence.recordAssertionEvidence(
+      "Process identity mismatch skips an unrelated child",
+      "Ledger-only down reported the exact identity-mismatch skip and completion line, left the unrelated process alive and retry entry present beside three retained entries, then the fixture removed both safely.",
+      true,
+    );
+
+    const guardPath = `/openwork-reaper-guard-${Math.random().toString(16).slice(2)}-does-not-exist`;
+    await appendFile(ledgerPath, `${JSON.stringify({
+      kind: "tmpdir",
+      id: guardPath,
+      at: new Date().toISOString(),
+    })}\n`, "utf8");
+    const confinementDown = await run(["down", fixtureName, "--stage", stage, "--purge"]);
+    assert.equal(confinementDown.code, 0, confinementDown.lines.join("\n"));
+    assert.equal(confinementDown.lines.includes(`Skipped tmpdir ${guardPath}: outside allowed roots.`), true);
+    assert.equal((await Promise.all(keptDirectories.map(exists))).every((present) => !present), true);
+    const confinementLedger = await readLedger(ledgerPath);
+    assert.deepEqual(confinementLedger.map((entry) => entry.id), [guardPath]);
+    await rewriteLedger(ledgerPath, []);
+    assert.equal(await exists(ledgerPath), false);
+    evidence.recordAssertionEvidence(
+      "Tmpdir confinement blocks paths outside OS temporary roots",
+      "Purge removed all three retained temporary directories but printed the exact outside-roots skip and retained only that guard entry until explicit test cleanup deleted the ledger.",
+      true,
+    );
+
+    process.env.OPENWORK_WORLD_STUB_CRASH = "1";
+    const midBootCrash = await up();
+    assert.equal(midBootCrash.code, 1, midBootCrash.lines.join("\n"));
+    assert.equal(midBootCrash.lines.includes(`Script world "${stagedName}" exited before creating its snapshot.`), true);
+    assert.equal(await exists(snapshotPath), false);
+    const crashedBootLedger = await readLedger(ledgerPath);
+    assert.equal(crashedBootLedger.length, 3);
+    const crashedBootProcess = crashedBootLedger.find((entry) => entry.kind === "process");
+    assert.ok(crashedBootProcess);
+    const crashedBootChildPid = Number(crashedBootProcess.id);
+    sleeperPids.add(crashedBootChildPid);
+    assert.equal(isProcessAlive(crashedBootChildPid), true);
+    delete process.env.OPENWORK_WORLD_STUB_CRASH;
+    const postCrashUp = await up();
+    assert.equal(postCrashUp.code, 0, postCrashUp.lines.join("\n"));
+    assert.equal(postCrashUp.lines[0], `Reaped 2 leaked resources from "${stagedName}".`);
+    assert.equal(postCrashUp.lines[1], retainedLine(1));
+    await eventually(() => !isProcessAlive(crashedBootChildPid), {
+      within: 5_000,
+      intervalMs: 25,
+      label: "mid-boot leaked sleeper is reaped",
+    });
+    const finalSnapshot = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(finalSnapshot);
+    launchedPids.add(finalSnapshot.pid);
+    const finalChildPid = Number(finalSnapshot.outputs.child);
+    sleeperPids.add(finalChildPid);
+    const finalProcesses = (await readLedger(ledgerPath)).filter((entry) => entry.kind === "process");
+    assert.equal(finalProcesses.length, 1);
+    assert.equal(finalProcesses[0]?.id, String(finalChildPid));
+    assert.equal(isProcessAlive(finalChildPid), true);
+    const finalDown = await run(["down", fixtureName, "--stage", stage, "--purge"]);
+    assert.equal(finalDown.code, 0, finalDown.lines.join("\n"));
+    await eventually(async () =>
+      !isProcessAlive(finalSnapshot.pid)
+      && !isProcessAlive(finalChildPid)
+      && !await exists(snapshotPath)
+      && !await exists(finalSnapshot.outputs.dir)
+      && !await exists(finalSnapshot.outputs.kept)
+      && !await exists(ledgerPath), {
+      within: 10_000,
+      intervalMs: 50,
+      label: "final purged world cleanup",
+    });
+    evidence.recordAssertionEvidence(
+      "A missing receipt with a crash ledger is reaped before boot",
+      "Mid-boot SIGKILL left no receipt but three tracked resources; the next up reaped two leaks, retained one, launched exactly one sleeper, and final purge removed every resource and the ledger.",
+      true,
+    );
+  } finally {
+    delete process.env.OPENWORK_WORLD_STUB_CRASH;
+    try { await main(["down", fixtureName, "--stage", stage, "--purge"], { ...options, print: () => {} }); } catch {}
+    for (const pid of launchedPids) {
+      try { await stopPid(pid, "crash-reap world cleanup"); } catch {}
+    }
+    for (const pid of sleeperPids) {
+      try { await stopPid(pid, "crash-reap sleeper cleanup"); } catch {}
+    }
+    if (unrelatedPid !== undefined) {
+      try { await stopPid(unrelatedPid, "crash-reap unrelated child cleanup"); } catch {}
+    }
+    if (previousSnapshotDirectory === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previousSnapshotDirectory;
+    if (previousStubCrash === undefined) delete process.env.OPENWORK_WORLD_STUB_CRASH;
+    else process.env.OPENWORK_WORLD_STUB_CRASH = previousStubCrash;
+    await rm(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/evals/specs/world-reap-docker.test.ts
+++ b/evals/specs/world-reap-docker.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { eventually, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+import {
+  isProcessAlive,
+  main,
+  readLedger,
+  readScriptWorldSnapshot,
+  type WorldCliOptions,
+} from "@openwork/world";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const execFileAsync = promisify(execFile);
+const requirements: TestNeeds = { commands: ["docker"] };
+const missing = unmetNeeds(requirements, process.env);
+const title = missing.length > 0
+  ? `docker-backed world resources are reaped after a crash skipped — needs: ${missing.join(", ")}`
+  : "docker-backed world resources are reaped after a crash and volumes honor retain";
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+async function dockerSucceeds(args: string[]): Promise<boolean> {
+  try {
+    await execFileAsync("docker", args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test.skipIf(missing.length > 0)(title, async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reap-docker-"));
+  const worldsDirectory = join(root, "worlds");
+  const scriptsDirectory = join(root, ".worlds", "scripts");
+  const fixtureName = "docker-reap-world";
+  const stage = "d";
+  const stagedName = `${fixtureName}--${stage}`;
+  const fixturePath = join(worldsDirectory, `${fixtureName}.ts`);
+  const snapshotPath = join(scriptsDirectory, `${stagedName}.json`);
+  const ledgerPath = join(scriptsDirectory, `${stagedName}.ledger.jsonl`);
+  const trackedName = `openwork-reap-spec-${randomBytes(4).toString("hex")}`;
+  const volumeName = `openwork-reap-vol-${randomBytes(4).toString("hex")}`;
+  const controlName = `openwork-reap-control-${randomBytes(4).toString("hex")}`;
+  const recipeUrl = pathToFileURL(join(REPO_ROOT, "evals", "packages", "env", "src", "recipe.ts")).href;
+  const previousSnapshotDirectory = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  let worldPid: number | undefined;
+  let printedLines: string[] = [];
+
+  const options: WorldCliOptions = {
+    cwd: root,
+    worldsDirectory,
+    print(line) {
+      printedLines.push(line);
+    },
+  };
+  const run = async (argv: string[]): Promise<{ code: number; lines: string[] }> => {
+    printedLines = [];
+    const code = await main(argv, options);
+    return { code, lines: [...printedLines] };
+  };
+
+  try {
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR = scriptsDirectory;
+    await execFileAsync("docker", ["pull", "alpine:3"]);
+    await execFileAsync("docker", ["run", "-d", "--name", controlName, "alpine:3", "sleep", "600"]);
+    await mkdir(worldsDirectory);
+    await writeFile(fixturePath, `
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { recipe, runRecipe } from ${JSON.stringify(recipeUrl)};
+
+const execFileAsync = promisify(execFile);
+const container = ${JSON.stringify(trackedName)};
+const volume = ${JSON.stringify(volumeName)};
+const world = recipe(${JSON.stringify(fixtureName)}, async (tools) => {
+  await execFileAsync("docker", ["run", "-d", "--name", container, "alpine:3", "sleep", "600"]);
+  await tools.track({ kind: "docker", id: container, label: "sleeper" });
+  await execFileAsync("docker", ["volume", "create", volume]);
+  await tools.track({ kind: "docker-volume", id: volume, retain: true });
+  tools.stack.use({
+    async [Symbol.asyncDispose](): Promise<void> {
+      await execFileAsync("docker", ["rm", "-f", container]);
+    },
+  });
+  return { container, volume };
+});
+
+export default world;
+if (import.meta.main) await runRecipe(world);
+`, "utf8");
+
+    const up = await run(["up", fixturePath, "--detach", "--stage", stage, "--timeout", "10000"]);
+    assert.equal(up.code, 0, up.lines.join("\n"));
+    const snapshot = await readScriptWorldSnapshot(snapshotPath);
+    assert.ok(snapshot);
+    worldPid = snapshot.pid;
+    assert.equal(await dockerSucceeds(["inspect", trackedName]), true);
+    assert.equal((await readLedger(ledgerPath)).length, 2);
+    evidence.recordAssertionEvidence(
+      "Docker world startup tracks its container and retained volume",
+      "Up succeeded, the tracked container was inspectable, and the ledger contained exactly the container and volume entries.",
+      true,
+    );
+
+    process.kill(snapshot.pid, "SIGKILL");
+    await eventually(() => !isProcessAlive(snapshot.pid), {
+      within: 10_000,
+      intervalMs: 50,
+      label: "docker world crashes",
+    });
+    assert.equal(await dockerSucceeds(["inspect", trackedName]), true);
+    evidence.recordAssertionEvidence(
+      "A crashed Docker world leaves a real container leak",
+      "After the world process exited from SIGKILL, docker inspect still succeeded for the tracked container.",
+      true,
+    );
+
+    const down = await run(["down", fixtureName, "--stage", stage]);
+    assert.equal(down.code, 0, down.lines.join("\n"));
+    assert.deepEqual(down.lines, [
+      `World "${stagedName}" torn down.`,
+      `Reaped 1 leaked resources from "${stagedName}".`,
+      `Retained 1 resources for "${stagedName}"; run pnpm world down ${fixtureName} --stage ${stage} --purge to remove them.`,
+    ]);
+    assert.equal(await dockerSucceeds(["inspect", trackedName]), false);
+    assert.equal(await dockerSucceeds(["volume", "inspect", volumeName]), true);
+    assert.equal(await dockerSucceeds(["inspect", controlName]), true);
+    evidence.recordAssertionEvidence(
+      "Down reaps only the tracked container and retains the volume",
+      "The exact teardown, reap, and retain lines were printed; the tracked container disappeared, the retained volume remained, and the untracked control container stayed untouched.",
+      true,
+    );
+
+    const purge = await run(["down", fixtureName, "--stage", stage, "--purge"]);
+    assert.equal(purge.code, 0, purge.lines.join("\n"));
+    assert.deepEqual(purge.lines, [
+      `Reaped 1 leaked resources from "${stagedName}".`,
+      `World "${stagedName}" has no receipt; reaped its ledger.`,
+    ]);
+    assert.equal(await dockerSucceeds(["volume", "inspect", volumeName]), false);
+    assert.equal(await exists(ledgerPath), false);
+    evidence.recordAssertionEvidence(
+      "Purge reaps the retained Docker volume and deletes its ledger",
+      "Ledger-only purge printed the exact reap and no-receipt completion lines, made volume inspect fail, and removed the empty ledger.",
+      true,
+    );
+  } finally {
+    try { await execFileAsync("docker", ["rm", "-f", trackedName, controlName]); } catch {}
+    try { await execFileAsync("docker", ["volume", "rm", "-f", volumeName]); } catch {}
+    const stalePid = worldPid;
+    if (stalePid !== undefined && isProcessAlive(stalePid)) {
+      try { process.kill(stalePid, "SIGKILL"); } catch {}
+      try {
+        await eventually(() => !isProcessAlive(stalePid), {
+          within: 5_000,
+          intervalMs: 25,
+          label: "docker world process cleanup",
+        });
+      } catch {}
+    }
+    if (previousSnapshotDirectory === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previousSnapshotDirectory;
+    await rm(root, { recursive: true, force: true });
+  }
+}, 180_000);

--- a/packages/world/src/cli.ts
+++ b/packages/world/src/cli.ts
@@ -1,6 +1,8 @@
-import { access, rm } from "node:fs/promises";
+import { access, readdir, rm } from "node:fs/promises";
 import { basename, extname, join, resolve } from "node:path";
+import { ledgerPath, readLedger } from "./ledger.ts";
 import { discoverWorlds, displayWorldPath, resolveWorldScript } from "./loader.ts";
+import { builtinReapers, reapLedger, type ReapReport, type Reaper } from "./reaper.ts";
 import { receiptName, resolveStage, sanitizeStage } from "./stage.ts";
 import { WorldStateStore } from "./store.ts";
 import {
@@ -23,7 +25,7 @@ export type WorldCommand =
       place?: "local" | "daytona";
       args: string[];
     }
-  | { kind: "down"; name: string; stage?: string }
+  | { kind: "down"; name: string; stage?: string; purge?: true }
   | { kind: "plan"; source: string; stage?: string }
   | { kind: "list" }
   | { kind: "forget"; name: string }
@@ -33,6 +35,7 @@ export interface WorldCliOptions {
   cwd: string;
   worldsDirectory: string;
   print?: (line: string) => void;
+  reapers?: Record<string, Reaper>;
 }
 
 function helpError(message: string): WorldCommand {
@@ -140,9 +143,32 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
     if (!name || name === "--" || name.startsWith("--")) {
       return helpError("The down command needs exactly one world name.");
     }
-    const parsed = parseStageOptions(options);
-    if (parsed.error) return helpError(parsed.error);
-    return { kind: "down", name, ...(parsed.stage === undefined ? {} : { stage: parsed.stage }) };
+    let stage: string | undefined;
+    let purge = false;
+    for (let index = 0; index < options.length; index += 1) {
+      const option = options[index];
+      if (option === "--stage" && stage === undefined) {
+        const value = options[index + 1];
+        try {
+          stage = sanitizeStage(value ?? "");
+        } catch {
+          return helpError("Use --stage followed by a non-empty stage value.");
+        }
+        index += 1;
+        continue;
+      }
+      if (option === "--purge" && !purge) {
+        purge = true;
+        continue;
+      }
+      return helpError(`Unknown world CLI option ${JSON.stringify(option)}.`);
+    }
+    return {
+      kind: "down",
+      name,
+      ...(stage === undefined ? {} : { stage }),
+      ...(purge ? { purge: true } : {}),
+    };
   }
   if (command === "forget") {
     return args.length === 1 && args[0]
@@ -162,7 +188,7 @@ async function helpText(options: WorldCliOptions): Promise<string> {
   return `Usage:
   pnpm world up <script-path-or-name> [--detach] [--timeout <ms>] [--stage <value>] [--place <local|daytona>] [-- <script args...>]
   pnpm world plan <script-path-or-name> [--stage <value>]
-  pnpm world down <name> [--stage <value>]
+  pnpm world down <name> [--stage <value>] [--purge]
   pnpm world list
   pnpm world forget <name>
   pnpm world help
@@ -195,6 +221,48 @@ async function pathExists(path: string): Promise<boolean> {
   return access(path).then(() => true, () => false);
 }
 
+const LEDGER_SUFFIX = ".ledger.jsonl";
+
+async function ledgerWorldNames(directory: string): Promise<string[]> {
+  try {
+    return (await readdir(directory))
+      .filter((name) => name.endsWith(LEDGER_SUFFIX))
+      .map((name) => name.slice(0, -LEDGER_SUFFIX.length))
+      .sort();
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function reapAndReport(
+  path: string,
+  stagedName: string,
+  name: string,
+  stage: string | undefined,
+  purge: boolean,
+  print: (line: string) => void,
+  options: WorldCliOptions,
+): Promise<ReapReport> {
+  const report = await reapLedger(path, {
+    cwd: options.cwd,
+    purge,
+    reapers: { ...builtinReapers, ...options.reapers },
+  });
+  if (report.reaped.length > 0) {
+    print(`Reaped ${report.reaped.length} leaked resources from ${JSON.stringify(stagedName)}.`);
+  }
+  for (const { entry, reason } of report.skipped) {
+    print(`Skipped ${entry.kind} ${entry.id}: ${reason}.`);
+  }
+  if (report.retained.length > 0 && !purge) {
+    print(`Retained ${report.retained.length} resources for ${JSON.stringify(stagedName)}; run pnpm world down ${name}${stage ? ` --stage ${stage}` : ""} --purge to remove them.`);
+  }
+  return report;
+}
+
 export async function main(argv: string[], options: WorldCliOptions): Promise<number> {
   const print = options.print ?? console.log;
   const command = parseWorldArgs(argv);
@@ -211,6 +279,7 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
       const stagedName = receiptName(script.name, stage);
       const snapshotPath = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
+      const worldLedgerPath = ledgerPath(snapshotDirectory, stagedName);
       const state = await classifyScriptReceipt(snapshotPath, recipeHash);
       if (state.kind === "running") {
         printOutputs(state.snapshot, print);
@@ -222,8 +291,11 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
         return 1;
       }
       if (state.kind === "orphaned") {
+        await reapAndReport(worldLedgerPath, stagedName, script.name, stage, false, print, options);
         await rm(snapshotPath, { force: true });
         print(`Removed stale world receipt ${JSON.stringify(stagedName)} (pid ${state.snapshot.pid}); recreating.`);
+      } else if (await pathExists(worldLedgerPath)) {
+        await reapAndReport(worldLedgerPath, stagedName, script.name, stage, false, print, options);
       }
       return await launchScriptWorld({
         path: script.path,
@@ -247,10 +319,9 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       const script = await resolveWorldScript(command.source, options);
       const stage = resolveStage(process.env, command.stage);
       const recipeHash = await computeRecipeHash(script.path);
-      const snapshotPath = scriptWorldSnapshotPath(
-        scriptWorldSnapshotDirectory(options.cwd),
-        receiptName(script.name, stage),
-      );
+      const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
+      const stagedName = receiptName(script.name, stage);
+      const snapshotPath = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
       const state = await classifyScriptReceipt(snapshotPath, recipeHash);
       const labels = {
         create: "+ create",
@@ -261,6 +332,16 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       print(labels[state.kind]);
       print(`receipt  ${snapshotPath}`);
       if (state.kind !== "create") printOutputs(state.snapshot, print);
+      const worldLedgerPath = ledgerPath(snapshotDirectory, stagedName);
+      if (await pathExists(worldLedgerPath)) {
+        const entries = await readLedger(worldLedgerPath);
+        const leaked = entries.filter((entry) => entry.retain !== true).length;
+        const retained = entries.filter((entry) => entry.retain === true).length;
+        if (leaked > 0 && (state.kind === "create" || state.kind === "orphaned")) {
+          print(`leaked  ${leaked} resources`);
+        }
+        if (retained > 0) print(`retained  ${retained} resources`);
+      }
       return 0;
     } catch (error) {
       print(messageText(error));
@@ -272,11 +353,19 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
       let stagedName = receiptName(command.name, command.stage);
       let path = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
-      if (command.stage === undefined && !await pathExists(path)) {
+      let worldLedgerPath = ledgerPath(snapshotDirectory, stagedName);
+      if (
+        command.stage === undefined
+        && !await pathExists(path)
+        && !await pathExists(worldLedgerPath)
+      ) {
         const prefix = `${command.name}--`;
-        const candidates = (await new WorldStateStore(snapshotDirectory).list())
+        const receiptCandidates = (await new WorldStateStore(snapshotDirectory).list())
           .map((candidatePath) => basename(candidatePath, extname(candidatePath)))
           .filter((candidate) => candidate.startsWith(prefix));
+        const ledgerCandidates = (await ledgerWorldNames(snapshotDirectory))
+          .filter((candidate) => candidate.startsWith(prefix));
+        const candidates = [...new Set([...receiptCandidates, ...ledgerCandidates])].sort();
         if (candidates.length > 1) {
           print(`Multiple staged world receipts match ${JSON.stringify(command.name)}:`);
           for (const candidate of candidates) print(`  ${candidate}`);
@@ -285,7 +374,27 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
         if (candidates[0]) {
           stagedName = candidates[0];
           path = scriptWorldSnapshotPath(snapshotDirectory, stagedName);
+          worldLedgerPath = ledgerPath(snapshotDirectory, stagedName);
         }
+      }
+      const receiptExists = await pathExists(path);
+      const ledgerExists = await pathExists(worldLedgerPath);
+      if (!receiptExists) {
+        if (!ledgerExists) {
+          print(`World receipt ${JSON.stringify(stagedName)} does not exist.`);
+          return 1;
+        }
+        await reapAndReport(
+          worldLedgerPath,
+          stagedName,
+          command.name,
+          command.stage,
+          command.purge === true,
+          print,
+          options,
+        );
+        print(`World ${JSON.stringify(stagedName)} has no receipt; reaped its ledger.`);
+        return 0;
       }
       const result = await downScriptWorld(path);
       if (!result.found) {
@@ -297,6 +406,15 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       } else {
         print(`World ${JSON.stringify(stagedName)} torn down.`);
       }
+      await reapAndReport(
+        worldLedgerPath,
+        stagedName,
+        command.name,
+        command.stage,
+        command.purge === true,
+        print,
+        options,
+      );
       return 0;
     } catch (error) {
       print(messageText(error));
@@ -308,13 +426,40 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
     print(`World scripts: ${discovered.map((world) => `${world.name} (${displayWorldPath(world.path, options.cwd)}, script)`).join(", ") || "(none)"}`);
     let count = 0;
     const receiptsDirectory = scriptWorldSnapshotDirectory(options.cwd);
+    const receiptNames = new Set<string>();
     for (const path of await new WorldStateStore(receiptsDirectory).list()) {
+      const receiptFileName = basename(path, extname(path));
+      receiptNames.add(receiptFileName);
       try {
         const receipt = await readScriptWorldSnapshot(path);
         if (!receipt) continue;
-        print(`${receipt.name}  ${receipt.createdAt}  script  ${isProcessAlive(receipt.pid) ? "alive" : `dead(pid ${receipt.pid})`}`);
+        const alive = isProcessAlive(receipt.pid);
+        const entries = await readLedger(ledgerPath(receiptsDirectory, receiptFileName));
+        const leaked = entries.filter((entry) => entry.retain !== true).length;
+        const retained = entries.filter((entry) => entry.retain === true).length;
+        let line = `${receipt.name}  ${receipt.createdAt}  script  ${alive ? "alive" : `dead(pid ${receipt.pid})`}`;
+        if (!alive && leaked > 0) line += `  leaked ${leaked}`;
+        if (retained > 0) line += `  retained ${retained}`;
+        print(line);
         count += 1;
       } catch (error) {
+        print(`Warning: skipped ${displayWorldPath(path, options.cwd)}: ${messageText(error)}`);
+      }
+    }
+    for (const stagedName of await ledgerWorldNames(receiptsDirectory)) {
+      if (receiptNames.has(stagedName)) continue;
+      try {
+        const entries = await readLedger(ledgerPath(receiptsDirectory, stagedName));
+        const leaked = entries.filter((entry) => entry.retain !== true).length;
+        const retained = entries.filter((entry) => entry.retain === true).length;
+        if (leaked === 0 && retained === 0) continue;
+        let line = `${stagedName}  -  script  down`;
+        if (retained > 0) line += `  retained ${retained}`;
+        if (leaked > 0) line += `  leaked ${leaked}`;
+        print(line);
+        count += 1;
+      } catch (error) {
+        const path = ledgerPath(receiptsDirectory, stagedName);
         print(`Warning: skipped ${displayWorldPath(path, options.cwd)}: ${messageText(error)}`);
       }
     }

--- a/packages/world/src/hold.ts
+++ b/packages/world/src/hold.ts
@@ -6,6 +6,13 @@ import { assertWorldName } from "./store.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 
+export function defaultScriptWorldSnapshotDirectory(): string {
+  return resolve(
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR
+      ?? join(REPO_ROOT, "evals", "results", ".worlds", "scripts"),
+  );
+}
+
 export interface ScriptWorldSnapshot {
   version: 1 | 2;
   kind: "script";
@@ -61,11 +68,7 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
   const place = process.env.OPENWORK_WORLD_PLACE;
   const stagedName = receiptName(name, stage);
 
-  const snapshotDirectory = resolve(
-    options.snapshotDir
-      ?? process.env.OPENWORK_WORLD_SNAPSHOT_DIR
-      ?? join(REPO_ROOT, "evals", "results", ".worlds", "scripts"),
-  );
+  const snapshotDirectory = resolve(options.snapshotDir ?? defaultScriptWorldSnapshotDirectory());
   const snapshotPath = join(snapshotDirectory, `${stagedName}.json`);
   const existingPid = await aliveSnapshotPid(snapshotPath);
   if (existingPid !== undefined) {
@@ -95,6 +98,7 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
   for (const [key, value] of Object.entries(outputs)) console.log(`${key}  ${value}`);
   console.log(`World ${JSON.stringify(stagedName)} is up. Ctrl-C (or pnpm world down ${name}${stage ? ` --stage ${stage}` : ""}) tears it down.`);
 
+  const keepAlive = setInterval(() => {}, 2_147_483_647);
   await new Promise<void>((done) => {
     let stopping = false;
     const stop = (): void => {
@@ -102,6 +106,7 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
       stopping = true;
       process.off("SIGINT", stop);
       process.off("SIGTERM", stop);
+      clearInterval(keepAlive);
       void unlink(snapshotPath).then(done, (error: unknown) => {
         console.error(`Could not remove script world snapshot ${snapshotPath}: ${error instanceof Error ? error.message : String(error)}`);
         done();

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -2,6 +2,8 @@ export * from "./loader.ts";
 export * from "./store.ts";
 export * from "./stage.ts";
 export * from "./hold.ts";
+export * from "./ledger.ts";
+export * from "./reaper.ts";
 export * from "./script-world.ts";
 export * from "./cli.ts";
 export * from "./headless-web-helpers.ts";

--- a/packages/world/src/ledger.ts
+++ b/packages/world/src/ledger.ts
@@ -1,0 +1,115 @@
+import { appendFile, chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export interface LedgerEntry {
+  kind: string;
+  id: string;
+  label?: string;
+  match?: string;
+  retain?: boolean;
+  at: string;
+}
+
+export const LEDGER_ENV = "OPENWORK_WORLD_LEDGER";
+
+export function ledgerPath(snapshotDirectory: string, receiptName: string): string {
+  return join(snapshotDirectory, `${receiptName}.ledger.jsonl`);
+}
+
+function isMissingFile(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "ENOENT";
+}
+
+function parseEntry(line: string): LedgerEntry | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (
+    typeof value !== "object"
+    || value === null
+    || Array.isArray(value)
+    || !("kind" in value)
+    || typeof value.kind !== "string"
+    || !("id" in value)
+    || typeof value.id !== "string"
+    || !("at" in value)
+    || typeof value.at !== "string"
+  ) {
+    return undefined;
+  }
+  const label = "label" in value ? value.label : undefined;
+  const match = "match" in value ? value.match : undefined;
+  const retain = "retain" in value ? value.retain : undefined;
+  if (
+    (label !== undefined && typeof label !== "string")
+    || (match !== undefined && typeof match !== "string")
+    || (retain !== undefined && typeof retain !== "boolean")
+  ) return undefined;
+  return {
+    kind: value.kind,
+    id: value.id,
+    ...(typeof label === "string" ? { label } : {}),
+    ...(typeof match === "string" ? { match } : {}),
+    ...(typeof retain === "boolean" ? { retain } : {}),
+    at: value.at,
+  };
+}
+
+export async function appendLedgerEntry(
+  path: string,
+  entry: Omit<LedgerEntry, "at">,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const recorded: LedgerEntry = { ...entry, at: new Date().toISOString() };
+  await appendFile(path, `${JSON.stringify(recorded)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+export async function readLedger(path: string): Promise<LedgerEntry[]> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if (isMissingFile(error)) return [];
+    throw error;
+  }
+  const entries = new Map<string, LedgerEntry>();
+  for (const line of text.split("\n")) {
+    if (line.trim().length === 0) continue;
+    const entry = parseEntry(line);
+    if (!entry) continue;
+    const key = `${entry.kind}\u0000${entry.id}`;
+    entries.delete(key);
+    entries.set(key, entry);
+  }
+  return [...entries.values()];
+}
+
+export async function rewriteLedger(path: string, entries: LedgerEntry[]): Promise<void> {
+  if (entries.length === 0) {
+    try {
+      await unlink(path);
+    } catch (error) {
+      if (!isMissingFile(error)) throw error;
+    }
+    return;
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await chmod(path, 0o600);
+}
+
+export async function trackResource(entry: Omit<LedgerEntry, "at">): Promise<void> {
+  const path = process.env[LEDGER_ENV];
+  if (path === undefined) return;
+  await appendLedgerEntry(path, entry);
+}

--- a/packages/world/src/reaper.ts
+++ b/packages/world/src/reaper.ts
@@ -1,0 +1,226 @@
+import { execFile } from "node:child_process";
+import { lstat, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { readLedger, rewriteLedger, type LedgerEntry } from "./ledger.ts";
+
+export type ExecFn = (
+  command: string,
+  args: string[],
+  timeoutMs: number,
+) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+export type ReapOutcome =
+  | { status: "reaped" }
+  | { status: "missing" }
+  | { status: "skipped"; reason: string };
+
+export interface ReapContext {
+  cwd: string;
+  exec: ExecFn;
+  allowedTmpRoots: string[];
+}
+
+export type Reaper = (entry: LedgerEntry, context: ReapContext) => Promise<ReapOutcome>;
+
+export interface ReapReport {
+  reaped: LedgerEntry[];
+  missing: LedgerEntry[];
+  skipped: Array<{ entry: LedgerEntry; reason: string }>;
+  retained: LedgerEntry[];
+}
+
+export interface ReapOptions {
+  cwd: string;
+  purge?: boolean;
+  reapers?: Record<string, Reaper>;
+  exec?: ExecFn;
+  allowedTmpRoots?: string[];
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error
+    ? error.code
+    : undefined;
+}
+
+const defaultExec: ExecFn = (command, args, timeoutMs) => new Promise((done) => {
+  execFile(command, args, {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 4 * 1024 * 1024,
+  }, (error, stdout, stderr) => {
+    if (!error) {
+      done({ code: 0, stdout, stderr });
+      return;
+    }
+    const code = errorCode(error);
+    const timedOut = "killed" in error && error.killed === true;
+    done({
+      code: timedOut ? 124 : code === "ENOENT" ? 127 : typeof code === "number" ? code : 1,
+      stdout,
+      stderr,
+    });
+  });
+});
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (processAlive(pid) && Date.now() < deadline) {
+    await delay(Math.min(100, Math.max(1, deadline - Date.now())));
+  }
+  return !processAlive(pid);
+}
+
+const processReaper: Reaper = async (entry, context) => {
+  if (entry.id.length === 0) return { status: "skipped", reason: "invalid pid" };
+  for (const character of entry.id) {
+    const code = character.charCodeAt(0);
+    if (code < 48 || code > 57) return { status: "skipped", reason: "invalid pid" };
+  }
+  const pid = Number(entry.id);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return { status: "skipped", reason: "invalid pid" };
+  if (!processAlive(pid)) return { status: "missing" };
+  if (entry.match === undefined || entry.match.length === 0) {
+    return { status: "skipped", reason: "no identity marker" };
+  }
+  const command = await context.exec("ps", ["-p", String(pid), "-o", "command="], 5_000);
+  if (!command.stdout.includes(entry.match)) {
+    return { status: "skipped", reason: "identity mismatch" };
+  }
+  try { process.kill(-pid, "SIGTERM"); } catch {}
+  try { process.kill(pid, "SIGTERM"); } catch {}
+  if (await waitForProcessExit(pid, 5_000)) return { status: "reaped" };
+  try { process.kill(-pid, "SIGKILL"); } catch {}
+  try { process.kill(pid, "SIGKILL"); } catch {}
+  return await waitForProcessExit(pid, 2_000)
+    ? { status: "reaped" }
+    : { status: "skipped", reason: "still alive" };
+};
+
+function firstLine(text: string): string {
+  const line = text.split("\n")[0] ?? "";
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+const dockerReaper: Reaper = async (entry, context) => {
+  const result = await context.exec("docker", ["rm", "--force", "--volumes", entry.id], 20_000);
+  if (result.code === 0) return { status: "reaped" };
+  if (result.stderr.includes("No such container")) return { status: "missing" };
+  return { status: "skipped", reason: `docker rm failed: ${firstLine(result.stderr)}` };
+};
+
+const dockerVolumeReaper: Reaper = async (entry, context) => {
+  const result = await context.exec("docker", ["volume", "rm", "--force", entry.id], 20_000);
+  if (result.code === 0) return { status: "reaped" };
+  if (result.stderr.includes("No such volume")) return { status: "missing" };
+  return { status: "skipped", reason: `docker volume rm failed: ${firstLine(result.stderr)}` };
+};
+
+async function canonicalPath(path: string): Promise<string> {
+  const suffix: string[] = [];
+  let candidate = resolve(path);
+  while (true) {
+    try {
+      const existing = await realpath(candidate);
+      return resolve(existing, ...suffix.reverse());
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+      const parent = dirname(candidate);
+      if (parent === candidate) throw error;
+      suffix.push(relative(parent, candidate));
+      candidate = parent;
+    }
+  }
+}
+
+function belowRoot(path: string, root: string): boolean {
+  return path !== root && path.startsWith(root.endsWith(sep) ? root : `${root}${sep}`);
+}
+
+async function pathPresent(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+}
+
+const tmpdirReaper: Reaper = async (entry, context) => {
+  if (!isAbsolute(entry.id)) return { status: "skipped", reason: "outside allowed roots" };
+  const canonical = await canonicalPath(entry.id);
+  if (!context.allowedTmpRoots.some((root) => belowRoot(canonical, root))) {
+    return { status: "skipped", reason: "outside allowed roots" };
+  }
+  if (!await pathPresent(entry.id)) return { status: "missing" };
+  await rm(entry.id, { recursive: true, force: true });
+  return { status: "reaped" };
+};
+
+export const builtinReapers: Record<string, Reaper> = {
+  process: processReaper,
+  docker: dockerReaper,
+  "docker-volume": dockerVolumeReaper,
+  tmpdir: tmpdirReaper,
+};
+
+async function existingRealpath(path: string): Promise<string | undefined> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function allowedTmpRoots(options: ReapOptions): Promise<string[]> {
+  if (options.allowedTmpRoots) {
+    return Promise.all(options.allowedTmpRoots.map((root) => canonicalPath(root)));
+  }
+  const systemRoots = await Promise.all(
+    [tmpdir(), "/tmp", "/private/tmp"].map((root) => existingRealpath(root)),
+  );
+  const workspaceRoot = await canonicalPath(join(options.cwd, "evals", "results"));
+  return [...new Set([...systemRoots.filter((root) => root !== undefined), workspaceRoot])];
+}
+
+export async function reapLedger(path: string, options: ReapOptions): Promise<ReapReport> {
+  const report: ReapReport = { reaped: [], missing: [], skipped: [], retained: [] };
+  const context: ReapContext = {
+    cwd: options.cwd,
+    exec: options.exec ?? defaultExec,
+    allowedTmpRoots: await allowedTmpRoots(options),
+  };
+  for (const entry of await readLedger(path)) {
+    if (entry.retain === true && options.purge !== true) {
+      report.retained.push(entry);
+      continue;
+    }
+    const reaper = options.reapers?.[entry.kind] ?? builtinReapers[entry.kind];
+    if (!reaper) {
+      report.skipped.push({ entry, reason: "no reaper for kind" });
+      continue;
+    }
+    const outcome = await reaper(entry, context);
+    if (outcome.status === "reaped") report.reaped.push(entry);
+    else if (outcome.status === "missing") report.missing.push(entry);
+    else report.skipped.push({ entry, reason: outcome.reason });
+  }
+  await rewriteLedger(path, [
+    ...report.retained,
+    ...report.skipped.map(({ entry }) => entry),
+  ]);
+  return report;
+}

--- a/packages/world/src/script-world.ts
+++ b/packages/world/src/script-world.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { access, chmod, mkdir, open, readFile, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { LEDGER_ENV, ledgerPath } from "./ledger.ts";
 import { receiptName } from "./stage.ts";
 import { assertWorldName } from "./store.ts";
 import type { ScriptWorldSnapshot } from "./hold.ts";
@@ -175,7 +176,11 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
   const path = resolve(options.path);
   const stagedName = receiptName(options.name, options.stage);
   const snapshotPath = scriptWorldSnapshotPath(options.snapshotDirectory, stagedName);
-  const env: NodeJS.ProcessEnv = { ...process.env, OPENWORK_WORLD_SNAPSHOT_DIR: options.snapshotDirectory };
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENWORK_WORLD_SNAPSHOT_DIR: options.snapshotDirectory,
+    [LEDGER_ENV]: ledgerPath(options.snapshotDirectory, stagedName),
+  };
   if (options.stage === undefined) delete env.OPENWORK_WORLD_STAGE;
   else env.OPENWORK_WORLD_STAGE = options.stage;
   if (options.recipeHash === undefined) delete env.OPENWORK_WORLD_RECIPE_HASH;

--- a/packages/world/test/cli.test.ts
+++ b/packages/world/test/cli.test.ts
@@ -58,6 +58,23 @@ test("world arguments expose only script lifecycle flags and forward arguments a
     name: "dev-headless",
     stage: "preview",
   });
+  assert.deepEqual(parseWorldArgs(["down", "dev-headless", "--purge"]), {
+    kind: "down",
+    name: "dev-headless",
+    purge: true,
+  });
+  assert.deepEqual(parseWorldArgs(["down", "dev-headless", "--stage", "preview", "--purge"]), {
+    kind: "down",
+    name: "dev-headless",
+    stage: "preview",
+    purge: true,
+  });
+  assert.deepEqual(parseWorldArgs(["down", "dev-headless", "--purge", "--stage", "preview"]), {
+    kind: "down",
+    name: "dev-headless",
+    stage: "preview",
+    purge: true,
+  });
 
   const invalidPlace = parseWorldArgs(["up", "dev-headless", "--place", "remote"]);
   assert.equal(invalidPlace.kind, "help");
@@ -73,6 +90,13 @@ test("world arguments expose only script lifecycle flags and forward arguments a
   assert.equal(unknownPlanFlag.kind, "help");
   if (unknownPlanFlag.kind !== "help") throw new Error("expected help");
   assert.match(unknownPlanFlag.error ?? "", /Unknown world CLI option "--detach"/);
+
+  for (const args of [["up", "dev-headless", "--purge"], ["plan", "dev-headless", "--purge"]]) {
+    const result = parseWorldArgs(args);
+    assert.equal(result.kind, "help");
+    if (result.kind !== "help") throw new Error("expected help");
+    assert.match(result.error ?? "", /Unknown world CLI option "--purge"/);
+  }
 });
 
 test("discovery, resolution, list, and help classify scripts without importing them", async () => {

--- a/packages/world/test/hold.test.ts
+++ b/packages/world/test/hold.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return true;
+    await delay(50);
+  }
+  return condition();
+}
+
+test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-hold-"));
+  const snapshots = join(root, "snapshots");
+  const worldPath = join(root, "hold-only.ts");
+  const receiptPath = join(snapshots, "hold-only.json");
+  const holdUrl = new URL("../src/hold.ts", import.meta.url).href;
+  await writeFile(worldPath, [
+    `import { hold } from ${JSON.stringify(holdUrl)};`,
+    'await hold({ outputs: { ok: "1" } });',
+    "",
+  ].join("\n"), "utf8");
+
+  const child = spawn(process.execPath, [worldPath], {
+    detached: true,
+    env: { ...process.env, OPENWORK_WORLD_SNAPSHOT_DIR: snapshots },
+    stdio: "ignore",
+  });
+  if (child.pid === undefined) throw new Error("child pid unavailable");
+  const pid = child.pid;
+  try {
+    assert.equal(
+      await waitFor(() => access(receiptPath).then(() => true, () => false), 5_000),
+      true,
+      "receipt was not created within 5s",
+    );
+    await delay(1_000);
+    assert.equal(isAlive(pid), true, "world exited while hold was awaiting a signal");
+
+    process.kill(pid, "SIGTERM");
+    assert.equal(await waitFor(() => !isAlive(pid), 5_000), true, "world did not exit after SIGTERM");
+    assert.equal(await access(receiptPath).then(() => true, () => false), false);
+  } finally {
+    if (isAlive(pid)) {
+      try { process.kill(-pid, "SIGKILL"); } catch {}
+      try { process.kill(pid, "SIGKILL"); } catch {}
+      await waitFor(() => !isAlive(pid), 2_000);
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/world/test/ledger.test.ts
+++ b/packages/world/test/ledger.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  appendLedgerEntry,
+  LEDGER_ENV,
+  readLedger,
+  rewriteLedger,
+  trackResource,
+} from "../src/ledger.ts";
+
+function absent(path: string): Promise<boolean> {
+  return access(path).then(() => false, () => true);
+}
+
+test("appendLedgerEntry creates a private JSONL ledger", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-ledger-append-"));
+  try {
+    const path = join(root, "nested", "world.ledger.jsonl");
+    await appendLedgerEntry(path, { kind: "docker", id: "container", label: "app" });
+    const mode = (await stat(path)).mode & 0o777;
+    assert.equal(mode, 0o600);
+    const line: unknown = JSON.parse((await readFile(path, "utf8")).trim());
+    assert.deepEqual(line, {
+      kind: "docker",
+      id: "container",
+      label: "app",
+      at: line && typeof line === "object" && "at" in line ? line.at : undefined,
+    });
+    assert.equal(line && typeof line === "object" && "at" in line && typeof line.at === "string", true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("readLedger skips invalid lines and keeps the last kind/id occurrence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-ledger-read-"));
+  try {
+    const path = join(root, "world.ledger.jsonl");
+    await writeFile(path, [
+      "",
+      "not-json",
+      JSON.stringify({ kind: "tmpdir", id: "/tmp/a", label: 42, at: "invalid" }),
+      JSON.stringify({ kind: "tmpdir", id: "/tmp/a", label: "first", at: "one" }),
+      JSON.stringify({ kind: "process", id: "123", at: "two" }),
+      JSON.stringify({ kind: "tmpdir", id: "/tmp/a", label: "last", retain: true, at: "three" }),
+      "",
+    ].join("\n"), "utf8");
+
+    assert.deepEqual(await readLedger(path), [
+      { kind: "process", id: "123", at: "two" },
+      { kind: "tmpdir", id: "/tmp/a", label: "last", retain: true, at: "three" },
+    ]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rewriteLedger unlinks an empty ledger", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-ledger-rewrite-"));
+  try {
+    const path = join(root, "world.ledger.jsonl");
+    await writeFile(path, "content\n", "utf8");
+    await rewriteLedger(path, []);
+    assert.equal(await absent(path), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("trackResource is inert without its env var and appends when configured", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-ledger-track-"));
+  const path = join(root, "world.ledger.jsonl");
+  const previous = process.env[LEDGER_ENV];
+  try {
+    delete process.env[LEDGER_ENV];
+    await trackResource({ kind: "tmpdir", id: "/tmp/noop" });
+    assert.equal(await absent(path), true);
+
+    process.env[LEDGER_ENV] = path;
+    await trackResource({ kind: "tmpdir", id: "/tmp/tracked", retain: true });
+    const entries = await readLedger(path);
+    assert.equal(entries.length, 1);
+    assert.deepEqual({ ...entries[0], at: "recorded" }, {
+      kind: "tmpdir",
+      id: "/tmp/tracked",
+      retain: true,
+      at: "recorded",
+    });
+  } finally {
+    if (previous === undefined) delete process.env[LEDGER_ENV];
+    else process.env[LEDGER_ENV] = previous;
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/world/test/reaper.test.ts
+++ b/packages/world/test/reaper.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { readLedger, rewriteLedger, type LedgerEntry } from "../src/ledger.ts";
+import { reapLedger, type ExecFn } from "../src/reaper.ts";
+
+function resource(kind: string, id: string, options: { match?: string; retain?: boolean } = {}): LedgerEntry {
+  return { kind, id, ...options, at: "2026-01-01T00:00:00.000Z" };
+}
+
+function present(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("docker reaping uses force/volumes and recognizes missing containers", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-docker-"));
+  try {
+    const path = join(root, "world.ledger.jsonl");
+    const calls: Array<{ command: string; args: string[]; timeoutMs: number }> = [];
+    const exec: ExecFn = async (command, args, timeoutMs) => {
+      calls.push({ command, args, timeoutMs });
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    await rewriteLedger(path, [resource("docker", "container-id")]);
+    const reaped = await reapLedger(path, { cwd: root, exec });
+    assert.deepEqual(reaped.reaped, [resource("docker", "container-id")]);
+    assert.deepEqual(calls, [{
+      command: "docker",
+      args: ["rm", "--force", "--volumes", "container-id"],
+      timeoutMs: 20_000,
+    }]);
+    assert.equal(await present(path), false);
+
+    await rewriteLedger(path, [resource("docker", "gone")]);
+    const missing = await reapLedger(path, {
+      cwd: root,
+      exec: async () => ({ code: 1, stdout: "", stderr: "Error: No such container: gone\n" }),
+    });
+    assert.deepEqual(missing.missing, [resource("docker", "gone")]);
+    assert.equal(await present(path), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("docker-volume reaping uses volume rm and recognizes missing volumes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-volume-"));
+  try {
+    const path = join(root, "world.ledger.jsonl");
+    const calls: string[][] = [];
+    await rewriteLedger(path, [resource("docker-volume", "volume-id")]);
+    const report = await reapLedger(path, {
+      cwd: root,
+      exec: async (_command, args) => {
+        calls.push(args);
+        return { code: 1, stdout: "", stderr: "No such volume: volume-id" };
+      },
+    });
+    assert.deepEqual(calls, [["volume", "rm", "--force", "volume-id"]]);
+    assert.deepEqual(report.missing, [resource("docker-volume", "volume-id")]);
+    assert.equal(await present(path), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("unknown resources are skipped and remain retryable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-unknown-"));
+  try {
+    const path = join(root, "world.ledger.jsonl");
+    const entry = resource("unknown", "thing");
+    await rewriteLedger(path, [entry]);
+    const report = await reapLedger(path, { cwd: root });
+    assert.deepEqual(report.skipped, [{ entry, reason: "no reaper for kind" }]);
+    assert.deepEqual(await readLedger(path), [entry]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("process reaping refuses a live pid without an identity marker", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-process-marker-"));
+  try {
+    const path = join(root, "world.ledger.jsonl");
+    const entry = resource("process", String(process.pid));
+    await rewriteLedger(path, [entry]);
+    const report = await reapLedger(path, { cwd: root });
+    assert.deepEqual(report.skipped, [{ entry, reason: "no identity marker" }]);
+    assert.equal(alive(process.pid), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("process reaping leaves a mismatched real child alive", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-process-mismatch-"));
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
+  try {
+    await once(child, "spawn");
+    if (child.pid === undefined) throw new Error("child pid unavailable");
+    const path = join(root, "world.ledger.jsonl");
+    const entry = resource("process", String(child.pid), { match: "marker-not-in-command" });
+    await rewriteLedger(path, [entry]);
+    const report = await reapLedger(path, { cwd: root });
+    assert.deepEqual(report.skipped, [{ entry, reason: "identity mismatch" }]);
+    assert.equal(alive(child.pid), true);
+  } finally {
+    if (child.pid !== undefined && alive(child.pid)) process.kill(child.pid, "SIGKILL");
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("process reaping terminates a real child with a matching command", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-process-match-"));
+  const marker = "openwork_reaper_identity_marker";
+  const child = spawn(process.execPath, ["-e", `setInterval(() => {}, 1000); // ${marker}`]);
+  try {
+    await once(child, "spawn");
+    if (child.pid === undefined) throw new Error("child pid unavailable");
+    const path = join(root, "world.ledger.jsonl");
+    const entry = resource("process", String(child.pid), { match: marker });
+    await rewriteLedger(path, [entry]);
+    const report = await reapLedger(path, { cwd: root });
+    assert.deepEqual(report.reaped, [entry]);
+    assert.equal(alive(child.pid), false);
+    assert.equal(await present(path), false);
+  } finally {
+    if (child.pid !== undefined && alive(child.pid)) process.kill(child.pid, "SIGKILL");
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("tmpdir reaping refuses paths outside configured roots", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-outside-"));
+  try {
+    const outside = join(root, "outside");
+    await mkdir(outside);
+    await writeFile(join(outside, "kept"), "kept", "utf8");
+    const path = join(root, "world.ledger.jsonl");
+    const entry = resource("tmpdir", outside);
+    await rewriteLedger(path, [entry]);
+    const report = await reapLedger(path, {
+      cwd: root,
+      allowedTmpRoots: [join(root, "allowed")],
+    });
+    assert.deepEqual(report.skipped, [{ entry, reason: "outside allowed roots" }]);
+    assert.equal(await present(join(outside, "kept")), true);
+    assert.deepEqual(await readLedger(path), [entry]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("tmpdir reaping removes paths below the OS temp directory", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-tmpdir-"));
+  const ledgerRoot = await mkdtemp(join(tmpdir(), "openwork-world-reaper-ledger-"));
+  try {
+    await writeFile(join(root, "removed"), "removed", "utf8");
+    const path = join(ledgerRoot, "world.ledger.jsonl");
+    const entry = resource("tmpdir", root);
+    await rewriteLedger(path, [entry]);
+    const report = await reapLedger(path, { cwd: ledgerRoot });
+    assert.deepEqual(report.reaped, [entry]);
+    assert.equal(await present(root), false);
+    assert.equal(await present(path), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(ledgerRoot, { recursive: true, force: true });
+  }
+});
+
+test("retained resources stay by default and are removed by purge", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-reaper-retain-"));
+  const ledgerRoot = await mkdtemp(join(tmpdir(), "openwork-world-reaper-retain-ledger-"));
+  try {
+    const path = join(ledgerRoot, "world.ledger.jsonl");
+    const entry = resource("tmpdir", root, { retain: true });
+    await rewriteLedger(path, [entry]);
+    const retained = await reapLedger(path, { cwd: ledgerRoot });
+    assert.deepEqual(retained.retained, [entry]);
+    assert.equal(await present(root), true);
+    assert.deepEqual(await readLedger(path), [entry]);
+
+    const purged = await reapLedger(path, { cwd: ledgerRoot, purge: true });
+    assert.deepEqual(purged.reaped, [entry]);
+    assert.equal(await present(root), false);
+    assert.equal(await present(path), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(ledgerRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Phase 2 of the world-engine plan (follows #4275). Phase 1 made `up` idempotent *via the receipt*; this closes the crash path, where the receipt is the only thing that dies and everything the world created keeps running with no owner.

## The gap (verified on `dev`)
`world down` on a dead pid just deleted the receipt and printed "torn down". Nothing inventoried the detached `pnpm dev:den:api|web` process groups, the `openwork-litellm-*` containers (whose Postgres image's anonymous volume leaked even on *graceful* disposal — `docker rm` had no `--volumes`), the ephemeral MySQL database, or the Electron process group. The next `up` duplicated all of them.

## What changed
**Ledger (`packages/world/src/ledger.ts`)** — every CLI-launched world child gets `OPENWORK_WORLD_LEDGER=<snapshotDir>/<receiptName>.ledger.jsonl`. Entries are appended *at creation time*, so a mid-boot crash that never wrote a receipt still leaves an inventory. `trackResource()` is a no-op without the env, so specs calling builders directly are untouched. Recipes get `tools.track()`; `runRecipe` prunes the ledger to retained entries only after clean disposal.

**Reaper (`packages/world/src/reaper.ts`)** — observe → ensure → sync over the ledger:
- `process`: refuses to signal any pid without an identity marker or whose `ps -o command=` doesn't contain it (pid-reuse safe); SIGTERM group+pid → 5s → SIGKILL.
- `docker` (`rm --force --volumes`), `docker-volume`, `tmpdir` (confined to OS temp roots + `evals/results`; never the root itself).
- `mysql-db` injected by the env CLI through the new `WorldCliOptions.reapers`, guarded to `openwork_eval_*` names. Engine stays dependency-free.
- `retain: true` entries survive `down`; `down --purge` removes them. Skipped entries stay in the ledger for retry.

**CLI** — `up` reaps the dead generation before recreating (orphaned receipt *or* receipt-less ledger); `down` reaps after teardown, and reaps a receipt-less ledger; `plan`/`list` show `leaked N` / `retained N`. Every new line is conditional on ledger content — the four existing exact-string engine specs pass unchanged.

**Builders self-track** — LiteLLM containers + config dir; Den MySQL DB + den-api/den-web groups (`match` = `dev:den:api` or the prepared `@openwork-ee/den-api`); Electron group + profile dir. LiteLLM disposal now passes `--volumes`.

**Engine fix surfaced by the new coverage** — `hold()` now owns its event-loop liveness. A world whose only resources are external (detached children, containers) previously exited immediately with `unsettled top-level await`; the earlier stubs only survived because they kept an HTTP server listening.

## Verification (all on PR head, local lane — no Daytona API credentials in this environment; local fallback per run-tests; engine specs are app-less)

| Check | Command | Result |
|---|---|---|
| World unit tests (ledger, reaper guards, hold liveness, CLI flags) | `pnpm --filter @openwork/world test` | 29/29 |
| **New** crash → reap → recreate, 8 claims incl. identity-guard and tmpdir-confinement negatives | `pnpm evals:pr specs/world-crash-reap.test.ts` | 1/1 |
| **New** real Docker: tracked container reaped, untracked control untouched, retained volume survives until `--purge` | `pnpm evals:pr specs/world-reap-docker.test.ts` | 1/1 (ran, not skipped) |
| Phase-1 exact-string specs unchanged | `pnpm evals:pr specs/{world-stage-isolation,world-plan-idempotent-up,script-world-lifecycle,shared-world-engine}.test.ts` | 1/1, 1/1, 1/1, 3/3 |
| Builder tracking regression (full Desktop + Den + LiteLLM world) | `node evals/bin/evals.mjs litellm-per-member-world --local` | 1/1 |
| Ledger smoke on the real world | `world up litellm-per-member --detach --stage b2` → 8 ledger rows (2 docker, 1 mysql-db, 3 process, 2 tmpdir) → `down` clean, no leftovers | manual, transcript in review thread |

Pre-existing, classified against clean `origin/dev@37fb919f2` with identical commands: `pnpm evals:typecheck` 582 errors on both (0 introduced; `den.ts:453→454` is the same error shifted by one import line); `specs/google-workspace-connector-retrieval.test.ts` fails identically on baseline; `specs/sso-super-admin-registration.test.ts` and `specs/den-api-production-package.test.ts` are green solo on this branch and failed only under full-lane parallelism.

Deliberately not in this PR: in-place adoption of a live Den/LiteLLM (needs this ledger first), deterministic container names, `world dev` watch mode.