### PR TITLE
fix(hosts): never prune a live sibling desktop's profile when spawning another

### DIFF
--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -2,7 +2,7 @@ import { execFile, spawn } from "node:child_process";
 import { constants, existsSync, openSync } from "node:fs";
 import { access, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { allocateFreePort, allocateFreePorts, listTargets, waitForCdp } from "@openwork/cdp";
 import {
   desktopBootstrapPath,
@@ -75,6 +75,16 @@ interface SpawnDetachedOptions {
   cwd: string;
   env: NodeJS.ProcessEnv;
   logPath: string;
+}
+
+const liveProfileRoots = new Set<string>();
+
+export function registerLiveProfileRoot(profileRoot: string): void {
+  liveProfileRoots.add(resolve(profileRoot));
+}
+
+export function unregisterLiveProfileRoot(profileRoot: string): void {
+  liveProfileRoots.delete(resolve(profileRoot));
 }
 
 interface KillLocalPidOptions {
@@ -668,6 +678,35 @@ export async function stopOwnedElectronSurface(pid: number, profileDir: string):
   await rm(profileDir, { recursive: true, force: true });
 }
 
+export async function pruneStaleSurfaceProfiles(
+  rootDir: string,
+  options: {
+    live?: ReadonlySet<string>;
+    log?: (message: string) => void;
+    kill?: (path: string) => Promise<void>;
+  },
+): Promise<{ removed: string[]; kept: string[] }> {
+  const entries = await readdir(rootDir).catch(() => []);
+  const removed: string[] = [];
+  const kept: string[] = [];
+  const live = options.live ?? liveProfileRoots;
+  const kill = options.kill ?? ((path: string) => new Promise<void>((done) => {
+    execFile("pkill", ["-f", path], () => done());
+  }));
+  for (const entry of entries) {
+    const path = resolve(rootDir, entry);
+    if (live.has(path)) {
+      kept.push(path);
+      continue;
+    }
+    await kill(path);
+    await rm(path, { recursive: true, force: true });
+    removed.push(path);
+  }
+  options.log?.(`Cleared ${removed.length} stale profile director${removed.length === 1 ? "y" : "ies"} in ${rootDir} (kept ${kept.length} live).`);
+  return { removed, kept };
+}
+
 function explicitPort(url: string): number | null {
   try {
     const parsed = new URL(url);
@@ -779,20 +818,6 @@ async function ensureDisplay(repoRoot: string, env: NodeJS.ProcessEnv, log: (mes
  * `Runtime.evaluate` for 240s, which reads exactly like a broken app. Pruning
  * here is cheap and keeps that failure from being invented again.
  */
-async function clearStaleSurfaces(rootDir: string, log: (message: string) => void): Promise<void> {
-  await new Promise<void>((resolve) => {
-    execFile("pkill", ["--full", rootDir], () => resolve());
-  });
-  // The default root is worker-scoped, so parallel files cannot kill or remove
-  // another worker's desktop while pruning their own stale profiles.
-  const stale = await readdir(rootDir).catch(() => []);
-  let removed = 0;
-  for (const entry of stale) {
-    await rm(join(rootDir, entry), { recursive: true, force: true }).then(() => { removed += 1; }).catch(() => undefined);
-  }
-  log(`Cleared Electron processes and ${removed} stale profile director${removed === 1 ? "y" : "ies"} in ${rootDir}.`);
-}
-
   return {
     kind: "local",
     workspaceRoot: options.repoRoot,
@@ -808,8 +833,9 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         throw new Error("Electron profileDir must not be empty.");
       }
       const callerOwnedProfile = opts.profileDir !== undefined;
-      if (!callerOwnedProfile) await clearStaleSurfaces(rootDir, log);
-      const profileRoot = opts.profileDir ?? join(rootDir, `${sanitizeSlug(name)}-${timestamp()}-${process.pid}`);
+      if (!callerOwnedProfile) await pruneStaleSurfaceProfiles(rootDir, { live: liveProfileRoots, log });
+      const profileRoot = opts.profileDir ?? resolve(rootDir, `${sanitizeSlug(name)}-${timestamp()}-${process.pid}`);
+      if (!callerOwnedProfile) registerLiveProfileRoot(profileRoot);
       const paths = electronProfilePaths(profileRoot);
       await ensureElectronProfile(paths);
       await writeBootstrap(paths.bootstrapPath, opts.bootstrap);
@@ -862,14 +888,16 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         cdpUrl,
         pid: spawned.pid,
         profileDir: profileRoot,
-        meta: { vitePort: String(port), cdpPort: String(cdpPort), log: logPath, profileOwner: callerOwnedProfile ? "caller" : "host" },
+        meta: { vitePort: String(port), cdpPort: String(cdpPort), log: logPath, profileRoot, profileOwner: callerOwnedProfile ? "caller" : "host" },
       };
       spawnedSurfaces.add(handle);
       return handle;
     },
 
     async spawnChrome(name: string, opts: ChromeSurfaceOptions = {}): Promise<SurfaceHandle> {
-      const profileRoot = join(rootDir, `${sanitizeSlug(name)}-${timestamp()}-${process.pid}`);
+      await pruneStaleSurfaceProfiles(rootDir, { live: liveProfileRoots, log });
+      const profileRoot = resolve(rootDir, `${sanitizeSlug(name)}-${timestamp()}-${process.pid}`);
+      registerLiveProfileRoot(profileRoot);
       const profileDir = join(profileRoot, "chrome-profile");
       await mkdir(profileDir, { recursive: true });
       const cdpPort = await allocateFreePort();
@@ -906,7 +934,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
         cdpUrl,
         pid: spawned.pid,
         profileDir,
-        meta: { cdpPort: String(cdpPort), log: logPath },
+        meta: { cdpPort: String(cdpPort), log: logPath, profileRoot },
       };
       spawnedSurfaces.add(handle);
       return handle;
@@ -943,6 +971,7 @@ async function clearStaleSurfaces(rootDir: string, log: (message: string) => voi
       }
       await disposeKnownPorts(handle);
       await removeOwnedSurfaceFiles(handle);
+      if (handle.meta?.profileOwner !== "caller" && handle.meta?.profileRoot) unregisterLiveProfileRoot(handle.meta.profileRoot);
       spawnedSurfaces.delete(handle);
     },
 

--- a/evals/packages/hosts/test/local-host.test.ts
+++ b/evals/packages/hosts/test/local-host.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 import { allocateFreePort } from "@openwork/cdp";
-import { electronProfilePaths, electronSurfaceEnv, freePort, resolveChromeBinary, stopOwnedElectronSurface } from "../src/local.ts";
+import { electronProfilePaths, electronSurfaceEnv, freePort, pruneStaleSurfaceProfiles, registerLiveProfileRoot, resolveChromeBinary, stopOwnedElectronSurface, unregisterLiveProfileRoot } from "../src/local.ts";
 
 const ENV_KEYS = [
   "APPDATA",
@@ -173,5 +173,81 @@ test("freePort kills a real child listener and releases its port", {
     });
   } finally {
     if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  }
+});
+
+test("pruneStaleSurfaceProfiles removes untracked profiles and never touches live ones", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "openwork-surface-prune-"));
+  const livePath = resolve(rootDir, "live-a");
+  const stalePath = resolve(rootDir, "stale-b");
+  const killed: string[] = [];
+  try {
+    await mkdir(livePath);
+    await mkdir(stalePath);
+    await writeFile(join(livePath, "marker.txt"), "keep", "utf8");
+    await writeFile(join(stalePath, "marker.txt"), "remove", "utf8");
+
+    const result = await pruneStaleSurfaceProfiles(rootDir, {
+      live: new Set([livePath]),
+      kill: async (path) => { killed.push(path); },
+    });
+
+    assert.deepEqual(result, { removed: [stalePath], kept: [livePath] });
+    assert.equal(await readFile(join(livePath, "marker.txt"), "utf8"), "keep");
+    await assert.rejects(access(stalePath));
+    assert.deepEqual(killed, [stalePath]);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("pruneStaleSurfaceProfiles kills only processes tied to stale profiles", {
+  skip: process.platform !== "darwin" && process.platform !== "linux",
+}, async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "openwork-surface-process-prune-"));
+  const livePath = resolve(rootDir, "live-a");
+  const stalePath = resolve(rootDir, "stale-b");
+  await mkdir(livePath);
+  await mkdir(stalePath);
+  const liveChild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", livePath], { detached: true, stdio: "ignore" });
+  const staleChild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", stalePath], { detached: true, stdio: "ignore" });
+  if (!liveChild.pid || !staleChild.pid) throw new Error("Surface process fixtures did not start.");
+  const livePid = liveChild.pid;
+  const stalePid = staleChild.pid;
+  try {
+    await new Promise((done) => setTimeout(done, 100));
+    await pruneStaleSurfaceProfiles(rootDir, { live: new Set([livePath]) });
+    const deadline = Date.now() + 5_000;
+    while (staleChild.exitCode === null && staleChild.signalCode === null && Date.now() < deadline) {
+      await new Promise((done) => setTimeout(done, 50));
+    }
+
+    assert.notEqual(staleChild.signalCode, null, "stale profile process should be dead");
+    assert.doesNotThrow(() => process.kill(livePid, 0));
+  } finally {
+    try { process.kill(livePid, "SIGKILL"); } catch {}
+    try { process.kill(stalePid, "SIGKILL"); } catch {}
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("disposing a surface unregisters its profile so a later prune can remove it", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "openwork-surface-unregister-"));
+  const profilePath = resolve(rootDir, "live-a");
+  await mkdir(profilePath);
+  try {
+    registerLiveProfileRoot(profilePath);
+    assert.deepEqual(await pruneStaleSurfaceProfiles(rootDir, { kill: async () => undefined }), {
+      removed: [],
+      kept: [profilePath],
+    });
+    unregisterLiveProfileRoot(profilePath);
+    assert.deepEqual(await pruneStaleSurfaceProfiles(rootDir, { kill: async () => undefined }), {
+      removed: [profilePath],
+      kept: [],
+    });
+  } finally {
+    unregisterLiveProfileRoot(profilePath);
+    await rm(rootDir, { recursive: true, force: true });
   }
 });

