### PR TITLE
fix(server): keep a thread's "Allow for session" across engine instance rebuilds

### DIFF
--- a/apps/server/src/engine-pool.ts
+++ b/apps/server/src/engine-pool.ts
@@ -66,6 +66,8 @@ export type EnginePoolHooks = {
   now?: () => number;
   schedule?: (operation: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
   waitForHealthy?: (handle: ManagedOpencodeServer) => Promise<void>;
+  /** Called once when the pool shuts down, before its engines are retired. */
+  onDisposed?: () => void;
   logger?: EnginePoolLogger;
 };
 
@@ -977,6 +979,7 @@ export class EnginePool {
   /** Close every engine this pool owns. Draining generations go first. */
   async disposeAll(): Promise<void> {
     this.disposed = true;
+    this.hooks.onDisposed?.();
     this.pendingRollover = null;
     if (this.recoveryTimer) clearTimeout(this.recoveryTimer);
     this.recoveryTimer = null;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -134,6 +134,7 @@ import {
 } from "./openwork-workspace-config-store.js";
 import { buildOpenworkRuntimeConfigObject, openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { findManagedEngineWorkspace } from "./workspaces.js";
+import { startThreadApprovalReplayer, type ThreadApprovalReplayer } from "./thread-approvals.js";
 import { CloudProviderSync, parseCloudProviderDenSession } from "./cloud-provider-sync.js";
 import pkg from "../package.json" with { type: "json" };
 import constants from "../../../constants.json" with { type: "json" };
@@ -4886,10 +4887,15 @@ export function createEnginePoolForConfig(input: {
   trustedIdentity: string | null;
 }): EnginePool {
   const { config } = input;
+  const logger = createServerLogger(config);
+  // Thread approvals live in OpenWork because the engine forgets an "always"
+  // reply whenever this pool rebuilds an instance or rolls over.
+  let threadApprovals: ThreadApprovalReplayer | null = null;
   const pool = new EnginePool({
     config,
     template: input.template,
     hooks: {
+      onDisposed: () => threadApprovals?.stop(),
       reloadInPlace: (poolConfig, workspace, options) =>
         reloadOpencodeEngineInPlace(poolConfig, workspace, undefined, options),
       engineBusy: (poolConfig, workspace) => engineHasActiveSessions(poolConfig, workspace),
@@ -4900,7 +4906,7 @@ export function createEnginePoolForConfig(input: {
       writeRuntimeConfigFile: (poolConfig) => writeOpenworkRuntimeConfigFile(poolConfig),
       registerTrusted: (poolConfig, generation) => registerTrustedOpencodeProcess(poolConfig, generation),
       clearTrusted: (poolConfig, identity) => clearTrustedOpencodeProcess(poolConfig, identity),
-      logger: createServerLogger(config),
+      logger,
     },
   });
   pool.adoptPrimary({
@@ -4910,6 +4916,22 @@ export function createEnginePoolForConfig(input: {
     trustedIdentity: input.trustedIdentity,
   });
   setEnginePoolForConfig(config, pool);
+  threadApprovals = startThreadApprovalReplayer({
+    config,
+    primary: () => pool.connections().find((entry) => entry.role === "primary") ?? null,
+    // The engine reports an instance by its canonical path (macOS resolves
+    // /tmp and /var through /private), so compare canonical forms.
+    workspaceIdForDirectory: async (directory) => {
+      const reported = await realpath(normalizeOpencodeDirectory(directory)).catch(() => normalizeOpencodeDirectory(directory));
+      for (const workspace of config.workspaces) {
+        const owned = resolveOpencodeDirectory(workspace);
+        if (!owned) continue;
+        if (owned === reported || (await realpath(owned).catch(() => owned)) === reported) return workspace.id;
+      }
+      return null;
+    },
+    logger,
+  });
   return pool;
 }
 

--- a/apps/server/src/thread-approvals.test.ts
+++ b/apps/server/src/thread-approvals.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { EnginePoolConnection } from "./engine-pool.js";
+import {
+  grantCovers,
+  listThreadApprovals,
+  matchesPermissionPattern,
+  rememberThreadApproval,
+  startThreadApprovalReplayer,
+} from "./thread-approvals.js";
+import type { ServerConfig } from "./types.js";
+
+const WORKSPACE_ID = "ws_thread";
+const DIRECTORY = "/tmp/thread-approvals-workspace";
+
+interface ReplyRecord {
+  requestId: string;
+  directory: string | null;
+  reply: unknown;
+}
+
+/** A stand-in engine: one scripted /global/event stream plus a reply recorder. */
+function fakeEngine() {
+  const replies: ReplyRecord[] = [];
+  let push: ((frame: unknown) => void) | null = null;
+  let streams = 0;
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/global/event") {
+        streams += 1;
+        const encoder = new TextEncoder();
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            push = (frame) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+          },
+          cancel() {
+            push = null;
+          },
+        });
+        return new Response(body, { headers: { "content-type": "text/event-stream" } });
+      }
+      const reply = url.pathname.match(/^\/permission\/([^/]+)\/reply$/);
+      if (request.method === "POST" && reply) {
+        replies.push({
+          requestId: decodeURIComponent(reply[1] ?? ""),
+          directory: url.searchParams.get("directory"),
+          reply: await request.json(),
+        });
+        return new Response("true", { headers: { "content-type": "application/json" } });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const connection: EnginePoolConnection = {
+    generationId: "gen_1",
+    role: "primary",
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    username: "probe",
+    password: "probe",
+  };
+  return {
+    connection,
+    replies,
+    streams: () => streams,
+    emit: async (event: Record<string, unknown>) => {
+      const deadline = Date.now() + 5_000;
+      while (!push && Date.now() < deadline) await Bun.sleep(10);
+      if (!push) throw new Error("no event stream attached");
+      push({ directory: DIRECTORY, payload: event });
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+function asked(id: string, sessionID: string, patterns: string[], always: string[], permission = "bash") {
+  return { type: "permission.asked", properties: { id, sessionID, permission, patterns, always } };
+}
+
+function replied(requestID: string, sessionID: string, reply: string) {
+  return { type: "permission.replied", properties: { requestID, sessionID, reply } };
+}
+
+async function settleAsync(predicate: () => Promise<boolean>, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await Bun.sleep(20);
+  }
+  return await predicate();
+}
+
+function settle(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
+  return settleAsync(async () => predicate(), timeoutMs);
+}
+
+const cleanups: Array<() => void | Promise<void>> = [];
+const previousDb = process.env.OPENWORK_RUNTIME_DB;
+
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousDb;
+});
+
+async function serverConfig(): Promise<ServerConfig> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-thread-approvals-"));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: WORKSPACE_ID, name: "Thread", path: DIRECTORY, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [DIRECTORY],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+describe("thread approval matching", () => {
+  test("mirrors the engine's wildcard semantics", () => {
+    expect(matchesPermissionPattern("git status --porcelain", "git status *")).toBe(true);
+    expect(matchesPermissionPattern("git status", "git status *")).toBe(true);
+    expect(matchesPermissionPattern("git push", "git status *")).toBe(false);
+    expect(matchesPermissionPattern("/shared/report.md", "/shared/*")).toBe(true);
+    expect(matchesPermissionPattern("/shared2/report.md", "/shared/*")).toBe(false);
+    expect(grantCovers({ permission: "bash", patterns: ["printf *"] }, "bash", ["printf 'a'"])).toBe(true);
+    expect(grantCovers({ permission: "bash", patterns: ["printf *"] }, "bash", ["printf 'a'", "rm -rf x"])).toBe(false);
+    expect(grantCovers({ permission: "bash", patterns: ["printf *"] }, "edit", ["printf 'a'"])).toBe(false);
+    expect(grantCovers({ permission: "bash", patterns: ["printf *"] }, "bash", [])).toBe(false);
+  });
+
+  test("stores grants per thread without duplicates", async () => {
+    const config = await serverConfig();
+    await rememberThreadApproval(config, WORKSPACE_ID, "ses_a", { permission: "bash", patterns: ["git status *"] });
+    await rememberThreadApproval(config, WORKSPACE_ID, "ses_a", { permission: "bash", patterns: ["git status *"] });
+    await rememberThreadApproval(config, WORKSPACE_ID, "ses_a", { permission: "external_directory", patterns: ["/shared/*"] });
+    expect(await listThreadApprovals(config, WORKSPACE_ID, "ses_a")).toEqual([
+      { permission: "bash", patterns: ["git status *"] },
+      { permission: "external_directory", patterns: ["/shared/*"] },
+    ]);
+    expect(await listThreadApprovals(config, WORKSPACE_ID, "ses_b")).toEqual([]);
+  });
+});
+
+describe("thread approval replayer", () => {
+  test("remembers an always reply and answers the same thread's repeat ask, and only that thread", async () => {
+    const config = await serverConfig();
+    const engine = fakeEngine();
+    cleanups.push(engine.stop);
+    const replayer = startThreadApprovalReplayer({
+      config,
+      primary: () => engine.connection,
+      workspaceIdForDirectory: async (directory) => (directory === DIRECTORY ? WORKSPACE_ID : null),
+      reconnectMs: 50,
+    });
+    cleanups.push(replayer.stop);
+
+    // The user approves once on thread A with the engine's suggested pattern.
+    await engine.emit(asked("perm_1", "ses_a", ["printf 'first'"], ["printf *"]));
+    await Bun.sleep(50);
+    expect(engine.replies).toHaveLength(0);
+    await engine.emit(replied("perm_1", "ses_a", "always"));
+    expect(await settleAsync(async () => (await listThreadApprovals(config, WORKSPACE_ID, "ses_a")).length === 1)).toBe(true);
+    expect(await listThreadApprovals(config, WORKSPACE_ID, "ses_a")).toEqual([{ permission: "bash", patterns: ["printf *"] }]);
+
+    // A later ask on the same thread that the grant covers is answered for the user.
+    await engine.emit(asked("perm_2", "ses_a", ["printf 'second'"], ["printf *"]));
+    expect(await settle(() => engine.replies.length === 1)).toBe(true);
+    expect(engine.replies[0]).toEqual({ requestId: "perm_2", directory: DIRECTORY, reply: { reply: "always" } });
+
+    // Negative halves: a different thread, a different permission, and a
+    // command outside the granted pattern all still reach the user.
+    await engine.emit(asked("perm_3", "ses_b", ["printf 'other thread'"], ["printf *"]));
+    await engine.emit(asked("perm_4", "ses_a", ["src/index.ts"], ["*"], "edit"));
+    await engine.emit(asked("perm_5", "ses_a", ["rm -rf build"], ["rm *"]));
+    await Bun.sleep(200);
+    expect(engine.replies).toHaveLength(1);
+
+    // "once" and "reject" replies are never remembered.
+    await engine.emit(replied("perm_5", "ses_a", "once"));
+    await engine.emit(replied("perm_3", "ses_b", "reject"));
+    await Bun.sleep(100);
+    expect(await listThreadApprovals(config, WORKSPACE_ID, "ses_a")).toEqual([{ permission: "bash", patterns: ["printf *"] }]);
+    expect(await listThreadApprovals(config, WORKSPACE_ID, "ses_b")).toEqual([]);
+  });
+
+  test("ignores directories OpenWork does not own and reconnects after the stream drops", async () => {
+    const config = await serverConfig();
+    const engine = fakeEngine();
+    cleanups.push(engine.stop);
+    const replayer = startThreadApprovalReplayer({
+      config,
+      primary: () => engine.connection,
+      workspaceIdForDirectory: async () => null,
+      reconnectMs: 50,
+    });
+    cleanups.push(replayer.stop);
+
+    await engine.emit(asked("perm_1", "ses_a", ["printf 'x'"], ["printf *"]));
+    await engine.emit(replied("perm_1", "ses_a", "always"));
+    await Bun.sleep(100);
+    expect(await listThreadApprovals(config, WORKSPACE_ID, "ses_a")).toEqual([]);
+
+    // Drop the stream: the replayer reattaches instead of giving up.
+    expect(engine.streams()).toBe(1);
+    engine.stop();
+    const restarted = fakeEngine();
+    cleanups.push(restarted.stop);
+    engine.connection.baseUrl = restarted.connection.baseUrl;
+    expect(await settle(() => restarted.streams() >= 1, 5_000)).toBe(true);
+  });
+});

--- a/apps/server/src/thread-approvals.ts
+++ b/apps/server/src/thread-approvals.ts
@@ -1,0 +1,317 @@
+/**
+ * Thread approvals: OpenWork's own memory of what a user approved on a thread.
+ *
+ * The engine keeps an "always" reply in the memory of the per-directory
+ * instance that received it — not on the session and not on disk. OpenWork
+ * rebuilds those instances routinely (config, skill, and MCP reload events,
+ * idle eviction, engine rollover), so a grant made mid-thread is forgotten
+ * while the thread itself lives on, and the same command asks again.
+ *
+ * This module records every "always" reply against its thread and, when the
+ * engine asks the same thread for something that grant already covers,
+ * answers on the user's behalf — with "always" again so the fresh instance
+ * remembers too. The engine stays the only adjudicator: OpenWork never
+ * approves anything the user did not approve on that very thread, and a
+ * `deny` rule never reaches the ask stage in the first place.
+ */
+import type { EnginePoolConnection, EnginePoolLogger } from "./engine-pool.js";
+import { BoundedSseFrameBuffer } from "./engine-pool.js";
+import { buildEngineAuthProbeHeader } from "./engine-registry.js";
+import { loopbackFetch } from "./server-fetch.js";
+import type { ServerConfig } from "./types.js";
+import { createWorkspaceKvStore, isRecord } from "./workspace-kv-store.js";
+
+export interface ThreadApprovalGrant {
+  permission: string;
+  patterns: string[];
+}
+
+interface WorkspaceThreadApprovals {
+  sessions: Record<string, ThreadApprovalGrant[]>;
+}
+
+function parseGrants(value: unknown): ThreadApprovalGrant[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.permission !== "string" || !Array.isArray(entry.patterns)) return [];
+    const patterns = entry.patterns.filter((pattern): pattern is string => typeof pattern === "string" && pattern.length > 0);
+    return patterns.length ? [{ permission: entry.permission, patterns }] : [];
+  });
+}
+
+function parseWorkspaceThreadApprovals(json: string): WorkspaceThreadApprovals {
+  try {
+    const value: unknown = JSON.parse(json);
+    if (!isRecord(value) || !isRecord(value.sessions)) return { sessions: {} };
+    return {
+      sessions: Object.fromEntries(
+        Object.entries(value.sessions).map(([sessionId, grants]) => [sessionId, parseGrants(grants)]),
+      ),
+    };
+  } catch {
+    return { sessions: {} };
+  }
+}
+
+const threadApprovalStore = createWorkspaceKvStore<WorkspaceThreadApprovals>({
+  tableName: "thread_approvals",
+  valueColumn: "approvals_json",
+  parse: parseWorkspaceThreadApprovals,
+  serialize: (value) => JSON.stringify(value),
+});
+
+/** Mirror of the engine's wildcard matcher (`*` any run, `?` one char, trailing ` *` optional). */
+export function matchesPermissionPattern(input: string, pattern: string): boolean {
+  const normalized = input.replaceAll("\\", "/");
+  let escaped = pattern
+    .replaceAll("\\", "/")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  if (escaped.endsWith(" .*")) escaped = escaped.slice(0, -3) + "( .*)?";
+  return new RegExp(`^${escaped}$`, process.platform === "win32" ? "si" : "s").test(normalized);
+}
+
+/** A grant covers a request when every requested pattern is matched by one of the granted patterns. */
+export function grantCovers(grant: ThreadApprovalGrant, permission: string, patterns: string[]): boolean {
+  if (!matchesPermissionPattern(permission, grant.permission)) return false;
+  return patterns.length > 0
+    && patterns.every((pattern) => grant.patterns.some((granted) => matchesPermissionPattern(pattern, granted)));
+}
+
+export async function listThreadApprovals(
+  config: ServerConfig,
+  workspaceId: string,
+  sessionId: string,
+): Promise<ThreadApprovalGrant[]> {
+  const stored = await threadApprovalStore.get(config, workspaceId);
+  return stored?.sessions[sessionId] ?? [];
+}
+
+export async function rememberThreadApproval(
+  config: ServerConfig,
+  workspaceId: string,
+  sessionId: string,
+  grant: ThreadApprovalGrant,
+): Promise<void> {
+  if (grant.patterns.length === 0) return;
+  const stored = (await threadApprovalStore.get(config, workspaceId)) ?? { sessions: {} };
+  const current = stored.sessions[sessionId] ?? [];
+  const duplicate = current.some((entry) =>
+    entry.permission === grant.permission
+    && entry.patterns.length === grant.patterns.length
+    && entry.patterns.every((pattern, index) => pattern === grant.patterns[index]));
+  if (duplicate) return;
+  await threadApprovalStore.set(config, workspaceId, {
+    sessions: { ...stored.sessions, [sessionId]: [...current, grant] },
+  });
+}
+
+export async function forgetThreadApprovals(config: ServerConfig, workspaceId: string, sessionId: string): Promise<void> {
+  const stored = await threadApprovalStore.get(config, workspaceId);
+  if (!stored?.sessions[sessionId]) return;
+  const { [sessionId]: _removed, ...sessions } = stored.sessions;
+  await threadApprovalStore.set(config, workspaceId, { sessions });
+}
+
+interface PendingAsk {
+  directory: string;
+  sessionId: string;
+  permission: string;
+  patterns: string[];
+  always: string[];
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0) : [];
+}
+
+function sseFramePayload(frame: string): unknown {
+  const data = frame
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trim())
+    .join("\n");
+  if (!data) return null;
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+export interface ThreadApprovalReplayerOptions {
+  config: ServerConfig;
+  /** The engine to observe; null while no primary is serving. */
+  primary: () => EnginePoolConnection | null;
+  /** Map an engine instance directory to the OpenWork workspace it serves; null for directories OpenWork does not own. */
+  workspaceIdForDirectory: (directory: string) => Promise<string | null>;
+  logger?: EnginePoolLogger;
+  reconnectMs?: number;
+  fetchImpl?: typeof loopbackFetch;
+}
+
+export interface ThreadApprovalReplayer {
+  stop: () => void;
+}
+
+/**
+ * Follow the engine's global event stream, remember "always" replies per
+ * thread, and answer repeat asks on the same thread that a remembered grant
+ * already covers. Reconnects when the stream drops or the primary engine
+ * changes; a lost connection only pauses replay, never approves anything.
+ */
+export function startThreadApprovalReplayer(options: ThreadApprovalReplayerOptions): ThreadApprovalReplayer {
+  const fetchImpl = options.fetchImpl ?? loopbackFetch;
+  const reconnectMs = options.reconnectMs ?? 1_000;
+  const pending = new Map<string, PendingAsk>();
+  let stopped = false;
+  let active: AbortController | null = null;
+
+  const log = (level: "info" | "warn" | "error", message: string, attributes?: Record<string, unknown>) =>
+    options.logger?.log(level, message, attributes);
+
+  const reply = async (connection: EnginePoolConnection, ask: PendingAsk, requestId: string): Promise<boolean> => {
+    const url = new URL(`/permission/${encodeURIComponent(requestId)}/reply`, connection.baseUrl);
+    url.searchParams.set("directory", ask.directory);
+    try {
+      const response = await fetchImpl(url.toString(), {
+        method: "POST",
+        headers: {
+          Authorization: buildEngineAuthProbeHeader(connection.username, connection.password),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ reply: "always" }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        log("warn", "Thread approval replay was not accepted by the engine.", {
+          "permission.request_id": requestId,
+          "engine.status": response.status,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      log("warn", "Thread approval replay failed.", {
+        "permission.request_id": requestId,
+        "engine.failure": error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  };
+
+  const onAsked = async (connection: EnginePoolConnection, directory: string, properties: Record<string, unknown>) => {
+    const requestId = typeof properties.id === "string" ? properties.id : "";
+    const sessionId = typeof properties.sessionID === "string" ? properties.sessionID : "";
+    const permission = typeof properties.permission === "string" ? properties.permission : "";
+    if (!requestId || !sessionId || !permission) return;
+    const ask: PendingAsk = {
+      directory,
+      sessionId,
+      permission,
+      patterns: stringList(properties.patterns),
+      always: stringList(properties.always),
+    };
+    pending.set(requestId, ask);
+    const workspaceId = await options.workspaceIdForDirectory(directory);
+    if (!workspaceId) return;
+    const grants = await listThreadApprovals(options.config, workspaceId, sessionId);
+    const covering = grants.find((grant) => grantCovers(grant, permission, ask.patterns));
+    if (!covering) return;
+    const replied = await reply(connection, ask, requestId);
+    if (replied) {
+      log("info", "Replayed a thread approval the user already gave.", {
+        "workspace.id": workspaceId,
+        "session.id": sessionId,
+        "permission.name": permission,
+      });
+    }
+  };
+
+  const onReplied = async (properties: Record<string, unknown>) => {
+    const requestId = typeof properties.requestID === "string" ? properties.requestID : "";
+    const ask = pending.get(requestId);
+    if (!ask) return;
+    pending.delete(requestId);
+    if (properties.reply !== "always") return;
+    const workspaceId = await options.workspaceIdForDirectory(ask.directory);
+    if (!workspaceId) return;
+    // The engine's suggested `always` patterns are what it would remember
+    // itself; fall back to the exact request when it suggests none.
+    const patterns = ask.always.length ? ask.always : ask.patterns;
+    await rememberThreadApproval(options.config, workspaceId, ask.sessionId, { permission: ask.permission, patterns });
+  };
+
+  const handleFrame = async (connection: EnginePoolConnection, frame: string) => {
+    const payload = sseFramePayload(frame);
+    if (!isRecord(payload) || typeof payload.directory !== "string" || !isRecord(payload.payload)) return;
+    const event = payload.payload;
+    const properties = isRecord(event.properties) ? event.properties : {};
+    if (event.type === "permission.asked") await onAsked(connection, payload.directory, properties);
+    else if (event.type === "permission.replied") await onReplied(properties);
+  };
+
+  const consume = async (connection: EnginePoolConnection, body: ReadableStream<Uint8Array>, signal: AbortSignal) => {
+    const reader = body.getReader();
+    const frames = new BoundedSseFrameBuffer();
+    try {
+      while (!signal.aborted) {
+        const chunk = await reader.read();
+        if (chunk.done) return;
+        const parsed = frames.push(chunk.value);
+        for (const frame of parsed.frames) await handleFrame(connection, frame);
+        if (parsed.overflow) return;
+      }
+    } finally {
+      await reader.cancel().catch(() => undefined);
+      reader.releaseLock();
+    }
+  };
+
+  const sleep = (ms: number) => new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+
+  const run = async () => {
+    while (!stopped) {
+      const connection = options.primary();
+      if (!connection) {
+        await sleep(reconnectMs);
+        continue;
+      }
+      const controller = new AbortController();
+      active = controller;
+      // A rollover leaves this stream attached to the draining engine; follow
+      // the primary instead of waiting for the old process to exit.
+      const follow = setInterval(() => {
+        if (options.primary()?.baseUrl !== connection.baseUrl) controller.abort();
+      }, 500);
+      follow.unref?.();
+      try {
+        const response = await fetchImpl(new URL("/global/event", connection.baseUrl).toString(), {
+          headers: { Authorization: buildEngineAuthProbeHeader(connection.username, connection.password) },
+          signal: controller.signal,
+        });
+        if (response.ok && response.body) await consume(connection, response.body, controller.signal);
+      } catch {
+        // Losing the stream only pauses replay; the loop reconnects below.
+      } finally {
+        clearInterval(follow);
+        if (active === controller) active = null;
+      }
+      pending.clear();
+      if (!stopped) await sleep(reconnectMs);
+    }
+  };
+
+  void run();
+
+  return {
+    stop: () => {
+      stopped = true;
+      active?.abort();
+    },
+  };
+}

--- a/evals/specs/thread-approvals-engine-memory.test.ts
+++ b/evals/specs/thread-approvals-engine-memory.test.ts
@@ -1,0 +1,363 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+import constants from "../../constants.json" with { type: "json" };
+
+/**
+ * The case for OpenWork owning thread approvals.
+ *
+ * "Allow for session" is an engine "always" reply. In the pinned engine that
+ * grant lives in the memory of the per-directory instance, so it covers every
+ * later matching call in that instance — until the instance is rebuilt, which
+ * OpenWork does on config, skill, and MCP reloads, idle eviction, and engine
+ * rollover. This spec drives the real engine with a scripted provider and
+ * shows exactly that: the grant works, the instance is disposed, and the very
+ * same thread asks again for a command the user already approved.
+ */
+
+const requirements: TestNeeds = { commands: ["opencode"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const skipSuffix = missingRequirements.length > 0 ? ` skipped — needs: ${missingRequirements.join(", ")}` : "";
+
+const providerId = "thread-approval-fixture";
+const modelId = "thread-approval-model";
+const AUTH = "Basic " + Buffer.from("probe:probe").toString("base64");
+
+interface PendingPermission {
+  id: string;
+  sessionID: string;
+  permission: string;
+  patterns: string[];
+  always: string[];
+}
+
+interface ToolState {
+  command: string;
+  status: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const probe = createNetServer();
+    probe.unref();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (!address || typeof address === "string") {
+        probe.close();
+        reject(new Error("Failed to allocate a free port"));
+        return;
+      }
+      probe.close(() => resolve(address.port));
+    });
+  });
+}
+
+/**
+ * OpenAI-compatible stand-in: the first call of a turn returns a bash tool
+ * call for the command named in the user's message (`RUN: <command>`); once a
+ * tool result is present it answers with a fixed completion marker.
+ */
+function scriptedProvider(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "GET" && url.pathname.endsWith("/models")) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+        return;
+      }
+      if (request.method !== "POST" || !url.pathname.endsWith("/chat/completions")) {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: { message: "not found" } }));
+        return;
+      }
+      let raw = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { raw += chunk; });
+      request.on("end", () => {
+        const body: unknown = JSON.parse(raw);
+        const messages = isRecord(body) && Array.isArray(body.messages) ? body.messages : [];
+        // A turn is: user prompt → one tool call → tool result → completion.
+        // Only the most recent message decides which step this request is.
+        const lastMessage = messages.at(-1);
+        const hasToolResult = isRecord(lastMessage) && lastMessage.role === "tool";
+        const lastUser = [...messages].reverse().find((message) => isRecord(message) && message.role === "user");
+        const text = isRecord(lastUser)
+          ? (typeof lastUser.content === "string"
+            ? lastUser.content
+            : Array.isArray(lastUser.content)
+              ? lastUser.content.map((part) => (isRecord(part) && typeof part.text === "string" ? part.text : "")).join("\n")
+              : "")
+          : "";
+        const command = text.match(/RUN:\s*(.+)$/m)?.[1]?.trim() ?? "printf 'no command'";
+        const id = `chatcmpl-${Date.now()}`;
+        const chunk = (delta: Record<string, unknown>, finish: string | null = null) =>
+          `data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`;
+        response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        response.write(chunk({ role: "assistant" }));
+        if (hasToolResult) {
+          response.write(chunk({ content: "FIXTURE-DONE" }));
+          response.write(chunk({}, "stop"));
+        } else {
+          response.write(chunk({
+            tool_calls: [{ index: 0, id: `call_${Date.now()}`, type: "function", function: { name: "bash", arguments: JSON.stringify({ command }) } }],
+          }));
+          response.write(chunk({}, "tool_calls"));
+        }
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+    });
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("provider did not bind"));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+interface Engine {
+  version: string;
+  workspace: string;
+  request: (method: string, path: string, body?: unknown) => Promise<unknown>;
+  [Symbol.asyncDispose]: () => Promise<void>;
+}
+
+async function stop(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.kill("SIGTERM");
+  const graceful = await Promise.race([exited.then(() => true), new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 2_500))]);
+  if (!graceful) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+async function bootEngine(providerPort: number): Promise<Engine> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-thread-approval-engine-"));
+  const workspace = join(root, "workspace");
+  const xdg = join(root, "xdg");
+  await Promise.all([mkdir(workspace, { recursive: true }), mkdir(join(xdg, "config", "opencode"), { recursive: true }), mkdir(join(root, "home"), { recursive: true })]);
+  // The workspace asks before every shell command so the approval flow is
+  // exercised; the provider is the local script above.
+  await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    permission: { bash: "ask" },
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Thread approval fixture",
+        options: { baseURL: `http://127.0.0.1:${providerPort}/v1`, apiKey: "fixture-key" },
+        models: { [modelId]: { name: "Thread approval fixture", tool_call: true } },
+      },
+    },
+  }), "utf8");
+  await writeFile(join(xdg, "config", "opencode", "opencode.json"), "{}", "utf8");
+
+  const port = await freePort();
+  const child = spawn("opencode", ["serve", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: workspace,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      OPENCODE_SERVER_USERNAME: "probe",
+      OPENCODE_SERVER_PASSWORD: "probe",
+      OPENCODE_TEST_HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(xdg, "config"),
+      XDG_DATA_HOME: join(xdg, "data"),
+      XDG_CACHE_HOME: join(xdg, "cache"),
+      XDG_STATE_HOME: join(xdg, "state"),
+      OPENCODE_CLIENT: "openwork-test",
+    },
+  });
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => { stderr += chunk; });
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const dispose = async () => {
+    await stop(child);
+    await rm(root, { recursive: true, force: true });
+  };
+
+  const request = async (method: string, path: string, body?: unknown): Promise<unknown> => {
+    const url = new URL(path, baseUrl);
+    url.searchParams.set("directory", workspace);
+    const response = await fetch(url.toString(), {
+      method,
+      headers: { Authorization: AUTH, ...(body === undefined ? {} : { "content-type": "application/json" }) },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error(`${method} ${path} → ${response.status} ${(await response.text()).slice(0, 300)}`);
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  };
+
+  const deadline = Date.now() + 45_000;
+  let version = "";
+  while (Date.now() < deadline && !version) {
+    if (child.exitCode !== null) break;
+    try {
+      const health = await request("GET", "/global/health");
+      if (isRecord(health) && health.healthy === true && typeof health.version === "string") version = health.version;
+    } catch {
+      // not up yet
+    }
+    if (!version) await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  if (!version) {
+    await dispose();
+    throw new Error(`opencode serve never became healthy: ${stderr.slice(0, 800)}`);
+  }
+  return { version, workspace, request, [Symbol.asyncDispose]: dispose };
+}
+
+async function pendingPermissions(engine: Engine): Promise<PendingPermission[]> {
+  const value = await engine.request("GET", "/permission");
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => isRecord(entry) && typeof entry.id === "string" && typeof entry.sessionID === "string"
+    ? [{
+      id: entry.id,
+      sessionID: entry.sessionID,
+      permission: typeof entry.permission === "string" ? entry.permission : "",
+      patterns: strings(entry.patterns),
+      always: strings(entry.always),
+    }]
+    : []);
+}
+
+async function toolStates(engine: Engine, sessionId: string): Promise<ToolState[]> {
+  const value = await engine.request("GET", `/session/${encodeURIComponent(sessionId)}/message`);
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((message) => {
+    const parts = isRecord(message) && Array.isArray(message.parts) ? message.parts : [];
+    return parts.flatMap((part) => {
+      if (!isRecord(part) || part.type !== "tool" || !isRecord(part.state)) return [];
+      const input = isRecord(part.state.input) ? part.state.input : {};
+      return [{ command: typeof input.command === "string" ? input.command : "", status: typeof part.state.status === "string" ? part.state.status : "" }];
+    });
+  });
+}
+
+async function sessionIdle(engine: Engine, sessionId: string): Promise<boolean> {
+  const value = await engine.request("GET", "/session/status");
+  const status = isRecord(value) ? value[sessionId] : undefined;
+  return !isRecord(status) || status.type === "idle";
+}
+
+async function until<T>(read: () => Promise<T>, done: (value: T) => boolean, label: string, timeoutMs = 60_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T = await read();
+  while (Date.now() < deadline) {
+    if (done(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    last = await read();
+  }
+  throw new Error(`${label}: ${JSON.stringify(last)}`);
+}
+
+async function prompt(engine: Engine, sessionId: string, command: string): Promise<void> {
+  await engine.request("POST", `/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+    model: { providerID: providerId, modelID: modelId },
+    parts: [{ type: "text", text: `Run the fixture command.\nRUN: ${command}` }],
+  });
+}
+
+/** Outcome of one prompt: either the engine asked (and we say what), or the tool ran without asking. */
+async function runTurn(engine: Engine, sessionId: string, command: string): Promise<{ asked: PendingPermission | null }> {
+  await prompt(engine, sessionId, command);
+  const settled = await until(
+    async () => ({
+      pending: (await pendingPermissions(engine)).find((entry) => entry.sessionID === sessionId) ?? null,
+      done: (await toolStates(engine, sessionId)).some((tool) => tool.command === command && tool.status === "completed"),
+    }),
+    (state) => state.pending !== null || state.done,
+    `turn for ${command} neither asked nor completed`,
+  );
+  return { asked: settled.pending };
+}
+
+async function finishTurn(engine: Engine, sessionId: string, command: string): Promise<void> {
+  await until(
+    async () => ({
+      completed: (await toolStates(engine, sessionId)).some((tool) => tool.command === command && tool.status === "completed"),
+      idle: await sessionIdle(engine, sessionId),
+    }),
+    (state) => state.completed && state.idle,
+    `turn for ${command} did not complete`,
+  );
+}
+
+test.skipIf(missingRequirements.length > 0)(
+  `the engine honours an always grant inside an instance and forgets it for the same thread once the instance is rebuilt${skipSuffix}`,
+  { timeout: 240_000 },
+  async ({ evidence }) => {
+    needs(requirements);
+    const provider = await scriptedProvider();
+    try {
+      await using engine = await bootEngine(provider.port);
+      expect(engine.version).toBe(constants.opencodeVersion.replace(/^v/, ""));
+
+      const created = await engine.request("POST", "/session", { title: "Thread approval memory" });
+      if (!isRecord(created) || typeof created.id !== "string") throw new Error(`session.create returned ${JSON.stringify(created)}`);
+      const thread = created.id;
+
+      // Turn 1: the workspace asks; the user replies "always" to the engine's suggested pattern.
+      const first = await runTurn(engine, thread, "printf 'grant one'");
+      if (!first.asked) throw new Error("the first command did not ask");
+      expect(first.asked.permission).toBe("bash");
+      expect(first.asked.always.length).toBeGreaterThan(0);
+      await engine.request("POST", `/permission/${encodeURIComponent(first.asked.id)}/reply`, { reply: "always" });
+      await finishTurn(engine, thread, "printf 'grant one'");
+
+      // Turn 2: same thread, same instance — the grant holds and nothing asks.
+      const second = await runTurn(engine, thread, "printf 'grant two'");
+      expect(second.asked).toBeNull();
+      await finishTurn(engine, thread, "printf 'grant two'");
+      evidence.recordAssertionEvidence(
+        "An always grant covers later matching calls on the thread while the engine instance lives",
+        `Reply "always" to ${JSON.stringify(first.asked.always)} on ${thread}; the next printf ran with no permission request.`,
+        true,
+      );
+
+      // Rebuild the instance the way OpenWork does on every reload, then ask
+      // the very same thread for another covered command.
+      await engine.request("POST", "/instance/dispose");
+      const third = await runTurn(engine, thread, "printf 'grant three'");
+      expect(third.asked).not.toBeNull();
+      expect(third.asked?.sessionID).toBe(thread);
+      expect(third.asked?.permission).toBe("bash");
+      evidence.recordAssertionEvidence(
+        "An always grant survives an engine instance rebuild for the same thread",
+        `After /instance/dispose, thread ${thread} asked again for ${JSON.stringify(third.asked?.patterns)} although ${JSON.stringify(first.asked.always)} was granted with "always" on this thread.`,
+        false,
+      );
+      if (third.asked) {
+        await engine.request("POST", `/permission/${encodeURIComponent(third.asked.id)}/reply`, { reply: "once" });
+        await finishTurn(engine, thread, "printf 'grant three'");
+      }
+    } finally {
+      await new Promise<void>((resolve) => provider.server.close(() => resolve()));
+    }
+  },
+);

--- a/evals/specs/thread-approvals-replay.test.ts
+++ b/evals/specs/thread-approvals-replay.test.ts
@@ -1,0 +1,390 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { needs, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+import { clearEnginePoolForConfig, computeEngineConfigFingerprint, type EngineSpawnTemplate } from "../../apps/server/src/engine-pool.js";
+import { buildEngineAuthProbeHeader } from "../../apps/server/src/engine-registry.js";
+import { createManagedOpencodeServer, type ManagedOpencodeServer } from "../../apps/server/src/managed-opencode.js";
+import { createEnginePoolForConfig, registerTrustedOpencodeProcess, startServer } from "../../apps/server/src/server.js";
+import { listThreadApprovals } from "../../apps/server/src/thread-approvals.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+
+/**
+ * OpenWork server + engine pool around the real pinned engine + a scripted
+ * provider. thread-approvals-engine-memory shows the engine forgetting an
+ * "always" reply once its instance is rebuilt; this spec shows OpenWork
+ * remembering it for the thread and answering the repeat ask. The engine's
+ * own event stream is watched, so "the engine asked and OpenWork answered" is
+ * observed at the source rather than inferred.
+ */
+
+const requirements: TestNeeds = { commands: ["opencode"] };
+const missingRequirements = unmetNeeds(requirements, process.env);
+const skipSuffix = missingRequirements.length > 0 ? ` skipped — needs: ${missingRequirements.join(", ")}` : "";
+
+const providerId = "thread-approval-fixture";
+const modelId = "thread-approval-model";
+const CLIENT_TOKEN = "owt_thread_approvals";
+const HOST_TOKEN = "owt_thread_approvals_host";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+interface EngineEvent {
+  type: string;
+  sessionID: string;
+  reply: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** OpenAI-compatible stand-in: user prompt → one bash tool call for `RUN: <command>`; tool result → completion. */
+function scriptedProvider(): Promise<{ server: Server; url: string; calls: string[] }> {
+  const calls: string[] = [];
+  return new Promise((resolve, reject) => {
+    const server = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "GET" && url.pathname.endsWith("/models")) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+        return;
+      }
+      if (request.method !== "POST" || !url.pathname.endsWith("/chat/completions")) {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: { message: "not found" } }));
+        return;
+      }
+      let raw = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => { raw += chunk; });
+      request.on("end", () => {
+        const body: unknown = JSON.parse(raw);
+        const messages = isRecord(body) && Array.isArray(body.messages) ? body.messages : [];
+        const last = messages.at(-1);
+        const toolResult = isRecord(last) && last.role === "tool";
+        const lastUser = [...messages].reverse().find((message) => isRecord(message) && message.role === "user");
+        const text = isRecord(lastUser)
+          ? (typeof lastUser.content === "string"
+            ? lastUser.content
+            : Array.isArray(lastUser.content) ? lastUser.content.map((part) => (isRecord(part) && typeof part.text === "string" ? part.text : "")).join("\n") : "")
+          : "";
+        const command = text.match(/RUN:\s*(.+)$/m)?.[1]?.trim() ?? "printf 'no command'";
+        const id = `chatcmpl-${Date.now()}`;
+        const chunk = (delta: Record<string, unknown>, finish: string | null = null) =>
+          `data: ${JSON.stringify({ id, object: "chat.completion.chunk", choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`;
+        response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        response.write(chunk({ role: "assistant" }));
+        if (toolResult) {
+          response.write(chunk({ content: "FIXTURE-DONE" }) + chunk({}, "stop"));
+        } else {
+          calls.push(command);
+          response.write(chunk({ tool_calls: [{ index: 0, id: `call_${Date.now()}`, type: "function", function: { name: "bash", arguments: JSON.stringify({ command }) } }] }));
+          response.write(chunk({}, "tool_calls"));
+        }
+        response.write("data: [DONE]\n\n");
+        response.end();
+      });
+    });
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("provider did not bind"));
+        return;
+      }
+      resolve({ server, url: `http://127.0.0.1:${address.port}`, calls });
+    });
+  });
+}
+
+interface Stack {
+  config: ServerConfig;
+  request: (method: string, path: string, body?: unknown) => Promise<unknown>;
+  events: EngineEvent[];
+  calls: string[];
+  [Symbol.asyncDispose]: () => Promise<void>;
+}
+
+async function bootStack(): Promise<Stack> {
+  const disposers: Array<() => Promise<void> | void> = [];
+  const dispose = async () => {
+    while (disposers.length) await disposers.pop()?.();
+  };
+  try {
+    const root = await mkdtemp(join(tmpdir(), "openwork-thread-approvals-stack-"));
+    disposers.push(() => rm(root, { recursive: true, force: true }));
+    const workspace = join(root, "workspace");
+    const xdg = join(root, "xdg");
+    await Promise.all([mkdir(workspace, { recursive: true }), mkdir(join(xdg, "config", "opencode"), { recursive: true }), mkdir(join(root, "home"), { recursive: true })]);
+    const previousEnv = {
+      OPENWORK_DATA_DIR: process.env.OPENWORK_DATA_DIR,
+      OPENWORK_TOKEN_STORE: process.env.OPENWORK_TOKEN_STORE,
+      OPENWORK_RUNTIME_DB: process.env.OPENWORK_RUNTIME_DB,
+    };
+    process.env.OPENWORK_DATA_DIR = join(root, "data");
+    process.env.OPENWORK_TOKEN_STORE = join(root, "tokens.json");
+    process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+    disposers.push(() => {
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    });
+
+    const provider = await scriptedProvider();
+    disposers.push(() => new Promise<void>((resolve) => provider.server.close(() => resolve())));
+    await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      permission: { bash: "ask" },
+      provider: {
+        [providerId]: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Thread approval fixture",
+          options: { baseURL: `${provider.url}/v1`, apiKey: "fixture-key" },
+          models: { [modelId]: { name: "Thread approval fixture", tool_call: true } },
+        },
+      },
+    }), "utf8");
+    await writeFile(join(xdg, "config", "opencode", "opencode.json"), "{}", "utf8");
+    const runtimeConfigPath = join(root, "runtime-opencode-config.json");
+    await writeFile(runtimeConfigPath, "{}\n", "utf8");
+
+    const engineEnv = {
+      OPENCODE_TEST_HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(xdg, "config"),
+      XDG_DATA_HOME: join(xdg, "data"),
+      XDG_CACHE_HOME: join(xdg, "cache"),
+      XDG_STATE_HOME: join(xdg, "state"),
+      OPENCODE_CONFIG: runtimeConfigPath,
+    };
+    const engine: ManagedOpencodeServer = await createManagedOpencodeServer({ cwd: workspace, env: engineEnv, timeoutMs: 60_000 });
+    disposers.push(() => engine.close());
+
+    const config: ServerConfig = {
+      host: "127.0.0.1",
+      port: 0,
+      configPath: join(root, "server.json"),
+      token: CLIENT_TOKEN,
+      hostToken: HOST_TOKEN,
+      approval: { mode: "auto", timeoutMs: 1000 },
+      corsOrigins: ["*"],
+      opencodeUsername: engine.username,
+      opencodePassword: engine.password,
+      workspaces: [{ id: "ws_1", name: "Workspace", path: workspace, preset: "starter", workspaceType: "local", baseUrl: engine.url }],
+      authorizedRoots: [workspace],
+      readOnly: false,
+      startedAt: Date.now(),
+      tokenSource: "cli",
+      hostTokenSource: "cli",
+      logFormat: "pretty",
+      logRequests: false,
+    };
+    registerTrustedOpencodeProcess(config, { baseUrl: engine.url, identity: "thread-approvals-spec", isAlive: engine.isAlive });
+    const template: EngineSpawnTemplate = { cwd: workspace, runtimeConfigPath, env: engineEnv, reservedPorts: () => [] };
+    const pool = createEnginePoolForConfig({
+      config,
+      template,
+      handle: engine,
+      fingerprint: await computeEngineConfigFingerprint(template),
+      registryId: null,
+      trustedIdentity: null,
+    });
+    disposers.push(async () => {
+      clearEnginePoolForConfig(config);
+      await pool.disposeAll();
+    });
+    const served = await startServer(config) as Served;
+    disposers.push(() => served.stop(true));
+
+    // Watch the engine's own event stream so asks and replies are observed at the source.
+    const events: EngineEvent[] = [];
+    const watcher = new AbortController();
+    disposers.push(() => watcher.abort());
+    void (async () => {
+      try {
+        const response = await fetch(new URL("/global/event", engine.url), {
+          headers: { Authorization: buildEngineAuthProbeHeader(engine.username, engine.password) },
+          signal: watcher.signal,
+        });
+        if (!response.body) return;
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffered = "";
+        while (true) {
+          const chunk = await reader.read();
+          if (chunk.done) return;
+          buffered += decoder.decode(chunk.value, { stream: true });
+          let index: number;
+          while ((index = buffered.indexOf("\n\n")) >= 0) {
+            const frame = buffered.slice(0, index);
+            buffered = buffered.slice(index + 2);
+            const data = frame.split("\n").filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trim()).join("");
+            if (!data) continue;
+            try {
+              const parsed: unknown = JSON.parse(data);
+              const payload = isRecord(parsed) && isRecord(parsed.payload) ? parsed.payload : null;
+              const properties = payload && isRecord(payload.properties) ? payload.properties : {};
+              if (payload && typeof payload.type === "string" && payload.type.startsWith("permission.")) {
+                events.push({
+                  type: payload.type,
+                  sessionID: typeof properties.sessionID === "string" ? properties.sessionID : "",
+                  reply: typeof properties.reply === "string" ? properties.reply : "",
+                });
+              }
+            } catch {
+              // ignore non-JSON frames
+            }
+          }
+        }
+      } catch {
+        // aborted at teardown
+      }
+    })();
+
+    const base = `http://127.0.0.1:${served.port}/workspace/ws_1`;
+    const request = async (method: string, path: string, body?: unknown): Promise<unknown> => {
+      const response = await fetch(`${base}${path}`, {
+        method,
+        headers: { Authorization: `Bearer ${CLIENT_TOKEN}`, "content-type": "application/json" },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(60_000),
+      });
+      const text = await response.text();
+      if (!response.ok) throw new Error(`${method} ${path} → ${response.status} ${text.slice(0, 300)}`);
+      return text ? JSON.parse(text) : null;
+    };
+    return { config, request, events, calls: provider.calls, [Symbol.asyncDispose]: dispose };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+}
+
+async function until<T>(read: () => Promise<T>, done: (value: T) => boolean, label: string, timeoutMs = 60_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await read();
+  while (Date.now() < deadline) {
+    if (done(last)) return last;
+    await sleep(200);
+    last = await read();
+  }
+  throw new Error(`${label}: ${JSON.stringify(last)}`);
+}
+
+async function pendingFor(stack: Stack, sessionId: string): Promise<Array<{ id: string; permission: string }>> {
+  const value = await stack.request("GET", "/opencode/permission");
+  return Array.isArray(value)
+    ? value.flatMap((entry) => isRecord(entry) && typeof entry.id === "string" && entry.sessionID === sessionId
+      ? [{ id: entry.id, permission: typeof entry.permission === "string" ? entry.permission : "" }]
+      : [])
+    : [];
+}
+
+async function completed(stack: Stack, sessionId: string, command: string): Promise<boolean> {
+  const value = await stack.request("GET", `/opencode/session/${encodeURIComponent(sessionId)}/message`);
+  if (!Array.isArray(value)) return false;
+  return value.some((message) => isRecord(message) && Array.isArray(message.parts) && message.parts.some((part) =>
+    isRecord(part) && part.type === "tool" && isRecord(part.state) && part.state.status === "completed"
+    && isRecord(part.state.input) && part.state.input.command === command));
+}
+
+/** Outcome of one prompt: the engine asked (never answered here) or the command completed. */
+async function turn(stack: Stack, sessionId: string, command: string) {
+  await stack.request("POST", `/opencode/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+    model: { providerID: providerId, modelID: modelId },
+    parts: [{ type: "text", text: `Run the fixture command.\nRUN: ${command}` }],
+  });
+  return until(
+    async () => ({ asked: (await pendingFor(stack, sessionId))[0] ?? null, done: await completed(stack, sessionId, command) }),
+    (state) => state.asked !== null || state.done,
+    `turn ${command}`,
+  );
+}
+
+async function createThread(stack: Stack, title: string): Promise<string> {
+  const created = await stack.request("POST", "/opencode/session", { title });
+  if (!isRecord(created) || typeof created.id !== "string") throw new Error(`session create returned ${JSON.stringify(created)}`);
+  return created.id;
+}
+
+test.skipIf(missingRequirements.length > 0)(
+  `an always reply on a thread is replayed by OpenWork after the engine instance is rebuilt, and only for that thread${skipSuffix}`,
+  { timeout: 240_000 },
+  async ({ evidence }) => {
+    needs(requirements);
+    await using stack = await bootStack();
+    const thread = await createThread(stack, "Thread approvals");
+
+    // Turn 1: the workspace asks; the user replies "always" through OpenWork's proxy.
+    const first = await turn(stack, thread, "printf 'grant one'");
+    if (!first.asked) throw new Error("the first command did not ask");
+    expect(first.asked.permission).toBe("bash");
+    await stack.request("POST", `/opencode/permission/${encodeURIComponent(first.asked.id)}/reply`, { reply: "always" });
+    await until(() => completed(stack, thread, "printf 'grant one'"), (done) => done, "first command completed");
+    const remembered = await until(
+      () => listThreadApprovals(stack.config, "ws_1", thread),
+      (grants) => grants.some((grant) => grant.permission === "bash"),
+      "OpenWork remembered the thread's grant",
+      10_000,
+    );
+    evidence.recordAssertionEvidence(
+      "OpenWork records an always reply against its thread",
+      `Thread ${thread} now carries ${JSON.stringify(remembered)} in OpenWork's own store.`,
+      true,
+    );
+
+    // Rebuild the instance as every reload does; the engine's own memory is gone.
+    await stack.request("POST", "/opencode/instance/dispose");
+
+    // Turn 2: same thread, covered command — the engine asks, OpenWork answers, the command runs.
+    const askedBefore = stack.events.filter((event) => event.type === "permission.asked" && event.sessionID === thread).length;
+    const second = await turn(stack, thread, "printf 'grant two'");
+    if (second.asked) {
+      // A poll may catch the ask before the replay lands; it must still resolve without a human.
+      await until(() => completed(stack, thread, "printf 'grant two'"), (done) => done, "second command completed without a human reply", 30_000);
+    }
+    expect(await completed(stack, thread, "printf 'grant two'")).toBe(true);
+    const askedAfter = stack.events.filter((event) => event.type === "permission.asked" && event.sessionID === thread).length;
+    expect(askedAfter).toBeGreaterThan(askedBefore);
+    const alwaysReplies = stack.events.filter((event) => event.type === "permission.replied" && event.sessionID === thread && event.reply === "always").length;
+    expect(alwaysReplies).toBeGreaterThanOrEqual(2);
+    expect(stack.calls).toEqual(["printf 'grant one'", "printf 'grant two'"]);
+    evidence.recordAssertionEvidence(
+      "After an engine instance rebuild the same thread's covered command runs without a human reply",
+      `The engine asked (${askedAfter - askedBefore} new ask on ${thread}), OpenWork answered "always" (${alwaysReplies} always replies observed on the engine's event stream), and the command completed.`,
+      true,
+    );
+
+    // Replaying with "always" re-seeds the engine's own memory, which is
+    // instance-wide today (one click covers every thread in the instance until
+    // it is rebuilt) — unchanged by this change. After another rebuild only
+    // OpenWork's memory is left, and that is per thread.
+    await stack.request("POST", "/opencode/instance/dispose");
+    const third = await turn(stack, thread, "printf 'grant three'");
+    if (third.asked) {
+      await until(() => completed(stack, thread, "printf 'grant three'"), (done) => done, "third command completed without a human reply", 30_000);
+    }
+    expect(await completed(stack, thread, "printf 'grant three'")).toBe(true);
+    await stack.request("POST", "/opencode/instance/dispose");
+    const sibling = await createThread(stack, "Sibling");
+    const siblingTurn = await turn(stack, sibling, "printf 'grant one'");
+    expect(siblingTurn.asked).not.toBeNull();
+    await sleep(1_000);
+    expect((await pendingFor(stack, sibling)).length).toBe(1);
+    expect(await listThreadApprovals(stack.config, "ws_1", sibling)).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "A thread's approval never replays for a sibling thread",
+      `Sibling ${sibling} asked for the same command and kept waiting; OpenWork holds no grant for it.`,
+      true,
+    );
+    if (siblingTurn.asked) {
+      await stack.request("POST", `/opencode/permission/${encodeURIComponent(siblingTurn.asked.id)}/reply`, { reply: "reject" });
+    }
+  },
+);


