### PR TITLE
fix(server): keep the OpenWork system prompt in a single system message

### DIFF
--- a/apps/server/src/opencode-plugins/agent-instruction-compose.test.ts
+++ b/apps/server/src/opencode-plugins/agent-instruction-compose.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  appendAgentInstructions,
   combineInstructionSections,
   composeAgentInstructions,
   createInstructionSection,
@@ -51,5 +52,27 @@ describe("agent instruction compose primitives", () => {
       observedSection,
     )).toEqual(["one", "two", "three"]);
     expect(observedBodyReads).toBe(1);
+  });
+
+  test("appendAgentInstructions extends the engine system entry without adding a system message", () => {
+    const system = ["engine header"];
+    appendAgentInstructions(system, createInstructionSection("a", "one"), createInstructionSection("b", "two"));
+    appendAgentInstructions(system, createInstructionSection("c", "three"));
+    expect(system).toEqual(["engine header\none\ntwo\nthree"]);
+  });
+
+  test("appendAgentInstructions starts one entry when the engine supplied none", () => {
+    const system: string[] = [];
+    appendAgentInstructions(system, createInstructionSection("a", "one"));
+    appendAgentInstructions(system, createInstructionSection("b", "two"));
+    expect(system).toEqual(["one\ntwo"]);
+  });
+
+  test("appendAgentInstructions leaves the system prompt untouched when every section is empty", () => {
+    const system = ["engine header", ""];
+    appendAgentInstructions(system, createInstructionSection("empty", "  "), null);
+    expect(system).toEqual(["engine header", ""]);
+    appendAgentInstructions(system, createInstructionSection("a", "one"));
+    expect(system).toEqual(["engine header", "one"]);
   });
 });

--- a/apps/server/src/opencode-plugins/agent-instruction-compose.ts
+++ b/apps/server/src/opencode-plugins/agent-instruction-compose.ts
@@ -74,3 +74,25 @@ export function composeAgentInstructions(...groups: AgentInstructionSectionGroup
   }
   return instructions;
 }
+
+/**
+ * Extend the engine's system prompt in place from an
+ * `experimental.chat.system.transform` hook.
+ *
+ * OpenCode sends every entry of `system` as its own `role: "system"` message.
+ * Several chat templates behind OpenAI-compatible endpoints reject any system
+ * message after the first ("System message must be at the beginning."), so
+ * OpenWork folds its instructions into the existing entry instead of pushing a
+ * second one. The engine alone sends a single system message; this keeps that
+ * shape intact.
+ */
+export function appendAgentInstructions(system: string[], ...groups: AgentInstructionSectionGroup[]): void {
+  const body = composeAgentInstructions(...groups).join("\n");
+  if (!body) return;
+  const last = system.length - 1;
+  if (last < 0) {
+    system.push(body);
+    return;
+  }
+  system[last] = system[last] ? `${system[last]}\n${body}` : body;
+}

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -41,6 +41,16 @@ describe("OpenWork capabilities knowledge plugin", () => {
     expect(knowledge).not.toContain("openwork_extensions_export");
   });
 
