### PR TITLE
fix(app,server): connect Den providers from locally saved Desktop credentials

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -108,15 +108,18 @@ export function CloudProvidersView({
         restrictToCloud,
         checkRestriction: checkDesktopAppRestriction,
       });
-      const syncError = lastSyncError[provider.id] ?? null;
+      // Modern server sync owns credential resolution, including local
+      // Environment variables. Den's shared-credential summary and errors
+      // from the legacy renderer path are not authoritative in this mode.
+      const syncError = serverSync === null ? lastSyncError[provider.id] ?? null : null;
       const env = getCloudProviderEnv(provider.providerConfig);
       const status = resolveCloudProviderRowStatus({
         imported: Boolean(imported),
         outOfSync,
         allowed,
         importsUnavailable,
-        needsCredential: !provider.hasApiKey && env.length > 0,
-        needsServer: provider.hasApiKey && env.length > 1 && !openworkServerAvailable,
+        needsCredential: serverSync === null && !provider.hasApiKey && env.length > 0,
+        needsServer: serverSync === null && provider.hasApiKey && env.length > 1 && !openworkServerAvailable,
         syncError,
         skippedByServer: Boolean(serverSync?.skippedProviders[provider.id]),
         reloadPending: serverSync?.reloadPending === true,

--- a/apps/app/tests/cloud-providers-view.test.ts
+++ b/apps/app/tests/cloud-providers-view.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 
 import {
   canRetryCloudProviderRow,
   resolveCloudProviderRowStatus,
   type CloudProviderRowStateInput,
 } from "../src/react-app/domains/settings/pages/cloud-providers-view";
+
+const viewSource = readFileSync(
+  new URL("../src/react-app/domains/settings/pages/cloud-providers-view.tsx", import.meta.url),
+  "utf8",
+);
 
 const ready: CloudProviderRowStateInput = {
   imported: true,
@@ -39,6 +45,25 @@ describe("Cloud provider status-only rows", () => {
     });
     expect(skipped).toBe("needs_credential");
     expect(canRetryCloudProviderRow(skipped)).toBe(false);
+  });
+
+  test("uses modern server materialization instead of Den's credential summary", () => {
+    // A Den provider without an org credential can still be materialized by
+    // the server from a matching local Desktop environment variable. When the
+    // server owns sync (serverSync !== null), the rows derive credential
+    // state only from the server's own skip list — Den's hasApiKey summary
+    // and legacy renderer sync errors are gated off at the call site.
+    expect(viewSource.includes(
+      "needsCredential: serverSync === null && !provider.hasApiKey && env.length > 0",
+    )).toBe(true);
+    expect(viewSource.includes(
+      "const syncError = serverSync === null ? lastSyncError[provider.id] ?? null : null;",
+    )).toBe(true);
+    // Server-materialized row: no legacy credential inputs, not skipped —
+    // Connected even though Den reports no organization credential.
+    expect(resolveCloudProviderRowStatus({ ...ready, skippedByServer: false })).toBe("connected");
+    // Server-side skip still wins over an otherwise connected-looking row.
+    expect(resolveCloudProviderRowStatus({ ...ready, skippedByServer: true })).toBe("needs_credential");
   });
 
   test("shows policy and workspace gates without retrying", () => {

--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -452,6 +452,108 @@ describe("cloud provider sync gateway", () => {
     }]);
   });
 
