### PR TITLE
test(evals): derive the Daytona regression inventory invariant instead of pinning bucket counts

### DIFF
--- a/evals/specs/daytona-e2e-regression-concurrency.test.ts
+++ b/evals/specs/daytona-e2e-regression-concurrency.test.ts
@@ -119,10 +119,17 @@ test("Daytona E2E regression profile excludes only audited shared-topology incom
   expect(categoryByTest.get("local-managed-mcp-oauth.e2e.test.ts")).toBe("raw-or-local-placement");
   expect(categoryByTest.get("slack-style-mcp-connector.e2e.test.ts")).toBe("raw-or-local-placement");
 
-  expect(inventory.all).toHaveLength(152);
-  expect(inventory.rawDesktop).toHaveLength(56);
-  expect(inventory.profile).toHaveLength(76);
-  expect(inventory.eligible).toHaveLength(19);
+  // The four buckets partition the inventory. Asserting the partition itself
+  // (instead of pinning each bucket's size to one moment of `dev`) keeps every
+  // spec accounted for without forcing each spec-adding PR to edit a shared
+  // counter that every concurrent PR also edits.
+  expect(inventory.all).toHaveLength(
+    inventory.rawDesktop.length
+      + inventory.profile.length
+      + dedicatedWorkflowTests.length
+      + inventory.eligible.length,
+  );
+  expect(inventory.eligible.length).toBeGreaterThanOrEqual(productFailuresThatMustRemainEligible.length);
   expect(inventory.rawDesktop).toContain("den-litellm-provider.e2e.test.ts");
   expect(inventory.eligible).not.toContain("org-team-lifecycle-critical-path.e2e.test.ts");
   expect(inventory.eligible).not.toContain("library-mcp-connect-error.e2e.test.ts");


### PR DESCRIPTION
## Problem

`daytona-e2e-regression-concurrency.test.ts` pins the four inventory buckets to literal sizes (`all=152 / rawDesktop=56 / profile=76 / eligible=19`). Those numbers are only correct for one exact state of `dev`, so **every** PR that adds, renames, or removes an E2E spec must edit this shared line — and every two concurrent spec-adding PRs are guaranteed to invalidate each other.

Observed since the guard landed in #4220 (2026-08-31): 8 PRs touched the line in ~48h (#4249 #4258 #4262 #4263 #4273 #4282 #4280 + this one's origin), and #4264 / #4280 / #4111 currently hold mutually incompatible values. #4280 went red on first push for exactly this, needed a `dev` merge + rebump + SHA-bound evidence re-run, and is already one behind again after #4282 merged.

## Change

Replace the four `toHaveLength(<literal>)` pins with what they were always implying:

- the buckets **partition** the inventory: `all = rawDesktop + profile + dedicated + eligible`
- the shared lane is **non-vacuous**: `eligible ≥ |productFailuresThatMustRemainEligible|`

Three lines, one file. Spec-adding PRs no longer touch this file at all.

## What is preserved (unchanged)

Category allowlist + mandatory reasons; profile sorted/unique/existing/non-overlapping with the auto-detected raw-desktop bucket; `list-daytona-raw-desktop-tests.mjs` vs source-scan parity; 13 named category spot-checks; `productFailuresThatMustRemainEligible`. The anti-green-washing purpose from #4220 is intact: an exclusion is still a categorized, reviewable JSON diff.

## What changes in behavior

A new spec that is not raw-desktop / profile-excluded / dedicated becomes `eligible` without a PR-time count failure. Placement is still prompted by #4268's `contracts.snapshot.json` guard (which fails naming the file — more actionable than `151 vs 152`) and enforced by the bi-daily shared lane itself.

## Verification (local, PR lane)

- `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/daytona-e2e-regression-concurrency.test.ts` — 3 passed / 0 failed
- Negative control: temporarily adding a profile entry that duplicates a raw-desktop spec → the audit test fails at the non-overlap assertion (1 failed / 2 passed); profile restored.