### PR TITLE
feat(world): live CLI view for world up — steps, resources, heartbeat, failure frames, attach

### DIFF
--- a/evals/packages/env/src/cli.ts
+++ b/evals/packages/env/src/cli.ts
@@ -1,10 +1,45 @@
+import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createConnection } from "mysql2/promise";
-import { main as runWorldCli, parseWorldArgs, type Reaper } from "@openwork/world";
-import { DEFAULT_MYSQL_URL } from "./place.ts";
+import { main as runWorldCli, parseWorldArgs, type PreflightCheck, type Reaper } from "@openwork/world";
+import { DEFAULT_MYSQL_URL, localMysqlIsRunning, localRedisIsRunning } from "./place.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const WORLDS_DIRECTORY = fileURLToPath(new URL("../../../../worlds", import.meta.url));
+
+const dockerCheck: PreflightCheck = {
+  id: "docker",
+  label: "docker",
+  run: () => new Promise((resolve) => {
+    execFile("docker", ["info"], (error) => resolve(error
+      ? { ok: false, detail: "unavailable", hint: "start Docker Desktop" }
+      : { ok: true }));
+  }),
+};
+
+const mysqlCheck: PreflightCheck = {
+  id: "mysql",
+  label: "mysql",
+  async run() {
+    return await localMysqlIsRunning()
+      ? { ok: true }
+      : { ok: false, detail: "unavailable", hint: "pnpm dev:den:mysql" };
+  },
+};
+
+const redisCheck: PreflightCheck = {
+  id: "redis",
+  label: "redis",
+  async run() {
+    return await localRedisIsRunning()
+      ? { ok: true }
+      : {
+          ok: false,
+          detail: "unavailable",
+          hint: "start Redis on 127.0.0.1:6379 (Den worlds stall at sign-in without it)",
+        };
+  },
+};
 
 export { parseWorldArgs };
 
@@ -46,6 +81,7 @@ export function main(argv = process.argv.slice(2)): Promise<number> {
   return runWorldCli(argv, {
     cwd: REPO_ROOT,
     worldsDirectory: WORLDS_DIRECTORY,
+    preflight: [dockerCheck, mysqlCheck, redisCheck],
     reapers: { "mysql-db": dropEphemeralDatabase },
   });
 }

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -16,7 +16,7 @@ import {
   startMockOnSandbox,
 } from "@openwork/hosts";
 import { denFetch, ensureMemberSession, freshSession, signIn } from "@openwork/behaviors";
-import { trackResource } from "@openwork/world";
+import { progress, trackResource } from "@openwork/world";
 import { createConnection } from "mysql2/promise";
 import type { ChildProcess } from "node:child_process";
 import type { DenRef, DenSession } from "@openwork/behaviors";
@@ -30,6 +30,7 @@ const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const DATABASE_ENCRYPTION_KEY = "local-dev-db-encryption-key-please-change-1234567890";
 const BETTER_AUTH_SECRET = "local-testkit-secret-not-for-production-use!!";
 const START_TIMEOUT_MS = 120_000;
