### PR TITLE
fix(automations): retry connectHealth through the managed-OpenCode warmup race

### DIFF
--- a/ee/apps/den-api/src/automations/cloud-agent-executor.ts
+++ b/ee/apps/den-api/src/automations/cloud-agent-executor.ts
@@ -290,6 +290,8 @@ export function cloudAgentRuntimeUnavailableResult(input: {
   }
 }
 
+const OPENCODE_WARMUP_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
+
 async function connectHealth(input: {
   baseUrl: string
   workspaceId: string
@@ -317,28 +319,60 @@ async function connectHealth(input: {
     const value: unknown = await response.json()
     return isRecord(value) ? value : null
   }
-  let value = await request("GET", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/health?${query}`)
-  let health = value
-  if (health?.usable !== true || health.usableByCurrentModel !== true) {
-    value = await request("POST", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/engine-refresh`, {
-      provider: input.action.model.providerId,
-      model: input.action.model.modelId,
-      trigger: "automation_run",
-    })
-    health = isRecord(value?.health) ? value.health : null
+  // Midna 2026-09-02: right after a cold Daytona boot, the sandbox's managed
+  // OpenCode engine (OPENWORK_MANAGE_OPENCODE=1, apps/server/src/cli.ts)
+  // is still spawning in the background — the outer `/health` route that
+  // Den's own wake waits on (routes/core.ts) reports ok as soon as the HTTP
+  // server binds, well before the `opencode serve` child process finishes
+  // and registers config.opencodeBaseUrl for the workspace
+  // (opencode-connection.ts). A human typing into Cloud Chat loses this race
+  // in practice; an Automation's first turn, sent immediately on wake, does
+  // not. This one attempt() below is the original single-shot probe;
+  // wrapped in a bounded retry so a transient "opencode_unconfigured"
+  // failure (server.ts) gets a few seconds' grace instead of permanently
+  // failing the run.
+  const attempt = async (): Promise<
+    | { ok: true }
+    | { ok: false; code: "connect_access_unavailable" | "model_access_lost"; message: string; retryableWarmup: boolean }
+  > => {
+    let value = await request("GET", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/health?${query}`)
+    let health = value
+    if (health?.usable !== true || health.usableByCurrentModel !== true) {
+      value = await request("POST", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/engine-refresh`, {
+        provider: input.action.model.providerId,
+        model: input.action.model.modelId,
+        trigger: "automation_run",
+      })
+      health = isRecord(value?.health) ? value.health : null
+    }
+    if (health?.usable === true && health.usableByCurrentModel === true) return { ok: true }
+    if (health?.usable === true && health.usableByCurrentModel !== true) {
+      return {
+        ok: false,
+        code: "model_access_lost",
+        message: "The selected model cannot use the current OpenWork Connect capabilities.",
+        retryableWarmup: false,
+      }
+    }
+    const failure = isRecord(health?.firstFailure) ? health.firstFailure : null
+    return {
+      ok: false,
+      code: "connect_access_unavailable",
+      message: typeof failure?.message === "string"
+        ? failure.message
+        : "OpenWork Connect is not ready in the Cloud runtime. Reconnect it before retrying this Automation.",
+      retryableWarmup: failure?.code === "opencode_unconfigured",
+    }
   }
-  if (health?.usable === true && health.usableByCurrentModel === true) return { ok: true }
-  if (health?.usable === true && health.usableByCurrentModel !== true) {
-    return { ok: false, code: "model_access_lost", message: "The selected model cannot use the current OpenWork Connect capabilities." }
+  let result = await attempt()
+  for (const delayMs of OPENCODE_WARMUP_RETRY_DELAYS_MS) {
+    if (result.ok || !result.retryableWarmup) break
+    await abortableSleep(delayMs, input.signal)
+    result = await attempt()
   }
-  const failure = isRecord(health?.firstFailure) ? health.firstFailure : null
-  return {
-    ok: false,
-    code: "connect_access_unavailable",
-    message: typeof failure?.message === "string"
-      ? failure.message
-      : "OpenWork Connect is not ready in the Cloud runtime. Reconnect it before retrying this Automation.",
-  }
+  if (result.ok) return result
+  const { retryableWarmup: _retryableWarmup, ...outcome } = result
+  return outcome
 }
 
 function usageFromTranscript(usage: {


### PR DESCRIPTION
## Summary
- `connectHealth()` in `ee/apps/den-api/src/automations/cloud-agent-executor.ts` now retries its probe with a short bounded backoff (1s/2s/4s/8s) when the failure is the specific `opencode_unconfigured` shape, instead of failing an Automation run on the first miss.

## Why
- Right after a cold Daytona boot, the sandbox's managed OpenCode engine (`OPENWORK_MANAGE_OPENCODE=1`, `apps/server/src/cli.ts`) is still spawning in the background. The outer `/health` route that Den's own wake waits on (`apps/server/src/routes/core.ts`) reports `ok` as soon as the HTTP server binds — well before the `opencode serve` child process finishes and registers `config.opencodeBaseUrl` for the workspace (`apps/server/src/opencode-connection.ts`). A human typing into OpenWork Web/Cloud Chat has enough typing/thinking time to often win this race; an Automation's first turn, sent immediately on wake with zero human delay, reliably loses it, and the run fails with "OpenCode base URL is missing for this workspace".

## Issue
- Closes #

## Scope
- `ee/apps/den-api/src/automations/cloud-agent-executor.ts`: wrap the existing single-shot `connectHealth()` probe in an `attempt()` closure, add `OPENCODE_WARMUP_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]`, and retry only when the failure's `firstFailure.code === "opencode_unconfigured"` (tracked as `retryableWarmup`). Every other failure shape (including `model_access_lost`) still fails immediately, unchanged from before.

## Out of scope
- The underlying race itself (the `/health` route reporting ready before the managed OpenCode child process is actually ready) is not fixed here — this only gives Automations bounded grace to ride it out. A proper fix would gate `/health` (or add a dedicated readiness check) on the managed OpenCode engine actually being up, upstream in `apps/server`.
- A separate, unrelated failure mode (Automations resolving a worker instance URL that Daytona's own proxy doesn't route) is out of scope for this PR.

## Testing
### Ran
- `pnpm run typecheck:automations` from `ee/apps/den-api`

### Result
- pass

## CI status
- pass: typecheck (see above)
- code-related failures: none observed
- external/env/auth blockers: none

## Manual verification
1. Deployed this exact fix as a live hot-patch on a self-hosted Den instance ahead of opening this PR, and restarted the `den` service.
2. Triggered a fresh Automation run immediately after a cold Daytona worker boot (the failure window is race-dependent, not reliably reproducible against an already-warm worker) — the run that previously failed within ~2s with "OpenCode base URL is missing for this workspace" completed normally.
3. Confirmed a non-retryable failure (e.g. an actually revoked/misconfigured OpenWork Connect grant) still fails immediately rather than being retried into a timeout.

## Evidence
- Self-hosted deployment logs and the MySQL `automation.needs_attention_reason` before/after are available on request; not attached here since they include internal workspace identifiers.

## Risk
- Low. The retry only triggers on one specific, already-transient failure shape (`opencode_unconfigured`), bounded to at most ~15s of added latency in the worst case, and only on the code path that was already about to fail the run. No behavior change for the success path or for any other failure code.

## Rollback
- Revert this commit; `connectHealth()` returns to its original single-shot probe.

**CLA**: submitted under the Individual Contributor License Agreement, by Javier Tallon (jtallon@dephensiva.eu), per `CONTRIBUTING.md`. DCO sign-off is on the commit.
