### PR TITLE
docs(changelog): dedupe the New Features filter tag

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -456,7 +456,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 11th" tags={["🚀 New features", "🐛 Bug Fixes"]}>
+<Update label="March 11th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.140): Improved workers, sharing skills, GOAuth
 


### PR DESCRIPTION
The changelog page showed four filters: 🐛 Bug Fixes, 🚀 New Features, 🏗️ Refactoring, and a duplicate 🚀 New features. The docs site derives the filter list from distinct tag strings, and the March 11th entry was the only one of 39 tagged `"🚀 New features"` (lowercase f) instead of `"🚀 New Features"`.

One-character fix; the file now contains exactly three distinct tag strings, matching the allowed set in .opencode/agents/changelog.md. Verified with `rg -o 'tags=...' | sort -u`.

Docs-only change with no runtime surface.
