### PR TITLE
fix(den-db): widen external_mcp_connection.scope from varchar(1024) to text

### DIFF
--- a/ee/packages/den-db/drizzle/0086_equal_steve_rogers.sql
+++ b/ee/packages/den-db/drizzle/0086_equal_steve_rogers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `external_mcp_connection` MODIFY COLUMN `scope` text;

--- a/ee/packages/den-db/src/schema/sharables/capability-credentials.ts
+++ b/ee/packages/den-db/src/schema/sharables/capability-credentials.ts
@@ -4,6 +4,7 @@ import {
   index,
   mysqlEnum,
   mysqlTable,
+  text,
   timestamp,
   uniqueIndex,
   varchar,
@@ -220,7 +221,20 @@ export const ExternalMcpConnectionTable = mysqlTable(
     accessToken: encryptedTextColumn("access_token"),
     refreshToken: encryptedTextColumn("refresh_token"),
     tokenType: varchar("token_type", { length: 64 }),
-    scope: varchar("scope", { length: 1024 }),
+    /**
+     * Space-delimited scope string returned by the OAuth server. Kept
+     * unbounded (`text`, matching accessToken/refreshToken above) rather
+     * than a fixed varchar: a provider granting many fine-grained scopes
+     * routinely exceeds a few hundred characters — Google Workspace
+     * connections requesting the full calendar/gmail/drive/docs/sheets/
+     * slides/tasks/contacts/userinfo/openid scope set return a scope
+     * string over 1100 characters, which overflowed the previous
+     * `varchar(1024)` and made MySQL reject the row (`ER_DATA_TOO_LONG`,
+     * errno 1406) after a fully successful token exchange — surfacing to
+     * the org admin as the generic, misleading "authorization server
+     * rejected the code or token refresh exchange" error.
+     */
+    scope: text("scope"),
     expiresAt: timestamp("expires_at", { fsp: 3 }),
     /**
      * Transient PKCE code verifier, present only between connect/start and


### PR DESCRIPTION
## Bug

`external_mcp_connection.scope` was `varchar(1024)`. A provider granting many fine-grained OAuth scopes can easily exceed that: a Google Workspace connection requesting the full calendar/gmail/drive/docs/sheets/slides/tasks/contacts/userinfo/openid scope set returns a scope string over 1100 characters.

When that happens, MySQL rejects the row with `ER_DATA_TOO_LONG` (errno 1406) — **after** an otherwise fully successful OAuth token exchange. Den's own error handling swallows that and surfaces the org admin a generic, misleading `external_mcp_connect_callback_token_exchange_failed` → "The authorization server rejected the code or token refresh exchange." There is nothing in the UI or the returned error to suggest the real cause is a column too short for the granted scope string, which makes this very hard to diagnose from the outside.

## Fix

Widen the column to `text`, matching `accessToken`/`refreshToken` on the same table, which are already unbounded. Generated the migration with `pnpm run db:generate` (`ee/packages/den-db/drizzle/0086_equal_steve_rogers.sql`):

```sql
ALTER TABLE `external_mcp_connection` MODIFY COLUMN `scope` text;
```

## Testing

- `pnpm test` in `ee/packages/den-db`: 15 passed, 0 failed, 3 skipped.
- `pnpm run build`: succeeds; `dist/current-schema.sql` shows `` `scope` text `` under `CREATE TABLE \`external_mcp_connection\``.
- Reproduced and verified live against a self-hosted Den instance (0.18.37) connecting a Google Workspace account through an external MCP OAuth connector: before the fix, the token exchange failed with the generic error above and Den's own logs showed errno 1406 on the `scope` column; after applying the equivalent `ALTER TABLE` by hand, the same connection flow completed end-to-end (200 OK, session created, tools listed).

## Note on generated files

I'm intentionally leaving `ee/packages/den-db/drizzle/meta/0086_snapshot.json` and the corresponding `_journal.json` entry out of this PR — they're drizzle-kit-generated (the snapshot alone is ~320KB) and I'd rather not hand-paste a generated blob that size through the GitHub web editor. Happy to add them if a maintainer regenerates via `pnpm run db:generate` and points me at the output, or if it's easier to just run that locally when merging.

Signed-off-by: Javier Tallon <jtallon@dephensiva.eu>