### PR TITLE
feat(world): structured outputs with secrets, groups, and world outputs --reveal

### DIFF
--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -151,10 +151,10 @@ export function McpAppTile({
   onAutoLaunchEnabledRef.current = onAutoLaunchEnabled;
   const onAutoLaunchDisabledRef = useRef(onAutoLaunchDisabled);
   onAutoLaunchDisabledRef.current = onAutoLaunchDisabled;
-  // A write-tool launch must map 1:1 to a Run/refresh press. The effect also
-  // re-runs when the client or workspace identity changes; this ref keeps such
-  // re-runs from repeating an already-executed data-modifying call.
-  const executedRunRef = useRef<number | null>(null);
+  // A write-tool launch must map 1:1 to a Run/refresh press. Dependency churn
+  // reuses the same in-flight promise; a null promise marks a settled nonce so
+  // later re-renders cannot repeat an already-executed data-modifying call.
+  const launchRef = useRef<{ nonce: number; promise: Promise<TileState> | null } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -162,8 +162,8 @@ export function McpAppTile({
       if (stateRef.current.phase !== "ready") setState({ phase: "idle" });
       return;
     }
-    if (executedRunRef.current === nonce) return;
-    executedRunRef.current = nonce;
+    const currentLaunch = launchRef.current?.nonce === nonce ? launchRef.current : null;
+    if (currentLaunch?.promise === null) return;
     setRefreshState("refreshing");
     if (stateRef.current.phase !== "ready") setState({ phase: "loading" });
     // Tiles are user-scoped while MCP servers are workspace-scoped: prefer the
@@ -171,6 +171,7 @@ export function McpAppTile({
     // still resolve this app.
     const candidates = launchEndpoints;
     if (candidates.length === 0) {
+      launchRef.current = { nonce, promise: null };
       if (stateRef.current.phase === "ready") setRefreshState("failed");
       else {
         setState({ phase: "error", message: "No connected workspace is available to launch this app." });
@@ -179,7 +180,7 @@ export function McpAppTile({
       return;
     }
     const userInitiated = userInitiatedNonceRef.current === nonce;
-    void (async (): Promise<TileState> => {
+    const promise = currentLaunch?.promise ?? (async (): Promise<TileState> => {
       // Connect app-host apps resolve through their connection reference; the
       // host revalidates the live UI binding before returning the resource.
       const launch = entry.connectionId
@@ -263,7 +264,17 @@ export function McpAppTile({
         // succeed without another tool_requires_approval response.
         autoLaunchEligible: !approvalWasRequired && !launchApprovedRef.current,
       };
-    })()
+    })();
+    if (!currentLaunch) {
+      launchRef.current = { nonce, promise };
+      const markSettled = () => {
+        if (launchRef.current?.nonce === nonce && launchRef.current.promise === promise) {
+          launchRef.current = { nonce, promise: null };
+        }
+      };
+      void promise.then(markSettled, markSettled);
+    }
+    void promise
       .then((next) => {
         if (cancelled) return;
         if (next.phase === "ready") {

--- a/evals/packages/env/src/recipe.ts
+++ b/evals/packages/env/src/recipe.ts
@@ -12,9 +12,12 @@ import {
   resolveStage,
   rewriteLedger,
   progress,
+  output,
+  secret,
   trackResource,
   type LedgerEntry,
   type Progress,
+  type WorldOutput,
 } from "@openwork/world";
 import { resolvePlace, type Place } from "./place.ts";
 
@@ -23,17 +26,19 @@ export interface RecipeTools {
   place: Place;
   stage: string;
   progress: Progress;
+  output: typeof output;
+  secret: typeof secret;
   stageName(base: string): string;
   track(entry: Omit<LedgerEntry, "at">): Promise<void>;
 }
 
-export interface WorldRecipe<O extends Record<string, string> = Record<string, string>> {
+export interface WorldRecipe<O extends Record<string, WorldOutput> = Record<string, WorldOutput>> {
   kind: "recipe";
   name: string;
   build(tools: RecipeTools): Promise<O>;
 }
 
-export function recipe<O extends Record<string, string>>(
+export function recipe<O extends Record<string, WorldOutput>>(
   name: string,
   build: (tools: RecipeTools) => Promise<O>,
 ): WorldRecipe<O> {
@@ -60,6 +65,8 @@ export async function runRecipe(def: WorldRecipe): Promise<void> {
         stack,
         place,
         progress: progress(),
+        output,
+        secret,
         stage,
         stageName: (base) => `${base} (${stage})`,
         track: trackResource,

--- a/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
+++ b/evals/specs/org-managed-dashboard-desktop.e2e.test.ts
@@ -113,6 +113,49 @@ test(title, async ({ evidence, place }) => {
     as: "admin",
     place,
   });
+  const launchProbeInstalled = await evalIn(desktop, `(() => {
+    const originalFetch = window.fetch.bind(window);
+    performance.clearResourceTimings();
+    window.fetch = async (input, init) => {
+      const requestUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      const response = await originalFetch(input, init);
+      const pathname = new URL(requestUrl).pathname;
+      if (!pathname.endsWith("/mcp-apps/resolve") && !pathname.endsWith("/mcp-apps/call")) return response;
+      let body = {};
+      try {
+        body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      } catch {
+        return response;
+      }
+      if (pathname.endsWith("/mcp-apps/resolve")) {
+        await new Promise((resolve) => window.setTimeout(resolve, 2_000));
+        const launch = body && typeof body === "object" && body.launch && typeof body.launch === "object"
+          ? body.launch
+          : {};
+        return Response.json({
+          app: {
+            serverName: "managed-dashboard-launch-probe",
+            toolName: typeof launch.toolName === "string" ? launch.toolName : "create_ticket",
+            resourceUri: typeof launch.resourceUri === "string" ? launch.resourceUri : "ui://fixture/ticket/view.html",
+            html: "<!doctype html><html><body><main>Managed dashboard launch completed</main></body></html>",
+            csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+            prefersBorder: true,
+          },
+        });
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, 1_500));
+      return Response.json({
+        content: [{ type: "text", text: "Managed dashboard launch completed" }],
+        structuredContent: { status: "ready" },
+      });
+    };
+    return true;
+  })()`);
+  expect(launchProbeInstalled).toBe(true);
   const dashboardHash = "#/dashboard";
   const dashboardOpened = await evalIn(desktop, `(() => {
     const button = [...document.querySelectorAll("button")]
@@ -132,6 +175,30 @@ test(title, async ({ evidence, place }) => {
   })()`, {
     timeoutMs: 90_000,
     label: "granted organization dashboard rendered in Desktop",
+  });
+  await waitFor(desktop, `Boolean(document.querySelector(${JSON.stringify('[aria-label="Loading Automatic ticket summary"]')}))`, {
+    timeoutMs: 30_000,
+    label: "automatic managed dashboard tile entered its loading state",
+  });
+  const churnStarted = await evalIn(desktop, `(() => {
+    const workspaceRequestsBefore = performance.getEntriesByType("resource")
+      .filter((entry) => new URL(entry.name).pathname === "/workspaces").length;
+    window.__managedDashboardLaunchProbe = {
+      startedAt: performance.now(),
+      workspaceRequestsBefore,
+    };
+    window.dispatchEvent(new Event("openwork-server-settings-changed"));
+    return true;
+  })()`);
+  expect(churnStarted).toBe(true);
+  await waitFor(desktop, `(() => {
+    const probe = window.__managedDashboardLaunchProbe;
+    if (!probe) return false;
+    return performance.getEntriesByType("resource")
+      .filter((entry) => new URL(entry.name).pathname === "/workspaces").length > probe.workspaceRequestsBefore;
+  })()`, {
+    timeoutMs: 15_000,
+    label: "workspace list refetched while the managed dashboard tile was loading",
   });
 
   const initialState = await evalIn(desktop, `(() => {
@@ -200,6 +267,86 @@ test(title, async ({ evidence, place }) => {
     };
   })()`);
   expect(organizationPolicyState).toMatchObject({ automaticAttemptVisible: true, runVisible: false });
+
+  const launchDeadline = Date.now() + 30_000;
+  let launchAfterChurn: unknown = null;
+  while (Date.now() < launchDeadline) {
+    launchAfterChurn = await evalIn(desktop, `(() => {
+      const probe = window.__managedDashboardLaunchProbe;
+      const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${grantedDashboardId}"]`)});
+      const tile = section instanceof HTMLElement
+        ? [...section.querySelectorAll("[data-dashboard-entry]")]
+          .find((entry) => entry.textContent?.includes("Automatic ticket summary"))
+        : null;
+      if (!probe || !(tile instanceof HTMLElement)) return null;
+      const resources = performance.getEntriesByType("resource");
+      const mcpRequests = resources.filter((entry) => new URL(entry.name).pathname.includes("/mcp-apps/"));
+      const recentMcpRequests = mcpRequests.filter((entry) => (
+        performance.now() - (entry.startTime + entry.duration) <= 5_000
+      ));
+      const callCount = mcpRequests.filter((entry) => new URL(entry.name).pathname.endsWith("/mcp-apps/call")).length;
+      const workspaceRequestCount = resources
+        .filter((entry) => new URL(entry.name).pathname === "/workspaces").length;
+      const loading = Boolean(tile.querySelector('[aria-label="Loading Automatic ticket summary"]'));
+      const cacheState = tile.querySelector("[data-dashboard-cache-state]")?.getAttribute("data-dashboard-cache-state") ?? null;
+      const page = document.querySelector("[data-dashboard-cache-scope]");
+      const scope = page instanceof HTMLElement ? page.dataset.dashboardCacheScope : undefined;
+      const entryId = tile.dataset.dashboardEntry;
+      let cached = false;
+      try {
+        const stored = scope ? JSON.parse(localStorage.getItem(scope) ?? "{}") : {};
+        cached = Boolean(entryId && stored?.[entryId]?.result);
+      } catch {
+        cached = false;
+      }
+      return {
+        cached,
+        cacheState,
+        callCount,
+        elapsedMs: performance.now() - probe.startedAt,
+        loading,
+        ready: !loading && cacheState === "idle" && Boolean(tile.querySelector("iframe")),
+        recentMcpRequestCount: recentMcpRequests.length,
+        workspaceRefetchCount: workspaceRequestCount - probe.workspaceRequestsBefore,
+      };
+    })()`);
+    if (isRecord(launchAfterChurn)) {
+      if (
+        launchAfterChurn.loading === true
+        && typeof launchAfterChurn.elapsedMs === "number"
+        && launchAfterChurn.elapsedMs > 8_000
+        && launchAfterChurn.recentMcpRequestCount === 0
+      ) {
+        throw new Error("Automatic ticket summary remained in Loading for more than 8 seconds with no MCP App request in the last 5 seconds.");
+      }
+      if (launchAfterChurn.ready === true) break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  expect(
+    launchAfterChurn,
+    "Automatic ticket summary should leave Loading and render its cached app within 30 seconds of workspace-list churn",
+  ).toMatchObject({
+    cached: true,
+    cacheState: "idle",
+    callCount: 1,
+    loading: false,
+    ready: true,
+  });
+  expect(isRecord(launchAfterChurn) && typeof launchAfterChurn.workspaceRefetchCount === "number"
+    ? launchAfterChurn.workspaceRefetchCount
+    : 0).toBeGreaterThanOrEqual(1);
+  evidence.recordAssertionEvidence(
+    "A managed dashboard launch survives workspace-list churn without hanging or duplicating its tool call",
+    `tile=Automatic ticket summary; state=${JSON.stringify(launchAfterChurn)}; loading was polled for network-idle hangs every 250ms`,
+    isRecord(launchAfterChurn)
+      && launchAfterChurn.cached === true
+      && launchAfterChurn.loading === false
+      && launchAfterChurn.ready === true
+      && launchAfterChurn.callCount === 1
+      && typeof launchAfterChurn.workspaceRefetchCount === "number"
+      && launchAfterChurn.workspaceRefetchCount >= 1,
+  );
   evidence.recordAssertionEvidence(
     "Desktop places Dashboard directly below Search in the left sidebar",
     `state=${JSON.stringify(initialState)}`,

--- a/evals/specs/world-outputs-secrets.test.ts
+++ b/evals/specs/world-outputs-secrets.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { eventually, test } from "@openwork/testkit";
+import {
+  isProcessAlive,
+  main,
+  readScriptWorldSnapshot,
+  type WorldCliOptions,
+} from "@openwork/world";
+import { MASK } from "../../packages/world/src/outputs.ts";
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+function assertRecord(value: unknown): asserts value is Record<string, unknown> {
+  assert.equal(typeof value, "object");
+  assert.notEqual(value, null);
+  assert.equal(Array.isArray(value), false);
+}
+
+test("world outputs publish grouped credentials and mask secrets everywhere but the receipt", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-outputs-secrets-"));
+  const worldsDirectory = join(root, "worlds");
+  const snapshotDirectory = join(root, ".worlds", "scripts");
+  const vaultPath = join(worldsDirectory, "vault-world.ts");
+  const plainPath = join(worldsDirectory, "plain-world.ts");
+  const vaultReceiptPath = join(snapshotDirectory, "vault-world--v.json");
+  const vaultLogPath = join(snapshotDirectory, "vault-world--v.log");
+  const vaultEventsPath = join(snapshotDirectory, "vault-world--v.events.jsonl");
+  const plainReceiptPath = join(snapshotDirectory, "plain-world--v.json");
+  const plainLogPath = join(snapshotDirectory, "plain-world--v.log");
+  const recipeUrl = pathToFileURL(join(REPO_ROOT, "evals", "packages", "env", "src", "recipe.ts")).href;
+  const previousSnapshotDirectory = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  const launchedPids = new Set<number>();
+  let printed: string[] = [];
+  let narrated: string[] = [];
+  const maskedLines = [
+    "url  http://127.0.0.1:1",
+    "Accounts",
+    "  adminEmail     alex@acme.test  org owner",
+    `  adminPassword  ${MASK}`,
+    "Keys",
+    `  apiKey  ${MASK}  master`,
+  ];
+  const revealedLines = [
+    "url  http://127.0.0.1:1",
+    "Accounts",
+    "  adminEmail     alex@acme.test  org owner",
+    "  adminPassword  Sup3rSecretPw!",
+    "Keys",
+    "  apiKey  sk-vault-123456  master",
+  ];
+  const options: WorldCliOptions = {
+    cwd: root,
+    worldsDirectory,
+    print: (line) => printed.push(line),
+    progress: (line) => narrated.push(line),
+  };
+  const run = async (argv: string[]): Promise<number> => {
+    printed.length = 0;
+    narrated.length = 0;
+    return main(argv, options);
+  };
+
+  try {
+    process.env.OPENWORK_WORLD_SNAPSHOT_DIR = snapshotDirectory;
+    await mkdir(worldsDirectory);
+    await writeFile(vaultPath, `
+import { recipe, runRecipe } from ${JSON.stringify(recipeUrl)};
+
+const world = recipe("vault-world", async (tools) => {
+  const prep = tools.progress.step("prep", "Prepare vault");
+  await prep.ok();
+  return {
+    url: "http://127.0.0.1:1",
+    adminEmail: tools.output("alex@acme.test", { group: "Accounts", note: "org owner" }),
+    adminPassword: tools.secret("Sup3rSecretPw!", { group: "Accounts" }),
+    apiKey: tools.secret("sk-vault-123456", { group: "Keys", note: "master" }),
+  };
+});
+
+export default world;
+if (import.meta.main) await runRecipe(world);
+`, "utf8");
+    await writeFile(plainPath, `
+import { recipe, runRecipe } from ${JSON.stringify(recipeUrl)};
+
+const world = recipe("plain-world", async () => {
+  return { url: "http://127.0.0.1:2" };
+});
+
+export default world;
+if (import.meta.main) await runRecipe(world);
+`, "utf8");
+
+    const upCode = await run(["up", vaultPath, "--detach", "--stage", "v", "--timeout", "10000"]);
+    assert.equal(upCode, 0, [...narrated, ...printed].join("\n"));
+    assert.deepEqual(printed, [
+      ...maskedLines,
+      `snapshot  ${vaultReceiptPath}`,
+      `log  ${vaultLogPath}`,
+    ]);
+    const upText = [...printed, ...narrated].join("\n");
+    assert.equal(upText.includes("Sup3rSecretPw!"), false);
+    assert.equal(upText.includes("sk-vault-123456"), false);
+    assert.equal(
+      narrated.some((line) => line.includes("pnpm world outputs vault-world --stage v --reveal")),
+      true,
+      narrated.join("\n"),
+    );
+    const vaultSnapshot = await readScriptWorldSnapshot(vaultReceiptPath);
+    assert.ok(vaultSnapshot);
+    launchedPids.add(vaultSnapshot.pid);
+    evidence.recordAssertionEvidence(
+      "Detached up publishes grouped outputs while masking every secret",
+      "Up exited 0 with the exact grouped stdout, neither raw secret appeared in stdout or progress, and progress included the exact reveal hint.",
+      true,
+    );
+
+    const vaultReceipt: unknown = JSON.parse(await readFile(vaultReceiptPath, "utf8"));
+    assertRecord(vaultReceipt);
+    assertRecord(vaultReceipt.outputs);
+    assert.equal(vaultReceipt.outputs.adminPassword, "Sup3rSecretPw!");
+    assert.equal(vaultReceipt.outputs.apiKey, "sk-vault-123456");
+    assertRecord(vaultReceipt.outputMeta);
+    assertRecord(vaultReceipt.outputMeta.adminPassword);
+    assert.equal(vaultReceipt.outputMeta.adminPassword.secret, true);
+    assertRecord(vaultReceipt.outputMeta.apiKey);
+    assert.equal(vaultReceipt.outputMeta.apiKey.group, "Keys");
+    assertRecord(vaultReceipt.outputMeta.adminEmail);
+    assert.equal(vaultReceipt.outputMeta.adminEmail.note, "org owner");
+    assert.equal((await stat(vaultReceiptPath)).mode & 0o777, 0o600);
+    const eventsText = await readFile(vaultEventsPath, "utf8");
+    assert.equal(eventsText.includes("Sup3rSecretPw!"), false);
+    assert.equal(eventsText.includes("sk-vault-123456"), false);
+    assert.equal(eventsText.includes(MASK), true);
+    assert.equal(eventsText.includes('"prep"'), true);
+    evidence.recordAssertionEvidence(
+      "The private receipt retains secrets while the events journal does not",
+      "The 0600 receipt contained both secrets and their metadata; the existing journal contained the mask and neither raw secret.",
+      true,
+    );
+
+    const outputsCode = await run(["outputs", "vault-world", "--stage", "v"]);
+    assert.equal(outputsCode, 0, printed.join("\n"));
+    assert.deepEqual(printed, maskedLines);
+    const revealCode = await run(["outputs", "vault-world", "--stage", "v", "--reveal"]);
+    assert.equal(revealCode, 0, printed.join("\n"));
+    assert.deepEqual(printed, revealedLines);
+    const jsonCode = await run(["outputs", "vault-world", "--stage", "v", "--json"]);
+    assert.equal(jsonCode, 0, printed.join("\n"));
+    assert.equal(printed.length, 1);
+    const maskedJson: unknown = JSON.parse(printed[0] ?? "");
+    assertRecord(maskedJson);
+    assert.equal(maskedJson.name, "vault-world--v");
+    assert.equal(maskedJson.stage, "v");
+    assert.equal(maskedJson.alive, true);
+    assertRecord(maskedJson.outputs);
+    assert.deepEqual(maskedJson.outputs.apiKey, {
+      value: MASK,
+      secret: true,
+      group: "Keys",
+      note: "master",
+    });
+    assert.deepEqual(maskedJson.outputs.url, {
+      value: "http://127.0.0.1:1",
+      secret: false,
+    });
+    const revealJsonCode = await run(["outputs", "vault-world", "--stage", "v", "--json", "--reveal"]);
+    assert.equal(revealJsonCode, 0, printed.join("\n"));
+    assert.equal(printed.length, 1);
+    const revealedJson: unknown = JSON.parse(printed[0] ?? "");
+    assertRecord(revealedJson);
+    assertRecord(revealedJson.outputs);
+    assertRecord(revealedJson.outputs.apiKey);
+    assert.equal(revealedJson.outputs.apiKey.value, "sk-vault-123456");
+    evidence.recordAssertionEvidence(
+      "Outputs supports grouped masked, revealed, and structured views",
+      "Masked and revealed text matched exactly; JSON was one line with the staged identity, live status, omitted absent metadata, masked default values, and an opt-in raw value.",
+      true,
+    );
+
+    const attachCode = await run(["attach", "vault-world", "--stage", "v"]);
+    assert.equal(attachCode, 0, [...narrated, ...printed].join("\n"));
+    assert.equal(narrated.join("\n").includes(maskedLines.join("\n")), true, narrated.join("\n"));
+    assert.equal(narrated.join("\n").includes("Sup3rSecretPw!"), false);
+    assert.equal(narrated.join("\n").includes("sk-vault-123456"), false);
+    evidence.recordAssertionEvidence(
+      "Attach replays grouped outputs without disclosing secrets",
+      "Attach exited 0, progress contained the contiguous grouped masked block, and neither raw secret appeared.",
+      true,
+    );
+
+    const plainUpCode = await run(["up", plainPath, "--detach", "--stage", "v"]);
+    assert.equal(plainUpCode, 0, [...narrated, ...printed].join("\n"));
+    assert.deepEqual(printed, [
+      "url  http://127.0.0.1:2",
+      `snapshot  ${plainReceiptPath}`,
+      `log  ${plainLogPath}`,
+    ]);
+    const plainSnapshot = await readScriptWorldSnapshot(plainReceiptPath);
+    assert.ok(plainSnapshot);
+    launchedPids.add(plainSnapshot.pid);
+    const plainJsonCode = await run(["outputs", "plain-world", "--stage", "v", "--json"]);
+    assert.equal(plainJsonCode, 0, printed.join("\n"));
+    assert.equal(printed.length, 1);
+    const plainJson: unknown = JSON.parse(printed[0] ?? "");
+    assertRecord(plainJson);
+    assertRecord(plainJson.outputs);
+    assertRecord(plainJson.outputs.url);
+    assert.equal(plainJson.outputs.url.secret, false);
+    const plainReceipt: unknown = JSON.parse(await readFile(plainReceiptPath, "utf8"));
+    assertRecord(plainReceipt);
+    assert.equal(Object.hasOwn(plainReceipt, "outputMeta"), false);
+    evidence.recordAssertionEvidence(
+      "Legacy plain outputs remain heading-free and metadata-free",
+      "The plain world printed only its legacy URL plus receipt and log, JSON marked the URL non-secret, and its receipt had no outputMeta key.",
+      true,
+    );
+
+    const downCode = await run(["down", "vault-world", "--stage", "v"]);
+    assert.equal(downCode, 0, printed.join("\n"));
+    const missingCode = await run(["outputs", "vault-world", "--stage", "v"]);
+    assert.equal(missingCode, 1, printed.join("\n"));
+    assert.deepEqual(printed, ['World receipt "vault-world--v" does not exist.']);
+    evidence.recordAssertionEvidence(
+      "Outputs fails exactly when the world receipt is gone",
+      "After a successful down, outputs exited 1 with only the exact missing-receipt line.",
+      true,
+    );
+  } finally {
+    for (const [name, path] of [["vault-world", vaultReceiptPath], ["plain-world", plainReceiptPath]]) {
+      try {
+        const snapshot = await readScriptWorldSnapshot(path);
+        if (snapshot) {
+          launchedPids.add(snapshot.pid);
+          await main(["down", name, "--stage", "v"], { ...options, print: () => {}, progress: () => {} });
+        }
+      } catch {}
+    }
+    for (const pid of launchedPids) {
+      if (!isProcessAlive(pid)) continue;
+      try { process.kill(pid, "SIGKILL"); } catch {}
+      try {
+        await eventually(() => !isProcessAlive(pid), {
+          within: 5_000,
+          intervalMs: 25,
+          label: "world outputs secrets cleanup",
+        });
+      } catch {}
+    }
+    if (previousSnapshotDirectory === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previousSnapshotDirectory;
+    await rm(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/evals/specs/world-up-progress.test.ts
+++ b/evals/specs/world-up-progress.test.ts
@@ -142,7 +142,7 @@ if (import.meta.main) await runRecipe(world);
       (line) => line.startsWith(`✔ ${stagedName} is up`),
       (line) => line === "url  http://127.0.0.1:1",
     ]);
-    assert.deepEqual(printed, []);
+    assert.equal(printed.length, 0);
     assert.equal(narrated.some((line) => line.includes("\u001b")), false);
     evidence.recordAssertionEvidence(
       "Attach replays completed progress through the ready block",

--- a/packages/world/src/cli.ts
+++ b/packages/world/src/cli.ts
@@ -4,6 +4,7 @@ import { styleText } from "node:util";
 import { eventsPath, readEvents, tailEvents, type WorldEvent } from "./events.ts";
 import { ledgerPath, readLedger } from "./ledger.ts";
 import { discoverWorlds, displayWorldPath, resolveWorldScript } from "./loader.ts";
+import { formatOutputLines, MASK } from "./outputs.ts";
 import { nodeCheck, runPreflight, type PreflightCheck } from "./preflight.ts";
 import { builtinReapers, reapLedger, type ReapReport, type Reaper } from "./reaper.ts";
 import { receiptName, resolveStage, sanitizeStage } from "./stage.ts";
@@ -34,6 +35,7 @@ export type WorldCommand =
     }
   | { kind: "attach"; name: string; stage?: string; plain?: true }
   | { kind: "down"; name: string; stage?: string; purge?: true }
+  | { kind: "outputs"; name: string; stage?: string; reveal?: true; json?: true }
   | { kind: "plan"; source: string; stage?: string }
   | { kind: "list" }
   | { kind: "forget"; name: string }
@@ -183,6 +185,43 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
     if (parsed.error) return helpError(parsed.error);
     return { kind: "plan", source, ...(parsed.stage === undefined ? {} : { stage: parsed.stage }) };
   }
+  if (command === "outputs") {
+    const [name, ...options] = args;
+    if (!name || name === "--" || name.startsWith("--")) {
+      return helpError("The outputs command needs exactly one world name.");
+    }
+    let stage: string | undefined;
+    let reveal = false;
+    let json = false;
+    for (let index = 0; index < options.length; index += 1) {
+      const option = options[index];
+      if (option === "--stage" && stage === undefined) {
+        try {
+          stage = sanitizeStage(options[index + 1] ?? "");
+        } catch {
+          return helpError("Use --stage followed by a non-empty stage value.");
+        }
+        index += 1;
+        continue;
+      }
+      if (option === "--reveal" && !reveal) {
+        reveal = true;
+        continue;
+      }
+      if (option === "--json" && !json) {
+        json = true;
+        continue;
+      }
+      return helpError(`Unknown world CLI option ${JSON.stringify(option)}.`);
+    }
+    return {
+      kind: "outputs",
+      name,
+      ...(stage === undefined ? {} : { stage }),
+      ...(reveal ? { reveal: true } : {}),
+      ...(json ? { json: true } : {}),
+    };
+  }
   if (command === "list") {
     return args.length === 0 ? { kind: "list" } : helpError("The list command does not take arguments.");
   }
@@ -223,7 +262,7 @@ export function parseWorldArgs(argv: string[]): WorldCommand {
       ? { kind: "forget", name: args[0] }
       : helpError("The forget command needs exactly one world name.");
   }
-  return helpError(`Unknown command ${JSON.stringify(command)}. Script worlds support up, attach, plan, down, list, forget, and help.`);
+  return helpError(`Unknown command ${JSON.stringify(command)}. Script worlds support up, attach, outputs, plan, down, list, forget, and help.`);
 }
 
 function messageText(error: unknown): string {
@@ -236,6 +275,7 @@ async function helpText(options: WorldCliOptions): Promise<string> {
   return `Usage:
   pnpm world up <script-path-or-name> [--detach] [--timeout <ms>] [--stage <value>] [--place <local|daytona>] [--plain] [-- <script args...>]
   pnpm world attach <name> [--stage <value>] [--plain]
+  pnpm world outputs <name> [--stage <value>] [--reveal] [--json]
   pnpm world plan <script-path-or-name> [--stage <value>]
   pnpm world down <name> [--stage <value>] [--purge]
   pnpm world list
@@ -263,7 +303,9 @@ function printOutputs(
   snapshot: NonNullable<Awaited<ReturnType<typeof readScriptWorldSnapshot>>>,
   print: (line: string) => void,
 ): void {
-  for (const [key, value] of Object.entries(snapshot.outputs)) print(`${key}  ${value}`);
+  for (const line of formatOutputLines(snapshot.outputs, snapshot.outputMeta ?? {}, { reveal: false })) {
+    print(line);
+  }
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -488,6 +530,7 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
         view.ready({
           name: stagedName,
           outputs: snapshot.outputs,
+          ...(snapshot.outputMeta === undefined ? {} : { outputMeta: snapshot.outputMeta }),
           elapsedMs: Date.now() - startedAt,
           resources: await resourceCount(worldLedgerPath),
           downHint: `pnpm world down ${script.name}${stage ? ` --stage ${stage}` : ""}`,
@@ -595,6 +638,7 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
       view.ready({
         name: candidate.stagedName,
         outputs: snapshot.outputs,
+        ...(snapshot.outputMeta === undefined ? {} : { outputMeta: snapshot.outputMeta }),
         elapsedMs: eventElapsed(events),
         resources: await resourceCount(ledgerPath(snapshotDirectory, candidate.stagedName)),
         downHint: `pnpm world down ${command.name}${snapshot.stage ? ` --stage ${snapshot.stage}` : ""}`,
@@ -627,6 +671,60 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
         alivePoll.unref();
         process.once("SIGINT", detach);
       });
+      return 0;
+    } catch (error) {
+      print(messageText(error));
+      return 1;
+    }
+  }
+  if (command.kind === "outputs") {
+    const snapshotDirectory = scriptWorldSnapshotDirectory(options.cwd);
+    const candidate = await stagedReceiptCandidate(
+      snapshotDirectory,
+      command.name,
+      command.stage,
+      print,
+    );
+    if (candidate.kind !== "found") {
+      if (candidate.kind === "multiple") return 1;
+      print(`World receipt ${JSON.stringify(receiptName(command.name, command.stage))} does not exist.`);
+      return 1;
+    }
+    try {
+      const snapshot = await readScriptWorldSnapshot(candidate.path);
+      if (!snapshot) {
+        print(`World receipt ${JSON.stringify(candidate.stagedName)} does not exist.`);
+        return 1;
+      }
+      const outputMeta = snapshot.outputMeta ?? {};
+      if (!command.json) {
+        for (const line of formatOutputLines(snapshot.outputs, outputMeta, { reveal: command.reveal === true })) {
+          print(line);
+        }
+        return 0;
+      }
+      const outputs: Record<string, {
+        value: string;
+        secret: boolean;
+        group?: string;
+        note?: string;
+      }> = {};
+      for (const [key, value] of Object.entries(snapshot.outputs)) {
+        const meta = outputMeta[key];
+        const isSecret = meta?.secret === true;
+        outputs[key] = {
+          value: command.reveal || !isSecret ? value : MASK,
+          secret: isSecret,
+          ...(meta?.group === undefined ? {} : { group: meta.group }),
+          ...(meta?.note === undefined ? {} : { note: meta.note }),
+        };
+      }
+      print(JSON.stringify({
+        name: candidate.stagedName,
+        ...(snapshot.stage === undefined ? {} : { stage: snapshot.stage }),
+        alive: isProcessAlive(snapshot.pid),
+        outputs,
+      }));
       return 0;
     } catch (error) {
       print(messageText(error));

--- a/packages/world/src/events.ts
+++ b/packages/world/src/events.ts
@@ -1,5 +1,6 @@
 import { appendFile, chmod, mkdir, readFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import type { OutputMeta } from "./outputs.ts";
 
 export const EVENTS_ENV = "OPENWORK_WORLD_EVENTS";
 
@@ -17,7 +18,7 @@ export type WorldEvent = { t: string } & (
       log?: string;
     }
   | { type: "resource"; kind: string; id: string; label?: string }
-  | { type: "ready"; outputs: Record<string, string> }
+  | { type: "ready"; outputs: Record<string, string>; outputMeta?: Record<string, OutputMeta> }
   | { type: "note"; text: string }
 );
 
@@ -39,6 +40,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function optionalString(value: Record<string, unknown>, key: string): string | undefined | false {
   const entry = value[key];
   return entry === undefined || typeof entry === "string" ? entry : false;
+}
+
+function parseOutputMeta(value: unknown): Record<string, OutputMeta> | false {
+  if (!isRecord(value)) return false;
+  const outputMeta: Record<string, OutputMeta> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      !isRecord(entry)
+      || Object.keys(entry).some((name) => name !== "secret" && name !== "group" && name !== "note")
+      || (entry.secret !== undefined && typeof entry.secret !== "boolean")
+      || (entry.group !== undefined && typeof entry.group !== "string")
+      || (entry.note !== undefined && typeof entry.note !== "string")
+    ) return false;
+    outputMeta[key] = {
+      ...(typeof entry.secret === "boolean" ? { secret: entry.secret } : {}),
+      ...(typeof entry.group === "string" ? { group: entry.group } : {}),
+      ...(typeof entry.note === "string" ? { note: entry.note } : {}),
+    };
+  }
+  return outputMeta;
 }
 
 function parseEvent(line: string): WorldEvent | undefined {
@@ -88,7 +109,14 @@ function parseEvent(line: string): WorldEvent | undefined {
     for (const [key, entry] of Object.entries(value.outputs)) {
       if (typeof entry === "string") outputs[key] = entry;
     }
-    return { t: value.t, type: "ready", outputs };
+    const outputMeta = value.outputMeta === undefined ? undefined : parseOutputMeta(value.outputMeta);
+    if (outputMeta === false) return undefined;
+    return {
+      t: value.t,
+      type: "ready",
+      outputs,
+      ...(outputMeta === undefined ? {} : { outputMeta }),
+    };
   }
   if (value.type === "note" && typeof value.text === "string") {
     return { t: value.t, type: "note", text: value.text };

--- a/packages/world/src/hold.ts
+++ b/packages/world/src/hold.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendEvent, EVENTS_ENV } from "./events.ts";
+import { formatOutputLines, maskOutputs, normalizeOutputs, type OutputMeta, type WorldOutput } from "./outputs.ts";
 import { receiptName, resolveStage } from "./stage.ts";
 import { assertWorldName } from "./store.ts";
 
@@ -22,6 +23,7 @@ export interface ScriptWorldSnapshot {
   pid: number;
   sourcePath: string;
   outputs: Record<string, string>;
+  outputMeta?: Record<string, OutputMeta>;
   stage?: string;
   recipeHash?: string;
   place?: string;
@@ -29,7 +31,7 @@ export interface ScriptWorldSnapshot {
 
 export interface HoldOptions {
   name?: string;
-  outputs?: Record<string, string>;
+  outputs?: Record<string, WorldOutput>;
   snapshotDir?: string;
 }
 
@@ -78,8 +80,9 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
     );
   }
 
-  const outputs = options.outputs ?? {};
-  const version = stage !== undefined || recipeHash !== undefined || place !== undefined ? 2 : 1;
+  const { values: outputs, meta: outputMeta } = normalizeOutputs(options.outputs ?? {});
+  const hasOutputMeta = Object.keys(outputMeta).length > 0;
+  const version = stage !== undefined || recipeHash !== undefined || place !== undefined || hasOutputMeta ? 2 : 1;
   const snapshot: ScriptWorldSnapshot = {
     version,
     kind: "script",
@@ -88,6 +91,7 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
     pid: process.pid,
     sourcePath,
     outputs,
+    ...(hasOutputMeta ? { outputMeta } : {}),
     ...(stage === undefined ? {} : { stage }),
     ...(recipeHash === undefined ? {} : { recipeHash }),
     ...(place === undefined ? {} : { place }),
@@ -97,10 +101,15 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
   await chmod(snapshotPath, 0o600);
   const eventPath = process.env[EVENTS_ENV];
   if (eventPath !== undefined) {
-    await appendEvent(eventPath, { t: new Date().toISOString(), type: "ready", outputs });
+    await appendEvent(eventPath, {
+      t: new Date().toISOString(),
+      type: "ready",
+      outputs: maskOutputs(outputs, outputMeta),
+      ...(hasOutputMeta ? { outputMeta } : {}),
+    });
   }
 
-  for (const [key, value] of Object.entries(outputs)) console.log(`${key}  ${value}`);
+  for (const line of formatOutputLines(outputs, outputMeta, { reveal: false })) console.log(line);
   console.log(`World ${JSON.stringify(stagedName)} is up. Ctrl-C (or pnpm world down ${name}${stage ? ` --stage ${stage}` : ""}) tears it down.`);
 
   const keepAlive = setInterval(() => {}, 2_147_483_647);

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -12,3 +12,4 @@ export * from "./standalone-cli.ts";
 export * from "./events.ts";
 export * from "./preflight.ts";
 export * from "./view.ts";
+export * from "./outputs.ts";

--- a/packages/world/src/outputs.ts
+++ b/packages/world/src/outputs.ts
@@ -1,0 +1,89 @@
+export interface OutputMeta {
+  secret?: boolean;
+  group?: string;
+  note?: string;
+}
+
+export type WorldOutput = string | ({ value: string } & OutputMeta);
+
+export const MASK = "••••••••";
+
+export function output(value: string, meta?: Omit<OutputMeta, "secret">): WorldOutput {
+  return { value, ...meta };
+}
+
+export function secret(value: string, meta?: Omit<OutputMeta, "secret">): WorldOutput {
+  return { value, secret: true, ...meta };
+}
+
+export function normalizeOutputs(outputs: Record<string, WorldOutput>): {
+  values: Record<string, string>;
+  meta: Record<string, OutputMeta>;
+} {
+  const values: Record<string, string> = {};
+  const meta: Record<string, OutputMeta> = {};
+  for (const [key, entry] of Object.entries(outputs)) {
+    if (typeof entry === "string") {
+      values[key] = entry;
+      continue;
+    }
+    values[key] = entry.value;
+    const entryMeta: OutputMeta = {};
+    if (entry.secret !== undefined) entryMeta.secret = entry.secret;
+    if (entry.group !== undefined) entryMeta.group = entry.group;
+    if (entry.note !== undefined) entryMeta.note = entry.note;
+    if (Object.keys(entryMeta).length > 0) meta[key] = entryMeta;
+  }
+  return { values, meta };
+}
+
+export function maskOutputs(
+  values: Record<string, string>,
+  meta: Record<string, OutputMeta>,
+): Record<string, string> {
+  const masked: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    masked[key] = meta[key]?.secret === true ? MASK : value;
+  }
+  return masked;
+}
+
+export function formatOutputLines(
+  values: Record<string, string>,
+  meta: Record<string, OutputMeta>,
+  options: { reveal: boolean },
+): string[] {
+  const entries = Object.entries(values);
+  const shown = options.reveal ? values : maskOutputs(values, meta);
+  if (!entries.some(([key]) => meta[key]?.group !== undefined)) {
+    return entries.map(([key]) => `${key}  ${shown[key]}`);
+  }
+
+  const ungrouped: Array<[string, string]> = [];
+  const groups = new Map<string, Array<[string, string]>>();
+  for (const entry of entries) {
+    const group = meta[entry[0]]?.group;
+    if (group === undefined) {
+      ungrouped.push(entry);
+      continue;
+    }
+    const groupEntries = groups.get(group) ?? [];
+    groupEntries.push(entry);
+    groups.set(group, groupEntries);
+  }
+
+  const lines: string[] = [];
+  const appendBlock = (block: Array<[string, string]>, indent: string): void => {
+    const width = Math.max(...block.map(([key]) => key.length));
+    for (const [key] of block) {
+      const note = meta[key]?.note;
+      lines.push(`${indent}${key.padEnd(width)}  ${shown[key]}${note === undefined ? "" : `  ${note}`}`);
+    }
+  };
+  if (ungrouped.length > 0) appendBlock(ungrouped, "");
+  for (const [group, groupEntries] of groups) {
+    lines.push(group);
+    appendBlock(groupEntries, "  ");
+  }
+  return lines;
+}

--- a/packages/world/src/script-world.ts
+++ b/packages/world/src/script-world.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { EVENTS_ENV, eventsPath } from "./events.ts";
 import { LEDGER_ENV, ledgerPath } from "./ledger.ts";
+import { formatOutputLines, type OutputMeta } from "./outputs.ts";
 import { receiptName } from "./stage.ts";
 import { assertWorldName } from "./store.ts";
 import type { ScriptWorldSnapshot } from "./hold.ts";
@@ -21,6 +22,26 @@ function isStringRecord(value: unknown): value is Record<string, string> {
   return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
 }
 
+function parseOutputMeta(value: unknown): Record<string, OutputMeta> | false {
+  if (!isRecord(value)) return false;
+  const outputMeta: Record<string, OutputMeta> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      !isRecord(entry)
+      || Object.keys(entry).some((name) => name !== "secret" && name !== "group" && name !== "note")
+      || (entry.secret !== undefined && typeof entry.secret !== "boolean")
+      || (entry.group !== undefined && typeof entry.group !== "string")
+      || (entry.note !== undefined && typeof entry.note !== "string")
+    ) return false;
+    outputMeta[key] = {
+      ...(typeof entry.secret === "boolean" ? { secret: entry.secret } : {}),
+      ...(typeof entry.group === "string" ? { group: entry.group } : {}),
+      ...(typeof entry.note === "string" ? { note: entry.note } : {}),
+    };
+  }
+  return outputMeta;
+}
+
 function recordedPid(text: string): number | undefined {
   const value: unknown = JSON.parse(text);
   if (!isRecord(value) || typeof value.pid !== "number" || !Number.isInteger(value.pid) || value.pid <= 0) {
@@ -31,6 +52,9 @@ function recordedPid(text: string): number | undefined {
 
 export function parseScriptWorldSnapshot(text: string): ScriptWorldSnapshot {
   const value: unknown = JSON.parse(text);
+  const outputMeta = isRecord(value) && value.outputMeta !== undefined
+    ? parseOutputMeta(value.outputMeta)
+    : undefined;
   if (
     !isRecord(value)
     || (value.version !== 1 && value.version !== 2)
@@ -42,6 +66,7 @@ export function parseScriptWorldSnapshot(text: string): ScriptWorldSnapshot {
     || value.pid <= 0
     || typeof value.sourcePath !== "string"
     || !isStringRecord(value.outputs)
+    || (value.outputMeta !== undefined && (value.version !== 2 || outputMeta === false))
     || (value.version === 2 && "stage" in value && value.stage !== undefined && typeof value.stage !== "string")
     || (value.version === 2 && "recipeHash" in value && value.recipeHash !== undefined && typeof value.recipeHash !== "string")
     || (value.version === 2 && "place" in value && value.place !== undefined && typeof value.place !== "string")
@@ -56,6 +81,7 @@ export function parseScriptWorldSnapshot(text: string): ScriptWorldSnapshot {
     pid: value.pid,
     sourcePath: value.sourcePath,
     outputs: value.outputs,
+    ...(outputMeta === undefined || outputMeta === false ? {} : { outputMeta }),
     ...(value.version === 2 && typeof value.stage === "string" ? { stage: value.stage } : {}),
     ...(value.version === 2 && typeof value.recipeHash === "string" ? { recipeHash: value.recipeHash } : {}),
     ...(value.version === 2 && typeof value.place === "string" ? { place: value.place } : {}),
@@ -249,7 +275,9 @@ export async function launchScriptWorld(options: LaunchScriptWorldOptions): Prom
     if (spawnError) throw spawnError;
     const snapshot = await readScriptWorldSnapshot(snapshotPath);
     if (snapshot) {
-      for (const [key, value] of Object.entries(snapshot.outputs)) options.print(`${key}  ${value}`);
+      for (const line of formatOutputLines(snapshot.outputs, snapshot.outputMeta ?? {}, { reveal: false })) {
+        options.print(line);
+      }
       options.print(`snapshot  ${snapshotPath}`);
       options.print(`log  ${logPath}`);
       return 0;

--- a/packages/world/src/view.ts
+++ b/packages/world/src/view.ts
@@ -1,5 +1,6 @@
 import { styleText } from "node:util";
 import type { WorldEvent } from "./events.ts";
+import { formatOutputLines, type OutputMeta } from "./outputs.ts";
 import type { PreflightResult } from "./preflight.ts";
 
 export interface ViewSink {
@@ -21,6 +22,7 @@ export interface WorldView {
   ready(input: {
     name: string;
     outputs: Record<string, string>;
+    outputMeta?: Record<string, OutputMeta>;
     elapsedMs: number;
     resources: number;
     downHint: string;
@@ -243,9 +245,11 @@ export function createWorldView(options: {
     ready(input): void {
       finish();
       const lines = [`${paint("green", "✔")} ${input.name} is up${options.mode === "tty" ? "  " : " "}(${formatElapsed(input.elapsedMs)} · ${input.resources} resources)`];
-      const width = Math.max(0, ...Object.keys(input.outputs).map((key) => key.length));
-      for (const [key, value] of Object.entries(input.outputs)) lines.push(`${key.padEnd(width)}  ${value}`);
-      lines.push(`Ctrl-C to stop · ${input.downHint}${input.log ? ` · log ${input.log}` : ""}`);
+      const outputMeta = input.outputMeta ?? {};
+      lines.push(...formatOutputLines(input.outputs, outputMeta, { reveal: false }));
+      const hasSecrets = Object.values(outputMeta).some((meta) => meta.secret === true);
+      const revealHint = input.downHint.replace("pnpm world down", "pnpm world outputs");
+      lines.push(`Ctrl-C to stop · ${input.downHint}${input.log ? ` · log ${input.log}` : ""}${hasSecrets ? ` · secrets: ${revealHint} --reveal` : ""}`);
       if (options.mode === "plain") {
         for (const line of lines) writeLine(line);
       } else {

--- a/packages/world/test/cli.test.ts
+++ b/packages/world/test/cli.test.ts
@@ -91,6 +91,25 @@ test("world arguments expose only script lifecycle flags and forward arguments a
     stage: "preview",
     plain: true,
   });
+  assert.deepEqual(parseWorldArgs(["outputs", "dev-headless"]), {
+    kind: "outputs",
+    name: "dev-headless",
+  });
+  assert.deepEqual(parseWorldArgs(["outputs", "dev-headless", "--stage", "preview", "--reveal", "--json"]), {
+    kind: "outputs",
+    name: "dev-headless",
+    stage: "preview",
+    reveal: true,
+    json: true,
+  });
+  const missingOutputsName = parseWorldArgs(["outputs"]);
+  assert.equal(missingOutputsName.kind, "help");
+  if (missingOutputsName.kind !== "help") throw new Error("expected help");
+  assert.match(missingOutputsName.error ?? "", /needs exactly one world name/);
+  const outputsPurge = parseWorldArgs(["outputs", "dev-headless", "--purge"]);
+  assert.equal(outputsPurge.kind, "help");
+  if (outputsPurge.kind !== "help") throw new Error("expected help");
+  assert.match(outputsPurge.error ?? "", /Unknown world CLI option "--purge"/);
   const missingAttachName = parseWorldArgs(["attach", "--plain"]);
   assert.equal(missingAttachName.kind, "help");
   if (missingAttachName.kind !== "help") throw new Error("expected help");

--- a/packages/world/test/hold.test.ts
+++ b/packages/world/test/hold.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 import { EVENTS_ENV, readEvents } from "../src/events.ts";
+import { MASK } from "../src/outputs.ts";
+import { parseScriptWorldSnapshot } from "../src/script-world.ts";
 
 function isAlive(pid: number): boolean {
   try {
@@ -32,9 +34,11 @@ test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
   const receiptPath = join(snapshots, "hold-only.json");
   const eventPath = join(snapshots, "hold-only.events.jsonl");
   const holdUrl = new URL("../src/hold.ts", import.meta.url).href;
+  const outputsUrl = new URL("../src/outputs.ts", import.meta.url).href;
   await writeFile(worldPath, [
     `import { hold } from ${JSON.stringify(holdUrl)};`,
-    'await hold({ outputs: { ok: "1" } });',
+    `import { secret } from ${JSON.stringify(outputsUrl)};`,
+    'await hold({ outputs: { url: "http://x", token: secret("s3cr3t", { group: "Keys" }) } });',
     "",
   ].join("\n"), "utf8");
 
@@ -53,7 +57,19 @@ test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
     );
     await delay(1_000);
     assert.equal(isAlive(pid), true, "world exited while hold was awaiting a signal");
-    assert.deepEqual((await readEvents(eventPath)).map((event) => event.type), ["ready"]);
+    const receiptText = await readFile(receiptPath, "utf8");
+    const receipt = parseScriptWorldSnapshot(receiptText);
+    assert.equal(receipt.version, 2);
+    assert.equal(receipt.outputs.token, "s3cr3t");
+    assert.equal(receipt.outputMeta?.token?.secret, true);
+    const events = await readEvents(eventPath);
+    assert.deepEqual(events, [{
+      t: events[0]?.t,
+      type: "ready",
+      outputs: { url: "http://x", token: MASK },
+      outputMeta: { token: { secret: true, group: "Keys" } },
+    }]);
+    assert.equal((await readFile(eventPath, "utf8")).includes("s3cr3t"), false);
 
     process.kill(pid, "SIGTERM");
     assert.equal(await waitFor(() => !isAlive(pid), 5_000), true, "world did not exit after SIGTERM");

--- a/packages/world/test/outputs.test.ts
+++ b/packages/world/test/outputs.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatOutputLines,
+  MASK,
+  maskOutputs,
+  normalizeOutputs,
+  output,
+  secret,
+} from "../src/outputs.ts";
+
+test("outputs normalize structured values and mask secrets", () => {
+  const normalized = normalizeOutputs({
+    url: "http://localhost",
+    email: output("a@b", { group: "Accounts" }),
+    token: secret("s3cr3t", { group: "Keys", note: "master" }),
+  });
+  assert.deepEqual(normalized, {
+    values: { url: "http://localhost", email: "a@b", token: "s3cr3t" },
+    meta: {
+      email: { group: "Accounts" },
+      token: { secret: true, group: "Keys", note: "master" },
+    },
+  });
+  assert.deepEqual(maskOutputs(normalized.values, normalized.meta), {
+    url: "http://localhost",
+    email: "a@b",
+    token: MASK,
+  });
+});
+
+test("legacy output lines retain the exact key, two spaces, value format", () => {
+  assert.deepEqual(formatOutputLines(
+    { url: "http://localhost", token: "s3cr3t" },
+    { token: { secret: true, note: "not rendered without groups" } },
+    { reveal: false },
+  ), [
+    "url  http://localhost",
+    `token  ${MASK}`,
+  ]);
+});
+
+test("grouped output lines preserve group order, align blocks, show notes, and reveal secrets", () => {
+  const values = {
+    url: "http://localhost",
+    adminEmail: "a@b",
+    apiKey: "sk-1",
+    adminPassword: "pw",
+  };
+  const meta = {
+    adminEmail: { group: "Accounts" },
+    apiKey: { secret: true, group: "Keys", note: "master" },
+    adminPassword: { secret: true, group: "Accounts" },
+  };
+  assert.deepEqual(formatOutputLines(values, meta, { reveal: false }), [
+    "url  http://localhost",
+    "Accounts",
+    "  adminEmail     a@b",
+    `  adminPassword  ${MASK}`,
+    "Keys",
+    `  apiKey  ${MASK}  master`,
+  ]);
+  assert.deepEqual(formatOutputLines(values, meta, { reveal: true }), [
+    "url  http://localhost",
+    "Accounts",
+    "  adminEmail     a@b",
+    "  adminPassword  pw",
+    "Keys",
+    "  apiKey  sk-1  master",
+  ]);
+});

--- a/packages/world/test/store.test.ts
+++ b/packages/world/test/store.test.ts
@@ -41,6 +41,7 @@ test("script world snapshots parse v1 and strict v2 receipts", () => {
     stage: "preview",
     recipeHash: "sha256:abc",
     place: "local",
+    outputMeta: { url: { secret: true, group: "Services", note: "primary" } },
   })), {
     version: 2,
     ...base,
@@ -48,10 +49,22 @@ test("script world snapshots parse v1 and strict v2 receipts", () => {
     stage: "preview",
     recipeHash: "sha256:abc",
     place: "local",
+    outputMeta: { url: { secret: true, group: "Services", note: "primary" } },
   });
   assert.throws(
     () => parseScriptWorldSnapshot(JSON.stringify({ version: 2, ...base, stage: 1 })),
     /not a valid script world snapshot/,
   );
+  for (const outputMeta of [
+    { url: { secret: "yes" } },
+    { url: { group: 1 } },
+    { url: { note: false } },
+    { url: { label: "extra" } },
+  ]) {
+    assert.throws(
+      () => parseScriptWorldSnapshot(JSON.stringify({ version: 2, ...base, outputMeta })),
+      /not a valid script world snapshot/,
+    );
+  }
   assert.throws(() => parseScriptWorldSnapshot("{}"), /not a valid script world snapshot/);
 });

--- a/packages/world/test/view.test.ts
+++ b/packages/world/test/view.test.ts
@@ -43,7 +43,7 @@ test("plain view emits stable event, ready, and failure lines without ANSI", () 
     "✖ Second — broken",
     "+ tmpdir  cache /tmp/a",
     "✔ demo is up (1m 04s · 1 resources)",
-    "url    http://localhost",
+    "url  http://localhost",
     "token  secret",
     "Ctrl-C to stop · pnpm world down demo · log /tmp/demo.log",
     "✖ demo failed at \"Second\" (12.3s)",
@@ -55,6 +55,30 @@ test("plain view emits stable event, ready, and failure lines without ANSI", () 
     "",
   ].join("\n"));
   assert.doesNotMatch(output, /\u001b/);
+});
+
+test("ready output masks secrets and adds the reveal hint", () => {
+  let output = "";
+  const sink: ViewSink = { write: (text) => { output += text; }, isTTY: false };
+  const view = createWorldView({ sink, mode: "plain", color: false });
+  view.ready({
+    name: "demo--preview",
+    outputs: { url: "http://localhost", token: "s3cr3t" },
+    outputMeta: { token: { secret: true } },
+    elapsedMs: 100,
+    resources: 0,
+    downHint: "pnpm world down demo --stage preview",
+    log: "/tmp/demo.log",
+  });
+  view.stop();
+  assert.equal(output, [
+    "✔ demo--preview is up (0.1s · 0 resources)",
+    "url  http://localhost",
+    `token  ••••••••`,
+    "Ctrl-C to stop · pnpm world down demo --stage preview · log /tmp/demo.log · secrets: pnpm world outputs demo --stage preview --reveal",
+    "",
+  ].join("\n"));
+  assert.equal(output.includes("s3cr3t"), false);
 });
 
 test("plain view emits a stalled-step heartbeat at most once per interval", async () => {

--- a/worlds/acme-demo.ts
+++ b/worlds/acme-demo.ts
@@ -5,6 +5,7 @@ import type { Den } from "../evals/packages/env/src/den.ts";
 import { resolvePlace } from "../evals/packages/env/src/place.ts";
 import type { Place } from "../evals/packages/env/src/place.ts";
 import { hold } from "../packages/world/src/hold.ts";
+import { output, secret } from "../packages/world/src/outputs.ts";
 
 export interface AcmeDemoWorld {
   den: Den;
@@ -20,6 +21,7 @@ export async function bootAcmeDemo(
   const den = stack.use(await server({
     place,
     ports: { api: 8790, web: 3005 },
+    env: { DEN_DASHBOARDS_ENABLED: "true" },
     seedProfile: "demo-org",
     web: true,
   }));
@@ -34,10 +36,14 @@ export async function main(): Promise<void> {
   await hold({
     name: "acme-demo",
     outputs: {
-      denWeb: den.ref.webUrl,
-      denApi: den.ref.apiUrl,
-      alexCdp: alex.handle.cdpUrl,
-      jordanCdp: jordan.handle.cdpUrl,
+      denWeb: output(den.ref.webUrl, { group: "URLs" }),
+      denApi: output(den.ref.apiUrl, { group: "URLs" }),
+      alexCdp: output(alex.handle.cdpUrl, { group: "URLs" }),
+      jordanCdp: output(jordan.handle.cdpUrl, { group: "URLs" }),
+      alexEmail: output(den.admin.email, { group: "Accounts", note: "org owner (Acme)" }),
+      alexPassword: secret(den.admin.password, { group: "Accounts" }),
+      jordan: output("not signed in", { group: "Accounts", note: "fresh desktop, no account" }),
+      dashboards: output("enabled", { group: "Org", note: "DEN_DASHBOARDS_ENABLED=true" }),
     },
   });
 }

--- a/worlds/litellm-per-member.ts
+++ b/worlds/litellm-per-member.ts
@@ -1,5 +1,6 @@
 import { app } from "../evals/packages/env/src/desktop-app.ts";
 import type { App } from "../evals/packages/env/src/desktop-app.ts";
+import { denFetch } from "../evals/packages/behaviors/src/den.ts";
 import { createAdmin, createOrg, inviteMember, server } from "../evals/packages/env/src/den.ts";
 import type { Den, DenOrgHandle } from "../evals/packages/env/src/den.ts";
 import { liteLlmPerMemberProvider } from "../evals/packages/env/src/litellm-provider.ts";
@@ -14,6 +15,14 @@ export const LITELLM_WORLD_MODEL = "openwork-litellm-per-member-model";
 export const LITELLM_WORLD_PASSWORD = "OpenWorkEval123!";
 
 const REPLY = "The database-backed per-member LiteLLM world is working.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function messageText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 export interface LiteLlmPerMemberWorld {
   gateway: LiteLlmHandle;
@@ -83,11 +92,42 @@ export async function bootLiteLlmPerMember(
 
 export const litellmPerMember = recipe("litellm-per-member", async (tools) => {
   const world = await bootLiteLlmPerMember(tools.stack, tools.place, tools);
+  let aliceKey = tools.output("unavailable", { group: "Keys", note: "member key was not requested" });
+  try {
+    const connected = await denFetch(
+      world.alice,
+      `/v1/llm-providers/${encodeURIComponent(world.provider.providerRecordId)}/connect`,
+      { headers: { authorization: `Bearer ${world.alice.token}` } },
+    );
+    if (!connected.response.ok) {
+      throw new Error(`LiteLLM member connect failed (${connected.response.status}): ${connected.text}`);
+    }
+    const connectedProvider = isRecord(connected.body) && isRecord(connected.body.llmProvider)
+      ? connected.body.llmProvider
+      : null;
+    const memberKey = connectedProvider && typeof connectedProvider.apiKey === "string"
+      ? connectedProvider.apiKey
+      : null;
+    if (memberKey === null) throw new Error("LiteLLM member connect response did not include an API key");
+    aliceKey = tools.secret(memberKey, { group: "Keys", note: "per-member virtual key (Den connect)" });
+  } catch (error) {
+    aliceKey = tools.output("unavailable", { group: "Keys", note: messageText(error) });
+  }
   return {
-    denWeb: world.den.ref.webUrl,
-    denApi: world.den.ref.apiUrl,
-    litellm: world.gateway.baseUrl,
-    cdp: world.desktop.handle.cdpUrl,
+    denWeb: tools.output(world.den.ref.webUrl, { group: "URLs" }),
+    denApi: tools.output(world.den.ref.apiUrl, { group: "URLs" }),
+    litellm: tools.output(world.gateway.baseUrl, { group: "URLs" }),
+    cdp: tools.output(world.desktop.handle.cdpUrl, { group: "URLs" }),
+    adminEmail: tools.output("litellm-admin@openwork.test", { group: "Accounts" }),
+    adminPassword: tools.secret(LITELLM_WORLD_PASSWORD, { group: "Accounts" }),
+    aliceEmail: tools.output("alice-litellm@openwork.test", { group: "Accounts" }),
+    alicePassword: tools.secret(LITELLM_WORLD_PASSWORD, { group: "Accounts" }),
+    litellmMasterKey: tools.secret(world.gateway.apiKey, { group: "Keys", note: "LiteLLM admin key" }),
+    litellmUpstreamKey: tools.secret(world.gateway.upstreamKey, { group: "Keys", note: "witness upstream key" }),
+    aliceKey,
+    providerId: tools.output(LITELLM_WORLD_PROVIDER, { group: "Provider" }),
+    modelId: tools.output(LITELLM_WORLD_MODEL, { group: "Provider" }),
+    providerRecordId: tools.output(world.provider.providerRecordId, { group: "Provider" }),
   };
 });
 


### PR DESCRIPTION
Follows #4286. Worlds can now publish what a human actually needs when testing — accounts, keys, ids — and secrets are handled deliberately instead of sprayed into terminals and journals. Also turns dashboards on by default in the demo.

## What you see

```
✔ litellm-per-member is up (1m 04s · 8 resources)
url-style plain keys first, then groups:
URLs
  denWeb            http://127.0.0.1:3005
  litellm           http://127.0.0.1:51877/v1
Accounts
  adminEmail        litellm-admin@openwork.test
  adminPassword     ••••••••
  aliceEmail        alice-litellm@openwork.test
  alicePassword     ••••••••
Keys
  litellmMasterKey  ••••••••  LiteLLM admin key
  litellmUpstreamKey ••••••••  witness upstream key
  aliceKey          ••••••••  per-member virtual key (Den connect)
Provider
  providerId        openwork-litellm-per-member
  modelId           openwork-litellm-per-member-model
Ctrl-C to stop · pnpm world down litellm-per-member · log … · secrets: pnpm world outputs litellm-per-member --reveal
```

`pnpm world outputs <name> [--stage] [--reveal] [--json]` re-prints any world's outputs; `--reveal` shows secrets; `--json` gives scripts/agents `{ name, stage?, alive, outputs: { key: { value, secret, group?, note? } } }` (secret values masked unless `--reveal`).

## What changed
- **Output model** (`packages/world/src/outputs.ts`): `string | { value, secret?, group?, note? }` via `output()` / `secret()` (also `tools.output` / `tools.secret` in recipes). Worlds with only string outputs render **byte-identically** to today (no headings) — every existing exact-string spec is unchanged.
- **Secrets**: raw values live only in the `0600` receipt. The events journal (`ready` event), the progress view, hold's stdout and the detach `print` lines all carry `••••••••`. The ready hint gains a `secrets: pnpm world outputs … --reveal` segment only when a secret exists.
- **acme-demo** publishes URLs, alex's account (`alex@acme.test` + secret password read from the Den handle), jordan's status, and now boots its Den with **`DEN_DASHBOARDS_ENABLED=true`** (verified at runtime: `GET /v1/me/desktop-config → dashboardEnabled=true`); the flag is echoed as an `Org › dashboards` output.
- **litellm-per-member** publishes admin/alice accounts, LiteLLM master + upstream keys, alice's per-member virtual key fetched through Den's `/llm-providers/:id/connect` with alice's session (graceful `unavailable` + reason if that call fails), and provider/model ids. `bootLiteLlmPerMember` is unchanged (the E2E spec still calls it 2-arg).
- Also fixes a `never[]` narrowing in `world-up-progress.test.ts` that #4286 introduced (an `assert.deepEqual(x, [])` assertion signature).

## Verification (PR head, local lane — no Daytona credentials in this environment; the spec is app-less)

| Check | Result |
|---|---|
| `pnpm --filter @openwork/world test` (outputs normalize/mask/group, receipt `outputMeta` parse, hold writes raw to receipt + masked to journal, CLI flags, view hint) | 43/43 |
| **New** `pnpm evals:pr specs/world-outputs-secrets.test.ts` — grouped masked stdout + narration, raw secret only in the 0600 receipt, journal never holds it, `outputs` / `--reveal` / `--json`, `attach` masked, legacy string world byte-identical, missing receipt | 1/1 |
| Exact-string guards: `world-up-progress`, `world-crash-reap`, `world-reap-docker`, `world-stage-isolation`, `world-plan-idempotent-up`, `script-world-lifecycle`, `shared-world-engine`, `local-host-live-profile-prune` | 1/1 ×7, 3/3 |
| `node evals/bin/evals.mjs litellm-per-member-world --local` | 1/1 |
| Runtime: `world up litellm-per-member --stage k` → `outputs --reveal` shows a real `sk-…` alice key; journal `grep -c sk-` = 0; `world up acme-demo` → alex creds revealed, `dashboardEnabled=true` from den-api | manual |

Classified: `pnpm evals:typecheck` = 594 on this branch vs 594 on clean `dev` (0 introduced; −1 vs #4286's leak); full PR lane reds are `google-workspace-connector-retrieval` (red on `dev`) and `sso-super-admin-registration` (solo-green, full-lane parallelism). One `@openwork/world` unit-test run out of eight failed with no reproducible test name under machine load during Docker teardown — flagging it; if CI shows it, I'll chase it.

**Not merging — left open for review as requested.**