### PR TITLE
docs: add Dashboards guide with MCP App widget tutorial

### DIFF
--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -200,6 +200,8 @@ Availability is governed by organization membership, role, policy, and exposure 
 
 Some gateway results come back as MCP Apps: rich, interactive UI rendered from a tool result instead of plain text — great for dynamic interfaces like a created-skill confirmation card or a workflow result view. OpenWork implements the standard [MCP Apps extension](https://modelcontextprotocol.io/docs/extensions/apps) (`ui://` resources declared on tools), so first-party OpenWork apps render in any MCP client that supports the extension, and fall back to readable text everywhere else.
 
+To put an MCP App on a team dashboard, see [Dashboards](/cloud/share-with-your-team/dashboards).
+
 <Frame>
   ![The skill-created MCP App rendering in the OpenWork desktop app after a create-skill request](/images/skill-created-mcp-app-card.png)
 </Frame>

--- a/packages/docs/cloud/share-with-your-team/dashboards.mdx
+++ b/packages/docs/cloud/share-with-your-team/dashboards.mdx
@@ -1,0 +1,180 @@
+---
+title: "Dashboards"
+description: "Give your team a dashboard made of MCP Apps, and build your own widget."
+---
+
+## What a Dashboard is
+
+A dashboard is a curated set of MCP Apps that admins assign to people or teams. After sign-in, it appears under **Dashboard** in each member's desktop sidebar.
+
+Each tile is an MCP App from one of the organization's **Connectors**. OpenWork renders the tile as real, interactive UI; what a member does inside it is not sent to the model.
+
+When the feature is enabled for the organization, Dashboards appear in the OpenWork Cloud admin sidebar under **Manage → Dashboards**.
+
+## Create and share a dashboard (admin)
+
+<Steps>
+  <Step title="Connect the MCP server">
+    In OpenWork Cloud, open **Connectors**, click **Add connector**, paste the **Server URL** (for example, `https://mcp.example.com/mcp`), and choose **Authentication** and **Account mode**: **Individual accounts** or **Org account**. Use **Test tools** to confirm the server responds. Only connectors that expose at least one MCP App can be added to a dashboard.
+  </Step>
+  <Step title="Create the dashboard">
+    Open **Dashboards**, click **New dashboard**, enter a **Name** such as `Support overview`, then click **Create dashboard**.
+  </Step>
+  <Step title="Add apps">
+    Click **Add app**, pick an **MCP**, choose one of its Apps, and click **Add**. MCPs without Apps are hidden. If the app's tool requires input, fill **Launch input (JSON)**. Reorder or remove apps from the list.
+  </Step>
+  <Step title="Decide how each app runs">
+    Apps run on request by default: the member clicks **Run**. Turn on **Run automatically** to run an app on dashboard load and refresh. This also applies to tools that modify data, so enable it only for apps you trust.
+  </Step>
+  <Step title="Share it">
+    In **Access**, turn on **Everyone in the organization**, or leave it off and add specific people and teams. Members see the dashboard the next time they open OpenWork.
+  </Step>
+</Steps>
+
+## What members see
+
+The desktop sidebar shows **Dashboard**, with one section per assigned dashboard labeled **Managed by your organization**.
+
+Tiles have one of these badges:
+
+- **Organization auto-run**
+- **Run on request**
+- **Run once to enable**
+
+A tool that is not read-only runs only when the member clicks **Run**, unless an admin enabled auto-run.
+
+## Build an MCP App widget
+
+[MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) are a standard extension of MCP (`io.modelcontextprotocol/ui`). An app is an ordinary MCP server with a tool that points to a UI resource and that resource served as HTML. Anything built to the specification runs in OpenWork and in any other host that implements it. The [`ext-apps` repository](https://github.com/modelcontextprotocol/ext-apps) provides the SDK and examples.
+
+### Requirements OpenWork checks
+
+- The tool's `_meta.ui.resourceUri` is a string starting with `ui://`.
+- If `_meta.ui.visibility` is set, it includes `"app"`.
+- `resources/read` for that URI returns exactly one content item with `mimeType` `text/html;profile=mcp-app`, at most 768 KiB.
+- Optional `_meta.ui.csp` on the resource supports `connectDomains`, `resourceDomains`, `frameDomains`, and `baseUriDomains`: HTTPS origins only, up to 16 each. `permissions` and `domain` are not supported; OpenWork rejects a resource containing either.
+- The server is reachable over HTTP(S) as a remote Streamable HTTP MCP server. Local stdio servers cannot be dashboard apps.
+- Mark read-only tools with `annotations: { readOnlyHint: true }`. Tools without it, or with `destructiveHint: true`, are treated as modifying data and run only on request unless an admin enables auto-run.
+- The dashboard picker uses `title`, or `annotations.title`, as the tile name. It shows a **Launch input** field when `inputSchema.required` is non-empty.
+
+### Example: a Team budget widget
+
+Install `@modelcontextprotocol/sdk`, `@modelcontextprotocol/ext-apps`, and `express`, then create these two files.
+
+<Steps>
+  <Step title="Create the MCP server">
+
+```ts server.ts
+import express from "express";
+import { readFile } from "node:fs/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  registerAppResource,
+  registerAppTool,
+  RESOURCE_MIME_TYPE,
+} from "@modelcontextprotocol/ext-apps/server";
+
+const server = new McpServer({ name: "team-budget", version: "1.0.0" });
+const html = await readFile(new URL("./view.html", import.meta.url), "utf8");
+
+registerAppResource(
+  server,
+  "budget-view",
+  "ui://team-budget/view.html",
+  { mimeType: RESOURCE_MIME_TYPE },
+  async () => ({
+    contents: [{
+      uri: "ui://team-budget/view.html",
+      mimeType: RESOURCE_MIME_TYPE,
+      text: html,
+    }],
+  }),
+);
+
+registerAppTool(
+  server,
+  "get_budget",
+  {
+    title: "Team budget",
+    description: "Current budget allocation by team",
+    inputSchema: {},
+    annotations: { readOnlyHint: true },
+    _meta: { ui: { resourceUri: "ui://team-budget/view.html" } },
+  },
+  async () => {
+    const data = { teams: [
+      { name: "Engineering", percent: 42 },
+      { name: "Sales", percent: 33 },
+      { name: "Operations", percent: 25 },
+    ] };
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+    };
+  },
+);
+
+const app = express();
+app.use(express.json());
+const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+await server.connect(transport);
+app.all("/mcp", (req, res) => transport.handleRequest(req, res, req.body));
+app.listen(3000);
+```
+
+  </Step>
+  <Step title="Create the view">
+    Bundle this file with Vite so it resolves the package import, or serve the import through an ESM CDN.
+
+```html view.html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Team budget</title>
+    <style>
+      body { font: 14px system-ui; margin: 0; padding: 16px; color: #18181b; }
+      h2 { font-size: 16px; margin: 0 0 16px; }
+      .team { display: grid; grid-template-columns: 100px 1fr 40px; gap: 8px; margin: 10px 0; }
+      .track { background: #e4e4e7; border-radius: 4px; overflow: hidden; }
+      .bar { background: #2563eb; height: 100%; }
+      .value { text-align: right; }
+    </style>
+  </head>
+  <body>
+    <h2>Team budget</h2>
+    <div id="teams">Loading…</div>
+    <script type="module">
+      import { App } from "@modelcontextprotocol/ext-apps";
+
+      const root = document.querySelector("#teams");
+      const render = (data) => {
+        root.replaceChildren(...data.teams.map(({ name, percent }) => {
+          const row = document.createElement("div");
+          row.className = "team";
+          row.innerHTML = `<span>${name}</span><span class="track"><span class="bar" style="display:block;width:${percent}%"></span></span><span class="value">${percent}%</span>`;
+          return row;
+        }));
+      };
+
+      const app = new App({ name: "Team budget", version: "1.0.0" });
+      app.addEventListener("toolresult", (params) => render(params.structuredContent));
+      await app.connect();
+    </script>
+  </body>
+</html>
+```
+
+  </Step>
+  <Step title="Add it to OpenWork">
+    Run the server on a public HTTPS URL, or use a tunnel for testing, then follow the admin steps above. You can test it in chat first: ask the agent to call `get_budget`, and the tile renders inline.
+  </Step>
+</Steps>
+
+## Tips
+
+- Keep the resource self-contained. If it loads remote assets, declare their origins in `_meta.ui.csp`.
+- Return the data the UI needs in `structuredContent`; text content is what the model sees.
+- One tool can drive one view. Ship several tools for several widgets.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -127,7 +127,8 @@
               "cloud/share-with-your-team/managed-llm-provider",
               "cloud/share-with-your-team/per-member-llm-credentials",
               "cloud/share-with-your-team/custom-llm-provider",
-              "cloud/share-with-your-team/shared-mcp-connections"
+              "cloud/share-with-your-team/shared-mcp-connections",
+              "cloud/share-with-your-team/dashboards"
             ]
           },
           {

--- a/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
@@ -45,6 +45,10 @@ Some MCP servers do not support dynamic client registration. If the server gives
 For an advanced local Slack setup, follow
 [Connect Slack as a custom MCP](/start-here/connect-your-stack/connect-slack-mcp).
 
+<Note>
+Workspace MCPs are local to you. To share an MCP App with the organization as a dashboard, add it in OpenWork Cloud **Connectors** and see [Dashboards](/cloud/share-with-your-team/dashboards).
+</Note>
+
 <Frame>
   ![Error when MCP server does not support dynamic client registration](/images/mcp-dynamic-registration-error.png)
 </Frame>


### PR DESCRIPTION
## Summary
New docs page **Cloud → Share with your team → Dashboards** (`packages/docs/cloud/share-with-your-team/dashboards.mdx`):

- What a Dashboard is (curated set of MCP Apps, assigned to people/teams, shows under **Dashboard** in the desktop sidebar).
- Admin walkthrough using the real Den labels: **Connectors → Add connector → Server URL / Authentication / Account mode / Test tools**, **Dashboards → New dashboard → Add app → MCP → Add / Launch input (JSON) / Run automatically**, **Access → Everyone in the organization**.
- What members see (**Managed by your organization**, tile badges **Organization auto-run / Run on request / Run once to enable**).
- Tutorial: build a "Team budget" MCP App widget — the exact requirements OpenWork checks (`_meta.ui.resourceUri` `ui://…`, `text/html;profile=mcp-app`, 768 KiB cap, `_meta.ui.csp` origins, `readOnlyHint` → auto-run eligibility, `title` / `inputSchema.required` → picker), then a ~55-line server with `@modelcontextprotocol/sdk` + `@modelcontextprotocol/ext-apps/server` (`registerAppTool` / `registerAppResource` / `RESOURCE_MIME_TYPE`, Streamable HTTP) and a ~40-line `view.html` using `App` + `addEventListener("toolresult", …)`.

Also: nav entry in `docs.json`; cross-links from `cloud-mcp.mdx` (MCP Apps section) and `add-an-mcp-server.mdx` (workspace MCPs are local; share via Connectors + Dashboards).

## Verification
Docs-only change — no runtime proof applies. Labels and detection rules were checked against `ee/apps/den-web` (`org-dashboards-screen.tsx`, `org-dashboard-detail-screen.tsx`, `mcp-connections-screen.tsx`), `ee/apps/den-api/src/routes/org/{dashboards,mcp-connections}.ts`, `apps/server/src/mcp-app-host.ts`, and the `@modelcontextprotocol/ext-apps@1.7.5` type definitions (`registerAppTool`, `App.addEventListener("toolresult")`, `structuredContent`). `docs.json` parses as valid JSON.