### PR DESCRIPTION
## The problem

"Allow for session" does not hold for the session. It is an engine `always` reply, and in the pinned engine (`v1.18.18`) that reply is kept in the memory of the **per-directory instance** that received it — not on the session and not on disk (`packages/opencode/src/permission/index.ts`: `approved` lives in `InstanceState`). Two consequences:

- OpenWork rebuilds engine instances routinely: config, skill, and MCP reload events, idle eviction, engine rollover. Each rebuild starts with an empty approval list, so the very same thread asks again for a command the user already approved mid-thread.
- The grant is not per thread at all: until the rebuild it covers every thread in that workspace's instance.

The engine's newer persisted permission store (`/api/permission/saved`) is not consulted by the tools OpenWork runs in this version, so there is nothing to switch on. `evals/specs/thread-approvals-engine-memory.test.ts` drives the real engine with a scripted provider and shows exactly this: the grant covers the next matching command in the same instance, then after `/instance/dispose` the same thread asks again (recorded as a failing engine claim).

## The fix

OpenWork owns the memory of what a user approved on a thread. That is the fundamental piece we need before any further execution control (persistent allow-lists, run modes, per-thread autonomy) can be built without re-litigating the engine's precedence rules.

- The server follows the managed engine's `/global/event` stream. Every `permission.replied` with `always` is recorded against its thread, using the patterns the engine itself proposed for that request (`always[]`).
- When the engine later asks **the same thread** for something a recorded grant covers (same wildcard matcher as the engine's), OpenWork answers `always` on the user's behalf, so the fresh instance remembers too.
- Grants are stored per workspace and thread in the runtime DB (`thread_approvals`). Nothing is approved that the user did not approve on that thread; `deny` rules never reach the ask stage; the engine's own in-instance behaviour is unchanged.
- The replayer follows the primary generation across rollovers, pauses (never approves) when the stream drops, and stops with the pool. The engine instance directory is compared canonically (macOS `/tmp` and `/var` resolve through `/private`).

No UI, no setting, no config written anywhere. The button the user already clicks now does what its label says.

## Proof (head `ed57ebb3a`, local lane — Daytona credentials unavailable in this shell)

| Check | Command | Result |
|---|---|---|
| The engine forgets an always grant on instance rebuild (the case) | `pnpm evals:pr specs/thread-approvals-engine-memory.test.ts` | 1 passed; evidence: grant holds in-instance ✅, survives rebuild ❌ (the engine's limit, by design of the spec) |
| OpenWork replays the thread's grant after rebuilds; never for a sibling thread | `pnpm evals:pr specs/thread-approvals-replay.test.ts` | 1 passed; 3 claims ✅ — observed on the engine's own event stream: the rebuilt instance asked, OpenWork answered `always`, the command ran; sibling thread waited |
| Replayer mechanics (record on `always` only, replay match, thread/permission/pattern negatives, unowned directories, reconnect) | `pnpm --filter openwork-server exec bun --conditions=development test thread-approvals` | 4 pass / 0 fail, 22 expects |
| Spec-impact guard | `pnpm evals:pr specs/spec-impact.test.ts` | 6 passed |
| Typecheck | `pnpm --filter openwork-server typecheck` | exit 0 |
| Full `apps/server` | `pnpm --filter openwork-server test` | 822 pass / 1 fail (`workspace-kv-store.node.test.ts`: `node:sqlite` under bun) |
| Control at `dd6ac0dd0` (clean worktree, same command) | `pnpm --filter openwork-server test` | 818 pass / 1 fail — identical failure → pre-existing |

## Known limits, stated plainly

- Replaying with `always` re-seeds the engine's instance-wide memory, exactly as a click on the button does today; a sibling thread in the same live instance is therefore covered until the next rebuild (unchanged behaviour). OpenWork's own memory is strictly per thread — proven by the sibling check after a fresh rebuild.
- Grants are recorded from the engine's `permission.asked`/`permission.replied` v1 events, which are what the tools OpenWork runs emit. Approvals answered while the server's stream is reconnecting are not recorded (the user simply approves again).
- Grants are not yet visible or revocable in the UI; that list (and a device-wide "Always allow") is the natural next step on the same store.
