### PR TITLE
fix(chat): reveal full commands, search patterns, and errors in tool groups

### DIFF
--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Fragment, useState } from "react"
-import { AlertTriangle, CircleHelp, CirclePause, MoreHorizontal } from "lucide-react"
+import { AlertTriangle, ChevronUp, CircleHelp, CirclePause, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
 import { ShellCommandText } from "@/components/chat/shell-command-text"
@@ -13,6 +13,7 @@ import {
   getToolAggregateLifecycle,
   getAggregateRowFile,
   getAggregateRowLabel,
+  getAggregateRowSearch,
   getAggregateSummary,
   getToolFamily,
   type AggregateThought,
@@ -42,10 +43,59 @@ function persistedRowStatus(part: AnyToolPart): "running" | "failed" | "done" {
   return "done"
 }
 
-function failureReason(part: AnyToolPart): string | null {
+function failureText(part: AnyToolPart): string | null {
   if (part.state !== "output-error" || !part.errorText) return null
-  const firstLine = part.errorText.split("\n")[0]?.trim()
-  return firstLine ? (firstLine.length > 120 ? `${firstLine.slice(0, 119)}…` : firstLine) : null
+  const text = part.errorText.trim()
+  return text || null
+}
+
+type DetailBoxProps = {
+  kind: "command" | "pattern" | "error"
+  text: string
+  expanded: boolean
+  onToggle: () => void
+}
+
+/**
+ * Monospace detail (a command, a search pattern, an error) shown as one
+ * clipped line; clicking reveals the whole text, wrapped, so nothing in
+ * an expanded tool group is ever unreadable.
+ */
+function DetailBox({ kind, text, expanded, onToggle }: DetailBoxProps) {
+  const noun = kind === "command" ? "command" : kind === "pattern" ? "search pattern" : "error"
+  const textClassName = cn("min-w-0 flex-1", expanded ? "whitespace-pre-wrap break-all" : "line-clamp-1 break-all")
+  return (
+    <button
+      type="button"
+      data-tool-aggregate-detail={kind}
+      data-tool-aggregate-command={kind === "command" ? "" : undefined}
+      data-command-expanded={expanded ? "true" : "false"}
+      aria-expanded={expanded}
+      aria-label={expanded ? `Collapse ${noun}` : `Show full ${noun}`}
+      onClick={onToggle}
+      className={cn(
+        "flex min-w-0 max-w-full cursor-pointer gap-2 rounded-xl border px-3 py-2 text-start font-mono transition-colors",
+        expanded ? "items-start [&>svg]:mt-0.5" : "items-center",
+        kind === "error"
+          ? "border-destructive/30 bg-destructive/5 text-xs text-destructive hover:border-destructive/50"
+          : "border-border/70 bg-gray-2/60 text-sm hover:border-border hover:bg-gray-3/60",
+      )}
+    >
+      {kind === "command" ? (
+        <>
+          <span className="shrink-0 text-muted-foreground/60">$</span>
+          <ShellCommandText command={text} className={textClassName} />
+        </>
+      ) : (
+        <code className={textClassName}>{text}</code>
+      )}
+      {expanded ? (
+        <ChevronUp aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
+      ) : (
+        <MoreHorizontal aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
+      )}
+    </button>
+  )
 }
 
 type AggregateRow = {
@@ -104,7 +154,28 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
   const latestToolCallId = parts.at(-1)?.toolCallId ?? groupKey
   const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
   const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
+  // Which detail boxes (command / pattern / error, per call) show full text.
+  const [fullDetailKeys, setFullDetailKeys] = useState<ReadonlySet<string>>(() => new Set())
   const resolveLifecycle = useCurrentToolLifecycleResolver()
+
+  const detailBox = (kind: DetailBoxProps["kind"], toolCallId: string, text: string) => {
+    const key = `${toolCallId}:${kind}`
+    return (
+      <DetailBox
+        kind={kind}
+        text={text}
+        expanded={fullDetailKeys.has(key)}
+        onToggle={() =>
+          setFullDetailKeys((current) => {
+            const next = new Set(current)
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            return next
+          })
+        }
+      />
+    )
+  }
 
   const setExpanded = (value: boolean) => {
     expandedByGroupKey.set(groupKey, value)
@@ -154,7 +225,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
   const soloFile = soloRow ? getAggregateRowFile(soloRow.part) : null
   if (soloRow && soloFile) {
     const status = currentLifecycle ?? persistedRowStatus(soloRow.part)
-    const reason = failureReason(soloRow.part)
+    const failure = failureText(soloRow.part)
     return (
       <div
         className={className}
@@ -189,8 +260,8 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
             <span>This step stopped before it finished. Retry to continue.</span>
           </div>
         ) : null}
-        {reason ? (
-          <div className="mt-1 text-[11px] text-muted-foreground">failed — {reason}</div>
+        {failure ? (
+          <div className="mt-1.5">{detailBox("error", soloRow.part.toolCallId, failure)}</div>
         ) : null}
       </div>
     )
@@ -264,12 +335,13 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                 ? lifecycle
                 : "unknown"
               : persistedRowStatus(part)
-            const reason = failureReason(part)
+            const failure = failureText(part)
             const bash = isBashToolPart(part)
             const command = bash ? part.input?.command?.trim() ?? "" : ""
             const commandDescription = bash
               ? part.input?.description?.trim() || "command"
               : ""
+            const search = bash ? null : getAggregateRowSearch(part)
             return (
               <Fragment key={part.toolCallId}>
               {thoughtsAt(row.index).map((thought) => (
@@ -287,7 +359,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                     <CircleHelp aria-label="Status unknown" className="size-3.5 shrink-0" />
                   ) : null}
                   {bash ? (
-                    <span className="min-w-0 truncate">
+                    <span className="min-w-0 break-words">
                       <span className={cn("text-foreground", status === "running" && "ow-text-shimmer")}>
                         {status === "running"
                           ? "Running"
@@ -298,6 +370,13 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                               : "Ran"}
                       </span>{" "}
                       <span>{commandDescription}</span>
+                    </span>
+                  ) : search ? (
+                    <span className="min-w-0 break-words">
+                      <span className={cn(status === "running" && "text-foreground ow-text-shimmer")}>
+                        {search.verb}
+                      </span>
+                      {search.scope ? <span> in {search.scope}</span> : null}
                     </span>
                   ) : (() => {
                     const file = getAggregateRowFile(part)
@@ -332,19 +411,9 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                   ) : null}
                   </div>
                 ) : null}
-                {bash && command ? (
-                  <div
-                    data-tool-aggregate-command
-                    className="flex min-w-0 items-center gap-2 rounded-xl border border-border/70 bg-gray-2/60 px-3 py-2 font-mono text-sm"
-                  >
-                    <span className="shrink-0 text-muted-foreground/60">$</span>
-                    <ShellCommandText command={command} className="min-w-0 flex-1 truncate" />
-                    <MoreHorizontal aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
-                  </div>
-                ) : null}
-                {reason ? (
-                  <div className="text-[11px] text-muted-foreground">failed — {reason}</div>
-                ) : null}
+                {bash && command ? detailBox("command", part.toolCallId, command) : null}
+                {search ? detailBox("pattern", part.toolCallId, search.pattern) : null}
+                {failure ? detailBox("error", part.toolCallId, failure) : null}
               </div>
               </Fragment>
             )

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -187,6 +187,31 @@ export function getAggregateRowFile(part: AnyToolPart): { verb: string; path: st
   return null
 }
 
+/**
+ * Search-family rows render as "Searched code in <scope>" above the exact
+ * pattern, so the pattern is never clipped by a summary label.
+ */
+export function getAggregateRowSearch(
+  part: AnyToolPart,
+): { verb: string; pattern: string; scope: string | null } | null {
+  const grep = isGrepToolPart(part)
+  if (!grep && !isGlobToolPart(part)) return null
+  if (!isRecord(part.input)) return null
+  const pattern = typeof part.input.pattern === "string" ? part.input.pattern.trim() : ""
+  if (!pattern) return null
+  const running = isToolPartInFlight(part)
+  const path = typeof part.input.path === "string" ? part.input.path.trim() : ""
+  const include = grep && typeof part.input.include === "string" ? part.input.include.trim() : ""
+  const scope = [path, include].filter(Boolean).join(" · ")
+  return {
+    verb: grep
+      ? (running ? "Searching code" : "Searched code")
+      : (running ? "Searching files" : "Searched files"),
+    pattern,
+    scope: scope || null,
+  }
+}
+
 /** Monospace action text for an expanded aggregate row. */
 export function getAggregateRowLabel(part: AnyToolPart): string {
   if (isBashToolPart(part)) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -406,6 +406,56 @@ function createSessionLifecycleEvalMessages(sessionId: string): UIMessage[] {
   ];
 }
 
+const TOOL_DETAILS_EVAL_COMMAND =
+  "pnpm world up dev-headless --detach -- --replace --keep-tokens && OPENWORK_EVAL_E2E_TESTS=1 pnpm vitest run evals/specs/chat-loading-shimmer.e2e.test.ts --reporter=verbose";
+const TOOL_DETAILS_EVAL_PATTERN =
+  "seed_unfinished_tools|git status --short --branch|createSessionLifecycleEvalMessages|useControlAction";
+const TOOL_DETAILS_EVAL_ERROR =
+  "Process exited with code 2\nerror: pathspec 'release/2026.09' did not match any file(s) known to git\nhint: use 'git fetch origin release/2026.09' first";
+
+function createToolDetailsEvalMessages(sessionId: string): UIMessage[] {
+  const now = Date.now();
+  return [
+    {
+      id: `${sessionId}:eval-tool-details-user`,
+      role: "user",
+      parts: [{ type: "text", text: "Run the headless proof and find the seed hook." }],
+      metadata: { opencode: { created: now } },
+    },
+    {
+      id: `${sessionId}:eval-tool-details-assistant`,
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "bash",
+          toolCallId: "eval-tool-details-bash",
+          state: "output-available",
+          input: { command: TOOL_DETAILS_EVAL_COMMAND, description: "Run the headless proof" },
+          output: "ok",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "grep",
+          toolCallId: "eval-tool-details-grep",
+          state: "output-available",
+          input: { pattern: TOOL_DETAILS_EVAL_PATTERN, path: "apps/app/src", include: "*.tsx" },
+          output: "2 matches",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "bash",
+          toolCallId: "eval-tool-details-failed",
+          state: "output-error",
+          input: { command: "git checkout release/2026.09", description: "Switch to the release branch" },
+          errorText: TOOL_DETAILS_EVAL_ERROR,
+        },
+      ],
+      metadata: { opencode: { created: now + 1, completed: now + 4_000 } },
+    },
+  ];
+}
+
 function createSubagentActivityEvalMessages(sessionId: string, childSessionId?: string): UIMessage[] {
   const now = Date.now();
   return [
@@ -1331,6 +1381,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId]);
   useControlAction(props.isControlTarget ? seedConnectorToolCallControlAction : null);
+  const seedToolDetailsControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.tool_details.seed",
+      label: "Seed a settled tool group with long details",
+      description: "Dev-only eval hook that renders a long command, a long search pattern, and a multi-line failure in one aggregate group.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: () => {
+        setEvalMarkdownMessages(createToolDetailsEvalMessages(props.sessionId));
+        return { ok: true };
+      },
+    };
+  }, [props.sessionId]);
+  useControlAction(props.isControlTarget ? seedToolDetailsControlAction : null);
   const seedSessionLifecycleControlAction = useMemo<OpenworkControlAction | null>(() => {
     if (!import.meta.env.DEV) return null;
 

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { DynamicToolUIPart } from "ai";
 
 import { ToolAggregateGroup, buildAggregateRows } from "../src/components/chat/tool-aggregate-group";
+import { getAggregateRowSearch } from "../src/lib/tool-aggregate";
 import { CurrentToolLifecycleProvider } from "../src/components/chat/current-tool-lifecycle-context";
 import { getToolAggregateLifecycle } from "../src/lib/tool-aggregate";
 
@@ -161,5 +162,58 @@ describe("tool aggregate row merging", () => {
     );
 
     expect(rows).toHaveLength(2);
+  });
+});
+
+describe("tool aggregate long details", () => {
+  const longPattern = "seed_unfinished_tools|git status --short --branch|createSessionLifecycleEvalMessages";
+  const multiLineError = "Process exited with code 2\nerror: pathspec 'release/2026.09' did not match any file(s) known to git\nhint: use 'git fetch origin release/2026.09' first";
+
+  test("search rows keep the exact pattern and name their scope", () => {
+    const grep: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "grep",
+      toolCallId: "grep-1",
+      state: "output-available",
+      input: { pattern: longPattern, path: "apps/app/src", include: "*.tsx" },
+      output: "2 matches",
+    };
+    const glob: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "glob",
+      toolCallId: "glob-1",
+      state: "input-available",
+      input: { pattern: "**/*.e2e.test.ts" },
+    };
+
+    expect(getAggregateRowSearch(grep)).toEqual({
+      verb: "Searched code",
+      pattern: longPattern,
+      scope: "apps/app/src · *.tsx",
+    });
+    expect(getAggregateRowSearch(glob)).toEqual({
+      verb: "Searching files",
+      pattern: "**/*.e2e.test.ts",
+      scope: null,
+    });
+    expect(getAggregateRowSearch(runningCommand)).toBeNull();
+  });
+
+  test("a failed solo file action exposes its whole error, not a clipped first line", () => {
+    const failedRead: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "read",
+      toolCallId: "failed-read",
+      state: "output-error",
+      input: { filePath: "/repo/missing.md" },
+      errorText: multiLineError,
+    };
+
+    const markup = renderToStaticMarkup(<ToolAggregateGroup parts={[failedRead]} />);
+
+    expect(markup).toContain('data-tool-aggregate-detail="error"');
+    expect(markup).toContain("aria-label=\"Show full error\"");
+    expect(markup).toContain("hint: use &#x27;git fetch origin release/2026.09&#x27; first");
+    expect(markup).not.toContain("failed —");
   });
 });

