### PR TITLE
feat(landing): show SOC 2 Type I badge and status

### DIFF
--- a/ee/apps/landing/components/landing-enterprise.tsx
+++ b/ee/apps/landing/components/landing-enterprise.tsx
@@ -90,8 +90,8 @@ const deployments = [
 
 const compliance = [
   {
-    title: "SOC 2 Type II",
-    body: "Audit in progress with an independent firm — report available under NDA on completion."
+    title: "SOC 2 Type I",
+    body: "Type I audit complete — report available under NDA. Type II audit in progress."
   },
   {
     title: "SAML SSO + SCIM",
@@ -158,6 +158,7 @@ export function LandingEnterprise(props: Props) {
               <a href="/docs" className="lp-pill-secondary">Read the docs</a>
             </div>
             <div className="mt-7 flex flex-wrap gap-2.5">
+              <span className="lp-pill-secondary lp-pill-sm !h-9 gap-2 !text-[13px]"><span className="h-2 w-2 rounded-full bg-[#10B981]" />SOC 2 Type I</span>
               <span className="lp-pill-secondary lp-pill-sm !h-9 gap-2 !text-[13px]"><span className="h-2 w-2 rounded-full bg-[#F59E0B]" />SOC 2 Type II — in progress</span>
               <span className="lp-pill-secondary lp-pill-sm !h-9 !text-[13px]">SAML SSO + SCIM</span>
               <span className="lp-pill-secondary lp-pill-sm !h-9 !text-[13px]">Audit logs</span>

--- a/ee/apps/landing/components/landing-trust.tsx
+++ b/ee/apps/landing/components/landing-trust.tsx
@@ -305,6 +305,12 @@ export function LandingTrustOverview(props: SharedProps) {
                 <tbody>
                   <tr className="border-b border-slate-200/70 last:border-0">
                     <td className="px-4 py-2.5 font-medium text-[#011627]">
+                      SOC 2 Type I
+                    </td>
+                    <td className="px-4 py-2.5 text-slate-600">Complete — report available under NDA</td>
+                  </tr>
+                  <tr className="border-b border-slate-200/70 last:border-0">
+                    <td className="px-4 py-2.5 font-medium text-[#011627]">
                       SOC 2 Type II
                     </td>
                     <td className="px-4 py-2.5 text-slate-600">In progress</td>

--- a/ee/apps/landing/components/site-footer.tsx
+++ b/ee/apps/landing/components/site-footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ShieldCheck } from "lucide-react";
 import { OpenCodeLogo } from "./opencode-logo";
 
 export function SiteFooter() {
@@ -15,6 +16,14 @@ export function SiteFooter() {
           >
             <OpenCodeLogo className="h-3 w-auto" />
           </a>
+          <Link
+            href="/trust"
+            aria-label="SOC 2 Type I — view Trust Center"
+            className="inline-flex items-center gap-1.5 rounded-full border border-[var(--lp-border)] px-2.5 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-800"
+          >
+            <ShieldCheck className="h-3.5 w-3.5" />
+            SOC 2 Type I
+          </Link>
         </div>
 
         <div className="flex flex-wrap items-center gap-x-5 gap-y-3 md:gap-x-8">

--- a/ee/apps/landing/test/site-footer.test.tsx
+++ b/ee/apps/landing/test/site-footer.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SiteFooter } from "../components/site-footer";
+
+describe("Site footer", () => {
+  test("links the SOC 2 Type I badge to the Trust Center", () => {
+    const html = renderToStaticMarkup(createElement(SiteFooter));
+
+    expect(html).toContain('href="/trust"');
+    expect(html).toContain("SOC 2 Type I");
+    expect(html).not.toContain("Type II");
+  });
+});


### PR DESCRIPTION
## Summary
Different AI completed its SOC 2 Type I audit. The marketing site previously only said "SOC 2 Type II — in progress".

- **Footer**: new `ShieldCheck` + "SOC 2 Type I" pill linking to `/trust` (self-drawn; no AICPA seal).
- **/trust** compliance table: `SOC 2 Type I — Complete, report available under NDA` + `SOC 2 Type II — In progress`.
- **/enterprise**: compliance card retitled to Type I with Type II-in-progress copy; hero pills show green Type I + amber Type II in progress.
- New `test/site-footer.test.tsx`: footer links `/trust`, contains "SOC 2 Type I", and does **not** claim Type II.

## Verification
- `cd ee/apps/landing && bun test --isolate test/` → `5 pass, 0 fail` (3 files)
- `pnpm --filter @openwork-ee/landing exec tsc --noEmit -p .` → clean

Marketing-site copy/markup change proven by the package's Bun unit tests; `ee/apps/landing` has no `evals/specs` testkit lane, so no E2E evidence is attached.

## Follow-ups (not in this PR)
- Add the audit firm name to `/trust` once confirmed from the signed report.
- Point the badge at the Comp AI Trust Center if it is published on a `trust.` subdomain.