### PR TITLE
Provide useful service connectors with setup and Chat before connection

### DIFF
--- a/apps/app/src/app/lib/deep-link-bridge.ts
+++ b/apps/app/src/app/lib/deep-link-bridge.ts
@@ -44,3 +44,16 @@ export function drainPendingDeepLinks(target: Window): string[] {
   }
   return [...pending];
 }
+
+/**
+ * Remove and return only the pending links a consumer owns, leaving the rest
+ * queued for the consumers that parse them.
+ */
+export function takePendingDeepLinks(target: Window, owns: (url: string) => boolean): string[] {
+  const pending = target.__OPENWORK__?.deepLinks ?? [];
+  const taken = pending.filter(owns);
+  if (target.__OPENWORK__ && taken.length > 0) {
+    target.__OPENWORK__.deepLinks = pending.filter((url) => !owns(url));
+  }
+  return taken;
+}

--- a/apps/app/src/app/lib/openwork-links.ts
+++ b/apps/app/src/app/lib/openwork-links.ts
@@ -20,6 +20,18 @@ export type ConnectDeepLink = {
   key: string;
 };
 
+/** `openwork://chat?prompt=…&connector=…` — open a new chat with a seeded composer. */
+export type ChatDeepLink = {
+  prompt: string;
+  /** Connector the prompt is about (rendered as a chip ahead of the prompt). */
+  connector: string | null;
+  /** Dedupe key so a replayed queue never seeds the same chat twice. */
+  key: string;
+};
+
+const CHAT_DEEP_LINK_PROMPT_MAX_LENGTH = 4000;
+const CHAT_DEEP_LINK_CONNECTOR_MAX_LENGTH = 80;
+
 function isSupportedDeepLinkProtocol(protocol: string): boolean {
   const normalized = protocol.toLowerCase();
   return normalized === "openwork:"
@@ -177,6 +189,45 @@ export function parseConnectDeepLink(rawUrl: string): ConnectDeepLink | null {
   }
 
   return { rawUrl, key: signed ? `signed:${token}` : `exchange:${apiBaseUrl}:${code}` };
+}
+
+export function parseChatDeepLink(rawUrl: string): ChatDeepLink | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // Chat seeding is a desktop handoff from Den; ordinary web URLs never
+  // pre-fill the composer.
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "openwork:" && protocol !== "openwork-dev:") {
+    return null;
+  }
+
+  const routeHost = url.hostname.toLowerCase();
+  const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
+  const routeSegments = routePath.split("/").filter(Boolean);
+  const routeTail = routeSegments[routeSegments.length - 1] ?? "";
+  if (routeHost !== "chat" && routePath !== "chat" && routeTail !== "chat") {
+    return null;
+  }
+
+  const prompt = (url.searchParams.get("prompt") ?? "").trim().slice(0, CHAT_DEEP_LINK_PROMPT_MAX_LENGTH);
+  const connector = (url.searchParams.get("connector") ?? "")
+    .trim()
+    .replace(/[\[\]\n\r]/g, "")
+    .slice(0, CHAT_DEEP_LINK_CONNECTOR_MAX_LENGTH);
+  if (!prompt && !connector) {
+    return null;
+  }
+
+  return {
+    prompt,
+    connector: connector || null,
+    key: `chat:${connector}:${prompt}`,
+  };
 }
 
 function normalizeDebugDeepLinkInput(rawValue: string): string {

--- a/apps/app/src/react-app/domains/session/chat/pending-chat-seed.ts
+++ b/apps/app/src/react-app/domains/session/chat/pending-chat-seed.ts
@@ -1,0 +1,21 @@
+/**
+ * One-shot handoff between a deep link and the new-task composer. The link
+ * consumer stores the draft and navigates; the hero picks it up on mount (or
+ * immediately, if it is already showing) and puts the caret after it.
+ */
+export const pendingChatSeedEvent = "openwork:pending-chat-seed";
+
+let pendingDraft: string | null = null;
+
+export function setPendingChatSeed(draft: string): void {
+  pendingDraft = draft;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(pendingChatSeedEvent));
+  }
+}
+
+export function consumePendingChatSeed(): string | null {
+  const draft = pendingDraft;
+  pendingDraft = null;
+  return draft;
+}

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -20,6 +20,7 @@ import {
   type NewTaskComposerContext,
   type NewTaskComposerHandoff,
 } from "./new-task-composer";
+import { consumePendingChatSeed, pendingChatSeedEvent } from "./pending-chat-seed";
 
 type HeroSuggestion = {
   title: string;
@@ -85,6 +86,20 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     const handlePromoChanged = () => setModelsPromoHidden(isOpenWorkModelsPromoHidden());
     window.addEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
     return () => window.removeEventListener(openWorkModelsPromoChangedEvent, handlePromoChanged);
+  }, []);
+
+  // A chat deep link (Den's connector "Chat" action) seeds the composer with
+  // the connector chip and its starter prompt; the person reviews and sends.
+  useEffect(() => {
+    const seed = () => {
+      const draft = consumePendingChatSeed();
+      if (draft === null) return;
+      setPrompt(draft);
+      window.dispatchEvent(new Event("openwork:focusPrompt"));
+    };
+    seed();
+    window.addEventListener(pendingChatSeedEvent, seed);
+    return () => window.removeEventListener(pendingChatSeedEvent, seed);
   }, []);
 
   // Quiet inline lead to OpenWork Models: replaces the old startup dialog

--- a/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
+++ b/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
@@ -6,6 +6,7 @@ import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge";
 import { t } from "@/i18n";
 import type { ComposerAttachment, ComposerDraft, ComposerPart } from "@/app/types";
 import { parseConnectSkillToken } from "@/react-app/domains/session/surface/composer/connect-skill-token";
+import { parseConnectorToken } from "@/react-app/domains/session/surface/composer/connector-token";
 import type { QueuedComposerItem } from "@/react-app/domains/session/surface/composer-state-store";
 
 export type QueuedMessagesPanelProps = {
@@ -17,7 +18,7 @@ export type QueuedMessagesPanelProps = {
   sending?: boolean;
 };
 
-const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\])/;
+const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\])/;
 
 function isImageAttachment(attachment: ComposerAttachment) {
   return attachment.kind === "image" || attachment.mimeType.startsWith("image/");
@@ -85,6 +86,20 @@ function QueuedDraftContent(props: { draft: ComposerDraft }) {
           title={`Skill: ${connectSkill?.name ?? skillName}`}
         >
           {`/${skillName}`}
+        </span>,
+      );
+      continue;
+    }
+
+    const connectorName = parseConnectorToken(segment);
+    if (connectorName) {
+      nodes.push(
+        <span
+          key={key}
+          className="mx-0.5 inline-flex items-center rounded-full border border-blue-6/35 bg-blue-3/20 px-2.5 py-1 text-xs font-medium text-blue-11 align-middle"
+          title={`Connector: ${connectorName}`}
+        >
+          {connectorName}
         </span>,
       );
       continue;

--- a/apps/app/src/react-app/domains/session/surface/composer/connector-token.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/connector-token.ts
@@ -1,0 +1,34 @@
+/**
+ * A `[connector …]` composer draft token names the connection (GitHub, Gmail,
+ * Notion, …) a prompt is about. The composer renders it as a chip ahead of
+ * the text; the send path expands it into a short steering sentence so the
+ * model reaches for that connector's tools. Den's connector catalog seeds it
+ * through the `openwork://chat` deep link.
+ */
+function sanitizeConnectorName(name: string) {
+  return name.replace(/[\[\]\n\r]/g, "").trim();
+}
+
+export function encodeConnectorToken(name: string) {
+  return `[connector ${sanitizeConnectorName(name)}]`;
+}
+
+/** The connector name carried by one `[connector …]` segment, or null. */
+export function parseConnectorToken(segment: string): string | null {
+  const match = segment.match(/^\[connector (.+)\]$/);
+  const name = match?.[1]?.trim();
+  return name ? name : null;
+}
+
+/** Expand a connector token into the model-facing steering text (same precedent as the skill load instruction). */
+export function connectorPrompt(name: string) {
+  return `This request is about the "${name}" connector; do not assume it is connected or that its tools are available. Answer planning and general questions without requiring a connection. For work needing live data or actions, discover capabilities normally with search_capabilities, omitting intent connect. Offer setup only if the requested operation needs an unavailable connection or the user explicitly asks to connect or set up the service; use intent connect only for an explicit setup request. Follow returned connection guidance and let the user authorize any connection themselves. This connector selection does not authorize sign-in, scope changes, or external writes; perform writes only when explicitly requested.`;
+}
+
+/** Draft text for a seeded chat: the connector chip, then the prompt. */
+export function seededConnectorDraft(input: { connector: string | null; prompt: string }) {
+  const prompt = input.prompt.trim();
+  if (!input.connector) return prompt;
+  const token = encodeConnectorToken(input.connector);
+  return prompt ? `${token} ${prompt}` : `${token} `;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -36,6 +36,7 @@ import {
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
 import { parseConnectSkillToken } from "./connect-skill-token";
+import { encodeConnectorToken, parseConnectorToken } from "./connector-token";
 import { shouldCollapsePastedText, splitPastedText } from "./pasted-text";
 import { insertPastedText } from "./pasted-text-insertion";
 
@@ -320,6 +321,86 @@ class ComposerSkillNode extends TextNode {
 
 function $createComposerSkillNode(skillName: string, skillToken?: string) {
   return $applyNodeReplacement(new ComposerSkillNode(skillName, skillToken));
+}
+
+type SerializedComposerConnectorNode = Spread<
+  {
+    connectorName: string;
+    type: "composer-connector";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+/** `[connector GitHub]` — the connection a seeded prompt is about, shown as a chip. */
+class ComposerConnectorNode extends TextNode {
+  __connectorName: string;
+
+  static override getType() {
+    return "composer-connector";
+  }
+
+  static override clone(node: ComposerConnectorNode) {
+    return new ComposerConnectorNode(node.__connectorName, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerConnectorNode) {
+    return $createComposerConnectorNode(serializedNode.connectorName);
+  }
+
+  constructor(connectorName = "", key?: NodeKey) {
+    super(encodeConnectorToken(connectorName), key);
+    this.__connectorName = connectorName;
+  }
+
+  override exportJSON(): SerializedComposerConnectorNode {
+    return {
+      ...super.exportJSON(),
+      connectorName: this.__connectorName,
+      type: "composer-connector",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig) {
+    const dom = document.createElement("span");
+    dom.className = "inline-flex items-center rounded-full border border-blue-6/35 bg-blue-3/20 px-2.5 py-1 text-xs font-medium text-blue-11";
+    dom.textContent = this.__connectorName;
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    dom.dataset.composerConnector = this.__connectorName;
+    dom.title = `Connector: ${this.__connectorName}`;
+    return dom;
+  }
+
+  override updateDOM(prevNode: ComposerConnectorNode, dom: HTMLElement) {
+    if (prevNode.__connectorName !== this.__connectorName) {
+      dom.textContent = this.__connectorName;
+      dom.dataset.composerConnector = this.__connectorName;
+      dom.title = `Connector: ${this.__connectorName}`;
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+function $createComposerConnectorNode(connectorName: string) {
+  return $applyNodeReplacement(new ComposerConnectorNode(connectorName));
 }
 
 function pastedTextChipLabel(lines: number) {
@@ -671,6 +752,7 @@ type ComposerInlineTokenNode =
   | ComposerMentionNode
   | ComposerSlashCommandNode
   | ComposerSkillNode
+  | ComposerConnectorNode
   | ComposerPastedTextNode
   | ComposerAttachmentNode;
 
@@ -678,6 +760,7 @@ function isComposerInlineTokenNode(node: unknown): node is ComposerInlineTokenNo
   return node instanceof ComposerMentionNode
     || node instanceof ComposerSlashCommandNode
     || node instanceof ComposerSkillNode
+    || node instanceof ComposerConnectorNode
     || node instanceof ComposerPastedTextNode
     || node instanceof ComposerAttachmentNode;
 }
@@ -747,11 +830,16 @@ function setPrompt(
     value = slashMatch[2] ?? "";
   }
 
-  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\]|@[^\s@]+)/);
   const pastedTextByLabel = new Map((pastedText ?? []).map((item) => [item.label, item]));
   const attachmentsById = new Map((attachments ?? []).map((item) => [item.id, item]));
   for (const segment of segments) {
     if (!segment) continue;
+    const connectorName = parseConnectorToken(segment);
+    if (connectorName) {
+      paragraph.append($createComposerConnectorNode(connectorName));
+      continue;
+    }
     const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
     if (attachmentMatch?.[1]) {
       const target = attachmentsById.get(attachmentMatch[1]);
@@ -1249,7 +1337,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         throw error;
       },
       editable: true,
-      nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode, ComposerAttachmentNode],
+      nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerConnectorNode, ComposerPastedTextNode, ComposerAttachmentNode],
       editorState: () => {
         setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
       },

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -58,6 +58,7 @@ import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMe
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
 import { parseConnectSkillToken } from "./composer/connect-skill-token";
+import { connectorPrompt, parseConnectorToken } from "./composer/connector-token";
 import { createPastedTextChip, resolvePastedTextPlaceholders } from "./composer/pasted-text";
 import {
   canAdmitNextQueuedItem,
@@ -1941,8 +1942,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   ): ComposerDraft => {
     const sourceMentions = sourceComposer?.mentions ?? mentions;
     const sourcePasteParts = sourceComposer?.pasteParts ?? pasteParts;
-    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment, index, segments) => {
+    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\]|@[^\s@]+)/).flatMap((segment, index, segments) => {
       if (!segment) return [] as ComposerDraft["parts"];
+      const connectorName = parseConnectorToken(segment);
+      if (connectorName) {
+        return [{ type: "text", text: connectorPrompt(connectorName) } satisfies ComposerDraft["parts"][number]];
+      }
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch) {
         // Attachment chips are visual tokens only; bytes travel via draft.attachments.
@@ -1984,6 +1989,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return token ? `/${token.slug}` : match;
     });
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
+    resolved = resolved.replace(/\[connector [^\]]+\]/g, (match) => {
+      const name = parseConnectorToken(match);
+      return name ? connectorPrompt(name) : match;
+    });
     for (const value of Object.keys(sourceMentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
     }

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -17,6 +17,7 @@ import {
 } from "./prompt-file-parts";
 import { mentionPromptParts } from "./mention-parts";
 import { parseConnectSkillToken } from "../surface/composer/connect-skill-token";
+import { connectorPrompt, parseConnectorToken } from "../surface/composer/connector-token";
 import { decodeComposerMentionValue } from "../surface/composer/mention-encoding";
 
 // All workspace-scoped server URLs/clients/tokens come from
@@ -75,9 +76,14 @@ export async function draftToParts(
         .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
         .map((part) => [part.label, part.text] as const),
     );
-    const segments = draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+    const segments = draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|\[connector [^\]]+\]|@[^\s@]+)/);
     for (const [index, segment] of segments.entries()) {
       if (!segment) continue;
+      const connectorName = parseConnectorToken(segment);
+      if (connectorName) {
+        parts.push({ type: "text", text: connectorPrompt(connectorName) });
+        continue;
+      }
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch?.[1]) {
         const filePart = attachmentFileById.get(attachmentMatch[1]);

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -28,6 +28,7 @@ import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { EnterpriseActivationGate } from "../domains/cloud/enterprise-activation-gate";
 import { OpenWorkWebAccessGate } from "../domains/cloud/openwork-web-access-gate";
 import { OrgOnboardingPage } from "../domains/cloud/org-onboarding-page";
+import { ChatDeepLinkListener } from "./chat-deep-link-listener";
 import { NewProvidersListener } from "./new-providers-listener";
 import { useDesktopFontZoomBehavior } from "./font-zoom";
 import { LoadingOverlay } from "./loading-overlay";
@@ -384,6 +385,7 @@ export function AppRoot() {
         <AppMenuProvider>
         <OpenworkControlProvider>
           <OpenworkRouteControlActions />
+          <ChatDeepLinkListener />
           <OpenworkContextPublisher />
           <DenAuthControlActions />
           <BrandThemeControlActions />

--- a/apps/app/src/react-app/shell/chat-deep-link-listener.tsx
+++ b/apps/app/src/react-app/shell/chat-deep-link-listener.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource react */
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router";
+
+import {
+  deepLinkBridgeEvent,
+  takePendingDeepLinks,
+  type DeepLinkBridgeDetail,
+} from "../../app/lib/deep-link-bridge";
+import { parseChatDeepLink } from "../../app/lib/openwork-links";
+import { isDesktopRuntime } from "../../app/utils";
+import { setPendingChatSeed } from "../domains/session/chat/pending-chat-seed";
+import { seededConnectorDraft } from "../domains/session/surface/composer/connector-token";
+import { readActiveWorkspaceId } from "./session-memory";
+import { workspaceSessionRoute } from "./workspace-routes";
+
+const isChatDeepLink = (url: string) => parseChatDeepLink(url) !== null;
+
+/**
+ * `openwork://chat?connector=…&prompt=…` from Den's connector catalog: land on
+ * the active workspace's new-task state with the connector chip and starter
+ * prompt already in the composer. Nothing is sent until the person presses
+ * send. Sibling of the connect and den-auth deep-link consumers; it only
+ * takes chat links out of the shared queue, and the same link may be opened
+ * again later to seed another chat.
+ */
+export function ChatDeepLinkListener() {
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !isDesktopRuntime()) return;
+
+    const handleUrls = (urls: readonly string[]) => {
+      const link = urls.map(parseChatDeepLink).findLast((parsed) => parsed !== null) ?? null;
+      if (!link) return;
+      setPendingChatSeed(seededConnectorDraft(link));
+      const workspaceId = readActiveWorkspaceId();
+      navigateRef.current(workspaceId ? workspaceSessionRoute(workspaceId) : "/session");
+    };
+
+    handleUrls(takePendingDeepLinks(window, isChatDeepLink));
+    const handleDeepLink = (event: Event) => {
+      const detail = (event as CustomEvent<DeepLinkBridgeDetail>).detail;
+      handleUrls(Array.isArray(detail?.urls) ? detail.urls : []);
+      // The bridge queues the same links it announces; clear ours so a later
+      // effect run does not replay them.
+      takePendingDeepLinks(window, isChatDeepLink);
+    };
+    window.addEventListener(deepLinkBridgeEvent, handleDeepLink);
+    return () => window.removeEventListener(deepLinkBridgeEvent, handleDeepLink);
+  }, []);
+
+  return null;
+}

--- a/apps/app/tests/chat-link-parse.test.ts
+++ b/apps/app/tests/chat-link-parse.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { parseChatDeepLink } from "../src/app/lib/openwork-links";
+
+const PROMPT = "Explain this repo's authentication using code and docs: components, request flow, and how credentials and tokens are handled";
+
+describe("parseChatDeepLink", () => {
+  test("parses connector and prompt from production and dev desktop links", () => {
+    const params = new URLSearchParams({ connector: "GitHub", prompt: PROMPT });
+    const parsed = parseChatDeepLink(`openwork://chat?${params}`);
+    expect(parsed).toEqual({ prompt: PROMPT, connector: "GitHub", key: `chat:GitHub:${PROMPT}` });
+    expect(parseChatDeepLink(`openwork-dev://chat?${params}`)?.connector).toBe("GitHub");
+    expect(parseChatDeepLink(`openwork:///chat?${params}`)?.prompt).toBe(PROMPT);
+  });
+
+  test("accepts a prompt without a connector and a connector without a prompt", () => {
+    expect(parseChatDeepLink("openwork://chat?prompt=Summarize%20my%20week")).toEqual({
+      prompt: "Summarize my week",
+      connector: null,
+      key: "chat::Summarize my week",
+    });
+    expect(parseChatDeepLink("openwork://chat?connector=Notion")?.connector).toBe("Notion");
+  });
+
+  test("strips token delimiters from the connector so it cannot break out of its chip", () => {
+    expect(parseChatDeepLink("openwork://chat?connector=%5BGit%5DHub%0A&prompt=x")?.connector).toBe("GitHub");
+  });
+
+  test("does not activate from web URLs, unrelated routes, or empty links", () => {
+    expect(parseChatDeepLink(`https://app.openworklabs.com/chat?prompt=${encodeURIComponent(PROMPT)}`)).toBeNull();
+    expect(parseChatDeepLink("openwork://connect?token=abc")).toBeNull();
+    expect(parseChatDeepLink("openwork://chat")).toBeNull();
+    expect(parseChatDeepLink("openwork://chat?prompt=%20%20")).toBeNull();
+    expect(parseChatDeepLink("not a url")).toBeNull();
+  });
+});

--- a/apps/app/tests/connector-chat-round-trip.test.ts
+++ b/apps/app/tests/connector-chat-round-trip.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { takePendingDeepLinks } from "../src/app/lib/deep-link-bridge";
+import { parseChatDeepLink } from "../src/app/lib/openwork-links";
+import { connectorPrompt, parseConnectorToken, seededConnectorDraft } from "../src/react-app/domains/session/surface/composer/connector-token";
+import {
+  connectorChatDeepLink,
+  connectorChatPrompt,
+  POPULAR_CONNECTORS,
+} from "../../../ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog";
+
+/**
+ * Den's connector "Chat" action and the desktop composer agree on one link
+ * shape. This pins both ends: every popular connector's link round-trips into
+ * a draft that leads with the connector chip and ends with its Explain prompt.
+ */
+describe("connector Chat deep link round trip", () => {
+  test("every popular connector's Chat link seeds the connector chip plus its Explain prompt", () => {
+    expect(POPULAR_CONNECTORS.length).toBeGreaterThan(0);
+    for (const connector of POPULAR_CONNECTORS) {
+      const href = connectorChatDeepLink({ connector: connector.displayName, prompt: connectorChatPrompt(connector.displayName) });
+      const link = parseChatDeepLink(href);
+      expect(link, href).not.toBeNull();
+      expect(link?.connector).toBe(connector.displayName);
+      expect(link?.prompt).toBe(connector.chatPrompt);
+      expect(connector.chatPrompt.startsWith("Explain")).toBe(true);
+
+      const draft = seededConnectorDraft({ connector: link?.connector ?? null, prompt: link?.prompt ?? "" });
+      const [chip, ...rest] = draft.split("] ");
+      expect(parseConnectorToken(`${chip}]`)).toBe(connector.displayName);
+      expect(rest.join("] ")).toBe(connector.chatPrompt);
+    }
+  });
+
+  test("the GitHub chip supports planning without assuming account access", () => {
+    const github = parseChatDeepLink(connectorChatDeepLink({ connector: "GitHub", prompt: connectorChatPrompt("GitHub") }));
+    const instruction = connectorPrompt(github?.connector ?? "");
+    expect(instruction).toContain('"GitHub"');
+    expect(instruction).toContain("do not assume it is connected");
+    expect(instruction).toContain("Answer planning and general questions without requiring a connection");
+    expect(github?.prompt).toBe(connectorChatPrompt("GitHub"));
+  });
+
+  test("only openwork://chat links seed a chat, and taking them leaves connect and den-auth links queued", () => {
+    expect(parseChatDeepLink("https://app.openworklabs.com/chat?prompt=hello")).toBeNull();
+    expect(parseChatDeepLink("openwork://connect?token=abc")).toBeNull();
+    expect(parseChatDeepLink("openwork://den-auth?grant=abc")).toBeNull();
+    expect(parseChatDeepLink("openwork://chat")).toBeNull();
+
+    const queue = {
+      deepLinks: ["openwork://connect?token=abc", "openwork://chat?connector=Notion&prompt=Explain", "openwork://den-auth?grant=xyz"],
+    };
+    const bridgeWindow = { __OPENWORK__: queue } as unknown as Window;
+    expect(takePendingDeepLinks(bridgeWindow, (url: string) => parseChatDeepLink(url) !== null))
+      .toEqual(["openwork://chat?connector=Notion&prompt=Explain"]);
+    expect(queue.deepLinks).toEqual(["openwork://connect?token=abc", "openwork://den-auth?grant=xyz"]);
+  });
+});

--- a/apps/app/tests/connector-token.test.ts
+++ b/apps/app/tests/connector-token.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  connectorPrompt,
+  encodeConnectorToken,
+  parseConnectorToken,
+  seededConnectorDraft,
+} from "../src/react-app/domains/session/surface/composer/connector-token";
+import { takePendingDeepLinks } from "../src/app/lib/deep-link-bridge";
+
+describe("connector composer token", () => {
+  test("round-trips a connector name through the draft token", () => {
+    expect(encodeConnectorToken("GitHub")).toBe("[connector GitHub]");
+    expect(parseConnectorToken("[connector GitHub]")).toBe("GitHub");
+    expect(parseConnectorToken("[connector Google Calendar]")).toBe("Google Calendar");
+    expect(parseConnectorToken("[skill GitHub]")).toBeNull();
+    expect(parseConnectorToken("plain text")).toBeNull();
+  });
+
+  test("keeps bracket characters out of the token so the chip boundary survives", () => {
+    expect(encodeConnectorToken("Git[Hub]\n")).toBe("[connector GitHub]");
+  });
+
+  test("seeds the chip ahead of the prompt and leaves a bare prompt untouched", () => {
+    expect(seededConnectorDraft({ connector: "GitHub", prompt: " Explain this repo " })).toBe("[connector GitHub] Explain this repo");
+    expect(seededConnectorDraft({ connector: "GitHub", prompt: "" })).toBe("[connector GitHub] ");
+    expect(seededConnectorDraft({ connector: null, prompt: "Explain this repo" })).toBe("Explain this repo");
+  });
+
+  test("steers discovery without assuming connection or authorizing setup and writes", () => {
+    const prompt = connectorPrompt("GitHub");
+    expect(prompt).toContain('This request is about the "GitHub" connector');
+    expect(prompt).toContain("do not assume it is connected or that its tools are available");
+    expect(prompt).toContain("Answer planning and general questions without requiring a connection");
+    expect(prompt).toContain("discover capabilities normally with search_capabilities, omitting intent connect");
+    expect(prompt).toContain("Offer setup only if the requested operation needs an unavailable connection or the user explicitly asks");
+    expect(prompt).toContain("use intent connect only for an explicit setup request");
+    expect(prompt).toContain("let the user authorize any connection themselves");
+    expect(prompt).toContain("does not authorize sign-in, scope changes, or external writes");
+    expect(prompt).toContain("perform writes only when explicitly requested");
+  });
+});
+
+describe("takePendingDeepLinks", () => {
+  test("removes only the links a consumer owns and leaves the rest queued", () => {
+    const target = { __OPENWORK__: { deepLinks: ["openwork://chat?prompt=hi", "openwork://connect?token=abc"] } } as unknown as Window;
+    expect(takePendingDeepLinks(target, (url) => url.startsWith("openwork://chat"))).toEqual(["openwork://chat?prompt=hi"]);
+    expect(target.__OPENWORK__?.deepLinks).toEqual(["openwork://connect?token=abc"]);
+    expect(takePendingDeepLinks(target, (url) => url.startsWith("openwork://chat"))).toEqual([]);
+  });
+});