+const steps = progress();
 
 export interface PersonShape {
   email?: string;
@@ -756,9 +757,12 @@ export async function server(options: ServerOptions): Promise<Den> {
   const services: SpawnedService[] = [];
   let database: DbHandle | undefined;
   try {
+    const databaseStep = steps.step("den-db", "Den database");
     database = await options.place.db(ephemeralDatabaseName());
     await trackResource({ kind: "mysql-db", id: database.name, label: "den-mysql" });
+    await databaseStep.note("schema push");
     await runDbPush(database.url);
+    await databaseStep.ok(database.name);
     let apiPort: number;
     let webPort: number;
     if (options.ports) {
@@ -791,7 +795,9 @@ export async function server(options: ServerOptions): Promise<Den> {
       await rm(join(REPO_ROOT, "ee", "apps", "den-web", ".next", "dev"), { recursive: true, force: true });
     }
     if (options.seedProfile === "demo-org") {
+      const seedStep = steps.step("den-seed", "Seed demo org", { log: join(logsDir, "seed-demo-org.log") });
       await runDemoOrgSeed(database.url, webPort, join(logsDir, "seed-demo-org.log"));
+      await seedStep.ok();
     }
     const orgShape = options.org ?? defaultLocalOrg(runId);
     const bootstrapAdmin = options.seedProfile === "demo-org"
@@ -828,6 +834,7 @@ export async function server(options: ServerOptions): Promise<Den> {
         ...options.env,
       };
     const api = spawnService("den-api", "dev:den:api", apiPort, { ...commonEnv, DEN_BIND_HOST: "127.0.0.1" }, join(logsDir, "api.log"));
+    const apiStep = steps.step("den-api", "den-api", { log: api.logPath });
     services.push(api);
     await trackResource({ kind: "process", id: String(api.pid), label: "den-api", match: prepared ? "@openwork-ee/den-api" : "dev:den:api" });
     const web = options.web === false
@@ -840,24 +847,39 @@ export async function server(options: ServerOptions): Promise<Den> {
           DEN_AUTH_ORIGIN: `http://localhost:${webPort}`,
           DEN_AUTH_FALLBACK_BASE: `http://127.0.0.1:${apiPort}`,
         }, join(logsDir, "web.log"));
+    const webStep = web ? steps.step("den-web", "den-web", { log: web.logPath }) : null;
     if (web) {
       services.push(web);
       await trackResource({ kind: "process", id: String(web.pid), label: "den-web", match: prepared ? "@openwork-ee/den-web" : "dev:den:web" });
     }
-    await waitForHttp(`${ref.apiUrl}/health`, api, (response) => response.ok);
-    if (web) {
-      await waitForHttp(`${ref.webUrl}/api/ready`, web, (response) => response.ok);
-      // /api/ready does not compile the dynamic /api/den proxy route. Locally,
-      // accept its 307 to /health because api.<host> derivation requires
-      // production DNS (see den-web app/api/_lib/den-api-redirect.ts).
-      await waitForHttp(`${ref.webUrl}/api/den/health`, web, (response) => {
-        if (response.ok) return true;
-        if (response.status !== 307 && response.status !== 308) return false;
-        const location = response.headers.get("location");
-        return location !== null && new URL(location, response.url).pathname === "/health";
-      }, { redirect: "manual" });
+    try {
+      await waitForHttp(`${ref.apiUrl}/health`, api, (response) => response.ok);
+      await apiStep.ok(ref.apiUrl);
+    } catch (error) {
+      await apiStep.fail(messageText(error));
+      throw error;
     }
+    if (web) {
+      try {
+        await waitForHttp(`${ref.webUrl}/api/ready`, web, (response) => response.ok);
+        // /api/ready does not compile the dynamic /api/den proxy route. Locally,
+        // accept its 307 to /health because api.<host> derivation requires
+        // production DNS (see den-web app/api/_lib/den-api-redirect.ts).
+        await waitForHttp(`${ref.webUrl}/api/den/health`, web, (response) => {
+          if (response.ok) return true;
+          if (response.status !== 307 && response.status !== 308) return false;
+          const location = response.headers.get("location");
+          return location !== null && new URL(location, response.url).pathname === "/health";
+        }, { redirect: "manual" });
+        await webStep?.ok(ref.webUrl);
+      } catch (error) {
+        await webStep?.fail(messageText(error));
+        throw error;
+      }
+    }
+    const authStep = steps.step("den-auth", "Den auth ready");
     await waitForAuthProbe(ref, api);
+    await authStep.ok();
     const organization = options.seedProfile === "demo-org"
       ? {
           admin: await signIn(ref, {
@@ -869,12 +891,17 @@ export async function server(options: ServerOptions): Promise<Den> {
         }
       : options.provision === false
         ? { admin: emptySession(ref), members: {}, createdOrgId: null }
-        : await provisionOrganization(
-            ref,
-            orgShape,
-            runId,
-            { databaseUrl: database.url, createOrg: true },
-          );
+        : await (async () => {
+            const orgStep = steps.step("den-org", "Provision organization");
+            const provisioned = await provisionOrganization(
+              ref,
+              orgShape,
+              runId,
+              { databaseUrl: database.url, createOrg: true },
+            );
+            await orgStep.ok(orgShape.name);
+            return provisioned;
+          })();
     let disposed = false;
     return {
       ref,

--- a/evals/packages/env/src/desktop-app.ts
+++ b/evals/packages/env/src/desktop-app.ts
@@ -3,10 +3,12 @@ import { attachSurface, evaluateOnSurface, isInteractive, probeAppStateOnSurface
 import type { Surface } from "@openwork/cdp";
 import { desktop } from "@openwork/hosts";
 import { liveSharedProductionStateEnv } from "@openwork/hosts";
-import { trackResource } from "@openwork/world";
+import { progress, trackResource } from "@openwork/world";
 import type { AppReadiness, DesktopHandle, Host, InstalledProductionDesktopState } from "@openwork/hosts";
 import type { Den } from "./den.ts";
 import type { Place } from "./place.ts";
+
+const steps = progress();
 
 interface SharedAppOptions {
   den: Den;
@@ -142,16 +144,25 @@ export async function app(options: AppOptions): Promise<App> {
     if (options.localServerDelayMs !== undefined) {
       env.OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS = String(options.localServerDelayMs);
     }
-    const surface = await desktop({
-      name: "testkit-fresh",
-      host: options.host ?? options.place.host(),
-      profileDir: options.profileDir,
-      bootstrap: {
-        baseUrl: options.den.ref.webUrl,
-        requireSignin: false,
-      },
-      env: Object.keys(env).length > 0 ? env : undefined,
-    });
+    const electronStep = steps.step("electron-fresh", "Electron (fresh)");
+    let surface: Awaited<ReturnType<typeof desktop>>;
+    try {
+      surface = await desktop({
+        name: "testkit-fresh",
+        host: options.host ?? options.place.host(),
+        profileDir: options.profileDir,
+        bootstrap: {
+          baseUrl: options.den.ref.webUrl,
+          requireSignin: false,
+        },
+        env: Object.keys(env).length > 0 ? env : undefined,
+      });
+    } catch (error) {
+      await electronStep.fail(error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+    await electronStep.note(`log ${surface.handle.meta?.log}`);
+    await electronStep.ok(surface.handle.cdpUrl);
     if (surface.handle.pid !== undefined) {
       await trackResource({ kind: "process", id: String(surface.handle.pid), label: "electron", match: process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim() || "dev:electron" });
     }
@@ -160,7 +171,9 @@ export async function app(options: AppOptions): Promise<App> {
     }
     try {
       const path = options.workspacePath ?? `/tmp/openwork-fresh-${Date.now()}`;
+      const workspaceStep = steps.step("workspace-fresh", "Create workspace");
       const { workspaceId } = await createAndSelectWorkspace(surface, { path });
+      await workspaceStep.ok(workspaceId);
       await options.beforeSignIn?.(surface);
       return {
         handle: surface.handle,
@@ -186,16 +199,25 @@ export async function app(options: AppOptions): Promise<App> {
   if (options.localServerDelayMs !== undefined) {
     env.OPENWORK_EVAL_LOCAL_SERVER_DELAY_MS = String(options.localServerDelayMs);
   }
-  const surface = await desktop({
-    name: `testkit-${options.as}`,
-    host: options.host ?? options.place.host(),
-    profileDir: options.profileDir,
-    bootstrap: {
-      baseUrl: options.den.ref.webUrl,
-      requireSignin: false,
-    },
-    env: Object.keys(env).length > 0 ? env : undefined,
-  });
+  const electronStep = steps.step(`electron-${options.as}`, `Electron (${options.as})`);
+  let surface: Awaited<ReturnType<typeof desktop>>;
+  try {
+    surface = await desktop({
+      name: `testkit-${options.as}`,
+      host: options.host ?? options.place.host(),
+      profileDir: options.profileDir,
+      bootstrap: {
+        baseUrl: options.den.ref.webUrl,
+        requireSignin: false,
+      },
+      env: Object.keys(env).length > 0 ? env : undefined,
+    });
+  } catch (error) {
+    await electronStep.fail(error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+  await electronStep.note(`log ${surface.handle.meta?.log}`);
+  await electronStep.ok(surface.handle.cdpUrl);
   if (surface.handle.pid !== undefined) {
     await trackResource({ kind: "process", id: String(surface.handle.pid), label: "electron", match: process.env.OPENWORK_EVAL_ELECTRON_BINARY?.trim() || "dev:electron" });
   }
@@ -206,9 +228,13 @@ export async function app(options: AppOptions): Promise<App> {
     // Workspace first, then the org sign-in: the signed-in org shell offers no
     // Add workspace entry, so a member's workspace exists before they connect.
     const path = options.workspacePath ?? `/tmp/openwork-${options.as}-${Date.now()}`;
-    await createAndSelectWorkspace(surface, { path });
+    const workspaceStep = steps.step(`workspace-${options.as}`, "Create workspace");
+    const { workspaceId: initialWorkspaceId } = await createAndSelectWorkspace(surface, { path });
+    await workspaceStep.ok(initialWorkspaceId);
     await options.beforeSignIn?.(surface);
+    const signInStep = steps.step(`signin-${options.as}`, `Sign in as ${options.as}`);
     await signInDesktopAs(surface, options.den.ref, member);
+    await signInStep.ok();
     const { workspaceId } = await createAndSelectWorkspace(surface, { path });
     return {
       handle: surface.handle,

--- a/evals/packages/env/src/litellm.ts
+++ b/evals/packages/env/src/litellm.ts
@@ -11,7 +11,7 @@ import {
   deleteSandboxes,
   execInSandbox,
 } from "@openwork/hosts";
-import { trackResource } from "@openwork/world";
+import { progress, trackResource } from "@openwork/world";
 import type { Server, ServerResponse } from "node:http";
 import { SkipError } from "./needs.ts";
 import type { Place } from "./place.ts";
@@ -33,6 +33,7 @@ const DAYTONA_LOG = "/tmp/openwork-litellm.log";
 const DAYTONA_WITNESS_LOG = "/tmp/openwork-litellm-witness.log";
 const BASE64_CHUNK_LENGTH = 8 * 1_024;
 const MAX_DAYTONA_COMMAND_LENGTH = 12 * 1_024;
+const steps = progress();
 const DEFAULT_MAX_INPUT_TOKENS = 128_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
 
@@ -645,7 +646,9 @@ async function startLocalLiteLlm(
   const postgresPassword = input.database ? randomBytes(32).toString("hex") : "";
   let root = "";
   let witness: Server | null = null;
+  let gatewayStep: ReturnType<typeof steps.step> | undefined;
   try {
+    const witnessStep = steps.step("litellm-witness", "LiteLLM witness");
     const startedWitness = await startWitness(
       input.modelId,
       input.reply,
@@ -653,6 +656,7 @@ async function startLocalLiteLlm(
       tokenId(secrets.controlKey),
       state,
     );
+    await witnessStep.ok(String(startedWitness.port));
     witness = startedWitness.server;
     root = await realpath(await mkdtemp(join(tmpdir(), "openwork-litellm-")));
     await trackResource({ kind: "tmpdir", id: root, label: "litellm-config" });
@@ -671,6 +675,7 @@ async function startLocalLiteLlm(
     );
     let postgresPort = 0;
     if (input.database) {
+      const postgresStep = steps.step("litellm-postgres", "LiteLLM Postgres");
       await run("docker", [
         "create", "--name", postgresContainer,
         "--env", `POSTGRES_PASSWORD=${postgresPassword}`,
@@ -682,6 +687,7 @@ async function startLocalLiteLlm(
       await run("docker", ["start", postgresContainer], 30_000);
       postgresPort = await mappedPostgresPort(postgresContainer);
       await waitForPostgres(postgresContainer);
+      await postgresStep.ok();
     }
     const createArgs = input.database
       ? [
@@ -697,6 +703,7 @@ async function startLocalLiteLlm(
           "--publish", "127.0.0.1::4000",
           IMAGE, "--config", "/app/config.json", "--port", "4000",
         ];
+    gatewayStep = steps.step("litellm", "LiteLLM gateway");
     await run("docker", createArgs);
     await trackResource({ kind: "docker", id: container, label: "litellm" });
     await run("docker", ["cp", configPath, `${container}:/app/config.json`], 30_000);
@@ -704,10 +711,12 @@ async function startLocalLiteLlm(
     const port = input.database
       ? await waitForLocalDatabaseProxy(container, secrets.masterKey, input.modelId)
       : await waitForLocalProxy(container, secrets.masterKey, input.modelId);
+    const baseUrl = `http://127.0.0.1:${port}/v1`;
+    await gatewayStep.ok(baseUrl);
     let placementDisposed = false;
     return makeHandle({
       ...secrets,
-      baseUrl: `http://127.0.0.1:${port}/v1`,
+      baseUrl,
       controlUrl: `http://127.0.0.1:${startedWitness.port}`,
       fetchImpl: fetch,
       redactedSecrets: input.database ? [postgresPassword] : undefined,
@@ -725,6 +734,7 @@ async function startLocalLiteLlm(
       },
     });
   } catch (error) {
+    await gatewayStep?.fail(messageText(error));
     const logs = await run("docker", ["logs", container], 10_000).then((result) => result.stdout + result.stderr, () => "");
     const postgresLogs = input.database
       ? await run("docker", ["logs", postgresContainer], 10_000).then((result) => result.stdout + result.stderr, () => "")

--- a/evals/packages/env/src/recipe.ts
+++ b/evals/packages/env/src/recipe.ts
@@ -2,6 +2,8 @@ import {
   assertWorldName,
   defaultDisplayStage,
   defaultScriptWorldSnapshotDirectory,
+  EVENTS_ENV,
+  eventsPath,
   hold,
   LEDGER_ENV,
   ledgerPath,
@@ -9,8 +11,10 @@ import {
   receiptName,
   resolveStage,
   rewriteLedger,
+  progress,
   trackResource,
   type LedgerEntry,
+  type Progress,
 } from "@openwork/world";
 import { resolvePlace, type Place } from "./place.ts";
 
@@ -18,6 +22,7 @@ export interface RecipeTools {
   stack: AsyncDisposableStack;
   place: Place;
   stage: string;
+  progress: Progress;
   stageName(base: string): string;
   track(entry: Omit<LedgerEntry, "at">): Promise<void>;
 }
@@ -41,6 +46,10 @@ export async function runRecipe(def: WorldRecipe): Promise<void> {
   const path = process.env[LEDGER_ENV]
     ?? ledgerPath(defaultScriptWorldSnapshotDirectory(), receiptName(def.name, worldStage));
   process.env[LEDGER_ENV] = path;
+  process.env[EVENTS_ENV] ??= eventsPath(
+    defaultScriptWorldSnapshotDirectory(),
+    receiptName(def.name, worldStage),
+  );
   let completed = false;
   try {
     {
@@ -50,6 +59,7 @@ export async function runRecipe(def: WorldRecipe): Promise<void> {
       const outputs = await def.build({
         stack,
         place,
+        progress: progress(),
         stage,
         stageName: (base) => `${base} (${stage})`,
         track: trackResource,

--- a/evals/specs/local-host-live-profile-prune.test.ts
+++ b/evals/specs/local-host-live-profile-prune.test.ts
@@ -62,7 +62,8 @@ test("pruning stale desktop profiles never touches a live sibling desktop", asyn
       intervalMs: 50,
       label: "stale profile process exits",
     });
-    assert.doesNotThrow(() => process.kill(livePid, 0));
+    const liveProbePid = liveChild.pid;
+    assert.doesNotThrow(() => process.kill(liveProbePid, 0));
     assert.equal(liveChild.exitCode, null);
     assert.equal(liveChild.signalCode, null);
     evidence.recordAssertionEvidence(

--- a/evals/specs/world-up-progress.test.ts
+++ b/evals/specs/world-up-progress.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { eventually, test } from "@openwork/testkit";
+import {
+  isProcessAlive,
+  main,
+  readScriptWorldSnapshot,
+  type WorldCliOptions,
+} from "@openwork/world";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(() => true, () => false);
+}
+
+function assertInOrder(lines: string[], predicates: Array<(line: string) => boolean>): void {
+  let index = -1;
+  for (const predicate of predicates) {
+    index = lines.findIndex((line, candidate) => candidate > index && predicate(line));
+    assert.notEqual(index, -1, lines.join("\n"));
+  }
+}
+
+test("world up narrates each step, stalls, failures, and attach replays them", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-up-progress-"));
+  const worldsDirectory = join(root, "worlds");
+  const scriptsDirectory = join(root, ".worlds", "scripts");
+  const fixtureName = "progress-world";
+  const stage = "ui";
+  const stagedName = `${fixtureName}--${stage}`;
+  const fixturePath = join(worldsDirectory, `${fixtureName}.ts`);
+  const receiptPath = join(scriptsDirectory, `${stagedName}.json`);
+  const logPath = join(scriptsDirectory, `${stagedName}.log`);
+  const recipeUrl = pathToFileURL(join(REPO_ROOT, "evals", "packages", "env", "src", "recipe.ts")).href;
+  const previousSnapshotDirectory = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  const previousHeartbeat = process.env.OPENWORK_WORLD_HEARTBEAT_MS;
+  const previousStall = process.env.OPENWORK_WORLD_STUB_STALL_MS;
+  const previousFail = process.env.OPENWORK_WORLD_STUB_FAIL;
+  const launchedPids = new Set<number>();
+  let printed: string[] = [];
+  let narrated: string[] = [];
+
+  const options: WorldCliOptions = {
+    cwd: root,
+    worldsDirectory,
+    print: (line) => printed.push(line),
+    progress: (line) => narrated.push(line),
+    preflight: [
+      { id: "fake-ok", label: "fake-ok", run: async () => ({ ok: true }) },
+      {
+        id: "fake-bad",
+        label: "fake-bad",
+        run: async () => ({ ok: false, detail: "127.0.0.1:1 refused", hint: "start fake" }),
+      },
+    ],
+  };
+  const run = async (argv: string[]): Promise<number> => {
+    printed.length = 0;
+    narrated.length = 0;
+    return main(argv, options);
+  };
+
+  try {
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR = scriptsDirectory;
+    process.env.OPENWORK_WORLD_HEARTBEAT_MS = "300";
+    process.env.OPENWORK_WORLD_STUB_STALL_MS = "1200";
+    delete process.env.OPENWORK_WORLD_STUB_FAIL;
+    await mkdir(worldsDirectory);
+    await writeFile(fixturePath, `
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recipe, runRecipe } from ${JSON.stringify(recipeUrl)};
+
+const world = recipe(${JSON.stringify(fixtureName)}, async (tools) => {
+  const a = tools.progress.step("alpha", "Alpha");
+  await a.ok("fast");
+  const dir = await mkdtemp(join(tmpdir(), "openwork-progress-"));
+  await tools.track({ kind: "tmpdir", id: dir, label: "scratch" });
+  tools.stack.use({
+    async [Symbol.asyncDispose](): Promise<void> {
+      await rm(dir, { recursive: true, force: true });
+    },
+  });
+  const b = tools.progress.step("beta", "Beta");
+  await new Promise((resolve) => setTimeout(resolve, Number(process.env.OPENWORK_WORLD_STUB_STALL_MS ?? "0")));
+  if (process.env.OPENWORK_WORLD_STUB_FAIL === "1") {
+    await b.fail("beta exploded");
+    throw new Error("beta exploded");
+  }
+  await b.ok("done");
+  return { url: "http://127.0.0.1:1" };
+});
+
+export default world;
+if (import.meta.main) await runRecipe(world);
+`, "utf8");
+
+    const upCode = await run(["up", fixturePath, "--detach", "--stage", stage, "--timeout", "10000"]);
+    assert.equal(upCode, 0, [...narrated, ...printed].join("\n"));
+    assertInOrder(narrated, [
+      (line) => line === `world  ${stagedName}  stage ${stage}`,
+      (line) => line === "preflight  node ✔  fake-ok ✔  fake-bad ✖",
+      (line) => line === "⚠ fake-bad 127.0.0.1:1 refused — start fake",
+      (line) => line === "▸ Alpha",
+      (line) => line.startsWith("✔ Alpha"),
+      (line) => line.startsWith("+ tmpdir  scratch "),
+      (line) => line === "▸ Beta",
+      (line) => line.startsWith("… still waiting on \"Beta\""),
+      (line) => line.startsWith("✔ Beta"),
+      (line) => line.startsWith(`✔ ${stagedName} is up`),
+      (line) => line === "url  http://127.0.0.1:1",
+      (line) => line.includes(`pnpm world down ${fixtureName} --stage ${stage}`),
+    ]);
+    assert.equal([...narrated, ...printed].some((line) => line.includes("\u001b")), false);
+    assert.deepEqual(printed, [
+      "url  http://127.0.0.1:1",
+      `snapshot  ${receiptPath}`,
+      `log  ${logPath}`,
+    ]);
+    assert.equal(await exists(receiptPath), true);
+    const snapshot = await readScriptWorldSnapshot(receiptPath);
+    assert.ok(snapshot);
+    launchedPids.add(snapshot.pid);
+    evidence.recordAssertionEvidence(
+      "Detached up narrates preflight, progress, resources, stalls, and readiness",
+      "Up exited 0 despite the warning, emitted every exact plain-mode milestone in order without ANSI, created a receipt, and kept stdout to the URL, snapshot, and log lines.",
+      true,
+    );
+
+    const attachCode = await run(["attach", fixtureName, "--stage", stage]);
+    assert.equal(attachCode, 0, [...narrated, ...printed].join("\n"));
+    assertInOrder(narrated, [
+      (line) => line === "▸ Alpha",
+      (line) => line.startsWith("✔ Alpha"),
+      (line) => line === "▸ Beta",
+      (line) => line.startsWith("✔ Beta"),
+      (line) => line.startsWith(`✔ ${stagedName} is up`),
+      (line) => line === "url  http://127.0.0.1:1",
+    ]);
+    assert.deepEqual(printed, []);
+    assert.equal(narrated.some((line) => line.includes("\u001b")), false);
+    evidence.recordAssertionEvidence(
+      "Attach replays completed progress through the ready block",
+      "Plain attach exited 0, replayed Alpha and Beta in order through the ready URL, printed nothing to stdout, and emitted no ANSI.",
+      true,
+    );
+
+    const downCode = await run(["down", fixtureName, "--stage", stage]);
+    assert.equal(downCode, 0, printed.join("\n"));
+    assert.equal(await exists(receiptPath), false);
+
+    process.env.OPENWORK_WORLD_STUB_FAIL = "1";
+    process.env.OPENWORK_WORLD_STUB_STALL_MS = "0";
+    const failedCode = await run(["up", fixturePath, "--detach", "--stage", stage, "--timeout", "10000"]);
+    assert.equal(failedCode, 1, [...narrated, ...printed].join("\n"));
+    const failedStep = narrated.findIndex((line) => line === "✖ Beta — beta exploded");
+    const failedWorld = narrated.findIndex((line) => line.startsWith(`✖ ${stagedName} failed`));
+    const lastLog = narrated.findIndex((line) => line.startsWith(`last `) && line.endsWith(` lines of ${logPath}:`));
+    const indentedError = narrated.findIndex((line, index) => index > lastLog && line.startsWith("  ") && line.includes("beta exploded"));
+    assert.ok(failedStep !== -1 && failedWorld > failedStep && lastLog > failedWorld && indentedError > lastLog, narrated.join("\n"));
+    assert.equal(narrated.some((line) => line.includes("is up")), false);
+    assert.equal(printed.includes(`Script world "${stagedName}" exited before creating its snapshot.`), true);
+    assert.equal(await exists(receiptPath), false);
+    evidence.recordAssertionEvidence(
+      "A failed step narrates failure context without readiness or a receipt",
+      "The failed launch exited 1, emitted the exact Beta failure before the world failure and indented beta-exploded log context, never said is up, printed the early-exit line, and created no receipt.",
+      true,
+    );
+
+    delete process.env.OPENWORK_WORLD_STUB_FAIL;
+    const missingAttachCode = await run(["attach", fixtureName, "--stage", stage]);
+    assert.equal(missingAttachCode, 1, printed.join("\n"));
+    assert.deepEqual(printed, [`World receipt "${stagedName}" does not exist.`]);
+    assert.deepEqual(narrated, []);
+    evidence.recordAssertionEvidence(
+      "Attach reports the missing failed-world receipt",
+      "After failure left no receipt, attach exited 1 with only the exact missing-receipt stdout line and no progress narration.",
+      true,
+    );
+  } finally {
+    delete process.env.OPENWORK_WORLD_STUB_FAIL;
+    try {
+      const snapshot = await readScriptWorldSnapshot(receiptPath);
+      if (snapshot) {
+        launchedPids.add(snapshot.pid);
+        await main(["down", fixtureName, "--stage", stage, "--purge"], { ...options, print: () => {}, progress: () => {} });
+      }
+    } catch {}
+    for (const pid of launchedPids) {
+      if (!isProcessAlive(pid)) continue;
+      try { process.kill(pid, "SIGKILL"); } catch {}
+      try {
+        await eventually(() => !isProcessAlive(pid), {
+          within: 5_000,
+          intervalMs: 25,
+          label: "progress world cleanup",
+        });
+      } catch {}
+    }
+    if (previousSnapshotDirectory === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previousSnapshotDirectory;
+    if (previousHeartbeat === undefined) delete process.env.OPENWORK_WORLD_HEARTBEAT_MS;
+    else process.env.OPENWORK_WORLD_HEARTBEAT_MS = previousHeartbeat;
+    if (previousStall === undefined) delete process.env.OPENWORK_WORLD_STUB_STALL_MS;
+    else process.env.OPENWORK_WORLD_STUB_STALL_MS = previousStall;
+    if (previousFail === undefined) delete process.env.OPENWORK_WORLD_STUB_FAIL;
+    else process.env.OPENWORK_WORLD_STUB_FAIL = previousFail;
+    await rm(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/packages/world/src/cli.ts
+++ b/packages/world/src/cli.ts
@@ -1,7 +1,10 @@
 import { access, readdir, rm } from "node:fs/promises";
 import { basename, extname, join, resolve } from "node:path";
+import { styleText } from "node:util";
+import { eventsPath, readEvents, tailEvents, type WorldEvent } from "./events.ts";
 import { ledgerPath, readLedger } from "./ledger.ts";
 import { discoverWorlds, displayWorldPath, resolveWorldScript } from "./loader.ts";
+import { nodeCheck, runPreflight, type PreflightCheck } from "./preflight.ts";
 import { builtinReapers, reapLedger, type ReapReport, type Reaper } from "./reaper.ts";
 import { receiptName, resolveStage, sanitizeStage } from "./stage.ts";
 import { WorldStateStore } from "./store.ts";
@@ -11,9 +14,12 @@ import {
   isProcessAlive,
   launchScriptWorld,
   readScriptWorldSnapshot,
+  readLastLogLines,
+  scriptWorldLogPath,
   scriptWorldSnapshotDirectory,
   scriptWorldSnapshotPath,
 } from "./script-world.ts";
+import { createWorldView, detectViewMode, type ViewSink, type WorldView } from "./view.ts";
 
 export type WorldCommand =
   | {
@@ -23,8 +29,10 @@ export type WorldCommand =
       timeoutMs?: number;
       stage?: string;
       place?: "local" | "daytona";
+      plain?: true;
       args: string[];
     }
+  | { kind: "attach"; name: string; stage?: string; plain?: true }
   | { kind: "down"; name: string; stage?: string; purge?: true }
   | { kind: "plan"; source: string; stage?: string }
   | { kind: "list" }
@@ -35,6 +43,9 @@ export interface WorldCliOptions {
   cwd: string;
   worldsDirectory: string;
   print?: (line: string) => void;
+  progress?: (line: string) => void;
+  preflight?: PreflightCheck[];
+  viewMode?: "tty" | "plain";
   reapers?: Record<string, Reaper>;
 }
 
@@ -78,6 +89,7 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
     let timeoutMs: number | undefined;
     let stage: string | undefined;
     let place: "local" | "daytona" | undefined;
+    let plain = false;
     for (let index = 0; index < options.length; index += 1) {
       const option = options[index];
       if (option === "--detach" && !detach) {
@@ -113,6 +125,10 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
         index += 1;
         continue;
       }
+      if (option === "--plain" && !plain) {
+        plain = true;
+        continue;
+      }
       return helpError(`Unknown world CLI option ${JSON.stringify(option)}. Pass script arguments after --.`);
     }
     if (timeoutMs !== undefined && !detach) return helpError("Use --timeout only with --detach.");
@@ -123,7 +139,39 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
       ...(timeoutMs === undefined ? {} : { timeoutMs }),
       ...(stage === undefined ? {} : { stage }),
       ...(place === undefined ? {} : { place }),
+      ...(plain ? { plain: true } : {}),
       args: scriptArgs,
+    };
+  }
+  if (command === "attach") {
+    const [name, ...options] = args;
+    if (!name || name === "--" || name.startsWith("--")) {
+      return helpError("The attach command needs exactly one world name.");
+    }
+    let stage: string | undefined;
+    let plain = false;
+    for (let index = 0; index < options.length; index += 1) {
+      const option = options[index];
+      if (option === "--stage" && stage === undefined) {
+        try {
+          stage = sanitizeStage(options[index + 1] ?? "");
+        } catch {
+          return helpError("Use --stage followed by a non-empty stage value.");
+        }
+        index += 1;
+        continue;
+      }
+      if (option === "--plain" && !plain) {
+        plain = true;
+        continue;
+      }
+      return helpError(`Unknown world CLI option ${JSON.stringify(option)}.`);
+    }
+    return {
+      kind: "attach",
+      name,
+      ...(stage === undefined ? {} : { stage }),
+      ...(plain ? { plain: true } : {}),
     };
   }
   if (command === "plan") {
@@ -175,7 +223,7 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
       ? { kind: "forget", name: args[0] }
       : helpError("The forget command needs exactly one world name.");
   }
-  return helpError(`Unknown command ${JSON.stringify(command)}. Script worlds support up, plan, down, list, forget, and help.`);
+  return helpError(`Unknown command ${JSON.stringify(command)}. Script worlds support up, attach, plan, down, list, forget, and help.`);
 }
 
 function messageText(error: unknown): string {
@@ -186,7 +234,8 @@ async function helpText(options: WorldCliOptions): Promise<string> {
   const discovered = await discoverWorlds(options.worldsDirectory);
   const sources = discovered.map((world) => displayWorldPath(world.path, options.cwd));
   return `Usage:
-  pnpm world up <script-path-or-name> [--detach] [--timeout <ms>] [--stage <value>] [--place <local|daytona>] [-- <script args...>]
+  pnpm world up <script-path-or-name> [--detach] [--timeout <ms>] [--stage <value>] [--place <local|daytona>] [--plain] [-- <script args...>]
+  pnpm world attach <name> [--stage <value>] [--plain]
   pnpm world plan <script-path-or-name> [--stage <value>]
   pnpm world down <name> [--stage <value>] [--purge]
   pnpm world list
@@ -263,6 +312,113 @@ async function reapAndReport(
   return report;
 }
 
+function createCliView(
+  options: WorldCliOptions,
+  flags: { plain?: boolean },
+): { view: WorldView; mode: "tty" | "plain" } {
+  const detected = detectViewMode(process.env, flags);
+  const mode = options.progress || flags.plain
+    ? "plain"
+    : options.viewMode ?? detected.mode;
+  const progress = options.progress ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const sink: ViewSink = mode === "plain"
+    ? {
+        write(text): void {
+          progress(text.endsWith("\n") ? text.slice(0, -1) : text);
+        },
+        isTTY: false,
+      }
+    : {
+        write: (text) => { process.stderr.write(text); },
+        isTTY: process.stderr.isTTY === true,
+        ...(process.stderr.columns === undefined ? {} : { columns: process.stderr.columns }),
+      };
+  return {
+    mode,
+    view: createWorldView({
+      sink,
+      mode,
+      color: mode === "tty" && detected.color,
+    }),
+  };
+}
+
+function reportProgress(options: WorldCliOptions, line: string): void {
+  if (options.progress) options.progress(line);
+  else process.stderr.write(`${line}\n`);
+}
+
+async function finishEventTail(
+  path: string,
+  tail: { stop(): void },
+  rendered: { count: number },
+  view: WorldView,
+): Promise<WorldEvent[]> {
+  tail.stop();
+  const events = await readEvents(path);
+  for (const event of events.slice(rendered.count)) {
+    rendered.count += 1;
+    view.apply(event);
+  }
+  return events;
+}
+
+async function resourceCount(path: string): Promise<number> {
+  return (await readLedger(path)).length;
+}
+
+function lastStepLabel(events: WorldEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.type === "step" && event.status !== "ok") return event.label;
+  }
+  return undefined;
+}
+
+async function stagedReceiptCandidate(
+  snapshotDirectory: string,
+  name: string,
+  stage: string | undefined,
+  print: (line: string) => void,
+): Promise<{ kind: "found"; stagedName: string; path: string } | { kind: "missing" | "multiple" }> {
+  const exactName = receiptName(name, stage);
+  const exactPath = scriptWorldSnapshotPath(snapshotDirectory, exactName);
+  if (await pathExists(exactPath)) return { kind: "found", stagedName: exactName, path: exactPath };
+  if (stage !== undefined) return { kind: "missing" };
+  const prefix = `${name}--`;
+  const candidates = (await new WorldStateStore(snapshotDirectory).list())
+    .map((candidatePath) => basename(candidatePath, extname(candidatePath)))
+    .filter((candidate) => candidate.startsWith(prefix))
+    .sort();
+  if (candidates.length > 1) {
+    print(`Multiple staged world receipts match ${JSON.stringify(name)}:`);
+    for (const candidate of candidates) print(`  ${candidate}`);
+    return { kind: "multiple" };
+  }
+  return candidates[0]
+    ? {
+        kind: "found",
+        stagedName: candidates[0],
+        path: scriptWorldSnapshotPath(snapshotDirectory, candidates[0]),
+      }
+    : { kind: "missing" };
+}
+
+function eventElapsed(events: WorldEvent[]): number {
+  if (events.length < 2) return 0;
+  const first = Date.parse(events[0]?.t ?? "");
+  const ready = [...events].reverse().find((event) => event.type === "ready");
+  const last = Date.parse(ready?.t ?? events[events.length - 1]?.t ?? "");
+  return Number.isFinite(first) && Number.isFinite(last) ? Math.max(0, last - first) : 0;
+}
+
+function planSymbolColor(kind: ScriptReceiptState["kind"]): "green" | "cyan" | "yellow" | "red" {
+  if (kind === "create") return "green";
+  if (kind === "running") return "cyan";
+  if (kind === "changed") return "yellow";
+  return "red";
+}
+
 export async function main(argv: string[], options: WorldCliOptions): Promise<number> {
   const print = options.print ?? console.log;
   const command = parseWorldArgs(argv);
@@ -297,18 +453,181 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       } else if (await pathExists(worldLedgerPath)) {
         await reapAndReport(worldLedgerPath, stagedName, script.name, stage, false, print, options);
       }
-      return await launchScriptWorld({
-        path: script.path,
-        name: script.name,
-        args: command.args,
-        snapshotDirectory,
-        detach: command.detach === true,
-        ...(command.timeoutMs === undefined ? {} : { timeoutMs: command.timeoutMs }),
+      const logPath = scriptWorldLogPath(snapshotDirectory, stagedName);
+      const eventPath = eventsPath(snapshotDirectory, stagedName);
+      await rm(eventPath, { force: true });
+      const preflight = await runPreflight([nodeCheck(), ...(options.preflight ?? [])]);
+      const { view, mode } = createCliView(options, { plain: command.plain });
+      view.header({
+        name: stagedName,
         ...(stage === undefined ? {} : { stage }),
-        recipeHash,
         ...(command.place === undefined ? {} : { place: command.place }),
-        print,
+        receipt: snapshotPath,
+        ...(command.detach || mode === "tty" ? { log: logPath } : {}),
+        preflight,
       });
+      const startedAt = Date.now();
+      const rendered = { count: 0 };
+      const tail = tailEvents(eventPath, (event) => {
+        rendered.count += 1;
+        view.apply(event);
+      }, { intervalMs: 50 });
+      let childPid: number | undefined;
+      let readyShown = false;
+      let stopped = false;
+      const showReady = async (): Promise<void> => {
+        if (readyShown) return;
+        const snapshot = await readScriptWorldSnapshot(snapshotPath);
+        if (!snapshot) return;
+        readyShown = true;
+        const events = await readEvents(eventPath);
+        for (const event of events.slice(rendered.count)) {
+          rendered.count += 1;
+          view.apply(event);
+        }
+        view.ready({
+          name: stagedName,
+          outputs: snapshot.outputs,
+          elapsedMs: Date.now() - startedAt,
+          resources: await resourceCount(worldLedgerPath),
+          downHint: `pnpm world down ${script.name}${stage ? ` --stage ${stage}` : ""}`,
+          ...(command.detach || mode === "tty" ? { log: logPath } : {}),
+        });
+      };
+      const receiptPoll = setInterval(() => { void showReady(); }, 50);
+      receiptPoll.unref();
+      const onSigint = (): void => {
+        if (stopped || childPid === undefined) return;
+        stopped = true;
+        view.apply({ t: new Date().toISOString(), type: "note", text: "stopping…" });
+        try { process.kill(childPid, "SIGINT"); } catch {}
+      };
+      if (!command.detach && mode === "tty") process.on("SIGINT", onSigint);
+      let code: number;
+      try {
+        code = await launchScriptWorld({
+          path: script.path,
+          name: script.name,
+          args: command.args,
+          snapshotDirectory,
+          detach: command.detach === true,
+          ...(command.timeoutMs === undefined ? {} : { timeoutMs: command.timeoutMs }),
+          ...(stage === undefined ? {} : { stage }),
+          recipeHash,
+          ...(command.place === undefined ? {} : { place: command.place }),
+          print,
+          foregroundLog: !command.detach && mode === "tty",
+          onSpawn: (pid) => { childPid = pid; },
+        });
+      } catch (error) {
+        clearInterval(receiptPoll);
+        if (!command.detach && mode === "tty") process.off("SIGINT", onSigint);
+        const events = await finishEventTail(eventPath, tail, rendered, view);
+        view.failed({
+          name: stagedName,
+          ...(lastStepLabel(events) === undefined ? {} : { step: lastStepLabel(events) }),
+          elapsedMs: Date.now() - startedAt,
+          lastLog: await readLastLogLines(logPath, 40),
+          logPath,
+          hint: messageText(error),
+        });
+        view.stop();
+        throw error;
+      }
+      clearInterval(receiptPoll);
+      if (!command.detach && mode === "tty") process.off("SIGINT", onSigint);
+      const events = await finishEventTail(eventPath, tail, rendered, view);
+      await showReady();
+      if (code === 0 && events.every((event) => event.type === "ready")) {
+        await rm(eventPath, { force: true });
+      }
+      if (code !== 0) {
+        view.failed({
+          name: stagedName,
+          ...(lastStepLabel(events) === undefined ? {} : { step: lastStepLabel(events) }),
+          elapsedMs: Date.now() - startedAt,
+          lastLog: await readLastLogLines(logPath, 40),
+          logPath,
+        });
+      } else if (!command.detach) {
+        view.stop();
+        reportProgress(options, `World ${JSON.stringify(stagedName)} stopped.`);
+      } else {
+        view.stop();
+      }
+      return code;
+    } catch (error) {
+      print(messageText(error));
+      return 1;
+    }
+  }
+  if (command.kind === "attach") {
+    const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
+    const candidate = await stagedReceiptCandidate(
+      snapshotDirectory,
+      command.name,
+      command.stage,
+      print,
+    );
+    if (candidate.kind !== "found") {
+      if (candidate.kind === "multiple") return 1;
+      print(`World receipt ${JSON.stringify(receiptName(command.name, command.stage))} does not exist.`);
+      return 1;
+    }
+    try {
+      const snapshot = await readScriptWorldSnapshot(candidate.path);
+      if (!snapshot) {
+        print(`World receipt ${JSON.stringify(candidate.stagedName)} does not exist.`);
+        return 1;
+      }
+      const { view, mode } = createCliView(options, { plain: command.plain });
+      const eventPath = eventsPath(snapshotDirectory, candidate.stagedName);
+      const logPath = scriptWorldLogPath(snapshotDirectory, candidate.stagedName);
+      view.header({
+        name: candidate.stagedName,
+        ...(snapshot.stage === undefined ? {} : { stage: snapshot.stage }),
+        ...(snapshot.place === undefined ? {} : { place: snapshot.place }),
+        receipt: candidate.path,
+        log: logPath,
+      });
+      const events = await readEvents(eventPath);
+      for (const event of events) view.apply(event);
+      view.ready({
+        name: candidate.stagedName,
+        outputs: snapshot.outputs,
+        elapsedMs: eventElapsed(events),
+        resources: await resourceCount(ledgerPath(snapshotDirectory, candidate.stagedName)),
+        downHint: `pnpm world down ${command.name}${snapshot.stage ? ` --stage ${snapshot.stage}` : ""}`,
+        log: logPath,
+      });
+      if (mode === "plain") {
+        view.stop();
+        return 0;
+      }
+      const tail = tailEvents(eventPath, (event) => view.apply(event), { intervalMs: 50 });
+      process.stdin.resume();
+      await new Promise<void>((done) => {
+        let finished = false;
+        const finish = (): void => {
+          if (finished) return;
+          finished = true;
+          clearInterval(alivePoll);
+          process.off("SIGINT", detach);
+          tail.stop();
+          view.stop();
+          process.stdin.pause();
+          done();
+        };
+        const detach = (): void => finish();
+        const alivePoll = setInterval(() => {
+          if (isProcessAlive(snapshot.pid)) return;
+          reportProgress(options, `World ${JSON.stringify(candidate.stagedName)} stopped.`);
+          finish();
+        }, 250);
+        alivePoll.unref();
+        process.once("SIGINT", detach);
+      });
+      return 0;
     } catch (error) {
       print(messageText(error));
       return 1;
@@ -329,7 +648,11 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
         changed: "~ stale (recipe changed)",
         orphaned: "- orphaned (stale receipt, will recreate)",
       };
-      print(labels[state.kind]);
+      const detected = detectViewMode(process.env, {});
+      const tty = options.progress === undefined && (options.viewMode ?? detected.mode) === "tty";
+      const color = tty && detected.color;
+      const label = labels[state.kind];
+      print(color ? `${styleText(planSymbolColor(state.kind), label[0] ?? "")} ${label.slice(2)}` : label);
       print(`receipt  ${snapshotPath}`);
       if (state.kind !== "create") printOutputs(state.snapshot, print);
       const worldLedgerPath = ledgerPath(snapshotDirectory, stagedName);

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -1,0 +1,246 @@
+import { appendFile, chmod, mkdir, readFile, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const EVENTS_ENV = "OPENWORK_WORLD_EVENTS";
+
+export function eventsPath(snapshotDirectory: string, receiptName: string): string {
+  return join(snapshotDirectory, `${receiptName}.events.jsonl`);
+}
+
+export type WorldEvent = { t: string } & (
+  | {
+      type: "step";
+      id: string;
+      label: string;
+      status: "start" | "ok" | "fail";
+      detail?: string;
+      log?: string;
+    }
+  | { type: "resource"; kind: string; id: string; label?: string }
+  | { type: "ready"; outputs: Record<string, string> }
+  | { type: "note"; text: string }
+);
+
+export interface StepHandle {
+  ok(detail?: string): Promise<void>;
+  fail(detail?: string): Promise<void>;
+  note(detail: string): Promise<void>;
+}
+
+export interface Progress {
+  step(id: string, label: string, options?: { log?: string }): StepHandle;
+  note(text: string): Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: Record<string, unknown>, key: string): string | undefined | false {
+  const entry = value[key];
+  return entry === undefined || typeof entry === "string" ? entry : false;
+}
+
+function parseEvent(line: string): WorldEvent | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(value) || typeof value.t !== "string" || typeof value.type !== "string") return undefined;
+  if (value.type === "step") {
+    const detail = optionalString(value, "detail");
+    const log = optionalString(value, "log");
+    if (
+      typeof value.id !== "string"
+      || typeof value.label !== "string"
+      || (value.status !== "start" && value.status !== "ok" && value.status !== "fail")
+      || detail === false
+      || log === false
+    ) return undefined;
+    return {
+      t: value.t,
+      type: "step",
+      id: value.id,
+      label: value.label,
+      status: value.status,
+      ...(detail === undefined ? {} : { detail }),
+      ...(log === undefined ? {} : { log }),
+    };
+  }
+  if (value.type === "resource") {
+    const label = optionalString(value, "label");
+    if (typeof value.kind !== "string" || typeof value.id !== "string" || label === false) return undefined;
+    return {
+      t: value.t,
+      type: "resource",
+      kind: value.kind,
+      id: value.id,
+      ...(label === undefined ? {} : { label }),
+    };
+  }
+  if (value.type === "ready") {
+    if (!isRecord(value.outputs) || !Object.values(value.outputs).every((entry) => typeof entry === "string")) {
+      return undefined;
+    }
+    const outputs: Record<string, string> = {};
+    for (const [key, entry] of Object.entries(value.outputs)) {
+      if (typeof entry === "string") outputs[key] = entry;
+    }
+    return { t: value.t, type: "ready", outputs };
+  }
+  if (value.type === "note" && typeof value.text === "string") {
+    return { t: value.t, type: "note", text: value.text };
+  }
+  return undefined;
+}
+
+function parseLines(text: string): WorldEvent[] {
+  const events: WorldEvent[] = [];
+  for (const line of text.split("\n")) {
+    if (line.trim().length === 0) continue;
+    const event = parseEvent(line);
+    if (event) events.push(event);
+  }
+  return events;
+}
+
+function isMissingFile(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+export async function appendEvent(path: string, event: WorldEvent): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+export async function readEvents(path: string): Promise<WorldEvent[]> {
+  try {
+    return parseLines(await readFile(path, "utf8"));
+  } catch (error) {
+    if (isMissingFile(error)) return [];
+    throw error;
+  }
+}
+
+export function tailEvents(
+  path: string,
+  onEvent: (event: WorldEvent) => void,
+  options: { intervalMs: number },
+): { stop(): void } {
+  let stopped = false;
+  let offset = 0;
+  let remainder = "";
+  let polling = false;
+
+  const poll = async (): Promise<void> => {
+    if (stopped || polling) return;
+    polling = true;
+    try {
+      let size: number;
+      try {
+        size = (await stat(path)).size;
+      } catch (error) {
+        if (isMissingFile(error)) {
+          offset = 0;
+          remainder = "";
+          return;
+        }
+        throw error;
+      }
+      if (size < offset) {
+        offset = 0;
+        remainder = "";
+      }
+      if (size === offset) return;
+      const bytes = await readFile(path);
+      if (bytes.length < offset) {
+        offset = 0;
+        remainder = "";
+      }
+      const added = bytes.subarray(offset).toString("utf8");
+      offset = bytes.length;
+      const text = remainder + added;
+      const completeThrough = text.lastIndexOf("\n");
+      if (completeThrough === -1) {
+        remainder = text;
+        return;
+      }
+      remainder = text.slice(completeThrough + 1);
+      for (const event of parseLines(text.slice(0, completeThrough))) onEvent(event);
+    } finally {
+      polling = false;
+    }
+  };
+
+  const timer = setInterval(() => { void poll().catch(() => {}); }, options.intervalMs);
+  timer.unref();
+  void poll().catch(() => {});
+  return {
+    stop(): void {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function noOpStep(): StepHandle {
+  return {
+    ok: () => Promise.resolve(),
+    fail: () => Promise.resolve(),
+    note: () => Promise.resolve(),
+  };
+}
+
+export function progress(): Progress {
+  const path = process.env[EVENTS_ENV];
+  if (path === undefined) {
+    return { step: noOpStep, note: () => Promise.resolve() };
+  }
+
+  let writes = Promise.resolve();
+  const emit = (event: WorldEvent): Promise<void> => {
+    writes = writes.then(() => appendEvent(path, event));
+    return writes;
+  };
+  return {
+    step(id, label, options = {}): StepHandle {
+      void emit({
+        t: timestamp(),
+        type: "step",
+        id,
+        label,
+        status: "start",
+        ...(options.log === undefined ? {} : { log: options.log }),
+      });
+      return {
+        ok: (detail) => emit({
+          t: timestamp(),
+          type: "step",
+          id,
+          label,
+          status: "ok",
+          ...(detail === undefined ? {} : { detail }),
+          ...(options.log === undefined ? {} : { log: options.log }),
+        }),
+        fail: (detail) => emit({
+          t: timestamp(),
+          type: "step",
+          id,
+          label,
+          status: "fail",
+          ...(detail === undefined ? {} : { detail }),
+          ...(options.log === undefined ? {} : { log: options.log }),
+        }),
+        note: (detail) => emit({ t: timestamp(), type: "note", text: detail }),
+      };
+    },
+    note: (text) => emit({ t: timestamp(), type: "note", text }),
+  };
+}

--- a/packages/world/src/hold.ts
+++ b/packages/world/src/hold.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { appendEvent, EVENTS_ENV } from "./events.ts";
 import { receiptName, resolveStage } from "./stage.ts";
 import { assertWorldName } from "./store.ts";
 
@@ -94,6 +95,10 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
   await mkdir(dirname(snapshotPath), { recursive: true });
   await writeFile(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   await chmod(snapshotPath, 0o600);
+  const eventPath = process.env[EVENTS_ENV];
+  if (eventPath !== undefined) {
+    await appendEvent(eventPath, { t: new Date().toISOString(), type: "ready", outputs });
+  }
 
   for (const [key, value] of Object.entries(outputs)) console.log(`${key}  ${value}`);
   console.log(`World ${JSON.stringify(stagedName)} is up. Ctrl-C (or pnpm world down ${name}${stage ? ` --stage ${stage}` : ""}) tears it down.`);

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -9,3 +9,6 @@ export * from "./cli.ts";
 export * from "./headless-web-helpers.ts";
 export * from "./headless-web.ts";
 export * from "./standalone-cli.ts";
+export * from "./events.ts";
+export * from "./preflight.ts";
+export * from "./view.ts";

--- a/packages/world/src/ledger.ts
+++ b/packages/world/src/ledger.ts
@@ -1,5 +1,6 @@
 import { appendFile, chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { appendEvent, EVENTS_ENV } from "./events.ts";
 
 export interface LedgerEntry {
   kind: string;
@@ -110,6 +111,15 @@ export async function rewriteLedger(path: string, entries: LedgerEntry[]): Promi
 
 export async function trackResource(entry: Omit<LedgerEntry, "at">): Promise<void> {
   const path = process.env[LEDGER_ENV];
-  if (path === undefined) return;
-  await appendLedgerEntry(path, entry);
+  if (path !== undefined) await appendLedgerEntry(path, entry);
+  const eventPath = process.env[EVENTS_ENV];
+  if (eventPath !== undefined) {
+    await appendEvent(eventPath, {
+      t: new Date().toISOString(),
+      type: "resource",
+      kind: entry.kind,
+      id: entry.id,
+      ...(entry.label === undefined ? {} : { label: entry.label }),
+    });
+  }
 }

--- a/packages/world/src/preflight.ts
+++ b/packages/world/src/preflight.ts
@@ -1,0 +1,54 @@
+export interface PreflightCheck {
+  id: string;
+  label: string;
+  run(): Promise<{ ok: boolean; detail?: string; hint?: string }>;
+}
+
+export type PreflightResult = {
+  id: string;
+  label: string;
+  ok: boolean;
+  detail?: string;
+  hint?: string;
+};
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runOne(check: PreflightCheck, timeoutMs: number): Promise<PreflightResult> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<{ ok: false; detail: string }>((resolve) => {
+    timer = setTimeout(() => resolve({ ok: false, detail: "timed out" }), timeoutMs);
+    timer.unref();
+  });
+  try {
+    const result = await Promise.race([
+      check.run().catch((error: unknown) => ({ ok: false, detail: errorText(error) })),
+      timeout,
+    ]);
+    return { id: check.id, label: check.label, ...result };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function runPreflight(
+  checks: PreflightCheck[],
+  timeoutMs = 5_000,
+): Promise<PreflightResult[]> {
+  return Promise.all(checks.map((check) => runOne(check, timeoutMs)));
+}
+
+export function nodeCheck(): PreflightCheck {
+  return {
+    id: "node",
+    label: "node",
+    async run() {
+      const major = Number(process.versions.node.split(".", 1)[0]);
+      return major >= 24
+        ? { ok: true, detail: process.versions.node }
+        : { ok: false, detail: `Node ${process.versions.node}`, hint: "install Node 24 or newer" };
+    },
+  };
+}

--- a/packages/world/src/script-world.ts
+++ b/packages/world/src/script-world.ts
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { access, chmod, mkdir, open, readFile, rm } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { EVENTS_ENV, eventsPath } from "./events.ts";
 import { LEDGER_ENV, ledgerPath } from "./ledger.ts";
 import { receiptName } from "./stage.ts";
 import { assertWorldName } from "./store.ts";
@@ -136,24 +137,44 @@ async function assertNoRunningSnapshot(path: string, name: string): Promise<void
   await rm(path, { force: true });
 }
 
-async function waitForChild(path: string, args: readonly string[], env: NodeJS.ProcessEnv): Promise<number> {
+async function waitForChild(
+  path: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  logPath: string | undefined,
+  onSpawn: ((pid: number) => void) | undefined,
+): Promise<number> {
   const ignoreSigint = (): void => {};
   process.on("SIGINT", ignoreSigint);
   try {
-    const child = spawn(process.execPath, [path, ...args], { env, stdio: "inherit" });
-    return await new Promise<number>((done, reject) => {
-      child.once("error", reject);
-      child.once("close", (code) => done(code ?? 1));
-    });
+    let log: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      if (logPath !== undefined) {
+        await mkdir(dirname(logPath), { recursive: true });
+        log = await open(logPath, "w", 0o600);
+        await chmod(logPath, 0o600);
+      }
+      const child = spawn(process.execPath, [path, ...args], {
+        env,
+        stdio: log ? ["inherit", log.fd, log.fd] : "inherit",
+      });
+      if (child.pid !== undefined) onSpawn?.(child.pid);
+      return await new Promise<number>((done, reject) => {
+        child.once("error", reject);
+        child.once("close", (code) => done(code ?? 1));
+      });
+    } finally {
+      await log?.close();
+    }
   } finally {
     process.off("SIGINT", ignoreSigint);
   }
 }
 
-async function lastLogLines(path: string): Promise<string[]> {
+export async function readLastLogLines(path: string, count: number): Promise<string[]> {
   try {
     const text = await readFile(path, "utf8");
-    return text.trimEnd().split(/\r?\n/).slice(-40);
+    return text.trimEnd().split(/\r?\n/).slice(-count);
   } catch {
     return [];
   }
@@ -170,16 +191,21 @@ export interface LaunchScriptWorldOptions {
   recipeHash?: string;
   place?: string;
   print: (line: string) => void;
+  foregroundLog?: boolean;
+  onSpawn?: (pid: number) => void;
 }
 
 export async function launchScriptWorld(options: LaunchScriptWorldOptions): Promise<number> {
   const path = resolve(options.path);
   const stagedName = receiptName(options.name, options.stage);
   const snapshotPath = scriptWorldSnapshotPath(options.snapshotDirectory, stagedName);
+  const eventPath = eventsPath(options.snapshotDirectory, stagedName);
+  const logPath = scriptWorldLogPath(options.snapshotDirectory, stagedName);
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     OPENWORK_WORLD_SNAPSHOT_DIR: options.snapshotDirectory,
     [LEDGER_ENV]: ledgerPath(options.snapshotDirectory, stagedName),
+    [EVENTS_ENV]: eventPath,
   };
   if (options.stage === undefined) delete env.OPENWORK_WORLD_STAGE;
   else env.OPENWORK_WORLD_STAGE = options.stage;
@@ -188,10 +214,18 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
   if (options.place === undefined) delete env.OPENWORK_WORLD_PLACE;
   else env.OPENWORK_WORLD_PLACE = options.place;
   await assertNoRunningSnapshot(snapshotPath, stagedName);
+  await rm(eventPath, { force: true });
 
-  if (!options.detach) return waitForChild(path, options.args, env);
+  if (!options.detach) {
+    return waitForChild(
+      path,
+      options.args,
+      env,
+      options.foregroundLog ? logPath : undefined,
+      options.onSpawn,
+    );
+  }
 
-  const logPath = scriptWorldLogPath(options.snapshotDirectory, stagedName);
   await mkdir(options.snapshotDirectory, { recursive: true });
   const log = await open(logPath, "w", 0o600);
   await chmod(logPath, 0o600);
@@ -223,7 +257,7 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
     if (child.exitCode !== null || child.signalCode !== null) {
       await removeDeadSnapshot(snapshotPath);
       options.print(`Script world ${JSON.stringify(stagedName)} exited before creating its snapshot.`);
-      for (const line of await lastLogLines(logPath)) options.print(line);
+      for (const line of await readLastLogLines(logPath, 40)) options.print(line);
       return 1;
     }
     await delay(Math.min(POLL_INTERVAL_MS, Math.max(1, deadline - Date.now())));
@@ -235,7 +269,7 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
   }
   await removeDeadSnapshot(snapshotPath);
   options.print(`Timed out after ${options.timeoutMs ?? DEFAULT_START_TIMEOUT_MS}ms waiting for script world ${JSON.stringify(stagedName)}.`);
-  for (const line of await lastLogLines(logPath)) options.print(line);
+  for (const line of await readLastLogLines(logPath, 40)) options.print(line);
   return 1;
 }
 

--- a/packages/world/src/view.ts
+++ b/packages/world/src/view.ts
@@ -1,0 +1,289 @@
+import { styleText } from "node:util";
+import type { WorldEvent } from "./events.ts";
+import type { PreflightResult } from "./preflight.ts";
+
+export interface ViewSink {
+  write(text: string): void;
+  isTTY: boolean;
+  columns?: number;
+}
+
+export interface WorldView {
+  header(input: {
+    name: string;
+    stage?: string;
+    place?: string;
+    receipt: string;
+    log?: string;
+    preflight?: PreflightResult[];
+  }): void;
+  apply(event: WorldEvent): void;
+  ready(input: {
+    name: string;
+    outputs: Record<string, string>;
+    elapsedMs: number;
+    resources: number;
+    downHint: string;
+    log?: string;
+  }): void;
+  failed(input: {
+    name: string;
+    step?: string;
+    elapsedMs: number;
+    lastLog: string[];
+    logPath: string;
+    hint?: string;
+  }): void;
+  stop(): void;
+}
+
+interface StepRow {
+  id: string;
+  label: string;
+  status: "start" | "ok" | "fail";
+  startedAt: number;
+  updatedAt: number;
+  lastHeartbeatAt: number;
+  detail?: string;
+  log?: string;
+}
+
+const SPINNER = ["◐", "◓", "◑", "◒"];
+
+export function formatElapsed(elapsedMs: number): string {
+  if (elapsedMs < 100) return "<0.1s";
+  if (elapsedMs < 60_000) return `${(elapsedMs / 1_000).toFixed(1)}s`;
+  const minutes = Math.floor(elapsedMs / 60_000);
+  const seconds = Math.floor((elapsedMs % 60_000) / 1_000).toString().padStart(2, "0");
+  return `${minutes}m ${seconds}s`;
+}
+
+function eventTime(event: WorldEvent, fallback: number): number {
+  const parsed = Date.parse(event.t);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function createWorldView(options: {
+  sink: ViewSink;
+  mode: "tty" | "plain";
+  color: boolean;
+  now?: () => number;
+  heartbeatMs?: number;
+  spinnerMs?: number;
+}): WorldView {
+  const now = options.now ?? Date.now;
+  const configuredHeartbeat = Number(process.env.OPENWORK_WORLD_HEARTBEAT_MS);
+  const heartbeatMs = options.heartbeatMs
+    ?? (Number.isFinite(configuredHeartbeat) && configuredHeartbeat > 0 ? configuredHeartbeat : 20_000);
+  const spinnerMs = options.spinnerMs ?? 100;
+  const steps: StepRow[] = [];
+  const resources: Array<{ kind: string; id: string; label?: string }> = [];
+  const notes: string[] = [];
+  let headerLines: string[] = [];
+  let renderedLines = 0;
+  let spinnerFrame = 0;
+  let stopped = false;
+  let terminalFrame: string[] | undefined;
+
+  const paint = (style: Parameters<typeof styleText>[0], text: string): string => (
+    options.color ? styleText(style, text) : text
+  );
+  const writeLine = (line: string): void => options.sink.write(`${line}\n`);
+
+  const waitingDetail = (step: StepRow): string | undefined => {
+    const waiting = now() - step.updatedAt;
+    if (step.status !== "start" || waiting < heartbeatMs) return undefined;
+    return `still waiting (${formatElapsed(waiting)})${step.log ? ` · log ${step.log}` : ""}`;
+  };
+
+  const ttyLines = (): string[] => {
+    if (terminalFrame) return terminalFrame;
+    const lines = [...headerLines];
+    for (const step of steps) {
+      const elapsed = formatElapsed((step.status === "start" ? now() : step.updatedAt) - step.startedAt);
+      if (step.status === "start") {
+        const waiting = waitingDetail(step);
+        const suffix = waiting
+          ? paint("yellow", `  ${waiting}`)
+          : step.detail ? `  ${step.detail}` : "";
+        lines.push(`${paint("cyan", SPINNER[spinnerFrame % SPINNER.length])} ${step.label}${suffix}`);
+      } else if (step.status === "ok") {
+        lines.push(`${paint("green", "✔")} ${step.label} (${elapsed})${step.detail ? `  ${step.detail}` : ""}`);
+      } else {
+        lines.push(`${paint("red", "✖")} ${step.label}${step.detail ? ` — ${step.detail}` : ""}`);
+      }
+    }
+    for (const resource of resources) {
+      lines.push(`${paint("green", "+")} ${resource.kind}  ${resource.label ? `${resource.label} ` : ""}${resource.id}`);
+    }
+    for (const note of notes) lines.push(`${paint("cyan", "·")} ${note}`);
+    return lines;
+  };
+
+  const redraw = (): void => {
+    if (options.mode !== "tty" || stopped) return;
+    const lines = ttyLines();
+    let output = renderedLines > 0 ? `\u001b[${renderedLines}A` : "";
+    for (const line of lines) output += `\r\u001b[2K${line}\n`;
+    for (let index = lines.length; index < renderedLines; index += 1) output += "\r\u001b[2K\n";
+    if (renderedLines > lines.length) output += `\u001b[${renderedLines - lines.length}A`;
+    renderedLines = lines.length;
+    options.sink.write(output);
+  };
+
+  const spinner = setInterval(() => {
+    if (!steps.some((step) => step.status === "start")) return;
+    spinnerFrame += 1;
+    redraw();
+  }, spinnerMs);
+  spinner.unref();
+
+  const heartbeat = setInterval(() => {
+    const step = [...steps].reverse().find((candidate) => candidate.status === "start");
+    if (!step) return;
+    const current = now();
+    if (current - step.updatedAt < heartbeatMs || current - step.lastHeartbeatAt < heartbeatMs) return;
+    step.lastHeartbeatAt = current;
+    if (options.mode === "plain") {
+      writeLine(`… still waiting on ${JSON.stringify(step.label)} (${formatElapsed(current - step.updatedAt)})${step.log ? ` · log ${step.log}` : ""}`);
+    } else {
+      redraw();
+    }
+  }, Math.min(heartbeatMs, 1_000));
+  heartbeat.unref();
+
+  const finish = (): void => {
+    clearInterval(spinner);
+    clearInterval(heartbeat);
+  };
+
+  return {
+    header(input): void {
+      const identity = [
+        `world  ${input.name}`,
+        ...(input.stage ? [`stage ${input.stage}`] : []),
+        ...(input.place ? [`place ${input.place}`] : []),
+      ].join("  ");
+      headerLines = [
+        paint("bold", identity),
+        `receipt  ${input.receipt}`,
+        ...(input.log ? [`log  ${input.log}`] : []),
+      ];
+      if (input.preflight && input.preflight.length > 0) {
+        headerLines.push(`preflight  ${input.preflight.map((result) => (
+          `${result.label} ${paint(result.ok ? "green" : "yellow", result.ok ? "✔" : "✖")}`
+        )).join("  ")}`);
+        for (const result of input.preflight) {
+          if (result.ok) continue;
+          headerLines.push(`${paint("yellow", "⚠")} ${result.label}${result.detail ? ` ${result.detail}` : ""}${result.hint ? ` — ${result.hint}` : ""}`);
+        }
+      }
+      if (options.mode === "plain") {
+        for (const line of headerLines) writeLine(line);
+      } else {
+        redraw();
+      }
+    },
+    apply(event): void {
+      if (stopped) return;
+      if (event.type === "step") {
+        const current = now();
+        const existing = steps.find((step) => step.id === event.id);
+        if (existing) {
+          const recorded = eventTime(event, current);
+          existing.label = event.label;
+          existing.status = event.status;
+          existing.updatedAt = recorded;
+          existing.lastHeartbeatAt = current;
+          existing.detail = event.detail;
+          existing.log = event.log ?? existing.log;
+        } else {
+          const recorded = eventTime(event, current);
+          steps.push({
+            id: event.id,
+            label: event.label,
+            status: event.status,
+            startedAt: recorded,
+            updatedAt: current,
+            lastHeartbeatAt: current,
+            ...(event.detail === undefined ? {} : { detail: event.detail }),
+            ...(event.log === undefined ? {} : { log: event.log }),
+          });
+        }
+        if (options.mode === "plain") {
+          if (event.status === "start") writeLine(`▸ ${event.label}`);
+          else if (event.status === "ok") {
+            const step = steps.find((candidate) => candidate.id === event.id);
+            writeLine(`✔ ${event.label} (${formatElapsed(step ? step.updatedAt - step.startedAt : 0)})`);
+          } else writeLine(`✖ ${event.label}${event.detail ? ` — ${event.detail}` : ""}`);
+        } else {
+          redraw();
+        }
+        return;
+      }
+      if (event.type === "resource") {
+        resources.push({
+          kind: event.kind,
+          id: event.id,
+          ...(event.label === undefined ? {} : { label: event.label }),
+        });
+        if (options.mode === "plain") {
+          writeLine(`+ ${event.kind}  ${event.label ? `${event.label} ` : ""}${event.id}`);
+        } else {
+          redraw();
+        }
+        return;
+      }
+      if (event.type === "note") {
+        notes.push(event.text);
+        if (options.mode === "plain") writeLine(`· ${event.text}`);
+        else redraw();
+      }
+    },
+    ready(input): void {
+      finish();
+      const lines = [`${paint("green", "✔")} ${input.name} is up${options.mode === "tty" ? "  " : " "}(${formatElapsed(input.elapsedMs)} · ${input.resources} resources)`];
+      const width = Math.max(0, ...Object.keys(input.outputs).map((key) => key.length));
+      for (const [key, value] of Object.entries(input.outputs)) lines.push(`${key.padEnd(width)}  ${value}`);
+      lines.push(`Ctrl-C to stop · ${input.downHint}${input.log ? ` · log ${input.log}` : ""}`);
+      if (options.mode === "plain") {
+        for (const line of lines) writeLine(line);
+      } else {
+        terminalFrame = lines;
+        redraw();
+      }
+    },
+    failed(input): void {
+      finish();
+      const lines = [
+        `${paint("red", "✖")} ${input.name} failed${input.step ? ` at ${JSON.stringify(input.step)}` : ""} (${formatElapsed(input.elapsedMs)})`,
+        `last ${input.lastLog.length} lines of ${input.logPath}:`,
+        ...input.lastLog.map((line) => `  ${line}`),
+        ...(input.hint ? [`hint: ${input.hint}`] : []),
+      ];
+      if (options.mode === "plain") {
+        for (const line of lines) writeLine(line);
+      } else {
+        terminalFrame = lines;
+        redraw();
+      }
+    },
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      finish();
+    },
+  };
+}
+
+export function detectViewMode(
+  env: NodeJS.ProcessEnv,
+  flags: { plain?: boolean },
+): { mode: "tty" | "plain"; color: boolean } {
+  const tty = process.stderr.isTTY === true
+    && !flags.plain
+    && !env.CI
+    && env.NO_COLOR === undefined
+    && env.TERM !== "dumb";
+  return { mode: tty ? "tty" : "plain", color: tty };
+}

--- a/packages/world/test/cli.test.ts
+++ b/packages/world/test/cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -75,6 +75,26 @@ test("world arguments expose only script lifecycle flags and forward arguments a
     stage: "preview",
     purge: true,
   });
+  assert.deepEqual(parseWorldArgs(["up", "dev-headless", "--plain"]), {
+    kind: "up",
+    source: "dev-headless",
+    plain: true,
+    args: [],
+  });
+  assert.deepEqual(parseWorldArgs(["attach", "dev-headless"]), {
+    kind: "attach",
+    name: "dev-headless",
+  });
+  assert.deepEqual(parseWorldArgs(["attach", "dev-headless", "--stage", "preview", "--plain"]), {
+    kind: "attach",
+    name: "dev-headless",
+    stage: "preview",
+    plain: true,
+  });
+  const missingAttachName = parseWorldArgs(["attach", "--plain"]);
+  assert.equal(missingAttachName.kind, "help");
+  if (missingAttachName.kind !== "help") throw new Error("expected help");
+  assert.match(missingAttachName.error ?? "", /needs exactly one world name/);
 
   const invalidPlace = parseWorldArgs(["up", "dev-headless", "--place", "remote"]);
   assert.equal(invalidPlace.kind, "help");
@@ -131,6 +151,72 @@ test("discovery, resolution, list, and help classify scripts without importing t
       assert.match(lines.join("\n"), /throwing/);
     }
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("preflight failures warn without blocking up and do not affect attach or plan", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-cli-preflight-"));
+  const worldsDirectory = join(root, "worlds");
+  const receiptPath = join(root, "evals", "results", ".worlds", "scripts", "warned.json");
+  const holdUrl = new URL("../src/hold.ts", import.meta.url).href;
+  let checks = 0;
+  const failingCheck = {
+    id: "fixture",
+    label: "fixture service",
+    async run() {
+      checks += 1;
+      return { ok: false, detail: "offline", hint: "start fixture" };
+    },
+  };
+  try {
+    await mkdir(worldsDirectory);
+    await writeFile(join(worldsDirectory, "warned.ts"), [
+      `import { hold } from ${JSON.stringify(holdUrl)};`,
+      'await hold({ name: "warned", outputs: { ready: "yes" } });',
+      "",
+    ].join("\n"), "utf8");
+
+    const progress: string[] = [];
+    assert.equal(await main(["up", "warned", "--detach"], {
+      cwd: root,
+      worldsDirectory,
+      preflight: [failingCheck],
+      print: () => {},
+      progress: (line) => progress.push(line),
+    }), 0);
+    assert.ok(progress.includes("preflight  node ✔  fixture service ✖"));
+    assert.ok(progress.includes("⚠ fixture service offline — start fixture"));
+    assert.equal(await access(receiptPath).then(() => true, () => false), true);
+
+    const attachProgress: string[] = [];
+    assert.equal(await main(["attach", "warned", "--plain"], {
+      cwd: root,
+      worldsDirectory,
+      preflight: [failingCheck],
+      print: () => {},
+      progress: (line) => attachProgress.push(line),
+    }), 0);
+    assert.ok(attachProgress.some((line) => line.startsWith("✔ warned is up")));
+    assert.equal(checks, 1, "attach does not run preflight");
+
+    const planLines: string[] = [];
+    assert.equal(await main(["plan", "warned"], {
+      cwd: root,
+      worldsDirectory,
+      preflight: [failingCheck],
+      print: (line) => planLines.push(line),
+      progress: () => {},
+    }), 0);
+    assert.equal(planLines[0], "• running (attachable)");
+    assert.equal(checks, 1, "plan does not run preflight");
+  } finally {
+    await main(["down", "warned"], {
+      cwd: root,
+      worldsDirectory,
+      print: () => {},
+      progress: () => {},
+    });
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/world/test/events.test.ts
+++ b/packages/world/test/events.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  appendEvent,
+  EVENTS_ENV,
+  eventsPath,
+  progress,
+  readEvents,
+  tailEvents,
+  type WorldEvent,
+} from "../src/events.ts";
+
+test("events append privately and read valid JSONL in order", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-events-"));
+  try {
+    const path = eventsPath(root, "demo");
+    const events: WorldEvent[] = [
+      { t: "one", type: "note", text: "first" },
+      { t: "two", type: "ready", outputs: { url: "http://localhost" } },
+    ];
+    await appendEvent(path, events[0]);
+    await writeFile(path, `${await readFile(path, "utf8")}invalid\n`, { mode: 0o600 });
+    await appendEvent(path, events[1]);
+    assert.deepEqual(await readEvents(path), events);
+    assert.equal((await stat(path)).mode & 0o777, 0o600);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("tailEvents emits newly completed lines in order", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-tail-"));
+  try {
+    const path = eventsPath(root, "demo");
+    const seen: string[] = [];
+    const tail = tailEvents(path, (event) => {
+      if (event.type === "note") seen.push(event.text);
+    }, { intervalMs: 5 });
+    await appendEvent(path, { t: "one", type: "note", text: "first" });
+    await appendEvent(path, { t: "two", type: "note", text: "second" });
+    await delay(30);
+    tail.stop();
+    assert.deepEqual(seen, ["first", "second"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("progress is inert without its env and emits step status with it", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-progress-"));
+  const path = eventsPath(root, "demo");
+  const previous = process.env[EVENTS_ENV];
+  try {
+    delete process.env[EVENTS_ENV];
+    const inert = progress().step("noop", "No-op");
+    await inert.ok();
+    assert.deepEqual(await readEvents(path), []);
+
+    process.env[EVENTS_ENV] = path;
+    const active = progress().step("build", "Build", { log: "/tmp/build.log" });
+    await active.ok("done");
+    const failing = progress().step("serve", "Serve");
+    await failing.fail("port busy");
+    assert.deepEqual((await readEvents(path)).map((event) => (
+      event.type === "step" ? [event.id, event.status, event.detail] : [event.type]
+    )), [
+      ["build", "start", undefined],
+      ["build", "ok", "done"],
+      ["serve", "start", undefined],
+      ["serve", "fail", "port busy"],
+    ]);
+  } finally {
+    if (previous === undefined) delete process.env[EVENTS_ENV];
+    else process.env[EVENTS_ENV] = previous;
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/world/test/hold.test.ts
+++ b/packages/world/test/hold.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
+import { EVENTS_ENV, readEvents } from "../src/events.ts";
 
 function isAlive(pid: number): boolean {
   try {
@@ -29,6 +30,7 @@ test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
   const snapshots = join(root, "snapshots");
   const worldPath = join(root, "hold-only.ts");
   const receiptPath = join(snapshots, "hold-only.json");
+  const eventPath = join(snapshots, "hold-only.events.jsonl");
   const holdUrl = new URL("../src/hold.ts", import.meta.url).href;
   await writeFile(worldPath, [
     `import { hold } from ${JSON.stringify(holdUrl)};`,
@@ -38,7 +40,7 @@ test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
 
   const child = spawn(process.execPath, [worldPath], {
     detached: true,
-    env: { ...process.env, OPENWORK_WORLD_SNAPSHOT_DIR: snapshots },
+    env: { ...process.env, OPENWORK_WORLD_SNAPSHOT_DIR: snapshots, [EVENTS_ENV]: eventPath },
     stdio: "ignore",
   });
   if (child.pid === undefined) throw new Error("child pid unavailable");
@@ -51,6 +53,7 @@ test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
     );
     await delay(1_000);
     assert.equal(isAlive(pid), true, "world exited while hold was awaiting a signal");
+    assert.deepEqual((await readEvents(eventPath)).map((event) => event.type), ["ready"]);
 
     process.kill(pid, "SIGTERM");
     assert.equal(await waitFor(() => !isAlive(pid), 5_000), true, "world did not exit after SIGTERM");

--- a/packages/world/test/ledger.test.ts
+++ b/packages/world/test/ledger.test.ts
@@ -3,6 +3,7 @@ import { access, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { EVENTS_ENV, readEvents } from "../src/events.ts";
 import {
   appendLedgerEntry,
   LEDGER_ENV,
@@ -73,13 +74,16 @@ test("rewriteLedger unlinks an empty ledger", async () => {
 test("trackResource is inert without its env var and appends when configured", async () => {
   const root = await mkdtemp(join(tmpdir(), "openwork-world-ledger-track-"));
   const path = join(root, "world.ledger.jsonl");
+  const eventPath = join(root, "world.events.jsonl");
   const previous = process.env[LEDGER_ENV];
+  const previousEvents = process.env[EVENTS_ENV];
   try {
     delete process.env[LEDGER_ENV];
     await trackResource({ kind: "tmpdir", id: "/tmp/noop" });
     assert.equal(await absent(path), true);
 
     process.env[LEDGER_ENV] = path;
+    process.env[EVENTS_ENV] = eventPath;
     await trackResource({ kind: "tmpdir", id: "/tmp/tracked", retain: true });
     const entries = await readLedger(path);
     assert.equal(entries.length, 1);
@@ -89,9 +93,14 @@ test("trackResource is inert without its env var and appends when configured", a
       retain: true,
       at: "recorded",
     });
+    assert.deepEqual((await readEvents(eventPath)).map((event) => (
+      event.type === "resource" ? { kind: event.kind, id: event.id } : event.type
+    )), [{ kind: "tmpdir", id: "/tmp/tracked" }]);
   } finally {
     if (previous === undefined) delete process.env[LEDGER_ENV];
     else process.env[LEDGER_ENV] = previous;
+    if (previousEvents === undefined) delete process.env[EVENTS_ENV];
+    else process.env[EVENTS_ENV] = previousEvents;
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/world/test/preflight.test.ts
+++ b/packages/world/test/preflight.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { runPreflight } from "../src/preflight.ts";
+import { createWorldView, type ViewSink } from "../src/view.ts";
+
+test("preflight preserves passing, failing, and timed-out check order", async () => {
+  const results = await runPreflight([
+    { id: "pass", label: "passing", run: async () => ({ ok: true, detail: "ready" }) },
+    { id: "fail", label: "failing", run: async () => ({ ok: false, detail: "offline", hint: "start it" }) },
+    { id: "slow", label: "slow", run: async () => { await delay(50); return { ok: true }; } },
+  ], 10);
+  assert.deepEqual(results, [
+    { id: "pass", label: "passing", ok: true, detail: "ready" },
+    { id: "fail", label: "failing", ok: false, detail: "offline", hint: "start it" },
+    { id: "slow", label: "slow", ok: false, detail: "timed out" },
+  ]);
+});
+
+test("view header renders preflight badges and failure guidance", () => {
+  let output = "";
+  const sink: ViewSink = { write: (text) => { output += text; }, isTTY: false };
+  const view = createWorldView({ sink, mode: "plain", color: false });
+  view.header({
+    name: "demo",
+    receipt: "/tmp/demo.json",
+    preflight: [
+      { id: "docker", label: "docker", ok: true },
+      { id: "mysql", label: "mysql", ok: false, detail: "unavailable", hint: "start mysql" },
+    ],
+  });
+  view.stop();
+  assert.match(output, /preflight  docker ✔  mysql ✖\n/);
+  assert.match(output, /⚠ mysql unavailable — start mysql\n/);
+});

--- a/packages/world/test/view.test.ts
+++ b/packages/world/test/view.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { createWorldView, detectViewMode, type ViewSink } from "../src/view.ts";
+
+function eventTime(milliseconds: number): string {
+  return new Date(milliseconds).toISOString();
+}
+
+test("plain view emits stable event, ready, and failure lines without ANSI", () => {
+  let output = "";
+  let current = 0;
+  const sink: ViewSink = { write: (text) => { output += text; }, isTTY: false };
+  const view = createWorldView({ sink, mode: "plain", color: false, now: () => current });
+  view.apply({ t: eventTime(0), type: "step", id: "one", label: "First", status: "start" });
+  current = 1_234;
+  view.apply({ t: eventTime(current), type: "step", id: "one", label: "First", status: "ok" });
+  view.apply({ t: eventTime(current), type: "step", id: "two", label: "Second", status: "start" });
+  view.apply({ t: eventTime(current), type: "step", id: "two", label: "Second", status: "fail", detail: "broken" });
+  view.apply({ t: eventTime(current), type: "resource", kind: "tmpdir", id: "/tmp/a", label: "cache" });
+  view.ready({
+    name: "demo",
+    outputs: { url: "http://localhost", token: "secret" },
+    elapsedMs: 64_000,
+    resources: 1,
+    downHint: "pnpm world down demo",
+    log: "/tmp/demo.log",
+  });
+  view.failed({
+    name: "demo",
+    step: "Second",
+    elapsedMs: 12_340,
+    lastLog: ["one", "two", "three"],
+    logPath: "/tmp/demo.log",
+    hint: "retry",
+  });
+  view.stop();
+
+  assert.equal(output, [
+    "▸ First",
+    "✔ First (1.2s)",
+    "▸ Second",
+    "✖ Second — broken",
+    "+ tmpdir  cache /tmp/a",
+    "✔ demo is up (1m 04s · 1 resources)",
+    "url    http://localhost",
+    "token  secret",
+    "Ctrl-C to stop · pnpm world down demo · log /tmp/demo.log",
+    "✖ demo failed at \"Second\" (12.3s)",
+    "last 3 lines of /tmp/demo.log:",
+    "  one",
+    "  two",
+    "  three",
+    "hint: retry",
+    "",
+  ].join("\n"));
+  assert.doesNotMatch(output, /\u001b/);
+});
+
+test("plain view emits a stalled-step heartbeat at most once per interval", async () => {
+  const lines: string[] = [];
+  let current = 0;
+  const sink: ViewSink = {
+    write: (text) => { lines.push(text.trimEnd()); },
+    isTTY: false,
+  };
+  const view = createWorldView({
+    sink,
+    mode: "plain",
+    color: false,
+    now: () => current,
+    heartbeatMs: 10,
+    spinnerMs: 5,
+  });
+  view.apply({ t: eventTime(0), type: "step", id: "slow", label: "Slow", status: "start", log: "/tmp/slow.log" });
+  current = 10;
+  await delay(12);
+  await delay(12);
+  view.stop();
+  assert.equal(lines.filter((line) => line.startsWith("…")).length, 1);
+  assert.ok(lines.includes("… still waiting on \"Slow\" (<0.1s) · log /tmp/slow.log"));
+});
+
+test("tty view redraws spinner rows and collapses to ready outputs", async () => {
+  let output = "";
+  const sink: ViewSink = { write: (text) => { output += text; }, isTTY: true, columns: 100 };
+  const view = createWorldView({ sink, mode: "tty", color: false, spinnerMs: 5, heartbeatMs: 1_000 });
+  view.header({ name: "demo", receipt: "/tmp/demo.json" });
+  view.apply({ t: new Date().toISOString(), type: "step", id: "one", label: "First", status: "start" });
+  await delay(12);
+  view.apply({ t: new Date().toISOString(), type: "step", id: "one", label: "First", status: "ok" });
+  view.ready({
+    name: "demo",
+    outputs: { url: "http://localhost" },
+    elapsedMs: 100,
+    resources: 0,
+    downHint: "pnpm world down demo",
+  });
+  view.stop();
+  assert.match(output, /[◐◓◑◒] First/);
+  assert.match(output, /✔ First/);
+  assert.match(output, /url  http:\/\/localhost/);
+  assert.match(output, /\u001b\[\d+A/);
+});
+
+test("view mode remains plain for plain, CI, no-color, and dumb terminals", () => {
+  assert.deepEqual(detectViewMode({}, { plain: true }), { mode: "plain", color: false });
+  assert.deepEqual(detectViewMode({ CI: "1" }, {}), { mode: "plain", color: false });
+  assert.deepEqual(detectViewMode({ NO_COLOR: "" }, {}), { mode: "plain", color: false });
+  assert.deepEqual(detectViewMode({ TERM: "dumb" }, {}), { mode: "plain", color: false });
+});


### PR DESCRIPTION
Phase 2.5 of the world-engine plan (follows #4275, #4279, #4284). `pnpm world up acme-demo` used to print **nothing** for 1–3 minutes — a genuine hang (e.g. Redis down → den-api retries auth forever) looked identical to a slow boot. Now it narrates every step.

## What `pnpm world up acme-demo` shows now (plain mode, verbatim from this branch)

```
world  acme-demo
receipt  …/acme-demo.json
log  …/acme-demo.log
preflight  node ✔  docker ✔  mysql ✔  redis ✔
▸ Den database
+ mysql-db  den-mysql openwork_eval_15796_mtj8cvd8_8da5404ec3e7
· schema push
✔ Den database (10.7s)
▸ Seed demo org
✔ Seed demo org (9.7s)
▸ den-api
+ process  den-api 23661
▸ den-web
+ process  den-web 23662
✔ den-api (17.1s)
✔ den-web (17.6s)
▸ Den auth ready
✔ Den auth ready (<0.1s)
▸ Electron (admin)
· log …/.surfaces/15796/testkit-admin-…/electron.log
✔ Electron (admin) (18.9s)
+ process  electron 31853
+ tmpdir  electron-profile …/testkit-admin-…
▸ Create workspace
✔ Create workspace (2.6s)
▸ Sign in as admin
✔ Sign in as admin (0.5s)
▸ Electron (fresh)
✔ Electron (fresh) (16.4s)
…
✔ acme-demo is up (1m 18s · 7 resources)
denWeb     http://127.0.0.1:3005
denApi     http://127.0.0.1:8790
alexCdp    http://127.0.0.1:55229
jordanCdp  http://127.0.0.1:55682
Ctrl-C to stop · pnpm world down acme-demo · log …/acme-demo.log
```

On a TTY the same events render as an Alchemy-style in-place view (spinner rows, per-step timing, resource rows, collapsing to the outputs block). Zero new dependencies — `util.styleText` + cursor escapes.

## What changed
- **Events journal** `<receipt>.events.jsonl` (`OPENWORK_WORLD_EVENTS`, pinned by the CLI, defaulted by `runRecipe`): `step start|ok|fail`, `resource`, `ready`, `note`. `progress()` is a no-op without the env → specs stay silent. `trackResource` emits a resource event; `hold()` emits `ready`.
- **Renderer** (`view.ts`): TTY vs plain via `detectViewMode` (TTY, not CI, `NO_COLOR` unset, no `--plain`). **Progress goes to stderr through a separate `progress` channel**, so every existing exact-string stdout assertion in the six engine specs is byte-identical.
- **Heartbeat**: no events on the in-flight step for 20s (`OPENWORK_WORLD_HEARTBEAT_MS`) → `… still waiting on "<step>" (45s) · log <path>`.
- **Failure frame**: `✖ <world> failed at "<step>" (…)` + `last N lines of <log>:` + hint.
- **Preflight** badges (node built-in; docker/mysql/redis supplied by the env CLI through `WorldCliOptions.preflight`): `⚠ redis 127.0.0.1:6379 refused — start Redis…`. Warns, **never blocks** — dev-headless needs none of them.
- **`world attach <name> [--stage] [--plain]`** replays a running world's steps and outputs.
- **Builders narrate**: Den database/schema push, seed, den-api, den-web, auth, org; LiteLLM witness/postgres/gateway; Electron, workspace, sign-in.
- Foreground on a TTY routes child stdio to the `.log` so the view owns the terminal and forwards Ctrl-C; non-TTY foreground keeps `stdio: inherit` exactly as before.
- Also fixes a `number | undefined` narrowing in `local-host-live-profile-prune.test.ts` (from #4284).

## Verification (PR head `5628017b1`, local lane — no Daytona credentials here; engine specs are app-less)

| Check | Command | Result |
|---|---|---|
| World unit tests (events, view frames TTY+plain, preflight, hold, ledger, CLI flags, non-blocking preflight) | `pnpm --filter @openwork/world test` | 39/39 |
| **New** `world-up-progress` — ordered narration incl. preflight ⚠, heartbeat, `is up` block; zero ANSI bytes and byte-identical stdout; failure frame with log tail; `attach` replay; attach on missing receipt | `pnpm evals:pr specs/world-up-progress.test.ts` | 1/1 |
| Exact-string guards unchanged | `world-crash-reap`, `world-reap-docker`, `world-stage-isolation`, `world-plan-idempotent-up`, `script-world-lifecycle`, `shared-world-engine`, `local-host-live-profile-prune` | 1/1 ×6, 3/3 |
| Builder narration regression | `node evals/bin/evals.mjs litellm-per-member-world --local` | 1/1 |
| Runtime | `world up acme-demo --detach --plain` transcript above; `down` clean | manual |

Classified against `origin/dev@c23119c4b`: `pnpm evals:typecheck` — 0 errors introduced (this branch removes one that #4284 added; the other new-vs-old-baseline errors are all in `working-status-liveness.e2e.test.ts`, merged to dev separately); `specs/google-workspace-connector-retrieval.test.ts` red on dev; `specs/world-attach.test.ts` solo-green, red only under full-lane parallelism (it boots a Den on shared MySQL/Redis).