### PR TITLE
feat(landing): widget-first copy and interactive dashboard preview on /dashboard

### DIFF
--- a/ee/apps/landing/app/dashboard/page.tsx
+++ b/ee/apps/landing/app/dashboard/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
-import { LayoutDashboard, ShieldCheck, Users } from "lucide-react";
+import { Blocks, MousePointerClick, Users } from "lucide-react";
 
 import { LpCta } from "../../components/lp-cta";
+import { LpDashboardPreview } from "../../components/lp-dashboard-preview";
 import { LpSectionHeader, LpTonalCard } from "../../components/lp-primitives";
 import { SiteFooter } from "../../components/site-footer";
 import { SiteNav } from "../../components/site-nav";
@@ -11,28 +12,28 @@ const CLOUD_SIGNUP_URL = "https://app.openworklabs.com";
 const MCP_APPS_URL = "https://github.com/modelcontextprotocol/ext-apps/tree/main";
 
 export const metadata: Metadata = {
-  title: "OpenWork Dashboard — instant information for your team",
+  title: "OpenWork Dashboard — build dashboards out of MCP Apps",
   description:
-    "Custom dashboards built from MCP Apps. Give your whole team the information they need without asking the chat.",
+    "Every MCP App is a widget. Compose a dashboard from the apps your team relies on and share it with the whole organization.",
   alternates: { canonical: "/dashboard" }
 };
 
 const dashboardFeatures = [
   {
-    title: "MCP that outputs UI",
-    body: "MCP Apps are an extension of the Model Context Protocol. A tool returns not just data but a rich, interactive interface that the host renders inline."
+    title: "MCP that returns UI",
+    body: "MCP Apps extend the Model Context Protocol: a tool returns an interactive interface, and the host renders it. That interface is your widget."
   },
   {
-    title: "Standard, not proprietary",
-    body: "Build to the spec once and your app runs in OpenWork and in any other host that implements it. Apps built for other hosts run in OpenWork too."
+    title: "Open standard",
+    body: "Build to the spec once and it runs in OpenWork and in every other host that implements MCP Apps. Apps built elsewhere work here too."
   },
   {
-    title: "Yes, dashboards again",
-    body: "We know chat was supposed to replace them. It replaced a lot — but for information you check every day, a dashboard is still faster."
+    title: "Private interactions",
+    body: "What happens inside a widget doesn't pass through the model. Enter credentials, approve a purchase, view sensitive data — safely."
   },
   {
-    title: "Just the beginning",
-    body: "This is the first version of Dashboard. Next up: creating MCP Apps directly inside OpenWork."
+    title: "Build your own",
+    body: "Follow the MCP Apps spec or point your agent at the reference repo. Next up: creating MCP Apps directly inside OpenWork."
   }
 ];
 
@@ -40,17 +41,17 @@ const steps = [
   {
     number: "01",
     title: "Connect an MCP server",
-    body: "Add any MCP server that ships an app in Settings → Connectors. OpenWork discovers the app automatically."
+    body: "Add any MCP server that ships an app under Connectors. OpenWork detects the app automatically."
   },
   {
     number: "02",
-    title: "Create a dashboard",
-    body: "In the admin panel, create a dashboard and add the apps you want on it."
+    title: "Compose a dashboard",
+    body: "Create a dashboard, add the widgets you want, arrange them."
   },
   {
     number: "03",
-    title: "Share it with the org",
-    body: "Toggle it on for everyone. Members see it the next time they open OpenWork."
+    title: "Share it",
+    body: "Toggle it on for the organization or specific teams. Members see it the next time they open OpenWork."
   }
 ];
 
