### PR TITLE
fix(app): stop per-frame shimmer repaints and nested pane blurs while a thread runs

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -487,7 +487,14 @@ select:disabled {
 }
 
 /* Quiet text shimmer for lightweight loading hints (e.g. cloud worker
-   sessions catching up): a soft highlight sweeps across muted text. */
+   sessions catching up): a soft highlight sweeps across muted text.
+
+   `background-position` is not a compositor-animatable property, so a smooth
+   sweep repaints the text mask on the main thread every vsync (120/s on
+   ProMotion) for as long as a run is active. On the macOS shell that damage
+   sits under the pane backdrop blur, so every one of those paints also
+   re-runs the full-pane blur pass. Stepping the sweep keeps the same look
+   while repainting twenty times a second instead of every frame. */
 @keyframes ow-text-shimmer {
   0% {
     background-position: 150% 0;
@@ -510,7 +517,7 @@ select:disabled {
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  animation: ow-text-shimmer 2.4s linear infinite;
+  animation: ow-text-shimmer 2.4s steps(48, end) infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1423,8 +1423,13 @@ export function SessionPage(props: SessionPageProps) {
             className="min-h-0 flex-1 max-lg:rounded-none lg:rounded-[14px]"
           >
             <ResizablePanel minSize={isMobile ? "0px" : "360px"} className="min-w-0">
-              <main className="flex h-full min-w-0 flex-col overflow-hidden bg-dls-surface max-lg:rounded-none max-lg:border-0 max-lg:shadow-none lg:rounded-[14px] lg:border lg:border-border lg:shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:lg:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
-          <header className="z-10 flex h-9 shrink-0 items-center justify-between border-b border-border px-3 max-lg:h-12 lg:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
+              <main data-session-pane className="flex h-full min-w-0 flex-col overflow-hidden bg-dls-surface max-lg:rounded-none max-lg:border-0 max-lg:shadow-none lg:rounded-[14px] lg:border lg:border-border lg:shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:lg:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+          {/* The pane `<main>` above already carries the macOS vibrancy blur. A
+              second backdrop filter on the header (or on the transcript surface
+              below) is invisible — nothing scrolls beneath either — but each
+              one forces an extra full-pane blur pass every frame the transcript
+              repaints. Keep the pane as the only backdrop surface. */}
+          <header className="z-10 flex h-9 shrink-0 items-center justify-between border-b border-border px-3 max-lg:h-12 lg:px-6 mac:titlebar-drag @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
               {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
               {parentSessionLink && !props.primarySlot && !hasMainContentTakeover ? (
@@ -1637,7 +1642,7 @@ export function SessionPage(props: SessionPageProps) {
             className="min-h-0 flex-1 overflow-hidden"
           >
             <ResizablePanel minSize="180px" className="min-h-0">
-            <div className="relative h-full min-w-0 overflow-hidden bg-dls-surface mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+            <div className="relative h-full min-w-0 overflow-hidden bg-dls-surface mac:bg-dls-surface/85">
               {props.primarySlot ? (
                 <div className="h-full overflow-y-auto" data-workspace-primary-slot>
                   {props.primarySlot}

--- a/evals/specs/chat-loading-shimmer.e2e.test.ts
+++ b/evals/specs/chat-loading-shimmer.e2e.test.ts
@@ -4,19 +4,91 @@ import { arrangeControl, shimmerChat } from "../worlds/chat.ts";
 
 const test = spec.world(shimmerChat);
 
+// `.ow-text-shimmer` animates `background-position`, which Chromium paints on
+// the main thread, so its sweep is stepped (`steps(48, end)` over 2.4s): twenty
+// repaints a second instead of one per vsync. A second of sampled frames should
+// therefore show about twenty distinct positions, with a little slack for step
+// boundaries, while a smooth `linear` sweep changes on every sampled frame.
+const maxDistinctShimmerPositions = 24;
+// Below this many animation frames per second the sample cannot tell a stepped
+// sweep from a smooth one, so the claim is unreadable rather than proven.
+const minSampledFrames = 30;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 test("chat working and command activity use quiet shimmer without spinners", async ({ world, user, seed, probe, step }) => {
-  await step("the main Working state shimmers without a spinner", async () => {
+  const working = await step("the main Working state shimmers without a spinner", async () => {
     await user.see({ text: /Working/ });
-    // TODO(primitive): inspect the visual treatment classes on a visible status row.
-    const working = await probe.eval(`(() => {
+    // TODO(primitive): inspect the visual treatment, animation cadence, and backdrop composition of a visible status row.
+    const reading = await probe.eval(`(async () => {
       const row = document.querySelector('[data-loading-message="working"]');
+      const shimmer = row?.querySelector(".ow-text-shimmer");
+      const pane = document.querySelector("main[data-session-pane]");
+      const header = pane?.querySelector("header");
+      const filterOf = (element) => getComputedStyle(element).backdropFilter;
+      const nestedFilters = [];
+      if (row instanceof HTMLElement && pane instanceof HTMLElement) {
+        for (let node = row.parentElement; node && node !== pane; node = node.parentElement) {
+          const filter = filterOf(node);
+          if (filter !== "none") nestedFilters.push(node.tagName.toLowerCase() + ": " + filter);
+        }
+      }
+      const positions = new Set();
+      let sampledFrames = 0;
+      if (shimmer instanceof HTMLElement) {
+        const startedAt = performance.now();
+        await new Promise((resolve) => {
+          const sample = (now) => {
+            positions.add(getComputedStyle(shimmer).backgroundPosition);
+            sampledFrames += 1;
+            if (now - startedAt >= 1000) resolve(undefined);
+            else requestAnimationFrame(sample);
+          };
+          requestAnimationFrame(sample);
+        });
+      }
       return {
         text: row instanceof HTMLElement ? row.innerText.trim() : "",
         hasSpinner: Boolean(row?.querySelector(".animate-spin")),
-        hasShimmer: Boolean(row?.querySelector(".ow-text-shimmer")),
+        hasShimmer: shimmer instanceof HTMLElement,
+        animationName: shimmer instanceof HTMLElement ? getComputedStyle(shimmer).animationName : "",
+        sampledFrames,
+        distinctPositions: positions.size,
+        isMac: document.documentElement.classList.contains("openwork-platform-mac"),
+        paneFilter: pane instanceof HTMLElement ? filterOf(pane) : "",
+        headerFilter: header instanceof HTMLElement ? filterOf(header) : "",
+        nestedFilters,
       };
-    })()`);
-    expect(working).toMatchObject({ text: expect.stringContaining("Working"), hasSpinner: false, hasShimmer: true });
+    })()`, { awaitPromise: true, timeoutMs: 15_000 });
+    expect(reading).toMatchObject({ text: expect.stringContaining("Working"), hasSpinner: false, hasShimmer: true });
+    return reading;
+  });
+
+  await step("the Working shimmer keeps sweeping but repaints on a bounded cadence instead of every frame", async () => {
+    expect(working).toMatchObject({ animationName: "ow-text-shimmer" });
+    if (!isRecord(working) || typeof working.sampledFrames !== "number" || typeof working.distinctPositions !== "number") {
+      throw new Error(`Shimmer cadence was not readable: ${JSON.stringify(working)}`);
+    }
+    expect(working.sampledFrames).toBeGreaterThanOrEqual(minSampledFrames);
+    expect(working.distinctPositions).toBeGreaterThanOrEqual(2);
+    expect(working.distinctPositions).toBeLessThanOrEqual(maxDistinctShimmerPositions);
+  });
+
+  await step("the session pane is the only backdrop-filter surface above the transcript", async () => {
+    // The macOS shell blurs the vibrancy backdrop once, on the session pane.
+    // Nothing scrolls beneath the pane header or behind the transcript surface,
+    // so any further backdrop filter between the pane and the Working row is an
+    // invisible extra full-pane blur pass on every transcript repaint.
+    if (!isRecord(working) || typeof working.isMac !== "boolean") {
+      throw new Error(`Pane composition was not readable: ${JSON.stringify(working)}`);
+    }
+    expect(working).toMatchObject({
+      paneFilter: working.isMac ? expect.stringContaining("blur(") : "none",
+      headerFilter: "none",
+      nestedFilters: [],
+    });
   });
 
   await arrangeControl(seed, world.app, "eval.session_lifecycle.seed_unfinished_tools", { lifecycle: "active" });


### PR DESCRIPTION
## Problem

The desktop app flickers intermittently while a thread is running, most visibly on macOS. Installed `0.18.41-alpha.2603` already contains the earlier render fixes (#4098, #4104, #4109, #4122, #4123, #4130, #4212, #4232, #4237), so the residual was traced live against the running app with Chrome tracing.

Two things kept the render pipeline hot for the whole run:

1. **The running-state shimmer repaints every frame.** `.ow-text-shimmer` animates `background-position` under `background-clip: text`. Chromium cannot run that on the compositor, so every "Working Ns" row and running tool label repainted its text mask on the main thread on every vsync — 120/s on ProMotion — for as long as the run was active. `PaintImage` events in the trace name the shimmer span.
2. **Three stacked backdrop blurs above the transcript.** On the macOS shell the session pane `<main>`, its `<header>`, and the transcript surface each carried `backdrop-filter: blur(40px) saturate(1.5)` over the `#00000001` vibrancy window. Nested backdrop filters need backdrop-scope surfaces, so viz drew five render passes per frame and re-ran full-pane blurs at 2× DPR on every repaint.

Baseline trace of a live run (44 s, 120 Hz display): 360 main-thread commits/s, 600 render passes/s, GPU process busy ~250 ms per second, 91 dropped frames, 18 frame gaps of 75–85 ms; after streaming ended and only the shimmer remained, draws fell to 42–55 fps with 21–27 partially presented frames per second. On a transparent vibrancy window those late/partial frames read as the whole window flashing.

## Change

- `.ow-text-shimmer`: `linear` → `steps(48, end)`. Same 2.4 s sweep, repainting 20 times a second instead of every frame. Measured on comparable streaming: commits 360 → 18/s, shimmer repaints 120 → ~20/s, GPU main thread ~180 → ~22 ms/s, dropped frames 91 → 3.
- Session pane stays the only backdrop-filter surface: removed the redundant `mac:backdrop-blur-2xl mac:backdrop-saturate-150` from the pane header and the transcript surface. Nothing scrolls beneath either, so the look is unchanged; the compositor now draws two render passes instead of five per repaint. The pane `<main>` keeps the vibrancy blur (`data-session-pane` added as the spec hook).
- `evals/specs/chat-loading-shimmer.e2e.test.ts`, on the `spec.world()` primitives from #4337. The existing Working-row probe now also reads the animation cadence and the backdrop composition, so the file stays at its channel-ratchet baseline of three raw probes and each claim gets its own `step`:
  - New claim: the Working shimmer keeps sweeping (`animation-name` stays `ow-text-shimmer`) but its painted position takes at most 24 distinct values across a second of sampled frames (≥ 30 frames required for the sample to be readable; a smooth sweep changes on every one). Negative control with the previous `linear` CSS fails this claim at `expected 121 to be less than or equal to 24`.
  - New claim: no backdrop filter sits between the Working row and the pane, the header reports `none`, and the pane itself reports `blur(` on the macOS shell (`none` elsewhere).
  - The aggregate-row alignment (`Reading brief.md` without the retired `Now:` prefix) landed on `dev` in #4337 and is no longer part of this diff.

## Proof

Lane: **local** (Daytona credentials unavailable in this environment — no `DAYTONA_*` variables and no Infisical login session; tooling is installed). Cold boot through the `shimmerChat` world, no Den reuse override set.

| Check | Command | Result |
| --- | --- | --- |
| Head-matching E2E | `pnpm evals:e2e chat-loading-shimmer --local` on `01344d6b1` | exit 0 — 1 passed / 0 failed / 0 skipped; evidence `gitSha 01344d6b1cf4ba09018dd1a3061059c227806715`; all 5 steps green (published above) |
| Negative control (old CSS) | same command with `index.css` from `origin/dev@b315c76d5` | exit 1 — `expected 121 to be less than or equal to 24` |
| Channel ratchet | `node evals/scripts/spec-channel-ratchet.mjs` | pass — `chat-loading-shimmer.e2e.test.ts` stays at its baseline of 3 |
| App typecheck | `pnpm --filter @openwork/app typecheck` | exit 0 |
| Focused unit tests | `bun test --isolate tests/message-list-loading.test.tsx tests/tool-aggregate-group.test.tsx tests/subagent-run-line.test.tsx` | 28 pass / 0 fail |
| Production CSS | `pnpm --filter @openwork/app build` | emits `animation:2.4s steps(48,end) infinite ow-text-shimmer` |
| Spec impact | `node evals/scripts/spec-impact.mjs --changed-file …` | `desktop.chat-composer` covered by the changed E2E test |
| Whitespace | `git diff --check` | clean |

Pre-existing, control-verified: `pnpm evals:typecheck` reports 615 errors on this branch and 615 on clean `origin/dev@b315c76d5` (identical set); none in the changed spec.

## Follow-ups (intentionally out of scope)

- The side-panel and artifact-panel header rows use the same nested `mac:backdrop-blur-2xl` pattern inside the already-blurred side-panel root; they only cost while that panel is open and belong to other contracts.
- A compositor-only shimmer (opacity/transform) would remove the remaining 20 paints/s entirely at the cost of a visual redesign; the stepped sweep keeps #4109's look.
- A `probe` primitive for computed-style and animation-cadence readings would let this spec drop its remaining raw probes.