--- a/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
@@ -50,12 +50,21 @@ export function requiredPluginMcpAuthType(input: {
   return preset?.authType ?? null
 }
 
+// Stored connections predate preset setup allowlists; only a required auth type
+// can disqualify them. New configuration must also pass the preset allowlist.
+export function existingPluginMcpAuthTypeCompatible(input: {
+  authType: PluginMcpAuthType
+  requiredAuthType: PluginMcpAuthType | null
+}): boolean {
+  return input.requiredAuthType === null || input.authType === input.requiredAuthType
+}
+
 export function pluginMcpAuthTypeCompatible(input: {
   authType: PluginMcpAuthType
   requiredAuthType: PluginMcpAuthType | null
   url: string
 }): boolean {
-  if (input.requiredAuthType && input.authType !== input.requiredAuthType) return false
+  if (!existingPluginMcpAuthTypeCompatible(input)) return false
   const preset = matchExternalMcpPresetForUrl(input.url)
   return !preset || (preset.supportedAuthTypes ?? [preset.authType]).includes(input.authType)
 }
@@ -72,6 +81,9 @@ export function resolveGithubPluginMcpImportAuthType(input: {
 }): PluginMcpAuthType {
   if (input.declaredAuthType) return input.declaredAuthType
   const preset = matchExternalMcpPresetForUrl(input.url)
-  if (input.existingAuthType && preset?.supportedAuthTypes?.includes(input.existingAuthType)) return input.existingAuthType
+  if (input.existingAuthType && preset?.supportedAuthTypes && existingPluginMcpAuthTypeCompatible({
+    authType: input.existingAuthType,
+    requiredAuthType: requiredPluginMcpAuthType(input),
+  })) return input.existingAuthType
   return preset?.authType ?? input.requestedAuthType
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
@@ -44,8 +44,20 @@ export function requiredPluginMcpAuthType(input: {
   declaredAuthType: "oauth" | null
   url: string
 }): PluginMcpAuthType | null {
+  if (input.declaredAuthType) return input.declaredAuthType
   const preset = matchExternalMcpPresetForUrl(input.url)
-  return preset?.authType ?? input.declaredAuthType
+  if (preset?.supportedAuthTypes && preset.supportedAuthTypes.length > 1) return null
+  return preset?.authType ?? null
+}
+
+export function pluginMcpAuthTypeCompatible(input: {
+  authType: PluginMcpAuthType
+  requiredAuthType: PluginMcpAuthType | null
+  url: string
+}): boolean {
+  if (input.requiredAuthType && input.authType !== input.requiredAuthType) return false
+  const preset = matchExternalMcpPresetForUrl(input.url)
+  return !preset || (preset.supportedAuthTypes ?? [preset.authType]).includes(input.authType)
 }
 
 export function pluginMcpRequiresPreRegisteredOAuthClient(url: string): boolean {
@@ -54,8 +66,12 @@ export function pluginMcpRequiresPreRegisteredOAuthClient(url: string): boolean 
 
 export function resolveGithubPluginMcpImportAuthType(input: {
   declaredAuthType: "oauth" | null
-  requestedAuthType: "none" | "oauth"
+  existingAuthType?: PluginMcpAuthType
+  requestedAuthType: PluginMcpAuthType
   url: string
 }): PluginMcpAuthType {
-  return requiredPluginMcpAuthType(input) ?? input.requestedAuthType
+  if (input.declaredAuthType) return input.declaredAuthType
+  const preset = matchExternalMcpPresetForUrl(input.url)
+  if (input.existingAuthType && preset?.supportedAuthTypes?.includes(input.existingAuthType)) return input.existingAuthType
+  return preset?.authType ?? input.requestedAuthType
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -21,7 +21,7 @@ import {
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
 import { env } from "../env.js"
-import { declaredPluginMcpAuthType, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
+import { declaredPluginMcpAuthType, pluginMcpAuthTypeCompatible, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
 import { isExternalMcpSharedCallbackRedirectUri } from "./external-mcp-oauth-contract.js"
 import {
   createExternalMcpIdentityBinding,
@@ -348,7 +348,11 @@ async function sourcedUsableExternalMcpConnections(input: {
     const requiredAuthType = entry
       ? requiredPluginMcpAuthType({ declaredAuthType: declaredPluginMcpAuthType(entry.config), url: declaredUrl })
       : null
-    if (!input.includeAuthMismatches && requiredAuthType && row.connection.authType !== requiredAuthType) return []
+    if (!input.includeAuthMismatches && !pluginMcpAuthTypeCompatible({
+      authType: row.connection.authType,
+      requiredAuthType,
+      url: declaredUrl,
+    })) return []
     return normalizeExternalMcpIdentityUrl(row.connection.url) === normalizeExternalMcpIdentityUrl(declaredUrl)
       ? [row.connection]
       : []

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -21,7 +21,7 @@ import {
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
 import { env } from "../env.js"
-import { declaredPluginMcpAuthType, pluginMcpAuthTypeCompatible, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
+import { declaredPluginMcpAuthType, existingPluginMcpAuthTypeCompatible, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
 import { isExternalMcpSharedCallbackRedirectUri } from "./external-mcp-oauth-contract.js"
 import {
   createExternalMcpIdentityBinding,
@@ -348,10 +348,9 @@ async function sourcedUsableExternalMcpConnections(input: {
     const requiredAuthType = entry
       ? requiredPluginMcpAuthType({ declaredAuthType: declaredPluginMcpAuthType(entry.config), url: declaredUrl })
       : null
-    if (!input.includeAuthMismatches && !pluginMcpAuthTypeCompatible({
+    if (!input.includeAuthMismatches && !existingPluginMcpAuthTypeCompatible({
       authType: row.connection.authType,
       requiredAuthType,
-      url: declaredUrl,
     })) return []
     return normalizeExternalMcpIdentityUrl(row.connection.url) === normalizeExternalMcpIdentityUrl(declaredUrl)
       ? [row.connection]

--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -12,7 +12,9 @@ export type ExternalMcpPreset = {
   displayName: string
   description: string
   url: string
+  // Setup default, not an exclusive requirement when supportedAuthTypes lists alternatives.
   authType: "oauth" | "apikey" | "none"
+  supportedAuthTypes?: readonly ("oauth" | "apikey" | "none")[]
   requiresOAuthClient?: boolean
   authorizationServerIssuer?: string
   defaultOAuthScopes?: readonly string[]
@@ -24,6 +26,7 @@ export const externalMcpPresetResponseSchema = z.object({
   description: z.string(),
   url: z.string(),
   authType: z.enum(["oauth", "apikey", "none"]),
+  supportedAuthTypes: z.array(z.enum(["oauth", "apikey", "none"])).optional(),
   requiresOAuthClient: z.boolean().optional(),
   authorizationServerIssuer: z.string().url().optional(),
   defaultOAuthScopes: z.array(z.string()).optional(),
@@ -34,6 +37,15 @@ export const externalMcpPresetListResponseSchema = z.object({
 }).meta({ ref: "ExternalMcpPresetListResponse" })
 
 export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
+  {
+    presetId: "github",
+    displayName: "GitHub",
+    description: "PRs, issues, code, and CI. Use a registered GitHub OAuth app for individual accounts, or a personal access token for a shared connection. Automatic app registration is not supported.",
+    url: "https://api.githubcopilot.com/mcp/",
+    authType: "oauth",
+    supportedAuthTypes: ["oauth", "apikey"],
+    requiresOAuthClient: true,
+  },
   {
     presetId: "notion",
     displayName: "Notion",
@@ -79,7 +91,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "slack",
     displayName: "Slack",
-    description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",
+    description: "Channels, DMs, and search. Requires an eligible internal or Slack Marketplace-published app; not every Slack app can use MCP. An admin configures its OAuth client once, then each person connects their own account. Automatic app registration is not supported.",
     url: "https://mcp.slack.com/mcp",
     authType: "oauth",
     requiresOAuthClient: true,
@@ -101,7 +113,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "exa",
     displayName: "Exa",
-    description: "AI web search, code search, and research for your agents. Paste your org's Exa API key from dashboard.exa.ai.",
+    description: "Web search, code context, and research. This connection uses your org's Exa API key from dashboard.exa.ai; provider usage limits and billing apply.",
     url: "https://mcp.exa.ai/mcp",
     authType: "apikey",
   },
@@ -115,7 +127,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "context7",
     displayName: "Context7",
-    description: "Search product docs with richer context.",
+    description: "Up-to-date library documentation and code examples. Connect without an API key using Context7's rate-limited anonymous access.",
     url: "https://mcp.context7.com/mcp",
     authType: "none",
   },

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -20,9 +20,10 @@ import {
 import {
   declaredPluginMcpAuthType,
   requiredPluginMcpAuthType,
+  pluginMcpAuthTypeCompatible,
+  pluginMcpRequiresPreRegisteredOAuthClient,
   type PluginMcpAuthType,
 } from "../capability-sources/external-mcp-auth-policy.js"
-import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
 import { getConnectedAccount, getOrgOAuthClient } from "../capability-sources/oauth-credentials.js"
 import { db } from "../db.js"
 import { resolvePluginArchGrantRole } from "../routes/org/plugin-system/access.js"
@@ -1010,7 +1011,11 @@ async function statusForRequirement(input: {
   usableConnections: ExternalMcpConnectionRow[]
 }): Promise<MarketplaceMcpRequirementStatus> {
   const connection = matchingConnectionForRequirement(input)
-  const authTypeMismatch = Boolean(connection && input.requirement.requiredAuthType && connection.authType !== input.requirement.requiredAuthType)
+  const authTypeMismatch = Boolean(connection && !pluginMcpAuthTypeCompatible({
+    authType: connection.authType,
+    requiredAuthType: input.requirement.requiredAuthType,
+    url: input.requirement.url,
+  }))
   const usable = connection && !authTypeMismatch
     ? connectionIsUsable({ connectionId: connection.id, usableConnections: input.usableConnections })
     : false
@@ -1023,7 +1028,11 @@ async function statusForRequirement(input: {
     ...(connection && usable ? { connectionId: connection.id, connectionName: connection.name, credentialMode: connection.credentialMode } : {}),
   }
 
-  if (!connection || !usable) {
+  if (!connection || !usable || (
+    connection.authType === "oauth"
+    && pluginMcpRequiresPreRegisteredOAuthClient(connection.url)
+    && !await getOrgOAuthClient(connection.organizationId, connection.id)
+  )) {
     const state = "needs_admin_setup"
     return {
       ...base,
@@ -1209,9 +1218,12 @@ async function resolveMcpReadinessConnections(input: {
       connectedCache.set(matched.id, connectedForMe)
     }
     let oauthClientConfigured: boolean | undefined
-    const preset = EXTERNAL_MCP_PRESETS.find((candidate) => comparablePluginMcpRequirementUrl(candidate.url) === comparablePluginMcpRequirementUrl(matched.url))
-    const authTypeMismatch = Boolean(dependency.requiredAuthType && matched.authType !== dependency.requiredAuthType)
-    const oauthClientRequired = dependency.requiredAuthType === "oauth" && preset?.requiresOAuthClient === true
+    const authTypeMismatch = !pluginMcpAuthTypeCompatible({
+      authType: matched.authType,
+      requiredAuthType: dependency.requiredAuthType,
+      url: dependency.url,
+    })
+    const oauthClientRequired = matched.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(matched.url)
     if (dependency.requiredAuthType === "oauth" || matched.authType === "oauth") {
       oauthClientConfigured = oauthClientConfiguredCache.get(matched.id)
       if (oauthClientConfigured === undefined) {

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -20,7 +20,7 @@ import {
 import {
   declaredPluginMcpAuthType,
   requiredPluginMcpAuthType,
-  pluginMcpAuthTypeCompatible,
+  existingPluginMcpAuthTypeCompatible,
   pluginMcpRequiresPreRegisteredOAuthClient,
   type PluginMcpAuthType,
 } from "../capability-sources/external-mcp-auth-policy.js"
@@ -1011,10 +1011,9 @@ async function statusForRequirement(input: {
   usableConnections: ExternalMcpConnectionRow[]
 }): Promise<MarketplaceMcpRequirementStatus> {
   const connection = matchingConnectionForRequirement(input)
-  const authTypeMismatch = Boolean(connection && !pluginMcpAuthTypeCompatible({
+  const authTypeMismatch = Boolean(connection && !existingPluginMcpAuthTypeCompatible({
     authType: connection.authType,
     requiredAuthType: input.requirement.requiredAuthType,
-    url: input.requirement.url,
   }))
   const usable = connection && !authTypeMismatch
     ? connectionIsUsable({ connectionId: connection.id, usableConnections: input.usableConnections })
@@ -1218,10 +1217,9 @@ async function resolveMcpReadinessConnections(input: {
       connectedCache.set(matched.id, connectedForMe)
     }
     let oauthClientConfigured: boolean | undefined
-    const authTypeMismatch = !pluginMcpAuthTypeCompatible({
+    const authTypeMismatch = !existingPluginMcpAuthTypeCompatible({
       authType: matched.authType,
       requiredAuthType: dependency.requiredAuthType,
-      url: dependency.url,
     })
     const oauthClientRequired = matched.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(matched.url)
     if (dependency.requiredAuthType === "oauth" || matched.authType === "oauth") {

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -106,7 +106,7 @@ import {
   externalMcpOAuthConfigurationDefaults,
   pluginMcpRequiresPreRegisteredOAuthClient,
   requiredPluginMcpAuthType,
-  pluginMcpAuthTypeCompatible,
+  existingPluginMcpAuthTypeCompatible,
   matchExternalMcpPresetForUrl,
 } from "../../capability-sources/external-mcp-auth-policy.js"
 import {
@@ -1156,8 +1156,7 @@ async function toConnectionResponse(
   if (requiredAuthTypes.length === 0 && presetRequiredAuthType) requiredAuthTypes.push(presetRequiredAuthType)
   const authPolicyConfirmed = options.identityManagedBy.length === 0 || requiredAuthTypes.length > 0
     || (row.kind === "external_mcp" && matchExternalMcpPresetForUrl(row.url) !== null)
-  const authTypeMismatch = requiredAuthTypes.some((requiredAuthType) => requiredAuthType !== row.authType)
-    || (row.kind === "external_mcp" && !pluginMcpAuthTypeCompatible({ authType: row.authType, requiredAuthType: null, url: row.url }))
+  const authTypeMismatch = requiredAuthTypes.some((requiredAuthType) => !existingPluginMcpAuthTypeCompatible({ authType: row.authType, requiredAuthType }))
   const oauthClientRequired = row.kind === "external_mcp" && row.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(row.url)
   const oauthClientConfigured = Boolean(oauthClient)
   const setupRequired = options.identityManagedBy.length > 0 && (

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -106,6 +106,8 @@ import {
   externalMcpOAuthConfigurationDefaults,
   pluginMcpRequiresPreRegisteredOAuthClient,
   requiredPluginMcpAuthType,
+  pluginMcpAuthTypeCompatible,
+  matchExternalMcpPresetForUrl,
 } from "../../capability-sources/external-mcp-auth-policy.js"
 import {
   EXTERNAL_MCP_DIAGNOSTIC_PHASES,
@@ -1153,7 +1155,9 @@ async function toConnectionResponse(
     : null
   if (requiredAuthTypes.length === 0 && presetRequiredAuthType) requiredAuthTypes.push(presetRequiredAuthType)
   const authPolicyConfirmed = options.identityManagedBy.length === 0 || requiredAuthTypes.length > 0
+    || (row.kind === "external_mcp" && matchExternalMcpPresetForUrl(row.url) !== null)
   const authTypeMismatch = requiredAuthTypes.some((requiredAuthType) => requiredAuthType !== row.authType)
+    || (row.kind === "external_mcp" && !pluginMcpAuthTypeCompatible({ authType: row.authType, requiredAuthType: null, url: row.url }))
   const oauthClientRequired = row.kind === "external_mcp" && row.authType === "oauth" && pluginMcpRequiresPreRegisteredOAuthClient(row.url)
   const oauthClientConfigured = Boolean(oauthClient)
   const setupRequired = options.identityManagedBy.length > 0 && (
@@ -1608,6 +1612,8 @@ async function createExternalConnectionResponse(
         await markExternalMcpConnectionConnected(created.id)
       }
     } catch (error) {
+      // Failed creation must not leave a saved API key looking ready or reserve its external key.
+      await deleteExternalMcpConnection({ organizationId: payload.organization.id, connectionId: created.id })
       const diagnostic = externalMcpDiagnosticForResponse(error, requestId, "MCP_INITIALIZE")
       logger.error("external_mcp_connection_validation_failed", {
         connection_id: created.id,

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -5469,8 +5469,9 @@ async function ensureImportedExternalMcpConnection(input: {
   if (existing) {
     const authType = resolveGithubPluginMcpImportAuthType({
       declaredAuthType: input.server.authType,
-      // A shared PAT must never replace a requested per-member OAuth connection.
-      existingAuthType: existing.credentialMode === input.credentialMode ? existing.authType : undefined,
+      // Legacy none always used shared mode, regardless of the import's OAuth
+      // mode default. A shared PAT must not replace per-member OAuth.
+      existingAuthType: existing.authType === "none" || existing.credentialMode === input.credentialMode ? existing.authType : undefined,
       requestedAuthType: input.authType,
       url: serverUrl,
     })
@@ -5480,9 +5481,9 @@ async function ensureImportedExternalMcpConnection(input: {
       existingAuthType: existing.authType,
       existingCredentialMode: existing.credentialMode,
     })
-    if (input.authType === "none") {
+    if (authType === "none") {
       try {
-        await validateConfiguredPluginMcpConnection({ authType: input.authType, connection: existing })
+        await validateConfiguredPluginMcpConnection({ authType, connection: existing })
       } catch (error) {
         await db.update(ExternalMcpConnectionTable).set({ connectedAt: null }).where(and(
           eq(ExternalMcpConnectionTable.organizationId, organizationId),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -107,6 +107,7 @@ import { openworkYourConnectionsUrl } from "../../../mcp/connection-navigation.j
 import {
   declaredPluginMcpAuthType,
   requiredPluginMcpAuthType,
+  pluginMcpAuthTypeCompatible,
   resolveGithubPluginMcpImportAuthType,
   type PluginMcpAuthType,
 } from "../../../capability-sources/external-mcp-auth-policy.js"
@@ -5466,8 +5467,15 @@ async function ensureImportedExternalMcpConnection(input: {
     .find((connection) => connection.kind === "external_mcp" && comparablePluginMcpRequirementUrl(connection.url) === comparablePluginMcpRequirementUrl(serverUrl))
 
   if (existing) {
+    const authType = resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: input.server.authType,
+      // A shared PAT must never replace a requested per-member OAuth connection.
+      existingAuthType: existing.credentialMode === input.credentialMode ? existing.authType : undefined,
+      requestedAuthType: input.authType,
+      url: serverUrl,
+    })
     await requireExistingExternalMcpConnectionMatchesImport({
-      authType: input.authType,
+      authType,
       credentialMode: input.credentialMode,
       existingAuthType: existing.authType,
       existingCredentialMode: existing.credentialMode,
@@ -5594,11 +5602,13 @@ export async function configureMarketplacePluginMcpRequirement(input: {
     declaredAuthType: declaredPluginMcpAuthType(server.config),
     url: server.url,
   })
-  if (declaredRequiredAuthType && declaredRequiredAuthType !== input.authType) {
+  if (!pluginMcpAuthTypeCompatible({ authType: input.authType, requiredAuthType: declaredRequiredAuthType, url: server.url })) {
     throw new PluginArchRouteFailure(
       409,
       "mcp_auth_type_mismatch",
-      `This MCP requirement must use ${declaredRequiredAuthType} authentication.`,
+      declaredRequiredAuthType
+        ? `This MCP requirement must use ${declaredRequiredAuthType} authentication.`
+        : "This authentication type is not supported by the MCP server.",
     )
   }
   const requiredAuthType = declaredRequiredAuthType ?? input.authType
@@ -5788,19 +5798,20 @@ export async function importGithubPluginMcps(input: {
   const imported: Array<{ connectionId: string; name: string; url: string }> = []
   const importedSkills: Array<{ configObjectId: ConfigObjectId; name: string; sourcePath: string }> = []
   for (const server of supportedServers) {
-    const authType = resolveGithubPluginMcpImportAuthType({
+    const defaultAuthType = resolveGithubPluginMcpImportAuthType({
       declaredAuthType: server.authType,
       requestedAuthType: input.authType,
       url: server.url ?? "",
     })
     const importedConnection = await ensureImportedExternalMcpConnection({
       access,
-      authType,
+      authType: defaultAuthType,
       context: input.context,
       credentialMode: input.credentialMode,
       server,
     })
     const connection = importedConnection.connection
+    const authType = connection.authType
     if (importedConnection.ownedByImportedPlugin) importedOwnedConnectionIds.add(connection.id)
     const payload = importedConnectionBackedMcpPayload({
       authType,

--- a/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
+++ b/ee/apps/den-api/test/external-mcp-preset-oauth-defaults.test.ts
@@ -26,6 +26,7 @@ describe("External MCP preset OAuth defaults", () => {
     const slack = EXTERNAL_MCP_PRESETS.find((preset) => preset.presetId === "slack")
     expect(slack?.authorizationServerIssuer).toBe("https://mcp.slack.com")
     expect(slack?.defaultOAuthScopes).toEqual(slackDefaultScopes)
+    expect(slack?.description).toContain("eligible internal or Slack Marketplace-published app")
   })
 
   test("applies preset defaults only when admin values are absent", () => {
@@ -50,8 +51,15 @@ describe("External MCP preset OAuth defaults", () => {
 
   test("presets response schema exposes OAuth defaults", () => {
     const result = externalMcpPresetListResponseSchema.parse({ presets: EXTERNAL_MCP_PRESETS })
+    expect(result.presets.find((preset) => preset.presetId === "github")).toMatchObject({
+      authType: "oauth",
+      supportedAuthTypes: ["oauth", "apikey"],
+      requiresOAuthClient: true,
+    })
     const slack = result.presets.find((preset) => preset.presetId === "slack")
     expect(slack?.authorizationServerIssuer).toBe("https://mcp.slack.com")
     expect(slack?.defaultOAuthScopes).toEqual(slackDefaultScopes)
+    expect(result.presets.find((preset) => preset.presetId === "context7")?.description).toContain("rate-limited anonymous access")
+    expect(result.presets.find((preset) => preset.presetId === "exa")?.description).toContain("provider usage limits and billing apply")
   })
 })

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -111,7 +111,7 @@ const {
   listUsableExternalMcpConnections,
 } = await import("../src/capability-sources/external-mcp-connections.js")
 
-test("plugin-sourced GitHub PATs remain usable without allowing anonymous or explicit OAuth mismatches", async () => {
+test("plugin-sourced GitHub PATs and legacy none remain usable without bypassing access or explicit OAuth", async () => {
   const organizationId = createDenTypeId("organization")
   const orgMembershipId = createDenTypeId("member")
   const pluginId = createDenTypeId("plugin")
@@ -121,13 +121,20 @@ test("plugin-sourced GitHub PATs remain usable without allowing anonymous or exp
   const cases = [
     { authType: "apikey", oauth: false, granted: true, usable: true },
     { authType: "oauth", oauth: false, granted: true, usable: true },
-    { authType: "none", oauth: false, granted: true, usable: false },
+    { authType: "none", oauth: false, granted: true, usable: true },
+    { authType: "none", oauth: true, granted: true, usable: false },
     { authType: "apikey", oauth: true, granted: true, usable: false },
     { authType: "oauth", oauth: true, granted: true, usable: true },
     { authType: "apikey", oauth: false, granted: false, usable: false },
+    { authType: "none", oauth: false, granted: false, usable: false },
   ]
   for (const input of cases) {
-    const candidate = { ...connection, organizationId, authType: input.authType, credentialMode: "shared", url, apiKey: "fixture-pat" }
+    const candidate = {
+      ...connection, organizationId, authType: input.authType, credentialMode: "shared", url,
+      apiKey: input.authType === "apikey" ? "fixture-pat" : null,
+      accessToken: input.authType === "oauth" ? "fixture-token" : null,
+      connectedAt: new Date(),
+    }
     queueSelectResults([
       [], // No direct grants: access must come from this plugin.
       [{ binding, connection: candidate, configObjectTitle: "GitHub" }],
@@ -143,7 +150,7 @@ test("plugin-sourced GitHub PATs remain usable without allowing anonymous or exp
   expect(transactionCalls).toBe(0)
 })
 
-test("GitHub plugin readiness accepts PATs and still requires a registered client for OAuth", async () => {
+test("GitHub plugin readiness preserves connected legacy none but still enforces OAuth setup", async () => {
   // The marketplace module imports the app graph; do not initialize auth's resource registry.
   mock.module("../src/auth.js", () => ({
     auth: { api: { getSession: async () => null }, handler: async () => new Response() },
@@ -167,7 +174,9 @@ test("GitHub plugin readiness accepts PATs and still requires a registered clien
   for (const input of [
     { authType: "apikey", oauth: false, client: false, state: "ready" },
     { authType: "apikey", oauth: true, client: false, state: "needs_admin_setup" },
-    { authType: "none", oauth: false, client: false, state: "needs_admin_setup" },
+    { authType: "none", oauth: false, client: false, state: "ready" },
+    { authType: "none", oauth: true, client: false, state: "needs_admin_setup" },
+    { authType: "none", oauth: false, client: false, state: "needs_admin_setup", disconnected: true },
     { authType: "oauth", oauth: false, client: false, state: "needs_admin_setup" },
     { authType: "oauth", oauth: false, client: true, state: "ready" },
   ]) {
@@ -175,7 +184,7 @@ test("GitHub plugin readiness accepts PATs and still requires a registered clien
       ...connection, organizationId, url, authType: input.authType, credentialMode: "shared",
       apiKey: input.authType === "apikey" ? "fixture-pat" : null,
       accessToken: input.authType === "oauth" ? "fixture-token" : null,
-      connectedAt: new Date(),
+      connectedAt: input.disconnected ? null : new Date(),
     }
     queueSelectResults([
       [{ id: configObjectId, objectType: "mcp", pluginId, title: "GitHub" }],
@@ -190,6 +199,7 @@ test("GitHub plugin readiness accepts PATs and still requires a registered clien
       organizationId, member: { orgMembershipId, teamIds: [] }, pluginIds: [pluginId],
     })
     expect(readiness.get(pluginId)?.state).toBe(input.state)
+    expect(readiness.get(pluginId)?.connections[0]?.authTypeMismatch).toBe(input.oauth && input.authType !== "oauth")
     expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.authType === "oauth" ? true : input.oauth ? false : undefined)
     expect(selectResults).toHaveLength(0)
   }

--- a/ee/apps/den-api/test/external-mcp-readiness.test.ts
+++ b/ee/apps/den-api/test/external-mcp-readiness.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, test } from "bun:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
 
 process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32)
 process.env.BETTER_AUTH_SECRET ??= "y".repeat(32)
@@ -9,6 +10,8 @@ process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_den"
 type QueryRows = Record<string, unknown>[]
 type FakeQuery = {
   from: (table: unknown) => FakeQuery
+  innerJoin: () => FakeQuery
+  orderBy: () => FakeQuery
   where: (condition: unknown) => FakeQuery
   limit: (count: number) => FakeQuery
   for: (mode: string) => FakeQuery
@@ -19,6 +22,8 @@ function fakeQuery(rows: QueryRows): FakeQuery {
   const promise = Promise.resolve(rows)
   const query: FakeQuery = {
     from: () => query,
+    innerJoin: () => query,
+    orderBy: () => query,
     where: () => query,
     limit: () => query,
     for: () => {
@@ -91,6 +96,7 @@ function queueSelectResults(results: QueryRows[]): void {
 mock.module("../src/db.js", () => ({
   db: {
     select: () => fakeQuery(selectResults.shift() ?? []),
+    selectDistinct: () => fakeQuery(selectResults.shift() ?? []),
     transaction: () => {
       transactionCalls += 1
       throw new Error("Read-only external MCP checks must not open a transaction")
@@ -102,7 +108,92 @@ const {
   readConnectedAccountForExternalMcpIdentity,
   readOrgOAuthClientForExternalMcpIdentity,
   readyExternalMcpConnectionsForMember,
+  listUsableExternalMcpConnections,
 } = await import("../src/capability-sources/external-mcp-connections.js")
+
+test("plugin-sourced GitHub PATs remain usable without allowing anonymous or explicit OAuth mismatches", async () => {
+  const organizationId = createDenTypeId("organization")
+  const orgMembershipId = createDenTypeId("member")
+  const pluginId = createDenTypeId("plugin")
+  const configObjectId = createDenTypeId("configObject")
+  const binding = { id: createDenTypeId("pluginMcpRequirementBinding"), pluginId, configObjectId, serverName: "github" }
+  const url = "https://api.githubcopilot.com/mcp/"
+  const cases = [
+    { authType: "apikey", oauth: false, granted: true, usable: true },
+    { authType: "oauth", oauth: false, granted: true, usable: true },
+    { authType: "none", oauth: false, granted: true, usable: false },
+    { authType: "apikey", oauth: true, granted: true, usable: false },
+    { authType: "oauth", oauth: true, granted: true, usable: true },
+    { authType: "apikey", oauth: false, granted: false, usable: false },
+  ]
+  for (const input of cases) {
+    const candidate = { ...connection, organizationId, authType: input.authType, credentialMode: "shared", url, apiKey: "fixture-pat" }
+    queueSelectResults([
+      [], // No direct grants: access must come from this plugin.
+      [{ binding, connection: candidate, configObjectTitle: "GitHub" }],
+      [{ configObjectId, normalizedPayloadJson: { mcpServers: { github: { url, oauth: input.oauth } } } }],
+      [],
+      input.granted ? [{ pluginId }] : [],
+      [],
+    ])
+    expect(await listUsableExternalMcpConnections({ organizationId, orgMembershipId, teamIds: [] }))
+      .toEqual(input.usable ? [candidate] : [])
+    expect(selectResults).toHaveLength(0)
+  }
+  expect(transactionCalls).toBe(0)
+})
+
+test("GitHub plugin readiness accepts PATs and still requires a registered client for OAuth", async () => {
+  // The marketplace module imports the app graph; do not initialize auth's resource registry.
+  mock.module("../src/auth.js", () => ({
+    auth: { api: { getSession: async () => null }, handler: async () => new Response() },
+    DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX: "ow_mcp_at_",
+    DEN_MCP_FIRST_PARTY_CLIENT_ID: "openwork-desktop",
+    DEN_MCP_FIRST_PARTY_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+    DEN_MCP_GRANT_ID_CLAIM: "https://openworklabs.com/grant_id",
+    DEN_MCP_ORG_ID_CLAIM: "https://openworklabs.com/org_id",
+    DEN_MCP_OAUTH_RESOURCE: "http://127.0.0.1:8790/mcp",
+    DEN_MCP_RESOURCE: "http://127.0.0.1:8790/mcp",
+    DEN_MCP_RESOURCE_CLAIM: "https://openworklabs.com/resource",
+    DEN_MCP_RESOURCES: ["http://127.0.0.1:8790/mcp"],
+    DEN_MCP_TOKEN_USE_CLAIM: "https://openworklabs.com/token_use",
+  }))
+  const { resolveMarketplacePluginCloudReadiness } = await import("../src/mcp/marketplace-capabilities.js")
+  const organizationId = createDenTypeId("organization")
+  const orgMembershipId = createDenTypeId("member")
+  const pluginId = createDenTypeId("plugin")
+  const configObjectId = createDenTypeId("configObject")
+  const url = "https://api.githubcopilot.com/mcp/"
+  for (const input of [
+    { authType: "apikey", oauth: false, client: false, state: "ready" },
+    { authType: "apikey", oauth: true, client: false, state: "needs_admin_setup" },
+    { authType: "none", oauth: false, client: false, state: "needs_admin_setup" },
+    { authType: "oauth", oauth: false, client: false, state: "needs_admin_setup" },
+    { authType: "oauth", oauth: false, client: true, state: "ready" },
+  ]) {
+    const candidate = {
+      ...connection, organizationId, url, authType: input.authType, credentialMode: "shared",
+      apiKey: input.authType === "apikey" ? "fixture-pat" : null,
+      accessToken: input.authType === "oauth" ? "fixture-token" : null,
+      connectedAt: new Date(),
+    }
+    queueSelectResults([
+      [{ id: configObjectId, objectType: "mcp", pluginId, title: "GitHub" }],
+      [{ configObjectId, normalizedPayloadJson: { mcpServers: { github: { url, oauth: input.oauth } } } }],
+      [{ connection: candidate }],
+      [],
+      [candidate],
+      [],
+      ...(input.oauth || input.authType === "oauth" ? [input.client ? [orgClient] : []] : []),
+    ])
+    const readiness = await resolveMarketplacePluginCloudReadiness({
+      organizationId, member: { orgMembershipId, teamIds: [] }, pluginIds: [pluginId],
+    })
+    expect(readiness.get(pluginId)?.state).toBe(input.state)
+    expect(readiness.get(pluginId)?.connections[0]?.oauthClientRequired).toBe(input.authType === "oauth" ? true : input.oauth ? false : undefined)
+    expect(selectResults).toHaveLength(0)
+  }
+})
 
 test("per-member connection list readiness reads credentials without row locks", async () => {
   queueSelectResults([[connection], [account], [connection]])

--- a/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
+++ b/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   declaredPluginMcpAuthType,
+  existingPluginMcpAuthTypeCompatible,
   pluginMcpAuthTypeCompatible,
   pluginMcpRequiresPreRegisteredOAuthClient,
   requiredPluginMcpAuthType,
@@ -23,7 +24,7 @@ describe("GitHub plugin MCP authentication", () => {
     }
   })
 
-  test("a compatible existing PAT can be reused, but never overrides an explicit OAuth declaration", () => {
+  test("existing PAT and legacy no-auth imports are preserved, but never override explicit OAuth", () => {
     expect(resolveGithubPluginMcpImportAuthType({
       declaredAuthType: null,
       existingAuthType: "apikey",
@@ -36,8 +37,16 @@ describe("GitHub plugin MCP authentication", () => {
       requestedAuthType: "none",
       url: githubUrl,
     })).toBe("oauth")
+    for (const requestedAuthType of ["none", "oauth"] as const) {
+      expect(resolveGithubPluginMcpImportAuthType({
+        declaredAuthType: null,
+        existingAuthType: "none",
+        requestedAuthType,
+        url: githubUrl,
+      })).toBe("none")
+    }
     expect(resolveGithubPluginMcpImportAuthType({
-      declaredAuthType: null,
+      declaredAuthType: "oauth",
       existingAuthType: "none",
       requestedAuthType: "none",
       url: githubUrl,
@@ -46,6 +55,15 @@ describe("GitHub plugin MCP authentication", () => {
     expect(requiredAuthType).toBe("oauth")
     expect(pluginMcpAuthTypeCompatible({ authType: "apikey", requiredAuthType, url: githubUrl })).toBe(false)
     expect(pluginMcpAuthTypeCompatible({ authType: "oauth", requiredAuthType, url: githubUrl })).toBe(true)
+  })
+
+  test("stored GitHub none remains compatible without permitting a new anonymous setup", () => {
+    for (const requiredAuthType of [null, "none"] as const) {
+      expect(existingPluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType })).toBe(true)
+      expect(pluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType, url: githubUrl })).toBe(false)
+    }
+    expect(existingPluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType: "oauth" })).toBe(false)
+    expect(existingPluginMcpAuthTypeCompatible({ authType: "apikey", requiredAuthType: "oauth" })).toBe(false)
   })
 
   test("single-auth presets still reject unsupported and anonymous connections", () => {
@@ -58,6 +76,8 @@ describe("GitHub plugin MCP authentication", () => {
       expect(requiredAuthType).toBe(authType)
       expect(pluginMcpAuthTypeCompatible({ authType, requiredAuthType, url })).toBe(true)
       expect(pluginMcpAuthTypeCompatible({ authType: authType === "none" ? "apikey" : "none", requiredAuthType, url })).toBe(false)
+      expect(existingPluginMcpAuthTypeCompatible({ authType, requiredAuthType })).toBe(true)
+      expect(existingPluginMcpAuthTypeCompatible({ authType: authType === "none" ? "apikey" : "none", requiredAuthType })).toBe(false)
     }
   })
 

--- a/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
+++ b/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
@@ -1,10 +1,74 @@
 import { describe, expect, test } from "bun:test"
 import {
   declaredPluginMcpAuthType,
+  pluginMcpAuthTypeCompatible,
+  pluginMcpRequiresPreRegisteredOAuthClient,
+  requiredPluginMcpAuthType,
   resolveGithubPluginMcpImportAuthType,
 } from "../src/capability-sources/external-mcp-auth-policy.js"
 
 describe("GitHub plugin MCP authentication", () => {
+  const githubUrl = "https://api.githubcopilot.com/mcp/"
+
+  test("GitHub defaults new imports to OAuth without making it the only supported authentication", () => {
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      requestedAuthType: "none",
+      url: githubUrl,
+    })).toBe("oauth")
+    expect(requiredPluginMcpAuthType({ declaredAuthType: null, url: githubUrl })).toBeNull()
+    expect(pluginMcpRequiresPreRegisteredOAuthClient(githubUrl)).toBe(true)
+    for (const authType of ["oauth", "apikey", "none"] as const) {
+      expect(pluginMcpAuthTypeCompatible({ authType, requiredAuthType: null, url: githubUrl })).toBe(authType !== "none")
+    }
+  })
+
+  test("a compatible existing PAT can be reused, but never overrides an explicit OAuth declaration", () => {
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      existingAuthType: "apikey",
+      requestedAuthType: "oauth",
+      url: githubUrl,
+    })).toBe("apikey")
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: "oauth",
+      existingAuthType: "apikey",
+      requestedAuthType: "none",
+      url: githubUrl,
+    })).toBe("oauth")
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      existingAuthType: "none",
+      requestedAuthType: "none",
+      url: githubUrl,
+    })).toBe("oauth")
+    const requiredAuthType = requiredPluginMcpAuthType({ declaredAuthType: "oauth", url: githubUrl })
+    expect(requiredAuthType).toBe("oauth")
+    expect(pluginMcpAuthTypeCompatible({ authType: "apikey", requiredAuthType, url: githubUrl })).toBe(false)
+    expect(pluginMcpAuthTypeCompatible({ authType: "oauth", requiredAuthType, url: githubUrl })).toBe(true)
+  })
+
+  test("single-auth presets still reject unsupported and anonymous connections", () => {
+    for (const [url, authType] of [
+      ["https://mcp.slack.com/mcp/", "oauth"],
+      ["https://mcp.exa.ai/mcp", "apikey"],
+      ["https://mcp.context7.com/mcp", "none"],
+    ] as const) {
+      const requiredAuthType = requiredPluginMcpAuthType({ declaredAuthType: null, url })
+      expect(requiredAuthType).toBe(authType)
+      expect(pluginMcpAuthTypeCompatible({ authType, requiredAuthType, url })).toBe(true)
+      expect(pluginMcpAuthTypeCompatible({ authType: authType === "none" ? "apikey" : "none", requiredAuthType, url })).toBe(false)
+    }
+  })
+
+  test("preset defaults cannot downgrade explicit OAuth even when the preset defaults to API key or no auth", () => {
+    for (const url of ["https://mcp.exa.ai/mcp", "https://mcp.context7.com/mcp"]) {
+      expect(requiredPluginMcpAuthType({ declaredAuthType: "oauth", url })).toBe("oauth")
+      expect(resolveGithubPluginMcpImportAuthType({ declaredAuthType: "oauth", requestedAuthType: "none", url })).toBe("oauth")
+      expect(pluginMcpAuthTypeCompatible({ authType: "none", requiredAuthType: "oauth", url })).toBe(false)
+    }
+  })
+
   test("preserves an explicit OAuth declaration from the plugin", () => {
     const declaredAuthType = declaredPluginMcpAuthType({ oauth: { clientId: "public-client" } })
 

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test"
 import { and, eq, inArray, sql } from "@openwork-ee/den-db/drizzle"
 import {
   AuthUserTable,
@@ -526,6 +526,56 @@ describe("marketplace cloud readiness payload", () => {
     const resolved = await resolvedPlugin({ context: org.context, marketplaceId: org.marketplaceId, pluginId: plugin.pluginId })
     expect(resolved.cloudReadiness?.state).toBe("ready")
     expect(resolved.cloudReadiness?.connections[0]).toMatchObject({ id: connectionId, credentialMode: "shared", connectedForMe: true })
+  })
+
+  test("GitHub reimport preserves stored none with either credential-mode default and rejects explicit OAuth", async () => {
+    const org = await seedOrg()
+    const url = "https://api.githubcopilot.com/mcp/"
+    const connectionId = await seedConnection({ org, name: "Legacy GitHub", url, credentialMode: "shared" })
+    let oauth = false
+    const files: Record<string, string> = {
+      ".claude-plugin/plugin.json": JSON.stringify({ name: "legacy-github", mcpServers: "./.mcp.json" }),
+    }
+    const fetchMock = spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const requestUrl = new URL(typeof input === "string" || input instanceof URL ? input : input.url)
+      if (requestUrl.origin !== "https://api.github.com") throw new Error("Unexpected provider request")
+      const path = requestUrl.pathname.replace("/repos/fixture/legacy-plugin", "")
+      if (path === "") return Response.json({ default_branch: "main", private: false })
+      if (path === "/commits/main") return Response.json({ sha: "head", commit: { tree: { sha: "tree" } } })
+      if (path === "/git/trees/tree") return Response.json({ tree: [".claude-plugin/plugin.json", ".mcp.json"].map((path) => ({ path, type: "blob", sha: path })) })
+      const file = path.slice("/contents/".length)
+      const text = file === ".mcp.json" ? JSON.stringify({ mcpServers: { github: { url, oauth } } }) : files[file]
+      if (!path.startsWith("/contents/") || !text) throw new Error(`Unexpected import request: ${path}`)
+      return Response.json({ encoding: "base64", content: Buffer.from(text).toString("base64") })
+    })
+    try {
+      for (const credentialMode of ["shared", "per_member"] as const) {
+        await store.importGithubPluginMcps({
+          authType: "none", credentialMode, context: org.context,
+          name: `Legacy GitHub ${credentialMode}`,
+          githubUrl: "https://github.com/fixture/legacy-plugin", marketplaceId: org.marketplaceId,
+        })
+      }
+      const bindings = await db.select().from(PluginMcpRequirementBindingTable).where(eq(PluginMcpRequirementBindingTable.organizationId, org.organizationId))
+      expect(bindings).toHaveLength(2)
+      for (const binding of bindings) {
+        expect(binding).toMatchObject({ externalMcpConnectionId: connectionId, requiredAuthType: "none" })
+        expect((await resolvedPlugin({ context: org.context, marketplaceId: org.marketplaceId, pluginId: binding.pluginId })).cloudReadiness?.state).toBe("ready")
+      }
+      expect(connectExternalMcpMock).toHaveBeenCalledTimes(2)
+      oauth = true
+      await expect(store.importGithubPluginMcps({
+        authType: "none", credentialMode: "shared", context: org.context,
+        name: "Explicit OAuth GitHub",
+        githubUrl: "https://github.com/fixture/legacy-plugin",
+      })).rejects.toMatchObject({ status: 409, error: "external_mcp_connection_config_mismatch" })
+      expect(connectExternalMcpMock).toHaveBeenCalledTimes(2)
+      const connections = await db.select().from(ExternalMcpConnectionTable).where(eq(ExternalMcpConnectionTable.organizationId, org.organizationId))
+      expect(connections).toHaveLength(1)
+      expect(connections[0]).toMatchObject({ id: connectionId, authType: "none", credentialMode: "shared" })
+    } finally {
+      fetchMock.mockRestore()
+    }
   })
 
   test("misclassified Slack bindings stay blocked until an admin repairs OAuth setup", async () => {

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -1736,11 +1736,13 @@ test("shared-callback version-two state is rejected by the legacy callback even 
   expect(await response.json()).toEqual({ error: "invalid_request", message: "Invalid or expired state." })
 })
 
-test("non-OAuth create validation returns the same structured network diagnostic", async () => {
+test.each(["none", "apikey"] as const)("failed %s creation returns the diagnostic without retaining a ready connection", async (authType) => {
+  const name = `Broken ${authType} MCP`
   const response = await staleSessionRequest("/v1/mcp-connections", "POST", {
-    name: "Broken no-auth MCP",
+    name,
     url: "http://127.0.0.1:9/mcp",
-    authType: "none",
+    authType,
+    ...(authType === "apikey" ? { apiKey: "invalid-test-api-key" } : {}),
     credentialMode: "shared",
   })
   expect(response.status).toBe(502)
@@ -1757,6 +1759,14 @@ test("non-OAuth create validation returns the same structured network diagnostic
   })
   expect(typeof body.diagnostic.referenceId).toBe("string")
   expect(response.headers.get("x-request-id")).toBeNull()
+  const retained = await db.select().from(schema.ExternalMcpConnectionTable).where(drizzle.and(
+    drizzle.eq(schema.ExternalMcpConnectionTable.organizationId, organizationId),
+    drizzle.eq(schema.ExternalMcpConnectionTable.name, name),
+  ))
+  expect(retained).toHaveLength(0)
+  expect(await db.select().from(schema.ExternalMcpConnectionTable).where(
+    drizzle.eq(schema.ExternalMcpConnectionTable.id, seededConnectionId()),
+  )).toHaveLength(1)
 })
 
 test("connection configuration rejects credentials embedded in MCP URLs", async () => {

--- a/ee/apps/den-web/app/(den)/_lib/brand-icon.ts
+++ b/ee/apps/den-web/app/(den)/_lib/brand-icon.ts
@@ -28,6 +28,8 @@ const BUNDLED_ICONS_BY_APEX: Record<string, string> = {
 };
 
 const SIMPLE_ICON_SLUG_BY_APEX: Record<string, string> = {
+  "githubcopilot.com": "github",
+  "github.com": "github",
   "slack.com": "slack",
   "granola.ai": "granola",
   "polar.sh": "polar",

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -687,6 +687,20 @@ export function getMcpConnectionsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/mcp-connections`;
 }
 
+export function getConfiguredMcpConnectionsRoute(orgSlug?: string | null, connectionId?: string | null): string {
+  const base = `${getMcpConnectionsRoute(orgSlug)}/configured`;
+  return connectionId ? `${base}?connectionId=${encodeURIComponent(connectionId)}` : base;
+}
+
+/**
+ * Detail page for one connector. `connectorId` is a configured connection id
+ * or, for connectors nobody has added yet, the catalog id (`gmail`, `notion`,
+ * `microsoft-365`) so the page can explain the connector and start setup.
+ */
+export function getMcpConnectionRoute(orgSlug: string | null | undefined, connectorId: string): string {
+  return `${getMcpConnectionsRoute(orgSlug)}/${encodeURIComponent(connectorId)}`;
+}
+
 export function getYourConnectionsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/your-connections`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/[connectorId]/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/[connectorId]/page.tsx
@@ -1,0 +1,11 @@
+import { McpConnectionsScreen } from "../../../_components/mcp-connections-screen";
+
+export default async function McpConnectionDetailPage({
+  params,
+}: {
+  params: Promise<{ connectorId: string }>;
+}) {
+  const { connectorId } = await params;
+
+  return <McpConnectionsScreen view="detail" connectorId={connectorId} />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/configured/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/mcp-connections/configured/page.tsx
@@ -1,0 +1,5 @@
+import { McpConnectionsScreen } from "../../../_components/mcp-connections-screen";
+
+export default function ConfiguredMcpConnectionsPage() {
+  return <McpConnectionsScreen view="configured" />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog-list.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog-list.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronRight, Loader2, MinusCircle, MoreHorizontal, Settings } from "lucide-react";
+import {
+  configuredConnectionForPopular,
+  connectionForPresetUrl,
+  connectorChatDeepLink,
+  connectorChatPrompt,
+  connectorMatchesFilter,
+  GOOGLE_WORKSPACE_QUICK_ADD_ID,
+  MICROSOFT_365_QUICK_ADD_ID,
+  POPULAR_CONNECTORS,
+  remainingPresets,
+  type PopularConnector,
+} from "./connector-catalog";
+import { IntegrationIcon } from "./integration-icon";
+import { connectorAccountStatus, connectorDetailPrimaryAction } from "./connector-detail";
+import { EFFORT_LABELS, presetEffort, type ConnectorEffort } from "./connector-effort";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
+
+const CONFIGURED_STRIP_LIMIT = 12;
+
+type CatalogRowIcon = { iconUrl?: string; simpleIconSlug?: string; serviceUrl?: string };
+
+export type ConnectorCatalogProps = {
+  connections: ExternalMcpConnection[];
+  presets: ExternalMcpPreset[];
+  filter: string;
+  configuredHref: string;
+  configuredConnectionHref: (connectionId: string) => string;
+  /**
+   * Detail page for a row. Receives the connection id when the row is
+   * configured, otherwise the catalog id (popular id, preset id, or
+   * `microsoft-365`), matching what the detail route resolves.
+   */
+  connectorHref: (connectorId: string) => string;
+  onAddPopular: (connector: PopularConnector) => void;
+  onAddPreset: (preset: ExternalMcpPreset) => void;
+  onAddMicrosoft365: () => void;
+  onManage: (connection: ExternalMcpConnection) => void;
+  onRemove: (connection: ExternalMcpConnection) => void;
+  onRecover?: (connection: ExternalMcpConnection) => void;
+  setupRequired?: (connection: ExternalMcpConnection) => boolean;
+  recoveringConnectionId?: string | null;
+  addingPresetId: string | null;
+  loading?: boolean;
+  unavailable?: boolean;
+  connectionsUnavailable?: boolean;
+};
+
+/**
+ * ConnectorChatLink
+ *
+ * "Chat" hands off to the desktop app: the deep link lands on a new chat with
+ * the connector chip and its starter prompt already in the composer.
+ */
+export function connectorChatHref(displayName: string): string {
+  return connectorChatDeepLink({ connector: displayName, prompt: connectorChatPrompt(displayName) });
+}
+
+function RowMenu({
+  name,
+  connection,
+  onManage,
+  onRemove,
+}: {
+  name: string;
+  connection: ExternalMcpConnection;
+  onManage: () => void;
+  onRemove: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const canRemove = connection.id !== GOOGLE_WORKSPACE_QUICK_ADD_ID && connection.id !== MICROSOFT_365_QUICK_ADD_ID;
+
+  useEffect(() => {
+    if (!open) return;
+    function handlePointerDown(event: PointerEvent) {
+      if (event.target instanceof Node && !menuRef.current?.contains(event.target)) setOpen(false);
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const itemClass = "flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left text-[13.5px] text-gray-700 transition hover:bg-gray-50 hover:text-gray-900";
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition hover:bg-gray-100 hover:text-gray-900"
+        aria-label={`Options for ${name}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid={`connector-options-${connection.id}`}
+      >
+        <MoreHorizontal className="h-5 w-5" aria-hidden="true" />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          aria-label={`Options for ${name}`}
+          className="absolute right-0 top-10 z-30 w-52 overflow-hidden rounded-2xl border border-gray-100 bg-white p-1.5 shadow-xl shadow-gray-900/10"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onManage();
+            }}
+            className={itemClass}
+            data-testid={`connector-manage-${connection.id}`}
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+            Manage
+          </button>
+          {canRemove ? (
+            <>
+              <div className="my-1 border-t border-gray-100" />
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  onRemove();
+                }}
+                className={`${itemClass} text-red-600 hover:bg-red-50 hover:text-red-700`}
+                data-testid={`connector-uninstall-${connection.id}`}
+              >
+                <MinusCircle className="h-4 w-4" aria-hidden="true" />
+                Uninstall
+              </button>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CatalogRow({
+  id,
+  name,
+  description,
+  icon,
+  connection,
+  href,
+  adding,
+  onAdd,
+  onManage,
+  onRemove,
+  effort,
+  setupUnavailable = false,
+  setupRequired = false,
+  onRecover,
+  recovering = false,
+}: {
+  id: string;
+  name: string;
+  description: string;
+  icon: CatalogRowIcon;
+  connection: ExternalMcpConnection | undefined;
+  href: string;
+  adding: boolean;
+  onAdd: () => void;
+  onManage: (connection: ExternalMcpConnection) => void;
+  onRemove: (connection: ExternalMcpConnection) => void;
+  effort: ConnectorEffort;
+  setupUnavailable?: boolean;
+  setupRequired?: boolean;
+  onRecover?: (connection: ExternalMcpConnection) => void;
+  recovering?: boolean;
+}) {
+  const status = connection ? connectorAccountStatus(connection, setupRequired) : setupUnavailable ? "Setup unavailable" : EFFORT_LABELS[effort];
+  const primaryAction = connectorDetailPrimaryAction(effort);
+  return (
+    <div className="group flex items-center gap-1 py-1" data-testid={`connector-row-${id}`} data-connector-id={id}>
+      <Link
+        href={href}
+        className="flex min-w-0 flex-1 items-center gap-3.5 rounded-2xl px-2 py-1.5 transition hover:bg-gray-50"
+        data-testid={`connector-open-${id}`}
+      >
+        <IntegrationIcon
+          name={name}
+          iconUrl={icon.iconUrl}
+          simpleIconSlug={icon.simpleIconSlug}
+          serviceUrl={icon.serviceUrl}
+          className="h-12 w-12 rounded-[14px]"
+          imageClassName="h-6 w-6"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[15px] font-medium leading-5 text-gray-900">{name}</span>
+          <span className="block text-[13px] leading-5 text-gray-500">{description}</span>
+          <span className="mt-0.5 block text-[12px] leading-5 text-gray-500" data-testid={`connector-status-${id}`}>{status}</span>
+        </span>
+      </Link>
+      <a
+        href={connectorChatHref(name)}
+        className="flex min-h-9 shrink-0 items-center rounded-lg px-2 text-[12px] font-medium text-gray-700 hover:bg-gray-100"
+        aria-label={`Chat with ${name} in OpenWork`}
+        data-testid={`connector-chat-${id}`}
+      >
+        Chat
+      </a>
+      {connection && status !== "Connected" && status !== "Connected as you" ? (
+        <button
+          type="button"
+          onClick={() => (onRecover ?? onManage)(connection)}
+          disabled={recovering}
+          className="min-h-9 shrink-0 rounded-lg px-2 text-[12px] font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+          data-testid={`connector-recover-${id}`}
+        >
+          {recovering ? "Connecting..." : status === "Setup required" ? "Set up" : status === "OAuth settings need review" ? "Review OAuth" : status === "Reconnect required" ? "Reconnect" : "Connect"}
+        </button>
+      ) : null}
+      {connection ? (
+        <RowMenu
+          name={name}
+          connection={connection}
+          onManage={() => onManage(connection)}
+          onRemove={() => onRemove(connection)}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={onAdd}
+          disabled={adding || setupUnavailable}
+          className="flex min-h-9 shrink-0 items-center justify-center gap-1.5 rounded-lg px-2 text-[12px] font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={`${primaryAction.label} ${name}`}
+          data-testid={`connector-add-${id}`}
+        >
+          {adding ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 className="mb-2 text-[15px] font-semibold text-gray-900">{children}</h3>;
+}
+
+export function ConfiguredConnectorStrip({
+  connections,
+  href,
+  connectionHref,
+}: {
+  connections: ExternalMcpConnection[];
+  href: string;
+  connectionHref: (connectionId: string) => string;
+}) {
+  const shown = connections.slice(0, CONFIGURED_STRIP_LIMIT);
+  const overflow = connections.length - shown.length;
+
+  return (
+    <section className="mb-8" data-testid="configured-connector-strip">
+      <Link
+        href={href}
+        className="inline-flex items-center gap-1 text-[15px] font-semibold text-gray-900 transition hover:text-gray-600"
+        data-testid="configured-connectors-link"
+      >
+        Configured ({connections.length})
+        <ChevronRight className="h-4 w-4" aria-hidden="true" />
+      </Link>
+      {shown.length === 0 ? (
+        <p className="mt-2 text-[13px] text-gray-500">Nothing configured yet. Add a connector below and it shows up here.</p>
+      ) : (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          {shown.map((connection) => (
+            <Link
+              key={connection.id}
+              href={connectionHref(connection.id)}
+              title={connection.name}
+              aria-label={`Manage ${connection.name}`}
+              className="rounded-[14px] transition hover:-translate-y-0.5 hover:shadow-md"
+            >
+              <IntegrationIcon
+                name={connection.name}
+                serviceUrl={connection.url}
+                className="h-12 w-12 rounded-[14px]"
+                imageClassName="h-6 w-6"
+              />
+            </Link>
+          ))}
+          {overflow > 0 ? (
+            <Link
+              href={href}
+              className="flex h-12 w-12 items-center justify-center rounded-[14px] border border-gray-100 bg-gray-50 text-[12px] font-semibold text-gray-600"
+            >
+              +{overflow}
+            </Link>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function ConnectorCatalog({
+  connections,
+  presets,
+  filter,
+  configuredHref,
+  configuredConnectionHref,
+  connectorHref,
+  onAddPopular,
+  onAddPreset,
+  onAddMicrosoft365,
+  onManage,
+  onRemove,
+  addingPresetId,
+  loading = false,
+  unavailable = false,
+  connectionsUnavailable = false,
+  onRecover,
+  setupRequired,
+  recoveringConnectionId,
+}: ConnectorCatalogProps) {
+  const [moreOpen, setMoreOpen] = useState(false);
+  const filtering = filter.trim().length > 0;
+  const availablePopular = POPULAR_CONNECTORS.filter((connector) => {
+    const target = connector.target;
+    return loading || unavailable || target.kind !== "preset" || presets.some((preset) => preset.presetId === target.presetId);
+  });
+  const popular = availablePopular.filter((connector) =>
+    connectorMatchesFilter(filter, connector.displayName, connector.description, connector.id));
+  const more = remainingPresets(presets).filter((preset) =>
+    connectorMatchesFilter(filter, preset.displayName, preset.description, preset.presetId));
+  const microsoftVisible = connectorMatchesFilter(filter, "Microsoft 365", "Outlook Email", "Outlook", "OneDrive", "microsoft-365");
+  const microsoftConnection = connections.find((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365");
+  const showMore = filtering || moreOpen;
+  const nothingMatches = filtering && popular.length === 0 && more.length === 0 && !microsoftVisible;
+  const total = availablePopular.length + remainingPresets(presets).length + 1;
+  const matching = popular.length + more.length + Number(microsoftVisible);
+  const shown = popular.length + (showMore ? more.length + Number(microsoftVisible) : 0);
+
+  return (
+    <div data-testid="connector-catalog">
+      {loading ? <p role="status" className="mb-4 text-[13px] text-gray-500">Loading connection setup options. Chat is still available.</p> : null}
+      {!filtering && !connectionsUnavailable ? (
+        <ConfiguredConnectorStrip connections={connections} href={configuredHref} connectionHref={configuredConnectionHref} />
+      ) : null}
+
+      <p role="status" className="mb-4 text-[13px] text-gray-500" data-testid="connector-catalog-count">
+        {filtering ? `${matching} of ${total} integrations match` : `Showing ${shown} of ${total} integrations`}
+      </p>
+
+      {nothingMatches ? (
+        <p className="text-[13px] text-gray-400">No connectors match &quot;{filter}&quot;. Paste an MCP server URL to add it directly.</p>
+      ) : null}
+
+      {popular.length > 0 ? (
+        <section className="mb-8" data-testid="popular-connectors">
+          <SectionTitle>Popular</SectionTitle>
+          <div className="grid gap-x-8 sm:grid-cols-2">
+            {popular.map((connector) => {
+              const connection = configuredConnectionForPopular(connector, connections, presets);
+              const presetId = connector.target.kind === "preset" ? connector.target.presetId : null;
+              const preset = presets.find((entry) => entry.presetId === presetId);
+              const adding = connector.target.kind === "preset" && addingPresetId === connector.target.presetId;
+              return (
+                <CatalogRow
+                  key={connector.id}
+                  id={connector.id}
+                  name={connector.displayName}
+                  description={connector.description}
+                  icon={connector.icon}
+                  connection={connection}
+                  href={connectorHref(connector.id)}
+                  effort={preset ? presetEffort(preset) : "guided"}
+                  adding={adding}
+                  setupUnavailable={connectionsUnavailable || (Boolean(presetId) && (loading || unavailable || !preset))}
+                  setupRequired={connection ? setupRequired?.(connection) : false}
+                  onRecover={onRecover}
+                  recovering={Boolean(connection && recoveringConnectionId === connection.id)}
+                  onAdd={() => onAddPopular(connector)}
+                  onManage={onManage}
+                  onRemove={onRemove}
+                />
+              );
+            })}
+          </div>
+          {!showMore ? (
+            <button
+              type="button"
+              onClick={() => setMoreOpen(true)}
+              className="mt-3 inline-flex items-center gap-3 rounded-2xl px-2 py-2 text-[15px] text-gray-700 transition hover:bg-gray-50 hover:text-gray-900"
+              data-testid="connector-catalog-more"
+            >
+              <span className="flex -space-x-2">
+                <IntegrationIcon name="Microsoft 365" simpleIconSlug="microsoft" className="h-7 w-7 rounded-[8px]" imageClassName="h-3.5 w-3.5" />
+                <IntegrationIcon name="Granola" serviceUrl="https://mcp.granola.ai/mcp" className="h-7 w-7 rounded-[8px]" imageClassName="h-3.5 w-3.5" />
+                <IntegrationIcon name="Linear" serviceUrl="https://mcp.linear.app/mcp" className="h-7 w-7 rounded-[8px]" imageClassName="h-3.5 w-3.5" />
+              </span>
+              Browse all {total} integrations
+            </button>
+          ) : null}
+        </section>
+      ) : null}
+
+      {showMore && (more.length > 0 || microsoftVisible) ? (
+        <section className="mb-8" data-testid="more-connectors">
+          <SectionTitle>More connectors</SectionTitle>
+          <div className="grid gap-x-8 sm:grid-cols-2">
+            {microsoftVisible ? (
+              <CatalogRow
+                id={MICROSOFT_365_QUICK_ADD_ID}
+                name="Microsoft 365"
+                description="Outlook email, calendar, and OneDrive"
+                icon={{ simpleIconSlug: "microsoft" }}
+                connection={microsoftConnection}
+                href={connectorHref(microsoftConnection?.id ?? MICROSOFT_365_QUICK_ADD_ID)}
+                effort="guided"
+                adding={false}
+                setupUnavailable={connectionsUnavailable}
+                setupRequired={microsoftConnection ? setupRequired?.(microsoftConnection) : false}
+                onRecover={onRecover}
+                recovering={Boolean(microsoftConnection && recoveringConnectionId === microsoftConnection.id)}
+                onAdd={onAddMicrosoft365}
+                onManage={onManage}
+                onRemove={onRemove}
+              />
+            ) : null}
+            {more.map((preset) => {
+              const connection = connectionForPresetUrl(connections, preset.url);
+              return (
+              <CatalogRow
+                key={preset.presetId}
+                id={preset.presetId}
+                name={preset.displayName}
+                description={preset.description}
+                icon={{ serviceUrl: preset.url }}
+                connection={connection}
+                href={connectorHref(preset.presetId)}
+                effort={presetEffort(preset)}
+                adding={addingPresetId === preset.presetId}
+                setupUnavailable={connectionsUnavailable || loading || unavailable}
+                setupRequired={connection ? setupRequired?.(connection) : false}
+                onRecover={onRecover}
+                recovering={connection?.id === recoveringConnectionId}
+                onAdd={() => onAddPreset(preset)}
+                onManage={onManage}
+                onRemove={onRemove}
+              />
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog.ts
@@ -28,7 +28,7 @@ export const POPULAR_CONNECTORS: PopularConnector[] = [
   {
     id: "gmail",
     displayName: "Gmail",
-    description: "Search and read Gmail, create drafts",
+    description: "Read, send, and manage Gmail",
     icon: { simpleIconSlug: "gmail" },
     target: { kind: "google-workspace" },
     chatPrompt: "Explain how I can triage my Gmail inbox. If access is available, search and summarize unread threads and suggest reply priorities. Otherwise, help me plan a triage routine without accessing my inbox.",
@@ -44,15 +44,15 @@ export const POPULAR_CONNECTORS: PopularConnector[] = [
   {
     id: "google-drive",
     displayName: "Google Drive",
-    description: "Search files, read Docs and Slides text, upload and share files",
+    description: "Organize files, read Docs and Slides, and edit Sheets",
     icon: { simpleIconSlug: "googledrive" },
     target: { kind: "google-workspace" },
-    chatPrompt: "Explain how I can find useful files in Google Drive. Ask me for a topic; if access is available, search for a small sample and summarize readable text, including Docs and Slides. Otherwise, help me plan the search without accessing Drive.",
+    chatPrompt: "Explain what changed in Google Drive this week. If access is available, list files modified in the last 7 days, follow pagination, and call out any incomplete search before summarizing the results. Otherwise, help me plan a file review without accessing Drive.",
   },
   {
     id: "google-calendar",
     displayName: "Google Calendar",
-    description: "List and create Google Calendar events",
+    description: "Create, reschedule, and manage Google Calendar events",
     icon: { simpleIconSlug: "googlecalendar" },
     target: { kind: "google-workspace" },
     chatPrompt: "Explain how I can plan my week with Google Calendar. If access is available, list my meetings, point out conflicts, and suggest focus time without changing events. Otherwise, help me plan a weekly schedule without accessing my calendar.",

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-catalog.ts
@@ -1,0 +1,147 @@
+import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
+
+/** Native provider connections keep fixed ids in Den. */
+export const GOOGLE_WORKSPACE_QUICK_ADD_ID = "google-workspace";
+export const MICROSOFT_365_QUICK_ADD_ID = "microsoft-365";
+
+/**
+ * Where a popular connector row lands when someone adds it. Gmail, Drive, and
+ * Calendar are one Google Workspace connection in Den; Outlook is Microsoft
+ * 365; everything else is a curated MCP preset.
+ */
+export type PopularConnectorTarget =
+  | { kind: "google-workspace" }
+  | { kind: "microsoft-365" }
+  | { kind: "preset"; presetId: string };
+
+export type PopularConnector = {
+  id: string;
+  displayName: string;
+  description: string;
+  icon: { iconUrl?: string; simpleIconSlug?: string; serviceUrl?: string };
+  target: PopularConnectorTarget;
+  /** Starter prompt seeded after the connector chip when someone picks Chat. */
+  chatPrompt: string;
+};
+
+export const POPULAR_CONNECTORS: PopularConnector[] = [
+  {
+    id: "gmail",
+    displayName: "Gmail",
+    description: "Search and read Gmail, create drafts",
+    icon: { simpleIconSlug: "gmail" },
+    target: { kind: "google-workspace" },
+    chatPrompt: "Explain how I can triage my Gmail inbox. If access is available, search and summarize unread threads and suggest reply priorities. Otherwise, help me plan a triage routine without accessing my inbox.",
+  },
+  {
+    id: "github",
+    displayName: "GitHub",
+    description: "PRs, issues, code, and CI — OAuth app or personal access token",
+    icon: { simpleIconSlug: "github", serviceUrl: "https://api.githubcopilot.com/mcp/" },
+    target: { kind: "preset", presetId: "github" },
+    chatPrompt: "Explain how I can review a GitHub repo's authentication. Ask which repo to use; if access is available, inspect its code and docs. Otherwise, outline a review checklist without accessing the repo.",
+  },
+  {
+    id: "google-drive",
+    displayName: "Google Drive",
+    description: "Search files, read Docs and Slides text, upload and share files",
+    icon: { simpleIconSlug: "googledrive" },
+    target: { kind: "google-workspace" },
+    chatPrompt: "Explain how I can find useful files in Google Drive. Ask me for a topic; if access is available, search for a small sample and summarize readable text, including Docs and Slides. Otherwise, help me plan the search without accessing Drive.",
+  },
+  {
+    id: "google-calendar",
+    displayName: "Google Calendar",
+    description: "List and create Google Calendar events",
+    icon: { simpleIconSlug: "googlecalendar" },
+    target: { kind: "google-workspace" },
+    chatPrompt: "Explain how I can plan my week with Google Calendar. If access is available, list my meetings, point out conflicts, and suggest focus time without changing events. Otherwise, help me plan a weekly schedule without accessing my calendar.",
+  },
+  {
+    id: "notion",
+    displayName: "Notion",
+    description: "Notion docs and workflows",
+    icon: { serviceUrl: "https://mcp.notion.com/mcp" },
+    target: { kind: "preset", presetId: "notion" },
+    chatPrompt: "Explain how I can organize a Notion workspace. If access is available, ask which pages to review and summarize their structure. Otherwise, suggest a workspace outline without accessing Notion.",
+  },
+  {
+    id: "slack",
+    displayName: "Slack",
+    description: "Messages and search — requires an internal or Marketplace-published Slack app",
+    icon: { simpleIconSlug: "slack", serviceUrl: "https://mcp.slack.com/mcp" },
+    target: { kind: "preset", presetId: "slack" },
+    chatPrompt: "Explain how I can catch up on Slack. If access is available, ask which channels or topics to search and summarize the messages found. Otherwise, help me plan a catch-up routine without accessing Slack.",
+  },
+];
+
+export const MORE_CONNECTORS_TEASER = "See Outlook Email, Granola, and more";
+
+/** Starter prompt for connectors without a curated one. */
+export function connectorChatPrompt(displayName: string): string {
+  const popular = POPULAR_CONNECTORS.find((connector) => connector.displayName === displayName);
+  return popular?.chatPrompt
+    ?? `Explain how I could use ${displayName}: suggest three useful tasks and distinguish general ideas from tools available here. If access is unavailable, help me plan without connecting.`;
+}
+
+/**
+ * Deep link that opens the desktop app on a new chat with the connector chip
+ * and starter prompt already in the composer. The app parses this in
+ * apps/app/src/app/lib/openwork-links.ts (parseChatDeepLink).
+ */
+export function connectorChatDeepLink(input: { connector: string; prompt: string }): string {
+  const params = new URLSearchParams({ connector: input.connector, prompt: input.prompt });
+  return `openwork://chat?${params.toString()}`;
+}
+
+function comparableMcpUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname;
+    return `${url.host.toLowerCase()}${pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+export function connectionForPresetUrl(
+  connections: readonly ExternalMcpConnection[],
+  presetUrl: string,
+): ExternalMcpConnection | undefined {
+  const target = comparableMcpUrl(presetUrl);
+  if (!target) return undefined;
+  return connections.find((connection) => comparableMcpUrl(connection.url) === target);
+}
+
+/** The configured connection a popular row represents, when one exists. */
+export function configuredConnectionForPopular(
+  connector: PopularConnector,
+  connections: readonly ExternalMcpConnection[],
+  presets: readonly ExternalMcpPreset[],
+): ExternalMcpConnection | undefined {
+  switch (connector.target.kind) {
+    case "google-workspace":
+      return connections.find((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID || connection.nativeProviderKey === "google-workspace");
+    case "microsoft-365":
+      return connections.find((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365");
+    case "preset": {
+      const presetId = connector.target.presetId;
+      const preset = presets.find((entry) => entry.presetId === presetId);
+      return preset ? connectionForPresetUrl(connections, preset.url) : undefined;
+    }
+  }
+}
+
+/** Curated presets that are not already represented by a popular row. */
+export function remainingPresets(presets: readonly ExternalMcpPreset[]): ExternalMcpPreset[] {
+  const popularPresetIds = new Set(
+    POPULAR_CONNECTORS.flatMap((connector) => connector.target.kind === "preset" ? [connector.target.presetId] : []),
+  );
+  return presets.filter((preset) => !popularPresetIds.has(preset.presetId));
+}
+
+export function connectorMatchesFilter(filter: string, ...haystack: string[]): boolean {
+  const normalized = filter.trim().toLowerCase();
+  if (!normalized) return true;
+  return haystack.some((value) => value.toLowerCase().includes(normalized));
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-detail.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-detail.ts
@@ -1,0 +1,319 @@
+import { apexDomain } from "../../_lib/brand-icon";
+import {
+  configuredConnectionForPopular,
+  connectionForPresetUrl,
+  GOOGLE_WORKSPACE_QUICK_ADD_ID,
+  MICROSOFT_365_QUICK_ADD_ID,
+  POPULAR_CONNECTORS,
+  type PopularConnector,
+} from "./connector-catalog";
+import { EFFORT_LABELS, presetEffort, type ConnectorEffort } from "./connector-effort";
+import { isNativeProviderConnectionId, type ExternalMcpConnection, type ExternalMcpPreset } from "./mcp-connections-data";
+import { connectionNeedsOAuthClientConfiguration } from "./mcp-connection-setup";
+
+/** Native clients have usable entries even when they have no managed MCP row. */
+export function displayedConnectorConnections(
+  manageable: readonly ExternalMcpConnection[],
+  usable: readonly ExternalMcpConnection[],
+): ExternalMcpConnection[] {
+  return [
+    ...usable.filter((connection) => isNativeProviderConnectionId(connection.id, connection.nativeProviderKey)
+      && !manageable.some((entry) => entry.id === connection.id)),
+    ...manageable,
+  ];
+}
+
+export function connectorAccountReady(connection: ExternalMcpConnection): boolean {
+  return !connection.setupRequired
+    && !connectionNeedsOAuthClientConfiguration(connection)
+    && !connection.issuerReviewRequired
+    && !connection.needsReconnect
+    && connection.credentialHealth !== "reconnect_required"
+    && (connection.credentialMode === "per_member" ? connection.connectedForMe : connection.connected);
+}
+
+/** Account readiness is personal, even on an organization management page. */
+export function connectorAccountStatus(connection: ExternalMcpConnection, setupRequired = false): string {
+  if (setupRequired || connection.setupRequired || connectionNeedsOAuthClientConfiguration(connection)) return "Setup required";
+  if (connection.issuerReviewRequired) return "OAuth settings need review";
+  if (connection.needsReconnect || connection.credentialHealth === "reconnect_required") return "Reconnect required";
+  if (connection.credentialMode === "per_member") return connection.connectedForMe ? "Connected as you" : "Needs your account";
+  return connection.connected ? "Connected" : "Not connected";
+}
+
+export const CONNECTOR_DOCS_URL = "https://openworklabs.com/docs/cloud/share-with-your-team/shared-mcp-connections";
+
+/**
+ * What a connector detail page is about. The route accepts one id that may
+ * name a configured connection, a popular catalog entry (Gmail, GitHub…), a
+ * curated preset, or the Microsoft 365 native provider. Configured entries
+ * always resolve to their connection so the page can offer connect,
+ * disconnect, tools, and removal; unconfigured ones keep their catalog
+ * identity so the page can explain and start setup.
+ */
+export type ConnectorDetailSubject =
+  | {
+      kind: "connection";
+      connection: ExternalMcpConnection;
+      /** Catalog identity when the connection came from a popular row or preset. */
+      popular?: PopularConnector;
+      preset?: ExternalMcpPreset;
+    }
+  | { kind: "popular"; popular: PopularConnector; preset?: ExternalMcpPreset }
+  | { kind: "preset"; preset: ExternalMcpPreset }
+  | { kind: "microsoft-365" }
+  | { kind: "not_found"; connectorId: string };
+
+function presetForConnection(
+  connection: ExternalMcpConnection,
+  presets: readonly ExternalMcpPreset[],
+): ExternalMcpPreset | undefined {
+  return presets.find((preset) => connectionForPresetUrl([connection], preset.url) !== undefined);
+}
+
+/**
+ * Only preset-backed popular rows map 1:1 to a connection. Gmail, Drive, and
+ * Calendar all share the Google Workspace connection, so a connection opened
+ * by its own id keeps the Google Workspace identity instead of adopting the
+ * first popular row that happens to point at it.
+ */
+function popularForConnection(
+  connection: ExternalMcpConnection,
+  presets: readonly ExternalMcpPreset[],
+): PopularConnector | undefined {
+  return POPULAR_CONNECTORS.find((connector) =>
+    connector.target.kind === "preset" && configuredConnectionForPopular(connector, [connection], presets)?.id === connection.id);
+}
+
+export function resolveConnectorDetailSubject(
+  connectorId: string,
+  connections: readonly ExternalMcpConnection[],
+  presets: readonly ExternalMcpPreset[],
+): ConnectorDetailSubject {
+  const connection = connections.find((entry) => entry.id === connectorId);
+  if (connection) {
+    return {
+      kind: "connection",
+      connection,
+      popular: popularForConnection(connection, presets),
+      preset: presetForConnection(connection, presets),
+    };
+  }
+
+  const popular = POPULAR_CONNECTORS.find((connector) => connector.id === connectorId);
+  if (popular) {
+    const target = popular.target;
+    const preset = target.kind === "preset"
+      ? presets.find((entry) => entry.presetId === target.presetId)
+      : undefined;
+    const configured = configuredConnectionForPopular(popular, connections, presets);
+    return configured
+      ? { kind: "connection", connection: configured, popular, preset }
+      : { kind: "popular", popular, preset };
+  }
+
+  const preset = presets.find((entry) => entry.presetId === connectorId);
+  if (preset) {
+    const configured = connectionForPresetUrl(connections, preset.url);
+    return configured
+      ? { kind: "connection", connection: configured, preset, popular: popularForConnection(configured, presets) }
+      : { kind: "preset", preset };
+  }
+
+  if (connectorId === MICROSOFT_365_QUICK_ADD_ID) {
+    const configured = connections.find((entry) => entry.id === MICROSOFT_365_QUICK_ADD_ID || entry.nativeProviderKey === "microsoft-365");
+    return configured ? { kind: "connection", connection: configured } : { kind: "microsoft-365" };
+  }
+
+  return { kind: "not_found", connectorId };
+}
+
+export type ConnectorDetailIdentity = {
+  name: string;
+  description: string;
+  icon: { iconUrl?: string; simpleIconSlug?: string; serviceUrl?: string };
+};
+
+const GOOGLE_WORKSPACE_IDENTITY: ConnectorDetailIdentity = {
+  name: "Google Workspace",
+  description: "Gmail, Google Drive, and Google Calendar for everyone in the org",
+  icon: { simpleIconSlug: "google", serviceUrl: "https://www.google.com" },
+};
+
+const MICROSOFT_365_IDENTITY: ConnectorDetailIdentity = {
+  name: "Microsoft 365",
+  description: "Outlook email, calendar, and OneDrive",
+  icon: { simpleIconSlug: "microsoft" },
+};
+
+/** Name, blurb, and icon for the page header. Catalog identity wins over the raw connection row. */
+export function connectorDetailIdentity(subject: ConnectorDetailSubject): ConnectorDetailIdentity {
+  switch (subject.kind) {
+    case "popular":
+      return { name: subject.popular.displayName, description: subject.popular.description, icon: subject.popular.icon };
+    case "preset":
+      return { name: subject.preset.displayName, description: subject.preset.description, icon: { serviceUrl: subject.preset.url } };
+    case "microsoft-365":
+      return MICROSOFT_365_IDENTITY;
+    case "connection": {
+      if (subject.popular) {
+        return { name: subject.popular.displayName, description: subject.popular.description, icon: subject.popular.icon };
+      }
+      if (subject.connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID || subject.connection.nativeProviderKey === "google-workspace") {
+        return { ...GOOGLE_WORKSPACE_IDENTITY, name: subject.connection.name || GOOGLE_WORKSPACE_IDENTITY.name };
+      }
+      if (subject.connection.id === MICROSOFT_365_QUICK_ADD_ID || subject.connection.nativeProviderKey === "microsoft-365") {
+        return { ...MICROSOFT_365_IDENTITY, name: subject.connection.name || MICROSOFT_365_IDENTITY.name };
+      }
+      return {
+        name: subject.connection.name,
+        description: subject.preset?.description ?? describeConnectionFallback(subject.connection),
+        icon: { serviceUrl: subject.connection.url },
+      };
+    }
+    case "not_found":
+      return { name: "Connector not found", description: "", icon: {} };
+  }
+}
+
+function describeConnectionFallback(connection: ExternalMcpConnection): string {
+  const host = apexDomain(connection.url);
+  return host ? `MCP server at ${host}` : "MCP server";
+}
+
+/** How much setup adding this connector takes, before it exists in the org. */
+export function connectorDetailEffort(subject: ConnectorDetailSubject): ConnectorEffort | null {
+  switch (subject.kind) {
+    case "popular":
+      if (subject.popular.target.kind !== "preset") return "guided";
+      return subject.preset ? presetEffort(subject.preset) : "guided";
+    case "preset":
+      return presetEffort(subject.preset);
+    case "microsoft-365":
+      return "guided";
+    default:
+      return null;
+  }
+}
+
+/** Primary call to action for an unconfigured connector. */
+export function connectorDetailPrimaryAction(effort: ConnectorEffort): { label: string; explanation: string } {
+  switch (effort) {
+    case "instant":
+      return { label: "Add", explanation: "Adds it for everyone in the org right away. No sign-in is needed." };
+    case "one_click":
+      return { label: "Connect", explanation: "Adds it for everyone in the org and opens the provider sign-in so your own account is connected in the same step. Everyone else connects theirs from Your Connections." };
+    case "api_key":
+      return { label: "Set up", explanation: "Needs your org's API key for this provider. You'll paste it in the next step." };
+    case "oauth_app":
+      return { label: "Set up", explanation: "Needs an OAuth app registered with this provider. You'll enter its client id and secret in the next step." };
+    case "guided":
+      return { label: "Set up", explanation: "A short guided setup collects what this provider needs before anyone can connect." };
+  }
+}
+
+export type ConnectorFact = {
+  label: string;
+  value: string;
+  href?: string;
+  mono?: boolean;
+};
+
+function formatDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function accessLabel(connection: ExternalMcpConnection, orgName: string): string | null {
+  const access = connection.access;
+  if (!access) return null;
+  if (access.orgWide) return `Everyone in ${orgName}`;
+  const parts: string[] = [];
+  if (access.teamIds.length > 0) parts.push(`${access.teamIds.length} ${access.teamIds.length === 1 ? "team" : "teams"}`);
+  if (access.memberIds.length > 0) parts.push(`${access.memberIds.length} ${access.memberIds.length === 1 ? "person" : "people"}`);
+  return parts.length > 0 ? parts.join(", ") : "Nobody yet";
+}
+
+function signInLabel(authType: ExternalMcpConnection["authType"], credentialMode?: ExternalMcpConnection["credentialMode"]): string {
+  const auth = authType === "oauth" ? "OAuth sign-in" : authType === "apikey" ? "API key" : "No sign-in";
+  if (!credentialMode) return auth;
+  return `${auth} · ${credentialMode === "per_member" ? "each person connects their own account" : "one shared org account"}`;
+}
+
+/**
+ * The "Information" table. Everything here is already known to the page from
+ * the connection list and preset catalog; nothing needs a second request.
+ */
+export function connectorDetailFacts(
+  subject: ConnectorDetailSubject,
+  context: { orgName: string; pluginHref: (pluginId: string) => string },
+): ConnectorFact[] {
+  const facts: ConnectorFact[] = [];
+
+  if (subject.kind === "connection") {
+    const { connection } = subject;
+    const native = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
+    const host = apexDomain(connection.url);
+    if (native) {
+      const provider = connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365" ? "Microsoft" : "Google";
+      facts.push({ label: "Provider", value: provider });
+      facts.push({ label: "Type", value: "Native OpenWork connector" });
+    } else {
+      if (host) facts.push({ label: "Provider", value: host, href: `https://${host}` });
+      facts.push({ label: "Type", value: subject.connection.identityManagedBy.length > 0 ? "MCP server from a plugin" : "Remote MCP server" });
+      facts.push({ label: "Server", value: connection.url, mono: true });
+    }
+    facts.push({ label: "Sign-in", value: signInLabel(connection.authType, connection.credentialMode) });
+    if (connection.exposeDirectly) facts.push({ label: "Exposure", value: "Available as a standard MCP server with its own tool catalog" });
+    const access = accessLabel(connection, context.orgName);
+    if (access) facts.push({ label: "Access", value: access });
+    const added = [connection.createdByName ? `Added by ${connection.createdByName}` : null, formatDate(connection.connectedAt ?? connection.updatedAt)]
+      .filter((part): part is string => Boolean(part))
+      .join(" · ");
+    if (added) facts.push({ label: "Added", value: added });
+    for (const owner of connection.identityManagedBy) {
+      facts.push({ label: "Managed by", value: owner.name, href: context.pluginHref(owner.pluginId) });
+    }
+    const requiredBy = connection.requiredBy.filter((plugin) => !connection.identityManagedBy.some((owner) => owner.pluginId === plugin.pluginId));
+    for (const plugin of requiredBy) {
+      facts.push({ label: "Required by", value: plugin.name, href: context.pluginHref(plugin.pluginId) });
+    }
+    if (subject.popular?.target.kind === "google-workspace") {
+      facts.push({ label: "Part of", value: "Google Workspace — one connection covers Gmail, Drive, and Calendar" });
+    }
+  } else if (subject.kind === "popular" || subject.kind === "preset") {
+    const preset = subject.kind === "preset" ? subject.preset : subject.preset;
+    if (subject.kind === "popular" && subject.popular.target.kind === "google-workspace") {
+      facts.push({ label: "Provider", value: "Google" });
+      facts.push({ label: "Type", value: "Native OpenWork connector" });
+      facts.push({ label: "Sign-in", value: "Google sign-in · each person connects their own account" });
+      facts.push({ label: "Part of", value: "Google Workspace — one connection covers Gmail, Drive, and Calendar" });
+    } else if (preset) {
+      const host = apexDomain(preset.url);
+      if (host) facts.push({ label: "Provider", value: host, href: `https://${host}` });
+      facts.push({ label: "Type", value: "Remote MCP server" });
+      facts.push({ label: "Server", value: preset.url, mono: true });
+      facts.push({ label: "Sign-in", value: signInLabel(preset.authType, preset.authType === "oauth" ? "per_member" : preset.authType === "none" ? undefined : "shared") });
+      facts.push({ label: "Setup", value: EFFORT_LABELS[presetEffort(preset)] });
+    } else if (subject.kind === "popular") {
+      const host = apexDomain(subject.popular.icon.serviceUrl);
+      if (host) facts.push({ label: "Provider", value: host, href: `https://${host}` });
+      facts.push({ label: "Type", value: "Remote MCP server" });
+      facts.push({ label: "Setup", value: EFFORT_LABELS.guided });
+    }
+  } else if (subject.kind === "microsoft-365") {
+    facts.push({ label: "Provider", value: "Microsoft" });
+    facts.push({ label: "Type", value: "Native OpenWork connector" });
+    facts.push({ label: "Sign-in", value: "Microsoft sign-in · each person connects their own account" });
+  }
+
+  facts.push({ label: "Docs", value: "Shared MCP connections", href: CONNECTOR_DOCS_URL });
+  return facts;
+}
+
+/** The stable id a catalog row or connection should link to for its detail page. */
+export function connectorDetailId(input: { connection?: ExternalMcpConnection; catalogId: string }): string {
+  return input.connection?.id ?? input.catalogId;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-detail.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-detail.ts
@@ -269,9 +269,7 @@ export function connectorDetailFacts(
     if (connection.exposeDirectly) facts.push({ label: "Exposure", value: "Available as a standard MCP server with its own tool catalog" });
     const access = accessLabel(connection, context.orgName);
     if (access) facts.push({ label: "Access", value: access });
-    const added = [connection.createdByName ? `Added by ${connection.createdByName}` : null, formatDate(connection.connectedAt ?? connection.updatedAt)]
-      .filter((part): part is string => Boolean(part))
-      .join(" · ");
+    const added = formatDate(connection.connectedAt ?? connection.updatedAt);
     if (added) facts.push({ label: "Added", value: added });
     for (const owner of connection.identityManagedBy) {
       facts.push({ label: "Managed by", value: owner.name, href: context.pluginHref(owner.pluginId) });

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { ArrowRight, Check, Loader2, Plus } from "lucide-react";
+import { GOOGLE_WORKSPACE_QUICK_ADD_ID, MICROSOFT_365_QUICK_ADD_ID } from "./connector-catalog";
 import { EFFORT_LABELS, type ConnectorEffort, presetEffort } from "./connector-effort";
 import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
 import { IntegrationIcon } from "./integration-icon";
 
-export const GOOGLE_WORKSPACE_QUICK_ADD_ID = "google-workspace";
-export const MICROSOFT_365_QUICK_ADD_ID = "microsoft-365";
+export { GOOGLE_WORKSPACE_QUICK_ADD_ID, MICROSOFT_365_QUICK_ADD_ID };
 
 const SUITE_CONNECTORS = [
   {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-form-controls.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-form-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ExternalMcpAuthType, ExternalMcpCredentialMode } from "./mcp-connections-data";
+import type { ExternalMcpAuthType, ExternalMcpCredentialMode, ExternalMcpPreset } from "./mcp-connections-data";
 
 /**
  * Form controls shared by every surface that configures an MCP connection:
@@ -56,6 +56,12 @@ export const AUTH_TYPE_OPTIONS: SegmentedControlOption<ExternalMcpAuthType>[] = 
   { value: "apikey", label: "API key" },
   { value: "none", label: "None" },
 ];
+
+export function presetAuthTypeOptions(preset: ExternalMcpPreset | null): SegmentedControlOption<ExternalMcpAuthType>[] {
+  if (!preset) return AUTH_TYPE_OPTIONS;
+  const allowed = preset.supportedAuthTypes ?? [preset.authType];
+  return AUTH_TYPE_OPTIONS.filter((option) => allowed.includes(option.value));
+}
 
 export const CREDENTIAL_MODE_OPTIONS: SegmentedControlOption<ExternalMcpCredentialMode>[] = [
   { value: "per_member", label: "Individual accounts" },

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -235,6 +235,7 @@ export type ExternalMcpPreset = {
   url: string;
   authType: ExternalMcpAuthType;
   requiresOAuthClient?: boolean;
+  supportedAuthTypes?: ExternalMcpAuthType[];
 };
 
 export type CreatedMcpConnection = ExternalMcpConnection & {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1,32 +1,48 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { type ReactNode, type Ref, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ArrowLeft, Check, Loader2, Minus, MoreHorizontal, Pencil, Plug, Puzzle, Search, Server, Trash2, Users, Wrench } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check, ChevronRight, Link2, Loader2, MessageCircle, Minus, MoreHorizontal, Pencil, Plus, Puzzle, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
 import { DenSelect } from "../../_components/ui/select";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
-import { getPluginRoute, getToolTesterRoute } from "../../_lib/den-org";
+import { DenChip } from "../../_components/ui/chip";
+import { DenPageHeader } from "../../_components/ui/page-header";
+import { getConfiguredMcpConnectionsRoute, getMcpConnectionRoute, getMcpConnectionsRoute, getPluginRoute, getToolTesterRoute, getYourConnectionsRoute } from "../../_lib/den-org";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
+import { ConnectorCatalog, connectorChatHref } from "./connector-catalog-list";
+import type { PopularConnector } from "./connector-catalog";
+import {
+  connectorAccountStatus,
+  connectorAccountReady,
+  displayedConnectorConnections,
+  connectorDetailEffort,
+  connectorDetailFacts,
+  connectorDetailIdentity,
+  connectorDetailPrimaryAction,
+  resolveConnectorDetailSubject,
+} from "./connector-detail";
+import { EFFORT_LABELS, presetEffort } from "./connector-effort";
 import { IntegrationIcon } from "./integration-icon";
 import { Microsoft365Dialog } from "./microsoft-365-dialog";
 import { openMcpAuthorizationTab, safeMcpAuthorizationUrl, showMcpAuthorizationFailure } from "./mcp-authorization-url";
+import { MCP_AUTHORIZATION_TIMEOUT_MESSAGE, MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE, MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE, resolveMcpAuthorizationPollOutcome } from "./mcp-account-authorization-state";
 import {
   editableMcpIdentityChanged,
   marketplaceIdentityOwnerNames,
   mcpAccessMode,
   type McpConnectionAccessMode,
 } from "./mcp-connection-editing";
-import { formatConnectionCreatorAttribution } from "./mcp-connection-display";
+import { formatConnectionCreatorAttribution, sortConnectionsForFocus, trustedConnectionFocusId } from "./mcp-connection-display";
 import {
   AUTH_TYPE_OPTIONS,
   CREDENTIAL_MODE_OPTIONS,
   credentialModeDescription,
   MCP_OAUTH_REDIRECT_DOCS_URL,
+  presetAuthTypeOptions,
   SegmentedControl,
   type SegmentedControlOption,
 } from "./mcp-connection-form-controls";
@@ -81,10 +97,13 @@ import {
 } from "./mcp-scope-selection";
 import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 import {
-  ConnectorQuickAddGrid,
   GOOGLE_WORKSPACE_QUICK_ADD_ID,
   MICROSOFT_365_QUICK_ADD_ID,
 } from "./connector-quick-add-grid";
+
+export type McpConnectionsScreenView = "catalog" | "configured" | "detail";
+type OAuthOutcome = "connected" | "pending" | "configuration_required" | "failed";
+type CreateOutcome = "created" | OAuthOutcome;
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -264,12 +283,13 @@ function importServerStatus(server: GithubPluginImportServer): string {
   return "unsupported";
 }
 
-export function McpConnectionsScreen() {
+export function McpConnectionsScreen({ view = "catalog", connectorId }: { view?: McpConnectionsScreenView; connectorId?: string }) {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
-  const { data: usableConnections = [], isLoading: usableConnectionsLoading } = useMcpConnections("usable");
-  const { data: presets = [] } = useMcpConnectionPresets();
+  const { data: usableConnections = [], isLoading: usableConnectionsLoading, error: usableConnectionsError } = useMcpConnections("usable");
+  const { data: presets = [], isLoading: presetsLoading, error: presetsError, refetch: refetchPresets } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
   const createNativeConnection = useCreateNativeProviderConnection();
   const updateConnection = useUpdateMcpConnection();
@@ -290,7 +310,7 @@ export function McpConnectionsScreen() {
   const [issuerReviewConnection, setIssuerReviewConnection] = useState<ExternalMcpConnection | null>(null);
   const [issuerReviewPreview, setIssuerReviewPreview] = useState<McpIssuerReview | null>(null);
   const [googleDialogMode, setGoogleDialogMode] = useState<"create" | "legacy" | null>(null);
-  const [microsoftDialogOpen, setMicrosoftDialogOpen] = useState(false);
+  const [microsoftDialogConnectionId, setMicrosoftDialogConnectionId] = useState<string | null>(null);
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const [oauthClientConfigurationRequiredIds, setOAuthClientConfigurationRequiredIds] = useState<string[]>([]);
@@ -302,9 +322,11 @@ export function McpConnectionsScreen() {
   const [smartBarResolution, setSmartBarResolution] = useState<McpConnectionResolution | null>(null);
   const [smartBarSubmitting, setSmartBarSubmitting] = useState(false);
   const [instantAddingPresetId, setInstantAddingPresetId] = useState<string | null>(null);
+  const [detailLinkCopied, setDetailLinkCopied] = useState(false);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const handledQuickAddId = useRef<string | null>(null);
   const smartBarRequestId = useRef(0);
+  const focusedRowRef = useRef<HTMLDivElement | null>(null);
 
   function openQuickAdd(id: string) {
     if (id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
@@ -313,7 +335,8 @@ export function McpConnectionsScreen() {
       return;
     }
     if (id === MICROSOFT_365_QUICK_ADD_ID) {
-      setMicrosoftDialogOpen(true);
+      saveNativeClient.reset();
+      setMicrosoftDialogConnectionId(MICROSOFT_365_QUICK_ADD_ID);
       return;
     }
 
@@ -326,21 +349,53 @@ export function McpConnectionsScreen() {
     setFormOpen(true);
   }
 
-  function openAdvancedSetup(initialName = "", initialUrl = "") {
+  function openAdvancedSetup(initialName = "", initialUrl = "", preset: ExternalMcpPreset | null = null) {
     createConnection.reset();
-    setFormPreset(null);
+    setFormPreset(preset);
     setFormInitialView("advanced");
     setFormInitialName(initialName);
     setFormInitialUrl(initialUrl);
     setFormOpen(true);
   }
 
-  function manageConnection(connectionId: string) {
-    const connection = connections.find((entry) => entry.id === connectionId);
-    if (!connection) return;
-    updateConnection.reset();
-    setConfiguringOAuthClient(false);
-    setEditingConnection(connection);
+  function manageConnection(connection: ExternalMcpConnection) {
+    router.push(getMcpConnectionRoute(orgSlug, connection.id));
+  }
+
+  /**
+   * Catalog "+" for curated presets: connectors that need nothing from the
+   * org are added on the spot. OAuth servers with automatic app registration
+   * are added for everyone and the authorization tab opens right away so the
+   * admin's own account is connected in the same gesture. Presets that need
+   * an org secret (API key, pre-registered OAuth app) land in the guided form.
+   */
+  function addPreset(preset: ExternalMcpPreset) {
+    if (presetsLoading || presetsError) return;
+    const effort = presetEffort(preset);
+    if (effort === "instant") {
+      void handleInstantAdd(preset);
+      return;
+    }
+    if (effort === "one_click") {
+      void handleOneClickAdd(preset);
+      return;
+    }
+    openQuickAdd(preset.presetId);
+  }
+
+  function addPopularConnector(connector: PopularConnector) {
+    if (connector.target.kind === "google-workspace") {
+      openQuickAdd(GOOGLE_WORKSPACE_QUICK_ADD_ID);
+      return;
+    }
+    if (connector.target.kind === "microsoft-365") {
+      openQuickAdd(MICROSOFT_365_QUICK_ADD_ID);
+      return;
+    }
+    const presetId = connector.target.presetId;
+    const preset = presets.find((entry) => entry.presetId === presetId);
+    if (preset) addPreset(preset);
+    else setConnectionActionError({ connectionId: connector.id, message: "Setup options are unavailable. Reload setup options and try again." });
   }
 
   const smartBarInputKind = classifySmartAddInput(smartQuery);
@@ -387,7 +442,9 @@ export function McpConnectionsScreen() {
         ? ["This provider needs a pre-registered OAuth app."]
         : smartBarResolution?.preset?.authType === "apikey"
           ? ["This provider needs your org's API key."]
-          : []
+          : smartBarResolution?.preset && smartBarResolution.preset.authType !== smartBarPlan.input.authType
+            ? ["The server check differs from this provider's required authentication. Continue with the provider setup."]
+            : []
     : [];
   const smartBarOneClick = smartBarPlan?.readiness === "one_click" && smartBarBlockers.length === 0
     ? smartBarPlan
@@ -410,10 +467,7 @@ export function McpConnectionsScreen() {
     };
   }, []);
 
-  const legacyGoogleConnection = usableConnections.find((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID);
-  const listedConnections = legacyGoogleConnection && !connections.some((connection) => connection.id === legacyGoogleConnection.id)
-    ? [legacyGoogleConnection, ...connections]
-    : connections;
+  const listedConnections = displayedConnectorConnections(connections, usableConnections);
 
   function stopPolling() {
     if (pollTimer.current) {
@@ -423,32 +477,54 @@ export function McpConnectionsScreen() {
     setPollingConnectionId(null);
   }
 
-  function pollUntilConnected(connectionId: string) {
+  function pollUntilConnected(connectionId: string, authorizationTab: Window) {
+    stopPolling();
     setPollingConnectionId(connectionId);
     const startedAt = Date.now();
-    pollTimer.current = setInterval(async () => {
+    let fetching = false;
+    const timer = setInterval(async () => {
+      if (fetching) return;
+      fetching = true;
       const result = await refetch();
+      fetching = false;
+      if (pollTimer.current !== timer) return;
       const connection = result.data?.find((entry) => entry.id === connectionId);
-      if (connection?.connected || Date.now() - startedAt > OAUTH_POLL_TIMEOUT_MS) {
+      const outcome = resolveMcpAuthorizationPollOutcome({
+        connected: !result.error && Boolean(connection && connectorAccountReady(connection)),
+        authorizationWindowClosed: authorizationTab.closed,
+        elapsedMs: Date.now() - startedAt,
+        timeoutMs: OAUTH_POLL_TIMEOUT_MS,
+      });
+      if (outcome !== "pending") {
         stopPolling();
+        if (outcome !== "connected") {
+          setConnectionActionNotice(null);
+          setConnectionActionError({ connectionId, message: outcome === "timeout" ? MCP_AUTHORIZATION_TIMEOUT_MESSAGE : MCP_AUTHORIZATION_WINDOW_CLOSED_MESSAGE });
+        }
       }
     }, OAUTH_POLL_INTERVAL_MS);
+    pollTimer.current = timer;
   }
 
-  async function handleConnectOAuth(connectionId: string, connectionName: string, pendingAuthorizationTab?: Window) {
+  async function handleConnectOAuth(connectionId: string, connectionName: string, pendingAuthorizationTab?: Window): Promise<OAuthOutcome> {
     setConnectionActionError(null);
+    setConnectionActionNotice(null);
+    stopPolling();
     let authorizationTab: Window | null = pendingAuthorizationTab ?? null;
     try {
       authorizationTab = authorizationTab ?? openMcpAuthorizationTab({ connectionId, connectionName });
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
+        const refreshed = await refetch();
+        const connection = refreshed.data?.find((entry) => entry.id === connectionId);
+        if (refreshed.error || !connection || !connectorAccountReady(connection)) throw new Error(MCP_AUTHORIZATION_UNCONFIRMED_CONNECTED_MESSAGE);
         authorizationTab.close();
-        void refetch();
-        return;
+        return "connected";
       }
       if (!result.authorizeUrl) throw new Error("The MCP provider did not return an authorization URL.");
       authorizationTab.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
-      pollUntilConnected(connectionId);
+      pollUntilConnected(connectionId, authorizationTab);
+      return "pending";
     } catch (connectError) {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.";
       showMcpAuthorizationFailure(authorizationTab, {
@@ -459,23 +535,21 @@ export function McpConnectionsScreen() {
           ? { details: connectError.details }
           : {}),
       });
+      setConnectionActionError({ connectionId, message });
       if (connectError instanceof McpOAuthConfigurationRequiredError) {
         setOAuthClientConfigurationRequiredIds((current) => current.includes(connectionId)
           ? current
           : [...current, connectionId]);
-        return;
+        return "configuration_required";
       }
-      setConnectionActionError({
-        connectionId,
-        message,
-      });
+      return "failed";
     }
   }
 
   async function handleCreate(
     input: CreateMcpConnectionInput,
     options: { startOAuth: boolean },
-  ): Promise<void> {
+  ): Promise<CreateOutcome> {
     const authorizationTab = options.startOAuth
       ? openMcpAuthorizationTab({ connectionId: "", connectionName: input.name })
       : undefined;
@@ -483,12 +557,11 @@ export function McpConnectionsScreen() {
       const created = await createConnection.mutateAsync(input);
       setFormOpen(false);
       setFormPreset(null);
-      // Shared-credential OAuth: the admin authorizes the org's single account
-      // right now. Per-member: nothing to authorize here — each granted person
-      // connects their own account from Your Connections.
+      // Only flows that explicitly request sign-in start authorization here.
       if (options.startOAuth) {
-        await handleConnectOAuth(created.id, input.name, authorizationTab);
+        return await handleConnectOAuth(created.id, input.name, authorizationTab);
       }
+      return "created";
     } catch (createError) {
       showMcpAuthorizationFailure(authorizationTab ?? null, {
         connectionId: "",
@@ -505,11 +578,12 @@ export function McpConnectionsScreen() {
     setConnectionActionError(null);
     setConnectionActionNotice(null);
     try {
-      await handleCreate(smartBarOneClick.input, {
+      const outcome = await handleCreate(smartBarOneClick.input, {
         startOAuth: smartBarOneClick.input.authType === "oauth" && smartBarOneClick.input.credentialMode === "shared",
       });
+      if (outcome === "failed" || outcome === "configuration_required") return;
       setSmartQuery("");
-      setConnectionActionNotice(`${smartBarOneClick.input.name} added for everyone in ${orgContext?.organization.name ?? "the organization"}.`);
+      setConnectionActionNotice(`${smartBarOneClick.input.name} added for everyone in ${orgContext?.organization.name ?? "the organization"}.${outcome === "pending" ? " Finish signing in to connect your account." : ""}`);
       await refetch();
     } catch (submitError) {
       setConnectionActionError({
@@ -563,6 +637,34 @@ export function McpConnectionsScreen() {
           </button>
         </>,
       );
+      await refetch();
+    } catch (createError) {
+      setConnectionActionError({
+        connectionId: preset.presetId,
+        message: createError instanceof Error ? createError.message : "Failed to add the MCP connection.",
+      });
+    } finally {
+      setInstantAddingPresetId(null);
+    }
+  }
+
+  async function handleOneClickAdd(preset: ExternalMcpPreset) {
+    setInstantAddingPresetId(preset.presetId);
+    setConnectionActionError(null);
+    setConnectionActionNotice(null);
+    try {
+      // Each person connects their own account; the admin's starts right now
+      // in the authorization tab handleCreate opens.
+      const outcome = await handleCreate({
+        name: preset.displayName,
+        url: preset.url,
+        authType: "oauth",
+        credentialMode: "per_member",
+        access: { orgWide: true, memberIds: [], teamIds: [] },
+      }, { startOAuth: true });
+      if (outcome === "failed" || outcome === "configuration_required") return;
+      const orgName = orgContext?.organization.name ?? "the organization";
+      setConnectionActionNotice(`${preset.displayName} added for everyone in ${orgName}. ${outcome === "connected" ? "Your account is connected." : "Finish signing in to connect your own account."}`);
       await refetch();
     } catch (createError) {
       setConnectionActionError({
@@ -645,13 +747,171 @@ export function McpConnectionsScreen() {
       : `${connection.name}'s current issuer was confirmed from live provider metadata.`);
   }
 
+  const configuredView = view === "configured";
+  const configuredRoute = getConfiguredMcpConnectionsRoute(orgSlug);
+  const focusConnectionId = configuredView ? trustedConnectionFocusId(listedConnections, searchParams.get("connectionId")) : null;
+  const configuredConnections = sortConnectionsForFocus(listedConnections, focusConnectionId);
+  const detailView = view === "detail";
+  const detailSubject = detailView ? resolveConnectorDetailSubject(connectorId ?? "", listedConnections, presets) : null;
+  const detailConnection = detailSubject?.kind === "connection" ? detailSubject.connection : null;
+  const detailIdentity = detailSubject ? connectorDetailIdentity(detailSubject) : null;
+  const detailEffort = detailSubject ? connectorDetailEffort(detailSubject) : null;
+  const detailPrimary = detailEffort ? connectorDetailPrimaryAction(detailEffort) : null;
+  const detailFacts = detailSubject
+    ? connectorDetailFacts(detailSubject, {
+      orgName: orgContext?.organization.name ?? "the org",
+      pluginHref: (pluginId) => getPluginRoute(orgSlug, pluginId),
+    })
+    : [];
+  const detailConnectionSetup = detailConnection ? connectionSetupState(detailConnection) : null;
+  const detailAccountStatus = detailConnection ? connectorAccountStatus(detailConnection, detailConnectionSetup?.setupRequired) : null;
+  const detailCanInspectTools = detailConnection && detailConnectionSetup
+    ? !isNativeProviderConnectionId(detailConnection.id, detailConnection.nativeProviderKey)
+      && !detailConnectionSetup.setupRequired
+      && connectorAccountReady(detailConnection)
+    : false;
+  const detailIsBusy = detailSubject?.kind === "popular"
+    ? detailSubject.popular.target.kind === "preset" && instantAddingPresetId === detailSubject.popular.target.presetId
+    : detailSubject?.kind === "preset"
+      ? instantAddingPresetId === detailSubject.preset.presetId
+      : false;
+  const detailSetupUnavailable = detailSubject?.kind === "popular" && detailSubject.popular.target.kind === "preset"
+    ? presetsLoading || Boolean(presetsError) || !detailSubject.preset
+    : detailSubject?.kind === "preset" && (presetsLoading || Boolean(presetsError));
+  const detailSetupDisabled = detailSetupUnavailable || isLoading || usableConnectionsLoading || Boolean(error || usableConnectionsError);
+
+  function connectionSetupState(connection: ExternalMcpConnection) {
+    const connectAttemptRequiresConfiguration = oauthClientConfigurationRequiredIds.includes(connection.id);
+    const needsOAuthClientConfiguration = connectionNeedsOAuthClientConfiguration(connection, connectAttemptRequiresConfiguration);
+    const needsPluginSetup = marketplaceConnectionNeedsAdminSetup(connection, presets) && !needsOAuthClientConfiguration;
+    return { needsOAuthClientConfiguration, needsPluginSetup, setupRequired: Boolean(connection.setupRequired) || needsPluginSetup || needsOAuthClientConfiguration };
+  }
+
+  function editConnection(connection: ExternalMcpConnection, configureOAuthClient = false) {
+    if (connection.id === MICROSOFT_365_QUICK_ADD_ID || connection.nativeProviderKey === "microsoft-365") {
+      saveNativeClient.reset();
+      setMicrosoftDialogConnectionId(connection.id);
+      return;
+    }
+    if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
+      saveNativeClient.reset();
+      setGoogleDialogMode("legacy");
+      return;
+    }
+    updateConnection.reset();
+    setConfiguringOAuthClient(configureOAuthClient);
+    setEditingConnection(connection);
+  }
+
+  function recoverConnection(connection: ExternalMcpConnection) {
+    const setup = connectionSetupState(connection);
+    if (setup.needsOAuthClientConfiguration) return editConnection(connection, true);
+    if (setup.needsPluginSetup && connection.identityManagedBy[0]) {
+      router.push(getPluginRoute(orgSlug, connection.identityManagedBy[0].pluginId));
+      return;
+    }
+    if (setup.setupRequired) return editConnection(connection);
+    if (connection.authType !== "oauth") return editConnection(connection);
+    if (isNativeProviderConnectionId(connection.id, connection.nativeProviderKey)) {
+      router.push(`${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(connection.id)}`);
+      return;
+    }
+    if (connection.issuerReviewRequired) return void handleOpenIssuerReview(connection);
+    void handleConnectOAuth(connection.id, connection.name);
+  }
+
+  /** Detail-page primary action: same paths the catalog "+" takes. */
+  function startDetailSetup() {
+    if (!detailSubject || detailSetupDisabled) return;
+    if (detailSubject.kind === "popular") {
+      addPopularConnector(detailSubject.popular);
+      return;
+    }
+    if (detailSubject.kind === "preset") {
+      addPreset(detailSubject.preset);
+      return;
+    }
+    if (detailSubject.kind === "microsoft-365") openQuickAdd(MICROSOFT_365_QUICK_ADD_ID);
+  }
+
+  async function copyDetailLink() {
+    if (typeof window === "undefined") return;
+    if (await copyTextToClipboard(window.location.href)) {
+      setDetailLinkCopied(true);
+      window.setTimeout(() => setDetailLinkCopied(false), 2000);
+    }
+  }
+
+  function renderConnectionRow(
+    connection: ExternalMcpConnection,
+    options: { highlighted?: boolean; rowRef?: Ref<HTMLDivElement> } = {},
+  ) {
+    const setup = connectionSetupState(connection);
+    const setupPluginId = connection.identityManagedBy[0]?.pluginId;
+    return <ConnectionRow
+      key={connection.id}
+      orgSlug={orgSlug}
+      connection={connection}
+      highlighted={options.highlighted ?? false}
+      rowRef={options.rowRef}
+      needsPluginSetup={setup.needsPluginSetup}
+      needsOAuthClientConfiguration={setup.needsOAuthClientConfiguration}
+      setupHref={setup.needsPluginSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
+      polling={pollingConnectionId === connection.id}
+      connecting={startOAuth.isPending && startOAuth.variables === connection.id}
+      errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
+      onEdit={() => editConnection(connection)}
+      onConfigure={() => editConnection(connection, true)}
+      onReviewIssuer={() => void handleOpenIssuerReview(connection)}
+      onConnect={() => void handleConnectOAuth(connection.id, connection.name)}
+      onDisconnect={() => void handleDisconnect(connection)}
+      onRemove={() => handleRemove(connection)}
+      disconnecting={disconnectConnection.isPending && disconnectConnection.variables === connection.id}
+      removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
+    />;
+  }
+
+  useEffect(() => {
+    if (!focusConnectionId || !focusedRowRef.current) return;
+    focusedRowRef.current.scrollIntoView({ block: "center" });
+    focusedRowRef.current.focus({ preventScroll: true });
+  }, [focusConnectionId, configuredConnections.length]);
+
   return (
-    <DashboardPageTemplate
-      icon={Plug}
-      title="Connectors"
-      description="Connectors is where you can add MCP servers that your whole team can use."
-      colors={["#E2E8F0", "#020617", "#0F172A", "#94A3B8"]}
-    >
+    <div className="mx-auto max-w-[860px] px-4 pb-16 pt-6 sm:px-6 md:px-8" data-testid="mcp-connections-page" data-view={view}>
+      {detailView ? (
+        <Link
+          href={getMcpConnectionsRoute(orgSlug)}
+          className="mb-6 inline-flex items-center gap-1.5 text-[13px] text-gray-400 transition hover:text-gray-700"
+          data-testid="connector-detail-back"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Connectors
+        </Link>
+      ) : (
+        <DenPageHeader
+          className="mb-8"
+          title={configuredView ? "Configured connectors" : "Connectors"}
+          description={configuredView
+            ? "Everything your team has set up: connect accounts, review tools, change access, or uninstall."
+            : "Connectors is where you can add MCP servers that your whole team can use."}
+          action={configuredView ? (
+            <Link
+              href={getMcpConnectionsRoute(orgSlug)}
+              className={buttonVariants({ variant: "primary" })}
+              data-testid="configured-add-connector"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add connector
+            </Link>
+          ) : (
+            <Link href={configuredRoute} className={buttonVariants({ variant: "secondary" })} data-testid="connectors-open-configured">
+              Configured
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          )}
+        />
+      )}
       {showStagingBanner ? (
         <div data-testid="mcp-connections-staging-banner" className="mb-6 rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] leading-6 text-amber-800">
           <p className="font-semibold text-amber-900">OpenWork Connect (beta) is staged for this org.</p>
@@ -667,9 +927,23 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
+      {usableConnectionsError ? (
+        <div className="mb-6 text-[14px] text-red-700" role="alert">Native connection status could not be loaded. Refresh before changing setup.</div>
+      ) : null}
+
+      {presetsError || detailSetupUnavailable ? (
+        <div className="mb-6 flex items-center gap-3 text-[14px] text-gray-600" role={presetsError ? "alert" : "status"}>
+          <span>{presetsLoading ? "Loading setup options. Chat is still available." : "Setup options are unavailable. Chat is still available."}</span>
+          {!presetsLoading ? <DenButton variant="secondary" size="sm" onClick={() => void refetchPresets()}>Reload setup options</DenButton> : null}
+        </div>
+      ) : null}
+
       {connectionActionError ? (
         <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700" role="alert">
           {connectionActionError.message}
+          {listedConnections.some((connection) => connection.id === connectionActionError.connectionId) ? (
+            <Link className="ml-2 font-semibold underline" href={getMcpConnectionRoute(orgSlug, connectionActionError.connectionId)}>Review connection</Link>
+          ) : null}
         </div>
       ) : null}
 
@@ -679,7 +953,7 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
-      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Quick add</h3>
+      {configuredView || detailView ? null : (
       <div className="mb-8">
         <div className="flex items-center gap-3">
           <div className="min-w-0 flex-1">
@@ -695,14 +969,14 @@ export function McpConnectionsScreen() {
           <button
             type="button"
             onClick={() => openAdvancedSetup()}
-            className="shrink-0 text-[12px] font-medium text-gray-500 underline decoration-gray-300 underline-offset-4 transition hover:text-gray-900"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 transition hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900"
+            aria-label="Advanced setup"
+            title="Advanced setup — add any MCP server by URL"
+            data-testid="connector-advanced-setup"
           >
-            Advanced setup
+            <Plus className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
-        <p className="mt-1.5 text-[11px] text-gray-400">
-          Typing filters the tiles below. Pasting a URL checks the server and offers to add it right here.
-        </p>
 
         {smartBarState === "waiting" || smartBarState === "resolving" ? (
           <div className="mt-4 flex items-center gap-2.5 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3.5 text-[13px] text-gray-500" role="status">
@@ -727,6 +1001,7 @@ export function McpConnectionsScreen() {
               onClick={() => openAdvancedSetup(
                 smartBarResolution?.preset?.displayName ?? "",
                 smartBarResolution?.preset?.url ?? (smartBarInputKind === "domain" ? `https://${smartQuery.trim()}` : smartQuery.trim()),
+                smartBarResolution?.preset ?? null,
               )}
               className="shrink-0 font-medium underline underline-offset-2"
             >
@@ -749,7 +1024,7 @@ export function McpConnectionsScreen() {
                 <DenButton
                   variant="secondary"
                   size="sm"
-                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url)}
+                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url, smartBarResolution?.preset ?? null)}
                 >
                   Options
                 </DenButton>
@@ -781,7 +1056,7 @@ export function McpConnectionsScreen() {
                 Needs a little more setup: {smartBarBlockers.join(" · ")}{" "}
                 <button
                   type="button"
-                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url)}
+                  onClick={() => openAdvancedSetup(smartBarName, smartBarMatch.url, smartBarResolution?.preset ?? null)}
                   className="font-semibold underline underline-offset-2"
                 >
                   Continue setup
@@ -791,73 +1066,188 @@ export function McpConnectionsScreen() {
           </div>
         ) : null}
 
-        <div className="mt-5">
-          <ConnectorQuickAddGrid
-            connections={connections}
+        <div className="mt-8">
+          <ConnectorCatalog
+            connections={listedConnections}
             presets={presets}
-            onSelect={openQuickAdd}
             filter={smartBarResolutionMode ? "" : smartQuery}
+            configuredHref={configuredRoute}
+            configuredConnectionHref={(connectionId) => getMcpConnectionRoute(orgSlug, connectionId)}
+            connectorHref={(id) => getMcpConnectionRoute(orgSlug, id)}
+            onAddPopular={addPopularConnector}
+            onAddPreset={addPreset}
+            onAddMicrosoft365={() => openQuickAdd(MICROSOFT_365_QUICK_ADD_ID)}
             onManage={manageConnection}
-            onInstantAdd={(preset) => void handleInstantAdd(preset)}
-            instantAddingPresetId={instantAddingPresetId}
+            onRemove={handleRemove}
+            onRecover={recoverConnection}
+            setupRequired={(connection) => connectionSetupState(connection).setupRequired}
+            recoveringConnectionId={pollingConnectionId ?? (startOAuth.isPending ? startOAuth.variables : null)}
+            addingPresetId={instantAddingPresetId}
+            loading={presetsLoading}
+            unavailable={Boolean(presetsError)}
+            connectionsUnavailable={isLoading || usableConnectionsLoading || Boolean(error || usableConnectionsError)}
           />
         </div>
       </div>
+      )}
 
-      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Your connectors</h3>
+      {!configuredView ? null : (
+      <>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Configured</h3>
+        <span className="text-[12px] text-gray-400">{configuredConnections.length} {configuredConnections.length === 1 ? "connector" : "connectors"}</span>
+      </div>
       {isLoading || usableConnectionsLoading ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
           Loading MCP connectors…
         </div>
-      ) : listedConnections.length === 0 ? (
+      ) : configuredConnections.length === 0 ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-center text-[14px] text-gray-500">
-          No MCP connectors yet.
+          No MCP connectors yet.{" "}
+          <Link href={getMcpConnectionsRoute(orgSlug)} className="font-semibold underline underline-offset-2">Browse connectors</Link>
         </div>
       ) : (
         <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
-          {listedConnections.map((connection) => {
-            const connectAttemptRequiresConfiguration = oauthClientConfigurationRequiredIds.includes(connection.id);
-            const needsOAuthClientConfiguration = connectionNeedsOAuthClientConfiguration(
-              connection,
-              connectAttemptRequiresConfiguration,
-            );
-            const needsPluginSetup = marketplaceConnectionNeedsAdminSetup(connection, presets)
-              && !needsOAuthClientConfiguration;
-            const setupPluginId = connection.identityManagedBy[0]?.pluginId;
-            return <ConnectionRow
-              key={connection.id}
-              orgSlug={orgSlug}
-              connection={connection}
-              needsPluginSetup={needsPluginSetup}
-              needsOAuthClientConfiguration={needsOAuthClientConfiguration}
-              setupHref={needsPluginSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
-              polling={pollingConnectionId === connection.id}
-              connecting={startOAuth.isPending && startOAuth.variables === connection.id}
-              errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
-              onEdit={() => {
-                if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
-                  saveNativeClient.reset();
-                  setGoogleDialogMode("legacy");
-                  return;
-                }
-                updateConnection.reset();
-                setConfiguringOAuthClient(false);
-                setEditingConnection(connection);
-              }}
-              onConfigure={() => {
-                updateConnection.reset();
-                setConfiguringOAuthClient(true);
-                setEditingConnection(connection);
-              }}
-              onReviewIssuer={() => void handleOpenIssuerReview(connection)}
-              onConnect={() => void handleConnectOAuth(connection.id, connection.name)}
-              onDisconnect={() => void handleDisconnect(connection)}
-              onRemove={() => handleRemove(connection)}
-              disconnecting={disconnectConnection.isPending && disconnectConnection.variables === connection.id}
-              removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
-            />;
-          })}
+          {configuredConnections.map((connection) => renderConnectionRow(connection, {
+            highlighted: focusConnectionId === connection.id,
+            rowRef: focusConnectionId === connection.id ? focusedRowRef : undefined,
+          }))}
         </div>
+      )}
+      </>
+      )}
+
+      {!detailView || !detailSubject || !detailIdentity ? null : detailSubject.kind === "not_found" ? (
+        <div
+          className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-center text-[14px] text-gray-500"
+          data-testid="connector-detail-not-found"
+        >
+          {isLoading || usableConnectionsLoading || presetsLoading ? "Loading connector…" : presetsError ? "Reload setup options to find this connector." : (
+            <>
+              We couldn&apos;t find that connector.{" "}
+              <Link href={getMcpConnectionsRoute(orgSlug)} className="font-semibold underline underline-offset-2">Browse connectors</Link>
+            </>
+          )}
+        </div>
+      ) : (
+        <article data-testid="connector-detail" data-connector-kind={detailSubject.kind}>
+          <header className="flex flex-col gap-5">
+            <IntegrationIcon
+              name={detailIdentity.name}
+              iconUrl={detailIdentity.icon.iconUrl}
+              simpleIconSlug={detailIdentity.icon.simpleIconSlug}
+              serviceUrl={detailIdentity.icon.serviceUrl}
+              className="h-[72px] w-[72px] rounded-[20px]"
+              imageClassName="h-9 w-9"
+            />
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h1 data-testid="connector-detail-title" className="flex flex-wrap items-center gap-2.5 text-[28px] font-medium leading-[34px] tracking-[-0.5px] text-gray-950">
+                  {detailIdentity.name}
+                  {detailConnection ? (
+                    <DenChip tone="neutral" size="sm" data-testid="connector-detail-state">
+                      {detailAccountStatus}
+                    </DenChip>
+                  ) : detailEffort ? (
+                    <DenChip tone="neutral" size="sm" data-testid="connector-detail-state">{EFFORT_LABELS[detailEffort]}</DenChip>
+                  ) : null}
+                </h1>
+                {detailIdentity.description ? (
+                  <p className="mt-2 text-[14px] leading-[20px] text-gray-500">{detailIdentity.description}</p>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <DenButton
+                  variant="secondary"
+                  size="sm"
+                  icon={detailLinkCopied ? Check : Link2}
+                  onClick={() => void copyDetailLink()}
+                  data-testid="connector-detail-copy-link"
+                >
+                  {detailLinkCopied ? "Copied" : "Copy link"}
+                </DenButton>
+                <DenButton size="sm" icon={MessageCircle} href={connectorChatHref(detailIdentity.name)} data-testid="connector-detail-chat">
+                  Chat
+                </DenButton>
+                {!detailConnection && detailPrimary ? (
+                  <DenButton size="sm" variant="secondary" loading={detailIsBusy} disabled={detailSetupDisabled} onClick={startDetailSetup} data-testid="connector-detail-primary">
+                    {detailPrimary.label}
+                  </DenButton>
+                ) : null}
+              </div>
+            </div>
+          </header>
+
+          <section className="mt-10" data-testid="connector-detail-connection">
+            <DetailSectionTitle>Connection</DetailSectionTitle>
+            {detailConnection ? (
+              <div className="rounded-2xl border border-gray-100 bg-white">
+                {renderConnectionRow(detailConnection)}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50/60 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-[14px] font-medium text-gray-900">{isLoading || usableConnectionsLoading ? "Checking connection setup..." : error || usableConnectionsError || detailSetupUnavailable ? "Connection setup could not be confirmed" : `Not set up for ${orgContext?.organization.name ?? "your org"} yet`}</p>
+                  {detailPrimary ? <p className="mt-1 max-w-[520px] text-[13px] leading-5 text-gray-500">{detailPrimary.explanation}</p> : null}
+                </div>
+                {detailPrimary ? (
+                  <DenButton className="shrink-0" loading={detailIsBusy} disabled={detailSetupDisabled} onClick={startDetailSetup} data-testid="connector-detail-setup">
+                    {detailPrimary.label}
+                  </DenButton>
+                ) : null}
+              </div>
+            )}
+          </section>
+
+          {detailConnection ? (
+            <section className="mt-10" data-testid="connector-detail-tools">
+              <DetailSectionTitle>Tools</DetailSectionTitle>
+              {detailCanInspectTools ? (
+                <div className="flex flex-col gap-4 rounded-2xl border border-gray-100 bg-white px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-[13px] leading-5 text-gray-500">
+                    Browse this connector&apos;s live tool catalog and run a tool against your connected account in the Tool Tester.
+                  </p>
+                  <Link
+                    href={`${getToolTesterRoute(orgSlug)}?connectionId=${encodeURIComponent(detailConnection.id)}`}
+                    className={buttonVariants({ variant: "secondary", size: "sm" })}
+                    data-testid="connector-detail-test-tools"
+                  >
+                    <Wrench className="h-3.5 w-3.5" aria-hidden="true" />
+                    Test tools
+                  </Link>
+                </div>
+              ) : (
+                <p className="text-[13px] leading-5 text-gray-500">
+                  {isNativeProviderConnectionId(detailConnection.id, detailConnection.nativeProviderKey)
+                    ? "Native connectors expose their capabilities through OpenWork Connect rather than an MCP tool catalog."
+                    : "Tools appear here once the connection is connected for you."}
+                </p>
+              )}
+            </section>
+          ) : null}
+
+          <section className="mt-10" data-testid="connector-detail-information">
+            <DetailSectionTitle>Information</DetailSectionTitle>
+            <dl className="divide-y divide-gray-100">
+              {detailFacts.map((fact) => (
+                <div key={`${fact.label}-${fact.value}`} className="grid gap-1 py-3 sm:grid-cols-[160px_1fr] sm:gap-6">
+                  <dt className="text-[13px] text-gray-400">{fact.label}</dt>
+                  <dd className={`min-w-0 text-[14px] text-gray-900 ${fact.mono ? "truncate font-mono text-[12.5px]" : ""}`}>
+                    {fact.href?.startsWith("/") ? (
+                      <Link href={fact.href} className="underline-offset-2 hover:underline">{fact.value}</Link>
+                    ) : fact.href ? (
+                      <a href={fact.href} target="_blank" rel="noopener noreferrer" className="underline-offset-2 hover:underline">{fact.value}</a>
+                    ) : fact.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <p className="mt-10 text-[12px] leading-5 text-gray-400">
+            When a connector is connected, OpenWork agents can use its tools with the connected account whenever a request calls for it. Tool calls follow the connector&apos;s tool policy, and anyone can disconnect their own account from Your Connections at any time.
+          </p>
+        </article>
       )}
 
       <AddConnectionDialog
@@ -930,17 +1320,19 @@ export function McpConnectionsScreen() {
         }}
       />
 
-      <Microsoft365Dialog
-        open={microsoftDialogOpen}
+      {microsoftDialogConnectionId ? <Microsoft365Dialog
+        key={microsoftDialogConnectionId}
+        providerId={microsoftDialogConnectionId}
+        open
         submitting={saveNativeClient.isPending}
         error={saveNativeClient.error}
-        onClose={() => setMicrosoftDialogOpen(false)}
+        onClose={() => setMicrosoftDialogConnectionId(null)}
         onSubmit={async (input) => {
-          await saveNativeClient.mutateAsync({ providerId: "microsoft-365", ...input });
-          setMicrosoftDialogOpen(false);
+          await saveNativeClient.mutateAsync({ providerId: microsoftDialogConnectionId, ...input });
+          setMicrosoftDialogConnectionId(null);
         }}
-      />
-    </DashboardPageTemplate>
+      /> : null}
+    </div>
   );
 }
 
@@ -1649,6 +2041,10 @@ function IssuerReviewDialog({
   );
 }
 
+function DetailSectionTitle({ children }: { children: ReactNode }) {
+  return <h2 className="mb-3 border-b border-gray-100 pb-3 text-[16px] font-medium tracking-[-0.02em] text-gray-950">{children}</h2>;
+}
+
 function accessSummaryLabel(connection: ExternalMcpConnection): string {
   const access = connection.access;
   if (!access) return "";
@@ -1662,6 +2058,8 @@ function accessSummaryLabel(connection: ExternalMcpConnection): string {
 function ConnectionRow({
   orgSlug,
   connection,
+  highlighted = false,
+  rowRef,
   needsPluginSetup,
   needsOAuthClientConfiguration,
   setupHref,
@@ -1679,6 +2077,8 @@ function ConnectionRow({
 }: {
   orgSlug: string | null;
   connection: ExternalMcpConnection;
+  highlighted?: boolean;
+  rowRef?: Ref<HTMLDivElement>;
   needsPluginSetup: boolean;
   needsOAuthClientConfiguration: boolean;
   setupHref: string | null;
@@ -1697,16 +2097,16 @@ function ConnectionRow({
   const isPerMember = connection.credentialMode === "per_member";
   const isNativeProvider = isNativeProviderConnectionId(connection.id, connection.nativeProviderKey);
   const isLegacyGoogleConnection = connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID;
+  const isLegacyNativeConnection = isLegacyGoogleConnection || connection.id === MICROSOFT_365_QUICK_ADD_ID;
   const creatorAttribution = formatConnectionCreatorAttribution(connection.createdByName);
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement>(null);
   const actionsTriggerRef = useRef<HTMLButtonElement>(null);
-  const setupRequired = needsPluginSetup || needsOAuthClientConfiguration;
-  const displayedConnected = connection.connected && !setupRequired;
-  const canConnectOAuth = !isLegacyGoogleConnection && !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"
-    && (isPerMember ? !connection.connectedForMe : !connection.connected);
-  const canInspectTools = !isNativeProvider && !setupRequired && !connection.issuerReviewRequired
-    && (connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe);
+  const setupRequired = Boolean(connection.setupRequired) || needsPluginSetup || needsOAuthClientConfiguration;
+  const displayedConnected = connectorAccountReady(connection) && !setupRequired;
+  const canConnectOAuth = !isNativeProvider && !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"
+    && !displayedConnected;
+  const canInspectTools = !isNativeProvider && !setupRequired && connectorAccountReady(connection);
 
   useEffect(() => {
     if (!actionsOpen) return;
@@ -1732,7 +2132,12 @@ function ConnectionRow({
   }, [actionsOpen]);
 
   return (
-    <div data-testid={`mcp-connection-row-${connection.id}`}>
+    <div
+      ref={rowRef}
+      tabIndex={highlighted ? -1 : undefined}
+      className={`outline-none transition ${highlighted ? "bg-blue-50/70 ring-2 ring-inset ring-blue-200" : ""}`}
+      data-testid={`mcp-connection-row-${connection.id}`}
+    >
       <div className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
@@ -1749,9 +2154,9 @@ function ConnectionRow({
                   OAuth settings need review
                 </span>
               ) : isPerMember ? (
-                <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${connection.connected ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
+                <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${displayedConnected ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
                   <Users className="h-3 w-3" />
-                  {connection.connected ? "Individual accounts connected" : "Not connected"}
+                  {polling ? "Waiting for authorization..." : connectorAccountStatus(connection, setupRequired)}
                 </span>
               ) : displayedConnected ? (
                 <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
@@ -1765,7 +2170,7 @@ function ConnectionRow({
                 </span>
               ) : (
                 <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-                  Not connected
+                  {connectorAccountStatus(connection, setupRequired)}
                 </span>
               )}
               {connection.access ? (
@@ -1793,6 +2198,14 @@ function ConnectionRow({
               Configure
             </DenButton>
           ) : null}
+          {setupRequired && !needsOAuthClientConfiguration && !setupHref ? (
+            <DenButton variant="primary" size="sm" onClick={onEdit}>Set up</DenButton>
+          ) : null}
+          {isNativeProvider && !setupRequired ? (
+            <DenButton variant="secondary" size="sm" href={`${getYourConnectionsRoute(orgSlug)}?connectionId=${encodeURIComponent(connection.id)}`}>
+              {displayedConnected ? "Your account" : connection.needsReconnect ? "Reconnect" : "Connect your account"}
+            </DenButton>
+          ) : null}
           {setupHref ? (
             <Link href={setupHref} className={buttonVariants({ variant: "primary", size: "sm" })}>
               Set up
@@ -1810,10 +2223,10 @@ function ConnectionRow({
               loading={connecting || polling}
               onClick={onConnect}
             >
-              Connect
+              {connection.needsReconnect || connection.credentialHealth === "reconnect_required" ? "Reconnect" : "Connect"}
             </DenButton>
           ) : null}
-          {displayedConnected && !isLegacyGoogleConnection ? (
+          {connection.connected && !isNativeProvider ? (
             <DenButton
               variant="secondary"
               size="sm"
@@ -1844,6 +2257,17 @@ function ConnectionRow({
                 aria-label={`Actions for ${connection.name}`}
                 className="absolute right-0 top-10 z-30 w-44 overflow-hidden rounded-2xl border border-gray-100 bg-white p-1.5 text-[13px] shadow-xl shadow-gray-900/10"
               >
+                <a
+                  role="menuitem"
+                  href={connectorChatHref(connection.name)}
+                  onClick={() => setActionsOpen(false)}
+                  className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900"
+                  aria-label={`Chat with ${connection.name} in OpenWork`}
+                  data-testid={`chat-mcp-connection-${connection.id}`}
+                >
+                  <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                  Chat
+                </a>
                 <button
                   type="button"
                   role="menuitem"
@@ -1851,7 +2275,7 @@ function ConnectionRow({
                     setActionsOpen(false);
                     onEdit();
                   }}
-                  disabled={!connection.updatedAt && !isLegacyGoogleConnection}
+                  disabled={!connection.updatedAt && !isNativeProvider}
                   className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
                   aria-label={`Edit ${connection.name}`}
                   data-testid={`edit-mcp-connection-${connection.id}`}
@@ -1878,7 +2302,7 @@ function ConnectionRow({
                   <Wrench className="h-3.5 w-3.5" aria-hidden="true" />
                   Test tools
                 </Link>
-                {!isLegacyGoogleConnection ? (
+                {!isLegacyNativeConnection ? (
                   <>
                     <div className="my-1 border-t border-gray-100" />
                     <button
@@ -2331,7 +2755,7 @@ function AddConnectionDialog({
   onSubmit: (
     input: CreateMcpConnectionInput,
     options: { startOAuth: boolean },
-  ) => Promise<void>;
+  ) => Promise<CreateOutcome>;
 }) {
   const { orgContext } = useOrgDashboard();
   const discoverRequirements = useDiscoverMcpConnectionRequirements();
@@ -2358,12 +2782,17 @@ function AddConnectionDialog({
   const [requirements, setRequirements] = useState<McpRequirementsDiscovery | null>(null);
   const [discoveryState, setDiscoveryState] = useState<"idle" | "waiting" | "checking" | "ready" | "error">("idle");
   const [discoveryError, setDiscoveryError] = useState<unknown>(null);
+  const [submissionError, setSubmissionError] = useState<unknown>(null);
   const [authorizationServerIssuer, setAuthorizationServerIssuer] = useState("");
   const [requestedScopes, setRequestedScopes] = useState<string[]>([]);
   const [accessMode, setAccessMode] = useState<AddConnectionAccessMode>("everyone");
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
   const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
   const discoveryRequestId = useRef(0);
+  const authTypeEdited = useRef(false);
+  const activePreset = preset ?? resolution?.preset ?? null;
+  const authTypeOptions = presetAuthTypeOptions(activePreset);
+  const formError = error ?? submissionError;
 
   useEffect(() => {
     if (!open) return;
@@ -2378,6 +2807,7 @@ function AddConnectionDialog({
     setName(preset?.displayName ?? initialName ?? "");
     setUrl(preset?.url ?? initialUrl ?? "");
     setAuthType(preset?.authType ?? "oauth");
+    authTypeEdited.current = false;
     setCredentialMode("per_member");
     setExposeDirectly(false);
     setApiKey("");
@@ -2387,6 +2817,7 @@ function AddConnectionDialog({
     setRequirements(null);
     setDiscoveryState("idle");
     setDiscoveryError(null);
+    setSubmissionError(null);
     discoveryRequestId.current += 1;
     setAuthorizationServerIssuer("");
     setRequestedScopes([]);
@@ -2406,7 +2837,7 @@ function AddConnectionDialog({
     return list.includes(id) ? list.filter((entry) => entry !== id) : [...list, id];
   }
 
-  const showOAuthClientFields = authType === "oauth" && (Boolean(preset?.requiresOAuthClient) || showOAuthClient);
+  const showOAuthClientFields = authType === "oauth" && (Boolean(activePreset?.requiresOAuthClient) || showOAuthClient);
   const authorizationServers = requirements?.authentication.authorizationServers ?? [];
   const selectedAuthorizationServer = authorizationServers.find((server) => server.issuer === authorizationServerIssuer);
   const requiredScopes = requirements?.authentication.requiredScopes ?? [];
@@ -2425,14 +2856,15 @@ function AddConnectionDialog({
     // A curated preset's auth type stays authoritative over the live probe,
     // matching the smart-add rule: an API-key server that also advertises
     // OAuth metadata (or initializes anonymously) must not lose its key field.
-    if (!preset) {
+    if (!activePreset && !authTypeEdited.current) {
       if (result.authentication.kind === "none") setAuthType("none");
       else if (result.authentication.kind === "oauth") setAuthType("oauth");
+      else if (result.authentication.kind === "manual_bearer") setAuthType("apikey");
     }
     const servers = result.authentication.authorizationServers;
     setAuthorizationServerIssuer(servers.length === 1 ? servers[0].issuer : "");
     setRequestedScopes(result.authentication.recommendedScopes);
-    setShowOAuthClient(Boolean(preset?.requiresOAuthClient) || result.authentication.recommendedRegistrationMethod === "pre_registered");
+    setShowOAuthClient(Boolean(activePreset?.requiresOAuthClient) || result.authentication.recommendedRegistrationMethod === "pre_registered");
   }
 
   async function discover(targetUrl: string, requestId: number) {
@@ -2526,7 +2958,9 @@ function AddConnectionDialog({
         ? ["This provider needs a pre-registered OAuth app."]
         : resolution?.preset?.authType === "apikey"
           ? ["This provider needs your org's API key."]
-          : []
+          : resolution?.preset && resolution.preset.authType !== smartPlan.input.authType
+            ? ["The server check differs from this provider's required authentication. Continue with the provider setup."]
+            : []
     : [];
   const smartOneClick = smartPlan?.readiness === "one_click" && smartBlockers.length === 0 ? smartPlan : null;
 
@@ -2557,12 +2991,13 @@ function AddConnectionDialog({
 
   async function submitSmart() {
     if (!smartOneClick) return;
+    setSubmissionError(null);
     try {
       await onSubmit(smartOneClick.input, {
         startOAuth: smartOneClick.input.authType === "oauth" && smartOneClick.input.credentialMode === "shared",
       });
-    } catch {
-      // The mutation's typed error is rendered by the dialog's error prop.
+    } catch (submitError) {
+      setSubmissionError(submitError);
     }
   }
 
@@ -2575,6 +3010,7 @@ function AddConnectionDialog({
   }
 
   async function submit() {
+    setSubmissionError(null);
     const trimmedClientId = oauthClientId.trim();
     const trimmedClientSecret = oauthClientSecret.trim();
     const input: CreateMcpConnectionInput = {
@@ -2600,10 +3036,8 @@ function AddConnectionDialog({
       await onSubmit(input, {
         startOAuth: authType === "oauth" && credentialMode === "shared" && !showOAuthClientFields,
       });
-    } catch {
-      // The mutation's typed error is rendered by the dialog's error prop.
-      // Consume the rejected promise so a clear validation failure does not
-      // also become an opaque browser-level unhandled rejection.
+    } catch (submitError) {
+      setSubmissionError(submitError);
     }
   }
 
@@ -2722,8 +3156,8 @@ function AddConnectionDialog({
               </div>
             ) : null}
 
-            {error ? (
-              <p className="mt-3 text-[13px] text-red-600">{error instanceof Error ? error.message : "Failed to add connection."}</p>
+            {formError ? (
+              <p role="alert" className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to add connection."}</p>
             ) : null}
 
             <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -2763,7 +3197,7 @@ function AddConnectionDialog({
           </button>
         ) : null}
         <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
-          {preset ? `Add ${preset.displayName}` : "Add a custom MCP server"}
+          {activePreset ? `Add ${activePreset.displayName}` : "Add a custom MCP server"}
         </h2>
 
         <div className="mt-5 space-y-4">
@@ -2785,7 +3219,7 @@ function AddConnectionDialog({
                 setDiscoveryError(null);
               }}
               placeholder="https://mcp.example.com/mcp"
-              disabled={Boolean(preset)}
+              disabled={Boolean(activePreset)}
             />
             {discoveryState === "waiting" || discoveryState === "checking" ? (
               <p className="mt-2 flex items-center gap-2 text-[12px] text-gray-500" role="status">
@@ -2801,14 +3235,25 @@ function AddConnectionDialog({
                 </button>
               </div>
             ) : null}
+            {discoveryState === "ready" && requirements && (requirements.status !== "ready" || requirements.server.initialize === "failed" || requirements.tools.visibility === "unavailable") ? (
+              <div className="mt-2 text-[12px] text-amber-800" role="alert">
+                <p>{requirements.server.initialize === "failed" || requirements.tools.visibility === "unavailable"
+                  ? "The server check did not verify usable tools. Review the requirements before adding it."
+                  : "The server needs additional setup before its tools can be used."}</p>
+                {requirements.manualRequirements.map((requirement) => <p key={requirement.code}>{requirement.label}: {requirement.reason}</p>)}
+                {requirements.warnings.map((warning) => <p key={warning.code}>{warning.message}</p>)}
+                <button type="button" className="mt-1 font-medium underline underline-offset-2" onClick={retryDiscovery}>Retry check</button>
+              </div>
+            ) : null}
           </div>
-          {!preset ? (
+          {authTypeOptions.length > 1 ? (
             <div>
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Authentication</label>
               <SegmentedControl
-                options={AUTH_TYPE_OPTIONS}
+                options={authTypeOptions}
                 value={authType}
                 onChange={(option) => {
+                  authTypeEdited.current = true;
                   setAuthType(option);
                   if (option !== "oauth") setShowOAuthClient(false);
                 }}
@@ -2828,7 +3273,7 @@ function AddConnectionDialog({
             </div>
           ) : null}
 
-          {authType === "oauth" && !preset?.requiresOAuthClient && !showOAuthClient ? (
+          {authType === "oauth" && !activePreset?.requiresOAuthClient && !showOAuthClient ? (
             <button
               type="button"
               onClick={() => setShowOAuthClient(true)}
@@ -3006,8 +3451,8 @@ function AddConnectionDialog({
           </div>
         </div>
 
-        {error ? (
-          <p className="mt-3 text-[13px] text-red-600">{error instanceof Error ? error.message : "Failed to add connection."}</p>
+        {formError ? (
+          <p role="alert" className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to add connection."}</p>
         ) : null}
 
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
@@ -22,18 +22,20 @@ async function copyText(text: string): Promise<boolean> {
 
 export function Microsoft365Dialog({
   open,
+  providerId,
   submitting,
   error,
   onClose,
   onSubmit,
 }: {
   open: boolean;
+  providerId: string;
   submitting: boolean;
   error: unknown;
   onClose: () => void;
   onSubmit: (input: { clientId?: string; clientSecret?: string; tenantId?: string; features: string[] }) => void;
 }) {
-  const clientConfig = useNativeProviderClient("microsoft-365", open);
+  const clientConfig = useNativeProviderClient(providerId, open);
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [tenantId, setTenantId] = useState("");
@@ -51,13 +53,13 @@ export function Microsoft365Dialog({
     setCopiedRedirectUri(false);
     setReplacingCredentials(false);
     featuresPrefilled.current = false;
-  }, [open]);
+  }, [open, providerId]);
 
   useEffect(() => {
     if (!open || featuresPrefilled.current || !clientConfig.isSuccess || clientConfig.isFetching) return;
     setFeatures(clientConfig.data.features);
     featuresPrefilled.current = true;
-  }, [open, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
+  }, [open, providerId, clientConfig.isSuccess, clientConfig.isFetching, clientConfig.data?.features]);
 
   if (!open) return null;
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -302,7 +302,7 @@ function YourConnectionRow({
             </DenButton>
           ) : null}
           {needsReconnect || needsMyConnect || needsAdminConnect ? (
-            <DenButton variant="primary" size="sm" loading={connecting || polling} onClick={onConnect}>
+            <DenButton variant="primary" size="sm" loading={connecting || polling} onClick={onConnect} data-testid={`connect-my-mcp-account-${connection.id}`}>
               {needsReconnect ? "Reconnect" : "Connect"}
             </DenButton>
           ) : null}

--- a/ee/apps/den-web/tests/connector-catalog-render.test.tsx
+++ b/ee/apps/den-web/tests/connector-catalog-render.test.tsx
@@ -1,0 +1,129 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "bun:test";
+import { ConnectorCatalog } from "../app/(den)/dashboard/_components/connector-catalog-list";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
+
+const PRESETS: ExternalMcpPreset[] = [
+  { presetId: "github", displayName: "GitHub", description: "PRs", url: "https://api.githubcopilot.com/mcp/", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "notion", displayName: "Notion", description: "Docs", url: "https://mcp.notion.com/mcp", authType: "oauth" },
+  { presetId: "slack", displayName: "Slack", description: "Chat", url: "https://mcp.slack.com/mcp", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "granola", displayName: "Granola", description: "Meeting notes", url: "https://mcp.granola.ai/mcp", authType: "oauth" },
+  { presetId: "context7", displayName: "Context7", description: "Docs", url: "https://mcp.context7.com/mcp", authType: "none" },
+];
+
+const NOTION: ExternalMcpConnection = {
+  id: "conn-notion",
+  name: "Notion",
+  url: "https://mcp.notion.com/mcp",
+  authType: "oauth",
+  credentialMode: "per_member",
+  exposeDirectly: false,
+  connected: true,
+  connectedAt: null,
+  updatedAt: null,
+  connectedForMe: true,
+  requiredBy: [],
+  identityManagedBy: [],
+  access: null,
+};
+
+const noop = () => {};
+
+function render(overrides: Partial<Parameters<typeof ConnectorCatalog>[0]> = {}) {
+  return renderToStaticMarkup(
+    createElement(ConnectorCatalog, {
+      connections: [NOTION],
+      presets: PRESETS,
+      filter: "",
+      configuredHref: "/dashboard/mcp-connections/configured",
+      configuredConnectionHref: (connectionId: string) => `/dashboard/mcp-connections/configured?connectionId=${connectionId}`,
+      connectorHref: (connectorId: string) => `/dashboard/mcp-connections/${connectorId}`,
+      onAddPopular: noop,
+      onAddPreset: noop,
+      onAddMicrosoft365: noop,
+      onManage: noop,
+      onRemove: noop,
+      addingPresetId: null,
+      ...overrides,
+    }),
+  );
+}
+
+describe("ConnectorCatalog", () => {
+  test("shows the configured strip, six popular rows, and the collapsed More teaser", () => {
+    const markup = render();
+
+    expect(markup.indexOf('data-testid="configured-connector-strip"')).toBeLessThan(markup.indexOf('data-testid="popular-connectors"'));
+    expect(markup).toContain('href="/dashboard/mcp-connections/configured"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/configured?connectionId=conn-notion"');
+    for (const id of ["gmail", "github", "google-drive", "google-calendar", "notion", "slack"]) {
+      expect(markup).toContain(`data-testid="connector-row-${id}"`);
+    }
+    expect(markup).toContain("Browse all 9 integrations");
+    expect(markup).not.toContain('data-testid="more-connectors"');
+  });
+
+  test("configured rows get the options menu while unconfigured rows explain the next step", () => {
+    const markup = render();
+
+    expect(markup).toContain('data-testid="connector-options-conn-notion"');
+    expect(markup).not.toContain('data-testid="connector-add-notion"');
+    expect(markup).toContain('data-testid="connector-add-github"');
+    expect(markup).toContain('aria-label="Set up GitHub"');
+    expect(markup).toContain('data-testid="connector-chat-github"');
+    expect(markup).toContain('data-testid="connector-chat-notion"');
+    expect(markup).not.toContain("autoSend");
+    expect(markup).not.toContain("auto-send");
+  });
+
+  test("preset outages keep Chat and native setup available while disabling dependent setup", () => {
+    for (const state of [{ loading: true }, { unavailable: true }]) {
+      const markup = render({ ...state, presets: [], filter: "github" });
+      expect(markup).toContain('data-testid="connector-chat-github"');
+      expect(markup).toMatch(/<button[^>]*disabled=""[^>]*data-testid="connector-add-github"/);
+      const nativeMarkup = render({ ...state, presets: [], filter: "microsoft" });
+      expect(nativeMarkup).toContain('data-testid="connector-chat-microsoft-365"');
+      expect(nativeMarkup).toContain('data-testid="connector-add-microsoft-365"');
+      expect(nativeMarkup).not.toContain('disabled=""');
+    }
+  });
+
+  test("configured rows expose personal sign-in and setup recovery alongside Chat", () => {
+    const markup = render({ connections: [{ ...NOTION, connectedForMe: false }], filter: "notion" });
+    expect(markup).toContain("Needs your account");
+    expect(markup).toContain('data-testid="connector-recover-notion"');
+    expect(markup).toContain('data-testid="connector-chat-notion"');
+    expect(markup).not.toContain("Connected as you");
+    const setupMarkup = render({ setupRequired: () => true, filter: "notion" });
+    expect(setupMarkup).toContain("Setup required");
+    expect(setupMarkup).toContain('data-testid="connector-recover-notion"');
+    expect(setupMarkup).toContain("Set up");
+  });
+
+  test("filtering opens the More section and hides the configured strip", () => {
+    const markup = render({ filter: "gran" });
+
+    expect(markup).not.toContain('data-testid="configured-connector-strip"');
+    expect(markup).not.toContain('data-testid="popular-connectors"');
+    expect(markup).toContain('data-testid="more-connectors"');
+    expect(markup).toContain('data-testid="connector-row-granola"');
+    expect(markup).not.toContain('data-testid="connector-row-context7"');
+  });
+
+  test("a filter with no matches says so", () => {
+    expect(render({ filter: "zzzz" })).toContain("No connectors match");
+  });
+
+  test("every row opens its detail page: stable catalog identity even when configured", () => {
+    const markup = render({ filter: "o" });
+
+    expect(markup).toContain('href="/dashboard/mcp-connections/notion"');
+    expect(markup).toContain('data-testid="connector-open-notion"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/github"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/google-drive"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/microsoft-365"');
+    expect(markup).toContain('href="/dashboard/mcp-connections/granola"');
+    expect(markup).not.toContain('href="/dashboard/mcp-connections/conn-notion"');
+  });
+});

--- a/ee/apps/den-web/tests/connector-catalog.test.ts
+++ b/ee/apps/den-web/tests/connector-catalog.test.ts
@@ -56,15 +56,15 @@ describe("popular connector catalog", () => {
     }
   });
 
-  test("limits Google descriptions and Drive's starter to supported operations", () => {
-    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "gmail")?.description).toBe("Search and read Gmail, create drafts");
-    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "google-calendar")?.description).toBe("List and create Google Calendar events");
+  test("describes the native service management delivered with the catalog", () => {
+    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "gmail")?.description).toBe("Read, send, and manage Gmail");
+    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "google-calendar")?.description).toBe("Create, reschedule, and manage Google Calendar events");
     const drive = POPULAR_CONNECTORS.find((connector) => connector.id === "google-drive");
-    expect(drive?.description).toBe("Search files, read Docs and Slides text, upload and share files");
-    expect(drive?.chatPrompt).toContain("Ask me for a topic");
-    expect(drive?.chatPrompt).toContain("search for a small sample");
-    expect(drive?.chatPrompt).toContain("summarize readable text");
-    expect(`${drive?.description} ${drive?.chatPrompt}`).not.toMatch(/Sheets|edit|changed|last 7 days|this week|everything/i);
+    expect(drive?.description).toBe("Organize files, read Docs and Slides, and edit Sheets");
+    expect(drive?.chatPrompt).toContain("last 7 days");
+    expect(drive?.chatPrompt).toContain("follow pagination");
+    expect(drive?.chatPrompt).toContain("incomplete search");
+    expect(drive?.chatPrompt).toContain("without accessing Drive");
   });
 
   test("builds an openwork:// chat deep link carrying the connector and its prompt", () => {

--- a/ee/apps/den-web/tests/connector-catalog.test.ts
+++ b/ee/apps/den-web/tests/connector-catalog.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+import {
+  configuredConnectionForPopular,
+  connectionForPresetUrl,
+  connectorChatDeepLink,
+  connectorChatPrompt,
+  POPULAR_CONNECTORS,
+  remainingPresets,
+} from "../app/(den)/dashboard/_components/connector-catalog";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
+
+function readDashboardFile(relativePath: string) {
+  return readFileSync(fileURLToPath(new URL(`../app/(den)/dashboard/${relativePath}`, import.meta.url)), "utf8");
+}
+
+const PRESETS: ExternalMcpPreset[] = [
+  { presetId: "github", displayName: "GitHub", description: "PRs", url: "https://api.githubcopilot.com/mcp/", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "notion", displayName: "Notion", description: "Docs", url: "https://mcp.notion.com/mcp", authType: "oauth" },
+  { presetId: "slack", displayName: "Slack", description: "Chat", url: "https://mcp.slack.com/mcp", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "linear", displayName: "Linear", description: "Issues", url: "https://mcp.linear.app/mcp", authType: "oauth" },
+  { presetId: "context7", displayName: "Context7", description: "Docs", url: "https://mcp.context7.com/mcp", authType: "none" },
+];
+
+function connection(overrides: Partial<ExternalMcpConnection> & Pick<ExternalMcpConnection, "id" | "name" | "url">): ExternalMcpConnection {
+  return {
+    authType: "oauth",
+    credentialMode: "per_member",
+    connected: false,
+    connectedAt: null,
+    updatedAt: null,
+    connectedForMe: false,
+    requiredBy: [],
+    identityManagedBy: [],
+    access: null,
+    ...overrides,
+  };
+}
+
+describe("popular connector catalog", () => {
+  test("lists the six popular connectors in the approved order with starter prompts", () => {
+    expect(POPULAR_CONNECTORS.map((connector) => connector.displayName)).toEqual([
+      "Gmail",
+      "GitHub",
+      "Google Drive",
+      "Google Calendar",
+      "Notion",
+      "Slack",
+    ]);
+    for (const connector of POPULAR_CONNECTORS) {
+      expect(connector.chatPrompt.startsWith("Explain")).toBe(true);
+      expect(connector.chatPrompt.toLowerCase()).toContain("if access is available");
+      expect(connector.chatPrompt).toContain("Otherwise,");
+      expect(connector.chatPrompt).toContain("without accessing");
+    }
+  });
+
+  test("limits Google descriptions and Drive's starter to supported operations", () => {
+    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "gmail")?.description).toBe("Search and read Gmail, create drafts");
+    expect(POPULAR_CONNECTORS.find((connector) => connector.id === "google-calendar")?.description).toBe("List and create Google Calendar events");
+    const drive = POPULAR_CONNECTORS.find((connector) => connector.id === "google-drive");
+    expect(drive?.description).toBe("Search files, read Docs and Slides text, upload and share files");
+    expect(drive?.chatPrompt).toContain("Ask me for a topic");
+    expect(drive?.chatPrompt).toContain("search for a small sample");
+    expect(drive?.chatPrompt).toContain("summarize readable text");
+    expect(`${drive?.description} ${drive?.chatPrompt}`).not.toMatch(/Sheets|edit|changed|last 7 days|this week|everything/i);
+  });
+
+  test("builds an openwork:// chat deep link carrying the connector and its prompt", () => {
+    const href = connectorChatDeepLink({ connector: "GitHub", prompt: connectorChatPrompt("GitHub") });
+    const url = new URL(href);
+    expect(url.protocol).toBe("openwork:");
+    expect(url.hostname).toBe("chat");
+    expect(url.searchParams.get("connector")).toBe("GitHub");
+    expect(url.searchParams.get("prompt")).toBe(
+      "Explain how I can review a GitHub repo's authentication. Ask which repo to use; if access is available, inspect its code and docs. Otherwise, outline a review checklist without accessing the repo.",
+    );
+  });
+
+  test("falls back to an explain prompt for connectors without a curated one", () => {
+    expect(connectorChatPrompt("Render")).toBe(
+      "Explain how I could use Render: suggest three useful tasks and distinguish general ideas from tools available here. If access is unavailable, help me plan without connecting.",
+    );
+  });
+
+  test("resolves Gmail, Drive, and Calendar to the single Google Workspace connection", () => {
+    const google = connection({ id: "conn-google", name: "Google Workspace", url: "https://www.googleapis.com", nativeProviderKey: "google-workspace" });
+    for (const id of ["gmail", "google-drive", "google-calendar"]) {
+      const popular = POPULAR_CONNECTORS.find((connector) => connector.id === id);
+      expect(popular).toBeDefined();
+      expect(configuredConnectionForPopular(popular!, [google], PRESETS)?.id).toBe("conn-google");
+      expect(configuredConnectionForPopular(popular!, [], PRESETS)).toBeUndefined();
+    }
+  });
+
+  test("matches preset-backed rows by comparable URL, ignoring a trailing slash", () => {
+    const github = connection({ id: "conn-github", name: "GitHub", url: "https://api.githubcopilot.com/mcp" });
+    const popularGithub = POPULAR_CONNECTORS.find((connector) => connector.id === "github")!;
+    expect(configuredConnectionForPopular(popularGithub, [github], PRESETS)?.id).toBe("conn-github");
+    expect(connectionForPresetUrl([github], "https://api.githubcopilot.com/mcp/")?.id).toBe("conn-github");
+    expect(connectionForPresetUrl([github], "https://mcp.notion.com/mcp")).toBeUndefined();
+  });
+
+  test("keeps only non-popular presets for the More section", () => {
+    expect(remainingPresets(PRESETS).map((preset) => preset.presetId)).toEqual(["linear", "context7"]);
+  });
+});
+
+describe("connector pages", () => {
+  test("the catalog page shows Configured first, then Popular, then More, and never the configured list", () => {
+    const screen = readDashboardFile("_components/mcp-connections-screen.tsx");
+    const catalog = readDashboardFile("_components/connector-catalog-list.tsx");
+
+    expect(screen).toContain("<ConnectorCatalog");
+    expect(screen).not.toContain("<ConnectorQuickAddGrid");
+    expect(catalog.indexOf("ConfiguredConnectorStrip connections")).toBeLessThan(catalog.indexOf('data-testid="popular-connectors"'));
+    expect(catalog.indexOf('data-testid="popular-connectors"')).toBeLessThan(catalog.indexOf('data-testid="more-connectors"'));
+    expect(catalog).toContain("Manage\n          </button>");
+    expect(catalog).toContain("Uninstall\n              </button>");
+  });
+
+  test("the configured page reuses the admin screen in its configured view", () => {
+    const page = readDashboardFile("(admin)/mcp-connections/configured/page.tsx");
+    const screen = readDashboardFile("_components/mcp-connections-screen.tsx");
+
+    expect(page).toContain('<McpConnectionsScreen view="configured" />');
+    expect(screen).toContain('title={configuredView ? "Configured connectors" : "Connectors"}');
+    expect(screen).toContain('data-testid="configured-add-connector"');
+    expect(screen).toContain("chat-mcp-connection-");
+  });
+
+  test("one-click OAuth presets are added for everyone and open the authorization tab in the same gesture", () => {
+    const screen = readDashboardFile("_components/mcp-connections-screen.tsx");
+    const oneClick = screen.slice(screen.indexOf("async function handleOneClickAdd"), screen.indexOf("async function handleUpdate"));
+
+    expect(oneClick).toContain('credentialMode: "per_member"');
+    expect(oneClick).toContain("{ startOAuth: true }");
+    expect(screen).toContain('if (effort === "one_click") {');
+  });
+});

--- a/ee/apps/den-web/tests/connector-detail.test.ts
+++ b/ee/apps/den-web/tests/connector-detail.test.ts
@@ -119,7 +119,8 @@ describe("connector detail copy", () => {
     expect(byLabel.Server).toMatchObject({ value: "https://mcp.notion.com/mcp/", mono: true });
     expect(byLabel["Sign-in"].value).toBe("OAuth sign-in · each person connects their own account");
     expect(byLabel.Access.value).toBe("Everyone in Acme");
-    expect(byLabel.Added.value).toContain("Added by Jalil");
+    expect(byLabel.Added.value).toBe(new Date(NOTION.connectedAt!).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }));
+    expect(facts.some((fact) => fact.value.includes("Added by"))).toBe(false);
     expect(byLabel["Required by"]).toMatchObject({ value: "Research kit", href: "/dashboard/plugins/plg_1" });
     expect(byLabel.Docs.href).toContain("shared-mcp-connections");
   });
@@ -134,6 +135,15 @@ describe("connector detail copy", () => {
     expect(googleFacts.find((fact) => fact.label === "Provider")?.value).toBe("Google");
     expect(googleFacts.some((fact) => fact.label === "Server")).toBe(false);
     expect(googleFacts.find((fact) => fact.label === "Part of")?.value).toContain("Google Workspace");
+  });
+
+  test("information facts never project the creator's name or email fallback", () => {
+    for (const createdByName of ["Connector creator", "creator@example.test"]) {
+      const connection = { ...NOTION, createdByName };
+      const facts = connectorDetailFacts({ kind: "connection", connection }, context);
+      expect(facts.some((fact) => fact.value.includes(createdByName))).toBe(false);
+      expect(facts.find((fact) => fact.label === "Added")).toBeDefined();
+    }
   });
 });
 

--- a/ee/apps/den-web/tests/connector-detail.test.ts
+++ b/ee/apps/den-web/tests/connector-detail.test.ts
@@ -1,0 +1,215 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  connectorAccountStatus,
+  connectorAccountReady,
+  displayedConnectorConnections,
+  connectorDetailEffort,
+  connectorDetailFacts,
+  connectorDetailIdentity,
+  connectorDetailPrimaryAction,
+  resolveConnectorDetailSubject,
+} from "../app/(den)/dashboard/_components/connector-detail";
+import type { ExternalMcpConnection, ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
+
+const PRESETS: ExternalMcpPreset[] = [
+  { presetId: "github", displayName: "GitHub", description: "PRs", url: "https://api.githubcopilot.com/mcp/", authType: "oauth", requiresOAuthClient: true },
+  { presetId: "notion", displayName: "Notion", description: "Docs", url: "https://mcp.notion.com/mcp", authType: "oauth" },
+  { presetId: "context7", displayName: "Context7", description: "Library docs", url: "https://mcp.context7.com/mcp", authType: "none" },
+];
+
+const NOTION: ExternalMcpConnection = {
+  id: "conn-notion",
+  name: "Notion",
+  url: "https://mcp.notion.com/mcp/",
+  authType: "oauth",
+  credentialMode: "per_member",
+  exposeDirectly: false,
+  connected: true,
+  connectedAt: "2026-09-02T10:00:00.000Z",
+  createdByName: "Jalil",
+  updatedAt: "2026-09-02T10:00:00.000Z",
+  connectedForMe: true,
+  requiredBy: [{ pluginId: "plg_1", name: "Research kit" }],
+  identityManagedBy: [],
+  access: { orgWide: true, memberIds: [], teamIds: [] },
+};
+
+const GOOGLE: ExternalMcpConnection = {
+  id: "google-workspace",
+  name: "Google Workspace",
+  url: "https://www.googleapis.com/",
+  authType: "oauth",
+  credentialMode: "per_member",
+  exposeDirectly: false,
+  connected: false,
+  connectedAt: null,
+  updatedAt: null,
+  connectedForMe: false,
+  nativeProviderKey: "google-workspace",
+  requiredBy: [],
+  identityManagedBy: [],
+  access: null,
+};
+
+const PLUGIN_OWNED: ExternalMcpConnection = {
+  ...NOTION,
+  id: "conn-plugin",
+  name: "Team wiki",
+  url: "https://wiki.example.com/mcp",
+  requiredBy: [{ pluginId: "plg_wiki", name: "Wiki plugin" }],
+  identityManagedBy: [{ pluginId: "plg_wiki", name: "Wiki plugin" }],
+};
+
+const context = { orgName: "Acme", pluginHref: (pluginId: string) => `/dashboard/plugins/${pluginId}` };
+
+describe("resolveConnectorDetailSubject", () => {
+  test("a connection id resolves to the connection with its catalog identity", () => {
+    const subject = resolveConnectorDetailSubject("conn-notion", [NOTION], PRESETS);
+    expect(subject.kind).toBe("connection");
+    if (subject.kind !== "connection") return;
+    expect(subject.preset?.presetId).toBe("notion");
+    expect(subject.popular?.id).toBe("notion");
+  });
+
+  test("a popular id resolves to its configured connection when one exists, else stays a catalog entry", () => {
+    const configured = resolveConnectorDetailSubject("notion", [NOTION], PRESETS);
+    expect(configured.kind).toBe("connection");
+
+    const unconfigured = resolveConnectorDetailSubject("notion", [], PRESETS);
+    expect(unconfigured.kind).toBe("popular");
+    if (unconfigured.kind === "popular") expect(unconfigured.preset?.presetId).toBe("notion");
+  });
+
+  test("Gmail keeps its own identity while the Google Workspace connection keeps Google's", () => {
+    const gmail = resolveConnectorDetailSubject("gmail", [GOOGLE], PRESETS);
+    expect(gmail.kind).toBe("connection");
+    expect(connectorDetailIdentity(gmail).name).toBe("Gmail");
+
+    const google = resolveConnectorDetailSubject("google-workspace", [GOOGLE], PRESETS);
+    expect(google.kind).toBe("connection");
+    expect(connectorDetailIdentity(google).name).toBe("Google Workspace");
+  });
+
+  test("a preset id outside the popular list resolves by URL and Microsoft 365 has a page before setup", () => {
+    expect(resolveConnectorDetailSubject("context7", [], PRESETS).kind).toBe("preset");
+    expect(resolveConnectorDetailSubject("microsoft-365", [], PRESETS).kind).toBe("microsoft-365");
+    expect(resolveConnectorDetailSubject("nope", [NOTION], PRESETS)).toEqual({ kind: "not_found", connectorId: "nope" });
+  });
+});
+
+describe("connector detail copy", () => {
+  test("effort drives the primary action for unconfigured connectors", () => {
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("context7", [], PRESETS))).toBe("instant");
+    expect(connectorDetailPrimaryAction("instant").label).toBe("Add");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("notion", [], PRESETS))).toBe("one_click");
+    expect(connectorDetailPrimaryAction("one_click").label).toBe("Connect");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("github", [], PRESETS))).toBe("oauth_app");
+    expect(connectorDetailPrimaryAction("oauth_app").label).toBe("Set up");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("gmail", [], PRESETS))).toBe("guided");
+    expect(connectorDetailEffort(resolveConnectorDetailSubject("conn-notion", [NOTION], PRESETS))).toBeNull();
+  });
+
+  test("information facts come from what the page already knows", () => {
+    const facts = connectorDetailFacts(resolveConnectorDetailSubject("conn-notion", [NOTION], PRESETS), context);
+    const byLabel = Object.fromEntries(facts.map((fact) => [fact.label, fact]));
+    expect(byLabel.Provider).toMatchObject({ value: "notion.com", href: "https://notion.com" });
+    expect(byLabel.Type.value).toBe("Remote MCP server");
+    expect(byLabel.Server).toMatchObject({ value: "https://mcp.notion.com/mcp/", mono: true });
+    expect(byLabel["Sign-in"].value).toBe("OAuth sign-in · each person connects their own account");
+    expect(byLabel.Access.value).toBe("Everyone in Acme");
+    expect(byLabel.Added.value).toContain("Added by Jalil");
+    expect(byLabel["Required by"]).toMatchObject({ value: "Research kit", href: "/dashboard/plugins/plg_1" });
+    expect(byLabel.Docs.href).toContain("shared-mcp-connections");
+  });
+
+  test("plugin-owned connections say so once, and native providers skip the server URL", () => {
+    const pluginFacts = connectorDetailFacts(resolveConnectorDetailSubject("conn-plugin", [PLUGIN_OWNED], PRESETS), context);
+    expect(pluginFacts.filter((fact) => fact.label === "Managed by")).toHaveLength(1);
+    expect(pluginFacts.some((fact) => fact.label === "Required by")).toBe(false);
+    expect(pluginFacts.find((fact) => fact.label === "Type")?.value).toBe("MCP server from a plugin");
+
+    const googleFacts = connectorDetailFacts(resolveConnectorDetailSubject("gmail", [GOOGLE], PRESETS), context);
+    expect(googleFacts.find((fact) => fact.label === "Provider")?.value).toBe("Google");
+    expect(googleFacts.some((fact) => fact.label === "Server")).toBe(false);
+    expect(googleFacts.find((fact) => fact.label === "Part of")?.value).toContain("Google Workspace");
+  });
+});
+
+describe("connectors screen surface", () => {
+  const root = join(import.meta.dir, "..", "app", "(den)", "dashboard");
+  const screen = readFileSync(join(root, "_components", "mcp-connections-screen.tsx"), "utf8");
+
+  test("leads with the flat page header instead of the gradient hero", () => {
+    expect(screen).toContain("<DenPageHeader");
+    expect(screen).not.toContain("DashboardPageTemplate");
+    expect(screen).toContain('title={configuredView ? "Configured connectors" : "Connectors"}');
+    expect(screen).toContain('data-testid="connectors-open-configured"');
+  });
+
+  test("has a detail view that composes the connection row, tools, and information", () => {
+    expect(screen).toContain('export type McpConnectionsScreenView = "catalog" | "configured" | "detail";');
+    for (const testId of [
+      "connector-detail-back",
+      "connector-detail",
+      "connector-detail-state",
+      "connector-detail-copy-link",
+      "connector-detail-chat",
+      "connector-detail-primary",
+      "connector-detail-connection",
+      "connector-detail-tools",
+      "connector-detail-information",
+      "connector-detail-not-found",
+    ]) {
+      expect(screen).toContain(`data-testid="${testId}"`);
+    }
+    expect(screen).toContain("router.push(getMcpConnectionRoute(orgSlug, connection.id));");
+    expect(screen).toContain('connectorHref={(id) => getMcpConnectionRoute(orgSlug, id)}');
+  });
+
+  test("the detail route renders the screen in detail view", () => {
+    const route = readFileSync(join(root, "(admin)", "mcp-connections", "[connectorId]", "page.tsx"), "utf8");
+    expect(route).toContain('<McpConnectionsScreen view="detail" connectorId={connectorId} />');
+  });
+});
+
+
+describe("connectorAccountStatus", () => {
+  test("another member's authorization never makes this account connected", () => {
+    expect(connectorAccountStatus({ ...NOTION, connected: true, connectedForMe: false })).toBe("Needs your account");
+    expect(connectorAccountStatus(NOTION)).toBe("Connected as you");
+    expect(connectorAccountStatus({ ...NOTION, credentialMode: "shared", connectedForMe: false })).toBe("Connected");
+  });
+
+  test("setup and credential recovery take precedence over old connected flags", () => {
+    expect(connectorAccountStatus({ ...NOTION, setupRequired: true })).toBe("Setup required");
+    expect(connectorAccountStatus({ ...NOTION, issuerReviewRequired: true })).toBe("OAuth settings need review");
+    expect(connectorAccountStatus({ ...NOTION, credentialHealth: "reconnect_required" })).toBe("Reconnect required");
+    expect(connectorAccountStatus({ ...NOTION, oauthClientRequired: true, oauthClientConfigured: false })).toBe("Setup required");
+  });
+});
+
+describe("displayed connections and personal readiness", () => {
+  test("includes both synthetic native providers without duplicating managed entries or importing other usable MCPs", () => {
+    const microsoft = { ...GOOGLE, id: "microsoft-365", name: "Microsoft 365", nativeProviderKey: "microsoft-365" };
+    const managedGoogle = { ...GOOGLE, id: "conn-google", name: "Work Google" };
+    const displayed = displayedConnectorConnections([NOTION, managedGoogle], [GOOGLE, microsoft, managedGoogle, PLUGIN_OWNED]);
+    expect(displayed.map((connection) => connection.id)).toEqual(["google-workspace", "microsoft-365", "conn-notion", "conn-google"]);
+    const subject = resolveConnectorDetailSubject("microsoft-365", displayed, PRESETS);
+    expect(subject.kind).toBe("connection");
+    expect(connectorDetailIdentity(subject).name).toBe("Microsoft 365");
+    expect(connectorAccountStatus(microsoft)).toBe("Needs your account");
+  });
+
+  test("OAuth polling waits for this member's healthy token, not another member's authorization", () => {
+    expect(connectorAccountReady({ ...NOTION, connectedForMe: false })).toBe(false);
+    expect(connectorAccountReady(NOTION)).toBe(true);
+    expect(connectorAccountReady({ ...NOTION, credentialMode: "shared", connectedForMe: false })).toBe(true);
+    expect(connectorAccountReady({ ...NOTION, setupRequired: true })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, issuerReviewRequired: true })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, needsReconnect: true })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, credentialHealth: "reconnect_required" })).toBe(false);
+    expect(connectorAccountReady({ ...NOTION, oauthClientRequired: true, oauthClientConfigured: false })).toBe(false);
+  });
+});

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -35,9 +35,9 @@ describe("connector and marketplace polish", () => {
   test("uses the smart connector bar and the approved connector copy", () => {
     const screen = readDashboardComponent("mcp-connections-screen.tsx");
 
-    expect(screen).toContain('title="Connectors"');
+    expect(screen).toContain('title={configuredView ? "Configured connectors" : "Connectors"}');
     expect(screen).not.toContain("badgeLabel");
-    expect(screen).toContain('description="Connectors is where you can add MCP servers that your whole team can use."');
+    expect(screen).toContain(': "Connectors is where you can add MCP servers that your whole team can use."');
     expect(screen).toContain('data-testid="connector-smart-bar"');
     expect(screen).not.toMatch(/>\s*Add MCP\s*</);
     expect(screen).not.toContain("<ImportPluginConnectionDialog");

--- a/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { presetAuthTypeOptions, SegmentedControl } from "../app/(den)/dashboard/_components/mcp-connection-form-controls";
+import type { ExternalMcpPreset } from "../app/(den)/dashboard/_components/mcp-connections-data";
 
 const screenPath = fileURLToPath(
   new URL("../app/(den)/dashboard/_components/mcp-connections-screen.tsx", import.meta.url),
@@ -13,7 +17,6 @@ describe("MCP URL entry UI contract", () => {
     expect(screen).toContain('useState<"smart" | "advanced">(preset ? "advanced" : "smart")');
     expect(screen).toContain("Add an MCP server");
     expect(screen).toContain("Paste the MCP server URL");
-    expect(screen).toContain("Paste a server URL and we&apos;ll check it for you.");
     expect(screen).toContain('placeholder="https://mcp.example.com/mcp"');
     expect(screen).toContain('if (kind !== "url" && kind !== "domain")');
     expect(screen).not.toContain('data-testid="select-custom-mcp"');
@@ -27,8 +30,9 @@ describe("MCP URL entry UI contract", () => {
     const screen = readFileSync(screenPath, "utf8");
 
     expect(screen).toContain("setFormPreset(preset);");
-    expect(screen).toContain("{preset ? `Add ${preset.displayName}` : \"Add a custom MCP server\"}");
-    expect(screen).toContain("disabled={Boolean(preset)}");
+    expect(screen).toContain("const activePreset = preset ?? resolution?.preset ?? null;");
+    expect(screen).toContain("{activePreset ? `Add ${activePreset.displayName}` : \"Add a custom MCP server\"}");
+    expect(screen).toContain("disabled={Boolean(activePreset)}");
     expect(screen).not.toContain("existingConnectionUrls");
     expect(screen).not.toContain("onSelectPreset");
   });
@@ -42,5 +46,27 @@ describe("MCP URL entry UI contract", () => {
     expect(screen).toContain('"Deselect all" : "Select all"');
     expect(screen).toContain('data-testid="toggle-all-optional-permissions"');
     expect(screen).toContain("toggleAllOptionalScopes(current, optionalScopes)");
+  });
+
+  test("GitHub offers OAuth and PAT without allowing anonymous auth or changing the OAuth default", () => {
+    const preset: ExternalMcpPreset = {
+      presetId: "github", displayName: "GitHub", description: "Code", url: "https://api.githubcopilot.com/mcp/",
+      authType: "oauth", supportedAuthTypes: ["oauth", "apikey"], requiresOAuthClient: true,
+    };
+    const options = presetAuthTypeOptions(preset);
+    expect(options.map((option) => option.value)).toEqual(["oauth", "apikey"]);
+    const render = (value: string) => renderToStaticMarkup(createElement(SegmentedControl, { options, value, onChange: () => {} }));
+    expect(render(preset.authType)).toMatch(/aria-pressed="true"[^>]*>OAuth<\/button>/);
+    expect(render("apikey")).toMatch(/aria-pressed="true"[^>]*>API key<\/button>/);
+    expect(render("apikey")).not.toContain(">None<");
+    expect(presetAuthTypeOptions({ ...preset, supportedAuthTypes: undefined }).map((option) => option.value)).toEqual(["oauth"]);
+    expect(presetAuthTypeOptions(null).map((option) => option.value)).toEqual(["oauth", "apikey", "none"]);
+
+    const screen = readFileSync(screenPath, "utf8");
+    expect(screen).toContain("const authTypeOptions = presetAuthTypeOptions(activePreset);");
+    expect(screen).toContain("authTypeOptions.length > 1");
+    expect(screen).toContain("options={authTypeOptions}");
+    expect(screen).toContain("if (!activePreset && !authTypeEdited.current)");
+    expect(screen).toContain("authTypeEdited.current = true;");
   });
 });

--- a/ee/apps/den-web/tests/microsoft-365-permissions.test.ts
+++ b/ee/apps/den-web/tests/microsoft-365-permissions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { MICROSOFT_365_DEFAULT_FEATURES } from "@openwork/types/den/microsoft-365";
 import {
   MICROSOFT_365_DISPLAY_SCOPES,
@@ -41,5 +42,25 @@ describe("Microsoft 365 permission picker", () => {
 
   test("keeps write permissions opt-in", () => {
     expect(MICROSOFT_365_DEFAULT_FEATURES).toEqual(["mailRead", "calendarRead", "filesRead"]);
+  });
+
+  test("edits load and save the selected Microsoft client, using the alias only for catalog setup", () => {
+    const screen = readFileSync(new URL("../app/(den)/dashboard/_components/mcp-connections-screen.tsx", import.meta.url), "utf8");
+    const dialog = readFileSync(new URL("../app/(den)/dashboard/_components/microsoft-365-dialog.tsx", import.meta.url), "utf8");
+    const edit = screen.slice(screen.indexOf("function editConnection("), screen.indexOf("function recoverConnection("));
+    expect(edit).toContain("setMicrosoftDialogConnectionId(connection.id)");
+    expect(edit).not.toContain("openQuickAdd(MICROSOFT_365_QUICK_ADD_ID)");
+    expect(screen).toContain("setMicrosoftDialogConnectionId(MICROSOFT_365_QUICK_ADD_ID)");
+    expect(screen).toContain("key={microsoftDialogConnectionId}");
+    expect(screen).toContain("providerId={microsoftDialogConnectionId}");
+    expect(screen).toContain("providerId: microsoftDialogConnectionId, ...input");
+    expect(dialog).toContain("useNativeProviderClient(providerId, open)");
+    expect(dialog).not.toContain('useNativeProviderClient("microsoft-365"');
+
+    // Google's legacy alias path is unchanged; named connections retain their exact row for edits.
+    expect(edit).toContain("if (connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID)");
+    expect(edit).not.toContain('connection.nativeProviderKey === "google-workspace"');
+    expect(edit).toContain("setEditingConnection(connection)");
+    expect(screen).toContain("connectionId: connection.id,");
   });
 });

--- a/evals/packages/behaviors/src/connector-catalog.ts
+++ b/evals/packages/behaviors/src/connector-catalog.ts
@@ -1,0 +1,43 @@
+import type { Surface } from "@openwork/cdp";
+import { evalIn } from "./desktop.ts";
+
+export interface ConnectorCatalogFacts {
+  summary: string;
+  entries: { id: string; text: string; href: string; status: string }[];
+  chatLinks: { testId: string; href: string }[];
+  horizontalOverflow: boolean;
+}
+
+/** Observe rendered catalog rows, never React state or product source. */
+export async function readConnectorCatalog(surface: Surface): Promise<ConnectorCatalogFacts> {
+  const value = await evalIn(surface, () => ({
+    summary: document.querySelector('[data-testid="connector-catalog-count"]')?.textContent?.trim() ?? "",
+    entries: Array.from(document.querySelectorAll<HTMLElement>('[data-connector-id]'), row => ({
+      id: row.getAttribute('data-connector-id') ?? "",
+      text: row.innerText,
+      href: row.querySelector('a')?.getAttribute('href') ?? "",
+      status: row.querySelector('[data-testid^="connector-status-"]')?.textContent?.trim() ?? "",
+    })),
+    chatLinks: Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href^="openwork://chat?"]'), link => ({
+      testId: link.getAttribute('data-testid') ?? "",
+      href: link.href,
+    })),
+    horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  }));
+  if (!value || typeof value !== "object" || !("summary" in value) || typeof value.summary !== "string"
+    || !("entries" in value) || !Array.isArray(value.entries)
+    || !("horizontalOverflow" in value) || typeof value.horizontalOverflow !== "boolean") {
+    throw new Error("The connector catalog did not expose its rendered summary and entries.");
+  }
+  const entries = value.entries.map((entry: unknown) => {
+    if (!entry || typeof entry !== "object"
+      || !("id" in entry) || typeof entry.id !== "string"
+      || !("text" in entry) || typeof entry.text !== "string"
+      || !("href" in entry) || typeof entry.href !== "string"
+      || !("status" in entry) || typeof entry.status !== "string") {
+      throw new Error("A connector row is missing its identity, link or setup status.");
+    }
+    return { id: entry.id, text: entry.text, href: entry.href, status: entry.status };
+  });
+  return { summary: value.summary, entries, chatLinks: value.chatLinks, horizontalOverflow: value.horizontalOverflow };
+}

--- a/evals/packages/behaviors/src/index.ts
+++ b/evals/packages/behaviors/src/index.ts
@@ -8,6 +8,7 @@ export * from "./diagnostics.ts";
 export * from "./engine-session-probe.ts";
 export * from "./onboarding.ts";
 export * from "./composer.ts";
+export * from "./connector-catalog.ts";
 export * from "./models.ts";
 export * from "./skills.ts";
 export * from "./sessions.ts";

--- a/evals/packages/cdp/src/cdp.ts
+++ b/evals/packages/cdp/src/cdp.ts
@@ -359,6 +359,9 @@ export async function navigate(client: CdpClient, url: string): Promise<void> {
 }
 
 export async function captureScreenshot(client: CdpClient): Promise<Buffer> {
+  // OAuth can foreground another tab. Activate this explicit target so its
+  // compositor can produce the requested frame instead of stalling in the background.
+  await client.send("Page.bringToFront");
   const payload = await client.send("Page.captureScreenshot", { format: "png" });
   if (!isRecord(payload) || typeof payload.data !== "string") {
     throw new Error("Page.captureScreenshot did not return base64 PNG data.");

--- a/evals/packages/env/src/seed.ts
+++ b/evals/packages/env/src/seed.ts
@@ -107,6 +107,8 @@ export interface Seed {
   denLink(den: Den, options?: SeedDenLinkOptions): Promise<SeedDenLink>;
   tmpPath(label: string): string;
   composerText(app: Surface, text: string): Promise<void>;
+  /** Deliver a fixture-owned link at the renderer ingress; does not exercise OS protocol registration. */
+  deepLink(app: Surface, url: string): Promise<void>;
   browserFixtureDiscovery(app: Surface, origin: string, action: "hold" | "release"): Promise<void>;
   /** Migration-only raw write escape hatch. New specs must not use it. */
   evalIn<T>(surface: Surface, expression: BrowserEvaluation<T>, options?: EvaluateOptions): Promise<Awaited<T>>;

--- a/evals/packages/test-evidence/test/test-evidence.test.ts
+++ b/evals/packages/test-evidence/test/test-evidence.test.ts
@@ -194,9 +194,12 @@ test("screenshot automatically records an artifact in ambient test evidence", as
   const dir = await mkdtemp(join(tmpdir(), "openwork-test-evidence-screenshot-"));
   try {
     const png = Buffer.from("ambient screenshot pixels");
+    const methods: string[] = [];
     const client: CdpClient = {
       close() {},
       async send(method) {
+        methods.push(method);
+        if (method === "Page.bringToFront") return {};
         if (method === "Page.captureScreenshot") return { data: png.toString("base64") };
         if (method === "Runtime.evaluate") {
           return { result: { value: { route: "#/ambient", visibleText: "Ambient screenshot" } } };
@@ -210,6 +213,7 @@ test("screenshot automatically records an artifact in ambient test evidence", as
     };
     const testEvidence = createTestEvidence({ name: "ambient screenshot", outDir: dir });
     const captured = await withTestEvidence(testEvidence, () => screenshot(app));
+    assert.deepEqual(methods.slice(0, 2), ["Page.bringToFront", "Page.captureScreenshot"]);
     assert.equal(captured.route, "#/ambient");
     await testEvidence.close();
 

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -11,6 +11,7 @@ import {
   readComposerState,
   readBrowserState,
   readBrowserTabMetrics,
+  readConnectorCatalog,
   renameSessionAndWait,
   signInDesktopAs,
   waitUntilInteractive,
@@ -596,6 +597,15 @@ export class SeedChannel implements Seed {
     });
   }
 
+  deepLink(app: Surface, url: string) {
+    return this.#runtime.call("seed", "deepLink", "deepLink(renderer ingress)", app, async () => {
+      if (new URL(url).protocol !== "openwork:") throw new Error("Expected an OpenWork deep link.");
+      await callFunctionOnSurface(app, (url) => {
+        window.dispatchEvent(new CustomEvent("openwork:deep-link", { detail: { urls: [url] } }));
+      }, [url]);
+    });
+  }
+
   browserFixtureDiscovery(app: Surface, origin: string, action: "hold" | "release") {
     return this.#runtime.call("seed", "browserFixtureDiscovery", `browserFixtureDiscovery(${action})`, app,
       () => setBrowserFixtureDiscovery(app, origin, action));
@@ -938,6 +948,11 @@ export class ProbeChannel implements Probe {
   composer() {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("probe", "composer", "composer", surface, () => readComposerState(surface));
+  }
+
+  connectorCatalog() {
+    const surface = requireSurface(this.#surface);
+    return this.#runtime.call("probe", "connectorCatalog", "connectorCatalog", surface, () => readConnectorCatalog(surface));
   }
 
   storage(key: string): Promise<unknown>;

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -73,6 +73,7 @@ export interface Probe {
   dom(selector: string): ReturnType<typeof import("@openwork/cdp").readDom>;
   has(text: string): Promise<boolean>;
   composer(): ReturnType<typeof import("@openwork/behaviors").readComposerState>;
+  connectorCatalog(): ReturnType<typeof import("@openwork/behaviors").readConnectorCatalog>;
   storage(key: string): Promise<unknown>;
   storage<T>(key: string, pick: (value: unknown) => T): Promise<T>;
   hash(): Promise<string>;

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -69,7 +69,8 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await probe.eventually(() => appProbe.composer(), {
     within: 15_000, label: "new session has an empty transcript", until: state => state.userMessageCount === 0,
   });
-  await agent.on(world.app).send(allConnectorsPrompt);
+  await appUser.type("composer", allConnectorsPrompt, { replace: true, verify: true });
+  await appUser.click({ role: "button", label: "Run task" });
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
   const listed = await appProbe.eval(() => {
     const cards = Array.from(document.querySelectorAll<HTMLElement>('[data-testid="connector-catalog"]'));

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -4,7 +4,7 @@ import { allConnectorsPrompt, allConnectorsReply, connectorCatalogDiscovery, con
 
 const test = spec.world(connectorCatalogDiscovery, { timeout: 600_000 });
 
-test("chat suggests Slack setup and lets an admin browse every quick-add connector", async ({ world, agent, user, probe, evidence }) => {
+test("chat suggests Slack setup and lets an admin browse every quick-add connector", async ({ world, seed, agent, user, probe, evidence, step }) => {
   const appUser = user.on(world.app);
   const appProbe = probe.on(world.app);
   const webUser = user.on(world.web);
@@ -76,4 +76,46 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);
   evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Clicking Set up Slack emitted exactly one OS browser request for the expected Den origin, connector page, and quickAdd=slack. Navigating that captured URL renders client fields; the agent only searched and did not execute setup or authorize an account", true);
+
+  await step("unconfigured catalog and detail Chat links seed a draft without sending or connecting", async () => {
+    const webProbe = probe.on(world.web);
+    const before = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    expect(before.response.ok).toBe(true);
+    const modelRequests = await world.den.mocks.connector.agentRequests();
+    const authRequests = (await world.den.mocks.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
+    const openedBefore = await world.browserUrls.opened();
+    await webUser.navigate(`${world.den.ref.webUrl}/dashboard/mcp-connections`);
+    await webUser.see({ testId: "connector-add-slack" }, { timeoutMs: 90_000 });
+    await webUser.see({ testId: "connector-chat-slack" });
+    const catalogLink = (await webProbe.connectorCatalog()).chatLinks.find((link) => link.testId === "connector-chat-slack");
+    if (!catalogLink) throw new Error("Unconfigured Slack has no catalog Chat link.");
+    await webUser.click({ testId: "connector-open-slack" });
+    await webUser.see({ testId: "connector-detail-chat" });
+    await webUser.see({ testId: "connector-detail-setup" }, { text: "Set up" });
+    const detailLink = (await webProbe.connectorCatalog()).chatLinks.find((link) => link.testId === "connector-detail-chat");
+    expect(detailLink?.href).toBe(catalogLink.href);
+    const link = new URL(catalogLink.href);
+    expect(`${link.protocol}//${link.host}`).toBe("openwork://chat");
+    expect(link.searchParams.get("connector")).toBe("Slack");
+    expect([...link.searchParams.keys()].sort()).toEqual(["connector", "prompt"]);
+    const prompt = link.searchParams.get("prompt");
+    if (!prompt) throw new Error("Chat link has no starter prompt.");
+    expect(prompt).not.toContain(world.connection.id);
+    // Bridge only OS delivery. The real desktop listener must parse the rendered link and seed its own composer.
+    await seed.deepLink(world.app, catalogLink.href);
+    await appUser.see("composer", { editable: true, text: new RegExp(prompt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")) });
+    const composer = await appProbe.composer();
+    expect(composer.draftText).toContain("Slack");
+    expect(composer.draftText).toContain(prompt);
+    expect(composer.userMessageCount).toBe(0);
+    expect(composer.assistantMessageCount).toBe(0);
+    await appUser.notSee({ testId: "desktop-connection-card" });
+    await appUser.notSee({ testId: "connector-catalog" });
+    expect((await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable")).body).toEqual(before.body);
+    expect(await world.den.mocks.connector.agentRequests()).toEqual(modelRequests);
+    expect((await world.den.mocks.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(authRequests);
+    expect(await probe.toolCalls(world.den.mocks.connector)).toEqual([]);
+    expect(await world.browserUrls.opened()).toEqual(openedBefore);
+    await appUser.screenshot();
+  });
 });

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -65,7 +65,10 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
   await appUser.click({ role: "button", label: "New session" });
-  await appUser.see({ text: "Try one of these:" });
+  await appUser.see("composer", { editable: true });
+  await probe.eventually(() => appProbe.composer(), {
+    within: 15_000, label: "new session has an empty transcript", until: state => state.userMessageCount === 0,
+  });
   await agent.on(world.app).send(allConnectorsPrompt);
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
   const listed = await appProbe.eval(() => {

--- a/evals/specs/den-connector-catalog.e2e.test.ts
+++ b/evals/specs/den-connector-catalog.e2e.test.ts
@@ -1,0 +1,175 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { connectorCatalogManagement, isRecord, records } from "../worlds/library.ts";
+
+const test = spec.world(connectorCatalogManagement, { timeout: 600_000 });
+
+test("Den catalog shows its full inventory, preserves service identity, and keeps account readiness personal", async ({ world, user, probe, step }) => {
+  const admin = user.on(world.web);
+  const member = user.on(world.memberWeb);
+  const catalog = probe.on(world.web);
+  const catalogUrl = `${world.den.ref.webUrl}/dashboard/mcp-connections`;
+  const presetResponse = await probe.api(world.den.admin, "/v1/mcp-connections/presets");
+  expect(presetResponse.response.ok).toBe(true);
+  if (!isRecord(presetResponse.body)) throw new Error("Den returned no preset inventory.");
+  const presets = records(presetResponse.body.presets);
+  const presetIds = presets.map((entry) => entry.presetId);
+  expect(presetIds).toEqual(expect.arrayContaining(["github", "notion", "slack", "context7", "exa"]));
+  expect(new Set(presetIds).size).toBe(presetIds.length);
+  const popularIds = ["gmail", "github", "google-drive", "google-calendar", "notion", "slack"];
+  const expectedIds = [...popularIds, "microsoft-365", ...presetIds.filter((id) => !popularIds.includes(String(id)))];
+  const before = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+  expect(before.response.ok).toBe(true);
+  const requestsBefore = (await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
+
+  await step("browse every integration with an accurate total and setup requirements", async () => {
+    await admin.see({ testId: "connector-catalog-count" }, { text: `Showing 6 of ${expectedIds.length} integrations`, timeoutMs: 90_000 });
+    await admin.see({ role: "button", label: "Set up Slack" });
+    await admin.see({ role: "button", label: "Connect Notion" });
+    await admin.click({ testId: "connector-catalog-more" });
+    const facts = await catalog.connectorCatalog();
+    expect(facts.entries.map((entry) => entry.id)).toEqual(expectedIds);
+    expect(facts.summary).toBe(`Showing ${expectedIds.length} of ${expectedIds.length} integrations`);
+    expect(facts.horizontalOverflow).toBe(false);
+    expect(facts.entries.find((entry) => entry.id === "slack")?.status).toBe("OAuth app required");
+    expect(facts.entries.find((entry) => entry.id === "exa")?.status).toBe("API key");
+    expect(facts.entries.find((entry) => entry.id === "context7")?.status).toBe("Instant — no sign-in");
+    expect(facts.chatLinks.map((link) => link.testId)).toEqual(expectedIds.map((id) => `connector-chat-${id}`));
+    for (const entry of facts.entries) {
+      expect(entry.text.trim().length).toBeGreaterThan(entry.id.length);
+      expect(entry.href).toContain(`/mcp-connections/${entry.id}`);
+      expect(entry.status.length).toBeGreaterThan(0);
+    }
+    await admin.screenshot();
+  });
+
+  await step("an unconfigured connector keeps Chat separate from setup", async () => {
+    const slackChat = (await catalog.connectorCatalog()).chatLinks.find((link) => link.testId === "connector-chat-slack");
+    expect(slackChat).toBeDefined();
+    await admin.click({ testId: "connector-open-slack" });
+    await admin.see({ testId: "connector-detail-chat" });
+    await admin.see({ testId: "connector-detail-setup" }, { text: "Set up" });
+    expect((await catalog.connectorCatalog()).chatLinks).toContainEqual({ testId: "connector-detail-chat", href: slackChat?.href });
+    await admin.reload();
+    await admin.see({ testId: "connector-detail-chat" });
+    await admin.see({ testId: "connector-detail-setup" }, { text: "Set up" });
+    await admin.navigate(catalogUrl);
+  });
+
+  await step("filter the full inventory and recover from an empty result", async () => {
+    await admin.type({ testId: "connector-smart-bar" }, "granola", { replace: true });
+    await admin.see({ testId: "connector-catalog-count" }, { text: `1 of ${expectedIds.length} integrations match` });
+    expect((await catalog.connectorCatalog()).entries.map((entry) => entry.id)).toEqual(["granola"]);
+    await admin.type({ testId: "connector-smart-bar" }, "catalog-no-match", { replace: true });
+    await admin.see({ testId: "connector-catalog-count" }, { text: `0 of ${expectedIds.length} integrations match` });
+    expect((await catalog.connectorCatalog()).entries).toEqual([]);
+    await admin.type({ testId: "connector-smart-bar" }, "gmail", { replace: true });
+    await admin.click({ testId: "connector-open-gmail" });
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Gmail\b/ });
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    await admin.reload();
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Gmail\b/ });
+    await admin.see({ text: "Google Workspace — one connection covers Gmail, Drive, and Calendar" });
+    await admin.screenshot();
+    for (const [id, label] of [["google-drive", "Google Drive"], ["google-calendar", "Google Calendar"]]) {
+      await admin.navigate(catalogUrl);
+      await admin.click({ testId: `connector-open-${id}` });
+      await admin.see({ testId: "connector-detail-title" }, { text: new RegExp(`^${label}\\b`) });
+    }
+    const after = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    expect(after.body).toEqual(before.body);
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(requestsBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+  });
+
+  await step("native Microsoft setup survives reload alongside Google without claiming account authorization", async () => {
+    await admin.navigate(catalogUrl);
+    await admin.type({ testId: "connector-smart-bar" }, "Microsoft", { replace: true });
+    await admin.click({ testId: "connector-add-microsoft-365" });
+    await admin.see({ testId: "microsoft-365-dialog" });
+    await admin.type({ testId: "microsoft-tenant-id" }, "11111111-1111-4111-8111-111111111111");
+    await admin.type({ placeholder: "00000000-0000-0000-0000-000000000000", nth: 1 }, "22222222-2222-4222-8222-222222222222");
+    await admin.type({ placeholder: "Paste the secret value, not its ID" }, "catalog-microsoft-test-secret");
+    await admin.click({ testId: "save-microsoft-365" });
+    await admin.notSee({ testId: "microsoft-365-dialog" });
+    await admin.reload();
+    await admin.see({ testId: "connector-catalog-count" }, { timeoutMs: 90_000 });
+    await admin.type({ testId: "connector-smart-bar" }, "", { replace: true });
+    await admin.click({ testId: "connector-catalog-more" });
+    for (const id of ["gmail", "google-drive", "google-calendar", "microsoft-365"]) {
+      await admin.see({ testId: `connector-status-${id}` }, { text: "Needs your account" });
+      await admin.see({ testId: `connector-recover-${id}` }, { text: "Connect" });
+      await admin.notSee({ testId: `connector-add-${id}` });
+    }
+    const manageable = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    expect(manageable.body).toEqual(before.body);
+    const usable = await probe.api(world.den.admin, "/v1/mcp-connections?scope=usable");
+    expect(usable.response.ok).toBe(true);
+    if (!isRecord(usable.body)) throw new Error("Den returned no usable connections.");
+    for (const id of ["google-workspace", "microsoft-365"]) {
+      expect(records(usable.body.connections).filter((entry) => entry.id === id)).toMatchObject([
+        { id, connectedForMe: false, connected: false },
+      ]);
+      await admin.navigate(`${catalogUrl}/${id}`);
+      await admin.reload();
+      await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+      await admin.see({ role: "link", label: "Connect your account" });
+      await admin.notSee({ testId: "connector-detail-setup" });
+      await admin.notSee({ testId: "connector-detail-test-tools" });
+    }
+    await admin.click({ testId: "mcp-connection-more-microsoft-365" });
+    await admin.click({ testId: "edit-mcp-connection-microsoft-365" });
+    await admin.see({ testId: "microsoft-365-dialog" }, { text: /Credentials saved/ });
+    await admin.see({ text: /Saved client ID:.*22222222-2222-4222-8222-222222222222/ });
+    await admin.click({ role: "button", label: "Cancel" });
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(requestsBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+  });
+
+  await step("a member connects without making the admin personally connected", async () => {
+    await member.see({ text: "Catalog Notes" }, { timeoutMs: 90_000 });
+    await member.click({ testId: `connect-my-mcp-account-${world.connection.id}` });
+    await member.see({ testId: `disconnect-my-mcp-account-${world.connection.id}` }, { timeoutMs: 120_000 });
+    const memberState = await probe.api(world.den.members.member, "/v1/mcp-connections?scope=usable");
+    if (!isRecord(memberState.body)) throw new Error("Den returned no member connections.");
+    expect(records(memberState.body.connections).find((entry) => entry.id === world.connection.id)).toMatchObject({ connectedForMe: true });
+    await admin.navigate(`${catalogUrl}/${world.connection.id}`);
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    await admin.notSee({ testId: "connector-detail-test-tools" });
+    const adminState = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    if (!isRecord(adminState.body)) throw new Error("Den returned no admin connections.");
+    expect(records(adminState.body.connections).find((entry) => entry.id === world.connection.id)).toMatchObject({ connectedForMe: false, connected: true });
+    // Trusted, hit-tested clicks must reach below the detail row, not merely find menu text.
+    await admin.click({ testId: `mcp-connection-more-${world.connection.id}` });
+    await admin.click({ testId: `edit-mcp-connection-${world.connection.id}` });
+    await admin.see({ testId: "edit-mcp-connection-dialog" });
+    await admin.see({ testId: "edit-mcp-name" }, { value: "Catalog Notes" });
+    await admin.click({ role: "button", label: "Cancel" });
+    await admin.notSee({ testId: "edit-mcp-connection-dialog" });
+    expect((await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable")).body).toEqual(adminState.body);
+    await admin.screenshot();
+  });
+
+  await step("OAuth startup rejection offers recovery without a success notice", async () => {
+    await admin.navigate(`${catalogUrl}/${world.rejectedConnection.id}`);
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    const requestsBefore = (await world.rejected.requestLog()).length;
+    const authBefore = (await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token");
+    await admin.click({ role: "button", label: "Connect" });
+    await admin.see({ text: /Could not connect "Catalog Recovery"/ }, { timeoutMs: 60_000 });
+    await admin.see({ role: "link", label: "Review connection" });
+    await admin.notSee({ text: /added for everyone|Finish signing in|Your account is connected/ });
+    const requests = (await world.rejected.requestLog()).slice(requestsBefore);
+    expect(requests.some((entry) => entry.path === "/mcp" && entry.faulted && entry.status === 503)).toBe(true);
+    expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(authBefore);
+    expect(await probe.toolCalls(world.connector)).toEqual([]);
+    await admin.click({ role: "link", label: "Review connection" });
+    await admin.see({ testId: "connector-detail-title" }, { text: /^Catalog Recovery\b/ });
+    await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    await admin.notSee({ testId: "connector-detail-test-tools" });
+    const state = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
+    if (!isRecord(state.body)) throw new Error("Den returned no connections after the failed sign-in.");
+    expect(records(state.body.connections).find((entry) => entry.id === world.rejectedConnection.id)).toMatchObject({ connectedForMe: false, connected: false });
+    await admin.screenshot();
+  });
+});

--- a/evals/specs/den-connector-catalog.e2e.test.ts
+++ b/evals/specs/den-connector-catalog.e2e.test.ts
@@ -136,6 +136,8 @@ test("Den catalog shows its full inventory, preserves service identity, and keep
     expect(records(memberState.body.connections).find((entry) => entry.id === world.connection.id)).toMatchObject({ connectedForMe: true });
     await admin.navigate(`${catalogUrl}/${world.connection.id}`);
     await admin.see({ testId: "connector-detail-state" }, { text: "Needs your account" });
+    const information = await catalog.dom('[data-testid="connector-detail-information"]');
+    expect(JSON.stringify(information)).not.toContain("Added by");
     await admin.notSee({ testId: "connector-detail-test-tools" });
     const adminState = await probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable");
     if (!isRecord(adminState.body)) throw new Error("Den returned no admin connections.");
@@ -161,7 +163,9 @@ test("Den catalog shows its full inventory, preserves service identity, and keep
     await admin.see({ role: "link", label: "Review connection" });
     await admin.notSee({ text: /added for everyone|Finish signing in|Your account is connected/ });
     const requests = (await world.rejected.requestLog()).slice(requestsBefore);
-    expect(requests.some((entry) => entry.path === "/mcp" && entry.faulted && entry.status === 503)).toBe(true);
+    expect(requests, "the provider endpoint receives the declared failure before authorization").toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "/mcp", faulted: true, status: 503 }),
+    ]));
     expect((await world.connector.requests()).filter((entry) => entry.path === "/authorize" || entry.path === "/token")).toEqual(authBefore);
     expect(await probe.toolCalls(world.connector)).toEqual([]);
     await admin.click({ role: "link", label: "Review connection" });

--- a/evals/specs/den-connector-catalog.e2e.test.ts
+++ b/evals/specs/den-connector-catalog.e2e.test.ts
@@ -107,8 +107,9 @@ test("Den catalog shows its full inventory, preserves service identity, and keep
     expect(usable.response.ok).toBe(true);
     if (!isRecord(usable.body)) throw new Error("Den returned no usable connections.");
     for (const id of ["google-workspace", "microsoft-365"]) {
+      // Legacy native entries use connected for configured client presence, not account authorization.
       expect(records(usable.body.connections).filter((entry) => entry.id === id)).toMatchObject([
-        { id, connectedForMe: false, connected: false },
+        { id, connectedForMe: false, connected: true, credentialMode: "per_member" },
       ]);
       await admin.navigate(`${catalogUrl}/${id}`);
       await admin.reload();

--- a/evals/specs/plugin-mcp-connector-parity.test.ts
+++ b/evals/specs/plugin-mcp-connector-parity.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
-import { localMysqlIsRunning, localRedisIsRunning, server, test } from "@openwork/testkit";
+import { queryDenDatabase } from "@openwork/env";
+import { localMysqlIsRunning, localRedisIsRunning, needs, server, test } from "@openwork/testkit";
 import {
   denLibraryPluginCreateRequest,
   emptyLibraryMcpConnectionForm,
@@ -162,6 +163,103 @@ test.skipIf(!mysqlOpen || !redisOpen)(title, { timeout: 300_000 }, async ({ evid
   evidence.recordAssertionEvidence(
     "A plugin-owned connector follows the plugin's archive and restore",
     "After POST /v1/plugins/:id/archive the manageable Connectors list no longer contained the plugin-owned connection; after POST /v1/plugins/:id/restore it was listed again with the plugin as its identity manager.",
+    true,
+  );
+});
+
+test("persisted GitHub no-auth bindings stay discoverable without allowing new anonymous setup or overriding OAuth", { timeout: 300_000 }, async ({ evidence, place, skip }) => {
+  needs({ placement: "local" });
+  if (!await localMysqlIsRunning() || !await localRedisIsRunning()) skip("needs: local MySQL and Redis");
+  const organizationName = `Legacy Connector ${Date.now().toString(36)}`;
+  await using den = await server({ place, web: false, org: { name: organizationName, members: {} } });
+  if (!den.database) throw new Error("Persisted legacy connector coverage requires an isolated database");
+  const orgId = await organizationId(den.admin, organizationName);
+  const headers = orgHeaders(den.admin, orgId);
+  const url = "https://api.githubcopilot.com/mcp/";
+  const databaseUrl = den.database.url;
+
+  async function createPlugin(authType: "none" | "oauth") {
+    return denFetch(den.admin, "/v1/plugins", {
+      method: "POST", headers,
+      body: JSON.stringify({ name: "Legacy GitHub", orgWide: true, components: [mcpComponent(url, { authType, credentialMode: "shared" })] }),
+    });
+  }
+
+  const rejected = await createPlugin("none");
+  expect(rejected.response.status, rejected.text).toBe(409);
+  expect(rejected.body).toMatchObject({ error: "mcp_auth_type_mismatch" });
+  const created = await createPlugin("oauth");
+  expect(created.response.status, created.text).toBe(201);
+  const plugin = isRecord(created.body) && isRecord(created.body.item) ? created.body.item : null;
+  if (!plugin || typeof plugin.id !== "string") throw new Error("Missing created plugin");
+  const bindings = await queryDenDatabase(databaseUrl,
+    "SELECT external_mcp_connection_id AS connectionId, config_object_id AS configObjectId FROM plugin_mcp_requirement_binding WHERE organization_id = ? AND plugin_id = ?",
+    [orgId, plugin.id],
+  );
+  const binding = bindings[0];
+  if (!isRecord(binding) || typeof binding.connectionId !== "string" || typeof binding.configObjectId !== "string") throw new Error("Missing created binding");
+  const connectionId = binding.connectionId;
+
+  // Only the isolated fixture bypasses current setup validation to model a row
+  // accepted before the GitHub preset existed. No provider request is needed.
+  await queryDenDatabase(databaseUrl,
+    "UPDATE external_mcp_connection SET auth_type = 'none', connected_at = NOW() WHERE organization_id = ? AND id = ?",
+    [orgId, connectionId],
+  );
+
+  const minted = await denFetch(den.admin, "/v1/mcp/token", {
+    method: "POST", headers, body: JSON.stringify({ scopes: ["mcp:read"] }),
+  });
+  expect(minted.response.status, minted.text).toBe(200);
+  if (!isRecord(minted.body) || typeof minted.body.appHostToken !== "string") throw new Error("Missing desktop MCP token");
+  const token = minted.body.appHostToken;
+
+  async function desktopServerIndex() {
+    const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
+      method: "POST", signal: AbortSignal.timeout(30_000),
+      headers: { authorization: `Bearer ${token}`, accept: "application/json, text/event-stream", "content-type": "application/json", "x-openwork-mcp-client-capabilities": "mcp-app-host-v1" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "resources/read", params: { uri: "openwork://connect/mcp-servers/index.json" } }),
+    });
+    const text = await response.text();
+    expect(response.status, text).toBe(200);
+    const data = text.split("\n").find((line) => line.startsWith("data:"));
+    const rpc: unknown = JSON.parse(data ? data.slice(5) : text);
+    if (!isRecord(rpc) || !isRecord(rpc.result) || !Array.isArray(rpc.result.contents)) throw new Error(`Missing MCP index: ${text}`);
+    const content = rpc.result.contents[0];
+    if (!isRecord(content) || typeof content.text !== "string") throw new Error("Missing MCP index content");
+    const index: unknown = JSON.parse(content.text);
+    if (!isRecord(index) || !Array.isArray(index.servers)) throw new Error("Invalid MCP index");
+    return index.servers.filter(isRecord).map((entry) => entry.connectionId);
+  }
+
+  for (const requiredAuthType of [null, "none", "oauth"]) {
+    if (requiredAuthType === "oauth") {
+      const versioned = await denFetch(den.admin, `/v1/config-objects/${binding.configObjectId}/versions`, {
+        method: "POST", headers,
+        body: JSON.stringify({ input: { normalizedPayloadJson: { mcpServers: { crm: { type: "remote", url, oauth: true } } } } }),
+      });
+      expect(versioned.response.status, versioned.text).toBe(201);
+    }
+    await queryDenDatabase(databaseUrl,
+      "UPDATE plugin_mcp_requirement_binding SET required_auth_type = ? WHERE organization_id = ? AND plugin_id = ?",
+      [requiredAuthType, orgId, plugin.id],
+    );
+    const listed = await denFetch(den.admin, "/v1/mcp-connections?scope=usable", { headers });
+    expect(listed.response.status, listed.text).toBe(200);
+    const rows = isRecord(listed.body) && Array.isArray(listed.body.connections) ? listed.body.connections.filter(isRecord) : [];
+    expect(rows.find((row) => row.id === connectionId)).toMatchObject({
+      authType: "none", connected: true, authPolicyConfirmed: true,
+      authTypeMismatch: requiredAuthType === "oauth", setupRequired: requiredAuthType === "oauth",
+    });
+    const index = await desktopServerIndex();
+    expect(index.includes(connectionId), `required auth: ${requiredAuthType}`).toBe(requiredAuthType !== "oauth");
+  }
+  expect(await queryDenDatabase(databaseUrl,
+    "SELECT auth_type AS authType FROM external_mcp_connection WHERE organization_id = ? AND id = ?", [orgId, connectionId],
+  )).toEqual([{ authType: "none" }]);
+  evidence.recordAssertionEvidence(
+    "Legacy GitHub discovery does not relax new setup or explicit OAuth",
+    "New anonymous plugin configuration was rejected. A persisted connected none binding, with either no required auth or required none, remained setup-ready and present in the desktop MCP index. Explicit OAuth blocked it without rewriting the stored auth type. No GitHub endpoint was contacted.",
     true,
   );
 });

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -387,14 +387,11 @@ export async function connectorCatalogManagement(seed: Seed) {
   });
   if (!google.response.ok) throw new Error("Could not arrange the native Google client.");
   // Fault the provider boundary, not Den's startup response or persisted readiness.
-  const rejected = await seed.faultProxy({
-    ...den,
-    ref: { apiUrl: den.mocks.connector.url, webUrl: den.mocks.connector.url },
-  });
+  const rejected = await seed.faultProxy(den);
   await rejected.faults.status("/mcp", 503, { times: 1000, body: { error: "catalog_provider_unavailable" } });
   const rejectedConnection = await seed.orgConnection(den.admin, {
     name: "Catalog Recovery",
-    url: `${rejected.ref.apiUrl}/mcp`,
+    url: `${rejected.ref.webUrl}/mcp`,
     authType: "oauth",
     credentialMode: "per_member",
     access: { orgWide: true },

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -368,10 +368,36 @@ export async function connectorBranding(seed: Seed) {
   return { app, den, prompt, failurePrompt, proof };
 }
 
-export async function connectorsQuickAdd(seed: Seed) {
+export async function connectorCatalogManagement(seed: Seed) {
   const den = await seed.den({
-    org: { name: `Connectors Quick Add ${Date.now()}`, admin: { name: "Sarah" } },
+    org: { name: `Connector Catalog ${Date.now()}`, admin: { name: "Catalog Admin" }, members: { member: { name: "Catalog Member" } } },
     mocks: { connector: seed.mock() },
+  });
+  const connection = await seed.orgConnection(den.admin, {
+    name: "Catalog Notes",
+    url: den.mocks.connector.mcpUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
+  });
+  // Native OAuth clients intentionally have no managed MCP row.
+  const google = await seed.api(den.admin, "/v1/oauth-providers/google-workspace/client", {
+    method: "POST",
+    body: JSON.stringify({ clientId: "catalog-test-client", clientSecret: "catalog-test-secret" }),
+  });
+  if (!google.response.ok) throw new Error("Could not arrange the native Google client.");
+  // Fault the provider boundary, not Den's startup response or persisted readiness.
+  const rejected = await seed.faultProxy({
+    ...den,
+    ref: { apiUrl: den.mocks.connector.url, webUrl: den.mocks.connector.url },
+  });
+  await rejected.faults.status("/mcp", 503, { times: 1000, body: { error: "catalog_provider_unavailable" } });
+  const rejectedConnection = await seed.orgConnection(den.admin, {
+    name: "Catalog Recovery",
+    url: `${rejected.ref.apiUrl}/mcp`,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
   });
   const web = await seed.web({
     den,
@@ -380,7 +406,10 @@ export async function connectorsQuickAdd(seed: Seed) {
     headless: true,
     viewport: { width: 1440, height: 1200 },
   });
-  return { web, connector: den.mocks.connector };
+  const memberWeb = await seed.web({
+    den, signedInAs: den.members.member, startPath: `/dashboard/your-connections?connectionId=${connection.id}`, headless: true,
+  });
+  return { den, web, memberWeb, connection, rejectedConnection, connector: den.mocks.connector, rejected };
 }
 
 export async function libraryConnectorDiscovery(seed: Seed) {

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -1982,6 +1982,7 @@ export type ExternalMcpPresetResponse = {
   description: string;
   url: string;
   authType: "oauth" | "apikey" | "none";
+  supportedAuthTypes?: Array<"oauth" | "apikey" | "none">;
   requiresOAuthClient?: boolean;
   authorizationServerIssuer?: string;
   defaultOAuthScopes?: Array<string>;


### PR DESCRIPTION
## Summary

Provide working service connectors with useful operations, reliable setup, and personal readiness. Native service management is implemented in companion #4693; narrowing descriptions is not the completion criterion. **Chat remains available before connection** for planning and setup help. It seeds an unsent draft and does not authorize account access or writes.

- Popular-first catalog with complete inventory/filtering, configured list, and service-specific detail pages.
- The earlier Google/Sheets/date-wide copy restrictions are superseded by the real service operations in #4693. Reconcile the catalog copy with that implementation during integration; removing service claims is not a substitute for functionality.
- Explain Slack app eligibility, GitHub OAuth/PAT choices, and anonymous-service limits.
- Preserve Chat during setup loading/failure; provide retry instead of a named empty custom form.
- Use personal readiness with setup, issuer-review, and reconnect precedence.
- Include native Microsoft/Google configurations after reload, and edit the exact selected Microsoft connection.
- Make OAuth startup outcomes explicit, retain recovery controls, and preserve selected authentication during discovery.
- Preserve GitHub PAT compatibility; separate strict new-setup validation from stored-connection compatibility.
- Roll back only the newly created record after failed initial API-key/anonymous validation.
- Keep detail menus reachable; omit creator name/email from the new Information facts.
- Regenerate the SDK for optional supported authentication metadata.

#4541's overlapping inventory/readiness work is incorporated here. Coordinate that PR rather than landing it independently. #4342 remains separate provided-Google-client work and needs reconciliation with this parent. No production provider accounts, credentials, merges, or releases are included.

## Service functionality — companion #4693

#4693 implements 32 native operations: Gmail sending and mailbox/label/draft management; Calendar read/edit/cancel; Drive folders, moves, trash/restore and paginated/date-filtered search; Sheets creation and cell read/write/append; and core Outlook/OneDrive management. It preserves selected-account identity and administrator permission controls. Existing draft-only access does not automatically enable sending.

The exact-head gateway journey on `3a2df689122a085b98238387ef07b0a2f7d8e974` passes: 33 discoverable contracts, five actual provider-witness mutations, read-only and confirmation denials, alternate-account isolation, and administrator write revocation. [Published eight-group evidence](https://github.com/different-ai/openwork/pull/4693#issuecomment-5607734994). This is executable backend functionality, not copy-only work; real-provider certification and the UI evidence gap below remain separate. Deliver the service implementation alongside this UI outcome.

## Review comments addressed

At `7a7563c431e2cfa148f07a984056e4be2976ecd8`:

- Creator attribution: Added now contains only the date. Negative tests cover names and email fallbacks in the Information facts.
- Legacy GitHub compatibility: previously accepted stored `none` bindings remain discoverable and retain their identity on reimport. New anonymous plugin configuration is rejected; explicit OAuth still blocks an incompatible connection. The existing boundary journey checks the persisted row and desktop MCP server index.
- The subsequent visible-versus-runtime listing comment was checked against the merge base: the listing route and `includeAuthMismatches` behavior already existed and are unchanged. A reply documents the comparison and the boundary assertions; the thread is resolved.

All current review threads are resolved. This does not replace executable proof or authorize merging.

## Verification — Incomplete

Head: `7a7563c431e2cfa148f07a984056e4be2976ecd8`.
Rebased onto `dev@9a8aeba852a91426e3142222d140f46c4a28ded8`; four signed commits.

### Passed on this head

| Check | Result |
|---|---|
| `pnpm evals:pr specs/plugin-mcp-connector-parity.test.ts` | **2 passed, 0 failed, 0 skipped**; real isolated local Den/MySQL/Redis. Includes legacy GitHub discovery, rejection of new anonymous setup, and explicit OAuth enforcement. |
| `pnpm evals:e2e connector-catalog` with the exact `OPENWORK_EVAL_REF` below | **1 passed, 0 failed, 0 skipped**; cold-boot Daytona, 388.74s. Full discovery/filtering, actual OS-to-Den setup handoff, new-task submission, and disconnected Chat producing an unsent draft without extra authorization/tool/model calls. |
| `test/github-plugin-mcp-auth.test.ts` | **8 passed**, 48 assertions. |
| `test/external-mcp-readiness.test.ts` | **5 passed**, 54 assertions. |
| `tests/connector-detail.test.ts` | **15 passed**, 77 assertions. |
| Selected `marketplace-cloud-readiness.test.ts` reimport regression | **1 passed**, 10 assertions, 33 unrelated tests filtered out; fresh isolated schema, mocked provider boundary. |

Focused commands:
```sh
pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/github-plugin-mcp-auth.test.ts
pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/external-mcp-readiness.test.ts
pnpm --filter @openwork-ee/den-web exec bun test --conditions development tests/connector-detail.test.ts
DATABASE_URL=<fresh-isolated-test-database> pnpm --filter @openwork-ee/den-api exec bun test --conditions development --test-name-pattern 'GitHub reimport preserves stored none with either credential-mode default and rejects explicit OAuth' test/marketplace-cloud-readiness.test.ts
```

### Remaining tooling/evidence gap

`den-connector-catalog` completed its functional assertions: inventory, disconnected Chat, filtering/service identity, Microsoft setup persistence, personal readiness, usable detail controls, creator-attribution exclusion, the injected `/mcp` 503 witness, recovery UI, and no false success notice. Its **final `Page.captureScreenshot` timed out after 59,636ms**. The runner therefore recorded **0 passed, 1 failed, 0 skipped**, exit 1, in 448.96s. It is not counted as a passing journey.

Both E2E commands printed `placement: daytona (daytona CLI authenticated)`:
```sh
env -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL OPENWORK_EVAL_REF=7a7563c431e2cfa148f07a984056e4be2976ecd8 pnpm evals:e2e den-connector-catalog
env -u OPENWORK_EVAL_DEN_API_URL -u OPENWORK_EVAL_DEN_WEB_URL OPENWORK_EVAL_REF=7a7563c431e2cfa148f07a984056e4be2976ecd8 pnpm evals:e2e connector-catalog
```

The old functional failures are resolved: the fault fixture now uses its root URL rather than the Den API prefix; the new-task step types and clicks Run task instead of invoking a session-only control. No assertions were weakened.

The reimport test initially could not initialize against an old shared test schema. It subsequently passed on a fresh owned schema; the shared database was not migrated. All owned test databases/services and all six final E2E sandboxes were cleaned up.

## Evidence

The [verification summary](https://github.com/different-ai/openwork/pull/4305#issuecomment-5606467021) records the full selection and remaining gap. Original exact-head run directories under `evals/results/test-runs/`:
- `2026-09-09T18-58-47-684Z-a-plugin-s-mcp-server-is-configured-like-a-connector-and-leaves-the-connectors-l`
- `2026-09-09T18-59-13-682Z-persisted-github-no-auth-bindings-stay-discoverable-without-allowing-new-anonymo`
- `2026-09-09T18-58-25-545Z-den-catalog-shows-its-full-inventory-preserves-service-identity-and-keeps-accoun`
- `2026-09-09T19-06-06-348Z-chat-suggests-slack-setup-and-lets-an-admin-browse-every-quick-add-connector`

Full composed-report upload remains unavailable in the local verification environment: the review publishing credential requires Infisical sign-in. The summary is not represented as a completed private report upload. Complete the screenshot run/report publication before claiming full merge-readiness proof.

Live sign-in/tool execution/refresh across all providers remains separate from hermetic PR verification and requires approved accounts/apps. This PR does not claim universal provider availability or full provider API parity.