### PR TITLE
fix(app): hide subagent sessions from the sidebar when their parent is archived or unloaded

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/utils.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/utils.ts
@@ -45,13 +45,13 @@ const normalizeSessionParentID = (session: SessionListItem) => {
   return parentID || "";
 };
 
-export const getRootSessions = (sessions: WorkspaceSessionGroup["sessions"]) => {
-  const byID = new Set(sessions.map((session) => session.id));
-  return sessions.filter((session) => {
-    const parentID = normalizeSessionParentID(session);
-    return !parentID || !byID.has(parentID);
-  });
-};
+/**
+ * A session with a parentID is a sub-agent child, whether or not its parent is
+ * in the loaded page (the parent may be archived, deleted, or beyond the list
+ * limit). Children are only reached from the task card in their parent.
+ */
+export const getRootSessions = (sessions: WorkspaceSessionGroup["sessions"]) =>
+  sessions.filter((session) => !normalizeSessionParentID(session));
 
 /**
  * Return every descendant of a session in stable session-list order. The

--- a/apps/app/tests/session-sidebar-utils.test.ts
+++ b/apps/app/tests/session-sidebar-utils.test.ts
@@ -57,12 +57,14 @@ describe("sidebar session rows", () => {
     expect(rows.map((row) => row.session.id)).toEqual(["session-b"]);
   });
 
-  test("keeps a child whose parent is outside the list as a root", () => {
+  test("hides a child even when its parent is archived or outside the list", () => {
     const orphaned: SidebarSessionItem[] = [
       { id: "session-c", title: "Orphan child", parentID: "missing-parent" },
+      { id: "session-d", title: "Archived parent", time: { archived: 1 } },
+      { id: "session-d-child", title: "Child of archived", parentID: "session-d" },
     ];
     const rows = flattenSessionRows(orphaned, Number.MAX_SAFE_INTEGER);
 
-    expect(rows.map((row) => row.session.id)).toEqual(["session-c"]);
+    expect(rows).toEqual([]);
   });
 });

--- a/evals/specs/sidebar-hides-subagent-sessions.test.ts
+++ b/evals/specs/sidebar-hides-subagent-sessions.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import {
+  flattenSessionRows,
+  type SessionListItem,
+} from "../../apps/app/src/react-app/domains/session/sidebar/utils";
+
+function session(overrides: Partial<SessionListItem> & { id: string }): SessionListItem {
+  return {
+    title: overrides.id,
+    time: { updated: 1, created: 1 },
+    ...overrides,
+  };
+}
+
+test("subagent sessions stay out of the sidebar even when their parent is archived or not loaded", async ({ evidence }) => {
+  // The reported bug: the sidebar filled up with "(@explore subagent)" rows.
+  // A child session was only hidden when its parent was also in the loaded
+  // list, so children of archived parents (archived rows are partitioned out
+  // before the root check) and children whose parent fell outside the
+  // session-list page were promoted to root rows.
+  const rows = flattenSessionRows(
+    [
+      session({ id: "root" }),
+      session({ id: "archived-parent", time: { updated: 1, created: 1, archived: 1 } }),
+      session({ id: "child-of-archived", parentID: "archived-parent" }),
+      session({ id: "child-of-unloaded", parentID: "ses_not_in_this_page" }),
+    ],
+    50,
+  );
+
+  expect(rows.map((row) => row.session.id)).toEqual(["root"]);
+
+  evidence.recordAssertionEvidence(
+    "Sidebar never promotes a subagent session to a root row",
+    "flattenSessionRows drops every session carrying a parentID, including children of archived parents and children whose parent is outside the loaded page; the real root still renders.",
+    true,
+  );
+});
+
+test("children of a loaded, active parent are still hidden and the parent still renders", async ({ evidence }) => {
+  // Negative half: tightening the filter must not remove the previously
+  // working case or start hiding real roots.
+  const rows = flattenSessionRows(
+    [
+      session({ id: "parent" }),
+      session({ id: "child", parentID: "parent" }),
+      session({ id: "another-root", parentID: null }),
+    ],
+    50,
+  );
+
+  expect(rows.map((row) => row.session.id)).toEqual(["parent", "another-root"]);
+
+  evidence.recordAssertionEvidence(
+    "Root sessions keep rendering after the subagent filter change",
+    "Roots with no parentID (undefined or null) render in order, and a child of a loaded parent stays hidden as before.",
+    true,
+  );
+});


### PR DESCRIPTION
## Problem

The sidebar fills up with `(@explore subagent)` rows. Sub-agent child sessions are meant to be reached only from the task card in their parent transcript (`sidebar/utils.ts` says so explicitly), but `getRootSessions` only hid a child when its parent was *also* in the loaded list:

```ts
return !parentID || !byID.has(parentID);
```

So a child was promoted to a root row whenever its parent was:
- **archived** — archived rows are partitioned out *before* the root check, so every child of an archived parent reappears;
- **outside the `limit: 200` page** — each subagent run is its own session, so they crowd parents out of the window;
- **deleted**.

The fallback is a leftover from the nested-tree sidebar (an orphan had nothing to nest under, so it became a root). #4088 removed nesting but kept the fallback and its test.

## Fix

`getRootSessions` now drops any session with a `parentID`, regardless of whether the parent is loaded. The `session.list` request is intentionally left unchanged (no `roots: true`): the "back to parent" control in a child session header looks the child up in that same list.

## Tests

- New `evals/specs/sidebar-hides-subagent-sessions.test.ts` (PR lane): archived-parent and out-of-window children produce no rows; real roots (`parentID` undefined or null) still render and a child of a loaded parent stays hidden. Red before the fix (both children leaked), green after.
- Updated `apps/app/tests/session-sidebar-utils.test.ts`: the old "keeps orphan child as root" case asserted the buggy behavior and now asserts the opposite, including the archived-parent case.

## Verification (local lane — Daytona not used; pure helper spec, no app/Den needed)

```
pnpm evals:pr specs/sidebar-hides-subagent-sessions.test.ts   # 2 passed, 0 skipped
cd apps/app && bun test tests/session-sidebar-utils.test.ts tests/sidebar-tree-nesting.test.ts   # 14 passed
pnpm --filter @openwork/app exec tsc --noEmit -p tsconfig.json   # exit 0
```

Verdict: **Passed**.