+  test("extends the engine system entry instead of adding a second system message", async () => {
+    const plugin = await OpenWorkCapabilitiesKnowledge();
+    const output = { system: ["engine header"] };
+
+    await plugin["experimental.chat.system.transform"]({}, output);
+
+    expect(output.system).toHaveLength(1);
+    expect(output.system[0].startsWith("engine header\nYou are running inside OpenWork.")).toBe(true);
+  });
+
   test("retrieves Slack connection guidance from bundled docs", async () => {
     process.env.OPENWORK_DOCS_DIR = resolve(import.meta.dir, "../../../../packages/docs");
 

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -2,6 +2,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
+import { appendAgentInstructions, createInstructionSection } from "./agent-instruction-compose.js";
 
 /**
  * OpenWork Capabilities Knowledge Plugin
@@ -237,7 +238,7 @@ function excerpt(content: string, query: string): string {
 
 export const OpenWorkCapabilitiesKnowledge = async () => ({
   "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
-    output.system.push(OPENWORK_CAPABILITIES_KNOWLEDGE);
+    appendAgentInstructions(output.system, createInstructionSection("capabilities-knowledge", OPENWORK_CAPABILITIES_KNOWLEDGE));
   },
   tool: {
     openwork_docs_search: {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -513,12 +513,30 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     await plugin["experimental.chat.system.transform"]({}, output);
 
     expect(requests).toEqual([{ query: { directory: "/tmp/archive" } }]);
-    expect(output.system[0]).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
-    expect(output.system.join("\n")).toContain(OPENWORK_LOCAL_SKILL_AUTHORING_INSTRUCTION);
-    expect(output.system.join("\n")).not.toContain(OPENWORK_CLOUD_SKILL_AUTHORING_INSTRUCTION);
+    expect(output.system).toHaveLength(1);
+    expect(output.system[0].startsWith(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION)).toBe(true);
+    expect(output.system[0]).toContain(OPENWORK_LOCAL_SKILL_AUTHORING_INSTRUCTION);
+    expect(output.system[0]).not.toContain(OPENWORK_CLOUD_SKILL_AUTHORING_INSTRUCTION);
     expect(output.system[0]).not.toContain("not ready");
     expect(output.system[0]).not.toContain("Repair and test");
     expect(output.system[0]).not.toContain("Do not use OpenWork documentation tools");
+  });
+
+  test("extends the engine system entry instead of adding a second system message", async () => {
+    const mcp = {
+      async status() {
+        return { data: { "openwork-cloud": { status: "connected" } } };
+      },
+    };
+    const plugin = await OpenWorkExtensionsPreview({ client: { mcp }, directory: "/tmp/archive" });
+    const output: { system: string[] } = { system: ["engine header"] };
+
+    await plugin["experimental.chat.system.transform"]({}, output);
+
+    expect(output.system).toHaveLength(1);
+    expect(output.system[0].startsWith("engine header\n")).toBe(true);
+    expect(output.system[0]).toContain("verified ready for this exact workspace/model");
+    expect(output.system[0]).toContain("## Built-in Browser (external websites)");
   });
 
   test("routes transcript reads through a remote workspace native mount", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import { automationProposalSchema } from "@openwork/types/automations";
 import {
-  composeAgentInstructions,
+  appendAgentInstructions,
   createInstructionSection,
 } from "./agent-instruction-compose.js";
 import {
@@ -961,14 +961,17 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
     }
     // One section id per concern — composition drops empties/duplicates so routing,
     // remote skills, session, and browser guidance never overlap by accident.
-    output.system.push(...composeAgentInstructions(
+    // Appended into the engine's existing system entry so the request still
+    // carries a single system message.
+    appendAgentInstructions(
+      output.system,
       createInstructionSection("routing", extensionInstruction),
       createInstructionSection("agent-surface", OPENWORK_AGENT_SURFACE_INSTRUCTION),
       createInstructionSection("skill-authoring", skillAuthoring.prompt),
       createInstructionSection("connect-skills", skillInstruction),
       createInstructionSection("automations", automationInstruction),
       createInstructionSection("browser", OPENWORK_BROWSER_INSTRUCTION),
-    ));
+    );
   },
   tool: {
     openwork_context: {

--- a/evals/specs/system-prompt-single-message.test.ts
+++ b/evals/specs/system-prompt-single-message.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { OpenWorkExtensionsPreview } from "../../apps/server/src/opencode-plugins/openwork-extensions-preview";
+import { OpenWorkCapabilitiesKnowledge } from "../../apps/server/src/opencode-plugins/openwork-capabilities-knowledge";
+
+test("OpenWork system-prompt hooks keep the engine request at one system message", async ({ evidence }) => {
+  // Claim: OpenCode sends each `system` entry as its own `role: "system"`
+  // message, and several chat templates behind OpenAI-compatible endpoints
+  // reject any system message after the first. Both OpenWork transform hooks,
+  // run in the order the runtime config registers them, must therefore extend
+  // the engine's single entry rather than push new ones.
+  const engineMcp = {
+    async status() {
+      return { data: { "openwork-cloud": { status: "connected" } } };
+    },
+  };
+  const extensions = await OpenWorkExtensionsPreview({ client: { mcp: engineMcp }, directory: "/tmp/spec" });
+  const knowledge = await OpenWorkCapabilitiesKnowledge();
+  const output: { system: string[] } = { system: ["engine header"] };
+
+  await extensions["experimental.chat.system.transform"]({}, output);
+  await knowledge["experimental.chat.system.transform"]({}, output);
+
+  expect(output.system).toHaveLength(1);
+  expect(output.system[0].startsWith("engine header\n")).toBe(true);
+  // Nothing was dropped to get there: both contributions are still present,
+  // in registration order, after the engine header.
+  const routing = output.system[0].indexOf("verified ready for this exact workspace/model");
+  const browser = output.system[0].indexOf("## Built-in Browser (external websites)");
+  const capabilities = output.system[0].indexOf("You are running inside OpenWork.");
+  expect(routing).toBeGreaterThan("engine header".length);
+  expect(browser).toBeGreaterThan(routing);
+  expect(capabilities).toBeGreaterThan(browser);
+
+  // Negative half: when the engine hands over an empty array the hooks still
+  // produce exactly one entry, never a leading empty message.
+  const empty: { system: string[] } = { system: [] };
+  await extensions["experimental.chat.system.transform"]({}, empty);
+  await knowledge["experimental.chat.system.transform"]({}, empty);
+  expect(empty.system).toHaveLength(1);
+  expect(empty.system[0].startsWith("\n")).toBe(false);
+
+  evidence.recordAssertionEvidence(
+    "OpenWork instructions fold into a single system message",
+    "Running the extensions-preview and capabilities-knowledge transform hooks in registration order leaves the engine system array at length 1, with the engine header first and every OpenWork section retained in order; an empty engine array also yields exactly one non-empty entry.",
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- Fold OpenWork's system-prompt contributions into the engine's existing system entry so every request carries a single `role: "system"` message.
- New shared helper `appendAgentInstructions` in `agent-instruction-compose.ts`; both `experimental.chat.system.transform` hooks (`openwork-extensions-preview`, `openwork-capabilities-knowledge`) use it instead of `output.system.push(...)`.

## Why
- A freshly created session looped on the retry card with `Jinja Exception: System message must be at the beginning.` (attempt 4 and counting).
- OpenCode sends every entry of its `system` array as its own system message and collapses anything beyond two into two. Vanilla OpenCode therefore sends exactly one, but OpenWork's two hooks each pushed a new entry, so every OpenWork request carried two. Chat templates behind several OpenAI-compatible endpoints reject any system message after the first, and the engine retries the identical payload, so affected sessions never recovered.

## Issue
- No linked issue; reproduced from an in-app retry card.

## Scope
- `apps/server/src/opencode-plugins/agent-instruction-compose.ts` (+ test)
- `apps/server/src/opencode-plugins/openwork-extensions-preview.ts` (+ test)
- `apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts` (+ test)
- `evals/specs/system-prompt-single-message.test.ts`

## Out of scope
- Engine-side (OpenCode) option to merge system entries for strict backends, which would also protect third-party plugins that still `push`.
- Third-party plugins that push their own system entries.

## Testing
### Ran
- `pnpm evals:pr specs/system-prompt-single-message.test.ts`
- `pnpm evals:pr specs/instruction-assembly-equivalence.test.ts`
- `apps/server`: `bun --conditions=development test src/opencode-plugins/agent-instruction-compose.test.ts src/opencode-plugins/openwork-capabilities-knowledge.test.ts src/opencode-plugins/openwork-extensions-preview.test.ts`
- `apps/server`: `tsc -p tsconfig.json --noEmit`

### Result
- pass/fail: pass — spec 1 passed / 0 failed / 0 skipped; adjacent spec 1 passed; bun suites 36 pass / 0 fail; tsc exit 0.
- Lane: local. The spec is app-less and launches no resources, so Daytona placement does not apply.
- Claims: both hooks run in registration order on `["engine header"]` leave the array at length 1, header first, every OpenWork section retained in order. Negative half: an empty engine array yields exactly one non-empty entry, never a leading empty message.

## CI status
- pass: pending at open
- code-related failures: none known
- external/env/auth blockers: none known

## Manual verification
1. Point a workspace at a model served behind an OpenAI-compatible endpoint whose chat template rejects a second system message.
2. Start a new session with any prompt.
3. Before: retry card `System message must be at the beginning.`; after: the turn completes.

## Evidence
- Test evidence comment on this PR (head `63fde150a`).

## Risk
- Low. Prompt content and order are unchanged; only the message boundary moves. Anthropic prompt caching now treats the whole system prompt as one block instead of header + OpenWork block; within a session the OpenWork block is stable, so the practical effect is small and matches what the engine sends without OpenWork.

## Rollback
- Revert this commit; hooks return to pushing separate system entries.
