### PR TITLE
ci(changelog): generate real release notes on every stable release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,10 @@
 name: Changelog
 
+# The release workflow publishes releases with GITHUB_TOKEN, and GitHub never
+# starts workflows from events created by that token, so `release: published`
+# only fires when a human publishes by hand. The primary entry point is the
+# `gh workflow run changelog.yml -f tag=...` dispatch issued by
+# release-macos-aarch64.yml right after it flips the draft.
 on:
   release:
     types: [published]
@@ -140,7 +145,7 @@ jobs:
       - name: Draft changelog entries
         if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: opencode run --agent changelog "$(cat /tmp/changelog_prompt.txt)"
 
       - name: Discard opencode runtime churn
@@ -191,3 +196,16 @@ jobs:
             --title "docs(changelog): release notes for $TAG" \
             --body-file /tmp/pr_body.txt)"
           gh pr merge "$pr_url" --auto --squash --delete-branch
+
+      - name: Update GitHub Release notes
+        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh release view "$TAG" --json body -q .body > /tmp/existing_release_body.md
+          node scripts/release/release-notes-from-changelog.mjs "$TAG" \
+            --existing-body /tmp/existing_release_body.md > /tmp/release_notes.md
+          gh release edit "$TAG" --notes-file /tmp/release_notes.md
+          echo "Replaced the static release body of $TAG with the generated changelog entry."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Draft changelog entries
         if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: opencode run --agent changelog "$(cat /tmp/changelog_prompt.txt)"
 
       - name: Discard opencode runtime churn

--- a/.github/workflows/opencode-agents.yml
+++ b/.github/workflows/opencode-agents.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Triage issue
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.number }}
         run: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Check for duplicate PRs
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ inputs.number }}
         run: |