@@ -76,12 +77,12 @@ export default async function DashboardPage() {
               <div className="max-w-[650px]">
                 <div className="mb-5 text-[15px] text-[var(--lp-muted)]">OpenWork Dashboard · Powered by MCP Apps</div>
                 <h1 className="text-[46px] font-light leading-[51px] tracking-[-0.02em] md:text-[58px] md:leading-[62px]">
-                  <span className="block">Instant information</span>
-                  <span className="font-pixel block font-normal">for your whole team</span>
+                  <span className="block">Build dashboards</span>
+                  <span className="font-pixel block font-normal">out of MCP Apps</span>
                 </h1>
               </div>
               <p className="max-w-[440px] pb-1 text-[16px] leading-[25px]">
-                Chat is great for getting work done. It&apos;s a slow way to get information. OpenWork Dashboard puts the numbers your team checks every day one click away — no prompt, no waiting for a reply.
+                Every MCP App is a widget. Pick the ones your team relies on — budgets, pipeline, incidents, anything with an MCP server — arrange them on a dashboard, and share it with the whole organization.
               </p>
             </div>
             <div className="mt-10 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
@@ -89,30 +90,37 @@ export default async function DashboardPage() {
                 <a href={CLOUD_SIGNUP_URL} className="lp-pill-primary">Open OpenWork Cloud</a>
                 <a href={MCP_APPS_URL} target="_blank" rel="noreferrer" className="lp-pill-secondary">Read the MCP Apps spec</a>
               </div>
-              <span className="text-[13.5px] text-[var(--lp-body)] sm:ml-2">Available now in OpenWork Cloud. Works with any MCP server that ships an app.</span>
+              <span className="text-[13.5px] text-[var(--lp-body)] sm:ml-2">Any MCP App works as a widget. Nothing to rebuild for OpenWork.</span>
             </div>
+          </section>
+
+          <section className="mt-[88px]" aria-label="OpenWork Dashboard preview">
+            <LpDashboardPreview />
+            <p className="mt-3 text-[13.5px] text-[var(--lp-muted)]">
+              Toggle apps on the left to add or remove widgets — that&apos;s the whole flow.
+            </p>
           </section>
 
           <section className="mt-[120px] grid gap-6 lg:grid-cols-3">
             <LpTonalCard className="flex flex-col p-7">
-              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white"><LayoutDashboard className="h-5 w-5 text-[var(--lp-ink)]" strokeWidth={1.75} /></span>
-              <h2 className="mt-8 text-[16.5px] font-semibold">See it without asking</h2>
-              <p className="mt-3 text-[14px] leading-[22px] text-[var(--lp-body)]">Open the dashboard and the information is already there. No prompting, no re-explaining context, no scrolling back through a thread.</p>
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white"><Blocks className="h-5 w-5 text-[var(--lp-ink)]" strokeWidth={1.75} /></span>
+              <h2 className="mt-8 text-[16.5px] font-semibold">Widgets from any MCP server</h2>
+              <p className="mt-3 text-[14px] leading-[22px] text-[var(--lp-body)]">If an MCP server ships an app, it&apos;s a widget. Connect it once and it&apos;s ready to drop onto a dashboard.</p>
+            </LpTonalCard>
+            <LpTonalCard className="flex flex-col p-7">
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white"><MousePointerClick className="h-5 w-5 text-[var(--lp-ink)]" strokeWidth={1.75} /></span>
+              <h2 className="mt-8 text-[16.5px] font-semibold">Live and interactive</h2>
+              <p className="mt-3 text-[14px] leading-[22px] text-[var(--lp-body)]">Widgets are real UI, not screenshots. Filter, drill in, approve, adjust — right on the dashboard.</p>
             </LpTonalCard>
             <LpTonalCard className="flex flex-col p-7">
               <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white"><Users className="h-5 w-5 text-[var(--lp-ink)]" strokeWidth={1.75} /></span>
-              <h2 className="mt-8 text-[16.5px] font-semibold">Build once, share with everyone</h2>
-              <p className="mt-3 text-[14px] leading-[22px] text-[var(--lp-body)]">An admin creates a dashboard, adds apps, and toggles it on for the organization. It shows up in everyone&apos;s OpenWork automatically.</p>
-            </LpTonalCard>
-            <LpTonalCard className="flex flex-col p-7">
-              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white"><ShieldCheck className="h-5 w-5 text-[var(--lp-ink)]" strokeWidth={1.75} /></span>
-              <h2 className="mt-8 text-[16.5px] font-semibold">Private by design</h2>
-              <p className="mt-3 text-[14px] leading-[22px] text-[var(--lp-body)]">What happens inside an app stays inside the app. The model never sees it — so approving a purchase or entering credentials is safe.</p>
+              <h2 className="mt-8 text-[16.5px] font-semibold">One dashboard, the whole org</h2>
+              <p className="mt-3 text-[14px] leading-[22px] text-[var(--lp-body)]">Compose it once in the admin panel and toggle it on for everyone. It appears in each member&apos;s OpenWork.</p>
             </LpTonalCard>
           </section>
 
           <section className="mt-[120px]">
-            <LpSectionHeader label="How it works" heading="Connect once. Share with everyone." />
+            <LpSectionHeader label="How it works" heading="Connect. Compose. Share." />
             <div className="mt-10 grid items-start gap-10 md:grid-cols-3">
               {steps.map((step) => (
                 <div key={step.number}>
@@ -129,7 +137,7 @@ export default async function DashboardPage() {
           </section>
 
           <section className="mt-[120px]">
-            <LpSectionHeader label="Under the hood: MCP Apps" heading="Interactive interfaces, built on an open standard." />
+            <LpSectionHeader label="Under the hood: MCP Apps" heading="Widgets are just MCP Apps." />
             <div className="mt-10 grid gap-6 md:grid-cols-2">
               {dashboardFeatures.map((feature) => (
                 <div key={feature.title} className="rounded-[24px] bg-[var(--lp-tonal)] p-7">
@@ -142,11 +150,11 @@ export default async function DashboardPage() {
 
           <div className="mt-[120px]">
             <LpCta
-              heading="Give your team instant information"
-              sub="Create your first dashboard in OpenWork Cloud, or build an MCP App and bring it anywhere."
+              heading="Put your team's widgets on one screen"
+              sub="Compose your first dashboard in OpenWork Cloud, or build an MCP App and use it anywhere."
               primary={{ label: "Open OpenWork Cloud", href: CLOUD_SIGNUP_URL }}
               secondary={{ label: "MCP Apps on GitHub", href: MCP_APPS_URL }}
-              trust="Free to start. Works with the standard MCP Apps spec."
+              trust="Free to start. Standard MCP Apps, no lock-in."
             />
           </div>
           <div className="mt-16"><SiteFooter /></div>

--- a/ee/apps/landing/components/lp-dashboard-preview.tsx
+++ b/ee/apps/landing/components/lp-dashboard-preview.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import {
+  Check,
+  CircleDollarSign,
+  GitBranch,
+  LayoutDashboard,
+  Library,
+  MessageSquare,
+  Plug,
+  Settings,
+  TrendingUp,
+  TriangleAlert,
+  Users
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+type AppId = "budget" | "pipeline" | "incidents" | "deploys";
+
+type AppDefinition = {
+  id: AppId;
+  name: string;
+  icon: LucideIcon;
+};
+
+const apps: AppDefinition[] = [
+  { id: "budget", name: "Budget Allocator", icon: CircleDollarSign },
+  { id: "pipeline", name: "Sales Pipeline", icon: TrendingUp },
+  { id: "incidents", name: "Incidents", icon: TriangleAlert },
+  { id: "deploys", name: "Deploys", icon: GitBranch }
+];
+
+const navItems = [
+  { label: "Dashboard", icon: LayoutDashboard },
+  { label: "Sessions", icon: MessageSquare },
+  { label: "Library", icon: Library },
+  { label: "Your Connections", icon: Plug },
+  { label: "Settings", icon: Settings }
+];
+
+const budgetRows = [
+  { label: "Engineering", value: 42 },
+  { label: "Sales", value: 28 },
+  { label: "Marketing", value: 18 },
+  { label: "Ops", value: 12 }
+];
+
+const incidents = [
+  { text: "API latency p95 elevated", time: "8m", color: "bg-[#f59e0b]" },
+  { text: "Payments — resolved", time: "24m", color: "bg-[#10b981]" },
+  { text: "Auth — investigating", time: "41m", color: "bg-[#ef4444]" }
+];
+
+const deploys = [
+  { service: "api", sha: "4f2a8c1", time: "2m ago" },
+  { service: "web", sha: "9de31b7", time: "2m ago" },
+  { service: "billing", sha: "17ac602", time: "2m ago" },
+  { service: "auth", sha: "c8b045e", time: "2m ago" },
+  { service: "worker", sha: "601fd2a", time: "2m ago" }
+];
+
+function TrafficLights() {
+  return (
+    <div className="flex gap-1.5" aria-hidden="true">
+      <span className="h-2.5 w-2.5 rounded-full bg-[#fb7185]" />
+      <span className="h-2.5 w-2.5 rounded-full bg-[#fbbf24]" />
+      <span className="h-2.5 w-2.5 rounded-full bg-[#34d399]" />
+    </div>
+  );
+}
+
+function AppToggle({ app, active, onToggle, compact = false }: { app: AppDefinition; active: boolean; onToggle: () => void; compact?: boolean }) {
+  const Icon = app.icon;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className={compact
+        ? `inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border px-3 text-[11.5px] font-medium transition-colors duration-150 ${active ? "border-[#bfdbfe] bg-[#eff6ff] text-[var(--lp-blue)]" : "border-[#e1e4e8] bg-white text-[var(--lp-muted)]"}`
+        : "flex h-8 w-full items-center gap-2 rounded-[8px] px-2 text-left text-[11.5px] text-[var(--lp-muted)] transition-colors duration-150 hover:bg-[#eceff3]"}
+    >
+      {compact ? <Icon className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" /> : (
+        <span className={`flex h-4 w-4 items-center justify-center rounded-[4px] border ${active ? "border-[var(--lp-blue)] bg-[var(--lp-blue)] text-white" : "border-[#cbd2da] bg-white"}`}>
+          {active ? <Check className="h-2.5 w-2.5" strokeWidth={2.5} aria-hidden="true" /> : null}
+        </span>
+      )}
+      <span>{app.name}</span>
+    </button>
+  );
+}
+
+function WidgetCard({ name, icon: Icon, children }: { name: string; icon: LucideIcon; children: ReactNode }) {
+  return (
+    <div className="h-full overflow-hidden rounded-[12px] border border-[#e1e4e8] bg-white">
+      <div className="flex h-11 items-center gap-2 border-b border-[#eef1f5] px-4">
+        <Icon className="h-3.5 w-3.5 text-[var(--lp-muted)]" strokeWidth={1.75} aria-hidden="true" />
+        <h3 className="text-[12.5px] font-medium text-[var(--lp-ink)]">{name}</h3>
+        <span className="ml-auto rounded-full bg-[#f1f5f9] px-2 py-0.5 text-[8px] font-semibold tracking-[0.08em] text-[var(--lp-faint)]">MCP App</span>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}
+
+function Widget({ app, reduceMotion }: { app: AppDefinition; reduceMotion: boolean | null }) {
+  let body: ReactNode;
+
+  if (app.id === "budget") {
+    body = (
+      <div className="space-y-3">
+        {budgetRows.map((row) => (
+          <div key={row.label}>
+            <div className="mb-1.5 flex justify-between text-[10.5px]"><span className="text-[var(--lp-muted)]">{row.label}</span><span className="font-medium text-[var(--lp-ink)]">{row.value}%</span></div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-[#eef1f5]"><div className="h-full rounded-full bg-[var(--lp-blue)]" style={{ width: `${row.value}%` }} /></div>
+          </div>
+        ))}
+      </div>
+    );
+  } else if (app.id === "pipeline") {
+    body = (
+      <div className="grid grid-cols-3 gap-2">
+        {[{ label: "Open", value: "$1.2M" }, { label: "Won this month", value: "$340k" }, { label: "Win rate", value: "31%" }].map((metric) => (
+          <div key={metric.label} className="rounded-[9px] bg-[#F8FAFC] px-2 py-4 text-center">
+            <div className="text-[16px] font-semibold tracking-[-0.02em] text-[var(--lp-ink)] sm:text-[18px]">{metric.value}</div>
+            <div className="mt-1 text-[9px] leading-[13px] text-[var(--lp-muted)]">{metric.label}</div>
+          </div>
+        ))}
+      </div>
+    );
+  } else if (app.id === "incidents") {
+    body = (
+      <div className="space-y-1.5">
+        {incidents.map((incident) => (
+          <div key={incident.text} className="flex min-h-9 items-center gap-2.5 rounded-[8px] bg-[#F8FAFC] px-3">
+            <span className={`h-2 w-2 shrink-0 rounded-full ${incident.color}`} />
+            <span className="min-w-0 flex-1 truncate text-[10.5px] text-[var(--lp-ink)]">{incident.text}</span>
+            <span className="text-[9.5px] text-[var(--lp-faint)]">{incident.time}</span>
+          </div>
+        ))}
+      </div>
+    );
+  } else {
+    body = (
+      <div className="space-y-1">
+        {deploys.map((deploy) => (
+          <div key={deploy.service} className="grid grid-cols-[16px_1fr_auto_auto] items-center gap-2 rounded-[7px] px-2 py-1.5 text-[10px] hover:bg-[#F8FAFC]">
+            <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[#d1fae5] text-[#059669]"><Check className="h-2.5 w-2.5" strokeWidth={2.5} aria-hidden="true" /></span>
+            <span className="font-medium text-[var(--lp-ink)]">{deploy.service}</span>
+            <span className="font-mono text-[var(--lp-muted)]">{deploy.sha}</span>
+            <span className="text-[var(--lp-faint)]">{deploy.time}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      layout
+      initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={reduceMotion ? undefined : { opacity: 0, y: -6 }}
+      transition={{ duration: reduceMotion ? 0 : 0.18 }}
+    >
+      <WidgetCard name={app.name} icon={app.icon}>{body}</WidgetCard>
+    </motion.div>
+  );
+}
+
+export function LpDashboardPreview() {
+  const [activeApps, setActiveApps] = useState<AppId[]>(["budget", "pipeline", "incidents"]);
+  const reduceMotion = useReducedMotion();
+  const toggleApp = (id: AppId) => setActiveApps((current) => current.includes(id) ? current.filter((item) => item !== id) : [...current, id]);
+
+  return (
+    <div className="overflow-hidden rounded-[20px] border border-[#e1e4e8] bg-white">
+      <div className="flex h-12 items-center gap-3 border-b border-[#e1e4e8] px-5">
+        <TrafficLights />
+        <span className="text-[12px] font-medium text-[var(--lp-muted)]">OpenWork — Acme Inc</span>
+      </div>
+      <div className="flex min-h-[570px]">
+        <aside className="hidden w-[200px] shrink-0 flex-col border-r border-[#e1e4e8] bg-[#f7f8fa] p-3 md:flex">
+          <div className="flex items-center gap-2.5 rounded-[11px] bg-white p-2.5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[8px] bg-[var(--lp-ink)] text-[12px] font-semibold text-white">A</span>
+            <div><div className="text-[12.5px] font-medium text-[var(--lp-ink)]">Acme Inc</div><div className="text-[10px] text-[var(--lp-faint)]">Organization</div></div>
+          </div>
+          <div className="px-2 pb-2 pt-5 text-[10px] font-semibold tracking-[0.14em] text-[var(--lp-faint)]">NAVIGATION</div>
+          <nav className="flex flex-col gap-0.5">
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              const active = item.label === "Dashboard";
+              return <div key={item.label} className={`flex h-8 items-center gap-2 rounded-[8px] px-2 text-[12px] ${active ? "bg-white font-medium text-[var(--lp-ink)] shadow-[0_1px_2px_rgba(1,22,39,0.06)]" : "text-[var(--lp-muted)]"}`}><Icon className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" /><span>{item.label}</span></div>;
+            })}
+          </nav>
+          <div className="px-2 pb-2 pt-6 text-[10px] font-semibold tracking-[0.14em] text-[var(--lp-faint)]">MCP APPS</div>
+          <div className="flex flex-col gap-0.5">
+            {apps.map((app) => <AppToggle key={app.id} app={app} active={activeApps.includes(app.id)} onToggle={() => toggleApp(app.id)} />)}
+          </div>
+        </aside>
+
+        <div className="min-w-0 flex-1 bg-white p-5 sm:p-8 lg:p-10">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <div className="min-w-0 flex-1"><h2 className="text-[15.5px] font-semibold text-[var(--lp-ink)]">Ops overview</h2><p className="mt-1 text-[12px] text-[var(--lp-muted)]">Live apps from your team&apos;s MCP servers.</p></div>
+            <div className="flex items-center gap-2">
+              <span className="inline-flex h-8 items-center gap-1.5 rounded-full bg-[#F8FAFC] px-3 text-[10.5px] text-[var(--lp-muted)]"><Users className="h-3 w-3" strokeWidth={1.75} aria-hidden="true" />Shared with everyone</span>
+              <button type="button" className="inline-flex h-8 items-center rounded-full bg-[var(--lp-ink)] px-3 text-[10.5px] font-medium text-white active:scale-[0.97]">+ Add app</button>
+            </div>
+          </div>
+          <div className="mt-5 flex gap-2 overflow-x-auto pb-1 md:hidden">
+            {apps.map((app) => <AppToggle key={app.id} app={app} active={activeApps.includes(app.id)} onToggle={() => toggleApp(app.id)} compact />)}
+          </div>
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <AnimatePresence initial={false}>
+              {apps.filter((app) => activeApps.includes(app.id)).map((app) => <Widget key={app.id} app={app} reduceMotion={reduceMotion} />)}
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Follow-up to #4302 — that squash merged only the first commit, so production `/dashboard` still shows the initial copy without the preview. This PR lands the intended version:

- `app/dashboard/page.tsx` — widget-first copy: every MCP App is a widget; compose a dashboard from them; share it with the org. Hero "Build dashboards / out of MCP Apps", "Connect. Compose. Share." steps, "Widgets are just MCP Apps." grid, CTA.
- `components/lp-dashboard-preview.tsx` — new client component mirroring `LpCloudConsole`'s window chrome: a mock OpenWork app with an "Ops overview" dashboard made of MCP App widgets (Budget Allocator, Sales Pipeline, Incidents, Deploys). Toggling apps in the sidebar (chips on mobile) adds/removes widgets with framer-motion layout animation; respects reduced motion. Static data, no new deps.

## Verification (same commit as previously pushed to #4302)
- `bun test --isolate test/` in `ee/apps/landing`: **5 pass, 0 fail**.
- `tsc --noEmit` (landing): **0 errors in changed files**; pre-existing errors in `packages/ui` / `packages/email` only.
- Local `next dev`: `GET /dashboard` → **200**, HTML contains "Build dashboards", "Ops overview", "Budget Allocator", "Widgets are just MCP Apps."; full-page headless-Chrome render checked visually.
- Vercel `openwork-landing` preview build **passed** for this exact commit on #4302.

Static marketing content; no `evals/specs` testkit lane applies to `ee/apps/landing`.