### PR TITLE
feat: choose workspace run modes from the composer

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1541,6 +1541,20 @@ async function requestBinary(
   return { data, contentType, filename };
 }
 
+export type WorkspaceRunMode = "default" | "approve" | "run-everything";
+export type WorkspaceRunModeResponse = {
+  mode: WorkspaceRunMode | null;
+  catchAll: "ask" | "allow" | "deny" | null;
+  path: string;
+  supported: boolean;
+  reason?: string;
+  refreshPending: boolean;
+};
+export type WorkspaceRunModeUpdate = WorkspaceRunModeResponse & {
+  changed: boolean;
+  refresh: "reloaded" | "deferred" | "skipped";
+};
+
 export function createOpenworkServerClient(options: { baseUrl: string; token?: string; hostToken?: string }) {
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
   const token = options.token;
@@ -1746,6 +1760,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         `/workspace/${workspaceId}/config`,
         { token, hostToken, timeoutMs: timeouts.config },
       ),
+    getWorkspaceRunMode: (workspaceId: string) =>
+      requestJson<WorkspaceRunModeResponse>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/permissions/mode`, {
+        token, hostToken, timeoutMs: timeouts.config,
+      }),
+    setWorkspaceRunMode: (workspaceId: string, mode: WorkspaceRunMode) =>
+      requestJson<WorkspaceRunModeUpdate>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/permissions/mode`, {
+        token, hostToken, method: "PUT", body: { mode }, timeoutMs: 60_000,
+      }),
     getEffectivePermissions: (workspaceId: string) =>
       requestJson<OpenworkEffectivePermissionsResponse>(
         baseUrl,

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -9,6 +9,7 @@ import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelOption, Mod
 import { t } from "@/i18n";
 import type { ComposerSettingsSection } from "@/react-app/domains/settings/library";
 import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
+import { WorkspaceRunModeMenu } from "@/react-app/domains/session/surface/composer/workspace-run-mode-menu";
 import { encodeComposerMentionValue, type ComposerMentionKind } from "@/react-app/domains/session/surface/composer/mention-encoding";
 import {
   createPastedTextChip,
@@ -253,6 +254,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
 
   return (
     <ReactSessionComposer
+      runModeControl={<WorkspaceRunModeMenu client={workspaceClient} workspaceId={workspaceId} busy={props.busy} />}
       draft={props.draft}
       mentions={mentions}
       onDraftChange={handleDraftChange}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -117,6 +117,7 @@ type ComposerProps = {
   /** Render inline in a page (new-task hero): no sticky dock chrome or inner max-width, aligning with sibling content. */
   flush?: boolean;
   topAccessory?: ReactNode;
+  runModeControl?: ReactNode;
 };
 
 const FLUSH_PROMPT_EVENT = "openwork:flushPromptDraft";
@@ -1650,6 +1651,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                     document.body,
                   ) : null}
                 </div>
+                {props.runModeControl}
                 <button
                   type="button"
                   className={`inline-flex h-9 max-h-9 w-9 shrink-0 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 ${

--- a/apps/app/src/react-app/domains/session/surface/composer/workspace-run-mode-menu.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/workspace-run-mode-menu.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Hand, LoaderCircle, ShieldAlert, ShieldCheck } from "lucide-react";
+import type { OpenworkServerClient, WorkspaceRunMode } from "@/app/lib/openwork-server";
+import { isDesktopRuntime } from "@/app/lib/runtime-env";
+import { toast } from "@/components/ui/sonner";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
+import { useFeatureFlagsPreferences } from "@/react-app/domains/settings/state/feature-flags-preferences";
+
+type Props = { client: OpenworkServerClient | null; workspaceId: string | null; busy: boolean };
+
+const modes = [
+  { value: "approve", label: "Ask before actions", description: "Pause for tool approval unless a workspace rule allows it.", icon: Hand },
+  { value: "default", label: "Workspace defaults", description: "Use your existing setup to decide when to ask.", icon: ShieldCheck },
+  { value: "run-everything", label: "Keep going", description: "Allow tools by default, including files outside this workspace.", icon: ShieldAlert },
+] satisfies { value: WorkspaceRunMode; label: string; description: string; icon: typeof Hand }[];
+
+export function WorkspaceRunModeMenu(props: Props) {
+  const { workspaceRunModeEnabled } = useFeatureFlagsPreferences();
+  const restricted = useDesktopRestriction("allowControlSettings");
+  if (!workspaceRunModeEnabled || restricted || !isDesktopRuntime() || !props.client || !props.workspaceId) return null;
+  // Remount on endpoint/workspace changes so a pending confirmation cannot
+  // apply the previous pane's choice to a newly selected workspace.
+  return <WorkspaceRunModePicker key={`${props.client.baseUrl}:${props.workspaceId}`} client={props.client} workspaceId={props.workspaceId} busy={props.busy} />;
+}
+
+function WorkspaceRunModePicker({ client, workspaceId, busy }: { client: OpenworkServerClient; workspaceId: string; busy: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const queryClient = useQueryClient();
+  const queryKey = ["workspace-run-mode", client.baseUrl, workspaceId];
+  const mode = useQuery({ queryKey, queryFn: () => client.getWorkspaceRunMode(workspaceId), retry: false });
+  const mutation = useMutation({
+    mutationKey: queryKey,
+    mutationFn: (value: WorkspaceRunMode) => client.setWorkspaceRunMode(workspaceId, value),
+    onSuccess: (result) => {
+      queryClient.setQueryData(queryKey, result);
+      setConfirm(false);
+      setOpen(false);
+      if (result.refreshPending) toast.warning(result.reason ?? "Saved. Reload this workspace before relying on the new mode.");
+      else toast.success("Workspace run mode updated.");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+      void mode.refetch();
+    },
+  });
+  const selected = modes.find((item) => item.value === mode.data?.mode);
+  const label = mode.isError ? "Unavailable" : selected?.label ?? (mode.isPending ? "Loading" : "Custom rules");
+  const Icon = mode.data?.supported === false || mode.isError || mode.data?.refreshPending ? ShieldAlert : selected?.icon ?? ShieldCheck;
+  const locked = busy || mutation.isPending || mode.isFetching || !mode.data?.supported;
+  const select = (value: unknown) => {
+    if (locked || (value !== "default" && value !== "approve" && value !== "run-everything")) return;
+    if (value === "run-everything") {
+      setOpen(false);
+      setConfirm(true);
+    } else mutation.mutate(value);
+  };
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={(next) => { setOpen(next); if (next) void mode.refetch(); }}>
+        <DropdownMenuTrigger
+          data-testid="workspace-run-mode-trigger"
+          aria-label={`Workspace run mode: ${label}${mode.data?.refreshPending ? " (refresh pending)" : ""}`}
+          title={`Workspace run mode: ${label}${mode.data?.refreshPending ? " — refresh pending" : ""}`}
+          className={`inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-gray-3 ${mode.data?.mode === "run-everything" || mode.data?.refreshPending ? "text-orange-600 dark:text-orange-400" : "text-gray-10"}`}
+        >
+          {mutation.isPending ? <LoaderCircle className="size-4 animate-spin" /> : <Icon className="size-4" />}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" sideOffset={10} className="w-[min(390px,calc(100vw-32px))] p-2">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel className="px-3 text-sm">How should OpenWork handle approvals?</DropdownMenuLabel>
+            <DropdownMenuRadioGroup value={mode.data?.mode ?? ""}>
+              {modes.map((item) => (
+                <DropdownMenuRadioItem key={item.value} value={item.value} onClick={() => select(item.value)} aria-label={item.label} data-testid={`run-mode-${item.value}`} disabled={locked} className={`gap-3 py-3 ${item.value === "run-everything" ? "text-orange-600 dark:text-orange-400" : ""}`}>
+                  <item.icon className="size-5" />
+                  <span className="min-w-0">
+                    <span className="block">{item.label}</span>
+                    <span className="mt-0.5 block text-xs font-normal text-muted-foreground">{item.description}</span>
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <p className="px-3 py-2 text-xs text-muted-foreground">Applies to every chat in this workspace. Specific workspace rules still apply.</p>
+          {busy ? <p role="status" className="px-3 pb-2 text-xs text-muted-foreground">Wait for this workspace to finish before changing its mode.</p> : null}
+          {mode.isError ? <p role="alert" className="px-3 pb-2 text-xs text-destructive">Run modes are unavailable. {mode.error.message}</p> : null}
+          {mode.data?.reason ? <p role="status" className="px-3 pb-2 text-xs text-muted-foreground">{mode.data.reason}</p> : null}
+          {mode.data?.refreshPending ? <p role="status" className="px-3 pb-2 text-xs text-orange-600">Saved, but engine refresh is pending. Select the mode again to retry.</p> : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog open={confirm} onOpenChange={setConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Let OpenWork keep going?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This changes every chat in this workspace. Tools can edit or delete files, run commands, and use the network without approval, including outside authorized folders. It can override global permission rules and repeated-action prompts. Specific workspace rules still apply; it does not grant operating-system or service access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={mutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction disabled={locked} onClick={() => mutation.mutate("run-everything")}>Enable Keep going</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -45,6 +45,7 @@ import type {
   CloudMcpSubmissionResult,
 } from "@/react-app/domains/connections/cloud-mcp-submit-readiness";
 import { ReactSessionComposer } from "./composer/composer";
+import { WorkspaceRunModeMenu } from "./composer/workspace-run-mode-menu";
 import { useSessionModelSelection } from "./session-model-store";
 import type { ProviderCatalog } from "./use-model-behavior";
 import type { ModelAvailability } from "./model-availability";
@@ -2913,6 +2914,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
           </div>
         ) : null}
         <ReactSessionComposer
+          runModeControl={<WorkspaceRunModeMenu client={props.client} workspaceId={props.workspaceId} busy={chatStreaming || preparingCloudTools || Boolean(props.activePermission || props.activeQuestion)} />}
           draft={draft}
           mentions={mentions}
           onDraftChange={handleComposerDraftChange}

--- a/apps/app/src/react-app/domains/settings/advanced-sections.ts
+++ b/apps/app/src/react-app/domains/settings/advanced-sections.ts
@@ -4,5 +4,6 @@ export const ADVANCED_SETTINGS_SECTIONS = [
   { id: "agent-access", title: "Agent access diagnostics", keywords: ["cloud mcp", "health", "tools", "connections"] },
   { id: "config-sources", title: "OpenCode config sources", keywords: ["runtime db", "injected config", "project config", "global config"] },
   { id: "experimental-engine", title: "Experimental engine", keywords: ["engine v2", "chat engine", "preview"] },
+  { id: "workspace-run-mode", title: "Workspace run mode", keywords: ["approvals", "permissions", "keep going", "feature flag"] },
   { id: "developer", title: "Developer", keywords: ["developer mode", "debug", "deep link"] },
 ];

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -26,6 +26,8 @@ import { isDesktopRuntime } from "@/app/utils";
 import { t } from "@/i18n";
 import { ControlPlaneUrlEditor } from "../cloud/control-plane-url-editor";
 import { usePlatform } from "../../../kernel/platform";
+import { useFeatureFlagsPreferences } from "../state/feature-flags-preferences";
+import { useDesktopRestriction } from "../../cloud/desktop-config-provider";
 import {
   displayCustomControlPlaneUrl,
   isValidControlPlaneUrl,
@@ -733,6 +735,34 @@ export function AdvancedOpencodeSection(props: AdvancedOpencodeSectionProps) {
           <AlertDescription>{t("settings.exa_unavailable")}</AlertDescription>
         </Alert>
         <LayoutSectionItemFootnote>{t("settings.exa_restart_hint")}</LayoutSectionItemFootnote>
+      </LayoutSectionItem>
+    </LayoutSection>
+  );
+}
+
+export function AdvancedWorkspaceRunModeSection() {
+  const { workspaceRunModeEnabled, toggleWorkspaceRunMode } = useFeatureFlagsPreferences();
+  const restricted = useDesktopRestriction("allowControlSettings");
+  if (!isDesktopRuntime()) return null;
+  return (
+    <LayoutSection id="advanced-workspace-run-mode">
+      <LayoutSectionHeader>
+        <LayoutSectionTitle>Workspace run mode</LayoutSectionTitle>
+        <LayoutSectionDescription>Experimental approval controls in the composer.</LayoutSectionDescription>
+      </LayoutSectionHeader>
+      <LayoutSectionItem>
+        <LayoutSectionItemHeader>
+          <LayoutSectionItemTitle>Show workspace run mode</LayoutSectionItemTitle>
+          <LayoutSectionItemDescription>
+            Choose when OpenWork asks before acting, using the icon beside attachments. Off by default. Available with the standard desktop engine.
+          </LayoutSectionItemDescription>
+          <LayoutSectionItemHeaderActions>
+            <Switch aria-label="Show workspace run mode" checked={workspaceRunModeEnabled} disabled={restricted} onCheckedChange={toggleWorkspaceRunMode} />
+          </LayoutSectionItemHeaderActions>
+        </LayoutSectionItemHeader>
+        <LayoutSectionItemFootnote>
+          This switch only shows or hides the control. Hiding it does not reset workspace permissions; choose Workspace defaults in the menu first if you want to remove the override.
+        </LayoutSectionItemFootnote>
       </LayoutSectionItem>
     </LayoutSection>
   );

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -757,7 +757,7 @@ export function AdvancedWorkspaceRunModeSection() {
             Choose when OpenWork asks before acting, using the icon beside attachments. Off by default. Available with the standard desktop engine.
           </LayoutSectionItemDescription>
           <LayoutSectionItemHeaderActions>
-            <Switch aria-label="Show workspace run mode" checked={workspaceRunModeEnabled} disabled={restricted} onCheckedChange={toggleWorkspaceRunMode} />
+            <Switch data-testid="workspace-run-mode-flag" aria-label="Show workspace run mode" checked={workspaceRunModeEnabled} disabled={restricted} onCheckedChange={toggleWorkspaceRunMode} />
           </LayoutSectionItemHeaderActions>
         </LayoutSectionItemHeader>
         <LayoutSectionItemFootnote>

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -20,6 +20,7 @@ import {
   AdvancedOrganizationServerSection,
   AdvancedRuntimeConfigSourcesSection,
   AdvancedRuntimeSection,
+  AdvancedWorkspaceRunModeSection,
 } from "./advanced-view-sections";
 
 type AdvancedOrganizationServerSession = Pick<
@@ -219,6 +220,8 @@ export function AdvancedView(props: AdvancedViewProps) {
           setEnabled={props.setEngineV2PreviewEnabled}
           setChatRouting={props.setEngineV2PreviewChatRouting}
         />
+
+        <AdvancedWorkspaceRunModeSection />
 
         <AdvancedDeveloperSection
           busy={props.busy}

--- a/apps/app/src/react-app/domains/settings/state/feature-flags-preferences.ts
+++ b/apps/app/src/react-app/domains/settings/state/feature-flags-preferences.ts
@@ -5,6 +5,17 @@ import { useLocal } from "../../../kernel/local-provider";
 export function useFeatureFlagsPreferences() {
   const { prefs, setPrefs } = useLocal();
 
+  const workspaceRunModeEnabled = prefs.featureFlags?.workspaceRunMode === true;
+  const toggleWorkspaceRunMode = useCallback(() => {
+    setPrefs((previous) => ({
+      ...previous,
+      featureFlags: {
+        ...previous.featureFlags,
+        workspaceRunMode: !previous.featureFlags?.workspaceRunMode,
+      },
+    }));
+  }, [setPrefs]);
+
   const microsandboxCreateSandboxEnabled =
     prefs.featureFlags?.microsandboxCreateSandbox === true;
 
@@ -19,6 +30,8 @@ export function useFeatureFlagsPreferences() {
   }, [setPrefs]);
 
   return {
+    workspaceRunModeEnabled,
+    toggleWorkspaceRunMode,
     microsandboxCreateSandboxEnabled,
     toggleMicrosandboxCreateSandbox,
   };

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -48,6 +48,7 @@ export type LocalPreferences = {
   releaseChannel: ReleaseChannel;
   featureFlags: {
     microsandboxCreateSandbox: boolean;
+    workspaceRunMode: boolean;
   };
   /**
    * Set to true after the user completes the welcome/onboarding flow
@@ -87,7 +88,7 @@ const INITIAL_PREFS: LocalPreferences = {
   defaultModel: null,
   selectedAgent: null,
   releaseChannel: "stable",
-  featureFlags: { microsandboxCreateSandbox: true },
+  featureFlags: { microsandboxCreateSandbox: true, workspaceRunMode: false },
   hasCompletedOnboarding: false,
   analyticsEnabled: true,
   desktopNotifications: DEFAULT_DESKTOP_NOTIFICATION_PREFERENCE,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -120,6 +120,7 @@ import {
 import { runAgentContextDiagnostics } from "./agent-context-diagnostics.js";
 import { createAgentDiagnosticsEngineFetch, validateEffectiveEngineSnapshot } from "./agent-context-engine-inspection.js";
 import { selectGoverningAgent, summarizeEffectivePermissions } from "./effective-permissions.js";
+import { readWorkspaceRunMode, setWorkspaceRunMode, type WorkspaceRunModeState } from "./workspace-run-mode.js";
 import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
 import {
   mergeOpencodeConfigs,
@@ -2840,6 +2841,97 @@ function createRoutes(
     return jsonResponse({ item: removed, warnings: [] });
   });
 
+  const pendingRunModeRefresh = new Set<string>();
+  const runModeState = async (workspace: WorkspaceInfo): Promise<WorkspaceRunModeState & { path: string }> => {
+    const state = await readWorkspaceRunMode(workspace.path);
+    if (engineV2Preview.status().chatRouting) {
+      return { ...state, supported: false, reason: "Workspace run modes are unavailable while OpenCode v2 chat routing is enabled." };
+    }
+    if (workspace.workspaceType === "remote" || resolve(resolveOpencodeDirectory(workspace) ?? workspace.path) !== resolve(workspace.path)) {
+      return { ...state, supported: false, reason: "Workspace run modes require an engine using this local workspace directory." };
+    }
+    return state;
+  };
+
+  addRoute(routes, "GET", "/workspace/:id/permissions/mode", "client", async (ctx) => {
+    const state = await runModeState(await resolveWorkspace(config, ctx.params.id));
+    return jsonResponse({ ...state, refreshPending: pendingRunModeRefresh.has(state.path) });
+  });
+
+  addRoute(routes, "PUT", "/workspace/:id/permissions/mode", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const mode = body.mode;
+    if (mode !== "default" && mode !== "approve" && mode !== "run-everything") {
+      throw new ApiError(400, "invalid_payload", 'mode must be "default", "approve", or "run-everything"');
+    }
+    const initial = await runModeState(workspace);
+    if (!initial.supported) throw new ApiError(409, "workspace_run_mode_unsupported", initial.reason);
+    await requireWorkspaceRunModeIdle(config, workspace);
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "config.write",
+      summary: mode === "run-everything"
+        ? "Allow tools by default in this workspace, keeping narrower permission rules"
+        : mode === "approve"
+          ? "Ask before tools by default in this workspace, keeping narrower permission rules"
+          : "Remove this workspace's permission catch-all, keeping narrower rules and inherited permissions",
+      paths: [initial.path],
+    });
+    return withEngineDirectoryFence(config, workspace, async () => {
+      // Approval can wait while another session starts or the runtime changes.
+      const current = await runModeState(workspace);
+      if (!current.supported) throw new ApiError(409, "workspace_run_mode_unsupported", current.reason);
+      await requireWorkspaceRunModeIdle(config, workspace);
+      const changed = await setWorkspaceRunMode(workspace.path, mode);
+      if (changed) {
+        pendingRunModeRefresh.add(current.path);
+        emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(current.path));
+      }
+      await recordAudit(workspace.path, {
+        id: shortId(),
+        workspaceId: workspace.id,
+        actor: ctx.actor ?? { type: "remote" },
+        action: "config.write",
+        target: current.path,
+        summary: `Set workspace run mode to ${mode}`,
+        timestamp: Date.now(),
+      });
+      let refresh: "reloaded" | "deferred" | "skipped" = "skipped";
+      if (pendingRunModeRefresh.has(current.path)) {
+        refresh = "deferred";
+        try {
+          if (engineV2Preview.status().chatRouting) throw new Error("OpenCode v2 chat routing is enabled");
+          await requireWorkspaceRunModeIdle(config, workspace);
+          // Directory-scoped disposal leaves other workspaces alone. The
+          // detached MCP sync uses the same fence, so do not await it here.
+          await reloadOpencodeEngineInPlace(config, workspace, engineMcpServerState, { awaitPostRefreshSync: false });
+          const opencode = createWorkspaceOpencodeClient(config, workspace, { boundedDiagnosticsReads: true });
+          const [configResult, agentResult] = await Promise.all([opencode.config.get({}), opencode.app.agents({})]);
+          const snapshot = validateEffectiveEngineSnapshot({
+            config: unwrapOpencodeResult(configResult, "/config"),
+            agents: unwrapOpencodeResult(agentResult, "/agent"),
+          });
+          if (engineV2Preview.status().chatRouting || !snapshot || !selectGoverningAgent(snapshot.agents, snapshot.defaultAgent)) throw new Error("Engine reload could not be confirmed");
+          pendingRunModeRefresh.delete(current.path);
+          refresh = "reloaded";
+        } catch {
+          // The file is saved, not necessarily applied. Keep the event and
+          // retry on a subsequent PUT even when the requested mode is unchanged.
+        }
+      }
+      return jsonResponse({
+        ...await runModeState(workspace),
+        changed,
+        refresh,
+        refreshPending: refresh === "deferred",
+        ...(refresh === "deferred" ? { reason: "Saved to the workspace config; engine refresh is pending. Wait for idle sessions and retry, or reload the workspace." } : {}),
+      });
+    });
+  });
+
   addRoute(routes, "GET", "/workspace/:id/permissions/effective", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     // The engine's own evaluated ruleset decides; OpenWork only names the
@@ -4430,6 +4522,40 @@ function parseOpencodeErrorBody(input: string): unknown {
 function opencodeDisposeTimeoutMs(): number {
   const configured = Number(process.env.OPENWORK_ENGINE_DISPOSE_TIMEOUT_MS ?? "");
   return Number.isFinite(configured) && configured > 0 ? configured : 30_000;
+}
+
+async function requireWorkspaceRunModeIdle(config: ServerConfig, workspace: WorkspaceInfo): Promise<void> {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const connections = new Map<string, string | undefined>();
+  if (connection.baseUrl) connections.set(connection.baseUrl, connection.authHeader);
+  // Include draining generations: a waiting permission can belong to an older
+  // engine even when the primary reports no active sessions.
+  for (const entry of enginePoolForConfig(config)?.connections() ?? []) {
+    connections.set(entry.baseUrl, buildEngineAuthProbeHeader(entry.username, entry.password));
+  }
+  await Promise.all([...connections].map(async ([baseUrl, authorization]) => {
+    await Promise.all(["/session/status", "/permission", "/question"].map(async (path) => {
+      let payload: unknown;
+      try {
+        const url = new URL(path, baseUrl);
+        const directory = resolveOpencodeDirectory(workspace);
+        if (directory) url.searchParams.set("directory", directory);
+        const response = await loopbackFetch(url.toString(), {
+          headers: authorization ? { Authorization: authorization } : {},
+          signal: AbortSignal.timeout(5_000),
+        });
+        if (!response.ok) throw new Error("Activity probe failed");
+        payload = await response.json();
+      } catch {
+        throw new ApiError(409, "workspace_run_mode_activity_unknown", "Cannot verify that all workspace sessions are idle; no permission change was made.");
+      }
+      if (path === "/session/status" ? !isRecord(payload) || Object.values(payload).some((status) => !isRecord(status) || typeof status.type !== "string") : !Array.isArray(payload)) {
+        throw new ApiError(409, "workspace_run_mode_activity_unknown", "OpenCode returned unreadable workspace activity; no permission change was made.");
+      }
+      const busy = Array.isArray(payload) ? payload.length > 0 : isRecord(payload) && Object.values(payload).some((status) => isRecord(status) && status.type !== "idle");
+      if (busy) throw new ApiError(409, "workspace_run_mode_busy", "Wait for all workspace sessions, including permission and question requests, to finish before changing run mode.");
+    }));
+  }));
 }
 
 /**

--- a/apps/server/src/workspace-run-mode.test.ts
+++ b/apps/server/src/workspace-run-mode.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse } from "jsonc-parser";
+import { readAuditEntries } from "./audit.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+import { opencodeConfigPath } from "./workspace-files.js";
+import { readWorkspaceRunMode, runModeFromPermissionBlock, setWorkspaceRunMode, type WorkspaceRunMode } from "./workspace-run-mode.js";
+
+const roots: string[] = [];
+const stops: Array<() => void | Promise<void>> = [];
+const savedEnv = {
+  OPENWORK_DATA_DIR: process.env.OPENWORK_DATA_DIR,
+  OPENWORK_TOKEN_STORE: process.env.OPENWORK_TOKEN_STORE,
+  OPENWORK_ENGINE_V2_PREVIEW: process.env.OPENWORK_ENGINE_V2_PREVIEW,
+};
+const headers = { authorization: "Bearer owt_run_mode", "content-type": "application/json" };
+const hostHeaders = { "x-openwork-host-token": "owt_run_mode_host", "content-type": "application/json" };
+
+async function workspaceRoot(content?: string) {
+  const root = await mkdtemp(join(tmpdir(), "openwork-run-mode-"));
+  roots.push(root);
+  if (content !== undefined) await writeFile(join(root, "opencode.json"), content);
+  return root;
+}
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("workspace run mode file", () => {
+  test("default means no catch-all, never deny or an unsupported rule shape", () => {
+    expect(runModeFromPermissionBlock(undefined)).toEqual({ mode: "default", catchAll: null, supported: true });
+    expect(runModeFromPermissionBlock({ bash: { "rm *": "deny" } })).toEqual({ mode: "default", catchAll: null, supported: true });
+    expect(runModeFromPermissionBlock("allow")).toEqual({ mode: "run-everything", catchAll: "allow", supported: true });
+    expect(runModeFromPermissionBlock({ "*": "ask" })).toEqual({ mode: "approve", catchAll: "ask", supported: true });
+    for (const block of ["deny", { "*": "deny" }, { "*": { "*": "allow" } }, { "*": null }, null, [], false, "invalid", { bash: 1 }, { edit: { "*": [] } }]) {
+      expect(runModeFromPermissionBlock(block)).toMatchObject({ mode: null, supported: false });
+    }
+  });
+
+  test("creates the preferred config only when needed and keeps shorthand spelling", async () => {
+    const root = await workspaceRoot();
+    expect(await setWorkspaceRunMode(root, "default")).toBe(false);
+    await expect(readFile(opencodeConfigPath(root))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await setWorkspaceRunMode(root, "approve")).toBe(true);
+    expect(opencodeConfigPath(root)).toBe(join(root, "opencode.jsonc"));
+    expect(parse(await readFile(opencodeConfigPath(root), "utf8"))).toEqual({ permission: { "*": "ask" } });
+    expect(await setWorkspaceRunMode(root, "approve")).toBe(false);
+    const shorthand = await workspaceRoot('{ /* root */ "permission" /* key */ : /* value */ "allow", // trailing\n "model": "local/model" }');
+    expect(await setWorkspaceRunMode(shorthand, "approve")).toBe(true);
+    expect(parse(await readFile(opencodeConfigPath(shorthand), "utf8"))).toEqual({ permission: "ask", model: "local/model" });
+    expect(await setWorkspaceRunMode(shorthand, "default")).toBe(true);
+    const content = await readFile(opencodeConfigPath(shorthand), "utf8");
+    expect(parse(content)).toEqual({ model: "local/model" });
+    for (const comment of ["/* root */", "/* key */", "/* value */", "// trailing"]) expect(content).toContain(comment);
+  });
+
+  test("places even an unchanged trailing catch-all before narrow rules without deleting comments", async () => {
+    const narrow = '"bash": { /* pattern */ "rm *": "deny", "git status": "allow" }';
+    for (const block of [
+      `// narrow\n${narrow}, // catch-all\n"*" /* key, */ : /* value */ "allow" // end`,
+      `"*": "allow", /* narrow */ ${narrow},`,
+      `"edit": "ask", "*": "allow", // narrow\n${narrow}`,
+      `/* narrow */ ${narrow}`,
+      `/* empty */`,
+    ]) {
+      const root = await workspaceRoot(`{\r\n // root\r\n "permission": {${block}\n}, "model": "local/model"\r\n}`);
+      const before = await readFile(opencodeConfigPath(root), "utf8");
+      await setWorkspaceRunMode(root, "run-everything");
+      const content = await readFile(opencodeConfigPath(root), "utf8");
+      const errors: { error: number; offset: number; length: number }[] = [];
+      const data = parse(content, errors, { allowTrailingComma: true });
+      expect(errors).toEqual([]);
+      expect(Object.keys(data.permission)[0]).toBe("*");
+      expect(data.model).toBe("local/model");
+      if (block.includes(narrow)) expect(content).toContain(narrow);
+      for (const comment of before.match(/\/\*[^]*?\*\/|\/\/[^\r\n]*/g) ?? []) expect(content).toContain(comment);
+      expect(await setWorkspaceRunMode(root, "run-everything")).toBe(false);
+      expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(content);
+      expect(await setWorkspaceRunMode(root, "default")).toBe(true);
+      const restored = await readFile(opencodeConfigPath(root), "utf8");
+      expect(parse(restored, [], { allowTrailingComma: true }).permission["*"]).toBeUndefined();
+      if (block.includes(narrow)) expect(restored).toContain(narrow);
+      for (const comment of before.match(/\/\*[^]*?\*\/|\/\/[^\r\n]*/g) ?? []) expect(restored).toContain(comment);
+    }
+  });
+
+  test("rejects invalid JSONC, duplicate keys, and unsupported shapes without touching bytes", async () => {
+    for (const content of [
+      "{ broken", "[]", "null", "", '{"permission":"deny"}', '{"permission":{"*":{"*":"ask"}}}',
+      '{"permission":{ "*":"allow", "*":"ask" }}', '{"permission":{},"permission":{}}',
+      '{"permission":{"bash":{"*":"ask","*":"deny"}}}', '{"permission":{"edit":false}}',
+    ]) {
+      const root = await workspaceRoot(content);
+      expect(await readWorkspaceRunMode(root)).toMatchObject({ mode: null, supported: false });
+      const modes: WorkspaceRunMode[] = ["default", "approve", "run-everything"];
+      for (const mode of modes) {
+        await expect(setWorkspaceRunMode(root, mode)).rejects.toMatchObject({ status: 409, code: "workspace_run_mode_unsupported" });
+        expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(content);
+      }
+    }
+  });
+});
+
+async function startModeServer(options: { readOnly?: boolean; approval?: ServerConfig["approval"]; engine?: boolean } = {}) {
+  const root = await workspaceRoot('{"permission":{"edit":"deny"},"model":"local/model"}');
+  process.env.OPENWORK_DATA_DIR = join(root, "data");
+  process.env.OPENWORK_TOKEN_STORE = join(root, "tokens.json");
+  delete process.env.OPENWORK_ENGINE_V2_PREVIEW;
+  const engineState: { statuses: unknown; permissions: unknown[]; questions: unknown[]; statusCode: number; disposeCode: number; agentCode: number; disposals: number; probes: string[] } = {
+    statuses: {}, permissions: [], questions: [], statusCode: 200, disposeCode: 200, agentCode: 200, disposals: 0, probes: [],
+  };
+  const engine = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (["/session/status", "/permission", "/question", "/instance/dispose"].includes(url.pathname)) engineState.probes.push(url.searchParams.get("directory") ?? "");
+      if (url.pathname === "/session/status") return Response.json(engineState.statuses, { status: engineState.statusCode });
+      if (url.pathname === "/permission") return Response.json(engineState.permissions);
+      if (url.pathname === "/question") return Response.json(engineState.questions);
+      if (url.pathname === "/instance/dispose") {
+        engineState.disposals++;
+        return Response.json(true, { status: engineState.disposeCode });
+      }
+      if (url.pathname === "/config") return Response.json({ default_agent: "build" });
+      if (url.pathname === "/agent") return Response.json([{ name: "build", mode: "primary", permission: [] }], { status: engineState.agentCode });
+      if (url.pathname === "/mcp") return Response.json({});
+      return Response.json({}, { status: 404 });
+    },
+  });
+  stops.push(() => engine.stop(true));
+  const config: ServerConfig = {
+    host: "127.0.0.1", port: 0, configPath: join(root, "server.json"), token: "owt_run_mode", hostToken: "owt_run_mode_host",
+    approval: options.approval ?? { mode: "auto", timeoutMs: 1_000 }, corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local", ...(options.engine === false ? {} : { baseUrl: `http://127.0.0.1:${engine.port}` }) }],
+    authorizedRoots: [root], readOnly: options.readOnly ?? false, startedAt: Date.now(), tokenSource: "cli", hostTokenSource: "cli", logFormat: "pretty", logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  const origin = `http://127.0.0.1:${server.port}`;
+  const base = `${origin}/workspace/ws_1/permissions/mode`;
+  const put = (mode: string) => fetch(base, { method: "PUT", headers, body: JSON.stringify({ mode }) });
+  return { root, origin, base, put, engineState };
+}
+
+describe("workspace run mode API", () => {
+  test("authenticates, preserves narrower rules, audits, emits config events, and reloads idle engines", async () => {
+    const { root, origin, base, put, engineState } = await startModeServer();
+    expect((await fetch(base)).status).toBe(401);
+    expect(await (await fetch(base, { headers })).json()).toEqual({ mode: "default", catchAll: null, supported: true, path: opencodeConfigPath(root), refreshPending: false });
+    const changed = await put("run-everything");
+    expect(changed.status).toBe(200);
+    expect(await changed.json()).toMatchObject({ mode: "run-everything", catchAll: "allow", supported: true, changed: true, refresh: "reloaded" });
+    expect(parse(await readFile(opencodeConfigPath(root), "utf8"))).toEqual({ permission: { "*": "allow", edit: "deny" }, model: "local/model" });
+    expect(engineState.disposals).toBe(1);
+    expect(engineState.probes.every((directory) => directory === root)).toBe(true);
+    expect(await (await put("run-everything")).json()).toMatchObject({ changed: false, refresh: "skipped" });
+    expect(engineState.disposals).toBe(1);
+    expect(await (await put("default")).json()).toMatchObject({ mode: "default", catchAll: null, changed: true, refresh: "reloaded" });
+    expect((await put("unknown")).status).toBe(400);
+    expect((await readAuditEntries(root, "ws_1")).some((entry) => entry.action === "config.write" && entry.target === opencodeConfigPath(root))).toBe(true);
+    const events = await (await fetch(`${origin}/workspace/ws_1/events`, { headers })).json();
+    expect(events.items.some((entry: { reason: string }) => entry.reason === "config")).toBe(true);
+    const issued = await (await fetch(`${origin}/tokens`, { method: "POST", headers: hostHeaders, body: JSON.stringify({ scope: "viewer", label: "viewer" }) })).json();
+    const viewerHeaders = { ...headers, authorization: `Bearer ${issued.token}` };
+    expect((await fetch(base, { headers: viewerHeaders })).status).toBe(200);
+    const before = await readFile(opencodeConfigPath(root), "utf8");
+    expect((await fetch(base, { method: "PUT", headers: viewerHeaders, body: JSON.stringify({ mode: "approve" }) })).status).toBe(403);
+    expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(before);
+  });
+
+  test("refuses other busy sessions, retries, permission waits, questions, and unknown activity before writing", async () => {
+    const { root, put, engineState } = await startModeServer();
+    const before = await readFile(opencodeConfigPath(root), "utf8");
+    for (const statuses of [{ current: { type: "idle" }, other: { type: "busy" } }, { child: { type: "retry", attempt: 1 } }]) {
+      engineState.statuses = statuses;
+      expect(await (await put("run-everything")).json()).toMatchObject({ code: "workspace_run_mode_busy" });
+    }
+    engineState.statuses = {};
+    engineState.permissions = [{ id: "permission_1", sessionID: "other" }];
+    expect((await put("approve")).status).toBe(409);
+    engineState.permissions = [];
+    engineState.questions = [{ id: "question_1", sessionID: "other" }];
+    expect((await put("approve")).status).toBe(409);
+    engineState.questions = [];
+    engineState.statuses = [];
+    expect(await (await put("approve")).json()).toMatchObject({ code: "workspace_run_mode_activity_unknown" });
+    engineState.statusCode = 503;
+    expect((await put("approve")).status).toBe(409);
+    expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(before);
+    expect(engineState.disposals).toBe(0);
+    expect(await readAuditEntries(root, "ws_1")).toEqual([]);
+  });
+
+  test("reports deferred after failed reload or snapshot and retries an unchanged saved mode", async () => {
+    const { put, engineState } = await startModeServer();
+    engineState.disposeCode = 503;
+    expect(await (await put("approve")).json()).toMatchObject({ mode: "approve", changed: true, refresh: "deferred", reason: expect.any(String) });
+    engineState.disposeCode = 200;
+    engineState.agentCode = 503;
+    expect(await (await put("approve")).json()).toMatchObject({ changed: false, refresh: "deferred" });
+    engineState.agentCode = 200;
+    expect(await (await put("approve")).json()).toMatchObject({ changed: false, refresh: "reloaded" });
+    expect(await (await put("approve")).json()).toMatchObject({ changed: false, refresh: "skipped" });
+  });
+
+  test("reports saved but deferred when no engine is configured", async () => {
+    const { put } = await startModeServer({ engine: false });
+    expect(await (await put("approve")).json()).toMatchObject({ mode: "approve", changed: true, refresh: "deferred" });
+  });
+
+  test("blocks unsupported configs and the live v2 chat-routing flag without touching the file", async () => {
+    const { root, origin, base, put, engineState } = await startModeServer();
+    for (const content of ['{"permission":"deny"}', '{"permission":{"*":{}}}', '{"permission":']) {
+      await writeFile(opencodeConfigPath(root), content);
+      expect(await (await fetch(base, { headers })).json()).toMatchObject({ mode: null, supported: false, reason: expect.any(String) });
+      expect((await put("default")).status).toBe(409);
+      expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(content);
+    }
+    const valid = '{"permission":"ask"}';
+    await writeFile(opencodeConfigPath(root), valid);
+    const toggle = await fetch(`${origin}/experimental/engine-v2-preview`, { method: "PUT", headers, body: JSON.stringify({ chatRouting: true }) });
+    expect(toggle.status).toBe(200);
+    expect(await (await fetch(base, { headers })).json()).toMatchObject({ mode: "approve", supported: false, reason: expect.stringContaining("v2") });
+    expect((await put("run-everything")).status).toBe(409);
+    expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(valid);
+    expect(engineState.disposals).toBe(0);
+  });
+
+  test("keeps the read-only and config.write approval gates", async () => {
+    const readOnly = await startModeServer({ readOnly: true });
+    expect((await readOnly.put("approve")).status).toBe(403);
+    const approval = await startModeServer({ approval: { mode: "manual", timeoutMs: 30 } });
+    const before = await readFile(opencodeConfigPath(approval.root), "utf8");
+    expect((await approval.put("approve")).status).toBe(403);
+    expect(await readFile(opencodeConfigPath(approval.root), "utf8")).toBe(before);
+    expect(approval.engineState.disposals).toBe(0);
+  });
+
+  test("rechecks workspace activity after config.write approval", async () => {
+    const { root, origin, put, engineState } = await startModeServer({ approval: { mode: "manual", timeoutMs: 2_000 } });
+    const before = await readFile(opencodeConfigPath(root), "utf8");
+    const pending = put("approve");
+    let approvalId: string | undefined;
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const approvals = await (await fetch(`${origin}/approvals`, { headers: { ...headers, ...hostHeaders } })).json();
+      const approval = approvals.items[0];
+      if (approval) {
+        expect(approval).toMatchObject({ action: "config.write", workspaceId: "ws_1", paths: [opencodeConfigPath(root)] });
+        approvalId = approval.id;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(approvalId).toBeDefined();
+    engineState.statuses = { other: { type: "busy" } };
+    const approved = await fetch(`${origin}/approvals/${approvalId}`, { method: "POST", headers: { ...headers, ...hostHeaders }, body: JSON.stringify({ reply: "allow" }) });
+    expect(approved.status).toBe(200);
+    expect((await pending).status).toBe(409);
+    expect(await readFile(opencodeConfigPath(root), "utf8")).toBe(before);
+    expect(engineState.disposals).toBe(0);
+  });
+});

--- a/apps/server/src/workspace-run-mode.ts
+++ b/apps/server/src/workspace-run-mode.ts
@@ -1,0 +1,138 @@
+import { applyEdits, createScanner, findNodeAtLocation, parseTree, SyntaxKind, type Edit, type Node } from "jsonc-parser";
+import { writeFile } from "node:fs/promises";
+import { ApiError } from "./errors.js";
+import { readJsoncFile } from "./jsonc.js";
+import { opencodeConfigPath } from "./workspace-files.js";
+
+export type WorkspaceRunMode = "default" | "approve" | "run-everything";
+export type WorkspaceRunModeState = {
+  catchAll: "allow" | "ask" | "deny" | null;
+} & ({ mode: WorkspaceRunMode; supported: true; reason?: never } | { mode: WorkspaceRunMode | null; supported: false; reason: string });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAction(value: unknown): value is "allow" | "ask" | "deny" {
+  return value === "allow" || value === "ask" || value === "deny";
+}
+
+export function runModeFromPermissionBlock(block: unknown): WorkspaceRunModeState {
+  const catchAll = isAction(block) ? block : isRecord(block) && isAction(block["*"]) ? block["*"] : null;
+  const unsupported = (reason: string): WorkspaceRunModeState => ({ mode: null, catchAll, supported: false, reason });
+  if (block !== undefined && !isAction(block) && !isRecord(block)) {
+    return unsupported("The workspace permission block is not an action or a rule object.");
+  }
+  if (isRecord(block)) {
+    if (Object.hasOwn(block, "*") && !isAction(block["*"])) {
+      return unsupported("An object or invalid catch-all cannot be represented by a workspace run mode.");
+    }
+    if (Object.values(block).some((value) => !isAction(value) && !(isRecord(value) && Object.values(value).every(isAction)))) {
+      return unsupported("The workspace contains an invalid permission rule.");
+    }
+  }
+  if (catchAll === "deny") return unsupported("A deny catch-all cannot be represented by a workspace run mode.");
+  return { mode: catchAll === "ask" ? "approve" : catchAll === "allow" ? "run-everything" : "default", catchAll, supported: true };
+}
+
+function hasDuplicateKeys(node: Node, recursive = false): boolean {
+  const keys = new Set<string>();
+  for (const property of node.children ?? []) {
+    const key: unknown = property.children?.[0]?.value;
+    if (typeof key !== "string" || keys.has(key)) return true;
+    keys.add(key);
+    const value = property.children?.[1];
+    if (recursive && value?.type === "object" && hasDuplicateKeys(value, true)) return true;
+  }
+  return false;
+}
+
+async function readRunModeFile(workspaceRoot: string) {
+  const path = opencodeConfigPath(workspaceRoot);
+  const { data, raw, invalid, missing } = await readJsoncFile<unknown>(path, {}, { allowInvalid: true });
+  const tree = parseTree(missing ? "{}" : raw, [], { allowTrailingComma: true });
+  const permission = tree && findNodeAtLocation(tree, ["permission"]);
+  let state: WorkspaceRunModeState;
+  if (invalid || !isRecord(data) || !tree || hasDuplicateKeys(tree) || (permission?.type === "object" && hasDuplicateKeys(permission, true))) {
+    state = { mode: null, catchAll: null, supported: false, reason: "The workspace config must be valid JSONC with an object root and no duplicate permission or top-level keys." };
+  } else {
+    state = runModeFromPermissionBlock(data.permission);
+  }
+  return { path, raw, tree, permission, state };
+}
+
+export async function readWorkspaceRunMode(workspaceRoot: string): Promise<WorkspaceRunModeState & { path: string }> {
+  const { state, path } = await readRunModeFile(workspaceRoot);
+  return { ...state, path };
+}
+
+// Delete syntax tokens, not trivia. JSONC's generic property removal can eat
+// adjacent comments; commas inside comments must never be treated as separators.
+function removeProperty(content: string, object: Node, property: Node): string {
+  const edits: Edit[] = [];
+  const scanner = createScanner(content);
+  scanner.setPosition(property.offset);
+  while (scanner.scan() !== SyntaxKind.EOF && scanner.getTokenOffset() < property.offset + property.length) {
+    const token = scanner.getToken();
+    if (token !== SyntaxKind.Trivia && token !== SyntaxKind.LineBreakTrivia && token !== SyntaxKind.LineCommentTrivia && token !== SyntaxKind.BlockCommentTrivia) {
+      edits.push({ offset: scanner.getTokenOffset(), length: scanner.getTokenLength(), content: "" });
+    }
+  }
+  const siblings = object.children ?? [];
+  const index = siblings.indexOf(property);
+  const separator = createScanner(content, true);
+  separator.setPosition(property.offset + property.length);
+  if (separator.scan() !== SyntaxKind.CommaToken && index > 0) {
+    const previous = siblings[index - 1];
+    separator.setPosition(previous.offset + previous.length);
+    separator.scan();
+  }
+  if (separator.getToken() === SyntaxKind.CommaToken) edits.push({ offset: separator.getTokenOffset(), length: 1, content: "" });
+  return applyEdits(content, edits);
+}
+
+function insertFirst(content: string, object: Node, key: string, value: unknown): string {
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const lineStart = content.lastIndexOf("\n", object.offset) + 1;
+  const indent = content.slice(lineStart, object.offset).match(/^[\t ]*/)?.[0] ?? "";
+  const entry = `${eol}${indent}  ${JSON.stringify(key)}: ${JSON.stringify(value)}${object.children?.length ? "," : ""}${eol}`;
+  return applyEdits(content, [{ offset: object.offset + 1, length: 0, content: entry }]);
+}
+
+/** Edit only the workspace catch-all; narrower rules keep their bytes and order. */
+export async function setWorkspaceRunMode(workspaceRoot: string, mode: WorkspaceRunMode): Promise<boolean> {
+  const { path, raw, tree, permission, state } = await readRunModeFile(workspaceRoot);
+  if (!state.supported) throw new ApiError(409, "workspace_run_mode_unsupported", state.reason);
+  if (!tree) throw new Error("Workspace config has no syntax tree");
+  const target = mode === "approve" ? "ask" : mode === "run-everything" ? "allow" : null;
+  const catchAllProperty = permission?.type === "object"
+    ? permission.children?.find((property) => property.children?.[0]?.value === "*")
+    : undefined;
+  const needsReorder = target !== null && catchAllProperty !== undefined && permission?.children?.[0] !== catchAllProperty;
+  if (state.catchAll === target && !needsReorder) return false;
+
+  let content = raw || "{}\n";
+  if (permission?.type === "string") {
+    if (target === null && permission.parent) content = removeProperty(content, tree, permission.parent);
+    else content = applyEdits(content, [{ offset: permission.offset, length: permission.length, content: JSON.stringify(target) }]);
+  } else if (permission?.type === "object") {
+    if (catchAllProperty && (target === null || needsReorder)) content = removeProperty(content, permission, catchAllProperty);
+    if (target !== null) {
+      const value = catchAllProperty?.children?.[1];
+      if (value && !needsReorder) content = applyEdits(content, [{ offset: value.offset, length: value.length, content: JSON.stringify(target) }]);
+      else {
+        const updatedTree = parseTree(content, [], { allowTrailingComma: true });
+        const object = updatedTree && findNodeAtLocation(updatedTree, ["permission"]);
+        if (!object) throw new Error("Workspace permission object disappeared during edit");
+        content = insertFirst(content, object, "*", target);
+      }
+    }
+  } else {
+    content = insertFirst(content, tree, "permission", { "*": target });
+  }
+  const errors: { error: number; offset: number; length: number }[] = [];
+  parseTree(content, errors, { allowTrailingComma: true });
+  if (errors.length) throw new Error("Workspace run mode edit produced invalid JSONC");
+  await writeFile(path, content, "utf8");
+  return true;
+}

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -873,6 +873,33 @@ export class ProbeChannel implements Probe {
     });
   }
 
