### PR TITLE
fix(app): keep binary file paths out of Read-expanded prompt parts

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -31,7 +31,7 @@ import type {
 } from "../../../../app/types";
 import { addOpencodeCacheHint, safeStringify } from "../../../../app/utils";
 import { clearSessionDraft, LOCAL_SESSION_DRAFT_SCOPE, saveSessionDraft } from "./draft-store";
-import { firstLineLocalFileParts } from "./prompt-file-parts";
+import { firstLineLocalFileParts, isReadInlineablePath } from "./prompt-file-parts";
 import { composerAttachmentToFilePart } from "./attachment-file-part";
 import { appMentionInstruction } from "../surface/composer/app-mentions";
 
@@ -169,6 +169,10 @@ export function createSessionActionsStore(options: {
       if (part.type === "file") {
         const absolute = toAbsolutePath(part.path);
         if (!absolute) continue;
+        if (!isReadInlineablePath(absolute)) {
+          parts.push({ type: "text", text: absolute } as TextPartInput);
+          continue;
+        }
         parts.push({
           type: "file",
           mime: "text/plain",
@@ -207,7 +211,7 @@ export function createSessionActionsStore(options: {
     for (const part of draft.parts) {
       if (part.type !== "file") continue;
       const absolute = toAbsolutePath(part.path);
-      if (!absolute) continue;
+      if (!absolute || !isReadInlineablePath(absolute)) continue;
       parts.push({
         type: "file",
         mime: "text/plain",

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -306,12 +306,13 @@ function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInp
   };
 }
 
-async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise<FilePartInput> {
-  // Binary/unknown mimes also get a `text/plain` file part: opencode expands
-  // text/plain `file://` parts through the Read tool (which fails gracefully
-  // with "Cannot read binary file") and never forwards them to the provider,
-  // so the transcript keeps an attachment badge without any provider risk.
-  const modelMime = modelFacingAttachmentMime(item.mime) ?? "text/plain";
+async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise<FilePartInput | null> {
+  // Binary/unknown mimes get no model-facing file part. A `text/plain`
+  // `file://` part would make opencode run the Read tool on the bytes, which
+  // refuses with "Cannot read binary file" as a session error and drops the
+  // part anyway; the synthetic workspace-path note already gives tools the file.
+  const modelMime = modelFacingAttachmentMime(item.mime);
+  if (!modelMime) return null;
 
   // Images need a browser-displayable URL so the transcript can show the same
   // expandable miniature preview as paste/composer attachments. Workspace
@@ -333,14 +334,21 @@ async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise
   };
 }
 
+export type WorkspaceAttachmentParts = {
+  /** Synthetic note listing every uploaded workspace path for tools. */
+  note: TextPartInput;
+  /** One entry per attachment, in order; `null` when the model gets no file part. */
+  files: Array<FilePartInput | null>;
+};
+
 export async function composerAttachmentsToWorkspaceFileParts(input: {
   attachments: ComposerAttachment[];
   endpoint: ChatAttachmentWorkspaceEndpoint;
   sessionId: string;
   workspaceRoot: string;
   createId?: () => string;
-}): Promise<Array<TextPartInput | FilePartInput>> {
-  if (input.attachments.length === 0) return [];
+}): Promise<WorkspaceAttachmentParts | null> {
+  if (input.attachments.length === 0) return null;
 
   const workspaceRoot = input.workspaceRoot.trim();
   if (!workspaceRoot) {
@@ -399,10 +407,10 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
     });
   }
 
-  return [
-    attachmentPathNotePart(uploaded),
-    ...(await Promise.all(uploaded.map(uploadedAttachmentFilePart))),
-  ];
+  return {
+    note: attachmentPathNotePart(uploaded),
+    files: await Promise.all(uploaded.map(uploadedAttachmentFilePart)),
+  };
 }
 
 export async function composerAttachmentToFilePart(attachment: ComposerAttachment): Promise<FilePartInput | null> {

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -11,6 +11,7 @@ import {
 } from "./attachment-file-part";
 import {
   firstLineLocalFileParts,
+  isReadInlineablePath,
   joinWorkspaceRelativePath,
   toFileUrl,
 } from "./prompt-file-parts";
@@ -56,16 +57,12 @@ export async function draftToParts(
       sessionId,
       workspaceRoot: root,
     });
-    for (const part of uploaded) {
-      if (part.type === "text") {
-        parts.push(part);
-        continue;
+    if (uploaded) {
+      parts.push(uploaded.note);
+      for (const [index, attachment] of draft.attachments.entries()) {
+        const filePart = uploaded.files[index];
+        if (filePart) attachmentFileById.set(attachment.id, filePart);
       }
-    }
-    const fileParts = uploaded.filter((part): part is FilePartInput => part.type === "file");
-    for (const [index, attachment] of draft.attachments.entries()) {
-      const filePart = fileParts[index];
-      if (filePart) attachmentFileById.set(attachment.id, filePart);
     }
   }
 
@@ -123,6 +120,10 @@ export async function draftToParts(
         if (mentionPart?.type === "file") {
           const absolute = toAbsolutePath(mentionPart.path);
           if (!absolute) continue;
+          if (!isReadInlineablePath(absolute)) {
+            parts.push({ type: "text", text: absolute });
+            continue;
+          }
           parts.push({
             type: "file",
             mime: "text/plain",
@@ -162,6 +163,10 @@ export async function draftToParts(
       if (part.type === "file") {
         const absolute = toAbsolutePath(part.path);
         if (!absolute) continue;
+        if (!isReadInlineablePath(absolute)) {
+          parts.push({ type: "text", text: absolute });
+          continue;
+        }
         parts.push({
           type: "file",
           mime: "text/plain",

--- a/apps/app/src/react-app/domains/session/sync/prompt-file-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/prompt-file-parts.ts
@@ -78,6 +78,35 @@ export function joinWorkspaceRelativePath(workspaceRoot: string, relativePath: s
   return `${root}/${relative}`;
 }
 
+// A `text/plain` `file://` part is expanded by opencode through the Read tool
+// before the model sees the message. Read inlines text and attaches images and
+// PDFs, but refuses every other binary with "Cannot read binary file", which
+// opencode surfaces as a session error. Paths with these extensions therefore
+// stay plain text in the prompt so tools can still act on the file.
+const READ_BINARY_EXTENSIONS = new Set([
+  // video / audio
+  "mp4", "m4v", "mov", "mkv", "avi", "webm", "wmv", "flv", "mpg", "mpeg",
+  "mp3", "m4a", "aac", "wav", "aif", "aiff", "flac", "ogg", "oga", "opus", "wma",
+  // images Read cannot attach
+  "heic", "heif", "tif", "tiff", "bmp", "ico", "psd", "ai", "raw", "sketch",
+  // archives / disk images
+  "zip", "tar", "gz", "tgz", "bz2", "xz", "7z", "rar", "dmg", "iso", "pkg",
+  // office / documents
+  "doc", "docx", "xls", "xlsx", "ppt", "pptx", "odt", "ods", "odp", "key", "numbers", "pages",
+  // compiled / executable / data
+  "exe", "dll", "so", "dylib", "bin", "dat", "obj", "o", "a", "lib", "wasm", "class", "jar", "war", "pyc", "pyo",
+  "sqlite", "sqlite3", "db",
+  // fonts
+  "ttf", "otf", "woff", "woff2",
+]);
+
+export function isReadInlineablePath(path: string) {
+  const basename = path.replace(/\\/g, "/").split("/").pop() ?? "";
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0 || dot === basename.length - 1) return true;
+  return !READ_BINARY_EXTENSIONS.has(basename.slice(dot + 1).toLowerCase());
+}
+
 export function firstLineLocalFileParts(text: string, workspaceRoot: string): FilePartInput[] {
   const firstLine = text.split(/\r?\n/, 1)[0] ?? "";
   const parts: FilePartInput[] = [];
@@ -89,6 +118,7 @@ export function firstLineLocalFileParts(text: string, workspaceRoot: string): Fi
     const absolute = toAbsolutePath(raw, workspaceRoot);
     if (!absolute || seen.has(absolute)) continue;
     seen.add(absolute);
+    if (!isReadInlineablePath(absolute)) continue;
     parts.push({
       type: "file",
       mime: "text/plain",

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -74,20 +74,25 @@ function uploadRecorder(workspaceId: string) {
   return { endpoint, calls };
 }
 
-function textPart(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>) {
-  const part = parts[0];
-  if (!part || part.type !== "text") throw new Error("Expected first attachment part to be a text note");
-  return part;
+type WorkspaceParts = Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>;
+
+function textPart(parts: WorkspaceParts) {
+  if (!parts) throw new Error("Expected attachment parts");
+  return parts.note;
 }
 
-function textPartText(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>) {
+function textPartText(parts: WorkspaceParts) {
   return textPart(parts).text;
 }
 
-function filePartUrl(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>, index: number) {
-  const part = parts[index];
-  if (!part || part.type !== "file") throw new Error(`Expected attachment part ${index} to be a file`);
-  return part.url;
+function filePart(parts: WorkspaceParts, index: number) {
+  const part = parts?.files[index];
+  if (!part) throw new Error(`Expected attachment ${index} to have a file part`);
+  return part;
+}
+
+function filePartUrl(parts: WorkspaceParts, index: number) {
+  return filePart(parts, index).url;
 }
 
 describe("composer attachment file parts", () => {
@@ -343,8 +348,8 @@ describe("composer attachment file parts", () => {
     expect(textPartText(parts).startsWith("Attached files were copied")).toBe(true);
     expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only scan.pdf");
     expect(textPartText(parts)).toContain("Read/Bash/MCP/Docling");
-    expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only%20scan.pdf");
-    expect(parts[1]).toMatchObject({
+    expect(filePartUrl(parts, 0)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only%20scan.pdf");
+    expect(filePart(parts, 0)).toMatchObject({
       type: "file",
       filename: "image-only scan.pdf",
       mime: "application/pdf",
@@ -372,9 +377,9 @@ describe("composer attachment file parts", () => {
     expect(textPart(parts)).toMatchObject({ type: "text", synthetic: true });
     expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_img/nonce-img-shot.png");
     expect(textPartText(parts)).toContain("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_img/nonce-img-shot.png");
-    expect(filePartUrl(parts, 1).startsWith("data:image/png;base64,")).toBe(true);
-    expect(Array.from(decodedDataUrlBytes(filePartUrl(parts, 1)))).toEqual(Array.from(JPEG_BYTES));
-    expect(parts[1]).toMatchObject({
+    expect(filePartUrl(parts, 0).startsWith("data:image/png;base64,")).toBe(true);
+    expect(Array.from(decodedDataUrlBytes(filePartUrl(parts, 0)))).toEqual(Array.from(JPEG_BYTES));
+    expect(filePart(parts, 0)).toMatchObject({
       type: "file",
       filename: "shot.png",
       mime: "image/png",
@@ -394,15 +399,15 @@ describe("composer attachment file parts", () => {
     });
 
     expect(calls).toHaveLength(1);
-    expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_xml/nonce-xml-sitemap.xml");
-    expect(parts[1]).toMatchObject({
+    expect(filePartUrl(parts, 0)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_xml/nonce-xml-sitemap.xml");
+    expect(filePart(parts, 0)).toMatchObject({
       type: "file",
       filename: "sitemap.xml",
       mime: "text/plain",
     });
   });
 
-  test("workspace binary attachments upload for tool access and emit a Read-mediated text/plain file part", async () => {
+  test("workspace binary attachments upload for tool access without a model-facing file part", async () => {
     const { endpoint, calls } = uploadRecorder("server-workspace-42");
     const file = new File([PPTX_BYTES], "recording.zip", { type: "application/zip" });
 
@@ -423,14 +428,10 @@ describe("composer attachment file parts", () => {
     expect(textPart(parts)).toMatchObject({ type: "text", synthetic: true });
     expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_bin/nonce-bin-recording.zip");
     expect(textPartText(parts)).toContain("Read/Bash/MCP/Docling");
-    // text/plain file parts never reach the provider (opencode expands them
-    // through the Read tool), so binaries keep a transcript badge safely.
-    expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_bin/nonce-bin-recording.zip");
-    expect(parts[1]).toMatchObject({
-      type: "file",
-      filename: "recording.zip",
-      mime: "text/plain",
-    });
+    // A text/plain file part would make opencode run Read on the bytes and
+    // surface "Cannot read binary file" as a session error; the path note is
+    // enough for tools, so the model gets no file part.
+    expect(parts?.files).toEqual([null]);
   });
 
   test("uploads duplicate filenames to distinct non-overwriting paths", async () => {
@@ -456,8 +457,8 @@ describe("composer attachment file parts", () => {
       "chat-attachments/ses_dupes/nonce-b-scan.pdf",
     ]);
     expect(new Set(calls.map((call) => call.path)).size).toBe(2);
-    expect(filePartUrl(parts, 1)).toBe("file:///C:/Users/Ada%20Lovelace/%E5%B7%A5%E4%BD%9C%E5%8C%BA/.opencode/openwork/inbox/chat-attachments/ses_dupes/nonce-a-scan.pdf");
-    expect(filePartUrl(parts, 2)).toBe("file:///C:/Users/Ada%20Lovelace/%E5%B7%A5%E4%BD%9C%E5%8C%BA/.opencode/openwork/inbox/chat-attachments/ses_dupes/nonce-b-scan.pdf");
+    expect(filePartUrl(parts, 0)).toBe("file:///C:/Users/Ada%20Lovelace/%E5%B7%A5%E4%BD%9C%E5%8C%BA/.opencode/openwork/inbox/chat-attachments/ses_dupes/nonce-a-scan.pdf");
+    expect(filePartUrl(parts, 1)).toBe("file:///C:/Users/Ada%20Lovelace/%E5%B7%A5%E4%BD%9C%E5%8C%BA/.opencode/openwork/inbox/chat-attachments/ses_dupes/nonce-b-scan.pdf");
   });
 
   test("fails before producing prompt parts when workspace upload fails", async () => {

--- a/apps/app/tests/prompt-file-parts.test.ts
+++ b/apps/app/tests/prompt-file-parts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { firstLineLocalFileParts } from "../src/react-app/domains/session/sync/prompt-file-parts";
+import { draftToParts } from "../src/react-app/domains/session/sync/draft-parts";
+import { firstLineLocalFileParts, isReadInlineablePath } from "../src/react-app/domains/session/sync/prompt-file-parts";
 import {
   connectSkillSlashCommandOptions,
   getSlashCommandQuery,
@@ -61,6 +62,63 @@ describe("first-line local file parts", () => {
         url: "file:///C:/Users/omar/list.csv",
         filename: "list.csv",
       },
+    ]);
+  });
+
+  test("leaves binary media paths as plain text instead of a Read-expanded file part", () => {
+    // opencode expands text/plain file parts through the Read tool, which
+    // refuses binaries with "Cannot read binary file" as a session error.
+    expect(firstLineLocalFileParts(
+      "could you add this to descript /Users/ben/Downloads/C0217.MP4",
+      "/Users/ben/code/openwork",
+    )).toEqual([]);
+    expect(firstLineLocalFileParts("unzip ~/Downloads/archive.zip and C:\\Users\\ben\\deck.pptx", "/Users/ben/code")).toEqual([]);
+  });
+
+  test("keeps text, image, and PDF paths as file parts", () => {
+    const parts = firstLineLocalFileParts(
+      "compare /Users/ben/notes.md /Users/ben/shot.PNG /Users/ben/paper.pdf /Users/ben/Makefile",
+      "/Users/ben/code",
+    );
+
+    expect(parts.map((part) => part.filename)).toEqual(["notes.md", "shot.PNG", "paper.pdf", "Makefile"]);
+  });
+});
+
+describe("read-inlineable paths", () => {
+  test("classifies by extension only", () => {
+    expect(isReadInlineablePath("/Users/ben/Downloads/C0217.MP4")).toBe(false);
+    expect(isReadInlineablePath("C:\\Users\\ben\\report.docx")).toBe(false);
+    expect(isReadInlineablePath("/tmp/build/app.wasm")).toBe(false);
+    expect(isReadInlineablePath("/Users/ben/notes.md")).toBe(true);
+    expect(isReadInlineablePath("/Users/ben/shot.png")).toBe(true);
+    expect(isReadInlineablePath("/Users/ben/paper.pdf")).toBe(true);
+    expect(isReadInlineablePath("/Users/ben/.env")).toBe(true);
+    expect(isReadInlineablePath("/Users/ben/Makefile")).toBe(true);
+    expect(isReadInlineablePath("/Users/ben/weird.")).toBe(true);
+  });
+});
+
+describe("draft file mentions", () => {
+  test("binary @file mentions become the absolute path as text", async () => {
+    const parts = await draftToParts(
+      {
+        mode: "prompt",
+        text: "add @/Users/ben/Downloads/C0217.MP4 and @notes.md",
+        parts: [
+          { type: "file", path: "/Users/ben/Downloads/C0217.MP4" },
+          { type: "file", path: "notes.md" },
+        ],
+        attachments: [],
+      },
+      "/Users/ben/code",
+      "ses_test",
+      null,
+    );
+
+    expect(parts).toEqual([
+      { type: "text", text: "/Users/ben/Downloads/C0217.MP4" },
+      { type: "file", mime: "text/plain", url: "file:///Users/ben/code/notes.md", filename: "notes.md" },
     ]);
   });
 });

--- a/evals/specs/binary-path-prompt-parts.test.ts
+++ b/evals/specs/binary-path-prompt-parts.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { draftToParts } from "../../apps/app/src/react-app/domains/session/sync/draft-parts";
+import { firstLineLocalFileParts } from "../../apps/app/src/react-app/domains/session/sync/prompt-file-parts";
+
+// opencode expands every `text/plain` `file://` part through the Read tool
+// before the model sees the prompt. Read inlines text and attaches images and
+// PDFs, but refuses other binaries with "Cannot read binary file", which the
+// engine publishes as a session error. A typed or mentioned path to such a
+// file must therefore reach the model as plain text, never as a file part.
+
+test("a typed binary media path is not attached as a text/plain file part", () => {
+  const parts = firstLineLocalFileParts(
+    "could you add this to descript /Users/ben/Downloads/C0217.MP4",
+    "/Users/ben/code/openwork",
+  );
+
+  expect(parts).toEqual([]);
+});
+
+test("a typed text path in the same position is still attached", () => {
+  const parts = firstLineLocalFileParts(
+    "could you summarize this /Users/ben/Downloads/notes.md",
+    "/Users/ben/code/openwork",
+  );
+
+  expect(parts).toEqual([{
+    type: "file",
+    mime: "text/plain",
+    url: "file:///Users/ben/Downloads/notes.md",
+    filename: "notes.md",
+  }]);
+});
+
+test("a binary @file mention keeps its path as text while a text mention stays a file part", async () => {
+  const parts = await draftToParts(
+    {
+      mode: "prompt",
+      text: "add @/Users/ben/Downloads/C0217.MP4 to descript and read @notes.md",
+      parts: [
+        { type: "file", path: "/Users/ben/Downloads/C0217.MP4" },
+        { type: "file", path: "notes.md" },
+      ],
+      attachments: [],
+    },
+    "/Users/ben/code",
+    "ses_binary_path",
+    null,
+  );
+
+  expect(parts.filter((part) => part.type === "file")).toEqual([
+    { type: "file", mime: "text/plain", url: "file:///Users/ben/code/notes.md", filename: "notes.md" },
+  ]);
+  expect(parts).toContainEqual({ type: "text", text: "/Users/ben/Downloads/C0217.MP4" });
+});

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     maxWorkers: e2eWorkers,
     projects: [
       {
+        resolve: appResolve,
         test: {
           ...common,
           name: "pr",


### PR DESCRIPTION
## Problem

Asking the agent to act on a local media file, e.g.

> could you add this to descript /Users/…/Downloads/C0217.MP4

showed a red session error `Cannot read binary file: /Users/…/C0217.MP4` above the message before the turn even started.

`firstLineLocalFileParts` (and the `@file` mention paths in `draft-parts.ts` / `actions-store.ts`) attach every detected local path as a `file://` part with a hard-coded `mime: "text/plain"`. opencode expands `text/plain` file parts through the Read tool before the model sees the prompt; Read inlines text and attaches images/PDFs but refuses other binaries, and `session/prompt.ts` publishes that failure as `session.error` while still continuing the turn. The user gets a scary error for a legitimate request.

`uploadedAttachmentFilePart` used the same `text/plain` fallback for uploaded binaries, on the assumption (in a comment) that Read "fails gracefully". It does not — it produces the same banner, and opencode drops the file part in that branch anyway.

## Change

- `prompt-file-parts.ts`: add `isReadInlineablePath()` — an extension denylist of files Read cannot inline (video/audio, archives, Office, executables, fonts, unsupported image formats). Extensionless and unknown extensions remain attached as before.
- Detected first-line paths to such files are no longer attached; the path stays in the message text so the model can hand it to bash/MCP tools.
- `@file` mentions to such files become the absolute path as a text part (both `draft-parts.ts` and the legacy `actions-store.ts` builders).
- `attachment-file-part.ts`: uploaded binaries keep their workspace copy and the synthetic path note but emit no model-facing file part. `composerAttachmentsToWorkspaceFileParts` now returns `{ note, files[] }` with one entry per attachment so `draft-parts.ts` chip alignment cannot drift when one is `null`.
- `evals/vitest.config.ts`: wire the existing `@/` app-source alias into the `pr` project (previously e2e-only) so app-less specs can import composer modules.

## Verification

Lane: **local** (the app-less `pr` project launches no resources; Daytona placement only applies to `prepare-stack` in the e2e project).

```
pnpm evals:pr specs/binary-path-prompt-parts.test.ts
```
exit 0 — Test Files 1 passed, Tests **3 passed**, 0 failed, 0 skipped. Claims: a typed `.MP4` path yields no file part; a typed `.md` path in the same position still does; a binary `@file` mention keeps its path as text while a text mention stays a file part.

```
cd apps/app && bun test --isolate tests/prompt-file-parts.test.ts tests/attachment-file-part.test.ts
```
exit 0 — 37 pass, 0 fail.

```
cd apps/app && pnpm typecheck
```
exit 0.

```
cd apps/app && bun test --isolate tests/
```
exit 1 — 1132 pass, 5 fail. The same 5 failures reproduce with the identical command on clean `origin/dev` (`bfc4b8324`: 1128 pass, 5 fail) in `connect-capability-inventory`, `cloud-workspace-overlay`, `session-provider-auth-server-sync`, `extensions-sidebar-header`; they pass when those files run in isolation, so they are pre-existing order-dependent failures unrelated to this change.

Verdict: **Passed**.

## Notes

- Behavior change for uploaded binaries (zip/mp4/etc.): previously a red session error plus no persisted badge; now no error and no model-facing part. The synthetic workspace-path note still gives tools the file.
- The Read tool's own extension list plus media types informed the denylist; images and PDFs are intentionally left inlineable because Read returns them as attachments.
