### PR TITLE
fix(chat): size the image lightbox to the window instead of the 448px dialog cap

### DIFF
--- a/apps/app/src/components/chat/image-attachment-badge.tsx
+++ b/apps/app/src/components/chat/image-attachment-badge.tsx
@@ -55,12 +55,12 @@ export function ImageAttachmentBadge({
         </button>
       ) : null}
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[90vh] w-auto max-w-[min(90vw,56rem)] overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-[min(90vw,56rem)]">
+        <DialogContent className="max-h-[95vh] w-auto max-w-[95vw] overflow-hidden border-none bg-transparent p-0 shadow-none ring-0 lg:w-max lg:max-w-[95vw]">
           <DialogTitle className="sr-only">{alt}</DialogTitle>
           <img
             src={src}
             alt={alt}
-            className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain"
+            className="max-h-[92vh] w-auto max-w-full rounded-xl object-contain"
           />
         </DialogContent>
       </Dialog>

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -350,13 +350,13 @@ function MarkdownBlockInner({
           if (!open) setImagePreview(null);
         }}
       >
-        <DialogContent className="max-h-[90vh] w-auto max-w-[min(90vw,56rem)] overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-[min(90vw,56rem)]">
+        <DialogContent className="max-h-[95vh] w-auto max-w-[95vw] overflow-hidden border-none bg-transparent p-0 shadow-none ring-0 lg:w-max lg:max-w-[95vw]">
           <DialogTitle className="sr-only">{imagePreview?.alt ?? "Image"}</DialogTitle>
           {imagePreview ? (
             <img
               src={imagePreview.src}
               alt={imagePreview.alt}
-              className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain"
+              className="max-h-[92vh] w-auto max-w-full rounded-xl object-contain"
             />
           ) : null}
         </DialogContent>

--- a/apps/app/src/components/ui/image.tsx
+++ b/apps/app/src/components/ui/image.tsx
@@ -121,12 +121,12 @@ export const Image = ({
         {image}
       </button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[90vh] w-auto max-w-[min(90vw,56rem)] overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-[min(90vw,56rem)]">
+        <DialogContent className="max-h-[95vh] w-auto max-w-[95vw] overflow-hidden border-none bg-transparent p-0 shadow-none ring-0 lg:w-max lg:max-w-[95vw]">
           <DialogTitle className="sr-only">{alt}</DialogTitle>
           <img
             src={imageSrc}
             alt={alt}
-            className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain"
+            className="max-h-[92vh] w-auto max-w-full rounded-xl object-contain"
           />
         </DialogContent>
       </Dialog>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -496,6 +496,50 @@ function createChatLoadingEvalMessages(sessionId: string): UIMessage[] {
   }];
 }
 
