### PR TITLE
Fix dashboard MCP App launch recovery

### DIFF
--- a/apps/app/src/app/lib/mcp-app-resolution.ts
+++ b/apps/app/src/app/lib/mcp-app-resolution.ts
@@ -1,0 +1,10 @@
+import { OpenworkServerError } from "./openwork-server"
+
+const TRANSIENT_MCP_APP_RESOLUTION_CODES = new Set(["server_unavailable", "mcp_unreachable"])
+const MCP_APP_RESOLUTION_RETRY_DELAYS_MS = [1_000, 3_000]
+
+/** Retry discovery only, never the launch tool or a deterministic rejection. */
+export function mcpAppResolutionRetryDelayMs(cause: unknown, attemptIndex: number): number | null {
+  if (!(cause instanceof OpenworkServerError) || !TRANSIENT_MCP_APP_RESOLUTION_CODES.has(cause.code)) return null
+  return MCP_APP_RESOLUTION_RETRY_DELAYS_MS[attemptIndex] ?? null
+}

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -12,6 +12,7 @@ import { ConnectionCard } from "./connection-card"
 import { connectionCardPayloadFromChatToolResult, reconnectActionFromChatToolResult } from "@/components/tools/error-attribution"
 import { AppChatArtifact } from "@/react-app/domains/apps/app-chat-artifact"
 import { openDesktopUrl } from "@/app/lib/desktop"
