### PR TITLE
fix(den-api): materialize cloud LLM providers for Automations runs

### DIFF
--- a/ee/apps/den-api/src/automations/cloud-agent-executor.ts
+++ b/ee/apps/den-api/src/automations/cloud-agent-executor.ts
@@ -7,6 +7,7 @@ import type { AutomationAction, AutomationError, AutomationUsage } from "@openwo
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { resolveCloudRuntimeAccess, type CloudWorkerAccess } from "../workers/worker-access.js"
+import { materializeCloudWorkerProviders } from "../llm/cloud-provider-materialization.js"
 import { organizationCloudEnabled } from "../capability-sources/cloud-rollout.js"
 import { CLOUD_INSTANCE_BACKEND } from "../workers/cloud-constants.js"
 import { wakeCloudWorker } from "../workers/cloud-lifecycle.js"
@@ -460,6 +461,27 @@ export async function executeCloudAgent(input: CloudAgentExecutorInput): Promise
     // Recovery keeps the receipt's workspace (the turn may already be running
     // there); otherwise the revision pin wins over the worker's active workspace.
     const workspaceId = previousReceipt?.workspaceId ?? input.workspaceId ?? runtime.workspaceId
+    // Automations never materialized the organization's custom LLM providers
+    // into the worker's OpenCode runtime -- that mechanism
+    // (llm/cloud-provider-materialization.ts) previously existed only for the
+    // Cloud Chat / gateway resolution path (routes/cloud/index.ts). A worker
+    // that only ever ran Automations therefore never received a custom
+    // provider's credentials or model catalog, and connectHealth below failed
+    // with connect_access_unavailable ("provider/model not found in OpenCode
+    // provider catalog"). Best-effort and non-fatal on purpose: on failure,
+    // connectHealth still runs right after and surfaces a real, actionable
+    // error instead of this call's own.
+    try {
+      await materializeCloudWorkerProviders({
+        organizationId: normalizeDenTypeId("organization", input.organizationId),
+        workerId: normalizeDenTypeId("worker", runtime.workerId),
+        instanceUrl: runtime.baseUrl,
+        hostToken: runtime.access.hostToken,
+        clientToken: runtime.access.clientToken,
+      })
+    } catch {
+      // swallow: see comment above.
+    }
     const connect = await connectHealth({ ...runtime, workspaceId, action: input.action, signal })
     if (!connect.ok) {
       return { ok: false, status: "failed", code: connect.code, message: connect.message, retryable: false, needsAttention: true }


### PR DESCRIPTION
##  Summary
- Automations running on a cloud (Daytona) worker never materialize the organization's custom LLM provider credentials/model catalog into that worker's OpenCode runtime, so a worker that only ever ran Automations (never Cloud Chat) fails every run with `connect_access_unavailable`.

## Why
- `materializeCloudWorkerProviders()` (`llm/cloud-provider-materialization.ts`) is only ever called from the Cloud Chat / gateway-resolution path (`routes/cloud/index.ts`). `automations/cloud-agent-executor.ts` resolves the worker and calls `connectHealth()` directly, skipping it entirely. Same provider, same worker, works fine from Cloud Chat and fails from Automations.

## Issue
- Closes # (no upstream issue filed; found and diagnosed directly against a self-hosted deployment)

## Scope
- `ee/apps/den-api/src/automations/cloud-agent-executor.ts`: call `materializeCloudWorkerProviders` right before `connectHealth`, best-effort and non-fatal.

## Out of scope
- Worker access/candidate-URL resolution (already rewritten in this branch as `resolveCloudRuntimeAccess`/`resolveCloudRuntimeState`, not touched here).

## Testing
### Ran
`pnpm run typecheck:automations` (from `ee/apps/den-api`)

### Result
pass: 0 errors
- if fail, exact files/errors: N/A (typecheck passed)

## CI status
- pass local typecheck only:
- code-related failures: none observed
- external/env/auth blockers: full CI suite not run from this environment (no CI credentials here); the equivalent JS was verified live instead, see Manual verification

## Manual verification
1. Applied the equivalent compiled-JS patch directly to a running production `den-api` v0.18.37 container (self-hosted deployment).
2. Triggered a real Automation configured with a custom LLM provider, on a worker that had only ever run Automations.
3. Before the patch: run failed with `connect_access_unavailable` / "provider/model not found in OpenCode provider catalog". After the patch: run succeeded end-to-end, including the automation's own email-sending action actually delivering.

## Evidence
- N/A (internal production logs from a private self-hosted deployment, not publishable)

## Risk
- Low. The added call is wrapped in `try/catch` and is non-fatal by design: on failure it swallows the error and `connectHealth` still runs immediately after, surfacing the same real, actionable error as before this change.

## Rollback
- Revert this commit. Behavior reverts to Automations never materializing custom providers (pre-existing behavior).

**CLA**: submitted under the Individual Contributor License Agreement, by Javier Tallon (jtallon@dephensiva.eu), per `CONTRIBUTING.md`. DCO sign-off is on the commit.