+function createImageLightboxEvalImageUrl(width: number, height: number, label: string) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect width="100%" height="100%" fill="#dbeafe"/><text x="50%" y="50%" font-family="sans-serif" font-size="${Math.round(Math.min(width, height) / 8)}" text-anchor="middle" dominant-baseline="middle" fill="#1e3a8a">${label}</text></svg>`;
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+function createImageLightboxEvalMessages(sessionId: string): UIMessage[] {
+  const now = Date.now();
+  return [
+    {
+      id: `${sessionId}:eval-image-lightbox-user`,
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          mediaType: "image/svg+xml",
+          filename: "landscape-screenshot.svg",
+          url: createImageLightboxEvalImageUrl(2000, 1112, "landscape 2000x1112"),
+        },
+        {
+          type: "file",
+          mediaType: "image/svg+xml",
+          filename: "small-icon.svg",
+          url: createImageLightboxEvalImageUrl(180, 180, "icon"),
+        },
+        { type: "text", text: "Inspect these images." },
+      ],
+      metadata: { opencode: { created: now } },
+    },
+    {
+      id: `${sessionId}:eval-image-lightbox-assistant`,
+      role: "assistant",
+      parts: [
+        {
+          type: "file",
+          mediaType: "image/svg+xml",
+          filename: "portrait-screenshot.svg",
+          url: createImageLightboxEvalImageUrl(1112, 2000, "portrait 1112x2000"),
+        },
+      ],
+      metadata: { opencode: { created: now + 1, completed: now + 2_000 } },
+    },
+  ];
+}
+
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
   environmentClient?: OpenworkServerClient | null;
@@ -1516,6 +1560,23 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId, props.workspaceId]);
   useControlAction(props.isControlTarget ? seedChatLoadingControlAction : null);
+  const seedImageLightboxControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.image_lightbox.seed",
+      label: "Seed image lightbox proof",
+      description: "Dev-only eval hook that renders user and assistant image parts with known pixel sizes.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: () => {
+        const seeded = createImageLightboxEvalMessages(props.sessionId);
+        setEvalMarkdownMessages(seeded);
+        return { ok: true, messageCount: seeded.length };
+      },
+    };
+  }, [props.sessionId]);
+  useControlAction(props.isControlTarget ? seedImageLightboxControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -294,6 +294,7 @@
         "evals/specs/composer-queued-drain-while-away.e2e.test.ts",
         "evals/specs/composer-queued-follow-ups-sequential.e2e.test.ts",
         "evals/specs/cross-workspace-composer-switch.e2e.test.ts",
+        "evals/specs/image-lightbox-size.e2e.test.ts",
         "evals/specs/safe-edit-resend.e2e.test.ts",
         "evals/specs/unfinished-tool-lifecycle.e2e.test.ts"
       ]

--- a/evals/specs/image-lightbox-size.e2e.test.ts
+++ b/evals/specs/image-lightbox-size.e2e.test.ts
@@ -1,0 +1,176 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, seedSessions, waitFor } from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { screenshot } from "@openwork/test-evidence";
+import { needs, test } from "@openwork/testkit";
+
+const enabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = enabled
+  ? "clicking a chat image opens it near the full window size, not the 448px dialog default"
+  : "image lightbox size skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+// Base `DialogContent` is capped at `lg:max-w-md` (28rem). The lightbox used to
+// inherit that cap on every window wider than 1024px, so "enlarging" a
+// screenshot rendered it at 448px. The viewport below is wide enough for the
+// `lg:` breakpoint and large enough that a 2000px image is still clamped by it.
+const VIEWPORT = { width: 1600, height: 1000 };
+const LEGACY_DIALOG_CAP_PX = 448;
+
+type LightboxProbe = {
+  thumbnailWidth: number;
+  dialogWidth: number;
+  dialogHeight: number;
+  imageWidth: number;
+  imageHeight: number;
+  naturalWidth: number;
+  naturalHeight: number;
+  closeButtonInsideImage: boolean;
+  viewportWidth: number;
+  viewportHeight: number;
+  // What the CSS `100vw` / `100vh` units resolve to; the lightbox is sized in vw/vh.
+  vwPx: number;
+  vhPx: number;
+};
+
+function isLightboxProbe(value: unknown): value is LightboxProbe {
+  return typeof value === "object" && value !== null && "imageWidth" in value && "dialogWidth" in value;
+}
+
+// Every chat thumbnail is a button with an `Expand <alt>` label wrapping an <img>.
+const thumbnailScript = (naturalWidth: number, naturalHeight: number) => `(() => {
+  const images = [...document.querySelectorAll('button[aria-label^="Expand "] img')];
+  return images.find((img) => img.naturalWidth === ${naturalWidth} && img.naturalHeight === ${naturalHeight}) ?? null;
+})()`;
+
+async function openLightbox(
+  app: Awaited<ReturnType<typeof desktop>>,
+  natural: { width: number; height: number },
+): Promise<LightboxProbe> {
+  await waitFor(app, `${thumbnailScript(natural.width, natural.height)} !== null`, {
+    timeoutMs: 15_000,
+    label: `${natural.width}x${natural.height} thumbnail loaded`,
+  });
+  await evalIn(app, `${thumbnailScript(natural.width, natural.height)}.closest('button').click()`);
+  await waitFor(app, `(() => {
+    const img = document.querySelector('[data-slot="dialog-content"] img');
+    return img instanceof HTMLImageElement && img.complete && img.naturalWidth > 0 && img.getBoundingClientRect().width > 0;
+  })()`, { timeoutMs: 10_000, label: "lightbox image rendered" });
+
+  const probe = await evalIn(app, `(() => {
+    const thumb = ${thumbnailScript(natural.width, natural.height)};
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    const img = dialog?.querySelector('img');
+    const close = dialog?.querySelector('[data-slot="dialog-close"]');
+    if (!(thumb instanceof HTMLElement) || !(dialog instanceof HTMLElement) || !(img instanceof HTMLImageElement) || !(close instanceof HTMLElement)) return null;
+    // Layout sizes (offset*) ignore the dialog's zoom-in open transform, which
+    // getBoundingClientRect would fold into the numbers.
+    const ruler = document.createElement('div');
+    ruler.style.cssText = 'position:fixed;top:0;left:0;width:100vw;height:100vh;visibility:hidden;pointer-events:none';
+    document.body.append(ruler);
+    const vwPx = ruler.offsetWidth;
+    const vhPx = ruler.offsetHeight;
+    ruler.remove();
+    // The close button is absolutely positioned inside the dialog; the dialog
+    // is its offsetParent, so offsets are relative to the dialog box.
+    const closeInsideDialog = close.offsetParent === dialog
+      && close.offsetLeft >= 0 && close.offsetTop >= 0
+      && close.offsetLeft + close.offsetWidth <= dialog.offsetWidth
+      && close.offsetTop + close.offsetHeight <= dialog.offsetHeight;
+    return {
+      thumbnailWidth: thumb.offsetWidth,
+      dialogWidth: dialog.offsetWidth,
+      dialogHeight: dialog.offsetHeight,
+      imageWidth: img.offsetWidth,
+      imageHeight: img.offsetHeight,
+      naturalWidth: img.naturalWidth,
+      naturalHeight: img.naturalHeight,
+      closeButtonInsideImage: closeInsideDialog && dialog.offsetWidth === img.offsetWidth && dialog.offsetHeight === img.offsetHeight,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      vwPx,
+      vhPx,
+    };
+  })()`);
+  if (!isLightboxProbe(probe)) {
+    throw new Error(`Lightbox for ${natural.width}x${natural.height} was not readable: ${JSON.stringify(probe)}`);
+  }
+  return probe;
+}
+
+async function closeLightbox(app: Awaited<ReturnType<typeof desktop>>) {
+  await evalIn(app, `document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]').click()`);
+  await waitFor(app, `document.querySelector('[data-slot="dialog-content"]') === null`, {
+    timeoutMs: 10_000,
+    label: "lightbox closed",
+  });
+}
+
+test.skipIf(!enabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "image-lightbox-size" });
+  await app.client.send("Emulation.setDeviceMetricsOverride", {
+    ...VIEWPORT,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await createAndSelectWorkspace(app, {
+    path: `/tmp/openwork-image-lightbox-${Date.now()}`,
+  });
+  await seedSessions(app, ["Image lightbox proof"]);
+  await waitFor(
+    app,
+    `window.__openworkControl.listActions().some((action) => action.id === "eval.image_lightbox.seed" && !action.disabled)`,
+    { timeoutMs: 30_000, label: "image lightbox seed control ready" },
+  );
+  await control(app, "eval.image_lightbox.seed");
+
+  // Landscape screenshot sent by the user: previously stuck at the 448px dialog cap.
+  const landscape = await openLightbox(app, { width: 2000, height: 1112 });
+  expect(landscape.viewportWidth).toBe(VIEWPORT.width);
+  // The window is wide enough for the `lg:` breakpoint where the old cap applied.
+  expect(landscape.vwPx).toBeGreaterThanOrEqual(1024);
+  expect(landscape.thumbnailWidth).toBeLessThan(100);
+  expect(landscape.imageWidth).toBeGreaterThan(LEGACY_DIALOG_CAP_PX);
+  // Width-bound: the image spans the full 95vw allowance (±1px rounding).
+  expect(Math.abs(landscape.imageWidth - landscape.vwPx * 0.95)).toBeLessThanOrEqual(1);
+  expect(landscape.imageHeight).toBeLessThanOrEqual(Math.ceil(landscape.vhPx * 0.92));
+  expect(landscape.dialogWidth).toBe(landscape.imageWidth);
+  expect(landscape.closeButtonInsideImage).toBe(true);
+  await screenshot(app);
+  evidence.recordAssertionEvidence(
+    "A landscape screenshot enlarges to 95% of the window width instead of the 448px dialog default",
+    `Thumbnail ${landscape.thumbnailWidth}px → lightbox image ${landscape.imageWidth}x${landscape.imageHeight}px where 100vw=${landscape.vwPx}px and 100vh=${landscape.vhPx}px (natural ${landscape.naturalWidth}x${landscape.naturalHeight}); the dialog hugged the image (${landscape.dialogWidth}px) with the close button inside its corner.`,
+    true,
+  );
+  await closeLightbox(app);
+
+  // Portrait screenshot from the assistant: height-bound, and the dialog must
+  // still shrink-wrap the image rather than stretching to the width cap.
+  const portrait = await openLightbox(app, { width: 1112, height: 2000 });
+  expect(Math.abs(portrait.imageHeight - portrait.vhPx * 0.92)).toBeLessThanOrEqual(1);
+  expect(portrait.imageWidth).toBeGreaterThan(LEGACY_DIALOG_CAP_PX);
+  expect(portrait.dialogWidth).toBe(portrait.imageWidth);
+  expect(portrait.dialogHeight).toBe(portrait.imageHeight);
+  expect(portrait.closeButtonInsideImage).toBe(true);
+  await screenshot(app);
+  evidence.recordAssertionEvidence(
+    "A portrait image fills 92% of the window height and the dialog wraps it exactly",
+    `Lightbox image ${portrait.imageWidth}x${portrait.imageHeight}px where 100vh=${portrait.vhPx}px; dialog ${portrait.dialogWidth}x${portrait.dialogHeight}px, close button inside the image.`,
+    true,
+  );
+  await closeLightbox(app);
+
+  // A small image must not be upscaled and blurred just to fill the window.
+  const icon = await openLightbox(app, { width: 180, height: 180 });
+  expect(icon.imageWidth).toBe(180);
+  expect(icon.imageHeight).toBe(180);
+  expect(icon.dialogWidth).toBe(180);
+  await screenshot(app);
+  evidence.recordAssertionEvidence(
+    "A small image opens at its natural size rather than being stretched",
+    `180x180 icon rendered at ${icon.imageWidth}x${icon.imageHeight}px inside a ${icon.dialogWidth}px dialog.`,
+    true,
+  );
+  await closeLightbox(app);
+});

