### PR TITLE
docs(changelog): add v0.18.40-v0.18.41 release notes

### DIFF
--- a/changelog/release-tracker-2026-08-31.md
+++ b/changelog/release-tracker-2026-08-31.md
@@ -1,0 +1,63 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.40
+
+#### Commit
+`214c32b8`
+
+#### Released at
+`2026-08-31T02:21:17Z`
+
+#### Title
+Portable Agent Plugins arrive and desktop sessions run calmer
+
+#### One-line summary
+Adds portable Agent Plugin support and workspace-pinned Automations while eliminating desktop request storms and hardening access security.
+
+#### Main changes
+- OpenWork can now import and run portable Agent Plugins, bringing Anthropic-compatible plugin packs into the desktop app.
+- Automations can be pinned to an explicit workspace, and remote-session commands now arrive in native local desktop sessions.
+- Fixed request storms and reload loops across Settings, desktop policies, the Library, the composer, and session search so long sessions stay fast.
+- Gmail replies gained collapsible quoting and reply attachments, and OpenWork Cloud members receive complimentary OpenWork Web access.
+- Strengthened SAML validation, organization API key authentication, and hosted-origin access checks, and made the desktop recover from socket and renderer crashes.
+
+#### Lines of code changed since previous release
+70230 lines changed since `v0.18.39` (63446 insertions, 6784 deletions).
+
+#### Release importance
+Major release: adds portable Agent Plugin support and remote-session delivery while stabilizing desktop performance and access security.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+4
+
+#### Major improvement details
+- Added portable Agent Plugin support.
+- Added workspace-pinned Automations and native delivery of remote-session commands.
+- Added collapsible Gmail reply quoting and reply attachments.
+- Granted complimentary OpenWork Web access to OpenWork Cloud members.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+4
+
+#### Major bug fix details
+- Stopped settings, desktop-policy, Library, and composer request storms and reload loops.
+- Kept actively streaming sessions alive through the engine drain deadline.
+- Recovered desktop sessions from socket and renderer crashes.
+- Validated SAML responses against the SP-advertised ACS origin and authenticated organization API keys.
+
+#### Deprecated features
+True
+
+#### Number of deprecated features
+1
+
+#### Deprecated details
+- Removed the dead legacy session surface from openwork-server.

--- a/changelog/release-tracker-2026-09-02.md
+++ b/changelog/release-tracker-2026-09-02.md
@@ -1,0 +1,62 @@
+# Release Changelog Tracker
+
+Internal preparation file for release summaries. This is not yet published to the changelog page or docs.
+
+## v0.18.41
+
+#### Commit
+`eb687539`
+
+#### Released at
+`2026-09-02T01:52:38Z`
+
+#### Title
+Session status gets honest and cloud providers connect with saved credentials
+
+#### One-line summary
+Makes Working indicators and session reconciliation truthful, connects Den providers from locally saved Desktop credentials, and publishes SOC 2 Type I status.
+
+#### Main changes
+- Working indicators now stop when a run errors or the engine is unreachable, and show minutes past the first hour.
+- Sessions reconcile more cleanly: completions are detected while you are elsewhere, queued composer messages send when a session is out of view, and archiving works from any workspace.
+- Den cloud providers now connect using credentials saved locally on the Desktop, and Google Workspace retrieval is more resilient.
+- The landing page shows OpenWork's SOC 2 Type I badge and status, and web boot failures and Stripe webhook errors now reach Sentry.
+- Remediated static-analysis security findings, isolated provider sync contexts, and improved internal test and release tooling.
+
+#### Lines of code changed since previous release
+25270 lines changed since `v0.18.40` (18863 insertions, 6407 deletions).
+
+#### Release importance
+Minor release: reliability fixes to session status and reconciliation, plus saved-credential provider connections and SOC 2 Type I disclosure.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+3
+
+#### Major improvement details
+- Connected Den cloud providers from locally saved Desktop credentials.
+- Published the SOC 2 Type I badge and status on the landing page.
+- Reported web boot failures and Stripe webhook errors to Sentry.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+4
+
+#### Major bug fix details
+- Stopped Working indicators from ticking after errors or while the engine is unreachable.
+- Reconciled active session completion, queued composer drains, and coalesced workspace session loads.
+- Fixed archiving sessions from non-selected workspaces.
+- Isolated provider sync contexts and hardened Google Workspace retrieval.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,30 @@
 ---
 title: "Changelog"
 ---
+<Update label="September 2nd" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
+
+  ## [v0.18.41](https://github.com/different-ai/openwork/compare/v0.18.40...v0.18.41): Session status gets honest and cloud providers connect with saved credentials
+
+  - The Working indicator now tells the truth: it stops when a run errors or the engine is unreachable, and shows minutes once a run passes the first hour.
+  - Sessions reconcile more cleanly — completions are detected while you're working elsewhere, queued messages send even when the session is out of view, and archiving works from any workspace.
+  - Cloud providers now connect using the credentials saved on your desktop, and Google Workspace retrieval is more resilient.
+  - OpenWork is SOC 2 Type I — the landing page now shows the badge and live status.
+  - Hardened security by fixing static-analysis findings and isolating provider sync contexts, alongside internal test and release tooling improvements.
+
+</Update>
+
+<Update label="August 31st" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
+
+  ## [v0.18.40](https://github.com/different-ai/openwork/compare/v0.18.39...v0.18.40): Portable Agent Plugins arrive and desktop sessions run calmer
+
+  - OpenWork can now import and run portable Agent Plugins, bringing Anthropic-compatible plugin packs into the desktop app.
+  - Automations can be pinned to a specific workspace, and remote-session commands now arrive in native local sessions on your desktop.
+  - Fixed request storms and reload loops across Settings, the Library, the composer, and desktop policies, so long sessions stay fast.
+  - Gmail replies support collapsible quoting and attachments, and OpenWork Cloud members get complimentary OpenWork Web access.
+  - Strengthened sign-in and access security and made the desktop recover cleanly from socket and renderer crashes.
+
+</Update>
+
 <Update label="August 27th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.18.39](https://github.com/different-ai/openwork/compare/v0.18.38...v0.18.39): Richer session artifacts and more resilient agent runs


### PR DESCRIPTION
Backfills the two stable releases the changelog automation missed (it has not been able to run since v0.18.16 — root cause and fix in #4310). Entries were drafted from the commits between `v0.18.39`…`v0.18.41` following .opencode/agents/changelog.md and verified with `node scripts/check-changelog-output.mjs` for both tags.

Docs-only change with no runtime surface. Once merged, the automation's dedupe check will skip these versions.