--- a/evals/specs/local-host-live-profile-prune.test.ts
+++ b/evals/specs/local-host-live-profile-prune.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  pruneStaleSurfaceProfiles,
+  registerLiveProfileRoot,
+  unregisterLiveProfileRoot,
+} from "@openwork/hosts";
+import { eventually, test } from "@openwork/testkit";
+
+test("pruning stale desktop profiles never touches a live sibling desktop", async ({ evidence }) => {
+  const rootDir = await mkdtemp(join(tmpdir(), "openwork-live-profile-prune-"));
+  const livePath = resolve(rootDir, "live-sibling");
+  const stalePath = resolve(rootDir, "stale-sibling");
+  const markerPath = join(livePath, "marker.bin");
+  const marker = Buffer.from([0, 1, 2, 127, 128, 254, 255]);
+  const killed: string[] = [];
+  let livePid: number | undefined;
+  let stalePid: number | undefined;
+
+  try {
+    await mkdir(livePath);
+    await mkdir(stalePath);
+    await writeFile(markerPath, marker);
+    await writeFile(join(stalePath, "marker.txt"), "stale", "utf8");
+    registerLiveProfileRoot(livePath);
+
+    const firstPrune = await pruneStaleSurfaceProfiles(rootDir, {
+      kill: async (path) => { killed.push(path); },
+    });
+    assert.deepEqual(firstPrune, { removed: [stalePath], kept: [livePath] });
+    assert.deepEqual(await readFile(markerPath), marker);
+    await assert.rejects(access(stalePath));
+    assert.deepEqual(killed, [stalePath]);
+    assert.equal(killed.includes(rootDir), false);
+    assert.equal(killed.includes(livePath), false);
+    evidence.recordAssertionEvidence(
+      "Live sibling profile survives stale-profile pruning",
+      "The registered live profile stayed byte-identical, the stale profile was removed, and kill received only the stale absolute path—not the root or live path.",
+      true,
+    );
+
+    await mkdir(stalePath);
+    const liveChild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", livePath], {
+      detached: true,
+      stdio: "ignore",
+    });
+    const staleChild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", stalePath], {
+      detached: true,
+      stdio: "ignore",
+    });
+    if (liveChild.pid === undefined || staleChild.pid === undefined) throw new Error("Desktop process fixtures did not start.");
+    livePid = liveChild.pid;
+    stalePid = staleChild.pid;
+    await new Promise((done) => setTimeout(done, 100));
+
+    await pruneStaleSurfaceProfiles(rootDir, {});
+    await eventually(() => staleChild.exitCode !== null || staleChild.signalCode !== null, {
+      within: 5_000,
+      intervalMs: 50,
+      label: "stale profile process exits",
+    });
+    assert.doesNotThrow(() => process.kill(livePid, 0));
+    assert.equal(liveChild.exitCode, null);
+    assert.equal(liveChild.signalCode, null);
+    evidence.recordAssertionEvidence(
+      "Default pruning kills only the stale profile process",
+      "A detached process whose argv named the stale profile exited within five seconds, while the registered live sibling process remained alive.",
+      true,
+    );
+
+    unregisterLiveProfileRoot(livePath);
+    const finalPrune = await pruneStaleSurfaceProfiles(rootDir, { kill: async () => undefined });
+    assert.deepEqual(finalPrune, { removed: [livePath], kept: [] });
+    await assert.rejects(access(livePath));
+    evidence.recordAssertionEvidence(
+      "Unregistered profiles become pruneable",
+      "After unregistering the formerly live profile, the next prune removed its directory and kept no live entries.",
+      true,
+    );
+  } finally {
+    unregisterLiveProfileRoot(livePath);
+    if (livePid !== undefined) {
+      try { process.kill(livePid, "SIGKILL"); } catch {}
+    }
+    if (stalePid !== undefined) {
+      try { process.kill(stalePid, "SIGKILL"); } catch {}
+    }
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}, 30_000);