+import { mcpAppResolutionRetryDelayMs } from "@/app/lib/mcp-app-resolution"
 import {
   OpenworkServerError,
   type OpenworkMcpAppLaunchReference,
@@ -44,6 +45,7 @@ const ACTIONABLE_MCP_APP_RESOLUTION_CODES = new Set([
   "invalid_resource_mime",
   "invalid_resource_uri",
   "invalid_launch_reference",
+  "mcp_unreachable",
   "resource_read_failed",
   "resource_too_large",
   "server_unavailable",
@@ -219,12 +221,18 @@ export function isActionableMcpAppResolutionError(cause: unknown): boolean {
 
 const CHAT_MCP_APP_UNAVAILABLE_NOTICE = "Interactive view unavailable. The normal tool result is still available."
 
-export function McpAppDiagnosticNotice({ error, notice }: { error: McpAppDiagnostic; notice: string }) {
+export function McpAppDiagnosticNotice({ error, notice, onRetry }: { error: McpAppDiagnostic; notice: string; onRetry?: () => void }) {
   const [detailsCopied, setDetailsCopied] = useState(false)
   const details = formatMcpAppDiagnostic(error)
   return (
     <div className="mt-2 text-xs text-muted-foreground" role="status">
       <p>{notice} {error.message}</p>
+      {error.causeCode === "server_unavailable" || error.causeCode === "mcp_unreachable" ? (
+        <p className="mt-1">The connection was not ready. Retry, or check the connection under Settings &gt; Library.</p>
+      ) : null}
+      {onRetry ? (
+        <button type="button" className="mt-1 underline underline-offset-2" onClick={onRetry}>Retry</button>
+      ) : null}
       <details className="mt-1">
         <summary className="cursor-pointer select-none">Technical details ({error.code})</summary>
         <p className="mt-1">Copy these details when reporting the rendering problem.</p>
@@ -625,6 +633,7 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const launch = useMemo(() => gatewayMcpAppLaunch(result?._meta), [result])
   const [app, setApp] = useState<OpenworkMcpAppResource | null>(null)
   const [error, setError] = useState<McpAppDiagnostic | null>(null)
+  const [resolveToken, setResolveToken] = useState(0)
   // The sandbox view unmounts on every preserved-result change; keep the last
   // measured height here so the rebuilt iframe does not snap back to default.
   const heightRef = useRef(DEFAULT_HEIGHT)
@@ -633,7 +642,7 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
     [launch, part.input],
   )
   // Retire the old view in the same commit, before the passive resolution effect runs.
-  const resolution = useMemo(() => ({}), [origin, part.toolName, part.toolCallId, result, inputArguments])
+  const resolution = useMemo(() => ({}), [origin, part.toolName, part.toolCallId, result, inputArguments, resolveToken])
   const resolvedFor = useRef<object | null>(null)
 
   useEffect(() => {
@@ -644,37 +653,54 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
         void openworkServerClient.releaseMcpApp(workspaceId, launchId).catch(() => undefined)
       }
     }
+    let retryTimer: number | undefined
     setApp(null)
     setError(null)
     if (draft || !result || !openworkServerClient || !workspaceId) return () => { cancelled = true }
     const startedAt = performance.now()
-    void openworkServerClient.resolveMcpApp(workspaceId, part.toolName, launch ?? undefined, origin ?? undefined)
-      .then(({ app: resolved }) => {
-        launchId = resolved?.launchId
-        if (cancelled) { release(); return }
-        // A preserved MCP result is neutral transport data. A null resolution
-        // means the current tool definition does not advertise an MCP App, so
-        // ordinary tools such as save_artifact_view render only their normal
-        // result without claiming an unavailable interactive view.
-        resolvedFor.current = resolution
-        setApp(resolved)
-      })
-      .catch((cause) => {
-        if (!cancelled && isActionableMcpAppResolutionError(cause)) {
-          const diagnostic: McpAppDiagnostic = {
-            code: "MCP_APP_RESOURCE_RESOLUTION_FAILED",
-            ...(cause instanceof OpenworkServerError ? { causeCode: cause.code } : {}),
-            stage: "resource-resolution",
-            message: safeMcpAppDiagnosticMessage(cause, "The interactive view resource could not be resolved."),
-            toolName: part.toolName,
-            elapsedMs: Math.round(performance.now() - startedAt),
-            checkpoints: ["resolve-started"],
+    const checkpoints = ["resolve-started"]
+    const attempt = (attemptIndex: number) => {
+      if (cancelled) return
+      void openworkServerClient.resolveMcpApp(workspaceId, part.toolName, launch ?? undefined, origin ?? undefined)
+        .then(({ app: resolved }) => {
+          launchId = resolved?.launchId
+          if (cancelled) { release(); return }
+          // A preserved MCP result is neutral transport data. A null resolution
+          // means the current tool definition does not advertise an MCP App, so
+          // ordinary tools such as save_artifact_view render only their normal
+          // result without claiming an unavailable interactive view.
+          resolvedFor.current = resolution
+          setApp(resolved)
+        })
+        .catch((cause) => {
+          if (cancelled) return
+          checkpoints.push(`resolve-failed-${attemptIndex + 1}+${Math.round(performance.now() - startedAt)}ms`)
+          const retryDelayMs = mcpAppResolutionRetryDelayMs(cause, attemptIndex)
+          if (retryDelayMs !== null) {
+            retryTimer = window.setTimeout(() => attempt(attemptIndex + 1), retryDelayMs)
+            return
           }
-          console.error(`[OpenWork MCP App] ${diagnostic.code}`, diagnostic)
-          setError(diagnostic)
-        }
-      })
-    return () => { cancelled = true; release() }
+          if (isActionableMcpAppResolutionError(cause)) {
+            const diagnostic: McpAppDiagnostic = {
+              code: "MCP_APP_RESOURCE_RESOLUTION_FAILED",
+              ...(cause instanceof OpenworkServerError ? { causeCode: cause.code } : {}),
+              stage: "resource-resolution",
+              message: safeMcpAppDiagnosticMessage(cause, "The interactive view resource could not be resolved."),
+              toolName: part.toolName,
+              elapsedMs: Math.round(performance.now() - startedAt),
+              checkpoints: [...checkpoints],
+            }
+            console.error(`[OpenWork MCP App] ${diagnostic.code}`, diagnostic)
+            setError(diagnostic)
+          }
+        })
+    }
+    attempt(0)
+    return () => {
+      cancelled = true
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer)
+      release()
+    }
   }, [draft, launch, openworkServerClient, part.toolName, result, workspaceId, origin, resolution])
 
   // A completed build opens a native artifact tab. Rendering still goes
@@ -690,7 +716,7 @@ function EmbeddedMcpAppFrame({ part }: { part: DynamicToolUIPart }) {
   }
   if (!result) return null
   if (!origin) return <p role="status">This App is missing its conversation origin. Reopen the conversation to use it.</p>
-  if (error) return <McpAppDiagnosticNotice error={error} notice={CHAT_MCP_APP_UNAVAILABLE_NOTICE} />
+  if (error) return <McpAppDiagnosticNotice error={error} notice={CHAT_MCP_APP_UNAVAILABLE_NOTICE} onRetry={() => setResolveToken((token) => token + 1)} />
   if (!app || resolvedFor.current !== resolution) return null
   return (
     <McpAppSandboxView

--- a/apps/app/src/react-app/domains/dashboard/dashboard-mcp-app-resolution.ts
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-mcp-app-resolution.ts
@@ -1,0 +1,62 @@
+import { mcpAppResolutionRetryDelayMs } from "@/app/lib/mcp-app-resolution"
+import type {
+  OpenworkMcpAppLaunchReference,
+  OpenworkMcpAppResource,
+  OpenworkServerClient,
+} from "@/app/lib/openwork-server"
+
+type McpAppResolutionEndpoint = {
+  client: Pick<OpenworkServerClient, "resolveMcpApp" | "releaseMcpApp">
+  workspaceId: string
+}
+
+type ResolveDashboardMcpAppOptions<TEndpoint extends McpAppResolutionEndpoint> = {
+  endpoints: TEndpoint[]
+  projectedToolName: string
+  expected: Pick<OpenworkMcpAppResource, "serverName" | "toolName" | "resourceUri">
+  launch?: OpenworkMcpAppLaunchReference
+  isActive?: (endpoint: TEndpoint) => boolean
+  wait?: (delayMs: number) => Promise<void>
+}
+
+/** Resolve the exact saved app before sending its arguments or launch approval. */
+export async function resolveDashboardMcpApp<TEndpoint extends McpAppResolutionEndpoint>({
+  endpoints,
+  projectedToolName,
+  expected,
+  launch,
+  isActive = () => true,
+  wait = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+}: ResolveDashboardMcpAppOptions<TEndpoint>): Promise<{ endpoint: TEndpoint; app: OpenworkMcpAppResource } | null> {
+  let attemptIndex = 0
+  let pending = endpoints
+  while (true) {
+    let resolveFailure: unknown = null
+    let retryDelayMs: number | null = null
+    const retryEndpoints: TEndpoint[] = []
+    for (const endpoint of pending) {
+      if (!isActive(endpoint)) continue
+      try {
+        // Discovery needs the binding, never the saved tool input or approval.
+        const reference = launch ? { ...launch, arguments: {} } : undefined
+        const { app } = await endpoint.client.resolveMcpApp(endpoint.workspaceId, projectedToolName, reference, { sessionId: null, readOnly: false })
+        if (isActive(endpoint) && app && app.serverName === expected.serverName
+          && app.toolName === expected.toolName && app.resourceUri === expected.resourceUri) return { endpoint, app }
+        if (app?.launchId) await endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined)
+      } catch (cause) {
+        if (!isActive(endpoint)) continue
+        resolveFailure ??= cause
+        const delay = mcpAppResolutionRetryDelayMs(cause, attemptIndex)
+        if (delay !== null) {
+          retryDelayMs = delay
+          retryEndpoints.push(endpoint)
+        }
+      }
+    }
+    if (!resolveFailure) return null
+    if (retryDelayMs === null) throw resolveFailure
+    await wait(retryDelayMs)
+    pending = retryEndpoints
+    attemptIndex += 1
+  }
+}

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -157,7 +157,7 @@ export function McpAppTile({
   // reuses the same in-flight promise; a null promise marks a settled nonce so
   // later re-renders cannot repeat an already-executed data-modifying call.
   const launchRef = useRef<{ nonce: number; promise: Promise<TileState> | null } | null>(null);
-  const lifetime = useMemo(() => ({ active: true }), [cacheScopeKey, entry.id, entry.projectedToolName, launchArguments, nonce]);
+  const lifetime = useMemo(() => ({ active: true }), [cacheScopeKey, entry.id, entry.projectedToolName, entry.connectionId, entry.serverName, entry.toolName, entry.resourceUri, launchArguments, nonce]);
   const endpointsRef = useRef(launchEndpoints);
   const ownedLaunches = useRef(new Map<string, DashboardLaunchEndpoint>());
   const releaseLaunches = () => {
@@ -206,6 +206,8 @@ export function McpAppTile({
     const assertActive = () => {
       if (!lifetime.active || launchRef.current?.nonce !== nonce) throw new Error("This App launch has closed or changed. Run the tile again.");
     };
+    const endpointIsActive = (endpoint: DashboardLaunchEndpoint) => lifetime.active
+      && endpointsRef.current.some(current => current.client === endpoint.client && current.workspaceId === endpoint.workspaceId);
     const promise = currentLaunch?.promise ?? (async (): Promise<TileState> => {
       // Connect app-host apps resolve through their connection reference; the
       // host revalidates the live UI binding before returning the resource.
@@ -222,13 +224,17 @@ export function McpAppTile({
         projectedToolName: entry.projectedToolName,
         expected: { serverName: entry.serverName, toolName: entry.toolName, resourceUri: entry.resourceUri },
         launch,
-        isActive: (endpoint) => lifetime.active
-          && endpointsRef.current.some(current => current.client === endpoint.client && current.workspaceId === endpoint.workspaceId),
+        isActive: endpointIsActive,
       });
       if (!resolved) {
         return { phase: "error", message: "This tool no longer advertises an interactive app." };
       }
       const { endpoint, app } = resolved;
+      // The owner can retire between the resolver returning and this continuation.
+      if (!endpointIsActive(endpoint) || launchRef.current?.nonce !== nonce) {
+        if (app.launchId) void endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined);
+        throw new Error("This App launch has closed or changed. Run the tile again.");
+      }
       if (app.launchId) ownedLaunches.current.set(app.launchId, endpoint);
       assertActive();
       if (!app.launchId) throw new Error("This App has no live launch context. Update OpenWork and run the tile again.");

--- a/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
+++ b/apps/app/src/react-app/domains/dashboard/mcp-app-tile.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { DashboardTileShell } from "./dashboard-tile-shell";
+import { resolveDashboardMcpApp } from "./dashboard-mcp-app-resolution";
 import {
   DASHBOARD_AUTO_REFRESH_INTERVAL_MS,
   dashboardTileLaunchIsApproved,
@@ -191,7 +192,7 @@ export function McpAppTile({
     // Tiles are user-scoped while MCP servers are workspace-scoped: prefer the
     // selected workspace's runtime, then any other available one that can
     // still resolve this app.
-    const candidates = launchEndpoints;
+    const candidates = endpointsRef.current;
     if (candidates.length === 0) {
       launchRef.current = { nonce, promise: null };
       if (stateRef.current.phase === "ready") setRefreshState("failed");
@@ -213,36 +214,22 @@ export function McpAppTile({
             connectionId: entry.connectionId,
             toolName: entry.toolName,
             resourceUri: entry.resourceUri,
-            arguments: launchArguments,
+            arguments: {},
           }
         : undefined;
-      let resolved: { endpoint: DashboardLaunchEndpoint; app: OpenworkMcpAppResource } | null = null;
-      let resolveFailure: unknown = null;
-      for (const endpoint of candidates) {
-        try {
-          const { app } = await endpoint.client.resolveMcpApp(endpoint.workspaceId, entry.projectedToolName, launch, { sessionId: null, readOnly: false });
-          if (!lifetime.active || launchRef.current?.nonce !== nonce) {
-            if (app?.launchId) void endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined);
-            assertActive();
-          }
-          if (!endpointsRef.current.some(current => current.client === endpoint.client && current.workspaceId === endpoint.workspaceId)) {
-            if (app?.launchId) void endpoint.client.releaseMcpApp(endpoint.workspaceId, app.launchId).catch(() => undefined);
-            continue;
-          }
-          if (app) {
-            if (app.launchId) ownedLaunches.current.set(app.launchId, endpoint);
-            resolved = { endpoint, app };
-            break;
-          }
-        } catch (cause) {
-          resolveFailure ??= cause;
-        }
-      }
+      const resolved = await resolveDashboardMcpApp({
+        endpoints: candidates,
+        projectedToolName: entry.projectedToolName,
+        expected: { serverName: entry.serverName, toolName: entry.toolName, resourceUri: entry.resourceUri },
+        launch,
+        isActive: (endpoint) => lifetime.active
+          && endpointsRef.current.some(current => current.client === endpoint.client && current.workspaceId === endpoint.workspaceId),
+      });
       if (!resolved) {
-        if (resolveFailure) throw resolveFailure;
         return { phase: "error", message: "This tool no longer advertises an interactive app." };
       }
       const { endpoint, app } = resolved;
+      if (app.launchId) ownedLaunches.current.set(app.launchId, endpoint);
       assertActive();
       if (!app.launchId) throw new Error("This App has no live launch context. Update OpenWork and run the tile again.");
       const request = {
@@ -369,7 +356,7 @@ export function McpAppTile({
     return () => {
       cancelled = true;
     };
-  }, [cacheScopeKey, entry.connectionId, entry.id, entry.projectedToolName, entry.resourceUri, entry.toolName, launchArguments, launchEndpoints, manualLaunch, nonce, started, lifetime]);
+  }, [cacheScopeKey, entry.connectionId, entry.id, entry.projectedToolName, entry.resourceUri, entry.serverName, entry.toolName, launchArguments, manualLaunch, nonce, started, lifetime]);
 
   useEffect(() => {
     if (manualLaunch) return;

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -111,7 +111,7 @@ describe("MCP App iframe policy", () => {
   })
 
   test("keeps ordinary tools silent while surfacing advertised resource failures", () => {
-    expect(isActionableMcpAppResolutionError(new OpenworkServerError(503, "mcp_unreachable", "offline"))).toBe(false)
+    expect(isActionableMcpAppResolutionError(new OpenworkServerError(503, "mcp_unreachable", "offline"))).toBe(true)
     expect(isActionableMcpAppResolutionError(new OpenworkServerError(404, "resource_read_failed", "missing"))).toBe(true)
     expect(isActionableMcpAppResolutionError(new Error("generic failure"))).toBe(false)
   })

--- a/apps/app/tests/mcp-app-origin.test.tsx
+++ b/apps/app/tests/mcp-app-origin.test.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -17,15 +17,33 @@ const result = { content: [{ type: "text", text: "ok" }] };
 const needsApproval = () => new OpenworkServerError(422, "tool_requires_approval", "Approval required");
 
 describe("App conversation ownership", () => {
-  test("split message origin supplies endpoint, workspace, session and archive state instead of the root workspace", async () => {
+  test.each([false, true])("split message origin survives discovery recovery and archive changes (retry: %j)", async (retry) => {
     GlobalRegistrator.register({ url: "http://localhost/" });
     const previousAct = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
     Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
     const requests: unknown[] = [];
+    const retryCallbacks: (() => void)[] = [];
+    const delays: number[] = [];
+    const setTimer = window.setTimeout.bind(window);
+    const timerSpy = spyOn(window, "setTimeout").mockImplementation((callback, delay, ...args) => {
+      if (typeof callback === "function" && (delay === 1_000 || delay === 3_000)) {
+        retryCallbacks.push(() => callback(...args));
+        delays.push(delay);
+        return setTimer(() => {}, 60_000);
+      }
+      return setTimer(callback, delay, ...args);
+    });
+    let toolCalls = 0;
     const primary = { ...createOpenworkServerClient({ baseUrl: "http://primary.invalid" }),
       resolveMcpApp: async () => { throw new Error("Must not use the primary endpoint"); } };
     const secondary: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://secondary.invalid" }),
-      resolveMcpApp: async (workspaceId, name, launch, context) => { requests.push({ workspaceId, name, launch, context }); return { app: null }; } };
+      resolveMcpApp: async (workspaceId, name, launch, context) => {
+        requests.push({ workspaceId, name, launch, context });
+        if (retry && requests.length <= 3) throw new OpenworkServerError(503, "mcp_unreachable", "Starting");
+        return { app: null };
+      },
+      callMcpAppTool: async () => { toolCalls++; return result; },
+    };
     const container = document.createElement("div");
     const root = createRoot(container);
     const render = (readOnly: boolean) => <WorkspaceProvider client={null} openworkServerClient={primary} workspaceId="workspace-a" selectedWorkspaceRoot="/a">
@@ -40,13 +58,30 @@ describe("App conversation ownership", () => {
     </WorkspaceProvider>;
     try {
       await act(async () => { root.render(render(false)); });
+      if (retry) {
+        for (let i = 0; i < 2; i++) {
+          const callback = retryCallbacks.shift();
+          if (!callback) throw new Error("Missing discovery retry");
+          await act(async () => callback());
+        }
+        expect(requests).toHaveLength(3);
+        expect(delays).toEqual([1_000, 3_000]);
+        expect(retryCallbacks).toEqual([]);
+        const button = container.querySelector<HTMLButtonElement>("button");
+        expect(button?.textContent).toBe("Retry");
+        await act(async () => button?.click());
+        expect(requests).toHaveLength(4);
+        expect(container.querySelector("button")).toBeNull();
+      }
       await act(async () => { root.render(render(true)); });
       expect(requests).toEqual([
-        { workspaceId: "workspace-b", name: "fixture_render", launch: undefined, context: { client: secondary, workspaceId: "workspace-b", sessionId: "session-b", readOnly: false } },
+        ...Array.from({ length: retry ? 4 : 1 }, () => ({ workspaceId: "workspace-b", name: "fixture_render", launch: undefined, context: { client: secondary, workspaceId: "workspace-b", sessionId: "session-b", readOnly: false } })),
         { workspaceId: "workspace-b", name: "fixture_render", launch: undefined, context: { client: secondary, workspaceId: "workspace-b", sessionId: "session-b", readOnly: true } },
       ]);
+      expect(toolCalls).toBe(0);
     } finally {
       await act(async () => { root.unmount(); });
+      timerSpy.mockRestore();
       Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousAct);
       await GlobalRegistrator.unregister();
     }

--- a/apps/app/tests/mcp-app-origin.test.tsx
+++ b/apps/app/tests/mcp-app-origin.test.tsx
@@ -27,9 +27,10 @@ describe("App conversation ownership", () => {
     const setTimer = window.setTimeout.bind(window);
     const timerSpy = spyOn(window, "setTimeout").mockImplementation((callback, delay, ...args) => {
       if (typeof callback === "function" && (delay === 1_000 || delay === 3_000)) {
-        retryCallbacks.push(() => callback(...args));
+        const timer = setTimer(() => {}, 60_000);
+        retryCallbacks.push(() => { window.clearTimeout(timer); callback(...args); });
         delays.push(delay);
-        return setTimer(() => {}, 60_000);
+        return timer;
       }
       return setTimer(callback, delay, ...args);
     });

--- a/apps/app/tests/mcp-app-tile.test.tsx
+++ b/apps/app/tests/mcp-app-tile.test.tsx
@@ -3,7 +3,9 @@ import { expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { act, useLayoutEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { createOpenworkServerClient, type OpenworkMcpAppResource, type OpenworkServerClient } from "../src/app/lib/openwork-server";
+import { createOpenworkServerClient, OpenworkServerError, type OpenworkMcpAppResource, type OpenworkServerClient } from "../src/app/lib/openwork-server";
+import { mcpAppResolutionRetryDelayMs } from "../src/app/lib/mcp-app-resolution";
+import { resolveDashboardMcpApp } from "../src/react-app/domains/dashboard/dashboard-mcp-app-resolution";
 import { createMcpAppActions } from "../src/components/chat/mcp-app-origin";
 import type { McpAppSandboxViewProps } from "../src/components/chat/mcp-app-frame";
 import { WorkspaceProvider } from "../src/react-app/shell/workspace-provider";
@@ -26,6 +28,121 @@ mock.module("@/components/chat/mcp-app-frame", () => ({
 
 const { McpAppTile } = await import("../src/react-app/domains/dashboard/mcp-app-tile");
 
+const resource: OpenworkMcpAppResource = {
+  serverName: "fixture", toolName: "render", resourceUri: "ui://fixture/view.html", html: "<p>Fixture</p>",
+  csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] }, prefersBorder: true,
+};
+const noRelease = async () => { throw new Error("No lease should be released"); };
+
+test("bounds retries to transient discovery failures", () => {
+  for (const code of ["server_unavailable", "mcp_unreachable"]) {
+    const cause = new OpenworkServerError(503, code, "starting");
+    expect(mcpAppResolutionRetryDelayMs(cause, 0)).toBe(1_000);
+    expect(mcpAppResolutionRetryDelayMs(cause, 1)).toBe(3_000);
+    expect(mcpAppResolutionRetryDelayMs(cause, 2)).toBeNull();
+  }
+  for (const code of ["tool_denied", "tool_resource_mismatch"]) {
+    expect(mcpAppResolutionRetryDelayMs(new OpenworkServerError(422, code, "denied"), 0)).toBeNull();
+  }
+  expect(mcpAppResolutionRetryDelayMs(new Error("unknown failure"), 0)).toBeNull();
+});
+
+test.each([false, true])("recovers or stops after three discovery attempts (exhausted: %j)", async (exhausted) => {
+  let attempts = 0;
+  const waits: number[] = [];
+  const failure = new OpenworkServerError(503, "mcp_unreachable", "starting");
+  const endpoint = {
+    workspaceId: "workspace-1",
+    client: { releaseMcpApp: noRelease, resolveMcpApp: async () => {
+      attempts += 1;
+      if (exhausted || attempts < 3) throw failure;
+      return { app: resource };
+    } },
+  };
+  const resolving = resolveDashboardMcpApp({
+    endpoints: [endpoint], projectedToolName: "fixture_render", expected: resource,
+    wait: async (delay) => { waits.push(delay); },
+  });
+  if (exhausted) await expect(resolving).rejects.toBe(failure);
+  else expect(await resolving).toEqual({ endpoint, app: resource });
+  expect(attempts).toBe(3);
+  expect(waits).toEqual([1_000, 3_000]);
+});
+
+test("tries another workspace before waiting and never retries deterministic failures", async () => {
+  let attempts = 0;
+  const failure = new OpenworkServerError(422, "tool_resource_mismatch", "resource moved");
+  const first = { workspaceId: "first", client: { releaseMcpApp: noRelease, resolveMcpApp: async () => { attempts += 1; throw failure; } } };
+  const second = { workspaceId: "second", client: { releaseMcpApp: noRelease, resolveMcpApp: async () => ({ app: resource }) } };
+  const options = {
+    projectedToolName: "fixture_render", expected: resource,
+    wait: async () => { throw new Error("must not retry"); },
+  };
+  expect(await resolveDashboardMcpApp({ ...options, endpoints: [first, second] })).toEqual({ endpoint: second, app: resource });
+  await expect(resolveDashboardMcpApp({ ...options, endpoints: [first] })).rejects.toBe(failure);
+  expect(attempts).toBe(2);
+  let transientAttempts = 0;
+  const transient = { workspaceId: "transient", client: { releaseMcpApp: noRelease, resolveMcpApp: async () => {
+    if (++transientAttempts < 3) throw new OpenworkServerError(503, "mcp_unreachable", "starting");
+    return { app: resource };
+  } } };
+  expect(await resolveDashboardMcpApp({ ...options, endpoints: [transient, first], wait: async () => {} })).toEqual({ endpoint: transient, app: resource });
+  expect(attempts).toBe(3);
+  expect(transientAttempts).toBe(3);
+});
+
+test.each([
+  { serverName: "other-server" },
+  { toolName: "other-tool" },
+  { resourceUri: "ui://fixture/other.html" },
+])("releases a mismatched saved identity without exposing launch arguments: %j", async (mismatch) => {
+  const released: string[] = [];
+  const references: unknown[] = [];
+  const lookalike = { workspaceId: "lookalike", client: {
+    resolveMcpApp: async (_workspace: string, _name: string, launch: unknown, context: unknown) => {
+      references.push({ launch, context });
+      return { app: { ...resource, ...mismatch, launchId: "lookalike-lease" } };
+    },
+    releaseMcpApp: async (_workspace: string, id: string) => { released.push(id); return { released: true }; },
+  } };
+  const matching = { workspaceId: "matching", client: { releaseMcpApp: noRelease, resolveMcpApp: async () => ({ app: resource }) } };
+  const options = {
+    projectedToolName: "fixture_render", expected: resource,
+    wait: async () => { throw new Error("identity mismatch must not retry"); },
+  };
+  expect(await resolveDashboardMcpApp({ ...options, endpoints: [lookalike, matching] })).toEqual({ endpoint: matching, app: resource });
+  expect(await resolveDashboardMcpApp({ ...options, endpoints: [lookalike] })).toBeNull();
+  const launch = { connectionId: "emc_fixture", toolName: resource.toolName, resourceUri: resource.resourceUri, arguments: { privateInput: "saved-input" } };
+  expect(await resolveDashboardMcpApp({ ...options, endpoints: [lookalike], launch })).toBeNull();
+  expect(references).toEqual([
+    { launch: undefined, context: { sessionId: null, readOnly: false } },
+    { launch: undefined, context: { sessionId: null, readOnly: false } },
+    { launch: { ...launch, arguments: {} }, context: { sessionId: null, readOnly: false } },
+  ]);
+  expect(released).toEqual(["lookalike-lease", "lookalike-lease", "lookalike-lease"]);
+});
+
+test.each(["resolve", "wait"])("stops discovery and releases late leases when ownership ends during %s", async (phase) => {
+  let active = true;
+  let attempts = 0;
+  const released: string[] = [];
+  const endpoint = { workspaceId: "owner", client: {
+    resolveMcpApp: async () => {
+      attempts += 1;
+      if (phase === "wait") throw new OpenworkServerError(503, "server_unavailable", "starting");
+      active = false;
+      return { app: { ...resource, launchId: "late-lease" } };
+    },
+    releaseMcpApp: async (_workspace: string, id: string) => { released.push(id); return { released: true }; },
+  } };
+  expect(await resolveDashboardMcpApp({
+    endpoints: [endpoint], expected: resource, projectedToolName: "fixture_render",
+    isActive: () => active, wait: async () => { active = false; },
+  })).toBeNull();
+  expect(attempts).toBe(1);
+  expect(released).toEqual(phase === "resolve" ? ["late-lease"] : []);
+});
+
 test("a mounted tile retains its lease across fallback refreshes, but releases on owner removal, refresh and unmount", async () => {
   GlobalRegistrator.register({ url: "http://localhost/" });
   const previousAct = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
@@ -34,21 +151,26 @@ test("a mounted tile retains its lease across fallback refreshes, but releases o
   const released: string[] = [];
   const calls: string[] = [];
   let resolutions = 0;
-  const resource: OpenworkMcpAppResource = {
-    serverName: "fixture", toolName: "render", resourceUri: "ui://fixture/view.html", html: "<p>Fixture</p>",
-    csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] }, prefersBorder: true,
-  };
+  let finishFirstResolution: (() => void) | undefined;
+  const firstResolution = new Promise<void>(resolve => { finishFirstResolution = resolve; });
   const primary: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://primary.invalid" }),
-    resolveMcpApp: async () => ({ app: null }) };
+    resolveMcpApp: async (_workspace, _tool, launch) => {
+      expect(launch?.arguments).toEqual({});
+      return { app: null };
+    } };
   const owner: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://owner.invalid" }),
-    resolveMcpApp: async () => {
+    resolveMcpApp: async (_workspace, _tool, launch, context) => {
+      expect(launch?.arguments).toEqual({});
+      expect(context).toEqual({ sessionId: null, readOnly: false });
       const launchId = `launch-${++resolutions}`;
       leases.add(launchId);
+      if (resolutions === 1) await firstResolution;
       return { app: { ...resource, launchId } };
     },
     callMcpAppTool: async (workspaceId, request) => {
       expect(workspaceId).toBe("owner-workspace");
       if (!request.launchId || !leases.has(request.launchId)) throw new Error("Lease revoked");
+      if (request.name === "render") expect(request.arguments).toEqual({ query: "saved input" });
       calls.push(request.name);
       return { content: [] };
     },
@@ -61,7 +183,8 @@ test("a mounted tile retains its lease across fallback refreshes, but releases o
   const unrelated: OpenworkServerClient = { ...createOpenworkServerClient({ baseUrl: "http://unrelated.invalid" }),
     resolveMcpApp: async () => { throw new Error("Must not relaunch through an unrelated workspace"); } };
   const entry: DashboardMcpAppEntry = { kind: "mcp", id: "tile", serverName: "fixture", toolName: "render",
-    projectedToolName: "fixture_render", resourceUri: resource.resourceUri, title: "Fixture", autoLaunch: true };
+    projectedToolName: "fixture_render", resourceUri: resource.resourceUri, title: "Fixture", autoLaunch: true,
+    connectionId: "emc_fixture", launchArguments: { query: "saved input" } };
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
@@ -81,6 +204,10 @@ test("a mounted tile retains its lease across fallback refreshes, but releases o
   try {
     await render();
     expect(resolutions).toBe(1);
+    await render();
+    await render(true, true);
+    expect(calls).toEqual([]);
+    await act(async () => { finishFirstResolution?.(); });
     const actionButton = button("button:not([aria-label])");
     await render();
     await render(true, true);

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -83,6 +83,8 @@ test(
     const witnessedByTool = new Map(calls.map((call) => [call.name, call.args]));
     expect(witnessedByTool.get("getConfluencePage")).toEqual({ pageId: "1122334455" });
     expect(witnessedByTool.get("searchJiraIssuesUsingJql")).toEqual({ jql: expectedJql });
+    expect(world.receivedCalls.filter((call) => call.name === "getConfluencePage")).toHaveLength(1);
+    expect(world.receivedCalls.filter((call) => call.name === "searchJiraIssuesUsingJql")).toHaveLength(1);
 
     evidence.recordAssertionEvidence(
       "The dashboard tile names the missing required argument instead of a generic server error",

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -9,9 +9,8 @@ import {
 import type { DashboardTileFacts } from "../worlds/dashboard-launch-input.ts";
 
 /**
- * Customer report (2026-09): Dashboard tiles for the Atlassian remote MCP
- * "don't work" with the exact pasted JSON payloads, identically across an
- * org-account and an individual-accounts connection.
+ * Dashboard tiles must surface the provider's missing-argument rejection
+ * when saved launch input omits the required `cloudId` argument.
  *
  * Root cause: both payloads omit the required `cloudId` argument. Before the
  * fix every hop hid the provider's rejection and the tile read "Unexpected
@@ -33,7 +32,7 @@ function requireTile(value: DashboardTileFacts | null, label: string): Dashboard
 }
 
 test(
-  "a dashboard tile launched with the reported Atlassian JSON names the missing required argument",
+  "a dashboard tile launched with saved JSON names the missing required argument",
   async ({ world, user, probe, evidence }) => {
     await probe.eventually(() => world.openDashboard(), {
       within: 90_000,
@@ -83,8 +82,8 @@ test(
     const witnessedByTool = new Map(calls.map((call) => [call.name, call.args]));
     expect(witnessedByTool.get("getConfluencePage")).toEqual({ pageId: "1122334455" });
     expect(witnessedByTool.get("searchJiraIssuesUsingJql")).toEqual({ jql: expectedJql });
-    expect(world.receivedCalls.filter((call) => call.name === "getConfluencePage")).toHaveLength(1);
-    expect(world.receivedCalls.filter((call) => call.name === "searchJiraIssuesUsingJql")).toHaveLength(1);
+    expect(calls.filter((call) => call.name === "getConfluencePage")).toHaveLength(1);
+    expect(calls.filter((call) => call.name === "searchJiraIssuesUsingJql")).toHaveLength(1);
 
     evidence.recordAssertionEvidence(
       "The dashboard tile names the missing required argument instead of a generic server error",


### PR DESCRIPTION
## Summary

Recover temporary MCP App discovery failures without replaying launch tools or weakening current launch ownership.

- Retry only `server_unavailable` and `mcp_unreachable`, at 1s and 3s, for at most three discovery attempts per endpoint. Deterministic failures, null results and mismatched identities are not retried, including in mixed-endpoint recovery.
- Require the exact saved server, tool and resource URI before dashboard execution, including entries without a connection reference.
- Never send saved tool arguments or approval to discovery endpoints. Connection references carry empty arguments; only the matching launch endpoint receives saved input during tool execution.
- Preserve sessionless dashboard launch context, ownership checks and lease release. Release rejected or late resources; stop discovery when the owner disappears. Recheck ownership between resolution and tool dispatch.
- Reuse dev's endpoint ref rather than introducing a second ref. Discovery-array churn no longer abandons an in-flight launch, while actual owner removal still retires it.
- Chat discovery retains its original endpoint, workspace, conversation, archive state and lease cleanup. Exhaustion offers a manual resource-resolution Retry, never a launch-tool replay.

## Current Dev Reconciliation

Previous head: `7fd901db1ee31717da59061e9786c5cd17847299`.
Current signed head: `78df7d03c0d08711c3e07f8a1d4f1023c34f1594`.
Fresh base and merge-base: `858414c41c63a22eecfe331d17f3f5dd348dfc6f` (`dev`).

Preserved the two existing commits, resolving conflicts against dev's newer originating-view and lease implementation (#4863). Added a narrow signed repair for ownership changing before the resolver continuation. Current draft previews, native connection cards, connector catalogs, private App readiness repair and the existing migrated dashboard journey remain intact. No retired resolver-only journey or API is restored.

The reviewed server/tool/resource identity fixes remain enforced. The previously recorded saved-argument disclosure finding is repaired: discovery sends no saved input even to rejected fallback endpoints. Rejected leases are also released. Existing neutral journey descriptions remain; no report or account narrative is restored.

#4862 owns result fidelity, gateway metadata isolation and truthful host protocol capabilities. Recovery tests now extend the existing tile/origin suites rather than overlapping its protocol fixture additions. The two candidate heads compose without textual conflicts; combined runtime behavior is not claimed. Neither PR's useful increment is already in dev, so neither is closed as obsolete.

## Verification

**Verdict: Incomplete.** Passed on the current head, all exit 0:

- `pnpm --filter @openwork/app exec bun test --isolate tests/mcp-app-tile.test.tsx tests/mcp-app-frame.test.ts tests/mcp-app-origin.test.tsx`: 30 passed, 0 failed, 0 skipped.
- `pnpm --filter @openwork/app typecheck`.
- Diff whitespace check; every feature commit verifies `G` with Jalil's existing signature.

The mounted-component checks cover pending discovery-array churn without duplicate calls, unchanged saved input at the matching execution endpoint, empty discovery arguments, exact identity refusal, transient-only retry bounds, rejected/late lease release, owner removal, and chat manual Retry preserving the conversation without calling a tool. The expected exhausted-discovery diagnostic is visible in output. These are component checks, not runtime journey proof.

Failed: none. Skipped: none in the selected checks. Deferred: `dashboard-atlassian-tile-error` and current-head runtime proof for recovery, identity refusal and endpoint churn. No manual cloud/E2E/review runs or local E2E were started. All previous-head results, skips, typechecks and security clearance statements are historical only. Normal CI remains required and unchanged.

No merge, deployment, review request or branch deletion is included.
