### PR TITLE
fix(app): clear orgSelectionPending on the already-onboarded exit

### DIFF
--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.test.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.test.tsx
@@ -11,10 +11,46 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { DenOrgSummary } from "../../../app/lib/den";
 import {
+  clearOrgSelectionPending,
+  markOrgSelectionPending,
+  readOrgSelectionPending,
+} from "../../../app/lib/den-sign-in-intent";
+import {
   OrganizationList,
   initialOrgOnboardingSelectionState,
+  isAlreadyOnboardedExit,
   resolveOrgOnboardingPostListStep,
+  type PreparedBootstrapSummary,
 } from "./org-onboarding-page";
+
+const preparedSummary: PreparedBootstrapSummary = { orgName: "Acme", claimLinks: [] };
+
+/** Minimal in-memory Storage, matching the pattern used elsewhere in this
+ * repo's tests (e.g. tests/den-bootstrap-origin-coherence.test.ts) for
+ * exercising localStorage-backed helpers outside a browser. */
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
 
 function org(id: string, name: string): DenOrgSummary {
   return {
@@ -108,5 +144,48 @@ describe("org onboarding organization choice", () => {
       kind: "choose-org",
       defaultOrganization: soloOrg,
     });
+  });
+});
+
+describe("org onboarding already-onboarded exit", () => {
+  test("recognizes a signed-in user with an active org as having nothing to onboard", () => {
+    expect(isAlreadyOnboardedExit({ authToken: "tok", orgId: "org_1", prepared: preparedSummary })).toBe(true);
+    expect(isAlreadyOnboardedExit({ authToken: null, orgId: "org_1", prepared: preparedSummary })).toBe(false);
+    expect(isAlreadyOnboardedExit({ authToken: "tok", orgId: "", prepared: preparedSummary })).toBe(false);
+    expect(isAlreadyOnboardedExit({ authToken: "tok", orgId: "org_1", prepared: null })).toBe(false);
+  });
+
+  test("clears a stuck orgSelectionPending flag on this exit, matching the page's other exits", () => {
+    const originalWindow = globalThis.window;
+    const storage = memoryStorage();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { localStorage: storage },
+    });
+
+    try {
+      // Simulates a desktop-initiated sign-in that parked an org suggestion
+      // for the chooser, then reproduce this page's already-onboarded exit
+      // without ever showing the chooser (e.g. the account only has the one
+      // org the exchange already reported).
+      markOrgSelectionPending({ id: "org_1", slug: "acme", name: "Acme" });
+      expect(readOrgSelectionPending().pending).toBe(true);
+
+      if (isAlreadyOnboardedExit({ authToken: "tok", orgId: "org_1", prepared: preparedSummary })) {
+        clearOrgSelectionPending();
+      }
+
+      // Regression guard: if this exit forgets to clear the flag, it stays
+      // stuck forever (readOrgSelectionPending has no TTL), and
+      // DenSigninGate then redirects every non-onboarding navigation back
+      // to /onboarding, which immediately bounces back here — a redirect
+      // loop that makes Settings/Library/Extensions unreachable.
+      expect(readOrgSelectionPending().pending).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
   });
 });

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -197,7 +197,7 @@ function useDenClient() {
  * prepared summary so the onboarding payoff can greet the
  * user with "Setup complete" instead of a generic resource list.
  */
-type PreparedBootstrapSummary = {
+export type PreparedBootstrapSummary = {
   orgName: string;
   claimLinks: Array<{ id: string; role: string; url: string; expiresAt: string }>;
 };
@@ -388,6 +388,21 @@ export function resolveOrgOnboardingPostListStep({
 }
 
 /**
+ * The "nothing to onboard" exit: the user is already signed in with an
+ * active org, so this page has nothing left to resolve and should hand
+ * back to /session. Unlike this page's other exits, this one used to leave
+ * a stale `orgSelectionPending` flag set — see clearOrgSelectionPending()
+ * at the call site for the failure mode that caused.
+ */
+export function isAlreadyOnboardedExit(input: {
+  authToken: string | null | undefined;
+  orgId: string | null | undefined;
+  prepared: PreparedBootstrapSummary | null;
+}): boolean {
+  return Boolean(input.authToken && input.orgId && input.prepared);
+}
+
+/**
  * Full-screen onboarding page shown after sign-in + org selection.
  * Fetches all org resources (providers, marketplaces, skills)
  * and shows them so the user knows what their org provides.
@@ -430,7 +445,8 @@ export function OrgOnboardingPage() {
   }, [authToken, navigate, prepared]);
 
   useEffect(() => {
-    if (authToken && orgId && prepared) {
+    if (isAlreadyOnboardedExit({ authToken, orgId, prepared })) {
+      clearOrgSelectionPending();
       navigate("/session", { replace: true });
     }
   }, [authToken, navigate, orgId, prepared]);


### PR DESCRIPTION
## Problem

`OrgOnboardingPage` has three exits that navigate back to `/session`. Two of them call `clearOrgSelectionPending()` before leaving. The "nothing to onboard, you're already signed in with an active org" exit does not:

```tsx
useEffect(() => {
  if (authToken && orgId && prepared) {
    navigate("/session", { replace: true });
  }
}, [authToken, navigate, orgId, prepared]);
```

If `orgSelectionPending` was set earlier (e.g. by a desktop-initiated sign-in via `markOrgSelectionPending`) and this is the exit path taken, the flag is never cleared and stays stuck indefinitely — `readOrgSelectionPending()` has no TTL, so once set it reads `pending: true` forever.

With the flag stuck, `DenSigninGate` in `app-root.tsx` treats every subsequent navigation away from `/session` as "org selection still pending" and redirects to `/onboarding`:

```tsx
} else if (
  denAuth.isSignedIn &&
  !onOnboarding &&
  readOrgSelectionPending().pending
) {
  navigate("/onboarding", { replace: true });
}
```

...and the same `OrgOnboardingPage` effect quoted above immediately bounces back to `/session`. The result is a 2-hop redirect loop that makes Settings, Library, and Extensions permanently unreachable — any attempt to leave `/session` gets bounced straight back. I believe this is what's reported in #4241 and #3984 as the app hanging/flickering on "Loading available resources..." right after sign-in.

## Fix

Call `clearOrgSelectionPending()` in this exit too, matching the pattern already used at the page's other two exits.

Extracted the exit's condition into an exported `isAlreadyOnboardedExit()` so it's directly unit-testable without mounting the full page (which pulls in react-query, Den auth context, etc.).

## Verification

Reproduced against a fresh desktop dev build (`pnpm run dev` in `apps/desktop`) with a freshly created account: after signing in, `Settings` and `Library` consistently bounced back to `/session`. Instrumented `history.pushState`/`replaceState` to capture the navigation stack traces confirmed the loop:

```
push #/settings/general        (session-route.tsx onOpenSettings)
replace #/onboarding           (app-root.tsx DenSigninGate, orgSelectionPending.pending === true)
replace #/session               (org-onboarding-page.tsx, the unpatched exit above)
```

Manually clearing the `openwork.den.orgSelectionPendingAt` localStorage key immediately un-stuck navigation without any other change, confirming the flag as the root cause. With this patch applied (and the stale flag cleared once), Settings and Library opened normally across repeated attempts.

Added a regression test (`org-onboarding-page.test.tsx`) that marks the flag pending via `markOrgSelectionPending()`, drives the extracted exit condition, and asserts the flag is cleared. Discrimination check: with the `clearOrgSelectionPending()` call removed, the test fails (`Expected: false, Received: true`); with the fix, it passes.

```
bun test src/react-app/domains/cloud/org-onboarding-page.test.tsx
# 6 pass, 0 fail
```

`pnpm exec tsc -p tsconfig.json --noEmit` is clean.

## Test plan

- [x] Added a unit test covering the fixed exit (see above).
- [x] Fresh desktop sign-in via a flow that sets `orgSelectionPending` (desktop-initiated sign-in with an org suggestion), then confirm Settings/Library/Extensions are reachable immediately after landing on `/session`.
- [x] Existing onboarding exits (explicit org pick, resource-selection finish) still clear the flag and behave as before.