### PR DESCRIPTION
## Symptom
`pnpm world up acme-demo` launches two desktops from one process (alex, then jordan). Alex showed **"OpenCode is unavailable for this workspace"** while jordan worked. Alex's profile directory was a hollow skeleton — no `electron.log`, no engine `opencode.log`.

## Root cause
`clearStaleSurfaces(rootDir)` in `evals/packages/hosts/src/local.ts` ran before **every** non-caller-owned spawn and `rm -rf`'d every entry under the surfaces root — which is scoped by the spawning *process* pid, so it is shared by every desktop that process launches. The second spawn deleted the first desktop's live userdata, `openwork-dev-data` and engine dirs from under the running Electron; the engine could no longer start or write, and every proxied `/opencode/*` call failed. On Linux the accompanying `pkill --full <rootDir>` would additionally kill the live sibling outright (BSD `pkill` on macOS has no `--full`, so that step silently no-op'd here). The pruner's one-desktop-per-process assumption is violated by any two-desktop world or spec.

## Fix
- Module-level registry of live profile roots (`resolveHost()` builds a **new** local host per `desktop()`, so a per-host set cannot see siblings). Registered at spawn (Electron and Chrome), unregistered on `disposeSurface`, so the original disk-leak protection (the reason the pruner exists) still applies to dead profiles.
- `pruneStaleSurfaceProfiles(rootDir, { live, kill, log })` replaces `clearStaleSurfaces`: prunes only untracked entries; kills per stale path with `pkill -f <path>` (BSD + GNU), never the root.
- `handle.meta.profileRoot` carries the registered path so disposal can unregister precisely.

## Verification (PR head `ef82ee66d`, local lane — no Daytona credentials in this environment; the spec is app-less)

| Check | Command | Result |
|---|---|---|
| **New spec** — live sibling kept byte-identical, stale removed, kill invoked once with the stale path only; real child on the stale path dies while the live-path child survives; unregister → later prune removes it | `pnpm evals:pr specs/local-host-live-profile-prune.test.ts` | 1/1 |
| Hosts unit tests (3 new) | `node --test evals/packages/hosts/test/local-host.test.ts` | 10/10 |
| World engine neighbors | `pnpm evals:pr specs/shared-world-engine.test.ts specs/world-crash-reap.test.ts` | 4/4 |
| **Runtime proof of the original symptom** | `node evals/bin/world.mjs up acme-demo --detach` → both `testkit-admin-*` and `testkit-fresh-*` profiles keep `electron.log` and `…/opencode/log/*.log`; alex's log shows `GET …/opencode/session 200`, `POST …/opencode/session 200`, `GET …/opencode/session/status 200`; `world down` clean | manual transcript |

Not in this PR (separate, product-side): the 5s first-load engine deadline vs. 15s engine-start deadline race (`apps/server/src/server.ts:1570,1712` vs `managed-opencode.ts:188`) that produces two transient 502s on a cold start under load — that one self-heals and is not what broke alex.