--- a/evals/specs/image-lightbox-size.test.ts
+++ b/evals/specs/image-lightbox-size.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+// The chat image lightbox is rendered from three places. All three must size
+// the dialog to the window and explicitly override the base Dialog's desktop
+// `lg:max-w-md` cap, otherwise "enlarging" an image yields a 448px preview.
+const LIGHTBOX_SOURCES = [
+  "apps/app/src/components/ui/image.tsx",
+  "apps/app/src/components/chat/image-attachment-badge.tsx",
+  "apps/app/src/components/markdown/markdown.tsx",
+];
+const DIALOG_CLASSES = "max-h-[95vh] w-auto max-w-[95vw] overflow-hidden border-none bg-transparent p-0 shadow-none ring-0 lg:w-max lg:max-w-[95vw]";
+const IMAGE_CLASSES = "max-h-[92vh] w-auto max-w-full rounded-xl object-contain";
+
+test("every chat image lightbox sizes its dialog to the window instead of the 448px dialog default", async ({ evidence }) => {
+  for (const relativePath of LIGHTBOX_SOURCES) {
+    const source = readFileSync(fileURLToPath(new URL(`../../${relativePath}`, import.meta.url)), "utf8");
+    expect(source, relativePath).toContain(`<DialogContent className="${DIALOG_CLASSES}">`);
+    expect(source, relativePath).toContain(`className="${IMAGE_CLASSES}"`);
+    expect(source, relativePath).not.toContain("56rem");
+    expect(source, relativePath).not.toContain("max-h-[85vh]");
+  }
+
+  const dialogSource = readFileSync(
+    fileURLToPath(new URL("../../apps/app/src/components/ui/dialog.tsx", import.meta.url)),
+    "utf8",
+  );
+  expect(dialogSource).toContain("lg:max-w-md");
+  expect(dialogSource).toContain("lg:w-[calc(100%-2rem)]");
+
+  evidence.recordAssertionEvidence(
+    "All three image lightboxes share one window-sized dialog contract that overrides the base Dialog desktop cap",
+    `${LIGHTBOX_SOURCES.join(", ")} each render DialogContent with "${DIALOG_CLASSES}" and the image with "${IMAGE_CLASSES}", with no remaining 56rem/85vh cap; the base Dialog still declares lg:max-w-md and lg:w-[calc(100%-2rem)], which is why the lg:max-w-[95vw] and lg:w-max overrides are required.`,
+    true,
+  );
+});