--- a/.github/workflows/opencode-agents.yml
+++ b/.github/workflows/opencode-agents.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Triage issue
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.number }}
         run: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Check for duplicate PRs
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ inputs.number }}
         run: |

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -992,10 +992,8 @@ jobs:
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       needs.publish-daytona-snapshot.result != 'cancelled'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      # actions: write lets this job dispatch changelog.yml after publishing.
-      actions: write
-      contents: write
+    outputs:
+      published_stable: ${{ steps.publish.outputs.published_stable }}
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
@@ -1027,6 +1025,7 @@ jobs:
         run: node scripts/release/publish-electron-assets.mjs --manifests-only "${{ runner.temp }}/electron-dist" "$RELEASE_TAG"
 
       - name: Publish release after assets are ready
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1043,9 +1042,28 @@ jobs:
 
           if [ "${RELEASE_PRERELEASE}" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
-            exit 0
+          else
+            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+            echo "published_stable=true" >> "$GITHUB_OUTPUT"
           fi
-          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+
+  dispatch-changelog:
+    name: Dispatch changelog
+    needs: [resolve-release, publish-release]
+    if: needs.publish-release.outputs.published_stable == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # This job deliberately checks out nothing and runs no repository code, so
+    # actions: write is never available to code executed from the release tag.
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+    steps:
+      - name: Dispatch changelog.yml for the published stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
 
           # GitHub does not start workflows from `release: published` events
           # created by GITHUB_TOKEN, so hand the stable tag to the changelog

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -992,6 +992,10 @@ jobs:
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       needs.publish-daytona-snapshot.result != 'cancelled'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      # actions: write lets this job dispatch changelog.yml after publishing.
+      actions: write
+      contents: write
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
@@ -1039,8 +1043,15 @@ jobs:
 
           if [ "${RELEASE_PRERELEASE}" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
-          else
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+            exit 0
+          fi
+          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+
+          # GitHub does not start workflows from `release: published` events
+          # created by GITHUB_TOKEN, so hand the stable tag to the changelog
+          # workflow explicitly. It writes docs + rewrites the release notes.
+          if ! gh workflow run changelog.yml --repo "$GITHUB_REPOSITORY" --ref dev -f "tag=$RELEASE_TAG"; then
+            echo "::warning::Could not dispatch changelog.yml for $RELEASE_TAG; run it manually: gh workflow run changelog.yml -f tag=$RELEASE_TAG"
           fi
 
   prepare-npm:

--- a/.opencode/agents/changelog.md
+++ b/.opencode/agents/changelog.md
@@ -1,7 +1,7 @@
 ---
 mode: primary
 hidden: true
-model: anthropic/claude-sonnet-4-5
+model: openai/gpt-5.6-luna
 color: "#7C6FF0"
 tools:
   "*": false

--- a/.opencode/agents/changelog.md
+++ b/.opencode/agents/changelog.md
@@ -1,7 +1,7 @@
 ---
 mode: primary
 hidden: true
-model: opencode/claude-sonnet-4-5
+model: anthropic/claude-sonnet-4-5
 color: "#7C6FF0"
 tools:
   "*": false

--- a/.opencode/agents/duplicate-pr.md
+++ b/.opencode/agents/duplicate-pr.md
@@ -1,7 +1,7 @@
 ---
 mode: primary
 hidden: true
-model: opencode/claude-haiku-4-5
+model: anthropic/claude-haiku-4-5
 color: "#E67E22"
 tools:
   "*": false

--- a/.opencode/agents/duplicate-pr.md
+++ b/.opencode/agents/duplicate-pr.md
@@ -1,7 +1,7 @@
 ---
 mode: primary
 hidden: true
-model: anthropic/claude-haiku-4-5
+model: openai/gpt-5.6-luna
 color: "#E67E22"
 tools:
   "*": false

--- a/.opencode/agents/triage.md
+++ b/.opencode/agents/triage.md
@@ -1,7 +1,7 @@
 ---
 mode: primary
 hidden: true
-model: anthropic/claude-haiku-4-5
+model: openai/gpt-5.6-luna
 color: "#44BA81"
 tools:
   "*": false

--- a/.opencode/agents/triage.md
+++ b/.opencode/agents/triage.md
@@ -1,7 +1,7 @@
 ---
 mode: primary
 hidden: true
-model: opencode/claude-haiku-4-5
+model: anthropic/claude-haiku-4-5
 color: "#44BA81"
 tools:
   "*": false

--- a/.opencode/skills/get-env-var/SKILL.md
+++ b/.opencode/skills/get-env-var/SKILL.md
@@ -40,9 +40,28 @@ Run the command through Infisical so all project secrets are available only to t
 infisical run -- <command>
 ```
 
+## Discover, check, and forward without ever seeing a value
+
+Always run from the repo root; outside it `infisical` errors and emits an empty stdout, which a downstream `gh secret set` will silently store.
+
+```bash
+# Which secrets exist? Names only, via structured output. Never list with
+# --plain or the default table: both print values, and multi-line values
+# (private keys) defeat any line-based filter such as cut or awk.
+infisical secrets --env dev --output json --silent 2>/dev/null | jq -r '.[].secretKey'
+
+# Does NAME exist and is it non-empty? Prints a byte count, never the value.
+infisical secrets get NAME --plain --silent 2>/dev/null | wc -c
+
+# Forward NAME to a consumer in one pipe (e.g. a GitHub Actions secret).
+infisical secrets get NAME --plain --silent 2>/dev/null | gh secret set NAME --repo <owner>/<repo>
+```
+
 ## Rules
 
 - Never echo, print, or otherwise log secret values.
 - Never write secrets to files, logs, commit messages, PR bodies, or comments.
-- Only use `--plain` inside command substitution, as in `export NAME="$(...)"`.
+- Only use `--plain` with `secrets get NAME` inside command substitution, as in `export NAME="$(...)"`, or piped straight into a single consumer as above. Never use `--plain` to list.
+- Never pass a secret-bearing stream through `grep`, `rg`, `awk`, `sed`, `cut`, `head`, or any line-based filter: multi-line values and one mismatched pattern both land values in the tool output. Listing is `--output json | jq -r '.[].secretKey'` only.
+- Treat every `infisical secrets ...` command as printing values unless it is the JSON name listing above, piped into `wc -c`, or piped into a consumer.
 - If a secret does not exist, STOP and tell the user exactly which secret name and environment to add in Infisical; do not invent values.

--- a/evals/specs/release-notes-from-changelog.test.ts
+++ b/evals/specs/release-notes-from-changelog.test.ts
@@ -1,0 +1,91 @@
+import { execFileSync, spawnSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { expect } from "vitest"
+import { test } from "@openwork/testkit"
+
+const script = fileURLToPath(new URL("../../scripts/release/release-notes-from-changelog.mjs", import.meta.url))
+
+const changelog = `---
+title: "Changelog"
+---
+<Update label="August 27th" tags={["🚀 New Features"]}>
+
+  ## [v0.18.39](https://github.com/different-ai/openwork/compare/v0.18.38...v0.18.39): Newer release title
+
+  - Newer bullet that must not leak into the older release.
+
+  ## [v0.18.38](https://github.com/different-ai/openwork/compare/v0.18.37...v0.18.38): Target release title
+
+  - First target bullet.
+  - Second target bullet.
+
+</Update>
+
+<Update label="August 26th" tags={["🐛 Bug Fixes"]}>
+
+  ## [v0.18.37](https://github.com/different-ai/openwork/compare/v0.18.36...v0.18.37): Older release title
+
+  - Older bullet that must not leak into the target release.
+
+</Update>
+`
+
+const staticBody = `## What's new
+
+OpenWork v0.18.38 desktop release.
+
+- Public artifacts use the openwork-* naming convention.
+
+*Windows installers are signed using Microsoft Artifact Signing.*
+`
+
+function fixture(): { docs: string; existing: string } {
+  const dir = mkdtempSync(join(tmpdir(), "release-notes-"))
+  const docs = join(dir, "changelog.mdx")
+  const existing = join(dir, "existing.md")
+  writeFileSync(docs, changelog)
+  writeFileSync(existing, staticBody)
+  return { docs, existing }
+}
+
+test("release notes are extracted for exactly one version and keep the signing note", ({ evidence }) => {
+  const { docs, existing } = fixture()
+  const notes = execFileSync(process.execPath, [script, "v0.18.38", "--docs", docs, "--existing-body", existing], {
+    encoding: "utf8",
+  })
+
+  expect(notes.startsWith("## Target release title\n")).toBe(true)
+  expect(notes).toContain("- First target bullet.\n- Second target bullet.")
+  expect(notes).toContain("[Compare](https://github.com/different-ai/openwork/compare/v0.18.37...v0.18.38)")
+  expect(notes).toContain("https://openworklabs.com/docs/changelog")
+  expect(notes.trimEnd().endsWith("*Windows installers are signed using Microsoft Artifact Signing.*")).toBe(true)
+
+  expect(notes).not.toContain("Newer bullet")
+  expect(notes).not.toContain("Older bullet")
+  expect(notes).not.toContain("<Update")
+  expect(notes).not.toContain("openwork-* naming convention")
+
+  evidence.recordAssertionEvidence(
+    "Generated release notes mirror one docs changelog entry",
+    "The target version's title, bullets, and compare link were emitted; neighbouring versions and the static boilerplate were excluded while the Windows signing note was preserved.",
+    true,
+  )
+})
+
+test("release notes extraction fails loudly for an undocumented tag", ({ evidence }) => {
+  const { docs } = fixture()
+  const result = spawnSync(process.execPath, [script, "v0.18.40", "--docs", docs], { encoding: "utf8" })
+
+  expect(result.status).toBe(1)
+  expect(result.stdout).toBe("")
+  expect(result.stderr).toContain("v0.18.40 is not documented")
+
+  evidence.recordAssertionEvidence(
+    "Undocumented tags never overwrite release notes",
+    "The script exited non-zero with no stdout, so the workflow's `gh release edit` step cannot run with empty notes.",
+    true,
+  )
+})

--- a/scripts/release/release-notes-from-changelog.mjs
+++ b/scripts/release/release-notes-from-changelog.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Extract one release's entry from packages/docs/changelog.mdx and print it as
+// GitHub Release notes markdown. Lines of the existing release body that carry
+// the Windows code-signing note (*Windows ...*) are preserved at the end so the
+// generated notes replace only the static "What's new" boilerplate.
+//
+// Usage:
+//   node scripts/release/release-notes-from-changelog.mjs <tag> [--docs <path>] [--existing-body <path>]
+
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const tag = args.find((arg) => !arg.startsWith("--"));
+let docsPath = "packages/docs/changelog.mdx";
+let existingBodyPath = null;
+
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] === "--docs") docsPath = args[index + 1];
+  if (args[index] === "--existing-body") existingBodyPath = args[index + 1];
+}
+
+function fail(message) {
+  console.error(`release-notes-from-changelog: ${message}`);
+  process.exit(1);
+}
+
+if (!tag || !/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+  fail("usage: release-notes-from-changelog.mjs <vX.Y.Z> [--docs <path>] [--existing-body <path>]");
+}
+
+const docs = readFileSync(docsPath, "utf8").split("\n");
+const headingPattern = /^\s*## \[(v[0-9]+\.[0-9]+\.[0-9]+)\]\((https:\/\/github\.com\/[^)]+)\):\s*(.+?)\s*$/;
+
+let start = -1;
+let compareUrl = "";
+let title = "";
+for (let index = 0; index < docs.length; index += 1) {
+  const match = docs[index].match(headingPattern);
+  if (match && match[1] === tag) {
+    start = index;
+    compareUrl = match[2];
+    title = match[3];
+    break;
+  }
+}
+if (start === -1) fail(`${tag} is not documented in ${docsPath}`);
+
+const body = [];
+for (let index = start + 1; index < docs.length; index += 1) {
+  const line = docs[index];
+  if (headingPattern.test(line) || /^\s*<\/Update>/.test(line) || /^\s*<Update\b/.test(line)) break;
+  body.push(line.replace(/^ {2}/, ""));
+}
+while (body.length > 0 && body[0].trim() === "") body.shift();
+while (body.length > 0 && body[body.length - 1].trim() === "") body.pop();
+if (body.length === 0) fail(`${tag} has an empty changelog entry in ${docsPath}`);
+
+const preserved = [];
+if (existingBodyPath) {
+  for (const line of readFileSync(existingBodyPath, "utf8").split("\n")) {
+    if (/^\*Windows .*\*\s*$/.test(line)) preserved.push(line.trim());
+  }
+}
+
+const notes = [
+  `## ${title}`,
+  "",
+  ...body,
+  "",
+  `Full changelog: https://openworklabs.com/docs/changelog · [Compare](${compareUrl})`,
+];
+if (preserved.length > 0) notes.push("", ...preserved);
+
+process.stdout.write(`${notes.join("\n")}\n`);


### PR DESCRIPTION
## Problem

Every GitHub release page (e.g. [v0.18.41](https://github.com/different-ai/openwork/releases/tag/v0.18.41)) shows the same static body ("Public artifacts use the openwork-* naming convention…") instead of real notes, while the docs changelog has been kept alive by hand-written batches.

Three independent causes:

1. **`changelog.yml` never fires on its own.** It listens for `release: published`, but `release-macos-aarch64.yml` flips the draft with `gh release edit --draft=false` using `GITHUB_TOKEN`, and GitHub does not start workflows from events created by that token. The only two runs ever (v0.18.14 / v0.18.16 on Aug 4–5) happened because a human clicked Publish seconds before the bot; the bot's log for v0.18.16 reads `Release v0.18.16 is already published; nothing to do.` Every release since v0.18.17 was bot-published → zero runs.
2. **When it did run, it failed.** `opencode run --agent changelog` died with `UnknownError` because `OPENCODE_API_KEY` was empty — the secret was never created (not in the repo, not in Infisical in any environment). The same missing key has kept `opencode-agents.yml` (issue triage, duplicate-PR detection) dead since May.
3. **Nothing ever rewrote the release body.** The automation only wrote docs and opened a PR.

## What changed

- **`release-macos-aarch64.yml`** — `publish-release` exports `published_stable=true` when it flips a stable release (permissions unchanged). A new `dispatch-changelog` job — no checkout, no repository code, `actions: write` only — then runs `gh workflow run changelog.yml --ref dev -f tag=$RELEASE_TAG`. Dispatch failure is a `::warning::`, never a release failure. Prereleases and human-published releases skip it (the latter already fire the native `release:` event).
- **`changelog.yml`** — new final step **Update GitHub Release notes**: reads the existing body, runs the extractor, `gh release edit "$TAG" --notes-file`. Header comment explains why `release:` is left in place (still useful for manual publishes).
- **`scripts/release/release-notes-from-changelog.mjs`** — extracts one `## [vX.Y.Z](compare…): Title` entry from `packages/docs/changelog.mdx` as release markdown (title, bullets, docs + compare links), preserving the `*Windows installers are signed…*` line. Exits 1 with empty stdout for an undocumented tag so a blank body can never be written.
- **Agents → `openai/gpt-5.6-luna`** — `changelog`, `triage`, `duplicate-pr` move from `opencode/claude-*` to `openai/gpt-5.6-luna` (per Ben; ID verified on models.dev). `changelog.yml` and `opencode-agents.yml` now pass `OPENAI_API_KEY`, the repo secret already used by the Daytona e2e workflows — no new secret. The empty `OPENCODE_API_KEY` secret was deleted.
- **`.opencode/skills/get-env-var/SKILL.md`** — adds value-safe Infisical listing (`--output json | jq -r '.[].secretKey'`), non-empty check (`| wc -c`), and one-pipe forwarding to `gh secret set`; bans line-based filters on value streams (multi-line secrets defeat `cut`/`awk`). Inert agent config, no runtime surface.

## Verification

Lane: **local PR lane** (pure script test; no Daytona/Den needed).

```
pnpm evals:pr specs/release-notes-from-changelog.test.ts
✓ |pr| specs/release-notes-from-changelog.test.ts (2 tests)
Test Files  1 passed (1)   Tests  2 passed (2)   skipped 0
```

Claims asserted by `evals/specs/release-notes-from-changelog.test.ts`:
- Target version's title, bullets, and compare link are emitted; neighbouring versions' bullets, `<Update>` tags, and the old boilerplate are absent; the Windows signing note is preserved.
- Undocumented tag → exit code 1 and empty stdout.

Both workflow files were parsed and checked for the expected `permissions` and final step. Not provable locally: the live `gh workflow run` dispatch and `gh release edit` — first real proof is the next stable release. Repro if it does not fire: `gh workflow run changelog.yml -f tag=<tag>`.

## After merge

```
gh workflow run changelog.yml -f tag=v0.18.40   # wait for its docs PR to auto-merge
gh workflow run changelog.yml -f tag=v0.18.41
```
Both will open docs PRs and rewrite their release bodies.