+  desktopApi(path: string): Promise<{ status: number; body: unknown }> {
+    const surface = requireSurface(this.#surface);
+    return this.#runtime.call("probe", "desktopApi", `desktopApi(GET ${path})`, surface, async () => {
+      if (!path.startsWith("/") || path.startsWith("//") || /[\\\s]/.test(path)) {
+        throw new Error("probe.desktopApi requires a root-relative server path.");
+      }
+      const value = await callFunctionOnSurface(surface, `async (path) => {
+        const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+        if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
+        const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + path, {
+          method: "GET",
+          headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
+          redirect: "error",
+          signal: AbortSignal.timeout(15_000),
+        });
+        const text = await response.text();
+        let body = text;
+        try { body = text ? JSON.parse(text) : null; } catch {}
+        return { status: response.status, body };
+      }`, [path], { awaitPromise: true, timeoutMs: 20_000 });
+      if (!isRecord(value) || typeof value.status !== "number" || !("body" in value)) {
+        throw new Error("Invalid desktop API probe response.");
+      }
+      return { status: value.status, body: value.body };
+    });
+  }
+
   toolCalls(mock: import("@openwork/env").MockHandle, options: Parameters<import("@openwork/env").MockHandle["toolCalls"]>[0] = {}) {
     return this.#runtime.call("probe", "toolCalls", `toolCalls(${options.name ?? "any"})`, null, () => mock.toolCalls(options));
   }

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -69,6 +69,8 @@ export interface Probe {
   eval(surface: Surface, expression: string, options?: ProbeEvalOptions): Promise<unknown>;
   connectState(app: Surface): ReturnType<typeof import("../state.ts").readConnectState>;
   api(session: DenSession, path: string, init?: RequestInit): Promise<DenFetchResult>;
+  /** GET from the bound desktop's local server; authentication stays in the renderer. */
+  desktopApi(path: string): Promise<{ status: number; body: unknown }>;
   toolCalls(mock: MockHandle, options?: Parameters<MockHandle["toolCalls"]>[0]): ReturnType<MockHandle["toolCalls"]>;
   eventually<T>(fn: () => Promise<T> | T, options: EventuallyOptions<T>): Promise<T>;
   on(surface: Surface): Probe;

--- a/evals/specs/composer-run-mode.e2e.test.ts
+++ b/evals/specs/composer-run-mode.e2e.test.ts
@@ -1,0 +1,171 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { emptySession } from "../worlds/desktop.ts";
+
+const test = spec.world(emptySession);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test("workspace run mode is opt-in, confirms Keep going, and preserves policy when hidden", async ({ world, user, probe, step }) => {
+  const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}`;
+  const trigger = { testId: "workspace-run-mode-trigger" };
+  const flag = { label: "Show workspace run mode" };
+  const confirmation = { text: "Let OpenWork keep going?" };
+  const footer = { text: "Applies to every chat in this workspace. Specific workspace rules still apply." };
+
+  const read = async (path: string) => {
+    const response = await probe.desktopApi(`${mount}/${path}`);
+    expect(response.status, path).toBe(200);
+    if (!isRecord(response.body)) throw new Error(`Expected an object from ${path}.`);
+    return response.body;
+  };
+  const flagEnabled = () => probe.storage("openwork.preferences", (value) => (
+    isRecord(value) && isRecord(value.featureFlags) && value.featureFlags.workspaceRunMode === true
+  ));
+  const modeIs = async (mode: "default" | "approve" | "run-everything", catchAll: "ask" | "allow" | null) => {
+    const state = await probe.eventually(() => read("permissions/mode"), {
+      within: 60_000,
+      label: `workspace persists ${mode}`,
+      until: (value) => value.mode === mode && value.catchAll === catchAll && value.refreshPending !== true,
+    });
+    expect(state).toMatchObject({ mode, catchAll, supported: true, path: expect.any(String) });
+    return state;
+  };
+  const mcpRow = async () => {
+    const effective = await read("permissions/effective");
+    if (!Array.isArray(effective.rows)) throw new Error("Effective permissions did not return rows.");
+    const row = effective.rows.find((value) => isRecord(value) && value.key === "mcp");
+    if (!isRecord(row)) throw new Error("Effective permissions did not return an MCP row.");
+    return row;
+  };
+  const mcpIs = async (action: "ask" | "allow") => {
+    const row = await probe.eventually(mcpRow, {
+      within: 60_000,
+      label: `engine applies workspace MCP ${action}`,
+      until: (value) => value.action === action && value.source === "workspace",
+    });
+    expect(row).toMatchObject({ action, source: "workspace", rule: { permission: "*", pattern: "*", action } });
+  };
+  const advanced = async () => {
+    await user.click({ testId: "account-status-menu" });
+    await user.click("Settings");
+    await user.click("Advanced");
+    await user.see(flag);
+  };
+  const menu = async (label: string) => {
+    await user.see({ ...trigger, label: `Workspace run mode: ${label}` });
+    await user.click(trigger);
+    await user.see(footer);
+    await user.see({ testId: "run-mode-default", label: "Workspace defaults" });
+    await user.see({ testId: "run-mode-approve", label: "Ask before actions" });
+    await user.see({ testId: "run-mode-run-everything", label: "Keep going" });
+  };
+  const confirmationClosed = async () => {
+    await probe.eventually(() => probe.has(confirmation.text), {
+      within: 60_000, label: "Keep going confirmation dismissed", until: (visible) => !visible,
+    });
+    await user.notSee(confirmation);
+  };
+
+  await user.see("composer", { editable: true });
+  await user.press("Escape");
+  const initialMode = await modeIs("default", null);
+  const initialMcp = await mcpRow();
+
+  await step("the control is absent until enabled in Advanced, without a policy write", async () => {
+    expect(await flagEnabled()).toBe(false);
+    await user.notSee(trigger);
+    const before = await read("config");
+    await advanced();
+    await user.click(flag);
+    expect(await probe.eventually(flagEnabled, { within: 5_000, label: "run mode flag enabled" })).toBe(true);
+    await user.click("Back to app");
+    await menu("Workspace defaults");
+    expect(await read("permissions/mode")).toEqual(initialMode);
+    expect(await read("config")).toEqual(before);
+  });
+
+  await step("Ask before actions persists a workspace catch-all and reaches the engine", async () => {
+    await user.click({ testId: "run-mode-approve" });
+    await modeIs("approve", "ask");
+    expect(await read("config")).toMatchObject({ opencode: { permission: { "*": "ask" } } });
+    await mcpIs("ask");
+    await user.see({ ...trigger, label: "Workspace run mode: Ask before actions" });
+    await user.reload();
+    await user.see({ ...trigger, label: "Workspace run mode: Ask before actions" });
+    expect(await flagEnabled()).toBe(true);
+  });
+
+  await step("opening and cancelling Keep going leaves saved and effective permissions unchanged", async () => {
+    const beforeMode = await read("permissions/mode");
+    const beforeConfig = await read("config");
+    const beforeMcp = await mcpRow();
+    await menu("Ask before actions");
+    await user.click({ testId: "run-mode-run-everything" });
+    await user.see(confirmation);
+    await user.see({ role: "button", label: "Enable Keep going" });
+    expect(await read("permissions/mode")).toEqual(beforeMode);
+    expect(await read("config")).toEqual(beforeConfig);
+    expect(await mcpRow()).toEqual(beforeMcp);
+    await user.click({ role: "button", label: "Cancel" });
+    await confirmationClosed();
+    await user.see({ ...trigger, label: "Workspace run mode: Ask before actions" });
+    expect(await read("permissions/mode")).toEqual(beforeMode);
+    expect(await read("config")).toEqual(beforeConfig);
+    expect(await mcpRow()).toEqual(beforeMcp);
+  });
+
+  await step("only confirming Keep going changes the workspace and effective MCP action to allow", async () => {
+    await menu("Ask before actions");
+    await user.click({ testId: "run-mode-run-everything" });
+    await user.see(confirmation);
+    await user.click({ role: "button", label: "Enable Keep going" });
+    await confirmationClosed();
+    await modeIs("run-everything", "allow");
+    expect(await read("config")).toMatchObject({ opencode: { permission: { "*": "allow" } } });
+    await mcpIs("allow");
+    await user.see({ ...trigger, label: "Workspace run mode: Keep going" });
+  });
+
+  await step("Workspace defaults removes the catch-all and restores inherited MCP permissions", async () => {
+    await menu("Keep going");
+    await user.click({ testId: "run-mode-default" });
+    expect(await modeIs("default", null)).toEqual(initialMode);
+    const config = await read("config");
+    if (!isRecord(config.opencode)) throw new Error("Workspace config did not return opencode.");
+    expect(config.opencode).not.toHaveProperty(["permission", "*"]);
+    const restored = await probe.eventually(mcpRow, {
+      within: 60_000,
+      label: "inherited MCP permissions restored",
+      until: (value) => value.action === initialMcp.action && value.source === initialMcp.source,
+    });
+    expect(restored).toEqual(initialMcp);
+    await user.see({ ...trigger, label: "Workspace run mode: Workspace defaults" });
+  });
+
+  await step("turning the flag off hides only the control, even with a non-default policy saved", async () => {
+    await menu("Workspace defaults");
+    await user.click({ testId: "run-mode-approve" });
+    const beforeMode = await modeIs("approve", "ask");
+    await mcpIs("ask");
+    const beforeConfig = await read("config");
+    const beforeMcp = await mcpRow();
+    await advanced();
+    await user.click(flag);
+    expect(await probe.eventually(flagEnabled, {
+      within: 5_000, label: "run mode flag disabled", until: (enabled) => !enabled,
+    })).toBe(false);
+    await user.click("Back to app");
+    await user.see("composer", { editable: true });
+    await user.notSee(trigger);
+    await user.reload();
+    await user.see("composer", { editable: true });
+    await user.notSee(trigger);
+    expect(await flagEnabled()).toBe(false);
+    expect(await read("permissions/mode")).toEqual(beforeMode);
+    expect(await read("config")).toEqual(beforeConfig);
+    expect(await mcpRow()).toEqual(beforeMcp);
+  });
+});

--- a/evals/specs/composer-run-mode.e2e.test.ts
+++ b/evals/specs/composer-run-mode.e2e.test.ts
@@ -21,6 +21,12 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
     if (!isRecord(response.body)) throw new Error(`Expected an object from ${path}.`);
     return response.body;
   };
+  // updatedAt includes runtime reattachment on reload, not just permission
+  // edits. Compare configuration values rather than that unrelated clock.
+  const readConfig = async () => {
+    const { opencode, openwork } = await read("config");
+    return { opencode, openwork };
+  };
   const flagEnabled = () => probe.storage("openwork.preferences", (value) => (
     isRecord(value) && isRecord(value.featureFlags) && value.featureFlags.workspaceRunMode === true
   ));
@@ -77,14 +83,14 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
   await step("the control is absent until enabled in Advanced, without a policy write", async () => {
     expect(await flagEnabled()).toBe(false);
     await user.notSee(trigger);
-    const before = await read("config");
+    const before = await readConfig();
     await advanced();
     await user.click(flag);
     expect(await probe.eventually(flagEnabled, { within: 5_000, label: "run mode flag enabled" })).toBe(true);
     await user.click("Back to app");
     await menu("Workspace defaults");
     expect(await read("permissions/mode")).toEqual(initialMode);
-    expect(await read("config")).toEqual(before);
+    expect(await readConfig()).toEqual(before);
   });
 
   await step("Ask before actions persists a workspace catch-all and reaches the engine", async () => {
@@ -100,20 +106,20 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
 
   await step("opening and cancelling Keep going leaves saved and effective permissions unchanged", async () => {
     const beforeMode = await read("permissions/mode");
-    const beforeConfig = await read("config");
+    const beforeConfig = await readConfig();
     const beforeMcp = await mcpRow();
     await menu("Ask before actions");
     await user.click({ testId: "run-mode-run-everything" });
     await user.see(confirmation);
     await user.see({ role: "button", label: "Enable Keep going" });
     expect(await read("permissions/mode")).toEqual(beforeMode);
-    expect(await read("config")).toEqual(beforeConfig);
+    expect(await readConfig()).toEqual(beforeConfig);
     expect(await mcpRow()).toEqual(beforeMcp);
     await user.click({ role: "button", label: "Cancel" });
     await confirmationClosed();
     await user.see({ ...trigger, label: "Workspace run mode: Ask before actions" });
     expect(await read("permissions/mode")).toEqual(beforeMode);
-    expect(await read("config")).toEqual(beforeConfig);
+    expect(await readConfig()).toEqual(beforeConfig);
     expect(await mcpRow()).toEqual(beforeMcp);
   });
 
@@ -150,7 +156,7 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
     await user.click({ testId: "run-mode-approve" });
     const beforeMode = await modeIs("approve", "ask");
     await mcpIs("ask");
-    const beforeConfig = await read("config");
+    const beforeConfig = await readConfig();
     const beforeMcp = await mcpRow();
     await advanced();
     await user.click(flag);
@@ -165,7 +171,7 @@ test("workspace run mode is opt-in, confirms Keep going, and preserves policy wh
     await user.notSee(trigger);
     expect(await flagEnabled()).toBe(false);
     expect(await read("permissions/mode")).toEqual(beforeMode);
-    expect(await read("config")).toEqual(beforeConfig);
+    expect(await readConfig()).toEqual(beforeConfig);
     expect(await mcpRow()).toEqual(beforeMcp);
   });
 });

--- a/evals/specs/composer-run-mode.e2e.test.ts
+++ b/evals/specs/composer-run-mode.e2e.test.ts
@@ -11,7 +11,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 test("workspace run mode is opt-in, confirms Keep going, and preserves policy when hidden", async ({ world, user, probe, step }) => {
   const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}`;
   const trigger = { testId: "workspace-run-mode-trigger" };
-  const flag = { label: "Show workspace run mode" };
+  const flag = { testId: "workspace-run-mode-flag", label: "Show workspace run mode" };
   const confirmation = { text: "Let OpenWork keep going?" };
   const footer = { text: "Applies to every chat in this workspace. Specific workspace rules still apply." };
 


### PR DESCRIPTION
## Summary

Add an opt-in workspace run-mode control immediately left of the composer attachment button, in both new tasks and existing chats.

- **Settings → Advanced → Show workspace run mode** is off by default. Enabling it reveals the control without changing permissions.
- The menu offers **Ask before actions**, **Workspace defaults**, and **Keep going**, with a selected indicator and short explanations.
- Keep going requires confirmation before allowing tools by default. The warning explains outside-folder access, global-rule precedence, and repeated-action prompts. Specific workspace rules remain in force; this does not grant OS or connected-service access.
- The choice applies to every chat in the workspace and is saved in its existing OpenCode JSON/JSONC file. Comments, unrelated settings, and narrower rules are preserved. Hiding the control does not reset the saved mode.
- Active sessions and pending approvals block changes instead of being interrupted. Unsupported/custom configurations, the experimental v2 chat engine, and organization-controlled settings are not silently bypassed. A failed engine refresh is shown as pending, not applied.

## Scope

Replaces this PR's older settings-only implementation with a standalone change targeting `dev`. It no longer depends on #4292; that PR's workspace-rule editor and approval actions remain separate.

## Verification

**Verdict: Incomplete for the extended permission-boundary matrix; the core desktop journey Passed.** Current head: `afbc0f8a7fa6903ffc0d419edec7a9db90f665a9`, based on `dev` at `46d13af3f`.

- **Passed — real desktop:** `OPENWORK_EVAL_REF=afbc0f8a7fa6903ffc0d419edec7a9db90f665a9 pnpm evals:e2e composer-run-mode`. Printed `placement: daytona (daytona CLI authenticated)`; exit 0; 1 passed, 0 failed, 0 skipped. Fresh isolated desktop, exact-head checkout, all 6 journey steps passed. [Published test evidence](https://github.com/different-ai/openwork/pull/4293#issuecomment-5554577451).
- **Passed — focused component checks:** `pnpm --filter openwork-server exec bun --conditions=development test src/workspace-run-mode.test.ts`; exit 0; 11 passed, 0 failed. Covers JSONC edits, authorization, invalid configurations, busy sessions, refresh retries, and v2 gating. These are component checks, not journey proof.
- **Passed — coherence:** `pnpm --filter @openwork/app typecheck`, `pnpm --filter openwork-server typecheck`, and `git diff --check`; exit 0.
- **Failed earlier, corrected:** the journey initially could not locate the switch using its label alone, then compared a runtime timestamp that legitimately advances on renderer reload. The final run uses an explicit switch test ID and compares configuration values; it passes on the current head.
- **Skipped:** none in the final selected journey.
- **Deferred:** actual cross-workspace/split-pane, organization-lock, and busy-session desktop journeys; engine-v2 support; cross-platform verification. Those boundaries are not claimed as fully runtime-proven by this PR.

The desktop journey covers the default-off flag, all three choices, cancellation/confirmation, effective engine permissions, renderer reload, and preserving a saved mode when the flag is disabled. No merge or release is included.