### PR DESCRIPTION
## Problem

Clicking an image in a chat session opens a Dialog, but the "enlarged" view was capped at **448px wide** on any window wider than 1024px. The base `DialogContent` declares `lg:max-w-md`; the three lightbox sites only overrode `sm:max-w-[min(90vw,56rem)]`, so at desktop widths the `lg:` rule won and a 2000px screenshot rendered at 22% scale — unreadable, and barely bigger than its thumbnail.

## Fix

All three lightbox sites (`ui/image.tsx` for assistant/tool images, `chat/image-attachment-badge.tsx` for user attachments, `markdown/markdown.tsx` for markdown images) now use the same classes:

- `DialogContent`: `max-h-[95vh] w-auto max-w-[95vw] … ring-0 lg:w-max lg:max-w-[95vw]`
- `<img>`: `max-h-[92vh] w-auto max-w-full rounded-xl object-contain`

`lg:max-w-[95vw]` beats the base cap; `lg:w-max` is needed because the popup is `fixed; left: 50%`, so an auto-width dialog shrink-wraps to the leftover half of the viewport (800px on a 1600px window) rather than to the image.

Measured on a 1600×1000 window (100vh=950 in the test Electron):

| Image | Before | After |
|---|---|---|
| Landscape 2000×1112 | 448×249 | 1520×845 (95vw) |
| Portrait 1112×2000 | 448×806 | 486×874 (92vh), dialog wraps the image |
| Small 180×180 | 180×180 | 180×180 (no upscaling) |

## Proof

- `evals/specs/image-lightbox-size.e2e.test.ts` — seeds user + assistant image parts via a new dev-only `eval.image_lightbox.seed` control, clicks each thumbnail and measures the rendered lightbox (layout sizes, vw/vh ruler, close button inside the image) for landscape, portrait and small images.
- `evals/specs/image-lightbox-size.test.ts` — PR-lane contract keeping the three sites on identical sizing classes and asserting the base Dialog still has the `lg:max-w-md` cap the overrides exist for.

Control: with the three component files reverted to `origin/dev`, the E2E spec fails with `expected 448 to be greater than 448`.

Lane: Daytona (`pnpm evals:e2e --daytona image-lightbox-size`, exit 0, 1 passed / 0 failed / 0 skipped) and `pnpm evals:pr specs/image-lightbox-size.test.ts` (exit 0, 1 passed). `pnpm --dir apps/app typecheck` exit 0.
