### PR TITLE
fix(world): make receipt writes atomic and receipt polls tolerant of torn reads

### DIFF
--- a/packages/world/src/cli.ts
+++ b/packages/world/src/cli.ts
@@ -537,7 +537,11 @@ export async function main(argv: string[], options: WorldCliOptions): Promise<nu
           ...(command.detach || mode === "tty" ? { log: logPath } : {}),
         });
       };
-      const receiptPoll = setInterval(() => { void showReady(); }, 50);
+      const receiptPoll = setInterval(() => {
+        void showReady().catch((error: unknown) => {
+          view.apply({ t: new Date().toISOString(), type: "note", text: `Could not read world receipt: ${messageText(error)}` });
+        });
+      }, 50);
       receiptPoll.unref();
       const onSigint = (): void => {
         if (stopped || childPid === undefined) return;

--- a/packages/world/src/hold.ts
+++ b/packages/world/src/hold.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendEvent, EVENTS_ENV } from "./events.ts";
@@ -97,7 +97,10 @@ export async function hold(options: HoldOptions = {}): Promise<void> {
     ...(place === undefined ? {} : { place }),
   };
   await mkdir(dirname(snapshotPath), { recursive: true });
-  await writeFile(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  const temporarySnapshotPath = `${snapshotPath}.tmp`;
+  await writeFile(temporarySnapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(temporarySnapshotPath, 0o600);
+  await rename(temporarySnapshotPath, snapshotPath);
   await chmod(snapshotPath, 0o600);
   const eventPath = process.env[EVENTS_ENV];
   if (eventPath !== undefined) {

--- a/packages/world/src/script-world.ts
+++ b/packages/world/src/script-world.ts
@@ -129,12 +129,21 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 export async function readScriptWorldSnapshot(path: string): Promise<ScriptWorldSnapshot | undefined> {
+  let text: string;
   try {
-    return parseScriptWorldSnapshot(await readFile(path, "utf8"));
+    text = await readFile(path, "utf8");
   } catch (error) {
     if (isMissingFile(error)) return undefined;
     throw error;
   }
+  if (text.trim() === "") return undefined;
+  try {
+    JSON.parse(text);
+  } catch (error) {
+    if (error instanceof SyntaxError) return undefined;
+    throw error;
+  }
+  return parseScriptWorldSnapshot(text);
 }
 
 async function removeDeadSnapshot(path: string): Promise<void> {

--- a/packages/world/test/cli.test.ts
+++ b/packages/world/test/cli.test.ts
@@ -179,6 +179,9 @@ test("preflight failures warn without blocking up and do not affect attach or pl
   const worldsDirectory = join(root, "worlds");
   const receiptPath = join(root, "evals", "results", ".worlds", "scripts", "warned.json");
   const holdUrl = new URL("../src/hold.ts", import.meta.url).href;
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown): void => { unhandledRejections.push(reason); };
+  process.on("unhandledRejection", onUnhandledRejection);
   let checks = 0;
   const failingCheck = {
     id: "fixture",
@@ -229,7 +232,10 @@ test("preflight failures warn without blocking up and do not affect attach or pl
     }), 0);
     assert.equal(planLines[0], "• running (attachable)");
     assert.equal(checks, 1, "plan does not run preflight");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(unhandledRejections, []);
   } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
     await main(["down", "warned"], {
       cwd: root,
       worldsDirectory,

--- a/packages/world/test/hold.test.ts
+++ b/packages/world/test/hold.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -59,6 +59,7 @@ test("hold keeps an otherwise idle world alive until SIGTERM", async () => {
     assert.equal(isAlive(pid), true, "world exited while hold was awaiting a signal");
     const receiptText = await readFile(receiptPath, "utf8");
     const receipt = parseScriptWorldSnapshot(receiptText);
+    assert.deepEqual((await readdir(snapshots)).filter((name) => name.endsWith(".tmp")), []);
     assert.equal(receipt.version, 2);
     assert.equal(receipt.outputs.token, "s3cr3t");
     assert.equal(receipt.outputMeta?.token?.secret, true);

--- a/packages/world/test/store.test.ts
+++ b/packages/world/test/store.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, open, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { parseScriptWorldSnapshot } from "../src/script-world.ts";
+import { setTimeout as delay } from "node:timers/promises";
+import { parseScriptWorldSnapshot, readScriptWorldSnapshot } from "../src/script-world.ts";
 import { WorldStateStore } from "../src/store.ts";
 
 test("local world state is owner-only and addressable by world name", async () => {
@@ -11,6 +12,7 @@ test("local world state is owner-only and addressable by world name", async () =
   try {
     const store = new WorldStateStore(join(root, "worlds"));
     const path = await store.save("demo", '{"name":"demo"}');
+    await writeFile(`${path}.tmp`, "partial", "utf8");
     assert.equal((await stat(path)).mode & 0o777, 0o600);
     assert.equal(await store.read("demo"), '{"name":"demo"}\n');
     assert.deepEqual(await store.list(), [path]);
@@ -67,4 +69,54 @@ test("script world snapshots parse v1 and strict v2 receipts", () => {
     );
   }
   assert.throws(() => parseScriptWorldSnapshot("{}"), /not a valid script world snapshot/);
+});
+
+test("script world snapshot reads tolerate a receipt being written byte by byte", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-world-receipt-race-"));
+  const path = join(root, "demo.json");
+  const expected = {
+    version: 2 as const,
+    kind: "script" as const,
+    name: "demo",
+    createdAt: "2026-09-01T00:00:00.000Z",
+    pid: 123,
+    sourcePath: "/tmp/demo.ts",
+    outputs: { ready: "yes" },
+    stage: "test",
+  };
+  const results: Array<Awaited<ReturnType<typeof readScriptWorldSnapshot>>> = [];
+  const errors: unknown[] = [];
+  let polling = true;
+  const poller = (async () => {
+    while (polling) {
+      try {
+        results.push(await readScriptWorldSnapshot(path));
+      } catch (error) {
+        errors.push(error);
+      }
+      await delay(5);
+    }
+  })();
+  try {
+    const file = await open(path, "w", 0o600);
+    try {
+      for (const byte of Buffer.from(`${JSON.stringify(expected)}\n`)) {
+        await file.write(Buffer.from([byte]));
+        await delay(1);
+      }
+    } finally {
+      await file.close();
+    }
+    polling = false;
+    await poller;
+    assert.deepEqual(errors, []);
+    for (const result of results) {
+      if (result !== undefined) assert.deepEqual(result, expected);
+    }
+    assert.deepEqual(await readScriptWorldSnapshot(path), expected);
+  } finally {
+    polling = false;
+    await poller;
+    await rm(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Fixes the macOS CI flake reported on #4280 (`openwork-tests (macos-14)` red with all 94 files passing): an unhandled rejection from `world-stage-isolation.test.ts` — `SyntaxError: Unexpected end of JSON input` at `parseScriptWorldSnapshot` ← `readScriptWorldSnapshot` ← `showReady` (`cli.ts`). Runs: 33567537248, 33575499618.

## Cause (the report's diagnosis was exact)
- `hold()` wrote the receipt with a plain `writeFile` → a 0-byte/partial file is observable (pre-existing since #4261, latent).
- #4286 (mine) added a **50 ms** receipt poll in the live view as a bare `void showReady()` with no `.catch`, and `readScriptWorldSnapshot` swallowed only ENOENT → a torn read became an **unhandled rejection**, which vitest reports as an errored run with 0 failing tests. `world-stage-isolation` boots four worlds side by side, so slower macOS I/O lost the race regularly; Ubuntu practically never did.

## Fix — all three layers
1. `hold.ts`: write `<name>.json.tmp` (0600) then `rename()` — atomic on APFS/ext4; readers see nothing or the whole receipt. `.json.tmp` is not matched by receipt/ledger listings (tested).
2. `script-world.ts` `readScriptWorldSnapshot`: empty or unparsable JSON = not ready yet → `undefined` so pollers retry; shape errors after a successful parse still throw.
3. `cli.ts`: the receipt poll is `.catch`-guarded and surfaces through the view as a note — a poll can never escape as an unhandled rejection.

## Verification (local lane; engine-only, app-less)
| Check | Result |
|---|---|
| `pnpm --filter @openwork/world test` — incl. new: byte-by-byte writer vs 5 ms poller never throws and only yields `undefined` or the full receipt; `hold` leaves no `.tmp` residue and the receipt parses; `up --detach` emits zero `unhandledRejection` events | 44/44 |
| `pnpm --filter @openwork/world typecheck` | clean |
| `world-stage-isolation` ×3, `world-plan-idempotent-up`, `world-up-progress`, `world-outputs-secrets`, `script-world-lifecycle`, `world-crash-reap` | all 1/1 |

Thanks to the reporter — the repro suggestion (poll while writing byte-by-byte) is the unit test.