### PR TITLE
fix(den-api): scope catalog providers' env names to the provider row

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -336,6 +336,12 @@ export type DenOrgLlmProvider = {
   name: string;
   providerConfig: Record<string, unknown>;
   hasApiKey: boolean;
+  /**
+   * The env names this provider actually reads on a member's machine. Catalog
+   * providers get provider-scoped names here (their stored `providerConfig.env`
+   * keeps the catalog's names); absent from Den servers that predate it.
+   */
+  runtimeEnvKeys?: string[];
   models: DenOrgLlmProviderModel[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -2056,6 +2062,7 @@ function parseDenOrgLlmProvider(value: unknown): DenOrgLlmProvider | null {
     name: value.name,
     providerConfig: parseJsonRecord(value.providerConfig),
     hasApiKey: value.hasApiKey === true,
+    runtimeEnvKeys: parseStringList(value.runtimeEnvKeys),
     models: Array.isArray(value.models)
       ? value.models.flatMap((model) => {
           const parsed = parseDenOrgLlmProviderModel(model);

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -394,7 +394,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       merged.set(id, {
         id,
         name: provider.name.trim() || id,
-        env: getCloudProviderEnv(provider.providerConfig),
+        env: provider.runtimeEnvKeys ?? getCloudProviderEnv(provider.providerConfig),
       });
     }
 

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -10,7 +10,14 @@ import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
 import { fetchPreviewNoRedirect, fetchWithConnectRetry, previewFetch } from "../workers/preview-fetch.js"
-import { decodeProviderCredential, readProviderEnvNames, selectLegacyScalarCredentialEnvName, selectPrimaryCredentialEnvName } from "./provider-credentials.js"
+import {
+  decodeProviderCredential,
+  readProviderEnvNames,
+  runtimeProviderEnvNames,
+  selectLegacyScalarCredentialEnvName,
+  selectPrimaryCredentialEnvName,
+  toRuntimeProviderEnv,
+} from "./provider-credentials.js"
 
 type JsonRecord = Record<string, unknown>
 type OrganizationId = typeof LlmProviderTable.$inferSelect.organizationId
@@ -269,8 +276,16 @@ function readOpenWorkInferenceBaseUrl(providerConfig: JsonRecord) {
 
 function providerEnvEntries(provider: CloudProviderMaterializationProvider): EnvEntry[] {
   const entries: EnvEntry[] = []
-  const envNames = readProviderEnvNames(provider.providerConfig)
-  const credential = decodeProviderCredential(provider.apiKey)
+  const stored = decodeProviderCredential(provider.apiKey)
+  // Stored rows keep the catalog's declared names; the worker sees the
+  // provider-scoped runtime names for both the block and the multi-env map.
+  const credential = toRuntimeProviderEnv({
+    id: provider.id,
+    source: provider.source,
+    providerConfig: provider.providerConfig,
+    apiKeys: stored.apiKeys,
+  })
+  const envNames = readProviderEnvNames(credential.providerConfig)
 
   if (credential.apiKeys) {
     const keys = Object.keys(credential.apiKeys)
@@ -283,16 +298,16 @@ function providerEnvEntries(provider: CloudProviderMaterializationProvider): Env
     }
   }
 
-  if (credential.apiKey && envNames[0]) {
+  if (stored.apiKey && envNames[0]) {
     upsertEnvEntry(
       entries,
       selectLegacyScalarCredentialEnvName(envNames) ?? envNames[0],
-      credential.apiKey,
+      stored.apiKey,
     )
   }
 
   const primaryCredentialEnvName = selectPrimaryCredentialEnvName(envNames, entries.map((entry) => entry.key))
-  const primaryCredential = credential.apiKey?.trim() || entries.find((entry) => entry.key === primaryCredentialEnvName)?.value || ""
+  const primaryCredential = stored.apiKey?.trim() || entries.find((entry) => entry.key === primaryCredentialEnvName)?.value || ""
   if (provider.source === "openwork" && primaryCredential) {
     upsertEnvEntry(entries, "OPENWORK_API_KEY", primaryCredential)
     const baseUrl = readOpenWorkInferenceBaseUrl(provider.providerConfig)
@@ -330,7 +345,7 @@ function buildProviderConfig(provider: CloudProviderMaterializationProvider) {
   const config: JsonRecord = {
     id: provider.providerId,
     name: provider.name,
-    env: readProviderEnvNames(provider.providerConfig),
+    env: runtimeProviderEnvNames(provider),
   }
 
   if (Object.keys(models).length > 0 || provider.source !== "openwork") {
@@ -366,7 +381,7 @@ function buildProviderConfig(provider: CloudProviderMaterializationProvider) {
 }
 
 function providerHasRequiredCredential(provider: CloudProviderMaterializationProvider, envEntries: EnvEntry[]) {
-  const envNames = readProviderEnvNames(provider.providerConfig)
+  const envNames = runtimeProviderEnvNames(provider)
   if (envNames.length === 0) {
     return true
   }

--- a/ee/apps/den-api/src/llm/provider-credentials.ts
+++ b/ee/apps/den-api/src/llm/provider-credentials.ts
@@ -57,6 +57,63 @@ export function selectLegacyScalarCredentialEnvName(envNames: string[]): string 
   return selectPrimaryCredentialEnvName(envNames, envNames) ?? envNames[0] ?? null
 }
 
+const RUNTIME_ENV_TAG_LENGTH = 5
+
+/**
+ * The tag that scopes a catalog provider's env names to one provider row:
+ * `LPR_` plus the last five alphanumerics of the row id, upper-cased
+ * (`lpr_01kx…120jv` → `LPR_120JV`). It is a pure function of the id, so the
+ * same row always yields the same names and nothing has to be stored or
+ * migrated.
+ */
+export function runtimeProviderEnvTag(providerRowId: string): string {
+  const tail = providerRowId.replace(/[^0-9A-Za-z]/g, "").toUpperCase().slice(-RUNTIME_ENV_TAG_LENGTH)
+  return `LPR_${tail}`
+}
+
+export type RuntimeEnvProvider = {
+  id: string
+  source: string
+  providerConfig: JsonRecord
+}
+
+/**
+ * Only providers created from the models.dev catalog get scoped names. Their
+ * declared names are well-known (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …):
+ * materialized bare, one organization provider would switch on OpenCode's whole
+ * built-in catalog for that vendor and shadow a key the member set themselves,
+ * and two rows for the same vendor would share one credential slot. Custom
+ * providers keep the exact names their author declared, and the hosted
+ * OpenWork provider keeps `OPENWORK_API_KEY`.
+ */
+export function usesRuntimeProviderEnvTag(provider: Pick<RuntimeEnvProvider, "source">): boolean {
+  return provider.source === "models_dev"
+}
+
+/** The env name a member's machine or a cloud worker sees for one declared name. */
+export function runtimeProviderEnvName(provider: Pick<RuntimeEnvProvider, "id" | "source">, declaredName: string): string {
+  return usesRuntimeProviderEnvTag(provider) ? `${runtimeProviderEnvTag(provider.id)}_${declaredName}` : declaredName
+}
+
+export function runtimeProviderEnvNames(provider: RuntimeEnvProvider): string[] {
+  return readProviderEnvNames(provider.providerConfig).map((name) => runtimeProviderEnvName(provider, name))
+}
+
+/**
+ * Rewrite a provider's declared env names (and the keys of a decoded multi-env
+ * credential) to their runtime names. Stored rows are never rewritten; this is
+ * applied where a provider leaves Den for a machine or worker.
+ */
+export function toRuntimeProviderEnv<T extends RuntimeEnvProvider & { apiKeys?: Record<string, string> | null }>(provider: T): T {
+  if (!usesRuntimeProviderEnvTag(provider) || provider.providerConfig.env === undefined) return provider
+  const providerConfig: JsonRecord = { ...provider.providerConfig, env: runtimeProviderEnvNames(provider) }
+  if (!provider.apiKeys) return { ...provider, providerConfig }
+  const apiKeys = Object.fromEntries(
+    Object.entries(provider.apiKeys).map(([name, value]) => [runtimeProviderEnvName(provider, name), value]),
+  )
+  return { ...provider, providerConfig, apiKeys }
+}
+
 /**
  * A stored credential is a multi-env map only when it parses to a non-empty
  * JSON object whose values are all strings. Real API keys never take that

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -22,6 +22,8 @@ import {
   listConfiguredEnvKeys,
   readProviderEnvNames,
   resolveProviderCredential,
+  runtimeProviderEnvNames,
+  toRuntimeProviderEnv,
 } from "../../llm/provider-credentials.js"
 import {
   jsonValidator,
@@ -730,6 +732,7 @@ async function loadLlmProviders(input: {
     } : {}),
     hasApiKey: Boolean(provider.apiKey && provider.apiKey.trim().length > 0),
     configuredEnvKeys: listConfiguredEnvKeys(provider.apiKey, readProviderEnvNames(provider.providerConfig ?? {})),
+    runtimeEnvKeys: runtimeProviderEnvNames({ ...provider, providerConfig: provider.providerConfig ?? {} }),
     models: (modelsByProviderId.get(provider.id) ?? [])
       .map((model) => ({
         id: model.modelId,
@@ -1009,11 +1012,13 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       // single-secret providers keep returning `apiKey`, multi-env providers
       // return `apiKeys` with `apiKey: null` so old clients fail with their
       // missing-credential error instead of applying a JSON blob as the key.
+      // Catalog providers leave Den under provider-scoped env names (see
+      // toRuntimeProviderEnv); the stored row keeps the catalog's names.
+      const runtime = toRuntimeProviderEnv({ ...provider, apiKeys: credential.apiKeys })
       return c.json({
         llmProvider: {
-          ...provider,
+          ...runtime,
           apiKey: credential.apiKey,
-          apiKeys: credential.apiKeys,
           ...(memberCredential ? { memberCredential } : {}),
           models: models
             .map((model) => ({
@@ -1454,6 +1459,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             credentialMode: input.credentialMode,
             hasApiKey: Boolean(normalized.apiKey),
             configuredEnvKeys: listConfiguredEnvKeys(normalized.apiKey, readProviderEnvNames(normalized.providerConfig)),
+            runtimeEnvKeys: runtimeProviderEnvNames({ id: llmProviderId, ...normalized }),
             createdAt: now,
             updatedAt: now,
           },
@@ -1625,6 +1631,7 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
             apiKey: undefined,
             hasApiKey: Boolean(normalized.apiKey),
             configuredEnvKeys: listConfiguredEnvKeys(normalized.apiKey, readProviderEnvNames(normalized.providerConfig)),
+            runtimeEnvKeys: runtimeProviderEnvNames({ id: provider.id, ...normalized }),
             updatedAt,
           },
         })

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -1,6 +1,16 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, test } from "bun:test"
 import type { CloudProviderMaterializationProvider } from "../src/llm/cloud-provider-materialization.js"
+import { runtimeProviderEnvTag } from "../src/llm/provider-credentials.js"
+
+// Fixed row ids so the provider-scoped runtime env names are stable across
+// the suite: a models.dev provider's declared names leave Den as
+// `<LPR_tag>_<declared name>`, derived from nothing but the row id.
+const ANTHROPIC_PROVIDER_ID = "lpr_01kx4t3amgendr682dmp6120jv" as const
+const AZURE_PROVIDER_ID = "lpr_01kx4t3apjendr685c2ryzevqe" as const
+const ANTHROPIC_API_KEY_ENV = `${runtimeProviderEnvTag(ANTHROPIC_PROVIDER_ID)}_ANTHROPIC_API_KEY`
+const AZURE_RESOURCE_NAME_ENV = `${runtimeProviderEnvTag(AZURE_PROVIDER_ID)}_AZURE_RESOURCE_NAME`
+const AZURE_API_KEY_ENV = `${runtimeProviderEnvTag(AZURE_PROVIDER_ID)}_AZURE_API_KEY`
 
 type MaterializerModule = typeof import("../src/llm/cloud-provider-materialization.js")
 type MaterializeInput = Parameters<MaterializerModule["materializeCloudWorkerProviders"]>[0]
@@ -87,7 +97,7 @@ function makeAnthropicProvider(input: {
 }): CloudProviderMaterializationProvider {
   const modelId = input.modelId ?? "claude-fable-5"
   return {
-    id: createDenTypeId("llmProvider"),
+    id: ANTHROPIC_PROVIDER_ID,
     source: "models_dev",
     providerId: "anthropic",
     name: "Anthropic",
@@ -124,7 +134,7 @@ function makeAnthropicRuntimeProvider(modelId = "claude-fable-5") {
         id: modelId,
       },
     },
-    env: ["ANTHROPIC_API_KEY"],
+    env: [ANTHROPIC_API_KEY_ENV],
     name: "Anthropic",
     id: "anthropic",
   }
@@ -132,7 +142,7 @@ function makeAnthropicRuntimeProvider(modelId = "claude-fable-5") {
 
 function makeAzureProvider(apiKeys: Record<string, string>): CloudProviderMaterializationProvider {
   return {
-    id: createDenTypeId("llmProvider"),
+    id: AZURE_PROVIDER_ID,
     source: "models_dev",
     providerId: "azure",
     name: "Azure",
@@ -344,7 +354,7 @@ describe("Cloud provider materialization", () => {
   test("does not rewrite matching provider state after the den-api cache is lost", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-anthropic" },
       runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
     })
     const workerId = createDenTypeId("worker")
@@ -369,7 +379,7 @@ describe("Cloud provider materialization", () => {
     const workerId = createDenTypeId("worker")
 
     const before = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-anthropic" },
       runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
     })
     await materialize({ workerId, providers: () => [provider], fetchImpl: before.fetchImpl })
@@ -390,7 +400,7 @@ describe("Cloud provider materialization", () => {
     expect(result.status).toBe("applied")
     expect(recycled.calls.filter((call) => call.method === "PUT" && call.path === "/env")).toHaveLength(1)
     expect(recycled.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
-      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
+      entries: [{ key: ANTHROPIC_API_KEY_ENV, value: "sk-anthropic" }],
     })
   })
 
@@ -408,14 +418,14 @@ describe("Cloud provider materialization", () => {
     expect(result.status).toBe("applied")
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
     ])
     expect(instance.calls[2]?.headers["x-openwork-host-token"]).toBe("host-token")
     expect(instance.calls[2]?.body).toEqual({
-      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
+      entries: [{ key: ANTHROPIC_API_KEY_ENV, value: "sk-anthropic" }],
     })
     expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
     expect(instance.calls[3]?.headers.authorization).toBeUndefined()
@@ -425,7 +435,7 @@ describe("Cloud provider materialization", () => {
         [provider.id]: {
           id: "anthropic",
           name: "Anthropic",
-          env: ["ANTHROPIC_API_KEY"],
+          env: [ANTHROPIC_API_KEY_ENV],
           models: {
             "claude-fable-5": {
               id: "claude-fable-5",
@@ -457,14 +467,45 @@ describe("Cloud provider materialization", () => {
     expect(result.ok).toBe(true)
     expect(instance.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
       entries: [
-        { key: "AZURE_RESOURCE_NAME", value: "resource-name" },
-        { key: "AZURE_API_KEY", value: "real-api-key" },
+        { key: AZURE_RESOURCE_NAME_ENV, value: "resource-name" },
+        { key: AZURE_API_KEY_ENV, value: "real-api-key" },
       ],
     })
     expect(instance.runtimeProvider(provider.id)).toMatchObject({
       id: "azure",
-      env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+      env: [AZURE_RESOURCE_NAME_ENV, AZURE_API_KEY_ENV],
     })
+  })
+
+  test("a custom provider keeps the exact env name its author declared", async () => {
+    // Organizations that route members to their own gateway (a LiteLLM
+    // deployment, for instance) declare the env name themselves and may leave
+    // the credential for the member's machine. That contract is theirs to
+    // keep: only models.dev rows get the provider-scoped runtime name.
+    const provider: CloudProviderMaterializationProvider = {
+      id: "lpr_01kx4t3aqfendr688a4dedf2m5",
+      source: "custom",
+      providerId: "gateway",
+      name: "Gateway",
+      providerConfig: {
+        id: "gateway",
+        name: "Gateway",
+        npm: "@ai-sdk/openai-compatible",
+        env: ["OPENAI_API_KEY"],
+        options: { baseURL: "https://gateway.example.test/v1" },
+      },
+      apiKey: "sk-gateway",
+      models: [{ modelId: "gpt-x", name: "gpt-x", modelConfig: { id: "gpt-x", name: "gpt-x" } }],
+    }
+    const instance = makeInstance()
+
+    const result = await materialize({ providers: () => [provider], fetchImpl: instance.fetchImpl, force: true })
+
+    expect(result.ok).toBe(true)
+    expect(instance.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
+      entries: [{ key: "OPENAI_API_KEY", value: "sk-gateway" }],
+    })
+    expect(instance.runtimeProvider(provider.id)).toMatchObject({ id: "gateway", env: ["OPENAI_API_KEY"] })
   })
 
   test("does not materialize Azure from a resource name without its API key", async () => {
@@ -479,7 +520,7 @@ describe("Cloud provider materialization", () => {
 
     expect(result.ok).toBe(true)
     expect(result.providers).toBe(0)
-    expect(instance.envValue("AZURE_RESOURCE_NAME")).toBeNull()
+    expect(instance.envValue(AZURE_RESOURCE_NAME_ENV)).toBeNull()
     expect(instance.runtimeProvider(provider.id)).toBeNull()
   })
 
@@ -497,11 +538,11 @@ describe("Cloud provider materialization", () => {
     expect(result.ok).toBe(true)
     expect(result.providers).toBe(1)
     expect(instance.calls.find((call) => call.method === "PUT" && call.path === "/env")?.body).toEqual({
-      entries: [{ key: "AZURE_API_KEY", value: "legacy-api-key" }],
+      entries: [{ key: AZURE_API_KEY_ENV, value: "legacy-api-key" }],
     })
     expect(instance.runtimeProvider(provider.id)).toMatchObject({
       id: "azure",
-      env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+      env: [AZURE_RESOURCE_NAME_ENV, AZURE_API_KEY_ENV],
     })
   })
 
@@ -509,7 +550,7 @@ describe("Cloud provider materialization", () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
     const instance = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-anthropic" },
       runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
     })
 
@@ -522,7 +563,7 @@ describe("Cloud provider materialization", () => {
     expect(result).toEqual({ ok: true, status: "noop", fingerprint, providers: 1 })
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
     ])
     expect(writeCalls(instance.calls)).toHaveLength(0)
   })
@@ -530,7 +571,7 @@ describe("Cloud provider materialization", () => {
   test("applies when the observed provider config is incomplete", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-anthropic" },
       runtimeProviders: { [provider.id]: { id: "anthropic" } },
     })
 
@@ -544,7 +585,7 @@ describe("Cloud provider materialization", () => {
     expect(result.status).toBe("applied")
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
@@ -567,14 +608,14 @@ describe("Cloud provider materialization", () => {
     }
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
       "PATCH /runtime-config/providers",
-      "DELETE /env/ANTHROPIC_API_KEY",
+      `DELETE /env/${ANTHROPIC_API_KEY_ENV}`,
     ])
-    expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
+    expect(instance.envValue(ANTHROPIC_API_KEY_ENV)).toBeNull()
   })
 
   test("fails when the provider is absent from engine-visible config", async () => {
@@ -633,7 +674,7 @@ describe("Cloud provider materialization", () => {
   test("removes a provider that is no longer desired", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const instance = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-anthropic" },
       runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
     })
 
@@ -654,7 +695,7 @@ describe("Cloud provider materialization", () => {
   test("rewrites env when an API key rotates", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-rotated" })
     const instance = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-original" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-original" },
       runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider() },
     })
 
@@ -667,14 +708,14 @@ describe("Cloud provider materialization", () => {
     expect(result.status).toBe("applied")
     expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH"])
     expect(instance.calls.find((call) => call.method === "PUT")?.body).toEqual({
-      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-rotated" }],
+      entries: [{ key: ANTHROPIC_API_KEY_ENV, value: "sk-rotated" }],
     })
   })
 
   test("rewrites providers when the model list changes", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic", modelId: "claude-updated" })
     const instance = makeInstance({
-      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      envValues: { [ANTHROPIC_API_KEY_ENV]: "sk-anthropic" },
       runtimeProviders: { [provider.id]: makeAnthropicRuntimeProvider("claude-original") },
     })
 
@@ -741,7 +782,7 @@ describe("Cloud provider materialization", () => {
     expect(failed.ok).toBe(false)
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
       "PUT /env",
     ])
     expect(instance.calls.some((call) => call.method === "PATCH")).toBe(false)
@@ -772,13 +813,13 @@ describe("Cloud provider materialization", () => {
     }
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
       "PUT /env",
       "PATCH /runtime-config/providers",
       "PATCH /runtime-config/providers",
-      "DELETE /env/ANTHROPIC_API_KEY",
+      `DELETE /env/${ANTHROPIC_API_KEY_ENV}`,
     ])
-    expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
+    expect(instance.envValue(ANTHROPIC_API_KEY_ENV)).toBeNull()
 
     instance.calls.length = 0
     const retried = await materialize({
@@ -836,12 +877,12 @@ describe("Cloud provider materialization", () => {
     expect(unsupported.status).toBe("unsupported")
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
-      "GET /env/ANTHROPIC_API_KEY",
+      `GET /env/${ANTHROPIC_API_KEY_ENV}`,
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /runtime/versions",
     ])
-    expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic")
+    expect(instance.envValue(ANTHROPIC_API_KEY_ENV)).toBe("sk-anthropic")
     expect(instance.calls.some((call) => call.method === "DELETE")).toBe(false)
     expect(logs).toHaveLength(1)
     expect(logs[0]).toMatchObject({
@@ -861,7 +902,7 @@ describe("Cloud provider materialization", () => {
     })
 
     expect(repeated.status).toBe("unsupported")
-    expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic")
+    expect(instance.envValue(ANTHROPIC_API_KEY_ENV)).toBe("sk-anthropic")
     expect(logs).toHaveLength(1)
     expect(instance.calls).toHaveLength(0)
 
@@ -875,7 +916,7 @@ describe("Cloud provider materialization", () => {
     })
 
     expect(changed.status).toBe("unsupported")
-    expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic-rotated")
+    expect(instance.envValue(ANTHROPIC_API_KEY_ENV)).toBe("sk-anthropic-rotated")
     expect(logs).toHaveLength(2)
   })
 

--- a/ee/apps/den-api/test/provider-credentials.test.ts
+++ b/ee/apps/den-api/test/provider-credentials.test.ts
@@ -6,8 +6,12 @@ import {
   listConfiguredEnvKeys,
   readProviderEnvNames,
   resolveProviderCredential,
+  runtimeProviderEnvName,
+  runtimeProviderEnvNames,
+  runtimeProviderEnvTag,
   selectLegacyScalarCredentialEnvName,
   selectPrimaryCredentialEnvName,
+  toRuntimeProviderEnv,
 } from "../src/llm/provider-credentials.js"
 
 const AWS_ENV = [
@@ -232,5 +236,53 @@ describe("listConfiguredEnvKeys", () => {
     expect(listConfiguredEnvKeys("sk-test", ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"])).toEqual(["AZURE_API_KEY"])
     expect(listConfiguredEnvKeys("sk-test", [])).toEqual([])
     expect(listConfiguredEnvKeys(null, AWS_ENV)).toEqual([])
+  })
+})
+
+describe("runtime provider env names", () => {
+  const rowId = "lpr_01kx4t3amgendr682dmp6120jv"
+
+  test("the tag is a pure function of the row id", () => {
+    expect(runtimeProviderEnvTag(rowId)).toBe("LPR_120JV")
+    expect(runtimeProviderEnvTag(rowId)).toBe(runtimeProviderEnvTag(rowId))
+    expect(runtimeProviderEnvTag("lpr_01kx4t3apjendr685c2ryzevqe")).toBe("LPR_ZEVQE")
+  })
+
+  test("catalog providers get provider-scoped names that still rank as credentials", () => {
+    const provider = { id: rowId, source: "models_dev", providerConfig: { env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] } }
+    const names = runtimeProviderEnvNames(provider)
+    expect(names).toEqual(["LPR_120JV_AZURE_RESOURCE_NAME", "LPR_120JV_AZURE_API_KEY"])
+    expect(selectPrimaryCredentialEnvName(names, names)).toBe("LPR_120JV_AZURE_API_KEY")
+  })
+
+  test("custom and hosted providers keep exactly the names they declare", () => {
+    const custom = { id: rowId, source: "custom", providerConfig: { env: ["LITELLM_API_KEY"] } }
+    const hosted = { id: rowId, source: "openwork", providerConfig: { env: ["OPENWORK_API_KEY"] } }
+    expect(runtimeProviderEnvNames(custom)).toEqual(["LITELLM_API_KEY"])
+    expect(runtimeProviderEnvName(custom, "OPENAI_API_KEY")).toBe("OPENAI_API_KEY")
+    expect(runtimeProviderEnvNames(hosted)).toEqual(["OPENWORK_API_KEY"])
+    expect(toRuntimeProviderEnv({ ...custom, apiKeys: { LITELLM_API_KEY: "k" } })).toEqual({
+      ...custom,
+      apiKeys: { LITELLM_API_KEY: "k" },
+    })
+  })
+
+  test("toRuntimeProviderEnv renames the block and the multi-env map together, never the stored input", () => {
+    const stored = {
+      id: rowId,
+      source: "models_dev",
+      providerConfig: { id: "azure", env: ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"] },
+      apiKeys: { AZURE_RESOURCE_NAME: "resource", AZURE_API_KEY: "secret" },
+    }
+    const runtime = toRuntimeProviderEnv(stored)
+    expect(runtime.providerConfig).toEqual({ id: "azure", env: ["LPR_120JV_AZURE_RESOURCE_NAME", "LPR_120JV_AZURE_API_KEY"] })
+    expect(runtime.apiKeys).toEqual({ LPR_120JV_AZURE_RESOURCE_NAME: "resource", LPR_120JV_AZURE_API_KEY: "secret" })
+    expect(stored.providerConfig.env).toEqual(["AZURE_RESOURCE_NAME", "AZURE_API_KEY"])
+    expect(Object.keys(stored.apiKeys)).toEqual(["AZURE_RESOURCE_NAME", "AZURE_API_KEY"])
+  })
+
+  test("a provider without a declared env list is returned untouched", () => {
+    const provider = { id: rowId, source: "models_dev", providerConfig: { id: "x" }, apiKeys: null }
+    expect(toRuntimeProviderEnv(provider)).toBe(provider)
   })
 })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
@@ -43,6 +43,8 @@ export type DenLlmProvider = {
   providerConfig: Record<string, unknown>;
   hasApiKey: boolean;
   configuredEnvKeys: string[];
+  /** The env names members' machines and cloud workers actually see for this provider. */
+  runtimeEnvKeys: string[];
   createdAt: string | null;
   updatedAt: string | null;
   canManage: boolean;
@@ -203,6 +205,7 @@ function asLlmProvider(value: unknown): DenLlmProvider | null {
     providerConfig: asJsonRecord(value.providerConfig),
     hasApiKey: value.hasApiKey === true,
     configuredEnvKeys: asStringList(value.configuredEnvKeys),
+    runtimeEnvKeys: asStringList(value.runtimeEnvKeys),
     createdAt: asIsoString(value.createdAt),
     updatedAt: asIsoString(value.updatedAt),
     canManage: value.canManage === true,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-editor-screen.tsx
@@ -1323,6 +1323,21 @@ export function LlmProviderEditorScreen({
                     </div>
 
                     {credentialFields}
+                    {provider?.source === "models_dev" && provider.runtimeEnvKeys.length > 0 ? (
+                        <p className="mt-6 text-[13px] leading-6 text-gray-500">
+                            On members&apos; machines and cloud workers this provider reads{" "}
+                            {provider.runtimeEnvKeys.map((envName, index) => (
+                                <span key={envName}>
+                                    {index > 0 ? ", " : null}
+                                    <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[12px]">
+                                        {envName}
+                                    </code>
+                                </span>
+                            ))}
+                            , so it never collides with a key someone set themselves or
+                            with another provider of the same kind.
+                        </p>
+                    ) : null}
                 </section>
             )}
 

--- a/evals/specs/cloud-provider-env-namespacing.test.ts
+++ b/evals/specs/cloud-provider-env-namespacing.test.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { CloudProviderSync } from "../../apps/server/src/cloud-provider-sync.js";
+import { EnvService } from "../../apps/server/src/env-file.js";
+import { resetManagedProviderAuthCache } from "../../apps/server/src/managed-provider-auth.js";
+import {
+  readGlobalRuntimeOpencodeConfig,
+  runtimeProviderMap,
+} from "../../apps/server/src/runtime-opencode-config-store.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+import {
+  runtimeProviderEnvTag,
+  toRuntimeProviderEnv,
+} from "../../ee/apps/den-api/src/llm/provider-credentials.js";
+
+// A catalog (models.dev) provider declaring a well-known name and a custom
+// provider declaring its own. Left bare, the catalog one would switch on
+// OpenCode's built-in OpenAI catalog and shadow a key the member set
+// themselves; the custom one belongs to the organization that wrote it and
+// must come through exactly as declared.
+const CATALOG_PROVIDER_ID = "lpr_01kx4t3amgendr682dmp6120jv";
+const CUSTOM_PROVIDER_ID = "lpr_01kx4t3aqfendr688a4dedf2m5";
+const DECLARED_ENV = "OPENAI_API_KEY";
+const CUSTOM_ENV = "GATEWAY_API_KEY";
+const SCOPED_ENV = `${runtimeProviderEnvTag(CATALOG_PROVIDER_ID)}_${DECLARED_ENV}`;
+const ORG_CREDENTIAL = "test-only-organization-credential";
+const GATEWAY_CREDENTIAL = "test-only-gateway-credential";
+const USER_CREDENTIAL = "test-only-users-own-credential";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function blockEnv(config: Awaited<ReturnType<typeof readGlobalRuntimeOpencodeConfig>>, providerId: string) {
+  const block = runtimeProviderMap(config)[providerId];
+  return isRecord(block) ? block.env : undefined;
+}
+
+test("a catalog provider is materialized under a provider-scoped env name while custom providers and the user's own key stay exactly as declared", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-provider-env-namespacing-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  resetManagedProviderAuthCache();
+
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: "client-token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_env_namespacing",
+      name: "Env namespacing",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+      baseUrl: "https://engine.example.test",
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+
+  // Stored Den rows, exactly as the dashboard saved them.
+  const storedCatalog = {
+    id: CATALOG_PROVIDER_ID,
+    providerId: "openai",
+    name: "Organization OpenAI",
+    source: "models_dev",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    providerConfig: { id: "openai", name: "OpenAI", npm: "@ai-sdk/openai", env: [DECLARED_ENV] },
+    apiKey: ORG_CREDENTIAL,
+    apiKeys: null,
+    models: [{ id: "assigned-model", name: "Assigned model", config: {} }],
+  };
+  const storedCustom = {
+    id: CUSTOM_PROVIDER_ID,
+    providerId: "gateway",
+    name: "Organization gateway",
+    source: "custom",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    providerConfig: {
+      id: "gateway",
+      name: "Gateway",
+      npm: "@ai-sdk/openai-compatible",
+      env: [CUSTOM_ENV],
+      options: { baseURL: "https://gateway.example.test/v1" },
+    },
+    apiKey: null,
+    apiKeys: { [CUSTOM_ENV]: GATEWAY_CREDENTIAL },
+    models: [{ id: "gateway-model", name: "Gateway model", config: {} }],
+  };
+  // What Den's connect route hands to a member's machine.
+  const connectPayloads: Record<string, Record<string, unknown>> = {
+    [CATALOG_PROVIDER_ID]: toRuntimeProviderEnv(storedCatalog),
+    [CUSTOM_PROVIDER_ID]: toRuntimeProviderEnv(storedCustom),
+  };
+
+  const deliveredAuth: Array<{ providerId: string; key: string | null }> = [];
+  const fetchImpl: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.hostname === "den.example.test") {
+      if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: [storedCatalog, storedCustom] });
+      const connect = /^\/v1\/llm-providers\/([^/]+)\/connect$/.exec(url.pathname);
+      const payload = connect ? connectPayloads[decodeURIComponent(connect[1] ?? "")] : undefined;
+      if (payload) return Response.json({ llmProvider: payload });
+    }
+    if (url.hostname === "engine.example.test") {
+      const auth = /^\/auth\/(.+)$/.exec(url.pathname);
+      if (auth) {
+        const body: unknown = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+        deliveredAuth.push({
+          providerId: decodeURIComponent(auth[1] ?? ""),
+          key: isRecord(body) && typeof body.key === "string" ? body.key : null,
+        });
+        return Response.json(true);
+      }
+    }
+    return Response.json({ error: "not_found" }, { status: 404 });
+  };
+  const env = new EnvService({ path: join(root, "env.json") });
+  const envValues = async () => new Map((await env.list()).map((entry) => [entry.key, entry.value]));
+  const sync = new CloudProviderSync({
+    config,
+    env,
+    fetchImpl,
+    reloadEngine: async () => undefined,
+    intervalMs: 3_600_000,
+  });
+
+  try {
+    // The member already uses their own OpenAI key under the well-known name.
+    await env.upsertMany([{ key: DECLARED_ENV, value: USER_CREDENTIAL }]);
+
+    await sync.setSession({ baseUrl: "https://den.example.test", token: "token", orgId: "org_env" });
+    expect((await sync.run("import")).status).toBe("applied");
+
+    const runtimeConfig = await readGlobalRuntimeOpencodeConfig(config);
+    const catalogEnv = blockEnv(runtimeConfig, CATALOG_PROVIDER_ID);
+    const customEnv = blockEnv(runtimeConfig, CUSTOM_PROVIDER_ID);
+    const afterImport = await envValues();
+
+    expect(catalogEnv).toEqual([SCOPED_ENV]);
+    expect(afterImport.get(SCOPED_ENV)).toBe(ORG_CREDENTIAL);
+    evidence.recordAssertionEvidence(
+      "The catalog provider's credential lives only under its provider-scoped env name",
+      `The ${CATALOG_PROVIDER_ID} block declares env ${JSON.stringify(catalogEnv)} and the env store holds ${SCOPED_ENV}; the name is derived from the row id alone, so nothing was stored or migrated in Den.`,
+      Array.isArray(catalogEnv) && catalogEnv.length === 1 && catalogEnv[0] === SCOPED_ENV && afterImport.get(SCOPED_ENV) === ORG_CREDENTIAL,
+    );
+
+    expect(customEnv).toEqual([CUSTOM_ENV]);
+    expect(afterImport.get(CUSTOM_ENV)).toBe(GATEWAY_CREDENTIAL);
+    evidence.recordAssertionEvidence(
+      "A custom provider keeps the exact env name its organization declared",
+      `The ${CUSTOM_PROVIDER_ID} block still declares env ${JSON.stringify(customEnv)} and the env store holds ${CUSTOM_ENV}: custom providers are outside the scoping rule.`,
+      Array.isArray(customEnv) && customEnv.length === 1 && customEnv[0] === CUSTOM_ENV && afterImport.get(CUSTOM_ENV) === GATEWAY_CREDENTIAL,
+    );
+
+    expect(afterImport.get(DECLARED_ENV)).toBe(USER_CREDENTIAL);
+    evidence.recordAssertionEvidence(
+      "The member's own key under the well-known name is never overwritten",
+      `${DECLARED_ENV} still holds the member's value after the import; the organization's OpenAI credential went to ${SCOPED_ENV} instead.`,
+      afterImport.get(DECLARED_ENV) === USER_CREDENTIAL,
+    );
+
+    const catalogAuth = deliveredAuth.filter((entry) => entry.providerId === CATALOG_PROVIDER_ID);
+    expect(catalogAuth).toEqual([{ providerId: CATALOG_PROVIDER_ID, key: ORG_CREDENTIAL }]);
+    evidence.recordAssertionEvidence(
+      "The engine still receives the organization credential through its auth API",
+      `PUT /auth/${CATALOG_PROVIDER_ID} carried the organization credential resolved from ${SCOPED_ENV}.`,
+      catalogAuth.length === 1 && catalogAuth[0]?.key === ORG_CREDENTIAL,
+    );
+
+    // Same rows, same ids: a second pass derives the same names and has nothing to do.
+    expect((await sync.run("repeat")).status).toBe("noop");
+    evidence.recordAssertionEvidence(
+      "Scoped names are deterministic, so a repeat sync is a no-op",
+      `A second sync of unchanged rows reported noop; ${SCOPED_ENV} is a pure function of ${CATALOG_PROVIDER_ID}.`,
+      true,
+    );
+
+    // Signing out removes what OpenWork wrote and nothing else.
+    await sync.clearSession();
+    const afterSignOut = await envValues();
+    expect(afterSignOut.has(SCOPED_ENV)).toBe(false);
+    expect(afterSignOut.get(DECLARED_ENV)).toBe(USER_CREDENTIAL);
+    evidence.recordAssertionEvidence(
+      "Sign-out removes only the entries OpenWork wrote",
+      `${SCOPED_ENV} was removed on sign-out and ${DECLARED_ENV} still holds the member's value.`,
+      !afterSignOut.has(SCOPED_ENV) && afterSignOut.get(DECLARED_ENV) === USER_CREDENTIAL,
+    );
+  } finally {
+    sync.stop();
+    resetManagedProviderAuthCache();
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -389,6 +389,7 @@
       "specs": [
         "evals/specs/cloud-provider-auto-import.e2e.test.ts",
         "evals/specs/cloud-provider-before-workspace.e2e.test.ts",
+        "evals/specs/cloud-provider-env-namespacing.test.ts",
         "evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts",
         "evals/specs/cloud-provider-sync-contract.e2e.test.ts",
         "evals/specs/composer-model-picker-no-subscribe-promo.e2e.test.ts",


### PR DESCRIPTION
## Problem

Den provider rows created from the models.dev catalog declare their credential env name straight from the catalog (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …). OpenWork materialized the organization credential under that exact name on members' machines and cloud workers. The desktop shell injects the user env store into the engine, and OpenCode treats a well-known env name as global provider config, so:

- one organization OpenAI provider switched on OpenCode's whole built-in OpenAI catalog next to the scoped `lpr_*` provider;
- it silently shadowed any `OPENAI_API_KEY` the member had set themselves;
- two rows for the same vendor (two OpenRouter keys, say) shared one credential slot.

## The change

Catalog providers now leave Den under a **provider-scoped** env name:

```
LPR_<last five characters of the row id>_<declared name>
lpr_01kx4t3amgendr682dmp6120jv + OPENAI_API_KEY  →  LPR_120JV_OPENAI_API_KEY
```

| Provider `source` | Runtime env names |
|---|---|
| `models_dev` (catalog) | scoped: `LPR_120JV_OPENAI_API_KEY` |
| `custom` | **unchanged** — exactly what the organization declared |
| `openwork` (hosted) | **unchanged** — `OPENWORK_API_KEY` |

The rename happens in one place, where a provider leaves Den: the `/connect` payload every desktop consumes (`providerConfig.env` and the `apiKeys` map) and the cloud-worker materializer. Desktop server, desktop app, and worker consumers need no logic changes; they use the names they are given.

### Why this shape

- **No storage, no migration, reversible.** The name is a pure function of the row id. Stored rows keep the catalog names, re-syncs are idempotent (a second pass is a `noop`), and reverting this PR returns bare names on the next sync. Existing catalog rows move to the scoped name on their next sync through the same owned-key cleanup that already handles env changes.
- **Custom providers are untouched.** Organizations that route members to their own gateway and declare the env name themselves keep that contract, including leaving the credential for the member's machine.
- **Prefix, not suffix.** Primary-credential selection ranks names by their `_API_KEY` / `_ACCESS_KEY_ID` suffix (three copies: den-api, desktop server, desktop app). A prefix keeps Azure's `LPR_…_AZURE_API_KEY` ranked above `LPR_…_AZURE_RESOURCE_NAME` without touching any of them.
- **Visible, not magic.** Provider responses gain an additive `runtimeEnvKeys` list. The Den editor shows the exact names members' machines read under the credential fields; the desktop provider list prefers them when present and falls back for older Den servers.

## Proof

- `pnpm evals:pr specs/cloud-provider-env-namespacing.test.ts` — app-less spec: a catalog row and a custom row go through den-api's transform and the desktop `CloudProviderSync`; asserts the scoped name in the provider block and env store, the custom name untouched, the member's own `OPENAI_API_KEY` never overwritten, the engine still receiving the org credential via `/auth`, a repeat sync as `noop`, and sign-out removing only what OpenWork wrote.
- `bun test test/provider-credentials.test.ts test/cloud-provider-materialization.test.ts` in `ee/apps/den-api` — 54 pass, including a new custom-provider case and the pure-function rule (determinism, ranking, no mutation of the stored input).
- `pnpm evals:pr specs/spec-impact.test.ts`, `tsc` for `ee/apps/den-api`, `ee/apps/den-web`, `apps/app` — green.

## Known edge

A catalog provider with **no** credential stored in Den, satisfied today by a member's locally saved bare `OPENAI_API_KEY`, now looks for `LPR_…_OPENAI_API_KEY` instead. The Den editor and desktop provider list show that exact name. This is the intended single rule (catalog → scoped, always) rather than a value-dependent exception.
