### PR TITLE
feat(access): add team modes, granular app permissions, and member guidance

### DIFF
--- a/apps/app/src/app/cloud/desktop-app-restrictions.ts
+++ b/apps/app/src/app/cloud/desktop-app-restrictions.ts
@@ -1,6 +1,9 @@
-import type { DesktopPolicyKey } from "@openwork/types/den/desktop-policies";
+import {
+  desktopPolicyUserNotices,
+  type DesktopPolicyKey,
+} from "@openwork/types/den/desktop-policies";
 import type { DenDesktopConfig } from "../lib/den";
-import type { ModelRef } from "../types";
+import type { ModelRef, SettingsTab } from "../types";
 
 export type DesktopAppRestrictionKey = DesktopPolicyKey;
 
@@ -15,6 +18,29 @@ export function checkDesktopAppRestriction(input: {
   restriction: DesktopAppRestrictionKey;
 }) {
   return input.config?.[input.restriction] === false;
+}
+
+/** Catalog copy explaining why the organization blocked a capability. */
+export function desktopRestrictionNotice(restriction: DesktopAppRestrictionKey) {
+  return desktopPolicyUserNotices[restriction];
+}
+
+/**
+ * Settings tabs that stay reachable when `allowControlSettings` is blocked.
+ * Members can still see their Cloud account, switch organizations, and use
+ * Cloud features that are not desktop settings; every other tab is hidden and
+ * redirected.
+ */
+const SETTINGS_TABS_WITHOUT_CONTROL = new Set<SettingsTab>(["cloud-account"]);
+
+export const SETTINGS_TAB_WITHOUT_CONTROL: SettingsTab = "cloud-account";
+
+export function isSettingsTabAllowed(input: {
+  tab: SettingsTab;
+  checkRestriction: DesktopAppRestrictionChecker;
+}) {
+  if (!input.checkRestriction({ restriction: "allowControlSettings" })) return true;
+  return SETTINGS_TABS_WITHOUT_CONTROL.has(input.tab);
 }
 
 export function isDesktopProviderBlocked(input: {

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -1,10 +1,13 @@
 import { useSyncExternalStore } from "react";
 
+import { desktopRestrictionNotice, type DesktopAppRestrictionChecker } from "../../../app/cloud/desktop-app-restrictions";
+
 import { applyEdits, modify, parse, printParseErrorCode } from "jsonc-parser";
 
 import { t } from "../../../i18n";
 import {
   getMcpServerName,
+  isBuiltInOpenWorkExtension,
   MCP_QUICK_CONNECT,
   type McpDirectoryInfo,
 } from "../../../app/constants";
@@ -109,6 +112,7 @@ export type McpConnectResult =
   | { ok: false; error: string };
 
 export function createConnectionsStore(options: {
+  checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   client: () => Client | null;
   setClient: (value: Client | null) => void;
   projectDir: () => string;
@@ -659,7 +663,31 @@ export function createConnectionsStore(options: {
     }
   }
 
+  function mcpMutationDenied(builtIn: boolean) {
+    const restriction = builtIn ? "allowBuiltInExtensions" : "allowManageExtensions";
+    if (!options.checkDesktopAppRestriction({ restriction })) return null;
+    const message = desktopRestrictionNotice(restriction);
+    setStateField("mcpStatus", message);
+    return message;
+  }
+
+  function builtInMcp(name: string) {
+    return MCP_QUICK_CONNECT.find((entry) =>
+      isBuiltInOpenWorkExtension(entry) && getMcpServerName(entry) === name,
+    );
+  }
+
   async function connectMcp(entry: McpDirectoryInfo): Promise<McpConnectResult> {
+    const builtIn = builtInMcp(getMcpServerName(entry));
+    // Use catalog configuration for built-ins; caller-supplied metadata must
+    // not turn an arbitrary URL or command into an allowed built-in.
+    if (builtIn) entry = builtIn;
+    // Cloud repair uses the signed-in organization's reconciler below, not
+    // caller-supplied MCP configuration. Existing service access stays usable.
+    if (entry.managedBy !== "openwork-connect") {
+      const error = mcpMutationDenied(Boolean(builtIn));
+      if (error) return { ok: false, error };
+    }
     const startedAt = perfNow();
     const openworkSnapshot = getOpenworkSnapshot();
     const isRemoteWorkspace =
@@ -756,7 +784,7 @@ export function createConnectionsStore(options: {
         if (!canUseOpenworkServer || !openworkClient || !openworkWorkspaceId) {
           throw new Error("OpenWork server is required to repair agent access to connected services.");
         }
-        const context = await resolveCloudMcpOperationContext(entry.url);
+        const context = await resolveCloudMcpOperationContext(null);
         if (!context) {
           throw new Error("Sign in to OpenWork Cloud and choose an organization first.");
         }
@@ -1206,6 +1234,7 @@ export function createConnectionsStore(options: {
   }
 
   async function removeMcp(name: string) {
+    if (mcpMutationDenied(Boolean(builtInMcp(name)))) return;
     try {
       setStateField("mcpStatus", null);
 
@@ -1288,6 +1317,7 @@ export function createConnectionsStore(options: {
   // this never gets called when the server is unavailable. Reload UX comes
   // from the existing reload-required popup; no extra banner here.
   async function setMcpEnabled(name: string, enabled: boolean) {
+    if (mcpMutationDenied(Boolean(builtInMcp(name)))) return;
     try {
       const { openworkClient, openworkWorkspaceId, canUseOpenworkServer } =
         await resolveWritableOpenworkTarget();

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -238,6 +238,8 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
   // When the organization blocks settings control, the settings surface is the
   // Cloud account page only, so the entry is labelled for where it lands and
   // the Debug shortcut is hidden.
+  // Reuses Den’s existing allowControlSettings boolean contract (PR #1838);
+  // no new response field is required. Missing values retain the hook’s default.
   const controlSettingsBlocked = useDesktopRestriction("allowControlSettings");
 
   const docsControlAction = useMemo<OpenworkControlAction>(() => ({

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import { t } from "@/i18n";
 import { usePlatform } from "../../../kernel/platform";
 import { isDenSessionRestoring, useDenAuth } from "../../cloud/den-auth-provider";
+import { useDesktopRestriction } from "../../cloud/desktop-config-provider";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useShellConfig } from "../../../shell/shell-config";
 import type { OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -234,6 +235,10 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
 
   const openSettings = props.onOpenAccountSettings;
   const openDocs = useCallback(() => platform.openLink(DOCS_URL), [platform]);
+  // When the organization blocks settings control, the settings surface is the
+  // Cloud account page only, so the entry is labelled for where it lands and
+  // the Debug shortcut is hidden.
+  const controlSettingsBlocked = useDesktopRestriction("allowControlSettings");
 
   const docsControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "status.docs.open",
@@ -456,7 +461,7 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
           </div>
         ) : null}
 
-        {connectNeedsAttention ? (
+        {connectNeedsAttention && !controlSettingsBlocked ? (
           <DropdownMenuItem onClick={() => navigate("/settings/debug")}>
             <Stethoscope className="size-3.5" />
             Run diagnostics
@@ -480,12 +485,12 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
             </span>
           </DropdownMenuItem>
         ) : null}
-        {connectNeedsAttention || promoVisible ? <DropdownMenuSeparator /> : null}
+        {(connectNeedsAttention && !controlSettingsBlocked) || promoVisible ? <DropdownMenuSeparator /> : null}
 
         {props.showSettingsButton !== false ? (
           <DropdownMenuItem onClick={openSettings}>
             <Settings className="size-3.5" />
-            {t("status.settings")}
+            {controlSettingsBlocked ? t("settings.tab_cloud_account") : t("status.settings")}
           </DropdownMenuItem>
         ) : null}
         {shellConfig.docsButton ? (

--- a/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import * as React from "react";
+import { desktopPolicyDefinitions } from "@openwork/types/den/desktop-policies";
 import { ArrowUpRight } from "lucide-react";
 import { useNavigate } from "react-router";
 
@@ -12,6 +13,14 @@ import {
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useOrgRestrictions } from "../../cloud/desktop-config-provider";
+import {
+  SettingsList,
+  SettingsListItem,
+  SettingsListItemContent,
+  SettingsListItemTitle,
+} from "../settings-list";
 import { t } from "@/i18n";
 import { SignInFallbackNotice } from "@/react-app/domains/cloud/signin-fallback-notice";
 import { CloudAccountSection } from "../cloud/cloud-account-section";
@@ -171,6 +180,55 @@ function DenSignedOutPanel({
   );
 }
 
+const permissionLabels = {
+  allowCustomProviders: "Add AI providers",
+  allowZenModel: "Use OpenCode models",
+  allowMultipleWorkspaces: "Create more workspaces",
+  allowControlSettings: "Change app settings",
+  allowManageExtensions: "Add tools, skills & MCP servers",
+  allowBuiltInExtensions: "Use built-in extensions",
+  allowAlphaUpdates: "Try experimental updates",
+  showWelcomePage: "Show welcome page",
+};
+
+function AppPermissionsView() {
+  const config = useOrgRestrictions();
+  return (
+    <SettingsStack>
+      <Separator />
+      <SettingsSection>
+        <SettingsSectionHeader>
+          <SettingsSectionHeaderContent>
+            <SettingsSectionHeaderTitle>Your app permissions</SettingsSectionHeaderTitle>
+            <SettingsSectionHeaderDescription>
+              These are your current permissions for this organization.
+            </SettingsSectionHeaderDescription>
+          </SettingsSectionHeaderContent>
+        </SettingsSectionHeader>
+        <SettingsList>
+          {desktopPolicyDefinitions.filter((entry) => entry.restrictedValue !== null).map((entry) => {
+            const allowed = config[entry.id] !== false;
+            return (
+              <div key={entry.id} data-testid={`app-permission-${entry.id}`}>
+                <SettingsListItem>
+                  <SettingsListItemContent>
+                    <SettingsListItemTitle>{permissionLabels[entry.id]}</SettingsListItemTitle>
+                  </SettingsListItemContent>
+                  <SettingsStatusBadge label={allowed ? "Allowed" : "Blocked"} tone={allowed ? "ready" : "neutral"} />
+                </SettingsListItem>
+              </div>
+            );
+          })}
+        </SettingsList>
+        <SettingsSectionHeaderDescription>
+          Your administrator manages team permissions in Cloud → Team → Access.
+          Ask them if you need a change, including access to an MCP server or skill.
+        </SettingsSectionHeaderDescription>
+      </SettingsSection>
+    </SettingsStack>
+  );
+}
+
 export function CloudAccountView({ developerMode, session }: CloudAccountViewProps) {
   const { activeOrganization, isSignedIn, statusMessage } = useCloudSession();
   const navigate = useNavigate();
@@ -180,7 +238,7 @@ export function CloudAccountView({ developerMode, session }: CloudAccountViewPro
     navigate("/onboarding", { replace: true });
   }, [isSignedIn, navigate, session.needsOrgSelection]);
 
-  return (
+  const accountContent = (
     <SettingsStack>
       <Separator />
 
@@ -256,5 +314,18 @@ export function CloudAccountView({ developerMode, session }: CloudAccountViewPro
         />
       ) : null}
     </SettingsStack>
+  );
+
+  if (!isSignedIn) return accountContent;
+
+  return (
+    <Tabs defaultValue="account" className="w-full max-w-3xl gap-y-6">
+      <TabsList variant="line" aria-label="Account pages">
+        <TabsTrigger value="account">Account</TabsTrigger>
+        <TabsTrigger value="permissions">App permissions</TabsTrigger>
+      </TabsList>
+      <TabsContent value="account">{accountContent}</TabsContent>
+      <TabsContent value="permissions"><AppPermissionsView /></TabsContent>
+    </Tabs>
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -26,6 +26,7 @@ import {
   Zap,
 } from "lucide-react";
 
+import { desktopRestrictionNotice } from "../../../../app/cloud/desktop-app-restrictions";
 import { isBuiltInOpenWorkExtension, getMcpServerName, type McpDirectoryInfo } from "../../../../app/constants";
 import { evaluateEnablement } from "../../../../app/enablement";
 import type { EnablementResult } from "../../../../app/extensions";
@@ -230,6 +231,7 @@ export type McpViewProps = {
 };
 
 const builtInExtensionDisabledReason = () => t("extensions.disabled_by_organization");
+const manageExtensionsDisabledReason = () => desktopRestrictionNotice("allowManageExtensions");
 
 const statusDot = (status: ReactMcpStatus) => {
   switch (status) {
@@ -892,6 +894,19 @@ export function McpView(props: McpViewProps) {
     return isQuickConnectConfigured(entry);
   };
 
+  // Built-in OpenWork extensions answer to `allowBuiltInExtensions`; every
+  // other directory entry is a local install governed by
+  // `allowManageExtensions`. Entries the member already installed stay usable
+  // but can no longer be managed.
+  const builtInDisabledReasonForEntry = (entry: McpDirectoryInfo) =>
+    props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)
+      ? builtInExtensionDisabledReason()
+      : null;
+  const manageDisabledReasonForEntry = (entry: McpDirectoryInfo) =>
+    !props.allowManageExtensions && !isBuiltInOpenWorkExtension(entry)
+      ? manageExtensionsDisabledReason()
+      : null;
+
   const launchCommandForEntry = (entry: McpDirectoryInfo) => {
     if (entry.serverName === "openwork-ui") return openworkUiMcpCommand ?? undefined;
     if (entry.serverName === "computer-use") return computerUseMcpCommand ?? entry.command;
@@ -976,10 +991,9 @@ export function McpView(props: McpViewProps) {
         const extensionConfigSlot = props.configSlotForEntry?.(detailEntry) ?? null;
         const hasConfigSlot = extensionConfigSlot !== null;
         const hidden = isOpenWorkExtensionHidden(detailEntry);
-        const disabledReason = props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(detailEntry)
-          ? builtInExtensionDisabledReason()
-          : null;
-        const isConnected = disabledReason
+        const builtInDisabledReason = builtInDisabledReasonForEntry(detailEntry);
+        const disabledReason = builtInDisabledReason ?? manageDisabledReasonForEntry(detailEntry);
+        const isConnected = builtInDisabledReason
           ? false
           : isToggleOnlyExtension(detailEntry)
           ? isOpenWorkExtensionEnabled(detailEntry)
@@ -1327,6 +1341,15 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
+      {props.allowManageExtensions ? null : (
+        <div
+          data-testid="manage-extensions-policy-notice"
+          className="mb-5 rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11"
+        >
+          {manageExtensionsDisabledReason()}
+        </div>
+      )}
+
       {libraryAddKinds.length > 0 || skillAddPending ? (
         <div className="mb-5 flex justify-end">
           <LibraryAddControl
@@ -1493,9 +1516,8 @@ export function McpView(props: McpViewProps) {
         isSkillHidden={(skill) => isOpenWorkExtensionHidden(getSkillHiddenId(skill))}
         isPluginHidden={(plugin) => isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)}
         disabledReasonForEntry={(entry) =>
-          props.builtInExtensionsDisabled && isBuiltInOpenWorkExtension(entry)
-            ? builtInExtensionDisabledReason()
-            : null
+          builtInDisabledReasonForEntry(entry)
+            ?? (isEntryConfigured(entry) ? null : manageDisabledReasonForEntry(entry))
         }
         isConfigured={isEntryConfigured}
         enablementForEntry={props.enablementContext ? enablementForEntry : undefined}
@@ -1596,7 +1618,7 @@ export function McpView(props: McpViewProps) {
         onReveal={revealConfig}
         onAddMcp={props.allowManageExtensions ? () => setAddMcpModalOpen(true) : undefined}
         onImportFromGithub={
-          props.previewClaudePlugin && props.installClaudePlugin
+          props.allowManageExtensions && props.previewClaudePlugin && props.installClaudePlugin
             ? () => setClaudeImportOpen(true)
             : undefined
         }
@@ -1620,7 +1642,7 @@ export function McpView(props: McpViewProps) {
         onCreate={handleCreateLibraryItem}
       />
 
-      {props.previewClaudePlugin && props.installClaudePlugin ? (
+      {props.allowManageExtensions && props.previewClaudePlugin && props.installClaudePlugin ? (
         <ClaudePluginImportModal
           open={claudeImportOpen}
           onClose={() => setClaudeImportOpen(false)}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1348,7 +1348,7 @@ export function McpView(props: McpViewProps) {
         >
           <p className="font-medium">Adding tools is managed by your organization</p>
           <p className="mt-1">{manageExtensionsDisabledReason()}</p>
-          <p className="mt-2">Need an MCP server or skill? Ask your organization admin to add it for your team or enable “Add and manage tools, skills &amp; MCP servers” in Team → Access. You can still sign in to available connections below.</p>
+          <p className="mt-2">Need an MCP server or skill? Ask your organization admin to add it for your team or enable “Add and manage local tools, skills &amp; MCP servers” in Team → Access. You can still sign in to available connections below.</p>
         </div>
       )}
 

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1335,7 +1335,7 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
-      {props.builtInExtensionsDisabled ? (
+      {props.builtInExtensionsDisabled && props.allowManageExtensions ? (
         <div className="mb-5 rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11">
           Built-in OpenWork extensions are disabled by your organization. Use Show hidden to review blocked built-ins.
         </div>
@@ -1344,11 +1344,12 @@ export function McpView(props: McpViewProps) {
       {props.allowManageExtensions ? null : (
         <div
           data-testid="manage-extensions-policy-notice"
-          className="mb-5 rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11"
+          className="mb-5 rounded-xl border border-dls-border bg-dls-hover px-4 py-4 text-xs leading-5 text-dls-secondary"
         >
-          <p className="font-medium">Adding tools is managed by your organization</p>
+          <p className="text-sm font-medium text-foreground">Your team’s tool access</p>
           <p className="mt-1">{manageExtensionsDisabledReason()}</p>
-          <p className="mt-2">Need an MCP server or skill? Ask your organization admin to add it for your team or enable “Add and manage local tools, skills &amp; MCP servers” in Team → Access. You can still sign in to available connections below.</p>
+          <p className="mt-2">Need an MCP server or skill? Ask your admin to share it with your team or allow local tools in Team → Access. You can still sign in to available connections below.</p>
+          {props.builtInExtensionsDisabled ? <p className="mt-2">Built-in OpenWork extensions are disabled by your organization. Use Show hidden to review blocked built-ins.</p> : null}
         </div>
       )}
 

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1346,7 +1346,9 @@ export function McpView(props: McpViewProps) {
           data-testid="manage-extensions-policy-notice"
           className="mb-5 rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11"
         >
-          {manageExtensionsDisabledReason()}
+          <p className="font-medium">Adding tools is managed by your organization</p>
+          <p className="mt-1">{manageExtensionsDisabledReason()}</p>
+          <p className="mt-2">Need an MCP server or skill? Ask your organization admin to add it for your team or enable “Add and manage tools, skills &amp; MCP servers” in Team → Access. You can still sign in to available connections below.</p>
         </div>
       )}
 

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import type * as React from "react";
+import { desktopPolicyDefinitions } from "@openwork/types/den/desktop-policies";
 import {
   ArrowLeft,
   Bug,
@@ -415,8 +416,20 @@ function DesktopPolicyBanner() {
           {t("settings.desktop_policy_active_title")}
         </p>
         <p className="mt-0.5 text-xs text-indigo-11">
-          {t("settings.desktop_policy_active_body")}
+          Your organization manages access in Cloud → Team → Access. These are your current app permissions; ask your admin if you need a change.
+
         </p>
+        <details className="mt-3">
+          <summary className="cursor-pointer text-xs font-medium text-indigo-12">What can I do?</summary>
+          <dl className="mt-2 divide-y divide-indigo-6/30">
+            {desktopPolicyDefinitions.filter((entry) => entry.restrictedValue !== null).map((entry) => (
+              <div key={entry.id} className="flex items-center justify-between gap-4 py-2 text-xs">
+                <dt>{entry.id === "allowManageExtensions" ? "Add tools, skills & MCP servers" : entry.name}</dt>
+                <dd className="shrink-0 font-medium">{config[entry.id] === false ? "Blocked by organization" : "Allowed"}</dd>
+              </div>
+            ))}
+          </dl>
+        </details>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
 import type * as React from "react";
-import { desktopPolicyDefinitions } from "@openwork/types/den/desktop-policies";
 import {
   ArrowLeft,
   Bug,
@@ -9,7 +8,6 @@ import {
   CloudCog,
   Cog,
   FolderLock,
-  Info,
   Paintbrush,
   Puzzle,
   RefreshCcw,
@@ -47,7 +45,7 @@ import type { PlatformCapabilities } from "../../../../app/lib/platform-capabili
 import type { SettingsTab } from "../../../../app/types";
 import { cn } from "@/lib/utils";
 import { usePlatform } from "../../../kernel/platform";
-import { useCheckDesktopRestriction, useOrgRestrictions } from "../../cloud/desktop-config-provider";
+import { useCheckDesktopRestriction } from "../../cloud/desktop-config-provider";
 import {
   SettingsContent,
   SettingsPanel,
@@ -393,48 +391,6 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
   );
 }
 
-function DesktopPolicyBanner() {
-  const config = useOrgRestrictions();
-
-  // Show the banner when the org has any active desktop policy restriction
-  // (a boolean set to false) or any white-label branding override.
-  const hasRestriction = Object.entries(config).some(
-    ([key, value]) => typeof value === "boolean" && value === false && key !== "allowedDesktopVersions",
-  );
-  const hasBranding = Boolean(config.brandAppName ?? config.brandLogoUrl ?? config.brandAccentColor);
-
-  if (!hasRestriction && !hasBranding) return null;
-
-  return (
-    <div
-      data-testid="desktop-policy-banner"
-      className="flex items-start gap-2.5 rounded-xl border border-indigo-6/30 bg-indigo-2/50 px-3.5 py-2.5 text-sm dark:border-indigo-7/25 dark:bg-indigo-3/30"
-    >
-      <Info className="mt-0.5 size-4 shrink-0 text-indigo-11" />
-      <div className="min-w-0 flex-1">
-        <p className="font-medium text-indigo-12">
-          {t("settings.desktop_policy_active_title")}
-        </p>
-        <p className="mt-0.5 text-xs text-indigo-11">
-          Your organization manages access in Cloud → Team → Access. These are your current app permissions; ask your admin if you need a change.
-
-        </p>
-        <details className="mt-3">
-          <summary className="cursor-pointer text-xs font-medium text-indigo-12">What can I do?</summary>
-          <dl className="mt-2 divide-y divide-indigo-6/30">
-            {desktopPolicyDefinitions.filter((entry) => entry.restrictedValue !== null).map((entry) => (
-              <div key={entry.id} className="flex items-center justify-between gap-4 py-2 text-xs">
-                <dt>{entry.id === "allowManageExtensions" ? "Add tools, skills & MCP servers" : entry.name}</dt>
-                <dd className="shrink-0 font-medium">{config[entry.id] === false ? "Blocked by organization" : "Allowed"}</dd>
-              </div>
-            ))}
-          </dl>
-        </details>
-      </div>
-    </div>
-  );
-}
-
 export function SettingsPageHeading({ activeTab }: Pick<SettingsPageProps, "activeTab">) {
   return (
     <SettingsPanelHeading>
@@ -449,7 +405,6 @@ export function SettingsPage(props: SettingsPageProps) {
     <SettingsContent>
       <SettingsPanel>
         <SettingsPageHeading activeTab={props.activeTab} />
-        <DesktopPolicyBanner />
 
         {props.showUpdateToolbar && props.activeTab === "general" ? (
           <SettingsPanelToolbar>

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -41,11 +41,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { t } from "../../../../i18n";
+import { isSettingsTabAllowed } from "../../../../app/cloud/desktop-app-restrictions";
 import type { PlatformCapabilities } from "../../../../app/lib/platform-capabilities";
 import type { SettingsTab } from "../../../../app/types";
 import { cn } from "@/lib/utils";
 import { usePlatform } from "../../../kernel/platform";
-import { useOrgRestrictions } from "../../cloud/desktop-config-provider";
+import { useCheckDesktopRestriction, useOrgRestrictions } from "../../cloud/desktop-config-provider";
 import {
   SettingsContent,
   SettingsPanel,
@@ -223,6 +224,32 @@ function SettingsSidebarTabLabel({ tab }: { tab: SettingsTab }) {
   );
 }
 
+export type SettingsNavGroups = {
+  hub: SettingsTab[];
+  workspace: SettingsTab[];
+  global: SettingsTab[];
+  cloud: SettingsTab[];
+};
+
+/**
+ * Every settings navigation surface (sidebar + compact section menu) reads its
+ * tabs from here so platform capabilities, preview flags, and the
+ * `allowControlSettings` desktop policy cannot drift between them. When the
+ * organization blocks settings control, only the Cloud group remains.
+ */
+export function useSettingsNavGroups(developerMode: boolean): SettingsNavGroups {
+  const platform = usePlatform();
+  const checkRestriction = useCheckDesktopRestriction();
+  const allowed = (tabs: SettingsTab[]) =>
+    tabs.filter((tab) => isSettingsTabAllowed({ tab, checkRestriction }));
+  return {
+    hub: allowed(["general"]),
+    workspace: allowed(getWorkspaceSettingsTabs()),
+    global: allowed(getGlobalSettingsTabs(developerMode, platform.capabilities)),
+    cloud: allowed(CLOUD_SETTINGS_TABS),
+  };
+}
+
 type SettingsPageProps = {
   activeTab: SettingsTab;
   onSelectTab: (tab: SettingsTab) => void;
@@ -248,11 +275,39 @@ type SettingsSidebarProps = Pick<SettingsPageProps, "activeTab" | "onSelectTab" 
   onSelectWorkspace: (workspaceId: string) => void;
 };
 
+function SettingsSidebarGroup(props: {
+  label: string;
+  tabs: SettingsTab[];
+  activeTab: SettingsTab;
+  onSelectTab: (tab: SettingsTab) => void;
+}) {
+  if (props.tabs.length === 0) return null;
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>{props.label}</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {props.tabs.map((tab) => {
+            const Icon = getSettingsTabIcon(tab);
+            return (
+              <SidebarDestination
+                key={tab}
+                active={isSettingsTabActive(props.activeTab, tab)}
+                icon={Icon}
+                label={getSettingsTabLabel(tab)}
+                labelContent={<SettingsSidebarTabLabel tab={tab} />}
+                onSelect={() => props.onSelectTab(tab)}
+              />
+            );
+          })}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
 export function SettingsSidebar(props: SettingsSidebarProps) {
-  const platform = usePlatform();
-  const workspaceTabs = getWorkspaceSettingsTabs();
-  const globalTabs = getGlobalSettingsTabs(props.developerMode, platform.capabilities);
-  const cloudTabs = CLOUD_SETTINGS_TABS;
+  const groups = useSettingsNavGroups(props.developerMode);
 
   return (
     <Sidebar collapsible="icon" className="mac:**:data-[sidebar=sidebar]:bg-transparent">
@@ -292,87 +347,45 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
       </SidebarHeader>
       <SidebarContent>
         {/* Top-level hub entry */}
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  type="button"
-                  isActive={isSettingsTabActive(props.activeTab, "general")}
-                  aria-current={isSettingsTabActive(props.activeTab, "general") ? "page" : undefined}
-                  tooltip={getSettingsTabLabel("general")}
-                  onClick={() => props.onSelectTab("general")}
-                >
-                  <Cog />
-                  <span>{getSettingsTabLabel("general")}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {groups.hub.length > 0 ? (
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    type="button"
+                    isActive={isSettingsTabActive(props.activeTab, "general")}
+                    aria-current={isSettingsTabActive(props.activeTab, "general") ? "page" : undefined}
+                    tooltip={getSettingsTabLabel("general")}
+                    onClick={() => props.onSelectTab("general")}
+                  >
+                    <Cog />
+                    <span>{getSettingsTabLabel("general")}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null}
 
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("settings.group_workspace")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {workspaceTabs.map((tab) => {
-                const Icon = getSettingsTabIcon(tab);
-                return (
-                  <SidebarDestination
-                    key={tab}
-                    active={isSettingsTabActive(props.activeTab, tab)}
-                    icon={Icon}
-                    label={getSettingsTabLabel(tab)}
-                    labelContent={<SettingsSidebarTabLabel tab={tab} />}
-                    onSelect={() => props.onSelectTab(tab)}
-                  />
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("settings.group_global")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {globalTabs.map((tab) => {
-                const Icon = getSettingsTabIcon(tab);
-                return (
-                  <SidebarDestination
-                    key={tab}
-                    active={isSettingsTabActive(props.activeTab, tab)}
-                    icon={Icon}
-                    label={getSettingsTabLabel(tab)}
-                    labelContent={<SettingsSidebarTabLabel tab={tab} />}
-                    onSelect={() => props.onSelectTab(tab)}
-                  />
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("settings.group_cloud")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {cloudTabs.map((tab) => {
-                const Icon = getSettingsTabIcon(tab);
-                return (
-                  <SidebarDestination
-                    key={tab}
-                    active={isSettingsTabActive(props.activeTab, tab)}
-                    icon={Icon}
-                    label={getSettingsTabLabel(tab)}
-                    labelContent={<SettingsSidebarTabLabel tab={tab} />}
-                    onSelect={() => props.onSelectTab(tab)}
-                  />
-                );
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        <SettingsSidebarGroup
+          label={t("settings.group_workspace")}
+          tabs={groups.workspace}
+          activeTab={props.activeTab}
+          onSelectTab={props.onSelectTab}
+        />
+        <SettingsSidebarGroup
+          label={t("settings.group_global")}
+          tabs={groups.global}
+          activeTab={props.activeTab}
+          onSelectTab={props.onSelectTab}
+        />
+        <SettingsSidebarGroup
+          label={t("settings.group_cloud")}
+          tabs={groups.cloud}
+          activeTab={props.activeTab}
+          onSelectTab={props.onSelectTab}
+        />
       </SidebarContent>
       <SidebarRail />
     </Sidebar>

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -19,18 +19,15 @@ import {
 } from "@/components/ui/sidebar";
 import { t } from "../../../../i18n";
 import { NotificationBell } from "../../../shell/notification-center";
-import { usePlatform } from "../../../kernel/platform";
 import type { SettingsTab } from "../../../../app/types";
 import {
-  CLOUD_SETTINGS_TABS,
   SettingsPage,
   SettingsBetaBadge,
   SettingsSidebar,
-  getGlobalSettingsTabs,
   getSettingsTabIcon,
   getSettingsTabLabel,
-  getWorkspaceSettingsTabs,
   isSettingsTabBeta,
+  useSettingsNavGroups,
 } from "./settings-page";
 
 type SettingsPageFrameProps = Omit<React.ComponentProps<typeof SettingsPage>, "children">;
@@ -163,13 +160,13 @@ export function SettingsShell(props: SettingsShellProps) {
 }
 
 function SettingsSectionMenu(props: Pick<SettingsPageFrameProps, "activeTab" | "developerMode" | "onSelectTab">) {
-  const platform = usePlatform();
+  const groups = useSettingsNavGroups(props.developerMode);
   const sections: Array<{ label: string | null; tabs: SettingsTab[] }> = [
-    { label: null, tabs: ["general"] },
-    { label: t("settings.group_workspace"), tabs: getWorkspaceSettingsTabs() },
-    { label: t("settings.group_global"), tabs: getGlobalSettingsTabs(props.developerMode, platform.capabilities) },
-    { label: t("settings.group_cloud"), tabs: CLOUD_SETTINGS_TABS },
-  ];
+    { label: null, tabs: groups.hub },
+    { label: t("settings.group_workspace"), tabs: groups.workspace },
+    { label: t("settings.group_global"), tabs: groups.global },
+    { label: t("settings.group_cloud"), tabs: groups.cloud },
+  ].filter((section) => section.tabs.length > 0);
   const ActiveIcon = getSettingsTabIcon(props.activeTab);
 
   return (

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { desktopRestrictionNotice, type DesktopAppRestrictionChecker } from "../../../../app/cloud/desktop-app-restrictions";
+
 import { applyEdits, modify } from "jsonc-parser";
 
 import { t } from "../../../../i18n";
@@ -350,6 +352,7 @@ function toProjectPluginListEntries(
 }
 
 export function createExtensionsStore(options: {
+  checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   client: () => Client | null;
   projectDir: () => string;
   selectedWorkspaceId: () => string;
@@ -1231,10 +1234,21 @@ export function createExtensionsStore(options: {
     }
   }
 
+  // Only manual local changes enter these handlers. Assigned Cloud inventory
+  // continues to reconcile through its separate refresh/sync paths.
+  function extensionMutationDenied() {
+    if (!options.checkDesktopAppRestriction({ restriction: "allowManageExtensions" })) return false;
+    options.setError(desktopRestrictionNotice("allowManageExtensions"));
+    return true;
+  }
+
   async function importCloudOrgPlugin(
     marketplaceId: string | null,
     plugin: DenOrgPlugin,
   ): Promise<{ ok: boolean; message: string; warnings: string[]; files: CloudImportedPluginFile[] }> {
+    if (extensionMutationDenied()) {
+      return { ok: false, message: desktopRestrictionNotice("allowManageExtensions"), warnings: [], files: [] };
+    }
     options.setBusy(true);
     options.setError(null);
     setStateField("cloudOrgMarketplacesStatus", null);
@@ -1292,6 +1306,7 @@ export function createExtensionsStore(options: {
   }
 
   async function installClaudePlugin(url: string): Promise<{ ok: boolean; message: string }> {
+    if (extensionMutationDenied()) return { ok: false, message: desktopRestrictionNotice("allowManageExtensions") };
     options.setBusy(true);
     options.setError(null);
     try {
@@ -1316,6 +1331,7 @@ export function createExtensionsStore(options: {
   }
 
   async function removeCloudOrgPlugin(pluginId: string): Promise<{ ok: boolean; message: string }> {
+    if (extensionMutationDenied()) return { ok: false, message: desktopRestrictionNotice("allowManageExtensions") };
     options.setBusy(true);
     options.setError(null);
     setStateField("cloudOrgMarketplacesStatus", null);
@@ -1740,6 +1756,7 @@ export function createExtensionsStore(options: {
   }
 
   async function addPlugin(pluginNameOverride?: string) {
+    if (extensionMutationDenied()) return;
     const pluginName = (pluginNameOverride ?? snapshot.pluginInput).trim();
     const isManualInput = pluginNameOverride == null;
     const triggerName = stripPluginVersion(pluginName);
@@ -1831,6 +1848,7 @@ export function createExtensionsStore(options: {
   }
 
   async function removePlugin(pluginName: string) {
+    if (extensionMutationDenied()) return;
     const name = pluginName.trim();
     if (!name) return;
     const triggerName = stripPluginVersion(name);
@@ -1914,6 +1932,7 @@ export function createExtensionsStore(options: {
   }
 
   async function importLocalSkill() {
+    if (extensionMutationDenied()) return;
     const isLocalWorkspace = options.workspaceType() === "local";
     if (!isDesktopRuntime()) {
       options.setError(t("skills.desktop_required"));
@@ -1954,6 +1973,7 @@ export function createExtensionsStore(options: {
   }
 
   async function installSkillCreator(): Promise<{ ok: boolean; message: string }> {
+    if (extensionMutationDenied()) return { ok: false, message: desktopRestrictionNotice("allowManageExtensions") };
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
     const { openworkSnapshot, openworkClient, openworkWorkspaceId, hasOpenworkTarget } =
@@ -2082,6 +2102,7 @@ export function createExtensionsStore(options: {
   }
 
   async function uninstallSkill(name: string) {
+    if (extensionMutationDenied()) return;
     const trimmed = name.trim();
     if (!trimmed) return;
 
@@ -2159,6 +2180,7 @@ export function createExtensionsStore(options: {
   }
 
   async function saveSkill(input: { name: string; content: string; description?: string }) {
+    if (extensionMutationDenied()) return;
     const trimmed = input.name.trim();
     if (!trimmed) return;
     const root = options.selectedWorkspaceRoot().trim();

--- a/apps/app/src/react-app/shell/command-palette-settings.ts
+++ b/apps/app/src/react-app/shell/command-palette-settings.ts
@@ -1,4 +1,5 @@
 import type { PlatformCapabilities } from "@/app/lib/platform-capabilities";
+import { isSettingsTabAllowed, type DesktopAppRestrictionChecker } from "@/app/cloud/desktop-app-restrictions";
 import type { SettingsTab } from "@/app/types";
 import {
   CLOUD_SETTINGS_TABS,
@@ -36,15 +37,18 @@ const LIBRARY_SECTIONS = [
 export function buildCommandPaletteSettingsItems(input: {
   developerMode: boolean;
   capabilities: Pick<PlatformCapabilities, "autoUpdate">;
+  /** Desktop policy checker; when `allowControlSettings` is blocked only the Cloud tabs remain. */
+  checkRestriction?: DesktopAppRestrictionChecker;
   onOpenSettings: (route: string) => void;
   onOpenExtensions: (section?: string) => void;
 }): PaletteItem[] {
-  const tabs = [
+  const checkRestriction = input.checkRestriction ?? (() => false);
+  const tabs = ([
     "general",
     ...getWorkspaceSettingsTabs(),
     ...getGlobalSettingsTabs(input.developerMode, input.capabilities),
     ...CLOUD_SETTINGS_TABS,
-  ] satisfies SettingsTab[];
+  ] satisfies SettingsTab[]).filter((tab) => isSettingsTabAllowed({ tab, checkRestriction }));
 
   const tabItems = tabs.map((tab): PaletteItem => ({
     id: `settings:${tab}`,

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -29,6 +29,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ChevronLeftIcon } from "lucide-react";
 import type { ModelOption, ModelRef } from "@/app/types";
+import { useCheckDesktopRestriction } from "../domains/cloud/desktop-config-provider";
 import { usePlatform } from "../kernel/platform";
 import {
   resolveSessionNumberShortcutOs,
@@ -207,6 +208,9 @@ export function CommandPalette(props: CommandPaletteProps) {
     [sessionNumberOs],
   );
   const hasNestedModelPicker = props.modelOptions !== undefined && props.onSelectModel !== undefined;
+  // Organization policy (`allowControlSettings`) can hide desktop settings;
+  // the settings palette entries follow the same allow-list as the settings nav.
+  const checkDesktopRestriction = useCheckDesktopRestriction();
 
   const rootItems = useMemo<PaletteItem[]>(() => [
     {
@@ -380,6 +384,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     () => buildCommandPaletteSettingsItems({
       developerMode: props.developerMode,
       capabilities: platform.capabilities,
+      checkRestriction: checkDesktopRestriction,
       onOpenSettings: (route) => {
         props.onClose();
         props.onOpenSettings(route);
@@ -390,6 +395,7 @@ export function CommandPalette(props: CommandPaletteProps) {
       },
     }),
     [
+      checkDesktopRestriction,
       platform.capabilities,
       props.developerMode,
       props.onClose,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -3613,7 +3613,7 @@ export function SessionRoute() {
       currentSessionForGroupMove={currentSessionForGroupMove}
       currentSessionGroupId={currentSessionGroupId}
       onMoveCurrentSessionToGroup={handleMoveCurrentSessionToGroup}
-      extraItems={[...currentSessionActionPaletteItems, ...(sessionFindPaletteItem ? [sessionFindPaletteItem] : []), sessionSearchPaletteItem, ...terminalPaletteItems, developerModePaletteItem, diagnosticsCopyPaletteItem, diagnosticsExportPaletteItem, nextSessionTabPaletteItem, prevSessionTabPaletteItem, reloadConfigPaletteItem]}
+      extraItems={[...currentSessionActionPaletteItems, ...(sessionFindPaletteItem ? [sessionFindPaletteItem] : []), sessionSearchPaletteItem, ...terminalPaletteItems, ...(checkDesktopRestriction({ restriction: "allowControlSettings" }) ? [] : [developerModePaletteItem]), diagnosticsCopyPaletteItem, diagnosticsExportPaletteItem, nextSessionTabPaletteItem, prevSessionTabPaletteItem, reloadConfigPaletteItem]}
       listAgents={listAgents}
       selectedAgent={selectedAgent}
       onSelectAgent={setSelectedAgent}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -592,6 +592,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   );
 
   const routeStateRef = useRef({
+    checkDesktopRestriction,
     activeClient: null as Client | null,
     providerBaseUrl: "",
     selectedWorkspaceId: "",
@@ -669,6 +670,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
 
   routeStateRef.current = {
+    checkDesktopRestriction,
     activeClient,
     providerBaseUrl: opencodeBaseUrl,
     selectedWorkspaceId,
@@ -741,6 +743,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const connectionsStore = useMemo(
     () =>
       createConnectionsStore({
+        checkDesktopAppRestriction: (input) => routeStateRef.current.checkDesktopRestriction(input),
         client: () => routeStateRef.current.activeClient,
         setClient: setActiveClient,
         projectDir: () => routeStateRef.current.selectedWorkspaceRoot,
@@ -804,6 +807,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const extensionsStore = useMemo(
     () =>
       createExtensionsStore({
+        checkDesktopAppRestriction: (input) => routeStateRef.current.checkDesktopRestriction(input),
         client: () => routeStateRef.current.activeClient,
         projectDir: () => routeStateRef.current.selectedWorkspaceRoot,
         selectedWorkspaceId: () => routeStateRef.current.selectedWorkspaceId,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -131,7 +131,12 @@ import {
   type WorkspaceList,
   revealDesktopItemInDir,
 } from "@/app/lib/desktop";
-import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
+import {
+  SETTINGS_TAB_WITHOUT_CONTROL,
+  desktopRestrictionNotice,
+  isDesktopProviderBlocked,
+  isSettingsTabAllowed,
+} from "@/app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction, useDesktopConfig } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
@@ -472,11 +477,19 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
   const [legacySelectedWorkspaceId, setLegacySelectedWorkspaceId] = useState(() => navigationWorkspaceId ?? readActiveWorkspaceId() ?? "");
   const selectedWorkspaceId = routeWorkspaceId || legacySelectedWorkspaceId;
+  // The standalone Library takeover is not a settings surface; the
+  // `allowControlSettings` policy only governs the settings shell.
+  const settingsTabBlocked = !props.standaloneExtensions
+    && !isSettingsTabAllowed({ tab: route.tab, checkRestriction: checkDesktopRestriction });
 
   useEffect(() => {
-    if (!props.embedded || !route.redirectPath) return;
-    setEmbeddedPath(route.redirectPath);
-  }, [props.embedded, route.redirectPath]);
+    if (!props.embedded) return;
+    if (route.redirectPath) {
+      setEmbeddedPath(route.redirectPath);
+      return;
+    }
+    if (settingsTabBlocked) setEmbeddedPath(SETTINGS_TAB_WITHOUT_CONTROL);
+  }, [props.embedded, route.redirectPath, settingsTabBlocked]);
 
   const navigateSettingsPath = useCallback((path: string) => {
     if (props.embedded) {
@@ -2339,6 +2352,20 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     return <Navigate to={target} replace state={location.state} />;
   }
 
+  if (!props.embedded && settingsTabBlocked) {
+    // Organization policy hides desktop settings. Library deep links keep
+    // working through the standalone Library surface; everything else lands on
+    // the Cloud account tab, which explains the active policy.
+    const target = route.tab === "extensions"
+      ? selectedWorkspaceId
+        ? workspaceExtensionsRoute(selectedWorkspaceId, extensionsPathForRoute(route))
+        : globalExtensionsRoute(extensionsPathForRoute(route))
+      : selectedWorkspaceId
+        ? workspaceSettingsRoute(selectedWorkspaceId, SETTINGS_TAB_WITHOUT_CONTROL)
+        : `/settings/${SETTINGS_TAB_WITHOUT_CONTROL}`;
+    return <Navigate to={target} replace state={location.state} />;
+  }
+
   const openCloudAccountSettings = () => {
     navigateSettingsPath("cloud-account");
   };
@@ -2457,9 +2484,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             hideDescription={props.standaloneExtensions !== true}
             selectedWorkspaceRoot={selectedWorkspaceRoot}
             isRemoteWorkspace={isRemoteWorkspace}
-            canEditPlugins={canWriteWorkspacePlugins}
+            canEditPlugins={canWriteWorkspacePlugins && allowManageExtensions}
             canUseGlobalScope={!isRemoteWorkspace}
-            accessHint={pluginsAccessHint}
+            accessHint={allowManageExtensions ? pluginsAccessHint : desktopRestrictionNotice("allowManageExtensions")}
             suggestedPlugins={SUGGESTED_PLUGINS}
             extensions={extensionsStore}
             initialSection={route.extensionsSection}
@@ -2768,7 +2795,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         }}
         selectedModelLabel={defaultModelLabel}
         sessions={paletteSessionOptions}
-        extraItems={[developerModePaletteItem]}
+        extraItems={checkDesktopRestriction({ restriction: "allowControlSettings" }) ? [] : [developerModePaletteItem]}
       />
 
       <ProviderAuthModal

--- a/apps/app/tests/desktop-policy-restricted.test.ts
+++ b/apps/app/tests/desktop-policy-restricted.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { MCP_QUICK_CONNECT, getMcpServerName, isBuiltInOpenWorkExtension } from "../src/app/constants";
+import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
+import { createOpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
+import { createConnectionsStore } from "../src/react-app/domains/connections/store";
+import { createExtensionsStore } from "../src/react-app/domains/settings/state/extensions-store";
 
 import {
   applyRestrictedDesktopPolicy,
@@ -158,5 +163,149 @@ describe("explicit team access limits", () => {
     });
     expect(result.access).toEqual(access);
     expect(calculateEffectiveDesktopPolicy({ orgPolicyCount: 2, defaultPolicy: desktopPolicyDefaults, assignedPolicies: [result] }).allowCustomProviders).toBe(false);
+  });
+});
+
+
+describe("desktop extension mutation boundaries", () => {
+  function fixture() {
+    let blocked = false;
+    let builtInsBlocked = false;
+    let writes = 0;
+    const errors: string[] = [];
+    const checkDesktopAppRestriction: DesktopAppRestrictionChecker = ({ restriction }) =>
+      restriction === "allowBuiltInExtensions" ? builtInsBlocked : blocked;
+    const server = createOpenworkServerStore({
+      startupPreference: () => "server",
+      documentVisible: () => true,
+      developerMode: () => false,
+      runtimeWorkspaceId: () => "policy-workspace",
+      activeClient: () => null,
+      selectedWorkspaceDisplay: () => ({
+        id: "policy-workspace", name: "Policy", path: "/tmp/policy", preset: "starter", workspaceType: "local",
+      }),
+      restartLocalServer: async () => false,
+      createRemoteWorkspaceFlow: async () => false,
+    });
+    const recordWrite = async () => {
+      writes += 1;
+      throw new Error("Mutation boundary reached");
+    };
+    const client = {
+      ...createOpenworkServerClient({ baseUrl: "http://127.0.0.1:1" }),
+      addPlugin: recordWrite,
+      removePlugin: recordWrite,
+      upsertSkill: recordWrite,
+      deleteSkill: recordWrite,
+      installClaudePlugin: recordWrite,
+      removeCloudPlugin: recordWrite,
+      addMcp: recordWrite,
+      removeMcp: recordWrite,
+      setMcpEnabled: recordWrite,
+    };
+    const getSnapshot: typeof server.getSnapshot = () => ({
+      ...server.getSnapshot(), openworkServerStatus: "connected", openworkServerClient: client,
+    });
+    const options = {
+      checkDesktopAppRestriction,
+      client: () => null,
+      projectDir: () => "/tmp/policy",
+      selectedWorkspaceId: () => "policy-workspace",
+      selectedWorkspaceRoot: () => "/tmp/policy",
+      workspaceType: (): "local" | "remote" => "remote",
+      openworkServer: { ...server, getSnapshot },
+      runtimeWorkspaceId: () => "policy-workspace",
+    };
+    const extensions = createExtensionsStore({
+      ...options,
+      setBusy: () => undefined,
+      setBusyLabel: () => undefined,
+      setBusyStartedAt: () => undefined,
+      setError: (message) => { if (message) errors.push(message); },
+    });
+    const connections = createConnectionsStore({
+      ...options,
+      setClient: () => undefined,
+      developerMode: () => false,
+    });
+    return {
+      extensions, connections, errors,
+      writes: () => writes,
+      restrict: (value: boolean) => { blocked = value; },
+      restrictBuiltIns: (value: boolean) => { builtInsBlocked = value; },
+    };
+  }
+
+  test("direct extension handlers refuse local writes and use the current policy", async () => {
+    const f = fixture();
+    await f.extensions.addPlugin("example-plugin");
+    expect(f.writes()).toBe(1);
+    f.restrict(true);
+    await f.extensions.addPlugin("example-plugin");
+    await f.extensions.removePlugin("example-plugin");
+    await f.extensions.importLocalSkill();
+    await f.extensions.installSkillCreator();
+    await f.extensions.uninstallSkill("example-skill");
+    await f.extensions.saveSkill({ name: "example-skill", content: "changed" });
+    await f.extensions.installClaudePlugin("https://example.com/plugin");
+    await f.extensions.removeCloudOrgPlugin("plugin-id");
+    await f.extensions.importCloudOrgPlugin(null, {
+      id: "plugin-id", name: "Example", description: null, status: "active",
+      memberCount: 1, updatedAt: null, componentCounts: {},
+    });
+    expect(f.writes()).toBe(1);
+    expect(f.errors).toEqual(Array(9).fill(desktopRestrictionNotice("allowManageExtensions")));
+    f.restrict(false);
+    await f.extensions.saveSkill({ name: "example-skill", content: "allowed" });
+    expect(f.writes()).toBe(2);
+  });
+
+  test("direct MCP mutations are blocked after a live policy change and restored after unlocking", async () => {
+    const f = fixture();
+    await f.connections.setMcpEnabled("example-mcp", true);
+    expect(f.writes()).toBe(1);
+    f.restrict(true);
+    const result = await f.connections.connectMcp({
+      name: "Example", serverName: "example-mcp", description: "", oauth: false,
+      type: "remote", url: "https://example.com/mcp",
+    });
+    await f.connections.removeMcp("example-mcp");
+    await f.connections.setMcpEnabled("example-mcp", true);
+    expect(result).toEqual({ ok: false, error: desktopRestrictionNotice("allowManageExtensions") });
+    expect(f.connections.getSnapshot().mcpStatus).toBe(desktopRestrictionNotice("allowManageExtensions"));
+    expect(f.writes()).toBe(1);
+    f.restrict(false);
+    await f.connections.removeMcp("example-mcp");
+    expect(f.writes()).toBe(2);
+  });
+
+  test("existing MCP sign-in remains available while local installation is blocked", async () => {
+    const f = fixture();
+    f.restrict(true);
+    await f.connections.authorizeMcp({
+      name: "approved-mcp", config: { type: "remote", url: "https://example.com/mcp", oauth: {} },
+    });
+    expect(f.connections.getSnapshot().mcpAuthModalOpen).toBe(true);
+    expect(f.connections.getSnapshot().mcpAuthEntry?.url).toBe("https://example.com/mcp");
+    expect(f.writes()).toBe(0);
+  });
+
+  test("built-in configuration obeys its own permission while custom installation is blocked", async () => {
+    const f = fixture();
+    const builtIn = MCP_QUICK_CONNECT.find(isBuiltInOpenWorkExtension);
+    if (!builtIn) throw new Error("Expected a built-in MCP in the catalog");
+    f.restrict(true);
+    await f.connections.setMcpEnabled(getMcpServerName(builtIn), true);
+    expect(f.writes()).toBe(1);
+    const forged = await f.connections.connectMcp({
+      ...builtIn, name: "Forged built-in", serverName: "custom-mcp", url: "https://example.com/mcp",
+    });
+    expect(forged).toEqual({ ok: false, error: desktopRestrictionNotice("allowManageExtensions") });
+    f.restrictBuiltIns(true);
+    const result = await f.connections.connectMcp(builtIn);
+    await f.connections.removeMcp(getMcpServerName(builtIn));
+    await f.connections.setMcpEnabled(getMcpServerName(builtIn), true);
+    expect(result).toEqual({ ok: false, error: desktopRestrictionNotice("allowBuiltInExtensions") });
+    expect(f.writes()).toBe(1);
   });
 });

--- a/apps/app/tests/desktop-policy-restricted.test.ts
+++ b/apps/app/tests/desktop-policy-restricted.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyRestrictedDesktopPolicy,
+  calculateEffectiveDesktopPolicy,
+  desktopPolicyDefaults,
+  desktopPolicyDefinitions,
+  isRestrictedDesktopPolicyValue,
+  restrictedDesktopPolicyValue,
+} from "@openwork/types/den/desktop-policies";
+import {
+  SETTINGS_TAB_WITHOUT_CONTROL,
+  checkDesktopAppRestriction,
+  desktopRestrictionNotice,
+  isSettingsTabAllowed,
+  type DesktopAppRestrictionChecker,
+} from "../src/app/cloud/desktop-app-restrictions";
+import { SETTINGS_TAB_VALUES } from "../src/app/types";
+
+const allowEverything: DesktopAppRestrictionChecker = () => false;
+const restrictedChecker: DesktopAppRestrictionChecker = ({ restriction }) =>
+  checkDesktopAppRestriction({ config: restrictedDesktopPolicyValue, restriction });
+
+describe("restricted desktop policy mode", () => {
+  test("locks every capability and leaves the welcome page preference alone", () => {
+    expect(restrictedDesktopPolicyValue).toEqual({
+      allowCustomProviders: false,
+      allowZenModel: false,
+      allowMultipleWorkspaces: false,
+      allowControlSettings: false,
+      allowManageExtensions: false,
+      allowBuiltInExtensions: false,
+      allowAlphaUpdates: false,
+      showWelcomePage: true,
+    });
+    expect(
+      applyRestrictedDesktopPolicy({ ...desktopPolicyDefaults, showWelcomePage: false }).showWelcomePage,
+    ).toBe(false);
+  });
+
+  test("every catalog key declares how Restricted treats it", () => {
+    for (const definition of desktopPolicyDefinitions) {
+      expect([true, false, null]).toContain(definition.restrictedValue);
+    }
+  });
+
+  test("derives the mode from saved values", () => {
+    expect(isRestrictedDesktopPolicyValue(restrictedDesktopPolicyValue)).toBe(true);
+    expect(isRestrictedDesktopPolicyValue({ ...restrictedDesktopPolicyValue, showWelcomePage: false })).toBe(true);
+    expect(isRestrictedDesktopPolicyValue(desktopPolicyDefaults)).toBe(false);
+    expect(isRestrictedDesktopPolicyValue({ ...restrictedDesktopPolicyValue, allowManageExtensions: true })).toBe(false);
+  });
+
+  test("a restricted default policy locks members down until an assigned policy grants more", () => {
+    const locked = calculateEffectiveDesktopPolicy({
+      orgPolicyCount: 1,
+      defaultPolicy: restrictedDesktopPolicyValue,
+      assignedPolicies: [],
+    });
+    expect(locked.allowControlSettings).toBe(false);
+    expect(locked.allowManageExtensions).toBe(false);
+    expect(locked.allowCustomProviders).toBe(false);
+    expect(locked.showWelcomePage).toBe(true);
+
+    const unlockedForTeam = calculateEffectiveDesktopPolicy({
+      orgPolicyCount: 2,
+      defaultPolicy: restrictedDesktopPolicyValue,
+      assignedPolicies: [{ allowManageExtensions: true }],
+    });
+    expect(unlockedForTeam.allowManageExtensions).toBe(true);
+    expect(unlockedForTeam.allowControlSettings).toBe(false);
+  });
+});
+
+describe("allowControlSettings settings gate", () => {
+  test("leaves every settings tab reachable without a policy", () => {
+    for (const tab of SETTINGS_TAB_VALUES) {
+      expect(isSettingsTabAllowed({ tab, checkRestriction: allowEverything })).toBe(true);
+    }
+  });
+
+  test("keeps only the Cloud tabs when the organization blocks settings control", () => {
+    const allowed = SETTINGS_TAB_VALUES.filter((tab) =>
+      isSettingsTabAllowed({ tab, checkRestriction: restrictedChecker }),
+    );
+    expect(allowed).toEqual(["cloud-account"]);
+    expect(allowed).toContain(SETTINGS_TAB_WITHOUT_CONTROL);
+    expect(isSettingsTabAllowed({ tab: "general", checkRestriction: restrictedChecker })).toBe(false);
+    expect(isSettingsTabAllowed({ tab: "extensions", checkRestriction: restrictedChecker })).toBe(false);
+    expect(isSettingsTabAllowed({ tab: "ai", checkRestriction: restrictedChecker })).toBe(false);
+  });
+
+  test("explains blocked capabilities with the catalog notice", () => {
+    expect(desktopRestrictionNotice("allowManageExtensions")).toBe(
+      "Your organization administrator has disabled local extension management.",
+    );
+    expect(desktopRestrictionNotice("allowControlSettings")).toBe(
+      "Your organization administrator has disabled changing desktop app settings.",
+    );
+  });
+});

--- a/apps/app/tests/desktop-policy-restricted.test.ts
+++ b/apps/app/tests/desktop-policy-restricted.test.ts
@@ -7,6 +7,8 @@ import {
   desktopPolicyDefinitions,
   isRestrictedDesktopPolicyValue,
   restrictedDesktopPolicyValue,
+  normalizeDesktopPolicyDocument,
+  resolveDesktopPolicyDocumentWrite,
 } from "@openwork/types/den/desktop-policies";
 import {
   SETTINGS_TAB_WITHOUT_CONTROL,
@@ -117,5 +119,44 @@ describe("allowControlSettings settings gate", () => {
     expect(desktopRestrictionNotice("allowControlSettings")).toBe(
       "Your organization administrator has disabled changing desktop app settings.",
     );
+  });
+});
+
+
+describe("explicit team access limits", () => {
+  test("a lock wins over all matching grants while preserving display preferences", () => {
+    const result = calculateEffectiveDesktopPolicy({
+      orgPolicyCount: 3,
+      defaultPolicy: desktopPolicyDefaults,
+      assignedPolicies: [desktopPolicyDefaults, JSON.stringify({ access: { mode: "locked", capabilities: {} } })],
+    });
+    expect(result).toEqual(restrictedDesktopPolicyValue);
+  });
+
+  test("custom limits block independently and cannot override another team's block", () => {
+    const result = calculateEffectiveDesktopPolicy({
+      orgPolicyCount: 3,
+      defaultPolicy: desktopPolicyDefaults,
+      assignedPolicies: [
+        { access: { mode: "custom", capabilities: { allowManageExtensions: false } } },
+        { access: { mode: "custom", capabilities: { allowManageExtensions: true, allowCustomProviders: false } } },
+      ],
+    });
+    expect(result.allowManageExtensions).toBe(false);
+    expect(result.allowCustomProviders).toBe(false);
+    expect(result.allowControlSettings).toBe(true);
+  });
+
+  test("JSON storage and edits by older callers preserve explicit access limits", () => {
+    const access = { mode: "locked", capabilities: { allowManageExtensions: false } };
+    const existingPolicy = JSON.stringify({ access });
+    expect(normalizeDesktopPolicyDocument(existingPolicy).access).toEqual(access);
+    const result = resolveDesktopPolicyDocumentWrite({
+      existingPolicy,
+      value: { allowCustomProviders: true },
+      preserveExistingOnboardingPrompts: true,
+    });
+    expect(result.access).toEqual(access);
+    expect(calculateEffectiveDesktopPolicy({ orgPolicyCount: 2, defaultPolicy: desktopPolicyDefaults, assignedPolicies: [result] }).allowCustomProviders).toBe(false);
   });
 });

--- a/apps/app/tests/desktop-policy-restricted.test.ts
+++ b/apps/app/tests/desktop-policy-restricted.test.ts
@@ -16,6 +16,7 @@ import {
   type DesktopAppRestrictionChecker,
 } from "../src/app/cloud/desktop-app-restrictions";
 import { SETTINGS_TAB_VALUES } from "../src/app/types";
+import { libraryAddAction } from "../src/react-app/domains/settings/library";
 
 const allowEverything: DesktopAppRestrictionChecker = () => false;
 const restrictedChecker: DesktopAppRestrictionChecker = ({ restriction }) =>
@@ -69,6 +70,25 @@ describe("restricted desktop policy mode", () => {
     });
     expect(unlockedForTeam.allowManageExtensions).toBe(true);
     expect(unlockedForTeam.allowControlSettings).toBe(false);
+
+    // Restricted on a targeted policy alone grants nothing extra: effective
+    // policy is the union of grants, so the permissive default still wins.
+    const restrictedTargetOnly = calculateEffectiveDesktopPolicy({
+      orgPolicyCount: 2,
+      defaultPolicy: desktopPolicyDefaults,
+      assignedPolicies: [restrictedDesktopPolicyValue],
+    });
+    expect(restrictedTargetOnly.allowControlSettings).toBe(true);
+  });
+});
+
+describe("allowManageExtensions Library gate", () => {
+  test("removes only the local add flows and keeps organization-approved ones", () => {
+    const signedInRestricted = { cloudSignedIn: true, allowManageExtensions: false };
+    expect(libraryAddAction("workspace-mcp", signedInRestricted)).toBeNull();
+    expect(libraryAddAction("mcp", signedInRestricted)).toEqual({ type: "den-modal", kind: "mcp" });
+    expect(libraryAddAction("skill", signedInRestricted)).toEqual({ type: "den-modal", kind: "skill" });
+    expect(libraryAddAction("workspace-mcp", { cloudSignedIn: true, allowManageExtensions: true })).toEqual({ type: "workspace-mcp" });
   });
 });
 

--- a/apps/app/tests/mcp-local-server-recovery.test.ts
+++ b/apps/app/tests/mcp-local-server-recovery.test.ts
@@ -38,6 +38,7 @@ describe("local MCP server recovery", () => {
       },
     } as unknown as OpenworkServerStore;
     const store = createConnectionsStore({
+      checkDesktopAppRestriction: () => false,
       client: () => null,
       setClient: () => undefined,
       projectDir: () => "/tmp/openwork-mcp-recovery",

--- a/ee/apps/den-api/src/desktop-policies.ts
+++ b/ee/apps/den-api/src/desktop-policies.ts
@@ -12,7 +12,6 @@ import {
   calculateEffectiveDesktopPolicy,
   desktopPolicyDefaults,
   normalizeDesktopPolicyDocument,
-  normalizeDesktopPolicyValue,
   selectEffectiveOnboardingPromptConfig,
   type DesktopConfig,
   type DesktopPolicyValue,
@@ -154,7 +153,7 @@ export async function calculateDesktopPolicyForOrgMember(input: {
   const effectivePolicy = calculateEffectiveDesktopPolicy({
     orgPolicyCount: orgPolicies.length,
     defaultPolicy: defaultPolicy?.policy ?? {},
-    assignedPolicies: uniqueAssignedPolicies.map((row) => normalizeDesktopPolicyValue(row.policy)),
+    assignedPolicies: uniqueAssignedPolicies.map((row) => row.policy),
   })
   const onboardingPromptConfig = selectEffectiveOnboardingPromptConfig({
     defaultPolicy: defaultPolicy?.policy ?? {},

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policies-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policies-screen.tsx
@@ -34,6 +34,7 @@ function formatPolicyTimestamp(value: string | null) {
 }
 
 function isRestrictedPolicy(policy: DesktopPolicyDocument) {
+  if (policy.access) return policy.access.mode === "locked";
   return isRestrictedDesktopPolicyValue(
     Object.fromEntries(
       desktopPolicyKeys.map((key) => [key, policy[key] === true]),
@@ -128,7 +129,9 @@ export function DesktopPoliciesScreen() {
             <DenCatalogRow
               key={policy.id}
               title={policy.policyName}
-              badge={policy.isDefault || isRestrictedPolicy(policy.policy) ? (
+              badge={policy.policy.access ? (
+                <span className="text-xs text-gray-500">Team access · {policy.policy.access.mode === "locked" ? "Locked" : "Custom"}</span>
+              ) : policy.isDefault || isRestrictedPolicy(policy.policy) ? (
                 <span className="inline-flex items-center gap-1">
                   {policy.isDefault ? (
                     <span className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-sky-700">Default</span>
@@ -150,7 +153,7 @@ export function DesktopPoliciesScreen() {
               action={
                 <div className="flex shrink-0 items-center gap-2">
                   <Link href={getDesktopPolicyRoute(orgSlug, policy.id)} className={buttonVariants({ variant: "secondary", size: "sm" })}>
-                    {canManage ? "Edit" : "View"}
+                    {policy.policy.access ? "View team access" : canManage ? "Edit" : "View"}
                   </Link>
                   {!policy.isDefault ? (
                     <DenButton type="button" variant="destructive" size="sm" onClick={() => void softDeletePolicy(policy)} disabled={!canManage || deleting}>Delete</DenButton>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policies-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policies-screen.tsx
@@ -3,6 +3,12 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Plus } from "lucide-react";
+import {
+  desktopPolicyKeys,
+  isRestrictedDesktopPolicyValue,
+  type DesktopPolicyDocument,
+  type DesktopPolicyValue,
+} from "@openwork/types/den/desktop-policies";
 import { DenButton, buttonVariants } from "../../_components/ui/button";
 import { DenCatalogList, DenCatalogRow } from "../../_components/ui/catalog-row";
 import { DenNotice } from "../../_components/ui/notice";
@@ -25,6 +31,14 @@ function formatPolicyTimestamp(value: string | null) {
     day: "numeric",
     year: "numeric",
   }).format(date);
+}
+
+function isRestrictedPolicy(policy: DesktopPolicyDocument) {
+  return isRestrictedDesktopPolicyValue(
+    Object.fromEntries(
+      desktopPolicyKeys.map((key) => [key, policy[key] === true]),
+    ) as Required<DesktopPolicyValue>,
+  );
 }
 
 export function DesktopPoliciesScreen() {
@@ -114,8 +128,20 @@ export function DesktopPoliciesScreen() {
             <DenCatalogRow
               key={policy.id}
               title={policy.policyName}
-              badge={policy.isDefault ? (
-                <span className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-sky-700">Default</span>
+              badge={policy.isDefault || isRestrictedPolicy(policy.policy) ? (
+                <span className="inline-flex items-center gap-1">
+                  {policy.isDefault ? (
+                    <span className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-sky-700">Default</span>
+                  ) : null}
+                  {isRestrictedPolicy(policy.policy) ? (
+                    <span
+                      data-testid="desktop-policy-restricted-badge"
+                      className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-amber-700"
+                    >
+                      Restricted
+                    </span>
+                  ) : null}
+                </span>
               ) : undefined}
               description={policy.isEnabled ? "Enabled" : "Disabled"}
               value={policy.isDefault ? "Fallback" : String(policy.priority)}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-data.tsx
@@ -109,6 +109,7 @@ function asDefinition(value: unknown): DesktopPolicyDefinition | null {
     description,
     userNotice,
     defaultValue: value.defaultValue === true,
+    restrictedValue: typeof value.restrictedValue === "boolean" ? value.restrictedValue : null,
   };
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-editor-screen.tsx
@@ -5,8 +5,10 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Laptop } from "lucide-react";
 import {
+  applyRestrictedDesktopPolicy,
   desktopPolicyDefaults,
   desktopPolicyKeys,
+  isRestrictedDesktopPolicyValue,
   type DesktopPolicyDocumentWrite,
   type DesktopPolicyValue,
 } from "@openwork/types/den/desktop-policies";
@@ -26,8 +28,11 @@ import {
 } from "./desktop-policy-data";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
 
+type PolicyMode = "custom" | "restricted";
+
 type PolicyDraft = {
   policyName: string;
+  mode: PolicyMode;
   policy: Required<DesktopPolicyValue>;
   priority: number;
   onboardingPromptsEnabled: boolean;
@@ -40,6 +45,7 @@ type PolicyDraft = {
 
 const EMPTY_DRAFT: PolicyDraft = {
   policyName: "New desktop policy",
+  mode: "custom",
   policy: { ...desktopPolicyDefaults },
   priority: 0,
   onboardingPromptsEnabled: false,
@@ -49,6 +55,21 @@ const EMPTY_DRAFT: PolicyDraft = {
   teamIds: [],
   roles: [],
 };
+
+const POLICY_MODES: Array<{ id: PolicyMode; name: string; description: string }> = [
+  {
+    id: "custom",
+    name: "Custom",
+    description: "Choose each capability below.",
+  },
+  {
+    id: "restricted",
+    name: "Restricted",
+    description:
+      "Chat and organization-approved skills only. Locks the capabilities below so members cannot change desktop settings, add providers or models, add workspaces, or install extensions and MCP servers.",
+  },
+];
+const POLICY_MODE_HELP_ID = "desktop-policy-mode-help";
 
 const ONBOARDING_PROMPT_LABELS = ["First prompt", "Second prompt", "Optional third prompt"];
 const ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH = 120;
@@ -65,9 +86,11 @@ function requiredPolicyValue(value: DesktopPolicyValue): Required<DesktopPolicyV
 function draftFromPolicy(policy: DenDesktopPolicy): PolicyDraft {
   const onboardingPrompts = policy.policy.onboardingPrompts ?? [];
   const onboardingPromptDescriptions = policy.policy.onboardingPromptDescriptions ?? [];
+  const policyValue = requiredPolicyValue(policy.policy);
   return {
     policyName: policy.policyName,
-    policy: requiredPolicyValue(policy.policy),
+    mode: isRestrictedDesktopPolicyValue(policyValue) ? "restricted" : "custom",
+    policy: policyValue,
     priority: policy.priority,
     onboardingPromptsEnabled: onboardingPrompts.length > 0,
     onboardingPromptTexts: [
@@ -236,6 +259,15 @@ export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId
   const priorityError = getPriorityError(draft, isDefault);
   const disabledPromptCopy = getDisabledPromptCopy(isDefault);
   const formDisabled = saving || togglingEnabled || !canManage;
+  const restrictedMode = draft.mode === "restricted";
+
+  const handleSelectMode = (mode: PolicyMode) => {
+    setDraft({
+      ...draft,
+      mode,
+      policy: mode === "restricted" ? applyRestrictedDesktopPolicy(draft.policy) : draft.policy,
+    });
+  };
 
   const handleSave = async () => {
     if (!canManage) {
@@ -419,30 +451,72 @@ export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId
             ) : null}
           </div>
 
+          <fieldset className="grid gap-3" aria-describedby={POLICY_MODE_HELP_ID} data-testid="desktop-policy-mode">
+            <legend className="text-[13px] font-medium text-gray-700">Policy mode</legend>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {POLICY_MODES.map((mode) => (
+                <label
+                  key={mode.id}
+                  className={`flex items-start gap-3 rounded-[22px] border px-5 py-4 ${
+                    draft.mode === mode.id ? "border-gray-900 bg-white" : "border-gray-200 bg-gray-50"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="desktop-policy-mode"
+                    className="mt-1 h-5 w-5"
+                    value={mode.id}
+                    checked={draft.mode === mode.id}
+                    onChange={() => handleSelectMode(mode.id)}
+                    disabled={formDisabled}
+                  />
+                  <span>
+                    <span className="block text-[14px] font-medium text-gray-950">{mode.name}</span>
+                    <span className="mt-1 block text-[13px] leading-6 text-gray-500">{mode.description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            <p id={POLICY_MODE_HELP_ID} className="text-[12px] text-gray-500">
+              {restrictedMode
+                ? isDefault
+                  ? "Locked capabilities stay off until you switch back to Custom."
+                  : "Targeted policies only grant capabilities. Apply Restricted to the default policy to lock members down."
+                : "Switch to Restricted to lock every capability to its restricted value."}
+            </p>
+          </fieldset>
+
           <div className="grid gap-3">
-            {definitions.map((definition) => (
-              <label
-                key={definition.id}
-                className="flex items-start justify-between gap-4 rounded-[22px] border border-gray-200 bg-gray-50 px-5 py-4"
-              >
-                <span>
-                  <span className="block text-[14px] font-medium text-gray-950">{definition.name}</span>
-                  <span className="mt-1 block text-[13px] leading-6 text-gray-500">{definition.description}</span>
-                </span>
-                <input
-                  type="checkbox"
-                  className="mt-1 h-5 w-5"
-                  checked={draft.policy[definition.id] === true}
-                  onChange={(event) =>
-                    setDraft({
-                      ...draft,
-                      policy: { ...draft.policy, [definition.id]: event.target.checked },
-                    })
-                  }
-                  disabled={formDisabled}
-                />
-              </label>
-            ))}
+            {definitions.map((definition) => {
+              const locked = restrictedMode && definition.restrictedValue !== null;
+              return (
+                <label
+                  key={definition.id}
+                  className="flex items-start justify-between gap-4 rounded-[22px] border border-gray-200 bg-gray-50 px-5 py-4"
+                >
+                  <span>
+                    <span className="block text-[14px] font-medium text-gray-950">{definition.name}</span>
+                    <span className="mt-1 block text-[13px] leading-6 text-gray-500">{definition.description}</span>
+                    {locked ? (
+                      <span className="mt-1 block text-[12px] text-gray-500">Locked by Restricted mode.</span>
+                    ) : null}
+                  </span>
+                  <input
+                    type="checkbox"
+                    className="mt-1 h-5 w-5"
+                    data-desktop-policy-key={definition.id}
+                    checked={draft.policy[definition.id] === true}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        policy: { ...draft.policy, [definition.id]: event.target.checked },
+                      })
+                    }
+                    disabled={formDisabled || locked}
+                  />
+                </label>
+              );
+            })}
           </div>
 
           <div className="grid gap-4 rounded-[22px] border border-gray-200 bg-gray-50 px-5 py-4">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-editor-screen.tsx
@@ -16,7 +16,7 @@ import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-templ
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenTextarea } from "../../_components/ui/textarea";
-import { getDesktopPoliciesRoute, getMembersRoute, getOrgAccessFlags } from "../../_lib/den-org";
+import { getDesktopPoliciesRoute, getMembersRoute, getTeamRoute, getOrgAccessFlags } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
   createDesktopPolicy,
@@ -358,7 +358,7 @@ export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId
     <DashboardPageTemplate
       icon={Laptop}
       title={isEditing ? "Edit desktop policy" : "New desktop policy"}
-      description="Default policy values apply org-wide. Other policies can grant access to specific users or teams."
+      description="Advanced app defaults and grants. Manage team modes and permissions from Team → Access."
       colors={["#F8FAFC", "#0F172A", "#38BDF8", "#A78BFA"]}
     >
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
@@ -385,6 +385,14 @@ export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId
         <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center text-[15px] text-gray-500">
           Desktop policy not found.
         </div>
+      ) : policy?.policy.access ? (
+        <section className="rounded-2xl border border-gray-200 bg-white p-6">
+          <h2 className="text-lg font-semibold">Managed in Team access</h2>
+          <p className="mt-2 text-sm text-gray-500">This configuration represents the team’s permissions. Change the mode and individual capabilities from the team’s Access page.</p>
+          {policy.assignments.flatMap((assignment) => assignment.teamId ? [
+            <DenButton key={assignment.teamId} className="mt-4" href={getTeamRoute(orgSlug, assignment.teamId)}>Open team access</DenButton>,
+          ] : [])}
+        </section>
       ) : !canView ? (
         <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center text-[15px] text-gray-500">
           Only workspace admins can view desktop policies.

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-detail-screen.tsx
@@ -9,6 +9,7 @@ import { DenNotice } from "../../_components/ui/notice";
 import { type TabItem, UnderlineTabs } from "../../_components/ui/tabs";
 import { getMarketplaceRoute, getMembersRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { TeamPermissionsPanel } from "./team-permissions-panel";
 import { OrgMemberIdentity } from "./org-member-identity";
 import {
   type TeamPluginAccessItem,
@@ -122,6 +123,9 @@ export function TeamDetailScreen({ teamId }: { teamId: string }) {
 
         {activeTab === "access" ? (
           <div role="tabpanel" aria-label="Access">
+            <TeamPermissionsPanel teamId={teamId} />
+            <h2 className="mb-2 text-lg font-semibold text-gray-950">Plugins & connections</h2>
+            <p className="mb-4 text-sm text-gray-500">Review what this team can use and where access comes from.</p>
             {accessQuery.isLoading ? (
               <div className="rounded-2xl border border-gray-100 bg-white px-6 py-8 text-[13px] text-gray-400">
                 Loading team access…

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-permissions-panel.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-permissions-panel.tsx
@@ -5,7 +5,7 @@ import { LockKeyhole, SlidersHorizontal, ShieldCheck } from "lucide-react";
 import { desktopPolicyDefaults, desktopPolicyDefinitions, type TeamAccess } from "@openwork/types/den/desktop-policies";
 import { DenButton } from "../../_components/ui/button";
 import { DenNotice } from "../../_components/ui/notice";
-import { getOrgAccessFlags } from "../../_lib/den-org";
+import { getMembersRoute, getOrgAccessFlags } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { createDesktopPolicy, updateDesktopPolicy, useOrgDesktopPolicies, type DenDesktopPolicy } from "./desktop-policy-data";
 
@@ -15,7 +15,7 @@ const capabilityLabels: Record<(typeof capabilities)[number]["id"], string> = {
   allowZenModel: "Use OpenCode models",
   allowMultipleWorkspaces: "Create more workspaces",
   allowControlSettings: "Change app settings",
-  allowManageExtensions: "Add and manage tools, skills & MCP servers",
+  allowManageExtensions: "Add and manage local tools, skills & MCP servers",
   allowBuiltInExtensions: "Use built-in extensions",
   allowAlphaUpdates: "Try experimental updates",
   showWelcomePage: "Show welcome page",
@@ -34,7 +34,6 @@ export function TeamPermissionsPanel({ teamId }: { teamId: string }) {
   if (error) return <DenNotice tone="error" message={error} />;
   if (busy || definitions.length === 0) return <p className="py-6 text-sm text-gray-500">Loading permissions…</p>;
   if (!team) return <DenNotice tone="error" message="This team is no longer available." />;
-  if (policy && !policy.isEnabled) return <DenNotice tone="warning" message="This team’s access configuration is disabled. Ask your organization owner to enable it before changing permissions." />;
   if (policies.length > 1 || !exclusivelyAssigned) return <DenNotice tone="error" message="This team has shared or overlapping access configurations. Ask your organization owner to review the assigned policies before editing team permissions." />;
 
   return <>{saved ? <DenNotice tone="info" className="mb-4" message="Permissions saved. Members receive updates when their app refreshes." /> : null}<TeamPermissionsEditor key={`${teamId}-${JSON.stringify(policy)}`} teamId={teamId} teamName={team.name} policy={policy} canManage={access.canManageSettings} onSaved={async () => { await reloadPolicies(); setSaved(true); }} /></>;
@@ -47,6 +46,7 @@ function TeamPermissionsEditor({ teamId, teamName, policy, canManage, onSaved }:
   canManage: boolean;
   onSaved: () => Promise<void>;
 }) {
+  const { orgSlug } = useOrgDashboard();
   const initial: TeamAccess = policy?.policy.access ?? { mode: "custom", capabilities: { ...desktopPolicyDefaults } };
   const [draft, setDraft] = useState(initial);
   const [saving, setSaving] = useState(false);
@@ -82,12 +82,13 @@ function TeamPermissionsEditor({ teamId, teamName, policy, canManage, onSaved }:
         <div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-gray-500" /><h2 className="text-lg font-semibold tracking-tight text-gray-950">What this team can do</h2></div>
         <p className="mt-1 text-sm text-gray-500">Set access here. Members see these permissions in their app.</p>
       </div>
+      {policy && !policy.isEnabled ? <DenNotice tone="warning" message="These permissions are currently disabled. Save permissions to enable them for this team." /> : null}
       {!canManage ? <DenNotice tone="info" message="Only an organization owner or super-admin can change these permissions." /> : null}
       <fieldset disabled={!canManage || saving} className="space-y-4">
         <legend className="mb-3 text-sm font-medium text-gray-800">Team mode</legend>
         <div className="grid gap-3 sm:grid-cols-2">
           {([
-            { mode: "locked", title: "Locked", icon: LockKeyhole, description: "Keep work focused. Members use available tools without adding their own or changing app settings." },
+            { mode: "locked", title: "Locked", icon: LockKeyhole, description: "Keep work focused. Members use available tools without adding local tools or changing app settings." },
             { mode: "custom", title: "Custom", icon: SlidersHorizontal, description: "Choose which capabilities this team can use. Organization restrictions still apply." },
           ] satisfies Array<{ mode: TeamAccess["mode"]; title: string; icon: typeof LockKeyhole; description: string }>).map((option) => (
             <label key={option.mode} className={`flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition ${draft.mode === option.mode ? "border-gray-900 bg-gray-50 ring-1 ring-gray-900" : "border-gray-200 bg-white"}`}>
@@ -113,11 +114,12 @@ function TeamPermissionsEditor({ teamId, teamName, policy, canManage, onSaved }:
         <p className="font-medium text-gray-800">Members can still chat and use available connections.</p>
         <p>Blocking wins over grants from other teams. Allowing a capability here does not override another restriction. Existing installed tools are not removed.</p>
         <p className="mt-2">Cloud editing is controlled by each member’s role. Plugin and tool access is managed below. These settings do not suspend accounts.</p>
+        <DenButton href={getMembersRoute(orgSlug)} variant="secondary" size="sm" className="mt-3">Review member roles</DenButton>
       </div>
       {error ? <DenNotice tone="error" message={error} /> : null}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p role="status" className="text-xs text-gray-500">{saved ? "Permissions saved." : dirty ? "Unsaved changes" : "Members receive updates when their app refreshes."}</p>
-        <DenButton onClick={() => void save()} disabled={!canManage || !dirty} loading={saving}>Save permissions</DenButton>
+        <DenButton onClick={() => void save()} disabled={!canManage || (!dirty && policy?.isEnabled !== false)} loading={saving}>Save permissions</DenButton>
       </div>
     </section>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-permissions-panel.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-permissions-panel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { LockKeyhole, SlidersHorizontal, ShieldCheck } from "lucide-react";
+import { desktopPolicyDefaults, desktopPolicyDefinitions, type TeamAccess } from "@openwork/types/den/desktop-policies";
+import { DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
+import { getOrgAccessFlags } from "../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { createDesktopPolicy, updateDesktopPolicy, useOrgDesktopPolicies, type DenDesktopPolicy } from "./desktop-policy-data";
+
+const capabilities = desktopPolicyDefinitions.filter((entry) => entry.restrictedValue !== null);
+const capabilityLabels: Record<(typeof capabilities)[number]["id"], string> = {
+  allowCustomProviders: "Add AI providers",
+  allowZenModel: "Use OpenCode models",
+  allowMultipleWorkspaces: "Create more workspaces",
+  allowControlSettings: "Change app settings",
+  allowManageExtensions: "Add and manage tools, skills & MCP servers",
+  allowBuiltInExtensions: "Use built-in extensions",
+  allowAlphaUpdates: "Try experimental updates",
+  showWelcomePage: "Show welcome page",
+};
+
+export function TeamPermissionsPanel({ teamId }: { teamId: string }) {
+  const { orgContext } = useOrgDashboard();
+  const [saved, setSaved] = useState(false);
+  const access = getOrgAccessFlags(orgContext?.currentMember.role ?? "member", orgContext?.currentMember.isOwner ?? false);
+  const { desktopPolicies, definitions, busy, error, reloadPolicies } = useOrgDesktopPolicies(orgContext?.organization.id ?? null);
+  const team = orgContext?.teams.find((entry) => entry.id === teamId);
+  const policies = desktopPolicies.filter((policy) => policy.policy.access !== undefined && policy.assignments.some((entry) => entry.teamId === teamId));
+  const policy = policies[0];
+  const exclusivelyAssigned = !policy || (!policy.isDefault && policy.assignments.length === 1 && policy.assignments[0]?.teamId === teamId);
+
+  if (error) return <DenNotice tone="error" message={error} />;
+  if (busy || definitions.length === 0) return <p className="py-6 text-sm text-gray-500">Loading permissions…</p>;
+  if (!team) return <DenNotice tone="error" message="This team is no longer available." />;
+  if (policy && !policy.isEnabled) return <DenNotice tone="warning" message="This team’s access configuration is disabled. Ask your organization owner to enable it before changing permissions." />;
+  if (policies.length > 1 || !exclusivelyAssigned) return <DenNotice tone="error" message="This team has shared or overlapping access configurations. Ask your organization owner to review the assigned policies before editing team permissions." />;
+
+  return <>{saved ? <DenNotice tone="info" className="mb-4" message="Permissions saved. Members receive updates when their app refreshes." /> : null}<TeamPermissionsEditor key={`${teamId}-${JSON.stringify(policy)}`} teamId={teamId} teamName={team.name} policy={policy} canManage={access.canManageSettings} onSaved={async () => { await reloadPolicies(); setSaved(true); }} /></>;
+}
+
+function TeamPermissionsEditor({ teamId, teamName, policy, canManage, onSaved }: {
+  teamId: string;
+  teamName: string;
+  policy: DenDesktopPolicy | undefined;
+  canManage: boolean;
+  onSaved: () => Promise<void>;
+}) {
+  const initial: TeamAccess = policy?.policy.access ?? { mode: "custom", capabilities: { ...desktopPolicyDefaults } };
+  const [draft, setDraft] = useState(initial);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const dirty = JSON.stringify(draft) !== JSON.stringify(initial);
+  const locked = draft.mode === "locked";
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        policyName: policy?.policyName ?? `${teamName} access`,
+        policy: { ...policy?.policy, access: draft },
+        teamIds: [teamId],
+        isEnabled: true,
+      };
+      if (policy) await updateDesktopPolicy(policy.id, payload);
+      else await createDesktopPolicy(payload);
+      setSaved(true);
+      await onSaved();
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Could not save team permissions.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section aria-label="Team permissions" className="mb-8 space-y-5">
+      <div>
+        <div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-gray-500" /><h2 className="text-lg font-semibold tracking-tight text-gray-950">What this team can do</h2></div>
+        <p className="mt-1 text-sm text-gray-500">Set access here. Members see these permissions in their app.</p>
+      </div>
+      {!canManage ? <DenNotice tone="info" message="Only an organization owner or super-admin can change these permissions." /> : null}
+      <fieldset disabled={!canManage || saving} className="space-y-4">
+        <legend className="mb-3 text-sm font-medium text-gray-800">Team mode</legend>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {([
+            { mode: "locked", title: "Locked", icon: LockKeyhole, description: "Keep work focused. Members use available tools without adding their own or changing app settings." },
+            { mode: "custom", title: "Custom", icon: SlidersHorizontal, description: "Choose which capabilities this team can use. Organization restrictions still apply." },
+          ] satisfies Array<{ mode: TeamAccess["mode"]; title: string; icon: typeof LockKeyhole; description: string }>).map((option) => (
+            <label key={option.mode} className={`flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition ${draft.mode === option.mode ? "border-gray-900 bg-gray-50 ring-1 ring-gray-900" : "border-gray-200 bg-white"}`}>
+              <input type="radio" name="team-access-mode" value={option.mode} checked={draft.mode === option.mode} onChange={() => { setDraft({ ...draft, mode: option.mode }); setSaved(false); }} className="mt-1 accent-gray-900" />
+              <span><span className="flex items-center gap-2 font-medium text-gray-950"><option.icon className="h-4 w-4" />{option.title}</span><span className="mt-1 block text-sm leading-5 text-gray-500">{option.description}</span></span>
+            </label>
+          ))}
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white">
+          <div className="border-b border-gray-100 px-4 py-3 text-sm font-medium text-gray-900">App capabilities <span className="ml-2 font-normal text-gray-500">{locked ? "Locked for this team" : "Fine-tune access"}</span></div>
+          <div className="divide-y divide-gray-100">
+            {capabilities.map((entry) => {
+              const allowed = !locked && draft.capabilities[entry.id] !== false;
+              return <label key={entry.id} className="flex items-center justify-between gap-5 px-4 py-3">
+                <span><span className="block text-sm font-medium text-gray-800">{capabilityLabels[entry.id]}</span><span className="mt-0.5 block text-xs leading-5 text-gray-500">{entry.description}</span></span>
+                <span className="flex shrink-0 items-center gap-2 text-xs text-gray-500"><span>{allowed ? "Allowed" : "Blocked"}</span><input aria-label={capabilityLabels[entry.id]} type="checkbox" checked={allowed} disabled={locked} onChange={(event) => { setDraft({ ...draft, capabilities: { ...draft.capabilities, [entry.id]: event.target.checked } }); setSaved(false); }} className="h-4 w-4 accent-gray-900" /></span>
+              </label>;
+            })}
+          </div>
+        </div>
+      </fieldset>
+      <div className="rounded-xl bg-gray-50 px-4 py-3 text-sm leading-6 text-gray-600">
+        <p className="font-medium text-gray-800">Members can still chat and use available connections.</p>
+        <p>Blocking wins over grants from other teams. Allowing a capability here does not override another restriction. Existing installed tools are not removed.</p>
+        <p className="mt-2">Cloud editing is controlled by each member’s role. Plugin and tool access is managed below. These settings do not suspend accounts.</p>
+      </div>
+      {error ? <DenNotice tone="error" message={error} /> : null}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p role="status" className="text-xs text-gray-500">{saved ? "Permissions saved." : dirty ? "Unsaved changes" : "Members receive updates when their app refreshes."}</p>
+        <DenButton onClick={() => void save()} disabled={!canManage || !dirty} loading={saving}>Save permissions</DenButton>
+      </div>
+    </section>
+  );
+}

--- a/evals/packages/cdp/src/app-state.ts
+++ b/evals/packages/cdp/src/app-state.ts
@@ -97,9 +97,11 @@ const PROBE_EXPRESSION = `(() => {
   const stored = localStorage.getItem("openwork.react.activeWorkspace");
   const routeMatch = (route.match(/\\/workspace\\/([^/?#]+)/) ?? [])[1] ?? null;
   const workspaceId = (stored && stored.length > 0 ? stored : null) ?? routeMatch;
-  // Any settings/extensions surface inside a workspace is interactive too.
+  // Any settings/extensions surface inside a workspace is interactive too. The
+  // settings shell always offers "Back to app" even when an organization
+  // policy hides every tab but Cloud; the /extensions route renders the Library.
   const settingsSurface = /\\/workspace\\/[^/?#]+\\/(settings|extensions)/.test(route)
-    && (text.includes("Extensions") || text.includes("Preferences") || text.includes("Permissions"));
+    && (text.includes("Back to app") || text.includes("Library") || text.includes("Extensions") || text.includes("Preferences") || text.includes("Permissions"));
   const surface = welcome
     ? "welcome"
     : (taskUi || settingsSurface) && workspaceId && !needsWorkspace

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -181,7 +181,7 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     expect(savedRestricted[key]).toBe(value);
   }
 
-  const { reopenedLockNotes, unlockedLockNotes, savedAfterCustom } = await step("the admin reopens the policy and returns it to Custom", async () => {
+  const { reopenedLockNotes, unlockedLockNotes, savedEnabled, savedAfterCustom } = await step("the admin reopens the policy and returns it to Custom", async () => {
     await admin.user.navigate(new URL(world.editorPath, world.den.ref.webUrl).toString());
     await admin.user.see({ text: "Policy mode" }, { timeoutMs: 90_000 });
     await admin.user.see({ text: lockNote }, { timeoutMs: 30_000 });
@@ -189,11 +189,22 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     await admin.user.click({ text: "Custom" });
     await admin.user.notSee({ text: lockNote }, { timeoutMs: 15_000 });
     const unlockedLockNotes = await lockNotes();
-    // Saving again from Custom without touching a checkbox must keep the same
-    // booleans: Custom unlocks the controls, it does not rewrite the values.
+    for (const card of lockedCards) {
+      await admin.user.see({ role: "checkbox", label: new RegExp(`^${card}`) }, { editable: true });
+    }
+    // Persist an actual edit, then restore it so the member still receives the
+    // fully restricted policy in the next phase.
+    for (const card of lockedCards) await admin.user.click({ role: "checkbox", label: new RegExp(`^${card}`) });
+    await admin.user.click("Save changes");
+    await admin.user.see({ text: /^default$/i }, { timeoutMs: 60_000 });
+    const savedEnabled = await savedPolicy();
+    for (const key of lockedKeys) expect(savedEnabled[key]).toBe(true);
+    await admin.user.navigate(new URL(world.editorPath, world.den.ref.webUrl).toString());
+    await admin.user.see({ role: "checkbox", label: /^Control Settings/ }, { editable: true, timeoutMs: 60_000 });
+    for (const card of lockedCards) await admin.user.click({ role: "checkbox", label: new RegExp(`^${card}`) });
     await admin.user.click("Save changes");
     await admin.user.see({ testId: "desktop-policy-restricted-badge" }, { timeoutMs: 60_000 });
-    return { reopenedLockNotes, unlockedLockNotes, savedAfterCustom: await savedPolicy() };
+    return { reopenedLockNotes, unlockedLockNotes, savedEnabled, savedAfterCustom: await savedPolicy() };
   });
   expect(reopenedLockNotes).toBe(lockedCards.length);
   expect(unlockedLockNotes).toBe(0);
@@ -201,9 +212,9 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     expect(savedAfterCustom[key]).toBe(value);
   }
   evidence.recordAssertionEvidence(
-    "Saving stores plain booleans, the editor reopens in Restricted, and Custom unlocks the checkboxes without changing values",
-    `saved=${JSON.stringify(lockedKeys.map((key) => [key, savedRestricted[key]]))}; reopenedLockNotes=${reopenedLockNotes}; unlockedLockNotes=${unlockedLockNotes}; savedAfterCustom unchanged=${lockedKeys.every((key) => savedAfterCustom[key] === savedRestricted[key])}`,
-    reopenedLockNotes === lockedCards.length && unlockedLockNotes === 0 && lockedKeys.every((key) => savedAfterCustom[key] === false),
+    "Custom lets the admin enable and save every governed capability before restoring the Restricted values",
+    `saved=${JSON.stringify(lockedKeys.map((key) => [key, savedRestricted[key]]))}; reopenedLockNotes=${reopenedLockNotes}; unlockedLockNotes=${unlockedLockNotes}; savedEnabled=${JSON.stringify(savedEnabled)}; savedAfterCustom unchanged=${lockedKeys.every((key) => savedAfterCustom[key] === savedRestricted[key])}`,
+    reopenedLockNotes === lockedCards.length && unlockedLockNotes === 0 && lockedKeys.every((key) => savedEnabled[key] === true) && lockedKeys.every((key) => savedAfterCustom[key] === false),
   );
 
   // Phase 3 — the member's desktop re-reads the effective policy. A reload
@@ -280,12 +291,23 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
       label: "built-in extensions notice",
       until: (shown) => shown,
     });
-    await member.user.click({ role: "button", label: /^MCPs$/ });
-    await member.user.see({ role: "button", label: "Add organization MCP" });
-    await member.user.notSee({ role: "button", label: /^Add$/ });
+    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.click({ role: "button", label: /^Add$/ });
+    await member.user.see({ testId: "library-add-choices" });
+    await member.user.see({ text: "Organization MCP" });
+    await member.user.notSee({ text: "Workspace MCP" });
+    const choicesText = await member.probe.text();
+    expect(choicesText).not.toContain("Workspace MCP");
+    await member.user.click({ text: "Organization MCP" });
+    await member.user.click({ role: "button", label: "Continue" });
+    await member.user.see({ text: "Add an MCP server" });
+    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
     await member.user.notSee({ text: "Add workspace MCP" });
-    const restrictedMcpText = await member.probe.text();
+    const restrictedMcpText = `${choicesText}\n${await member.probe.text()}`;
+    expect(restrictedMcpText).not.toContain("Workspace MCP");
     expect(restrictedMcpText).not.toContain("Add workspace MCP");
+    await member.user.press("Escape");
+    await member.user.notSee({ text: "Add an MCP server" });
     await member.user.click({ role: "button", label: /^All$/ });
     return { libraryHashAfter: await member.probe.hash(), builtInNoticeShown, restrictedMcpText };
   });
@@ -297,8 +319,8 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
   ]);
   evidence.recordAssertionEvidence(
     "The Library removes the local workspace MCP add path while keeping organization MCP authoring available",
-    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}; MCPs filter=${restrictedMcpText}`,
-    libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Add organization MCP") && !restrictedMcpText.includes("Add workspace MCP"),
+    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}; add choices and organization form=${restrictedMcpText}`,
+    libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Saved to your organization Library as a remote MCP connection.") && !restrictedMcpText.includes("Workspace MCP") && !restrictedMcpText.includes("Add workspace MCP"),
   );
 
 });
@@ -460,13 +482,24 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     await member.user.click("Library");
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
     await member.user.see({ text: /Need an MCP server or skill/ });
-    await member.user.click({ role: "button", label: /^MCPs$/ });
-    await member.user.see({ role: "button", label: "Add organization MCP" });
-    await member.user.notSee({ role: "button", label: /^Add$/ });
+    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.click({ role: "button", label: /^Add$/ });
+    await member.user.see({ testId: "library-add-choices" });
+    await member.user.see({ text: "Organization MCP" });
+    await member.user.notSee({ text: "Workspace MCP" });
+    const choicesText = await member.probe.text();
+    expect(choicesText).not.toContain("Workspace MCP");
+    await member.user.click({ text: "Organization MCP" });
+    await member.user.click({ role: "button", label: "Continue" });
+    await member.user.see({ text: "Add an MCP server" });
+    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
     await member.user.notSee({ text: "Add workspace MCP" });
-    const mcpText = await member.probe.text();
+    const mcpText = `${choicesText}\n${await member.probe.text()}`;
+    expect(mcpText).not.toContain("Workspace MCP");
     expect(mcpText).not.toContain("Add workspace MCP");
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Add organization MCP") && !mcpText.includes("Add workspace MCP"));
+    await member.user.press("Escape");
+    await member.user.notSee({ text: "Add an MCP server" });
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
     await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && count(permissionsText, "Blocked") === lockedKeys.length && libraryText.includes("Need an MCP server or skill"));
@@ -497,13 +530,24 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     for (const key of lockedKeys.filter((key) => key !== "allowManageExtensions")) expect(config[key]).toBe(true);
     await member.user.reload();
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
-    await member.user.click({ role: "button", label: /^MCPs$/ });
-    await member.user.see({ role: "button", label: "Add organization MCP" });
-    await member.user.notSee({ role: "button", label: /^Add$/ });
+    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.click({ role: "button", label: /^Add$/ });
+    await member.user.see({ testId: "library-add-choices" });
+    await member.user.see({ text: "Organization MCP" });
+    await member.user.notSee({ text: "Workspace MCP" });
+    const choicesText = await member.probe.text();
+    expect(choicesText).not.toContain("Workspace MCP");
+    await member.user.click({ text: "Organization MCP" });
+    await member.user.click({ role: "button", label: "Continue" });
+    await member.user.see({ text: "Add an MCP server" });
+    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
     await member.user.notSee({ text: "Add workspace MCP" });
-    const mcpText = await member.probe.text();
+    const mcpText = `${choicesText}\n${await member.probe.text()}`;
+    expect(mcpText).not.toContain("Workspace MCP");
     expect(mcpText).not.toContain("Add workspace MCP");
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Add organization MCP") && !mcpText.includes("Add workspace MCP"));
+    await member.user.press("Escape");
+    await member.user.notSee({ text: "Add an MCP server" });
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
     await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     await member.user.click(accountMenu);

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -530,25 +530,6 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     for (const key of lockedKeys.filter((key) => key !== "allowManageExtensions")) expect(config[key]).toBe(true);
     await member.user.reload();
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
-    await member.user.click({ role: "button", label: /^All$/ });
-    await member.user.click({ role: "button", label: /^Add$/ });
-    await member.user.see({ testId: "library-add-choices" });
-    await member.user.see({ text: "Organization MCP" });
-    await member.user.notSee({ text: "Workspace MCP" });
-    const choicesText = await member.probe.text();
-    expect(choicesText).not.toContain("Workspace MCP");
-    await member.user.click({ text: "Organization MCP" });
-    await member.user.click({ role: "button", label: "Continue" });
-    await member.user.see({ text: "Add an MCP server" });
-    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
-    await member.user.notSee({ text: "Add workspace MCP" });
-    const mcpText = `${choicesText}\n${await member.probe.text()}`;
-    expect(mcpText).not.toContain("Workspace MCP");
-    expect(mcpText).not.toContain("Add workspace MCP");
-    await member.user.press("Escape");
-    await member.user.notSee({ text: "Add an MCP server" });
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path while the organization MCP add form remains reachable", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
-    await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     await member.user.click(accountMenu);
     await member.user.see(settingsMenuItem);
@@ -569,6 +550,32 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     expect(count(permissionsText, "Allowed")).toBe(lockedKeys.length - 1);
     evidence.recordAssertionEvidence("The Custom account permissions tab shows Settings Allowed and tools Blocked", permissionsText, count(permissionsText, "Blocked") === 1 && count(permissionsText, "Allowed") === lockedKeys.length - 1);
     await member.user.looks(["The dedicated App permissions tab shows Change app settings Allowed and Add tools, skills & MCP servers Blocked, without a policy banner"]);
+    // Reopen Library after account refresh has settled. Its restriction notice
+    // appears before Cloud inventory hydrates, so wait for the approved plugin
+    // before opening a dialog that hydration could otherwise remount.
+    await member.user.click({ role: "button", label: "Back to app" });
+    await member.user.click("Library");
+    await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
+    await member.user.see({ text: world.pluginName }, { timeoutMs: 90_000 });
+    await member.user.click({ role: "button", label: /^All$/ });
+    await member.user.click({ role: "button", label: /^Add$/ });
+    await member.user.see({ testId: "library-add-choices" });
+    await member.user.see({ text: "Organization MCP" });
+    await member.user.notSee({ text: "Workspace MCP" });
+    const choicesText = await member.probe.text();
+    expect(choicesText).not.toContain("Workspace MCP");
+    await member.user.click({ text: "Organization MCP" });
+    await member.user.click({ role: "button", label: "Continue" });
+    await member.user.see({ text: "Add an MCP server" });
+    await member.user.see({ text: "Saved to your organization Library as a remote MCP connection." });
+    await member.user.notSee({ text: "Add workspace MCP" });
+    const mcpText = `${choicesText}\n${await member.probe.text()}`;
+    expect(mcpText).not.toContain("Workspace MCP");
+    expect(mcpText).not.toContain("Add workspace MCP");
+    await member.user.press("Escape");
+    await member.user.notSee({ text: "Add an MCP server" });
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path while the organization MCP add form remains reachable", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
+    await member.user.click({ role: "button", label: /^All$/ });
     await admin.user.looks(["Custom is selected with tool installation Blocked and other capabilities Allowed"]);
   });
 

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -318,7 +318,7 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     "A notice says built-in OpenWork extensions are disabled by your organization",
   ]);
   evidence.recordAssertionEvidence(
-    "The Library removes the local workspace MCP add path while keeping organization MCP authoring available",
+    "The Library removes the local workspace MCP add path while the organization MCP add form remains reachable",
     `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}; add choices and organization form=${restrictedMcpText}`,
     libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Saved to your organization Library as a remote MCP connection.") && !restrictedMcpText.includes("Workspace MCP") && !restrictedMcpText.includes("Add workspace MCP"),
   );
@@ -499,7 +499,7 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     expect(mcpText).not.toContain("Add workspace MCP");
     await member.user.press("Escape");
     await member.user.notSee({ text: "Add an MCP server" });
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path while the organization MCP add form remains reachable", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
     await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && count(permissionsText, "Blocked") === lockedKeys.length && libraryText.includes("Need an MCP server or skill"));
@@ -547,7 +547,7 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     expect(mcpText).not.toContain("Add workspace MCP");
     await member.user.press("Escape");
     await member.user.notSee({ text: "Add an MCP server" });
-    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path while the organization MCP add form remains reachable", mcpText, mcpText.includes("Saved to your organization Library as a remote MCP connection.") && !mcpText.includes("Workspace MCP") && !mcpText.includes("Add workspace MCP"));
     await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     await member.user.click(accountMenu);

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -84,20 +84,31 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
   // no extension-management notice, and the settings hub and every settings
   // group are reachable. Settings comes last so the desktop is still on that
   // route when it reloads in phase 3.
-  const libraryHashBefore = await step("the member opens the Library before the policy changes", async () => {
+  const { libraryHashBefore, localMcpFormText } = await step("the member opens the Library before the policy changes", async () => {
     await member.user.click("Library");
     await member.user.see({ text: "Library" }, { timeoutMs: 90_000 });
     await member.user.notSee(manageExtensionsNotice);
-    return member.probe.hash();
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.click({ role: "button", label: /^Add$/ });
+    await member.user.see({ text: "Workspace MCP" });
+    await member.user.click({ text: "Workspace MCP" });
+    await member.user.click({ role: "button", label: "Continue" });
+    await member.user.see({ text: "Add workspace MCP" });
+    await member.user.see({ role: "textbox", label: "App name" });
+    const localMcpFormText = await member.probe.text();
+    await member.user.press("Escape");
+    await member.user.notSee({ text: "Add workspace MCP" });
+    await member.user.click({ role: "button", label: /^All$/ });
+    return { libraryHashBefore: await member.probe.hash(), localMcpFormText };
   });
   expect(libraryHashBefore).toContain("/extensions");
   await member.user.looks([
     "The Library page is open and shows no notice that extension management was disabled by an organization administrator",
   ]);
   evidence.recordAssertionEvidence(
-    "Before the policy change the Library carries no extension-management restriction",
-    `hash=${libraryHashBefore}; manage-extensions notice absent`,
-    libraryHashBefore.includes("/extensions"),
+    "Before the policy change the member can open the local workspace MCP add form",
+    `hash=${libraryHashBefore}; manage-extensions notice absent; local form=${localMcpFormText}`,
+    libraryHashBefore.includes("/extensions") && localMcpFormText.includes("Add workspace MCP") && localMcpFormText.includes("App name"),
   );
 
   const hashBefore = await step("the member opens settings from the account menu before the policy changes", async () => {
@@ -224,7 +235,7 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     hashAfter.includes("/settings/cloud-account"),
   );
 
-  const redirectedHash = await step("a hidden settings tab redirects", async () => {
+  const redirectedHash = await step("a forced hidden appearance route redirects to the visible Account page", async () => {
     await member.agent.run("route.settings.appearance");
     return member.probe.eventually(() => member.probe.hash(), {
       within: 60_000,
@@ -233,37 +244,50 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     });
   });
   expect(redirectedHash).toContain("/settings/cloud-account");
+  await member.user.see(accountTab);
+  await member.user.see(signOut);
+  await member.user.notSee(settingsHub);
   evidence.recordAssertionEvidence(
     "A route to a hidden settings tab lands on the Cloud account page instead",
-    `requested=/settings/appearance; landed=${redirectedHash}`,
+    `forced route=/settings/appearance; landed=${redirectedHash}; Account tab and Sign out visible; Settings hub absent`,
     redirectedHash.includes("/settings/cloud-account"),
   );
 
-  await step("the account menu offers only the Account page", async () => {
+  const restrictedMenuText = await step("the account menu offers only the Account page", async () => {
     await member.user.click({ role: "button", label: "Back to app" });
     await member.user.click(accountMenu);
     await member.user.see(accountMenuItem);
     await member.user.notSee(settingsMenuItem);
+    const menuText = await member.probe.text();
     await member.user.press("Escape");
     await member.user.notSee(accountMenuItem, { timeoutMs: 10_000 });
+    return menuText;
   });
   evidence.recordAssertionEvidence(
     "Under the Restricted policy the account menu leads to the Account page instead of desktop settings",
-    "account menu shows an Account item and no Settings item",
-    true,
+    restrictedMenuText,
+    restrictedMenuText.includes("Account") && !restrictedMenuText.includes("Settings"),
   );
 
-  const { libraryHashAfter, builtInNoticeShown } = await step("the member opens the Library under the Restricted policy", async () => {
+  const { libraryHashAfter, builtInNoticeShown, restrictedMcpText } = await step("the member opens the Library under the Restricted policy", async () => {
     await member.user.click("Library");
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000, text: /disabled local extension management/ });
     // Restricted also turns off allowBuiltInExtensions, so the Library's
     // existing built-in banner appears alongside the new notice.
+    await member.user.see({ text: builtInExtensionsNotice });
     const builtInNoticeShown = await member.probe.eventually(() => member.probe.has(builtInExtensionsNotice), {
       within: 30_000,
       label: "built-in extensions notice",
       until: (shown) => shown,
     });
-    return { libraryHashAfter: await member.probe.hash(), builtInNoticeShown };
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.see({ role: "button", label: "Add organization MCP" });
+    await member.user.notSee({ role: "button", label: /^Add$/ });
+    await member.user.notSee({ text: "Add workspace MCP" });
+    const restrictedMcpText = await member.probe.text();
+    expect(restrictedMcpText).not.toContain("Add workspace MCP");
+    await member.user.click({ role: "button", label: /^All$/ });
+    return { libraryHashAfter: await member.probe.hash(), builtInNoticeShown, restrictedMcpText };
   });
   expect(libraryHashAfter).toContain("/extensions");
   expect(builtInNoticeShown).toBe(true);
@@ -272,9 +296,9 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
     "A notice says built-in OpenWork extensions are disabled by your organization",
   ]);
   evidence.recordAssertionEvidence(
-    "The Library stays reachable but local extension and MCP add flows are disabled with the catalog notice",
-    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}`,
-    libraryHashAfter.includes("/extensions") && builtInNoticeShown,
+    "The Library removes the local workspace MCP add path while keeping organization MCP authoring available",
+    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}; MCPs filter=${restrictedMcpText}`,
+    libraryHashAfter.includes("/extensions") && builtInNoticeShown && restrictedMcpText.includes("Add organization MCP") && !restrictedMcpText.includes("Add workspace MCP"),
   );
 
 });
@@ -317,7 +341,16 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     await admin.user.see({ text: mode === "Locked" ? "Locked for this team" : "Fine-tune access" }, { timeoutMs: 60_000 });
   };
 
-  await step("both ordinary members start unrestricted and the target can open Settings", async () => {
+  const targetBaseline = await effective(world.den.members.jordan);
+  const controlBaseline = await effective(world.den.members.casey);
+  const defaultPolicy = await readDefaultDesktopPolicy(probe, world.den.admin);
+  if (!isRecord(defaultPolicy.policy)) throw new Error("Expected default policy capabilities");
+  expect(defaultPolicy.policy.allowAlphaUpdates).toBe(false);
+  const grantPolicy = (await policies()).find((entry) => Array.isArray(entry.assignments)
+    && entry.assignments.some((assignment: unknown) => isRecord(assignment) && assignment.teamId === world.grantTeamId));
+  if (!grantPolicy || !isRecord(grantPolicy.policy)) throw new Error("Expected overlapping grant policy");
+  expect(grantPolicy.policy.allowAlphaUpdates).toBe(true);
+  await step("the target receives Alpha access only from the overlapping grant and can open Settings", async () => {
     const roles = [];
     for (const identity of [world.den.members.jordan, world.den.members.casey]) {
       const org = await probe.api(identity, "/v1/org");
@@ -326,7 +359,9 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
       roles.push(org.body.currentMember.role);
       expect(org.body.currentMember.role).toBe("member");
       const config = await effective(identity);
-      for (const key of lockedKeys) expect(config[key]).toBe(true);
+      for (const key of lockedKeys) {
+        expect(config[key]).toBe(identity === world.den.members.jordan || key !== "allowAlphaUpdates");
+      }
     }
     await member.user.click(accountMenu);
     await member.user.click(settingsMenuItem);
@@ -342,11 +377,11 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     expect(baselinePermissions).not.toContain("Blocked");
     await member.user.click(accountTab);
     await member.user.see(signOut);
-    await member.agent.run("route.settings.general");
+    await member.user.click(settingsHub);
     await member.user.see(settingsHub);
     const hash = await member.probe.hash();
     expect(hash).toContain("/settings/general");
-    evidence.recordAssertionEvidence("The target and control have the same ordinary role and unrestricted baseline with a working App permissions tab", JSON.stringify({ roles, hash, baselinePermissions }), roles.every((role) => role === "member") && hash.includes("/settings/general") && count(baselinePermissions, "Allowed") === lockedKeys.length && !baselinePermissions.includes("Blocked"));
+    evidence.recordAssertionEvidence("The same-role target receives grant-only Alpha access while the outside control does not, and the target can inspect all Allowed permissions", JSON.stringify({ roles, hash, baselinePermissions, targetBaseline, controlBaseline, defaultPolicy, grantPolicy }), roles.every((role) => role === "member") && targetBaseline.allowAlphaUpdates === true && controlBaseline.allowAlphaUpdates === false && hash.includes("/settings/general") && count(baselinePermissions, "Allowed") === lockedKeys.length && !baselinePermissions.includes("Blocked"));
   });
 
   await step("the admin locks the team through Team Access", async () => {
@@ -357,9 +392,9 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
   const control = await effective(world.den.members.casey);
   for (const key of lockedKeys) {
     expect(lockedMember[key]).toBe(false);
-    expect(control[key]).toBe(true);
+    expect(control[key]).toBe(controlBaseline[key]);
   }
-  evidence.recordAssertionEvidence("Team blocks override overlapping grants while an ordinary member outside the team stays unrestricted", JSON.stringify({ lockedMember, control }), lockedKeys.every((key) => lockedMember[key] === false && control[key] === true));
+  evidence.recordAssertionEvidence("Team blocks override the grant-only Alpha permission while the outside ordinary member keeps their baseline", JSON.stringify({ targetBaseline, lockedMember, controlBaseline, control }), targetBaseline.allowAlphaUpdates === true && lockedKeys.every((key) => lockedMember[key] === false && control[key] === controlBaseline[key]));
   await admin.user.looks(["The Focused work team Access page shows Locked selected and blocked app capabilities"]);
 
   await step("locked members retain their approved team skill without exposing it outside the team", async () => {
@@ -390,10 +425,12 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     await member.user.notSee(settingsHub);
     await member.user.notSee({ text: "Workspace" });
     await member.user.notSee({ text: "Global" });
+    // Force a hidden route to test the guard, rather than a user navigation path.
     await member.agent.run("route.settings.appearance");
     const forbiddenRoute = await member.probe.eventually(() => member.probe.hash(), {
       within: 60_000, label: "forbidden appearance route redirects", until: (hash) => hash.includes("/settings/cloud-account"),
     });
+    await member.user.see(accountTab);
     await member.user.see(signOut);
     await member.user.click(permissionsTab);
     await member.user.see({ text: "Your app permissions" });
@@ -423,6 +460,14 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     await member.user.click("Library");
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
     await member.user.see({ text: /Need an MCP server or skill/ });
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.see({ role: "button", label: "Add organization MCP" });
+    await member.user.notSee({ role: "button", label: /^Add$/ });
+    await member.user.notSee({ text: "Add workspace MCP" });
+    const mcpText = await member.probe.text();
+    expect(mcpText).not.toContain("Add workspace MCP");
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Add organization MCP") && !mcpText.includes("Add workspace MCP"));
+    await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && count(permissionsText, "Blocked") === lockedKeys.length && libraryText.includes("Need an MCP server or skill"));
     await member.user.looks(["The Library shows organization restrictions and guidance for requesting an MCP server or skill"]);
@@ -452,6 +497,14 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     for (const key of lockedKeys.filter((key) => key !== "allowManageExtensions")) expect(config[key]).toBe(true);
     await member.user.reload();
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
+    await member.user.click({ role: "button", label: /^MCPs$/ });
+    await member.user.see({ role: "button", label: "Add organization MCP" });
+    await member.user.notSee({ role: "button", label: /^Add$/ });
+    await member.user.notSee({ text: "Add workspace MCP" });
+    const mcpText = await member.probe.text();
+    expect(mcpText).not.toContain("Add workspace MCP");
+    evidence.recordAssertionEvidence("Blocked local tool management removes the workspace MCP add path without removing organization MCP authoring", mcpText, mcpText.includes("Add organization MCP") && !mcpText.includes("Add workspace MCP"));
+    await member.user.click({ role: "button", label: /^All$/ });
     const libraryText = await member.probe.text();
     await member.user.click(accountMenu);
     await member.user.see(settingsMenuItem);

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -7,7 +7,21 @@ import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy, teamAcce
 // real member desktop side by side: the editor locks every governed capability
 // and stores plain booleans, and the member's settings and Library surfaces
 // collapse to what the policy leaves reachable.
-const test = spec.world(defaultPolicyEditorAndMemberDesktop, { timeout: 900_000 });
+const defaultJourney = "an admin restricts the default policy and the member desktop enforces it";
+const teamJourney = "team access overrides overlapping grants and restores only selected desktop capabilities";
+// Register one fixture extension: Vitest 3 accumulates fixtures when the same
+// base is extended twice. Choose the setup at the test boundary, keeping the
+// worlds framework-free and each sequential journey isolated.
+const test = spec.world(async (seed) => {
+  const name = expect.getState().currentTestName;
+  if (name?.endsWith(defaultJourney)) {
+    return { defaultPolicy: await defaultPolicyEditorAndMemberDesktop(seed), team: null };
+  }
+  if (name?.endsWith(teamJourney)) {
+    return { defaultPolicy: null, team: await teamAccess(seed) };
+  }
+  throw new Error(`No desktop policy world selected for ${name}`);
+}, { timeout: 900_000 });
 
 // The capability cards as the editor labels them. Restricted locks the first
 // seven; the Welcome Page display preference stays editable in both modes.
@@ -52,7 +66,9 @@ function count(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-test("an admin restricts the default policy and the member desktop enforces it", async ({ world, user, agent, probe, step, evidence }) => {
+test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, evidence }) => {
+  const world = selectedWorld.defaultPolicy;
+  if (!world) throw new Error("Expected the default-policy world");
   const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
   const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
   const lockNotes = () => admin.probe.text().then((text) => count(text, lockNote));
@@ -261,8 +277,9 @@ test("an admin restricts the default policy and the member desktop enforces it",
 
 });
 
-const teamTest = spec.world(teamAccess, { timeout: 900_000 });
-teamTest("team access overrides overlapping grants and restores only selected desktop capabilities", async ({ world, user, agent, probe, step, evidence, seed }) => {
+test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evidence, seed }) => {
+  const world = selectedWorld.team;
+  if (!world) throw new Error("Expected the Team Access world");
   const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
   const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
   const effective = async (identity: typeof world.den.admin) => {

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -37,6 +37,9 @@ const restrictedSavedValues: Record<string, boolean> = {
 const lockedKeys = Object.keys(restrictedSavedValues).filter((key) => key !== "showWelcomePage");
 
 const settingsHub = { role: "button", label: "Settings" } as const;
+const accountMenu = { testId: "account-status-menu" };
+const settingsMenuItem = { role: "menuitem", label: "Settings" } as const;
+const accountMenuItem = { role: "menuitem", label: "Account" } as const;
 const policyBanner = { testId: "desktop-policy-banner" };
 const manageExtensionsNotice = { testId: "manage-extensions-policy-notice" };
 const builtInExtensionsNotice = "Built-in OpenWork extensions are disabled by your organization";
@@ -65,7 +68,7 @@ test("an admin switches the default desktop policy to Restricted and a member's 
   // banner is not a discriminator here: it already reacts to unrelated
   // organization flags such as Dashboards or Automations being off.)
   const libraryHashBefore = await step("the member opens the Library before the policy changes", async () => {
-    await member.agent.run("route.extensions.skills");
+    await member.user.click("Library");
     await member.user.see({ text: "Library" }, { timeoutMs: 90_000 });
     await member.user.notSee(manageExtensionsNotice);
     return member.probe.hash();
@@ -80,8 +83,10 @@ test("an admin switches the default desktop policy to Restricted and a member's 
     libraryHashBefore.includes("/extensions"),
   );
 
-  const hashBefore = await step("the member opens settings before the policy changes", async () => {
-    await member.agent.run("route.settings.general");
+  const hashBefore = await step("the member opens settings from the account menu before the policy changes", async () => {
+    await member.user.click(accountMenu);
+    await member.user.see(settingsMenuItem);
+    await member.user.click(settingsMenuItem);
     await member.user.see(settingsHub, { timeoutMs: 60_000 });
     for (const group of ["Workspace", "Global", "Cloud"]) await member.user.see({ text: group });
     return member.probe.hash();
@@ -216,8 +221,22 @@ test("an admin switches the default desktop policy to Restricted and a member's 
     redirectedHash.includes("/settings/cloud-account"),
   );
 
+  await step("the account menu offers only the Account page", async () => {
+    await member.user.click({ role: "button", label: "Back to app" });
+    await member.user.click(accountMenu);
+    await member.user.see(accountMenuItem);
+    await member.user.notSee(settingsMenuItem);
+    await member.user.press("Escape");
+    await member.user.notSee(accountMenuItem, { timeoutMs: 10_000 });
+  });
+  evidence.recordAssertionEvidence(
+    "Under the Restricted policy the account menu leads to the Account page instead of desktop settings",
+    "account menu shows an Account item and no Settings item",
+    true,
+  );
+
   const { libraryHashAfter, builtInNoticeShown } = await step("the member opens the Library under the Restricted policy", async () => {
-    await member.agent.run("route.extensions.skills");
+    await member.user.click("Library");
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000, text: /disabled local extension management/ });
     // Restricted also turns off allowBuiltInExtensions, so the Library's
     // existing built-in banner appears alongside the new notice.

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -296,7 +296,8 @@ test("an admin controls default and team access while members can understand the
   await step("the admin locks the team from its Access page", async () => {
     await admin.user.navigate(teamPath);
     await admin.user.see({ text: "What this team can do" }, { timeoutMs: 90_000 });
-    await admin.user.click({ role: "radio", label: /^Locked/ });
+    await admin.user.looks(["The team Access page shows Locked and Custom modes above a list of individual app capabilities"]);
+    await admin.user.click({ text: "Locked" });
     await admin.user.click("Save permissions");
     await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowManageExtensions, {
       within: 30_000, label: "team lock overrides the default grant", until: (value) => value === false,
@@ -329,7 +330,7 @@ test("an admin controls default and team access while members can understand the
   evidence.recordAssertionEvidence("Members can inspect app permissions and find instructions for requesting an MCP server", "Library MCP guidance and expanded account permission list visible", true);
 
   await step("the admin grants selected capabilities while keeping tool installation blocked", async () => {
-    await admin.user.click({ role: "radio", label: /^Custom/ });
+    await admin.user.click({ text: "Custom" });
     await admin.user.click({ role: "checkbox", label: "Add and manage local tools, skills & MCP servers" });
     await admin.user.click("Save permissions");
     await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowControlSettings, {

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy } from "../worlds/desktop-policies.ts";
+import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy, teamAccess } from "../worlds/desktop-policies.ts";
 
 // An organization that wants a vanilla OpenWork picks one decision, Restricted,
 // in the Den policy editor. This spec drives the real editor as the admin and a
@@ -52,7 +52,7 @@ function count(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-test("an admin controls default and team access while members can understand their permissions", async ({ world, user, agent, probe, step, evidence, seed }) => {
+test("an admin restricts the default policy and the member desktop enforces it", async ({ world, user, agent, probe, step, evidence }) => {
   const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
   const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
   const lockNotes = () => admin.probe.text().then((text) => count(text, lockNote));
@@ -259,110 +259,190 @@ test("an admin controls default and team access while members can understand the
     libraryHashAfter.includes("/extensions") && builtInNoticeShown,
   );
 
-  // Team limits must win even when the organization grants every capability.
-  await step("prepare an unrestricted organization with a focused-work team", async () => {
-    const reset = await seed.api(world.den.admin, `/v1/desktop-policies/${world.policyId}`, {
-      method: "PATCH",
-      body: JSON.stringify({ policyName: "Default desktop policy", policy: Object.fromEntries(Object.keys(restrictedSavedValues).map((key) => [key, true])) }),
-    });
-    expect(reset.response.ok).toBe(true);
-  });
-  const org = await probe.api(world.den.members.jordan, "/v1/org");
-  const currentMember = isRecord(org.body) && isRecord(org.body.currentMember) ? org.body.currentMember : null;
-  expect(typeof currentMember?.id).toBe("string");
-  const createdTeam = await seed.api(world.den.admin, "/v1/teams", {
-    method: "POST",
-    body: JSON.stringify({ name: "Focused work", memberIds: [currentMember?.id] }),
-  });
-  expect(createdTeam.response.ok).toBe(true);
-  const team = isRecord(createdTeam.body) && isRecord(createdTeam.body.team) ? createdTeam.body.team : null;
-  if (typeof team?.id !== "string") throw new Error("Expected a created team");
-  const otherTeamResult = await seed.api(world.den.admin, "/v1/teams", {
-    method: "POST", body: JSON.stringify({ name: "Additional tools", memberIds: [currentMember?.id] }),
-  });
-  const otherTeam = isRecord(otherTeamResult.body) && isRecord(otherTeamResult.body.team) ? otherTeamResult.body.team : null;
-  if (typeof otherTeam?.id !== "string") throw new Error("Expected overlapping team");
-  const overlappingGrant = await seed.api(world.den.admin, "/v1/desktop-policies", {
-    method: "POST", body: JSON.stringify({ policyName: "Additional team grants", policy: Object.fromEntries(lockedKeys.map((key) => [key, true])), teamIds: [otherTeam.id] }),
-  });
-  expect(overlappingGrant.response.ok).toBe(true);
-  const teamPath = new URL(`/dashboard/members/teams/${team.id}`, world.den.ref.webUrl).toString();
+});
+
+const teamTest = spec.world(teamAccess, { timeout: 900_000 });
+teamTest("team access overrides overlapping grants and restores only selected desktop capabilities", async ({ world, user, agent, probe, step, evidence, seed }) => {
+  const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
+  const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
   const effective = async (identity: typeof world.den.admin) => {
     const result = await probe.api(identity, "/v1/me/desktop-config");
     expect(result.response.ok).toBe(true);
     if (!isRecord(result.body)) throw new Error("Expected effective permissions");
     return result.body;
   };
-  await step("the admin locks the team from its Access page", async () => {
-    await admin.user.navigate(teamPath);
-    await admin.user.see({ text: "What this team can do" }, { timeoutMs: 90_000 });
-    await admin.user.looks(["The team Access page shows Locked and Custom modes above a list of individual app capabilities"]);
-    await admin.user.click({ text: "Locked" });
+  const policies = async () => {
+    const result = await probe.api(world.den.admin, "/v1/desktop-policies");
+    expect(result.response.ok).toBe(true);
+    if (!isRecord(result.body) || !Array.isArray(result.body.desktopPolicies)) throw new Error("Expected policies");
+    return result.body.desktopPolicies.filter(isRecord);
+  };
+  const teamPolicy = async () => {
+    const policy = (await policies()).find((entry) => Array.isArray(entry.assignments)
+      && entry.assignments.some((assignment: unknown) => isRecord(assignment) && assignment.teamId === world.teamId)
+      && isRecord(entry.policy) && isRecord(entry.policy.access));
+    if (!policy || typeof policy.id !== "string") throw new Error("Expected team access policy");
+    return policy;
+  };
+  const accessOf = (policy: Record<string, unknown>) => {
+    if (!isRecord(policy.policy) || !isRecord(policy.policy.access) || !isRecord(policy.policy.access.capabilities)) throw new Error("Expected saved access capabilities");
+    return { mode: policy.policy.access.mode, capabilities: policy.policy.access.capabilities };
+  };
+  const saveMode = async (mode: "Locked" | "Custom") => {
+    await admin.user.click({ text: mode });
     await admin.user.click("Save permissions");
-    await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowManageExtensions, {
-      within: 30_000, label: "team lock overrides the default grant", until: (value) => value === false,
+    await admin.probe.eventually(async () => accessOf(await teamPolicy()).mode, {
+      within: 30_000, label: `${mode} saved`, until: (value) => value === mode.toLowerCase(),
     });
     await admin.user.reload();
-    await admin.user.see({ text: "Locked for this team" }, { timeoutMs: 60_000 });
+    await admin.user.see({ text: mode === "Locked" ? "Locked for this team" : "Fine-tune access" }, { timeoutMs: 60_000 });
+  };
+
+  await step("both ordinary members start unrestricted and the target can open Settings", async () => {
+    const roles = [];
+    for (const identity of [world.den.members.jordan, world.den.members.casey]) {
+      const org = await probe.api(identity, "/v1/org");
+      expect(org.response.ok).toBe(true);
+      if (!isRecord(org.body) || !isRecord(org.body.currentMember)) throw new Error("Expected member role");
+      roles.push(org.body.currentMember.role);
+      expect(org.body.currentMember.role).toBe("member");
+      const config = await effective(identity);
+      for (const key of lockedKeys) expect(config[key]).toBe(true);
+    }
+    await member.user.click(accountMenu);
+    await member.user.click(settingsMenuItem);
+    await member.user.see(settingsHub, { timeoutMs: 60_000 });
+    const hash = await member.probe.hash();
+    expect(hash).toContain("/settings/general");
+    evidence.recordAssertionEvidence("The target and control have the same ordinary role and unrestricted baseline", JSON.stringify({ roles, hash }), roles.every((role) => role === "member") && hash.includes("/settings/general"));
+  });
+
+  await step("the admin locks the team through Team Access", async () => {
+    await admin.user.see({ text: "What this team can do" }, { timeoutMs: 90_000 });
+    await saveMode("Locked");
   });
   const lockedMember = await effective(world.den.members.jordan);
-  const unlockedAdmin = await effective(world.den.admin);
+  const control = await effective(world.den.members.casey);
   for (const key of lockedKeys) {
     expect(lockedMember[key]).toBe(false);
-    expect(unlockedAdmin[key]).toBe(true);
+    expect(control[key]).toBe(true);
   }
-  await admin.user.looks([
-    "The Focused work team Access page shows Locked selected, a list of blocked app capabilities, and Plugins & connections below",
-  ]);
-  evidence.recordAssertionEvidence("Team lock overrides organization and overlapping team grants without restricting someone outside the team", JSON.stringify({ lockedMember, unlockedAdmin }), lockedKeys.every((key) => lockedMember[key] === false && unlockedAdmin[key] === true));
+  evidence.recordAssertionEvidence("Team blocks override overlapping grants while an ordinary member outside the team stays unrestricted", JSON.stringify({ lockedMember, control }), lockedKeys.every((key) => lockedMember[key] === false && control[key] === true));
+  await admin.user.looks(["The Focused work team Access page shows Locked selected and blocked app capabilities"]);
 
-  await step("the member can understand the restriction and how to get an MCP server", async () => {
+  await step("locked members retain their approved team skill without exposing it outside the team", async () => {
+    const allowed = await probe.api(world.den.members.jordan, `/v1/plugins/${world.pluginId}/resolved`);
+    const denied = await probe.api(world.den.members.casey, `/v1/plugins/${world.pluginId}/resolved`);
+    expect(allowed.response.ok).toBe(true);
+    const items = isRecord(allowed.body) && Array.isArray(allowed.body.items) ? allowed.body.items.filter(isRecord) : [];
+    const skill = items.find((item) => isRecord(item.configObject) && item.configObject.objectType === "skill"
+      && isRecord(item.configObject.latestVersion) && item.configObject.latestVersion.rawSourceText === world.rawSourceText);
+    expect(skill).toBeDefined();
+    expect([403, 404]).toContain(denied.response.status);
+    expect(denied.text).not.toContain(world.rawSourceText);
+    const listed = await probe.api(world.den.members.jordan, `/v1/plugins?q=${encodeURIComponent(world.pluginName)}`);
+    const outside = await probe.api(world.den.members.casey, `/v1/plugins?q=${encodeURIComponent(world.pluginName)}`);
+    expect(listed.response.ok).toBe(true);
+    expect(outside.response.ok).toBe(true);
+    const pluginIds = (body: unknown) => isRecord(body) && Array.isArray(body.items) ? body.items.filter(isRecord).map((item) => item.id) : [];
+    expect(pluginIds(listed.body)).toContain(world.pluginId);
+    expect(pluginIds(outside.body)).not.toContain(world.pluginId);
+    evidence.recordAssertionEvidence("Lock preserves read access to an approved team skill while another ordinary member cannot discover or resolve it", JSON.stringify({ skill, deniedStatus: denied.response.status, memberPlugins: pluginIds(listed.body), outsidePlugins: pluginIds(outside.body) }), skill !== undefined && [403, 404].includes(denied.response.status) && pluginIds(listed.body).includes(world.pluginId) && !pluginIds(outside.body).includes(world.pluginId));
+  });
+
+  await step("the target desktop enforces the team lock and explains MCP access", async () => {
     await member.user.reload();
-    await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
-    await member.user.see({ text: /Need an MCP server or skill/ });
-    await member.user.click(accountMenu);
-    await member.user.click(accountMenuItem);
-    await member.user.see({ text: "What can I do?" }, { timeoutMs: 60_000 });
+    const redirected = await member.probe.eventually(() => member.probe.hash(), {
+      within: 90_000, label: "team lock redirects settings", until: (hash) => hash.includes("/settings/cloud-account"),
+    });
+    await member.user.notSee(settingsHub);
+    await member.user.notSee({ text: "Workspace" });
+    await member.user.notSee({ text: "Global" });
+    await member.agent.run("route.settings.appearance");
+    const forbiddenRoute = await member.probe.eventually(() => member.probe.hash(), {
+      within: 60_000, label: "forbidden appearance route redirects", until: (hash) => hash.includes("/settings/cloud-account"),
+    });
+    await member.user.see({ text: "What can I do?" });
     await member.user.click({ text: "What can I do?" });
     await member.user.see({ text: "Add tools, skills & MCP servers" });
+    const permissionsText = await member.probe.text();
+    expect(permissionsText).toContain("Blocked by organization");
+    await member.user.click({ role: "button", label: "Back to app" });
+    await member.user.click(accountMenu);
+    await member.user.see(accountMenuItem);
+    await member.user.notSee(settingsMenuItem);
+    const menuText = await member.probe.text();
+    await member.user.press("Escape");
+    await member.user.click("Library");
+    await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
+    await member.user.see({ text: /Need an MCP server or skill/ });
+    const libraryText = await member.probe.text();
+    evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && permissionsText.includes("Blocked by organization") && libraryText.includes("Need an MCP server or skill"));
+    await member.user.looks(["The Library shows organization restrictions and guidance for requesting an MCP server or skill"]);
   });
-  await member.user.looks(["The account page shows expanded app permissions with capabilities marked Blocked by organization"]);
-  evidence.recordAssertionEvidence("Members can inspect app permissions and find instructions for requesting an MCP server", "Library MCP guidance and expanded account permission list visible", true);
 
-  await step("the admin grants selected capabilities while keeping tool installation blocked", async () => {
+  await step("Custom allows Settings but keeps local tools blocked", async () => {
     await admin.user.click({ text: "Custom" });
     await admin.user.click({ role: "checkbox", label: "Add and manage local tools, skills & MCP servers" });
     await admin.user.click("Save permissions");
-    await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowControlSettings, {
-      within: 30_000, label: "custom mode restores selected capabilities", until: (value) => value === true,
+    await admin.probe.eventually(async () => accessOf(await teamPolicy()).mode, {
+      within: 30_000, label: "custom permissions saved", until: (mode) => mode === "custom",
     });
     await admin.user.reload();
     await admin.user.see({ text: "Fine-tune access" }, { timeoutMs: 60_000 });
+    const chosen = accessOf(await teamPolicy());
+    expect(chosen.capabilities.allowManageExtensions).toBe(false);
+    await saveMode("Locked");
+    const locked = accessOf(await teamPolicy());
+    expect(locked.capabilities).toEqual(chosen.capabilities);
+    const lockedAgain = await effective(world.den.members.jordan);
+    for (const key of lockedKeys) expect(lockedAgain[key]).toBe(false);
+    await saveMode("Custom");
+    const restored = accessOf(await teamPolicy());
+    expect(restored).toEqual(chosen);
+    const config = await effective(world.den.members.jordan);
+    expect(config.allowManageExtensions).toBe(false);
+    for (const key of lockedKeys.filter((key) => key !== "allowManageExtensions")) expect(config[key]).toBe(true);
+    await member.user.reload();
+    await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
+    const libraryText = await member.probe.text();
+    await member.user.click(accountMenu);
+    await member.user.see(settingsMenuItem);
+    await member.user.click(settingsMenuItem);
+    await member.user.see(settingsHub, { timeoutMs: 60_000 });
+    for (const group of ["Workspace", "Global", "Cloud"]) await member.user.see({ text: group });
+    const hash = await member.probe.hash();
+    expect(hash).toContain("/settings/general");
+    evidence.recordAssertionEvidence("Custom survives Locked and reloads with tools still blocked while Settings returns on the real desktop", JSON.stringify({ chosen, locked, restored, config, hash, libraryText }), restored.capabilities.allowManageExtensions === false && config.allowControlSettings === true && config.allowManageExtensions === false && hash.includes("/settings/general"));
+    await admin.user.looks(["Custom is selected with tool installation Blocked and other capabilities Allowed"]);
   });
-  const customMember = await effective(world.den.members.jordan);
-  expect(customMember.allowManageExtensions).toBe(false);
-  expect(customMember.allowControlSettings).toBe(true);
-  expect(customMember.allowCustomProviders).toBe(true);
-  await admin.user.looks(["The team Access page shows Custom selected, tool installation Blocked, and other capabilities Allowed"]);
-  evidence.recordAssertionEvidence("Custom permissions persist independently: settings and providers allowed, tool installation blocked", JSON.stringify(customMember), customMember.allowManageExtensions === false && customMember.allowControlSettings === true && customMember.allowCustomProviders === true);
 
-  const forbidden = await seed.api(world.den.members.jordan, "/v1/desktop-policies", {
-    method: "POST", body: JSON.stringify({ policyName: "Unauthorized access change", policy: { access: { mode: "custom", capabilities: {} } }, teamIds: [team.id] }),
+  await step("an ordinary member cannot create or overwrite team permissions", async () => {
+    const before = await policies();
+    const stored = await teamPolicy();
+    const effectiveBefore = await effective(world.den.members.jordan);
+    const statuses = [];
+    for (const method of ["POST", "PATCH"]) {
+      const result = await seed.api(world.den.members.jordan, method === "POST" ? "/v1/desktop-policies" : `/v1/desktop-policies/${stored.id}`, {
+        method, body: JSON.stringify({ policyName: "Unauthorized access change", policy: { access: { mode: "custom", capabilities: { allowManageExtensions: true } } }, teamIds: [world.teamId] }),
+      });
+      statuses.push(result.response.status);
+      expect(result.response.status).toBe(403);
+      expect(await policies()).toEqual(before);
+      expect(await effective(world.den.members.jordan)).toEqual(effectiveBefore);
+    }
+    const after = await policies();
+    const effectiveAfter = await effective(world.den.members.jordan);
+    evidence.recordAssertionEvidence("Member POST and PATCH are rejected without changing stored or effective permissions", JSON.stringify({ statuses, before, after, effectiveBefore, effectiveAfter }), statuses.every((status) => status === 403) && JSON.stringify(before) === JSON.stringify(after) && JSON.stringify(effectiveBefore) === JSON.stringify(effectiveAfter));
   });
-  expect(forbidden.response.status).toBe(403);
-  expect((await effective(world.den.members.jordan)).allowManageExtensions).toBe(false);
-  evidence.recordAssertionEvidence("A member cannot change their own team permissions", `HTTP ${forbidden.response.status}; tool installation remains blocked`, forbidden.response.status === 403);
 
-  const policyList = await probe.api(world.den.admin, "/v1/desktop-policies");
-  const teamPolicy = isRecord(policyList.body) && Array.isArray(policyList.body.desktopPolicies)
-    ? policyList.body.desktopPolicies.find((entry: unknown) => isRecord(entry) && isRecord(entry.policy) && isRecord(entry.policy.access))
-    : undefined;
-  if (!isRecord(teamPolicy) || typeof teamPolicy.id !== "string") throw new Error("Expected team policy");
-  await admin.user.navigate(new URL(`/dashboard/desktop-policies/${teamPolicy.id}`, world.den.ref.webUrl).toString());
+  const saved = await teamPolicy();
+  await admin.user.navigate(new URL(`/dashboard/desktop-policies/${saved.id}`, world.den.ref.webUrl).toString());
   await admin.user.see({ text: "Managed in Team access" }, { timeoutMs: 60_000 });
   await admin.user.notSee({ role: "button", label: "Save changes" });
+  const legacyText = await admin.probe.text();
   await admin.user.click("Open team access");
   await admin.user.see({ text: "What this team can do" }, { timeoutMs: 60_000 });
-  evidence.recordAssertionEvidence("Advanced policy settings direct team permission changes back to Team Access", "Team access link reaches the team; legacy Save changes absent", true);
-
+  const teamText = await admin.probe.text();
+  evidence.recordAssertionEvidence("Advanced policy settings direct changes to Team Access", JSON.stringify({ legacyText, teamText }), legacyText.includes("Managed in Team access") && teamText.includes("What this team can do"));
 });

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -52,7 +52,7 @@ function count(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-test("an admin switches the default desktop policy to Restricted and a member's desktop hides settings and local extension add flows", async ({ world, user, agent, probe, step, evidence }) => {
+test("an admin switches the default desktop policy to Restricted and a member's desktop hides settings and local extension add flows", async ({ world, user, agent, probe, step, evidence, seed }) => {
   const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
   const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
   const lockNotes = () => admin.probe.text().then((text) => count(text, lockNote));
@@ -258,4 +258,98 @@ test("an admin switches the default desktop policy to Restricted and a member's 
     `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}`,
     libraryHashAfter.includes("/extensions") && builtInNoticeShown,
   );
+
+  // Team limits must win even when the organization grants every capability.
+  await step("prepare an unrestricted organization with a focused-work team", async () => {
+    const reset = await seed.api(world.den.admin, `/v1/desktop-policies/${world.policyId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ policyName: "Default desktop policy", policy: Object.fromEntries(Object.keys(restrictedSavedValues).map((key) => [key, true])) }),
+    });
+    expect(reset.response.ok).toBe(true);
+  });
+  const org = await probe.api(world.den.members.jordan, "/v1/org");
+  const currentMember = isRecord(org.body) && isRecord(org.body.currentMember) ? org.body.currentMember : null;
+  expect(typeof currentMember?.id).toBe("string");
+  const createdTeam = await seed.api(world.den.admin, "/v1/teams", {
+    method: "POST",
+    body: JSON.stringify({ name: "Focused work", memberIds: [currentMember?.id] }),
+  });
+  expect(createdTeam.response.ok).toBe(true);
+  const team = isRecord(createdTeam.body) && isRecord(createdTeam.body.team) ? createdTeam.body.team : null;
+  if (typeof team?.id !== "string") throw new Error("Expected a created team");
+  const otherTeamResult = await seed.api(world.den.admin, "/v1/teams", {
+    method: "POST", body: JSON.stringify({ name: "Additional tools", memberIds: [currentMember?.id] }),
+  });
+  const otherTeam = isRecord(otherTeamResult.body) && isRecord(otherTeamResult.body.team) ? otherTeamResult.body.team : null;
+  if (typeof otherTeam?.id !== "string") throw new Error("Expected overlapping team");
+  const overlappingGrant = await seed.api(world.den.admin, "/v1/desktop-policies", {
+    method: "POST", body: JSON.stringify({ policyName: "Additional team grants", policy: Object.fromEntries(lockedKeys.map((key) => [key, true])), teamIds: [otherTeam.id] }),
+  });
+  expect(overlappingGrant.response.ok).toBe(true);
+  const teamPath = new URL(`/dashboard/members/teams/${team.id}`, world.den.ref.webUrl).toString();
+  const effective = async (identity: typeof world.den.admin) => {
+    const result = await probe.api(identity, "/v1/me/desktop-config");
+    expect(result.response.ok).toBe(true);
+    if (!isRecord(result.body)) throw new Error("Expected effective permissions");
+    return result.body;
+  };
+  await step("the admin locks the team from its Access page", async () => {
+    await admin.user.navigate(teamPath);
+    await admin.user.see({ text: "What this team can do" }, { timeoutMs: 90_000 });
+    await admin.user.click({ role: "radio", label: /^Locked/ });
+    await admin.user.click("Save permissions");
+    await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowManageExtensions, {
+      within: 30_000, label: "team lock overrides the default grant", until: (value) => value === false,
+    });
+    await admin.user.reload();
+    await admin.user.see({ text: "Locked for this team" }, { timeoutMs: 60_000 });
+  });
+  const lockedMember = await effective(world.den.members.jordan);
+  const unlockedAdmin = await effective(world.den.admin);
+  for (const key of lockedKeys) {
+    expect(lockedMember[key]).toBe(false);
+    expect(unlockedAdmin[key]).toBe(true);
+  }
+  await admin.user.looks([
+    "The Focused work team Access page shows Locked selected, a list of blocked app capabilities, and Plugins & connections below",
+  ]);
+  evidence.recordAssertionEvidence("Team lock overrides organization and overlapping team grants without restricting someone outside the team", JSON.stringify({ lockedMember, unlockedAdmin }), lockedKeys.every((key) => lockedMember[key] === false && unlockedAdmin[key] === true));
+
+  await step("the member can understand the restriction and how to get an MCP server", async () => {
+    await member.user.reload();
+    await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
+    await member.user.see({ text: /Need an MCP server or skill/ });
+    await member.user.click(accountMenu);
+    await member.user.click(accountMenuItem);
+    await member.user.see({ text: "What can I do?" }, { timeoutMs: 60_000 });
+    await member.user.click({ text: "What can I do?" });
+    await member.user.see({ text: "Add tools, skills & MCP servers" });
+  });
+  await member.user.looks(["The account page shows expanded app permissions with capabilities marked Blocked by organization"]);
+  evidence.recordAssertionEvidence("Members can inspect app permissions and find instructions for requesting an MCP server", "Library MCP guidance and expanded account permission list visible", true);
+
+  await step("the admin grants selected capabilities while keeping tool installation blocked", async () => {
+    await admin.user.click({ role: "radio", label: /^Custom/ });
+    await admin.user.click({ role: "checkbox", label: "Add and manage tools, skills & MCP servers" });
+    await admin.user.click("Save permissions");
+    await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowControlSettings, {
+      within: 30_000, label: "custom mode restores selected capabilities", until: (value) => value === true,
+    });
+    await admin.user.reload();
+    await admin.user.see({ text: "Fine-tune access" }, { timeoutMs: 60_000 });
+  });
+  const customMember = await effective(world.den.members.jordan);
+  expect(customMember.allowManageExtensions).toBe(false);
+  expect(customMember.allowControlSettings).toBe(true);
+  expect(customMember.allowCustomProviders).toBe(true);
+  await admin.user.looks(["The team Access page shows Custom selected, tool installation Blocked, and other capabilities Allowed"]);
+  evidence.recordAssertionEvidence("Custom permissions persist independently: settings and providers allowed, tool installation blocked", JSON.stringify(customMember), customMember.allowManageExtensions === false && customMember.allowControlSettings === true && customMember.allowCustomProviders === true);
+
+  const forbidden = await seed.api(world.den.members.jordan, "/v1/desktop-policies", {
+    method: "POST", body: JSON.stringify({ policyName: "Unauthorized access change", policy: { access: { mode: "custom", capabilities: {} } }, teamIds: [team.id] }),
+  });
+  expect(forbidden.response.status).toBe(403);
+  expect((await effective(world.den.members.jordan)).allowManageExtensions).toBe(false);
+  evidence.recordAssertionEvidence("A member cannot change their own team permissions", `HTTP ${forbidden.response.status}; tool installation remains blocked`, forbidden.response.status === 403);
+
 });

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -7,7 +7,7 @@ import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy } from ".
 // real member desktop side by side: the editor locks every governed capability
 // and stores plain booleans, and the member's settings and Library surfaces
 // collapse to what the policy leaves reachable.
-const test = spec.world(defaultPolicyEditorAndMemberDesktop, { timeout: 600_000 });
+const test = spec.world(defaultPolicyEditorAndMemberDesktop, { timeout: 900_000 });
 
 // The capability cards as the editor labels them. Restricted locks the first
 // seven; the Welcome Page display preference stays editable in both modes.
@@ -52,7 +52,7 @@ function count(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-test("an admin switches the default desktop policy to Restricted and a member's desktop hides settings and local extension add flows", async ({ world, user, agent, probe, step, evidence, seed }) => {
+test("an admin controls default and team access while members can understand their permissions", async ({ world, user, agent, probe, step, evidence, seed }) => {
   const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
   const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
   const lockNotes = () => admin.probe.text().then((text) => count(text, lockNote));
@@ -330,7 +330,7 @@ test("an admin switches the default desktop policy to Restricted and a member's 
 
   await step("the admin grants selected capabilities while keeping tool installation blocked", async () => {
     await admin.user.click({ role: "radio", label: /^Custom/ });
-    await admin.user.click({ role: "checkbox", label: "Add and manage tools, skills & MCP servers" });
+    await admin.user.click({ role: "checkbox", label: "Add and manage local tools, skills & MCP servers" });
     await admin.user.click("Save permissions");
     await admin.probe.eventually(async () => (await effective(world.den.members.jordan)).allowControlSettings, {
       within: 30_000, label: "custom mode restores selected capabilities", until: (value) => value === true,
@@ -351,5 +351,17 @@ test("an admin switches the default desktop policy to Restricted and a member's 
   expect(forbidden.response.status).toBe(403);
   expect((await effective(world.den.members.jordan)).allowManageExtensions).toBe(false);
   evidence.recordAssertionEvidence("A member cannot change their own team permissions", `HTTP ${forbidden.response.status}; tool installation remains blocked`, forbidden.response.status === 403);
+
+  const policyList = await probe.api(world.den.admin, "/v1/desktop-policies");
+  const teamPolicy = isRecord(policyList.body) && Array.isArray(policyList.body.desktopPolicies)
+    ? policyList.body.desktopPolicies.find((entry: unknown) => isRecord(entry) && isRecord(entry.policy) && isRecord(entry.policy.access))
+    : undefined;
+  if (!isRecord(teamPolicy) || typeof teamPolicy.id !== "string") throw new Error("Expected team policy");
+  await admin.user.navigate(new URL(`/dashboard/desktop-policies/${teamPolicy.id}`, world.den.ref.webUrl).toString());
+  await admin.user.see({ text: "Managed in Team access" }, { timeoutMs: 60_000 });
+  await admin.user.notSee({ role: "button", label: "Save changes" });
+  await admin.user.click("Open team access");
+  await admin.user.see({ text: "What this team can do" }, { timeoutMs: 60_000 });
+  evidence.recordAssertionEvidence("Advanced policy settings direct team permission changes back to Team Access", "Team access link reaches the team; legacy Save changes absent", true);
 
 });

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -54,7 +54,10 @@ const settingsHub = { role: "button", label: "Settings" } as const;
 const accountMenu = { testId: "account-status-menu" };
 const settingsMenuItem = { role: "menuitem", label: "Settings" } as const;
 const accountMenuItem = { role: "menuitem", label: "Account" } as const;
-const policyBanner = { testId: "desktop-policy-banner" };
+const removedPolicyBanner = { testId: "desktop-policy-banner" };
+const permissionsTab: { role: "tab"; label: string } = { role: "tab", label: "App permissions" };
+const accountTab: { role: "tab"; label: string } = { role: "tab", label: "Account" };
+const signOut: { role: "button"; label: string } = { role: "button", label: "Sign out" };
 const manageExtensionsNotice = { testId: "manage-extensions-policy-notice" };
 const builtInExtensionsNotice = "Built-in OpenWork extensions are disabled by your organization";
 
@@ -80,9 +83,7 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
   // Phase 1 — the member's desktop before any restriction: the Library carries
   // no extension-management notice, and the settings hub and every settings
   // group are reachable. Settings comes last so the desktop is still on that
-  // route when it reloads in phase 3. (The generic "Organization policies active"
-  // banner is not a discriminator here: it already reacts to unrelated
-  // organization flags such as Dashboards or Automations being off.)
+  // route when it reloads in phase 3.
   const libraryHashBefore = await step("the member opens the Library before the policy changes", async () => {
     await member.user.click("Library");
     await member.user.see({ text: "Library" }, { timeoutMs: 90_000 });
@@ -200,7 +201,8 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
   // is the level-based safety net.
   const hashAfter = await step("the member's desktop refreshes on the settings route", async () => {
     await member.user.reload();
-    await member.user.see(policyBanner, { timeoutMs: 90_000 });
+    await member.user.see(permissionsTab, { timeoutMs: 90_000 });
+    await member.user.notSee(removedPolicyBanner);
     return member.probe.eventually(() => member.probe.hash(), {
       within: 90_000,
       label: "restricted settings navigation redirected to the Cloud account tab",
@@ -214,11 +216,11 @@ test(defaultJourney, async ({ world: selectedWorld, user, agent, probe, step, ev
   await member.user.notSee(settingsHub);
   await member.user.looks([
     "The settings navigation shows only a Cloud group and no Workspace or Global group",
-    "An Organization policies active notice is visible on the account page",
+    "The account page has Account and App permissions tabs without a policy banner",
   ]);
   evidence.recordAssertionEvidence(
     "Under the Restricted default policy the settings surface collapses to the Cloud account page",
-    `hash=${hashAfter}; Cloud group visible; Workspace and Global groups absent; Settings hub absent; policy banner visible`,
+    `hash=${hashAfter}; Cloud group visible; Workspace and Global groups absent; Settings hub absent; App permissions tab visible; policy banner absent`,
     hashAfter.includes("/settings/cloud-account"),
   );
 
@@ -329,9 +331,22 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     await member.user.click(accountMenu);
     await member.user.click(settingsMenuItem);
     await member.user.see(settingsHub, { timeoutMs: 60_000 });
+    await member.user.click({ role: "button", label: /^Account$/ });
+    await member.user.click(permissionsTab);
+    await member.user.notSee(signOut);
+    for (const key of lockedKeys) {
+      await member.user.see({ testId: `app-permission-${key}` }, { text: /Allowed/ });
+    }
+    const baselinePermissions = await member.probe.text();
+    expect(count(baselinePermissions, "Allowed")).toBe(lockedKeys.length);
+    expect(baselinePermissions).not.toContain("Blocked");
+    await member.user.click(accountTab);
+    await member.user.see(signOut);
+    await member.agent.run("route.settings.general");
+    await member.user.see(settingsHub);
     const hash = await member.probe.hash();
     expect(hash).toContain("/settings/general");
-    evidence.recordAssertionEvidence("The target and control have the same ordinary role and unrestricted baseline", JSON.stringify({ roles, hash }), roles.every((role) => role === "member") && hash.includes("/settings/general"));
+    evidence.recordAssertionEvidence("The target and control have the same ordinary role and unrestricted baseline with a working App permissions tab", JSON.stringify({ roles, hash, baselinePermissions }), roles.every((role) => role === "member") && hash.includes("/settings/general") && count(baselinePermissions, "Allowed") === lockedKeys.length && !baselinePermissions.includes("Blocked"));
   });
 
   await step("the admin locks the team through Team Access", async () => {
@@ -379,11 +394,26 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     const forbiddenRoute = await member.probe.eventually(() => member.probe.hash(), {
       within: 60_000, label: "forbidden appearance route redirects", until: (hash) => hash.includes("/settings/cloud-account"),
     });
-    await member.user.see({ text: "What can I do?" });
-    await member.user.click({ text: "What can I do?" });
-    await member.user.see({ text: "Add tools, skills & MCP servers" });
+    await member.user.see(signOut);
+    await member.user.click(permissionsTab);
+    await member.user.see({ text: "Your app permissions" });
+    await member.user.notSee(signOut);
+    await member.user.notSee(removedPolicyBanner);
+    for (const key of lockedKeys) {
+      await member.user.see({ testId: `app-permission-${key}` }, { text: /Blocked/ });
+    }
     const permissionsText = await member.probe.text();
-    expect(permissionsText).toContain("Blocked by organization");
+    expect(count(permissionsText, "Blocked")).toBe(lockedKeys.length);
+    expect(permissionsText).not.toContain("Allowed");
+    await member.user.looks([
+      "App permissions is the selected account tab and seven read-only capability rows show Blocked",
+      "The permissions page uses the app settings layout with no colored policy banner and no account sign-out controls",
+    ]);
+    await member.user.click(accountTab);
+    await member.user.see(signOut);
+    await member.user.notSee({ text: "Your app permissions" });
+    const accountText = await member.probe.text();
+    evidence.recordAssertionEvidence("Account and App permissions are separate working tabs under Locked access", JSON.stringify({ permissionsText, accountText }), count(permissionsText, "Blocked") === lockedKeys.length && !permissionsText.includes("Allowed") && !accountText.includes("Your app permissions"));
     await member.user.click({ role: "button", label: "Back to app" });
     await member.user.click(accountMenu);
     await member.user.see(accountMenuItem);
@@ -394,7 +424,7 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000 });
     await member.user.see({ text: /Need an MCP server or skill/ });
     const libraryText = await member.probe.text();
-    evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && permissionsText.includes("Blocked by organization") && libraryText.includes("Need an MCP server or skill"));
+    evidence.recordAssertionEvidence("The locked desktop hides Settings, redirects forbidden routes, and explains how to get an MCP server", JSON.stringify({ redirected, forbiddenRoute, permissionsText, menuText, libraryText }), redirected.includes("/settings/cloud-account") && forbiddenRoute.includes("/settings/cloud-account") && count(permissionsText, "Blocked") === lockedKeys.length && libraryText.includes("Need an MCP server or skill"));
     await member.user.looks(["The Library shows organization restrictions and guidance for requesting an MCP server or skill"]);
   });
 
@@ -431,6 +461,17 @@ test(teamJourney, async ({ world: selectedWorld, user, agent, probe, step, evide
     const hash = await member.probe.hash();
     expect(hash).toContain("/settings/general");
     evidence.recordAssertionEvidence("Custom survives Locked and reloads with tools still blocked while Settings returns on the real desktop", JSON.stringify({ chosen, locked, restored, config, hash, libraryText }), restored.capabilities.allowManageExtensions === false && config.allowControlSettings === true && config.allowManageExtensions === false && hash.includes("/settings/general"));
+    await member.user.click({ role: "button", label: /^Account$/ });
+    await member.user.click(permissionsTab);
+    await member.user.notSee(signOut);
+    await member.user.notSee(removedPolicyBanner);
+    await member.user.see({ testId: "app-permission-allowControlSettings" }, { text: /Change app settings\s*Allowed/ });
+    await member.user.see({ testId: "app-permission-allowManageExtensions" }, { text: /Add tools, skills & MCP servers\s*Blocked/ });
+    const permissionsText = await member.probe.text();
+    expect(count(permissionsText, "Blocked")).toBe(1);
+    expect(count(permissionsText, "Allowed")).toBe(lockedKeys.length - 1);
+    evidence.recordAssertionEvidence("The Custom account permissions tab shows Settings Allowed and tools Blocked", permissionsText, count(permissionsText, "Blocked") === 1 && count(permissionsText, "Allowed") === lockedKeys.length - 1);
+    await member.user.looks(["The dedicated App permissions tab shows Change app settings Allowed and Add tools, skills & MCP servers Blocked, without a policy banner"]);
     await admin.user.looks(["Custom is selected with tool installation Blocked and other capabilities Allowed"]);
   });
 

--- a/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
+++ b/evals/specs/desktop-policy-restricted-mode.e2e.test.ts
@@ -1,0 +1,242 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { defaultPolicyEditorAndMemberDesktop, readDefaultDesktopPolicy } from "../worlds/desktop-policies.ts";
+
+// An organization that wants a vanilla OpenWork picks one decision, Restricted,
+// in the Den policy editor. This spec drives the real editor as the admin and a
+// real member desktop side by side: the editor locks every governed capability
+// and stores plain booleans, and the member's settings and Library surfaces
+// collapse to what the policy leaves reachable.
+const test = spec.world(defaultPolicyEditorAndMemberDesktop, { timeout: 600_000 });
+
+// The capability cards as the editor labels them. Restricted locks the first
+// seven; the Welcome Page display preference stays editable in both modes.
+const lockedCards = [
+  "Custom providers",
+  "Enable OpenCode Zen Models",
+  "Multiple workspaces",
+  "Control Settings",
+  "Manage Extensions",
+  "Built-in Extensions",
+  "Alpha updates",
+];
+const editableCards = ["Welcome Page"];
+const lockNote = "Locked by Restricted mode.";
+// What Den must hold after saving a Restricted policy: plain booleans, not a
+// mode flag, so older desktops keep reading the same keys.
+const restrictedSavedValues: Record<string, boolean> = {
+  allowCustomProviders: false,
+  allowZenModel: false,
+  allowMultipleWorkspaces: false,
+  allowControlSettings: false,
+  allowManageExtensions: false,
+  allowBuiltInExtensions: false,
+  allowAlphaUpdates: false,
+  showWelcomePage: true,
+};
+const lockedKeys = Object.keys(restrictedSavedValues).filter((key) => key !== "showWelcomePage");
+
+const settingsHub = { role: "button", label: "Settings" } as const;
+const policyBanner = { testId: "desktop-policy-banner" };
+const manageExtensionsNotice = { testId: "manage-extensions-policy-notice" };
+const builtInExtensionsNotice = "Built-in OpenWork extensions are disabled by your organization";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+test("an admin switches the default desktop policy to Restricted and a member's desktop hides settings and local extension add flows", async ({ world, user, agent, probe, step, evidence }) => {
+  const member = { user: user.on(world.member), agent: agent.on(world.member), probe: probe.on(world.member) };
+  const admin = { user: user.on(world.admin), probe: probe.on(world.admin) };
+  const lockNotes = () => admin.probe.text().then((text) => count(text, lockNote));
+  const savedPolicy = async () => {
+    const policy = await readDefaultDesktopPolicy(probe, world.den.admin);
+    return isRecord(policy.policy) ? policy.policy : {};
+  };
+
+  // Phase 1 — the member's desktop before any restriction: the Library carries
+  // no extension-management notice, and the settings hub and every settings
+  // group are reachable. Settings comes last so the desktop is still on that
+  // route when it reloads in phase 3. (The generic "Organization policies active"
+  // banner is not a discriminator here: it already reacts to unrelated
+  // organization flags such as Dashboards or Automations being off.)
+  const libraryHashBefore = await step("the member opens the Library before the policy changes", async () => {
+    await member.agent.run("route.extensions.skills");
+    await member.user.see({ text: "Library" }, { timeoutMs: 90_000 });
+    await member.user.notSee(manageExtensionsNotice);
+    return member.probe.hash();
+  });
+  expect(libraryHashBefore).toContain("/extensions");
+  await member.user.looks([
+    "The Library page is open and shows no notice that extension management was disabled by an organization administrator",
+  ]);
+  evidence.recordAssertionEvidence(
+    "Before the policy change the Library carries no extension-management restriction",
+    `hash=${libraryHashBefore}; manage-extensions notice absent`,
+    libraryHashBefore.includes("/extensions"),
+  );
+
+  const hashBefore = await step("the member opens settings before the policy changes", async () => {
+    await member.agent.run("route.settings.general");
+    await member.user.see(settingsHub, { timeoutMs: 60_000 });
+    for (const group of ["Workspace", "Global", "Cloud"]) await member.user.see({ text: group });
+    return member.probe.hash();
+  });
+  expect(hashBefore).toContain("/settings/general");
+  await member.user.looks([
+    "A settings page with a left navigation that lists Workspace, Global, and Cloud groups",
+    "The main area shows settings cards such as Preferences, Permissions, or AI Providers",
+  ]);
+  evidence.recordAssertionEvidence(
+    "Before the policy change the member reaches the full settings surface",
+    `hash=${hashBefore}; Settings hub visible; Workspace, Global, and Cloud groups visible`,
+    hashBefore.includes("/settings/general"),
+  );
+
+  // Phase 2 — the admin switches the default policy to Restricted in Den Web.
+  await step("the default policy editor opens in Custom mode", async () => {
+    await admin.user.see({ text: "Policy mode" }, { timeoutMs: 90_000 });
+    for (const card of [...lockedCards, ...editableCards]) {
+      await admin.user.see({ role: "checkbox", label: new RegExp(`^${card}`) });
+    }
+    await admin.user.notSee({ text: lockNote });
+  });
+  const customLockNotes = await lockNotes();
+  expect(customLockNotes).toBe(0);
+  await admin.user.looks([
+    "A Policy mode selector with Custom and Restricted options appears above the capability list",
+    "Custom is selected and the capability checkboxes are enabled",
+  ]);
+  evidence.recordAssertionEvidence(
+    "The existing editor flow is unchanged: the default policy opens in Custom mode with every capability editable",
+    `cards=${lockedCards.length + editableCards.length}; lockNotes=${customLockNotes}`,
+    customLockNotes === 0,
+  );
+
+  const restrictedLockNotes = await step("the admin selects Restricted", async () => {
+    await admin.user.click({ text: "Restricted" });
+    await admin.user.see({ text: lockNote }, { timeoutMs: 30_000 });
+    return lockNotes();
+  });
+  // One lock note per governed card and none under the Welcome Page card.
+  expect(restrictedLockNotes).toBe(lockedCards.length);
+  await admin.user.looks([
+    "Restricted is the selected policy mode",
+    "The seven cards from Custom providers through Alpha updates each show an unchecked checkbox and a Locked by Restricted mode note",
+    "The Welcome Page card shows a checked checkbox and no Locked by Restricted mode note",
+  ]);
+  evidence.recordAssertionEvidence(
+    "Restricted locks every governed capability in the editor and leaves the welcome page editable",
+    `lockNotes=${restrictedLockNotes} of ${lockedCards.length} governed cards; editable=${JSON.stringify(editableCards)}`,
+    restrictedLockNotes === lockedCards.length,
+  );
+
+  const savedRestricted = await step("the admin saves the policy", async () => {
+    await admin.user.click("Save changes");
+    await admin.user.see({ testId: "desktop-policy-restricted-badge" }, { timeoutMs: 60_000 });
+    await admin.user.see({ text: /^default$/i });
+    return savedPolicy();
+  });
+  await admin.user.looks([
+    "A desktop policies list shows the default policy with both a Default badge and a Restricted badge next to its name",
+  ]);
+  for (const [key, value] of Object.entries(restrictedSavedValues)) {
+    expect(savedRestricted[key]).toBe(value);
+  }
+
+  const { reopenedLockNotes, unlockedLockNotes, savedAfterCustom } = await step("the admin reopens the policy and returns it to Custom", async () => {
+    await admin.user.navigate(new URL(world.editorPath, world.den.ref.webUrl).toString());
+    await admin.user.see({ text: "Policy mode" }, { timeoutMs: 90_000 });
+    await admin.user.see({ text: lockNote }, { timeoutMs: 30_000 });
+    const reopenedLockNotes = await lockNotes();
+    await admin.user.click({ text: "Custom" });
+    await admin.user.notSee({ text: lockNote }, { timeoutMs: 15_000 });
+    const unlockedLockNotes = await lockNotes();
+    // Saving again from Custom without touching a checkbox must keep the same
+    // booleans: Custom unlocks the controls, it does not rewrite the values.
+    await admin.user.click("Save changes");
+    await admin.user.see({ testId: "desktop-policy-restricted-badge" }, { timeoutMs: 60_000 });
+    return { reopenedLockNotes, unlockedLockNotes, savedAfterCustom: await savedPolicy() };
+  });
+  expect(reopenedLockNotes).toBe(lockedCards.length);
+  expect(unlockedLockNotes).toBe(0);
+  for (const [key, value] of Object.entries(restrictedSavedValues)) {
+    expect(savedAfterCustom[key]).toBe(value);
+  }
+  evidence.recordAssertionEvidence(
+    "Saving stores plain booleans, the editor reopens in Restricted, and Custom unlocks the checkboxes without changing values",
+    `saved=${JSON.stringify(lockedKeys.map((key) => [key, savedRestricted[key]]))}; reopenedLockNotes=${reopenedLockNotes}; unlockedLockNotes=${unlockedLockNotes}; savedAfterCustom unchanged=${lockedKeys.every((key) => savedAfterCustom[key] === savedRestricted[key])}`,
+    reopenedLockNotes === lockedCards.length && unlockedLockNotes === 0 && lockedKeys.every((key) => savedAfterCustom[key] === false),
+  );
+
+  // Phase 3 — the member's desktop re-reads the effective policy. A reload
+  // drives the same organization-config refresh as the Den settings-changed
+  // event, an account refresh, or an organization switch; the hourly refresh
+  // is the level-based safety net.
+  const hashAfter = await step("the member's desktop refreshes on the settings route", async () => {
+    await member.user.reload();
+    await member.user.see(policyBanner, { timeoutMs: 90_000 });
+    return member.probe.eventually(() => member.probe.hash(), {
+      within: 90_000,
+      label: "restricted settings navigation redirected to the Cloud account tab",
+      until: (hash) => hash.includes("/settings/cloud-account"),
+    });
+  });
+  expect(hashAfter).toContain("/settings/cloud-account");
+  await member.user.see({ text: "Cloud" });
+  await member.user.notSee({ text: "Workspace" });
+  await member.user.notSee({ text: "Global" });
+  await member.user.notSee(settingsHub);
+  await member.user.looks([
+    "The settings navigation shows only a Cloud group and no Workspace or Global group",
+    "An Organization policies active notice is visible on the account page",
+  ]);
+  evidence.recordAssertionEvidence(
+    "Under the Restricted default policy the settings surface collapses to the Cloud account page",
+    `hash=${hashAfter}; Cloud group visible; Workspace and Global groups absent; Settings hub absent; policy banner visible`,
+    hashAfter.includes("/settings/cloud-account"),
+  );
+
+  const redirectedHash = await step("a hidden settings tab redirects", async () => {
+    await member.agent.run("route.settings.appearance");
+    return member.probe.eventually(() => member.probe.hash(), {
+      within: 60_000,
+      label: "appearance route redirected",
+      until: (hash) => hash.includes("/settings/cloud-account"),
+    });
+  });
+  expect(redirectedHash).toContain("/settings/cloud-account");
+  evidence.recordAssertionEvidence(
+    "A route to a hidden settings tab lands on the Cloud account page instead",
+    `requested=/settings/appearance; landed=${redirectedHash}`,
+    redirectedHash.includes("/settings/cloud-account"),
+  );
+
+  const { libraryHashAfter, builtInNoticeShown } = await step("the member opens the Library under the Restricted policy", async () => {
+    await member.agent.run("route.extensions.skills");
+    await member.user.see(manageExtensionsNotice, { timeoutMs: 90_000, text: /disabled local extension management/ });
+    // Restricted also turns off allowBuiltInExtensions, so the Library's
+    // existing built-in banner appears alongside the new notice.
+    const builtInNoticeShown = await member.probe.eventually(() => member.probe.has(builtInExtensionsNotice), {
+      within: 30_000,
+      label: "built-in extensions notice",
+      until: (shown) => shown,
+    });
+    return { libraryHashAfter: await member.probe.hash(), builtInNoticeShown };
+  });
+  expect(libraryHashAfter).toContain("/extensions");
+  expect(builtInNoticeShown).toBe(true);
+  await member.user.looks([
+    "The Library is open and shows a notice that the organization administrator disabled local extension management",
+    "A notice says built-in OpenWork extensions are disabled by your organization",
+  ]);
+  evidence.recordAssertionEvidence(
+    "The Library stays reachable but local extension and MCP add flows are disabled with the catalog notice",
+    `hash=${libraryHashAfter}; manage-extensions notice visible; builtInNotice=${builtInNoticeShown}`,
+    libraryHashAfter.includes("/extensions") && builtInNoticeShown,
+  );
+});

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -66,6 +66,37 @@ export async function teamAccess(seed: Seed) {
     },
   });
   if (!den.members.jordan || !den.members.casey) throw new Error("Missing ordinary member sessions");
+  // Publish a deterministic catalog before desktop boot, as in the cloud
+  // provider sync world. An empty organization leaves the launch model
+  // unavailable and legitimately opens model recovery when Custom restores
+  // provider access. This journey exercises permissions, not inference.
+  const provider = await seed.api(den.admin, "/v1/llm-providers", {
+    method: "POST",
+    body: JSON.stringify({
+      name: "Team access model",
+      source: "custom",
+      customConfig: {
+        id: "team-access-eval-provider",
+        name: "Team access model",
+        npm: "@ai-sdk/openai-compatible",
+        env: ["TEAM_ACCESS_EVAL_PROVIDER_API_KEY"],
+        models: [{ id: "team-access-eval-model", name: "Team access model" }],
+      },
+      apiKey: "sk-openwork-team-access-eval-only",
+      allMembers: true,
+      memberIds: [],
+      teamIds: [],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const llmProvider = isRecord(provider.body) && isRecord(provider.body.llmProvider) ? provider.body.llmProvider : null;
+  if (provider.response.status !== 201 || typeof llmProvider?.id !== "string") {
+    throw new Error(`Organization model setup failed: HTTP ${provider.response.status}`);
+  }
+  const connected = await seed.api(den.members.jordan, `/v1/llm-providers/${encodeURIComponent(llmProvider.id)}/connect`, {
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (connected.response.status !== 200) throw new Error(`Member model entitlement setup failed: HTTP ${connected.response.status}`);
   const flags = {
     allowCustomProviders: true, allowZenModel: true, allowMultipleWorkspaces: true,
     allowControlSettings: true, allowManageExtensions: true, allowBuiltInExtensions: true,

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -53,7 +53,8 @@ export async function defaultPolicyEditorAndMemberDesktop(seed: Seed) {
   return { den, member, admin, policyId, editorPath };
 }
 
-/** Two ordinary members share an all-allow default. Jordan belongs to both the
+/** Two ordinary members share defaults that block Alpha updates. Jordan gets
+ * Alpha access only from the overlapping grant team and belongs to both the
  * focused team and an overlapping grant team; Casey is the unaffected control.
  * The admin starts at Team Access and Jordan starts in a real desktop. */
 export async function teamAccess(seed: Seed) {
@@ -72,7 +73,7 @@ export async function teamAccess(seed: Seed) {
   };
   const initial = await readDefaultDesktopPolicy(seed, den.admin);
   const reset = await seed.api(den.admin, `/v1/desktop-policies/${initial.id}`, {
-    method: "PATCH", body: JSON.stringify({ policyName: "Default desktop policy", policy: flags }),
+    method: "PATCH", body: JSON.stringify({ policyName: "Default desktop policy", policy: { ...flags, allowAlphaUpdates: false } }),
   });
   if (!reset.response.ok) throw new Error(`Default grants failed: ${reset.text}`);
   const org = await seed.api(den.members.jordan, "/v1/org");

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -1,0 +1,54 @@
+import type { Seed } from "@openwork/env";
+import { isRecord, records } from "./library.ts";
+
+/**
+ * The organization's default desktop policy as Den returns it, with the shape
+ * checks a spec needs before comparing saved values.
+ */
+export async function readDefaultDesktopPolicy(
+  channel: Pick<Seed, "api">,
+  admin: Parameters<Seed["api"]>[0],
+): Promise<Record<string, unknown>> {
+  const result = await channel.api(admin, "/v1/desktop-policies");
+  const policies = isRecord(result.body) ? records(result.body.desktopPolicies) : [];
+  const policy = policies.find((entry) => entry.isDefault === true);
+  if (!result.response.ok || !policy || typeof policy.id !== "string") {
+    throw new Error(`Reading the default desktop policy failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return policy;
+}
+
+/**
+ * One organization whose default desktop policy is still Custom, a member
+ * signed in to a fresh desktop, and the admin signed in to that policy's Den
+ * Web editor. Only Den and the member desktop are placed; the admin browser
+ * shares the Den's placement so Den Web is reached over loopback.
+ */
+export async function defaultPolicyEditorAndMemberDesktop(seed: Seed) {
+  const stamp = Date.now();
+  const den = await seed.den({
+    org: {
+      name: `Restricted Policy ${stamp}`,
+      admin: { name: "Sarah" },
+      members: { jordan: { name: "Jordan Eval" } },
+    },
+  });
+  if (!den.members.jordan) throw new Error("seed.den() did not provision the jordan member session");
+
+  const policyBefore = await readDefaultDesktopPolicy(seed, den.admin);
+  const policyId = String(policyBefore.id);
+  const editorPath = `/dashboard/desktop-policies/${encodeURIComponent(policyId)}`;
+
+  const member = await seed.desktop({ den, as: "jordan" });
+  const admin = await seed.web({
+    den,
+    signedInAs: den.admin,
+    startPath: editorPath,
+    headless: true,
+    // Tall enough that the whole capability list, through the editable
+    // Welcome Page row, stays inside the frame the vision judge sees.
+    viewport: { width: 1440, height: 2100 },
+  });
+
+  return { den, member, admin, policyId, editorPath };
+}

--- a/evals/worlds/desktop-policies.ts
+++ b/evals/worlds/desktop-policies.ts
@@ -52,3 +52,60 @@ export async function defaultPolicyEditorAndMemberDesktop(seed: Seed) {
 
   return { den, member, admin, policyId, editorPath };
 }
+
+/** Two ordinary members share an all-allow default. Jordan belongs to both the
+ * focused team and an overlapping grant team; Casey is the unaffected control.
+ * The admin starts at Team Access and Jordan starts in a real desktop. */
+export async function teamAccess(seed: Seed) {
+  const den = await seed.den({
+    org: {
+      name: `Team Access ${Date.now()}`,
+      admin: { name: "Sarah" },
+      members: { jordan: { name: "Jordan Eval" }, casey: { name: "Casey Eval" } },
+    },
+  });
+  if (!den.members.jordan || !den.members.casey) throw new Error("Missing ordinary member sessions");
+  const flags = {
+    allowCustomProviders: true, allowZenModel: true, allowMultipleWorkspaces: true,
+    allowControlSettings: true, allowManageExtensions: true, allowBuiltInExtensions: true,
+    allowAlphaUpdates: true, showWelcomePage: true,
+  };
+  const initial = await readDefaultDesktopPolicy(seed, den.admin);
+  const reset = await seed.api(den.admin, `/v1/desktop-policies/${initial.id}`, {
+    method: "PATCH", body: JSON.stringify({ policyName: "Default desktop policy", policy: flags }),
+  });
+  if (!reset.response.ok) throw new Error(`Default grants failed: ${reset.text}`);
+  const org = await seed.api(den.members.jordan, "/v1/org");
+  const currentMember = isRecord(org.body) && isRecord(org.body.currentMember) ? org.body.currentMember : null;
+  if (!org.response.ok || typeof currentMember?.id !== "string") throw new Error("Missing target member ID");
+  async function createTeam(name: string) {
+    const result = await seed.api(den.admin, "/v1/teams", {
+      method: "POST", body: JSON.stringify({ name, memberIds: [currentMember?.id] }),
+    });
+    const team = isRecord(result.body) && isRecord(result.body.team) ? result.body.team : null;
+    if (!result.response.ok || typeof team?.id !== "string") throw new Error(`Team setup failed: ${result.text}`);
+    return team.id;
+  }
+  const teamId = await createTeam("Focused work");
+  const grantTeamId = await createTeam("Additional tools");
+  const grant = await seed.api(den.admin, "/v1/desktop-policies", {
+    method: "POST", body: JSON.stringify({ policyName: "Additional team grants", policy: flags, teamIds: [grantTeamId] }),
+  });
+  if (!grant.response.ok) throw new Error(`Overlapping grant failed: ${grant.text}`);
+  const pluginName = "Approved briefing";
+  const rawSourceText = "---\nname: approved-briefing\ndescription: An approved team briefing skill.\n---\nSummarize the supplied notes into decisions and next steps. Team access proof.";
+  const plugin = await seed.api(den.admin, "/v1/plugins", {
+    method: "POST", body: JSON.stringify({ name: pluginName, components: [{ type: "skill", input: { rawSourceText } }] }),
+  });
+  const item = isRecord(plugin.body) && isRecord(plugin.body.item) ? plugin.body.item : null;
+  if (!plugin.response.ok || typeof item?.id !== "string") throw new Error(`Approved skill setup failed: ${plugin.text}`);
+  const pluginId = item.id;
+  const shared = await seed.api(den.admin, `/v1/plugins/${pluginId}/access`, {
+    method: "POST", body: JSON.stringify({ teamId, role: "viewer" }),
+  });
+  if (!shared.response.ok) throw new Error(`Approved skill sharing failed: ${shared.text}`);
+  const editorPath = `/dashboard/members/teams/${teamId}`;
+  const member = await seed.desktop({ den, as: "jordan" });
+  const admin = await seed.web({ den, signedInAs: den.admin, startPath: editorPath, headless: true, viewport: { width: 1440, height: 2100 } });
+  return { den, member, admin, teamId, grantTeamId, editorPath, pluginId, pluginName, rawSourceText };
+}

--- a/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
+++ b/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
@@ -18,7 +18,7 @@ Current desktop policy keys map to concrete product capabilities:
 - `Alpha updates`: allow or block opting into experimental Alpha desktop updates.
 - `Welcome Page`: show or hide the getting-started page for new users.
 
-A member's effective policy is the union of the default policy and every policy assigned to them: a capability is allowed when any applicable policy allows it. Restrict members by turning capabilities off in the default policy, then grant more to specific members or teams with assigned policies.
+Legacy desktop policies combine grants from the default policy and every assigned policy: any grant can allow a capability. Explicit Team Access blocks are applied afterward and take precedence over those grants. Restrict members by turning capabilities off in the default policy, then grant more to specific members or teams with assigned policies.
 
 ## Restricted mode
 

--- a/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
+++ b/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
@@ -39,3 +39,13 @@ Because the effective policy is a union of grants, apply `Restricted` to the def
 6. Save the policy, then have members reload, refresh their Cloud account, switch the active organization, or wait for the hourly desktop-config refresh.
 
 The desktop app explains blocked capabilities as organization-controlled. For example, a built-in extension disabled by policy is hidden from the normal catalog and can appear in hidden views with a `Disabled by organization` explanation, and the Cloud account page shows an `Organization policies active` notice.
+
+## Team access
+
+Open **Members → your team → Access** to choose **Locked** or **Custom** and save permissions. Owners and super-admins can change these controls; other administrators can review them.
+
+Locked blocks app customization, including adding tools and MCP servers, changing settings, adding providers and workspaces, using built-in extensions and OpenCode models, and opting into experimental updates. Members can still chat and use available connections. Existing installed tools are not removed, Cloud authoring still follows member roles, and this does not suspend accounts.
+
+Custom lets you block individual app capabilities. Switching to Locked and back preserves the Custom choices. A block applies even when the default policy or another team grants that capability. Allowing a capability does not override another restriction. Existing policies without explicit access limits retain their grant behavior.
+
+The desktop account page explains the resulting permissions under **What can I do?** The Library explains how to ask an administrator for an MCP server when local tool management is blocked. Updates arrive when the app refreshes, including on reload or its periodic configuration refresh.

--- a/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
+++ b/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
@@ -38,7 +38,7 @@ Because the effective policy is a union of grants, apply `Restricted` to the def
 5. Assign the policy to members or teams when it should not apply to everyone.
 6. Save the policy, then have members reload, refresh their Cloud account, switch the active organization, or wait for the hourly desktop-config refresh.
 
-The desktop app explains blocked capabilities as organization-controlled. For example, a built-in extension disabled by policy is hidden from the normal catalog and can appear in hidden views with a `Disabled by organization` explanation, and the Cloud account page shows an `Organization policies active` notice.
+The desktop app explains blocked capabilities as organization-controlled. For example, a built-in extension disabled by policy is hidden from the normal catalog and can appear in hidden views with a `Disabled by organization` explanation, and the account page lists effective capabilities in its **App permissions** tab.
 
 ## Team access
 
@@ -48,4 +48,4 @@ Locked blocks app customization, including adding tools and MCP servers, changin
 
 Custom lets you block individual app capabilities. Switching to Locked and back preserves the Custom choices. A block applies even when the default policy or another team grants that capability. Allowing a capability does not override another restriction. Existing policies without explicit access limits retain their grant behavior.
 
-The desktop account page explains the resulting permissions under **What can I do?** The Library explains how to ask an administrator for an MCP server when local tool management is blocked. Updates arrive when the app refreshes, including on reload or its periodic configuration refresh.
+Open **Account → App permissions** in the desktop app to see which capabilities are Allowed or Blocked and how to request changes from your administrator. These permissions are read-only in the desktop app. The Library explains how to ask an administrator for an MCP server when local tool management is blocked. Updates arrive when the app refreshes, including on reload or its periodic configuration refresh.

--- a/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
+++ b/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
@@ -12,18 +12,30 @@ Current desktop policy keys map to concrete product capabilities:
 - `Custom providers`: allow or block locally added model providers that were not deployed through OpenWork Cloud.
 - `Enable OpenCode Zen Models`: allow or block built-in OpenCode models.
 - `Multiple workspaces`: allow or block creating or configuring more than one local workspace.
-- `Control Settings`: allow or block changing desktop settings.
-- `Manage Extensions`: allow or block local extension management.
+- `Control Settings`: allow or block desktop settings. When blocked, the desktop app hides every settings page except the Cloud account page, and hides the settings shortcuts in the command palette and account menu. Members can still see their account, switch organizations, and log out.
+- `Manage Extensions`: allow or block installing and managing local extensions and MCP servers. When blocked, the Library hides the workspace MCP and GitHub import flows and marks third-party directory entries as `Disabled by organization`; organization-approved skills, connections, and built-in OpenWork extensions still work.
 - `Built-in Extensions`: allow or block OpenWork-provided built-in extensions, including browser, image, and local-provider extensions.
+- `Alpha updates`: allow or block opting into experimental Alpha desktop updates.
 - `Welcome Page`: show or hide the getting-started page for new users.
+
+A member's effective policy is the union of the default policy and every policy assigned to them: a capability is allowed when any applicable policy allows it. Restrict members by turning capabilities off in the default policy, then grant more to specific members or teams with assigned policies.
+
+## Restricted mode
+
+Every policy has a mode selector at the top of its editor:
+
+- `Custom` lets you choose each capability.
+- `Restricted` gives members a vanilla OpenWork: they can chat and use organization-approved skills, but cannot change desktop settings, add providers or use models outside the organization, add workspaces, use built-in extensions, install extensions or MCP servers, or opt into Alpha updates. The locked capabilities stay off until you switch the policy back to `Custom`. The `Welcome Page` preference stays editable in both modes.
+
+Because the effective policy is a union of grants, apply `Restricted` to the default policy to lock members down. A targeted policy in `Restricted` mode grants nothing on its own.
 
 ## Configure a policy
 
 1. Open [app.openworklabs.com](https://app.openworklabs.com/) and choose your organization.
 2. Go to `Desktop policies`.
 3. Create a new policy or edit the default policy.
-4. Turn capabilities on or off.
+4. Pick `Restricted`, or stay in `Custom` and turn capabilities on or off.
 5. Assign the policy to members or teams when it should not apply to everyone.
 6. Save the policy, then have members reload, refresh their Cloud account, switch the active organization, or wait for the hourly desktop-config refresh.
 
-The desktop app explains blocked capabilities as organization-controlled. For example, a built-in extension disabled by policy is hidden from the normal catalog and can appear in hidden views with a `Disabled by organization` explanation.
+The desktop app explains blocked capabilities as organization-controlled. For example, a built-in extension disabled by policy is hidden from the normal catalog and can appear in hidden views with a `Disabled by organization` explanation, and the Cloud account page shows an `Organization policies active` notice.

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -6,6 +6,11 @@ type DesktopPolicyDefinitionEntry = {
   description: string;
   userNotice: string;
   defaultValue: boolean;
+  /**
+   * Value the Restricted policy mode locks this key to, or `null` when the key
+   * is a display preference that Restricted leaves editable.
+   */
+  restrictedValue: boolean | null;
 };
 
 // Canonical desktop policy catalog.
@@ -13,10 +18,12 @@ type DesktopPolicyDefinitionEntry = {
 // To add a new desktop policy item:
 // 1. Add a matching entry to `desktopPolicyDefinitions` below.
 // 2. Choose a safe `defaultValue` for orgs with missing/older policy data.
-// 3. Wire desktop app behavior to read the key through the desktop config hooks.
-// 4. If the key affects Den web editing copy, update the `name`, `description`,
+// 3. Choose its `restrictedValue`: the value the Restricted policy mode locks
+//    the key to, or `null` for a display preference Restricted leaves alone.
+// 4. Wire desktop app behavior to read the key through the desktop config hooks.
+// 5. If the key affects Den web editing copy, update the `name`, `description`,
 //    and `userNotice` here rather than duplicating that copy elsewhere.
-// 5. Do not manually edit `desktopPolicyValueSchema`; it is generated from the
+// 6. Do not manually edit `desktopPolicyValueSchema`; it is generated from the
 //    IDs in this definition list.
 //
 // Policy booleans usually use allow-style names. For every policy item,
@@ -32,6 +39,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has disabled adding custom providers.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "allowZenModel",
@@ -39,6 +47,7 @@ export const desktopPolicyDefinitions = [
     description: "Allow users to use the built in models provided by OpenCode.",
     userNotice: "Your administrator has disabled access to OpenCode Models.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "allowMultipleWorkspaces",
@@ -48,6 +57,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has restricted access to adding additional workspaces.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "allowControlSettings",
@@ -56,6 +66,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has disabled changing desktop app settings.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "allowManageExtensions",
@@ -64,6 +75,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has disabled local extension management.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "allowBuiltInExtensions",
@@ -73,6 +85,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has disabled built-in OpenWork extensions.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "allowAlphaUpdates",
@@ -82,6 +95,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has disabled Alpha desktop updates.",
     defaultValue: true,
+    restrictedValue: false,
   },
   {
     id: "showWelcomePage",
@@ -90,6 +104,7 @@ export const desktopPolicyDefinitions = [
     userNotice:
       "Your organization administrator has disabled the Getting Started page.",
     defaultValue: true,
+    restrictedValue: null,
   },
 ] as const satisfies readonly DesktopPolicyDefinitionEntry[];
 
@@ -161,6 +176,48 @@ export const desktopPolicyDefaults = Object.fromEntries(
     definition.defaultValue,
   ]),
 ) as Required<DesktopPolicyValue>;
+
+/** Catalog copy the desktop app shows when a policy blocks a capability. */
+export const desktopPolicyUserNotices = Object.fromEntries(
+  desktopPolicyDefinitions.map((definition) => [
+    definition.id,
+    definition.userNotice,
+  ]),
+) as Record<DesktopPolicyKey, string>;
+
+// ---------------------------------------------------------------------------
+// Restricted policy mode: chat and organization-approved skills only.
+//
+// Restricted is an editor mode, not a stored flag. A policy is Restricted when
+// every key with a `restrictedValue` holds that value; display preferences
+// (`restrictedValue: null`) stay editable in both modes. Because the effective
+// policy is a union of grants, Restricted only locks members down when it is
+// applied to the default policy.
+// ---------------------------------------------------------------------------
+export function applyRestrictedDesktopPolicy(
+  value: Required<DesktopPolicyValue>,
+): Required<DesktopPolicyValue> {
+  return Object.fromEntries(
+    desktopPolicyDefinitions.map((definition) => [
+      definition.id,
+      definition.restrictedValue ?? value[definition.id],
+    ]),
+  ) as Required<DesktopPolicyValue>;
+}
+
+export function isRestrictedDesktopPolicyValue(
+  value: Required<DesktopPolicyValue>,
+): boolean {
+  return desktopPolicyDefinitions.every(
+    (definition) =>
+      definition.restrictedValue === null ||
+      value[definition.id] === definition.restrictedValue,
+  );
+}
+
+export const restrictedDesktopPolicyValue = applyRestrictedDesktopPolicy(
+  desktopPolicyDefaults,
+);
 
 // ---------------------------------------------------------------------------
 // Radix color families that can be used as a brand accent.

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -141,8 +141,23 @@ export type OnboardingPromptConfig = {
   onboardingPromptDescriptions?: string[];
 };
 
+// Explicit access limits are applied after legacy grants. Omitted access keeps
+// existing policies' grant semantics unchanged.
+export const teamAccessSchema = z.object({
+  mode: z.enum(["custom", "locked"]),
+  capabilities: desktopPolicyValueSchema,
+});
+export type TeamAccess = z.infer<typeof teamAccessSchema>;
+
+function normalizeTeamAccess(value: unknown): TeamAccess | undefined {
+  const raw = coerceJsonRecord(value);
+  const parsed = teamAccessSchema.safeParse(isRecord(raw) ? raw.access : undefined);
+  return parsed.success ? parsed.data : undefined;
+}
+
 export const desktopPolicyDocumentSchema = desktopPolicyValueSchema
   .extend({
+    access: teamAccessSchema.optional(),
     onboardingPrompts: onboardingPromptsSchema.optional(),
     onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.optional(),
   })
@@ -150,6 +165,7 @@ export const desktopPolicyDocumentSchema = desktopPolicyValueSchema
 
 export const desktopPolicyDocumentWriteSchema = desktopPolicyValueSchema
   .extend({
+    access: teamAccessSchema.optional(),
     onboardingPrompts: onboardingPromptsSchema.nullable().optional(),
     onboardingPromptDescriptions: onboardingPromptDescriptionsSchema
       .nullable()
@@ -162,6 +178,7 @@ export type DesktopPolicyDocumentWrite = z.infer<
   typeof desktopPolicyDocumentWriteSchema
 >;
 export type DefaultDesktopPolicyDocument = Required<DesktopPolicyValue> & {
+  access?: TeamAccess;
   onboardingPrompts?: string[];
   onboardingPromptDescriptions?: string[];
 };
@@ -385,8 +402,10 @@ export function normalizeDesktopPolicyDocument(
   const policy = normalizeDesktopPolicyValue(coerced);
   const onboardingPromptConfig = normalizeOnboardingPromptConfig(coerced);
 
+  const access = normalizeTeamAccess(coerced);
   return {
     ...policy,
+    ...(access !== undefined ? { access } : {}),
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   };
 }
@@ -405,8 +424,10 @@ export function normalizeDesktopPolicyDocumentWrite(
     onboardingPrompts?.length,
   );
 
+  const access = normalizeTeamAccess(coerced);
   return {
     ...policy,
+    ...(access !== undefined ? { access } : {}),
     ...(rawPrompts === null
       ? { onboardingPrompts: null, onboardingPromptDescriptions: null }
       : onboardingPrompts !== undefined
@@ -455,8 +476,10 @@ export function resolveDesktopPolicyDocumentWrite(input: {
           )
         : undefined;
 
+  const access = write.access ?? normalizeTeamAccess(input.existingPolicy);
   return {
     ...policy,
+    ...(access !== undefined ? { access } : {}),
     ...(onboardingPrompts !== undefined ? { onboardingPrompts } : {}),
     ...(onboardingPromptDescriptions !== undefined
       ? { onboardingPromptDescriptions }
@@ -471,8 +494,10 @@ export function normalizeDefaultDesktopPolicyDocument(
   const policy = normalizeDefaultDesktopPolicyValue(coerced);
   const onboardingPromptConfig = normalizeOnboardingPromptConfig(coerced);
 
+  const access = normalizeTeamAccess(coerced);
   return {
     ...policy,
+    ...(access !== undefined ? { access } : {}),
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   };
 }
@@ -506,6 +531,17 @@ export function calculateEffectiveDesktopPolicy(input: {
     for (const key of desktopPolicyKeys) {
       if (policy[key] === true) {
         calculated[key] = true;
+      }
+    }
+  }
+
+  for (const document of [input.defaultPolicy, ...input.assignedPolicies]) {
+    const access = normalizeTeamAccess(document);
+    if (!access) continue;
+    for (const definition of desktopPolicyDefinitions) {
+      if (definition.restrictedValue === null) continue;
+      if (access.mode === "locked" || access.capabilities[definition.id] === false) {
+        calculated[definition.id] = false;
       }
     }
   }


### PR DESCRIPTION
## Team access is the starting point

Admins can now open **Members → Team → Access** to choose **Locked** or **Custom**, review individual app capabilities, and save the team's permissions. The same page shows plugin grants and links to member roles. Desktop settings explain the resulting access; they are not the place to configure team permissions.

- **Locked** blocks governed app capabilities, including local tool/MCP installation and app settings. **Custom** lets an admin block capabilities individually. Switching between modes retains the custom choices.
- Explicit team blocks apply after the existing grant calculation. A default policy or another team cannot re-enable a blocked capability; people outside the team are unaffected. Policies without explicit limits retain their existing semantics.
- The desktop account page has **Account** and **App permissions** tabs, using the existing desktop tabs, settings rows, and status badges. The permissions tab lists each capability as Allowed or Blocked, including when all are allowed. The global policy banner is removed. The Library explains how to ask an admin for an MCP server when local extension management is blocked.
- The advanced policies screen identifies team configurations and routes editing back to the team's Access page. Owners and super-admins retain write authority; ordinary members cannot change their own permissions.

The earlier work in this PR remains: legacy Custom/Restricted policy controls and enforcement of the app settings and local extension-management flags.

## Scope

This locks app customization, not account sign-in. Existing installed tools remain available; Cloud authoring follows member roles, and access to individual plugins/connections follows their grants. These are called out on the team page. Tool-level execution permissions and account suspension are not added here. Updates use the existing app refresh/reload mechanism.

Team limits are stored inside the existing policy JSON document, with no database migration. Older policy edits preserve those limits. The API still sends effective booleans to the desktop.

Manual local plugin, skill, and MCP mutations check the current effective permissions inside their action handlers, including after permissions change. Built-in extension operations use their separate capability; existing MCP authentication and managed Cloud synchronization retain their existing behavior. These app controls do not revoke separately issued OpenWork server credentials or sandbox the machine owner.

## Screens

**Account → App permissions, Custom**

![Custom app permissions](https://github.com/user-attachments/assets/4da60c72-3e3e-4bad-8922-20088fcbf372)

**Account → App permissions, Locked**

![Locked app permissions](https://github.com/user-attachments/assets/c6575386-b19c-4476-a192-4d4618ec12f4)

**Team → Access**

![Locked team access](https://github.com/user-attachments/assets/c6abf171-fa13-4e79-ac9b-818665481a0e)

## Verification — Passed

Final head: `4c370b9d122dd238b56f0df17cb20e117f5d7255`.

[Published evidence for both journeys](https://github.com/different-ai/openwork/pull/4306#issuecomment-5547978562): **2 passed, 0 failed, 0 skipped**, with 12 screenshots passing visual validation. Daytona run completed in 835 seconds, exit 0.

```sh
OPENWORK_EVAL_REF=feature/restricted-desktop-policy pnpm evals:e2e desktop-policy-restricted-mode
```

- The default-policy journey proves Restricted enforcement and saves all seven legacy Custom controls both enabled and disabled.
- The Team Access world uses ordinary members, a same-role outside control, an overlapping team that alone grants Alpha access, an approved team skill, and an entitled organization model. Locked overrides the overlapping grant without changing the outsider’s baseline; Custom restores only selected capabilities.
- The real desktop verifies all-allowed, all-blocked, and mixed Account / App permissions tabs, settings restrictions, MCP guidance, a blocked local MCP add path, and a reachable organization MCP add form. The form check does not claim organization MCP creation or execution.
- Approved skill discovery and content resolution remain scoped to the team. Unauthorized team-policy POST and PATCH return 403 without changing permissions. Saved Custom choices survive mode changes and reloads.
- **46 focused tests passed**, with 193 assertions, including direct action-handler denials, live permission changes, separate built-in permissions, forged built-in metadata, and existing MCP authentication. App typecheck, spec ratchets, and dependency-layer checks passed.
- [Final Warden run](https://github.com/different-ai/openwork/actions/runs/33931639728): **0 findings**, including security and sync findings. Required CI passed.