--- a/evals/specs/chat-loading-shimmer.e2e.test.ts
+++ b/evals/specs/chat-loading-shimmer.e2e.test.ts
@@ -65,7 +65,9 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   if (!aggregate || typeof aggregate !== "object" || !("text" in aggregate) || typeof aggregate.text !== "string") {
     throw new Error(`Aggregate activity row was not readable: ${JSON.stringify(aggregate)}`);
   }
-  expect(aggregate.text).toContain("Now:");
+  // #4134 dropped the "Now:" prefix: the whole current action shimmers instead.
+  expect(aggregate.text).not.toContain("Now:");
+  expect(aggregate.text).toContain("Reading brief.md");
   if (!("singularSummary" in aggregate) || typeof aggregate.singularSummary !== "string") {
     throw new Error(`Aggregate summary was not readable: ${JSON.stringify(aggregate)}`);
   }

--- a/evals/specs/chat-tool-details-expand.e2e.test.ts
+++ b/evals/specs/chat-tool-details-expand.e2e.test.ts
@@ -1,0 +1,169 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, seedSessions, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "expanded tool groups reveal full commands, search patterns, and errors on click"
+  : "chat tool details expand skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+// Tails of the seeded values (see eval.tool_details.seed). Each is well past the
+// old clip points (44-char pattern cap, 120-char error first line, one-line
+// command box), so seeing it proves the whole value is readable.
+const COMMAND_TAIL = "chat-loading-shimmer.e2e.test.ts --reporter=verbose";
+const PATTERN_TAIL = "createSessionLifecycleEvalMessages|useControlAction";
+const ERROR_TAIL = "hint: use 'git fetch origin release/2026.09' first";
+
+type DetailKind = "command" | "pattern" | "error";
+
+type DetailProbe = {
+  kind: string;
+  expanded: string | null;
+  ariaLabel: string | null;
+  isButton: boolean;
+  visibleLines: number;
+  clipped: boolean;
+  text: string;
+};
+
+function isDetailProbe(value: unknown): value is DetailProbe {
+  return typeof value === "object" && value !== null && "kind" in value && "text" in value && "visibleLines" in value;
+}
+
+// Longest detail box of the requested kind (the seed's failed row also has a
+// short command box; the long one is what the claims are about).
+const probeScript = (kind: DetailKind, click: boolean) => `(() => {
+  const boxes = [...document.querySelectorAll('[data-tool-aggregate-detail="${kind}"]')];
+  const box = boxes
+    .map((el) => ({ el, len: (el.querySelector('code')?.textContent ?? '').length }))
+    .sort((a, b) => b.len - a.len)[0]?.el;
+  if (!box) return null;
+  if (${click}) box.click();
+  const code = box.querySelector('code');
+  if (!code) return null;
+  const lineHeight = parseFloat(getComputedStyle(code).lineHeight) || 20;
+  return {
+    kind: box.getAttribute('data-tool-aggregate-detail'),
+    expanded: box.getAttribute('data-command-expanded'),
+    ariaLabel: box.getAttribute('aria-label'),
+    isButton: box.tagName === 'BUTTON',
+    visibleLines: Math.round(code.getBoundingClientRect().height / lineHeight),
+    clipped: code.scrollHeight > code.clientHeight + 1 || code.scrollWidth > code.clientWidth + 1,
+    text: code.textContent ?? '',
+  };
+})()`;
+
+async function probe(app: Awaited<ReturnType<typeof desktop>>, kind: DetailKind, click: boolean): Promise<DetailProbe> {
+  if (click) {
+    // Let React commit the toggle before measuring.
+    await evalIn(app, probeScript(kind, true));
+    await waitFor(app, `document.querySelector('[data-tool-aggregate-detail="${kind}"]') !== null`, {
+      timeoutMs: 5_000,
+      label: `${kind} detail box still mounted`,
+    });
+  }
+  const result = await evalIn(app, probeScript(kind, false));
+  if (!isDetailProbe(result)) {
+    throw new Error(`${kind} detail box was not readable: ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+test.skipIf(!enabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "chat-tool-details-expand" });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-chat-tool-details-${Date.now()}`,
+  });
+  await seedSessions(app, ["Tool details proof"]);
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "eval.tool_details.seed" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "tool details seed control ready" },
+  );
+  await control(app, "eval.tool_details.seed");
+
+  await waitFor(app, `Boolean(document.querySelector('[data-tool-aggregate] > button'))`, {
+    timeoutMs: 15_000,
+    label: "aggregate group header",
+  });
+  const opened = await evalIn(app, `(() => {
+    const trigger = document.querySelector('[data-tool-aggregate] > button');
+    if (!(trigger instanceof HTMLButtonElement)) return false;
+    if (trigger.getAttribute('aria-expanded') !== 'true') trigger.click();
+    return true;
+  })()`);
+  expect(opened).toBe(true);
+  await waitFor(app, `document.querySelectorAll('[data-tool-aggregate-detail]').length >= 4`, {
+    timeoutMs: 15_000,
+    label: "expanded rows with detail boxes",
+  });
+
+  // The search row names its scope in prose and does not clip the pattern in JS.
+  const searchLabel = await evalIn(app, `(() => {
+    const box = document.querySelector('[data-tool-aggregate-detail="pattern"]');
+    const row = box?.parentElement;
+    return row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, ' ').trim() : '';
+  })()`);
+  if (typeof searchLabel !== "string") throw new Error(`Search row was not readable: ${JSON.stringify(searchLabel)}`);
+  expect(searchLabel).toContain("Searched code in apps/app/src · *.tsx");
+  expect(searchLabel).not.toContain("Searching for");
+  expect(searchLabel).not.toContain("...");
+  evidence.recordAssertionEvidence(
+    "A finished search row reads in past tense and names its path and include scope",
+    `Row text was “${searchLabel}”; it contained no in-flight “Searching for” label and no JS “...” clip.`,
+    true,
+  );
+
+  const cases: { kind: DetailKind; tail: string; noun: string }[] = [
+    { kind: "command", tail: COMMAND_TAIL, noun: "command" },
+    { kind: "pattern", tail: PATTERN_TAIL, noun: "search pattern" },
+    { kind: "error", tail: ERROR_TAIL, noun: "error" },
+  ];
+
+  for (const { kind, tail, noun } of cases) {
+    const collapsed = await probe(app, kind, false);
+    expect(collapsed.isButton).toBe(true);
+    expect(collapsed.expanded).toBe("false");
+    expect(collapsed.ariaLabel).toBe(`Show full ${noun}`);
+    expect(collapsed.visibleLines).toBe(1);
+    expect(collapsed.clipped).toBe(true);
+    // The full value is in the DOM even while collapsed — nothing was cut in JS.
+    expect(collapsed.text).toContain(tail);
+
+    const expanded = await probe(app, kind, true);
+    expect(expanded.expanded).toBe("true");
+    expect(expanded.ariaLabel).toBe(`Collapse ${noun}`);
+    expect(expanded.visibleLines).toBeGreaterThan(1);
+    expect(expanded.clipped).toBe(false);
+    expect(expanded.text).toContain(tail);
+
+    const recollapsed = await probe(app, kind, true);
+    expect(recollapsed.expanded).toBe("false");
+    expect(recollapsed.visibleLines).toBe(1);
+
+    evidence.recordAssertionEvidence(
+      `A long ${noun} is one clipped line until clicked, then fully readable, then collapsible again`,
+      `Collapsed: 1 visible line, clipped, labelled “Show full ${noun}”. Expanded: ${expanded.visibleLines} lines, not clipped, ending “${tail}”. Re-collapsed to 1 line.`,
+      true,
+    );
+  }
+
+  // Toggles are independent: expanding the error must not expand the command.
+  await probe(app, "error", true);
+  const command = await probe(app, "command", false);
+  const error = await probe(app, "error", false);
+  expect(error.expanded).toBe("true");
+  expect(command.expanded).toBe("false");
+  evidence.recordAssertionEvidence(
+    "Each detail box toggles independently of the others in the same group",
+    `After expanding the error box, the error read expanded=${error.expanded} while the command box stayed expanded=${command.expanded}.`,
+    true,
+  );
+
+  // The old clipped-first-line "failed — …" summary is gone.
+  const legacyFailedSummary = await evalIn(app, `document.body.innerText.includes('failed — ')`);
+  expect(legacyFailedSummary).toBe(false);
+});

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -277,6 +277,7 @@
       "id": "desktop.chat-composer",
       "description": "Desktop chat rendering, composer drafts, queued sends, attachments, and resend behavior",
       "implementation": [
+        "apps/app/src/components/chat/**",
         "apps/app/src/react-app/domains/session/chat/**",
         "apps/app/src/react-app/domains/session/surface/**",
         "apps/app/src/react-app/domains/session/sync/**"
@@ -286,6 +287,7 @@
         "evals/specs/chat-loading-shimmer.e2e.test.ts",
         "evals/specs/chat-render-cycle-stability.e2e.test.ts",
         "evals/specs/chat-survives-flaky-den-link.e2e.test.ts",
+        "evals/specs/chat-tool-details-expand.e2e.test.ts",
         "evals/specs/clamp-html-errors.e2e.test.ts",
         "evals/specs/composer-draft-reload.e2e.test.ts",
         "evals/specs/composer-focus-continuity.e2e.test.ts",


### PR DESCRIPTION
## Problem

When a session runs commands and you click the tool line to expand it, long content is clipped with no way to read it:

- The **command** box ended in a `MoreHorizontal` "…" icon that was `aria-hidden` and not clickable — it looked like an affordance but did nothing. Long commands were unreadable.
- **grep/glob patterns** were cut to 44 chars *in JavaScript* (`truncateText`), so even the DOM didn't contain the full pattern. The row also read in-flight "Searching for …" for finished searches and never showed `path`/`include`.
- **Failure text** kept only a 120-char first line; remaining lines were dropped.
- Bash **descriptions** used CSS `truncate` with no tooltip.

## Fix

- Every detail in an expanded tool group (command, search pattern, error) is a real `<button>` (`data-tool-aggregate-detail="command|pattern|error"`, `aria-expanded`, `aria-label` "Show full …"/"Collapse …") that toggles between one clipped line (`line-clamp-1`) and the full wrapped text (`whitespace-pre-wrap`). Toggles are independent per call.
- Collapsed is strictly one line for every command — previously multi-line commands rendered every line (each clipped) because Shiki emits `<br>`; this also removes the layout jump when async highlighting lands.
- Search rows: new `getAggregateRowSearch` → "Searched code in apps/app/src · *.tsx" / "Searched files", correct tense, exact pattern in the box.
- Bash description wraps instead of clipping.
- New dev-only `eval.tool_details.seed` control renders a settled group with a long command, a long scoped grep, and a multi-line failure.
- **Stale spec repair:** `chat-loading-shimmer.e2e.test.ts` asserted the `Now:` prefix that #4134 removed (the unit tests at HEAD already assert its absence). It was red on `dev` before this PR; now asserts the current product text.

Not in scope (tracked separately, see audit in the originating session): session error `technicalDetails` never rendered; subagent description clipped; webfetch/websearch success output hidden; dead `components/tools/{bash,grep,glob,…}.tsx`.

## Verification

Lane: **local** (no Daytona credentials or Infisical in this environment).

```
pnpm --filter ./apps/app typecheck                       # clean
cd apps/app && bun test tests/tool-aggregate-group.test.tsx tests/message-list-step-fold.test.tsx tests/message-list-loading.test.tsx   # 22 pass, 0 fail
pnpm evals:e2e chat-tool-details-expand                   # 1 passed, 0 failed, 0 skipped
pnpm evals:e2e chat-loading-shimmer                       # 1 passed, 0 failed, 0 skipped
```

Test evidence for both specs (gitSha = PR head) is published in the sticky comment below.