+  test("materializes a credential-less Den provider from a matching local Desktop environment key", async () => {
+    const root = await createRoot();
+    const credentialKey = "LOCAL_FALLBACK_API_KEY";
+    const localSecret = "sk-local-fallback-never-cloud-owned";
+    const provider: FakeProvider = {
+      ...buildProvider([{ id: "allowed-local-model", name: "Allowed Local Model", config: {} }]),
+      id: "lpr_local_fallback",
+      name: "Local Credential Provider",
+      apiKey: "",
+      apiKeys: null,
+      providerConfig: {
+        env: [credentialKey],
+        npm: "@ai-sdk/openai-compatible",
+      },
+    };
+    const denTraffic: Array<{ url: string; body: string | null }> = [];
+    const engineTraffic: Array<{ method: string; url: string; body: string | null }> = [];
+    const fetchImpl = Object.assign(async (
+      input: Parameters<typeof globalThis.fetch>[0],
+      init?: Parameters<typeof globalThis.fetch>[1],
+    ) => {
+      const url = new URL(String(input));
+      const body = typeof init?.body === "string" ? init.body : null;
+      if (url.hostname === "den.example.test") {
+        denTraffic.push({ url: url.toString(), body });
+        if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: [provider] });
+        if (url.pathname === `/v1/llm-providers/${provider.id}/connect`) {
+          return Response.json({ llmProvider: provider });
+        }
+      }
+      if (url.hostname === "engine.example.test") {
+        engineTraffic.push({ method: init?.method ?? "GET", url: url.toString(), body });
+        return Response.json(true);
+      }
+      return Response.json({ error: "not_found" }, { status: 404 });
+    }, { preconnect: globalThis.fetch.preconnect });
+    const config = serverConfig(root, "https://engine.example.test");
+    const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
+    const sync = new CloudProviderSync({
+      config,
+      env,
+      fetchImpl,
+      reloadEngine: async () => undefined,
+      intervalMs: 3_600_000,
+    });
+    stops.push(() => sync.stop());
+
+    await sync.setSession({
+      baseUrl: "https://den.example.test",
+      token: "den-token",
+      orgId: "org-local-fallback",
+    });
+    await sync.run("initial-missing");
+    expect(sync.status().providers).toEqual([]);
+    expect(sync.status().skippedProviders).toEqual([{
+      cloudProviderId: provider.id,
+      providerId: provider.id,
+      name: provider.name,
+      reason: "missing_credentials",
+    }]);
+
+    await env.upsertMany([{ key: "UNRELATED_API_KEY", value: "sk-unrelated" }]);
+    await sync.run("mismatched-local-key");
+    expect(sync.status().providers).toEqual([]);
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[provider.id]).toBeUndefined();
+
+    await env.upsertMany([{ key: credentialKey, value: localSecret }]);
+    expect((await sync.run("matching-local-key")).status).toBe("applied");
+    expect(sync.status().providers.map((entry) => entry.cloudProviderId)).toEqual([provider.id]);
+    expect(sync.status().skippedProviders).toEqual([]);
+    expect(sync.status().lastRun?.detail?.envUpserts).toBe(0);
+    const runtimeProvider = expectRecord(
+      runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[provider.id],
+      "local fallback runtime provider",
+    );
+    expect(Object.keys(expectRecord(runtimeProvider.models, "local fallback models"))).toEqual(["allowed-local-model"]);
+    expect(JSON.stringify(runtimeProvider)).not.toContain(localSecret);
+    expect(JSON.stringify(sync.status())).not.toContain(localSecret);
+    expect(JSON.stringify(denTraffic)).not.toContain(localSecret);
+    expect(engineTraffic.some((request) => request.method === "PUT" && request.body?.includes(localSecret))).toBe(true);
+    expect((await env.list()).find((entry) => entry.key === credentialKey)?.value).toBe(localSecret);
+
+    await sync.clearSession();
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[provider.id]).toBeUndefined();
+    expect((await env.list()).find((entry) => entry.key === credentialKey)?.value).toBe(localSecret);
+
+    await sync.setSession({
+      baseUrl: "https://den.example.test",
+      token: "den-token",
+      orgId: "org-local-fallback",
+    });
+    await sync.run("restore-with-local-key");
+    expect(sync.status().providers.map((entry) => entry.cloudProviderId)).toEqual([provider.id]);
+
+    await env.delete(credentialKey);
+    expect((await sync.run("local-key-removed")).status).toBe("applied");
+    expect(sync.status().providers).toEqual([]);
+    expect(sync.status().skippedProviders[0]?.reason).toBe("missing_credentials");
+    expect(runtimeProviderMap(await readGlobalRuntimeOpencodeConfig(config))[provider.id]).toBeUndefined();
+    expect((await env.list()).find((entry) => entry.key === "UNRELATED_API_KEY")?.value).toBe("sk-unrelated");
+  });
+
   test("materializes Den providers globally, reconciles changes, and sweeps the session", async () => {
     const root = await createRoot();
     const engineRequests: string[] = [];

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
 import type { EnvService } from "./env-file.js";
-import { syncManagedProviderAuth } from "./managed-provider-auth.js";
+import { selectPrimaryCredentialEnvName, syncManagedProviderAuth } from "./managed-provider-auth.js";
 import { writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import {
   hasOpenworkWorkspaceConfig,
@@ -473,9 +473,13 @@ function buildProviderConfig(provider: DenProviderConnection): JsonRecord {
   return config;
 }
 
-function prepareMaterialization(providers: DenProviderConnection[]): PreparedMaterialization {
+function prepareMaterialization(
+  providers: DenProviderConnection[],
+  localEnvNames: Iterable<string>,
+): PreparedMaterialization {
   const materialized: MaterializedProvider[] = [];
   const skipped: CloudProviderSyncSkippedProvider[] = [];
+  const availableLocalEnvNames = [...localEnvNames];
   for (const provider of providers) {
     if (provider.memberCredentialState && provider.memberCredentialState !== "active") {
       skipped.push({
@@ -488,11 +492,17 @@ function prepareMaterialization(providers: DenProviderConnection[]): PreparedMat
     }
     const envEntries = providerEnvEntries(provider);
     const envNames = readProviderEnvNames(provider.providerConfig);
-    if (envNames.length > 0 && !envEntries.some((entry) => envNames.includes(entry.key))) {
+    const primaryCredentialName = provider.apiKey?.trim()
+      ? envNames[0] ?? null
+      : selectPrimaryCredentialEnvName(
+          envNames,
+          [...envEntries.map((entry) => entry.key), ...availableLocalEnvNames],
+        );
+    if (envNames.length > 0 && !primaryCredentialName) {
       // The provider declares credential env vars but the connect payload
-      // yielded no value for any of them. Materializing it would produce a
-      // provider whose every request fails with a missing API key, so it is
-      // skipped — loudly, so status readers can see why it never appeared.
+      // and the local Desktop environment yielded no primary credential.
+      // Materializing it would produce a provider whose every request fails
+      // with a missing API key, so it is skipped loudly.
       skipped.push({
         cloudProviderId: provider.id,
         providerId: runtimeProviderId(provider),
@@ -874,7 +884,16 @@ export class CloudProviderSync {
   private async runPass(request: CloudProviderSyncRequest): Promise<CloudProviderSyncRunResult> {
     const { reason, session } = request;
     try {
-      const prepared = prepareMaterialization(await fetchProviders(this.fetchImpl, session));
+      const [providers, storedEnv] = await Promise.all([
+        fetchProviders(this.fetchImpl, session),
+        this.env.list(),
+      ]);
+      // Local credentials only satisfy materialization eligibility. Never add
+      // their values to Den's env entries or cloud cleanup ownership.
+      const localEnvNames = storedEnv
+        .filter((entry) => entry.value.trim().length > 0 && !this.ownedEnvKeys.has(entry.key))
+        .map((entry) => entry.key);
+      const prepared = prepareMaterialization(providers, localEnvNames);
       if (request.generation !== this.contextGeneration) return { status: "no_session" };
       const { changed, detail, reloadError } = await this.apply(prepared);
       // The materialization itself succeeded (config + env writes landed), so

--- a/apps/server/src/managed-provider-auth.ts
+++ b/apps/server/src/managed-provider-auth.ts
@@ -164,7 +164,10 @@ function credentialEnvRank(name: string): number | null {
   return null;
 }
 
-function selectPrimaryCredentialEnvName(envNames: string[], availableNames: Iterable<string>): string | null {
+export function selectPrimaryCredentialEnvName(
+  envNames: string[],
+  availableNames: Iterable<string>,
+): string | null {
   const available = new Set([...availableNames].filter((name) => name.trim().length > 0));
   const orderedNames = envNames.filter((name) => available.has(name));
   const ranked = orderedNames

--- a/evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts
+++ b/evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts
@@ -1,0 +1,339 @@
+import { expect, onTestFinished } from "vitest";
+import { denFetch, evalIn, go, readAvailableModels, waitFor } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { app, eventually, needs, server, test } from "@openwork/testkit";
+
+const ORGANIZATION_NAME = "Cloud Provider Local Credential Fallback";
+const PROVIDER_NAME = "Local Credential Models";
+const PROVIDER_KEY = "local-credential-models";
+const PROVIDER_ENV = "LOCAL_CREDENTIAL_FALLBACK_API_KEY";
+const ALLOWED_MODEL_ID = "local-credential-allowed-model";
+const DENIED_PROVIDER_NAME = "Unassigned Local Credential Models";
+const DENIED_PROVIDER_KEY = "unassigned-local-credential-models";
+const DENIED_MODEL_ID = "local-credential-denied-model";
+const LOCAL_SECRET = "sk-local-credential-eval-only";
+const MISMATCHED_ENV = "MISMATCHED_LOCAL_CREDENTIAL_API_KEY";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(session: DenSession): Promise<string> {
+  const result = await denFetch(session, "/v1/me/orgs", {
+    headers: auth(session),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === ORGANIZATION_NAME);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) throw new Error(`Finding the test organization failed with HTTP ${result.response.status}.`);
+  return id;
+}
+
+async function createProvider(
+  admin: DenSession,
+  orgId: string,
+  input: { name: string; providerKey: string; modelId: string; allMembers: boolean },
+): Promise<string> {
+  const result = await denFetch(admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    body: JSON.stringify({
+      name: input.name,
+      source: "custom",
+      customConfig: {
+        id: input.providerKey,
+        name: input.name,
+        npm: "@ai-sdk/openai-compatible",
+        env: [PROVIDER_ENV],
+        models: [{ id: input.modelId, name: input.modelId }],
+      },
+      allMembers: input.allMembers,
+      memberIds: [],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const provider = isRecord(result.body) && isRecord(result.body.llmProvider) ? result.body.llmProvider : null;
+  const id = provider && typeof provider.id === "string" ? provider.id : "";
+  if (result.response.status !== 201 || !id) {
+    throw new Error(`Creating ${input.name} failed: HTTP ${result.response.status} ${result.text.slice(0, 300)}`);
+  }
+  return id;
+}
+
+async function deleteProvider(admin: DenSession, orgId: string, providerId: string): Promise<void> {
+  await denFetch(admin, `/v1/llm-providers/${encodeURIComponent(providerId)}`, {
+    method: "DELETE",
+    headers: { ...auth(admin), "x-openwork-org-id": orgId },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}
+
+async function memberProviderList(member: DenSession, orgId: string): Promise<Record<string, unknown>[]> {
+  const result = await denFetch(member, "/v1/llm-providers", {
+    headers: { ...auth(member), "x-openwork-org-id": orgId },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!result.response.ok) throw new Error(`Listing member providers failed with HTTP ${result.response.status}.`);
+  return isRecord(result.body) && Array.isArray(result.body.llmProviders)
+    ? result.body.llmProviders.filter(isRecord)
+    : [];
+}
+
+async function localServerRequest(
+  surface: Parameters<typeof evalIn>[0],
+  path: string,
+  input: { method?: string; body?: Record<string, unknown>; host?: boolean } = {},
+): Promise<{ status: number; body: unknown }> {
+  const value = await evalIn(surface, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
+    const headers = { "content-type": "application/json" };
+    if (${input.host === true}) headers["x-openwork-host-token"] = String(info.hostToken ?? "");
+    else headers.authorization = "Bearer " + String(info.ownerToken ?? info.clientToken ?? "");
+    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + ${JSON.stringify(path)}, {
+      method: ${JSON.stringify(input.method ?? "GET")},
+      headers,
+      body: ${input.body ? JSON.stringify(JSON.stringify(input.body)) : "undefined"},
+    });
+    const text = await response.text();
+    let body = text;
+    try { body = text ? JSON.parse(text) : null; } catch {}
+    return { status: response.status, body };
+  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  if (!isRecord(value) || typeof value.status !== "number") {
+    throw new Error(`Invalid local server response for ${path}: ${JSON.stringify(value)}`);
+  }
+  return { status: value.status, body: value.body };
+}
+
+async function runSync(surface: Parameters<typeof evalIn>[0], reason: string): Promise<Record<string, unknown>> {
+  const result = await localServerRequest(surface, "/cloud-provider-sync/run", {
+    method: "POST",
+    host: true,
+    body: { reason },
+  });
+  if (result.status !== 200 || !isRecord(result.body)) {
+    throw new Error(`Provider sync failed: HTTP ${result.status} ${JSON.stringify(result.body)}`);
+  }
+  return result.body;
+}
+
+async function readSyncStatus(surface: Parameters<typeof evalIn>[0]): Promise<Record<string, unknown>> {
+  const result = await localServerRequest(surface, "/cloud-provider-sync/status");
+  if (result.status !== 200 || !isRecord(result.body)) {
+    throw new Error(`Reading provider sync status failed: HTTP ${result.status} ${JSON.stringify(result.body)}`);
+  }
+  return result.body;
+}
+
+function providerIds(status: Record<string, unknown>): string[] {
+  return Array.isArray(status.providers)
+    ? status.providers.filter(isRecord).flatMap((provider) => (
+        typeof provider.cloudProviderId === "string" ? [provider.cloudProviderId] : []
+      ))
+    : [];
+}
+
+function skipReason(status: Record<string, unknown>, providerId: string): string | null {
+  const skipped = Array.isArray(status.skippedProviders) ? status.skippedProviders.filter(isRecord) : [];
+  const provider = skipped.find((entry) => entry.cloudProviderId === providerId);
+  return provider && typeof provider.reason === "string" ? provider.reason : null;
+}
+
+async function waitForProviderRow(
+  surface: Parameters<typeof evalIn>[0],
+  workspaceId: string,
+  statusLabel: string,
+): Promise<void> {
+  const route = `/workspace/${workspaceId}/settings/cloud-providers`;
+  await go(surface, `/workspace/${workspaceId}/session`);
+  await go(surface, route);
+  await waitFor(surface, `(() => {
+    const title = [...document.querySelectorAll("span")]
+      .find((element) => (element.textContent ?? "").trim() === ${JSON.stringify(PROVIDER_NAME)});
+    const row = title?.parentElement?.parentElement?.parentElement;
+    return Boolean(row && (row.textContent ?? "").includes(${JSON.stringify(statusLabel)}));
+  })()`, { timeoutMs: 120_000, label: `${PROVIDER_NAME} row shows ${statusLabel}` });
+}
+
+async function closeModelPicker(surface: Parameters<typeof evalIn>[0]): Promise<void> {
+  await evalIn(surface, `(() => {
+    const close = document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]');
+    if (close instanceof HTMLElement) close.click();
+    return true;
+  })()`);
+  await waitFor(surface, `!document.querySelector('[data-slot="dialog-content"]')`, {
+    timeoutMs: 15_000,
+    label: "model picker closed",
+  });
+}
+
+test("a Den provider can use a matching local Desktop credential without giving Den ownership", {
+  timeout: 15 * 60_000,
+}, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  await using den = await server({
+    place,
+    org: {
+      name: ORGANIZATION_NAME,
+      admin: { name: "Provider Admin" },
+      members: { member: { name: "Provider Member" } },
+    },
+  });
+  const member = den.members.member;
+  if (!member) throw new Error("The testkit did not provision the organization member.");
+  const orgId = await organizationId(den.admin);
+  const providerId = await createProvider(den.admin, orgId, {
+    name: PROVIDER_NAME,
+    providerKey: PROVIDER_KEY,
+    modelId: ALLOWED_MODEL_ID,
+    allMembers: true,
+  });
+  const deniedProviderId = await createProvider(den.admin, orgId, {
+    name: DENIED_PROVIDER_NAME,
+    providerKey: DENIED_PROVIDER_KEY,
+    modelId: DENIED_MODEL_ID,
+    allMembers: false,
+  });
+  onTestFinished(async () => {
+    await Promise.all([
+      deleteProvider(den.admin, orgId, providerId),
+      deleteProvider(den.admin, orgId, deniedProviderId),
+    ]).catch(() => undefined);
+  });
+
+  const visibleProviders = await memberProviderList(member, orgId);
+  const visibleProviderIds = visibleProviders.flatMap((provider) => (
+    typeof provider.id === "string" ? [provider.id] : []
+  ));
+  const visibleProvider = visibleProviders.find((provider) => provider.id === providerId);
+  expect(visibleProvider?.hasApiKey).toBe(false);
+  expect(visibleProviderIds).toContain(providerId);
+  expect(visibleProviderIds).not.toContain(deniedProviderId);
+
+  await using desktopApp = await app({ den, as: "member", place });
+  expect((await localServerRequest(desktopApp, "/den-session", {
+    method: "PUT",
+    host: true,
+    body: { baseUrl: den.ref.apiUrl, token: member.token, orgId },
+  })).status).toBe(204);
+  await runSync(desktopApp, "initial-missing-local-credential");
+
+  const initialStatus = await readSyncStatus(desktopApp);
+  const initiallyMissing = !providerIds(initialStatus).includes(providerId)
+    && skipReason(initialStatus, providerId) === "missing_credentials";
+  evidence.recordAssertionEvidence(
+    "A credential-less Den provider starts in the missing-credential state",
+    `Provider materialized: ${providerIds(initialStatus).includes(providerId)}; skip reason: ${skipReason(initialStatus, providerId)}`,
+    initiallyMissing,
+  );
+  expect(initiallyMissing).toBe(true);
+  await waitForProviderRow(desktopApp, desktopApp.workspaceId, "Needs organization credential");
+
+  expect((await localServerRequest(desktopApp, "/env", {
+    method: "PUT",
+    host: true,
+    body: { entries: [{ key: MISMATCHED_ENV, value: "sk-mismatched-eval-only" }] },
+  })).status).toBe(200);
+  await runSync(desktopApp, "mismatched-local-credential");
+  const mismatchedStatus = await readSyncStatus(desktopApp);
+  const mismatchRejected = !providerIds(mismatchedStatus).includes(providerId)
+    && skipReason(mismatchedStatus, providerId) === "missing_credentials";
+  evidence.recordAssertionEvidence(
+    "An unrelated local environment variable cannot unlock the provider",
+    `Provider materialized: ${providerIds(mismatchedStatus).includes(providerId)}; skip reason: ${skipReason(mismatchedStatus, providerId)}`,
+    mismatchRejected,
+  );
+  expect(mismatchRejected).toBe(true);
+
+  expect((await localServerRequest(desktopApp, "/env", {
+    method: "PUT",
+    host: true,
+    body: { entries: [{ key: PROVIDER_ENV, value: LOCAL_SECRET }] },
+  })).status).toBe(200);
+  await runSync(desktopApp, "matching-local-credential");
+  const connectedStatus = await eventually(() => readSyncStatus(desktopApp), {
+    within: 60_000,
+    intervalMs: 2_000,
+    label: "local credential provider materialized",
+    until: (status) => providerIds(status).includes(providerId) && skipReason(status, providerId) === null,
+  });
+  await waitForProviderRow(desktopApp, desktopApp.workspaceId, "Connected");
+  await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
+  const models = await eventually(() => readAvailableModels(desktopApp), {
+    within: 60_000,
+    intervalMs: 2_000,
+    label: "Den-allowed local credential model",
+    until: (candidates) => candidates.some((candidate) => candidate.id === ALLOWED_MODEL_ID && candidate.selectable),
+  });
+  const allowedModelPresent = models.some((model) => model.id === ALLOWED_MODEL_ID && model.selectable);
+  const deniedModelAbsent = !models.some((model) => model.id === DENIED_MODEL_ID);
+  evidence.recordAssertionEvidence(
+    "The matching local credential connects only the provider and model granted by Den",
+    `Allowed model selectable: ${allowedModelPresent}; unassigned model present: ${!deniedModelAbsent}`,
+    providerIds(connectedStatus).includes(providerId) && allowedModelPresent && deniedModelAbsent,
+  );
+  expect(allowedModelPresent).toBe(true);
+  expect(deniedModelAbsent).toBe(true);
+  await closeModelPicker(desktopApp);
+
+  const savedCredential = await localServerRequest(desktopApp, `/env/${PROVIDER_ENV}`, { host: true });
+  const savedItem = isRecord(savedCredential.body) && isRecord(savedCredential.body.item)
+    ? savedCredential.body.item
+    : {};
+  expect(savedItem.value).toBe(LOCAL_SECRET);
+  expect(JSON.stringify(connectedStatus)).not.toContain(LOCAL_SECRET);
+  expect(await den.apiLog()).not.toContain(LOCAL_SECRET);
+
+  expect((await localServerRequest(desktopApp, "/den-session", { method: "DELETE", host: true })).status).toBe(204);
+  const afterCloudCleanup = await localServerRequest(desktopApp, `/env/${PROVIDER_ENV}`, { host: true });
+  const cleanupItem = isRecord(afterCloudCleanup.body) && isRecord(afterCloudCleanup.body.item)
+    ? afterCloudCleanup.body.item
+    : {};
+  const localCredentialPreserved = cleanupItem.value === LOCAL_SECRET;
+  evidence.recordAssertionEvidence(
+    "Cloud cleanup neither rewrites nor removes the locally saved credential",
+    `The exact local value remained present after DELETE /den-session: ${localCredentialPreserved}`,
+    localCredentialPreserved,
+  );
+  expect(localCredentialPreserved).toBe(true);
+
+  expect((await localServerRequest(desktopApp, "/den-session", {
+    method: "PUT",
+    host: true,
+    body: { baseUrl: den.ref.apiUrl, token: member.token, orgId },
+  })).status).toBe(204);
+  await runSync(desktopApp, "restore-after-cloud-cleanup");
+  expect(providerIds(await readSyncStatus(desktopApp))).toContain(providerId);
+
+  expect((await localServerRequest(desktopApp, `/env/${PROVIDER_ENV}`, {
+    method: "DELETE",
+    host: true,
+  })).status).toBe(200);
+  await runSync(desktopApp, "matching-local-credential-removed");
+  const removedStatus = await eventually(() => readSyncStatus(desktopApp), {
+    within: 60_000,
+    intervalMs: 2_000,
+    label: "provider returns to missing credential",
+    until: (status) => !providerIds(status).includes(providerId)
+      && skipReason(status, providerId) === "missing_credentials",
+  });
+  await waitForProviderRow(desktopApp, desktopApp.workspaceId, "Needs organization credential");
+  const returnedToMissing = !providerIds(removedStatus).includes(providerId)
+    && skipReason(removedStatus, providerId) === "missing_credentials";
+  evidence.recordAssertionEvidence(
+    "Removing the local credential returns the provider to missing",
+    `Provider materialized: ${providerIds(removedStatus).includes(providerId)}; skip reason: ${skipReason(removedStatus, providerId)}; UI label: Needs organization credential`,
+    returnedToMissing,
+  );
+  expect(returnedToMissing).toBe(true);
+});

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -396,6 +396,7 @@
       "specs": [
         "evals/specs/cloud-provider-auto-import.e2e.test.ts",
         "evals/specs/cloud-provider-before-workspace.e2e.test.ts",
+        "evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts",
         "evals/specs/cloud-provider-sync-contract.e2e.test.ts",
         "evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts",
         "evals/specs/model-lands-mid-run.e2e.test.ts",


### PR DESCRIPTION
## Problem

A Den-managed provider with no organization credential but with required `providerConfig.env` (e.g. `OPENAI_API_KEY`) could never materialize on desktops: the server-owned sync skipped it with `missing_credentials` even when the member had saved the exact matching variable locally in Settings → Environment, and the settings row treated Den's `hasApiKey` as definitive.

## Fix

- **Server** (`apps/server/src/cloud-provider-sync.ts`): `prepareMaterialization` now also considers locally stored env keys when deciding whether a provider's declared credential env vars are satisfiable, reusing `selectPrimaryCredentialEnvName` from `managed-provider-auth.ts` (Azure/multi-env semantics preserved). Cloud-owned env keys are excluded, so a credential owned by another Den provider can never masquerade as a local one.
- **Boundaries kept**: Den model/access policy stays authoritative (only Den-granted models appear); the local secret is never sent to Den, never rewritten as cloud-owned, and survives cloud cleanup (`DELETE /den-session`).
- **UI** (`cloud-providers-view.tsx`): when the server owns sync, rows derive credential state from the server's skip list only; Den's `hasApiKey` summary and legacy renderer sync errors are gated off. A server-side `missing_credentials` skip still shows "Needs organization credential".

## Verification (local lane; Daytona credentials not available in this environment)

- `pnpm --filter openwork-server test src/cloud-provider-sync.e2e.test.ts src/managed-provider-auth.test.ts` — 21 pass / 0 fail
- `pnpm --dir apps/app exec bun test --isolate tests/cloud-providers-view.test.ts` — 7 pass / 0 fail
- `tsc --noEmit` clean for `openwork-server` and `@openwork/app`
- Authoritative spec `evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts` (real Den + real Electron): initial missing state → mismatched local var stays missing → matching local var connects with only Den-allowed models → cloud cleanup preserves the local secret byte-for-byte → removal returns to missing. E2E evidence re-run at this head is being published to this PR.

Also validated interactively against a seeded local Den (org-credential provider + credential-less provider): row flips Needs organization credential → Connected on local save, model picker serves only granted models.