### PR TITLE
fix(den-api): show manual-close guidance when the browser blocks closing the OAuth callback tab

### DIFF
--- a/ee/apps/den-api/src/capability-sources/oauth-callback-page.ts
+++ b/ee/apps/den-api/src/capability-sources/oauth-callback-page.ts
@@ -11,7 +11,8 @@ export function connectCallbackPage(input:
   | { ok: true; name: string }
   | { ok: false; name: string; message: string; referenceId?: string }): string {
   const title = input.ok ? "You're connected" : "Connection failed"
-  const closeButton = `<button type="button" onclick="window.close()">Close window</button>`
+  const closeButton = `<button id="close-window-button" type="button">Close window</button>
+       <p id="manual-close-guidance" class="close-guidance" role="status" aria-live="polite" hidden>Your browser prevented OpenWork from closing this tab automatically. Close this tab to return to OpenWork.</p>`
   const body = input.ok
     ? `<div class="status-row success">
         <span class="status-icon" aria-hidden="true">✓</span>
@@ -53,6 +54,7 @@ export function connectCallbackPage(input:
       button { margin-top: 30px; border: 0; border-radius: 12px; padding: 12px 18px; color: #fff; background: #101828; font: inherit; font-weight: 600; cursor: pointer; box-shadow: 0 1px 2px rgba(16, 24, 40, .12); }
       button:hover { background: #1d2939; }
       button:focus-visible { outline: 3px solid rgba(59, 130, 246, .28); outline-offset: 3px; }
+      .close-guidance { margin-top: 30px; color: #475467; font-weight: 600; }
       @media (max-width: 560px) { body { padding: 16px; } main { padding: 32px 22px; border-radius: 24px; } .status-row { margin-top: 30px; padding: 18px; } }
     </style>
   </head>
@@ -62,6 +64,20 @@ export function connectCallbackPage(input:
       <h1>${title}</h1>
       ${body}
     </main>
+    <script>
+      // Browsers only let a script close a tab that a script opened. OpenWork
+      // launches this page through the OS default browser, so window.close()
+      // is usually a no-op there; fall back to telling the user to close the tab.
+      const closeButton = document.getElementById("close-window-button");
+      const manualCloseGuidance = document.getElementById("manual-close-guidance");
+      closeButton.addEventListener("click", () => {
+        window.close();
+        window.setTimeout(() => {
+          closeButton.hidden = true;
+          manualCloseGuidance.hidden = false;
+        }, 250);
+      });
+    </script>
   </body>
 </html>`
 }

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -1239,8 +1239,10 @@ describe("external MCP diagnostics", () => {
 
     expect(html).toContain("You're connected")
     expect(html).toContain("Enterprise MCP &lt;test&gt; is connected to OpenWork.")
-    expect(html).toContain("window.close()")
+    expect(html).toContain("window.close();")
     expect(html).toContain("Close window")
+    expect(html).toContain("Your browser prevented OpenWork from closing this tab automatically.")
+    expect(html).toContain("manualCloseGuidance.hidden = false")
     expect(html).toContain("OpenWork Connect")
     expect(html).toContain("background: #f8fbff")
     expect(html).not.toContain("@keyframes")

--- a/evals/specs/oauth-callback-close-guidance.test.ts
+++ b/evals/specs/oauth-callback-close-guidance.test.ts
@@ -1,0 +1,22 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { connectCallbackPage } from "../../ee/apps/den-api/src/capability-sources/oauth-callback-page";
+
+test("OAuth completion gives usable guidance when a system browser refuses to close its tab", async ({ evidence }) => {
+  const html = connectCallbackPage({ ok: true, name: "Notion" });
+
+  expect(html).toContain('id="close-window-button"');
+  expect(html).toContain("window.close();");
+  expect(html).toContain("window.setTimeout");
+  expect(html).toContain("closeButton.hidden = true");
+  expect(html).toContain("manualCloseGuidance.hidden = false");
+  expect(html).toContain("Your browser prevented OpenWork from closing this tab automatically.");
+  expect(html).toContain("Close this tab to return to OpenWork.");
+  expect(html).not.toContain('onclick="window.close()"');
+
+  evidence.recordAssertionEvidence(
+    "OAuth completion handles browser-enforced tab closing restrictions",
+    "The completion page first asks the browser to close, then replaces the ineffective control with accessible manual-close guidance if the externally opened tab remains visible.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- After an MCP OAuth flow (Notion, Slack, …) the Den callback page's **Close window** button appeared to do nothing in Chrome.
- Keep the button, attempt `window.close()`, and if the tab is still alive 250 ms later swap the button for an accessible status message: *"Your browser prevented OpenWork from closing this tab automatically. Close this tab to return to OpenWork."*

## Why
- OpenWork Desktop launches the OAuth URL via Electron `shell.openExternal()`, so the browser creates a top-level tab with no script opener. Chrome deliberately ignores `window.close()` for such tabs ("Scripts may close only the windows that were opened by them"). No page-side change can force the close, so the honest fix is to degrade to manual-close guidance instead of showing a dead control.
- The desktop app never depends on the tab closing (`use-org-mcp-connections.ts` polls Den for `connectedForMe`), so this is purely a UX fix.

## Issue
- N/A (reported in-app)

## Scope
- `ee/apps/den-api/src/capability-sources/oauth-callback-page.ts` — id'd button + hidden `role="status"` guidance, inline script with the close-then-fallback behaviour.
- `ee/apps/den-api/test/external-mcp-diagnostics.test.ts` — extend existing callback-page assertions.
- `evals/specs/oauth-callback-close-guidance.test.ts` — new `@openwork/testkit` PR-lane spec.

## Out of scope
- Removing the button entirely (considered; loses the cases where closing does work, e.g. web-app `window.open` path).
- Changing how Desktop launches the OAuth URL.

## Testing
### Ran
- `pnpm evals:pr specs/oauth-callback-close-guidance.test.ts` — local lane (no Daytona credentials in this environment; app-less PR-lane spec)
- `bun test --conditions development test/external-mcp-diagnostics.test.ts` (in `ee/apps/den-api`)
- `tsc --noEmit -p ee/apps/den-api` — no errors in the touched file

### Result
- pass/fail: **pass** — evals: 1 passed / 0 failed / 0 skipped (exit 0); den-api: 83 pass / 0 fail (exit 0)
- Test run on PR head `f82a8f275`: `evals/results/test-runs/2026-09-02T02-31-08-290Z-oauth-completion-gives-usable-guidance-when-a-system-browser-refuses-to-close-it`

## CI status
- pass: pending
- code-related failures: none known
- external/env/auth blockers: none

## Manual verification
1. In OpenWork Desktop, Settings → Library → Connections, connect Notion or Slack.
2. Complete OAuth in Chrome; the callback page shows **You're connected** with **Close window**.
3. Click **Close window**: in Chrome the button is replaced by the manual-close guidance; in a browser that allows script closing, the tab closes.

## Evidence
- Testkit evidence published via sticky `<!-- test-evidence -->` comment (see below).

## Risk
- Low. Static HTML served by den-api; no auth or data-path changes. The unit test still asserts no `@keyframes` and the existing page chrome.

## Rollback
- Revert this single commit.