### PR TITLE
docs: add Google SSO and SCIM guidance

### DIFF
--- a/packages/docs/cloud/scim-google-workspace.mdx
+++ b/packages/docs/cloud/scim-google-workspace.mdx
@@ -1,0 +1,83 @@
+---
+title: "Google Workspace SCIM provisioning"
+description: "Current Google Workspace SCIM support for OpenWork"
+---
+
+Use [Google Workspace SAML SSO](/cloud/sso-google-workspace) when members
+should authenticate to OpenWork with Google. Google Workspace custom SAML apps do
+not currently expose a generic outbound SCIM connector that can provision users
+and groups into OpenWork.
+
+## Current support
+
+OpenWork supports SCIM provisioning through identity providers that can send
+SCIM requests to the OpenWork SCIM base URL with a bearer token. Google
+Workspace's automated user provisioning is app-catalog based: Google provides
+provisioning setup screens and app-specific guides for supported applications.
+
+For a custom SAML app created for OpenWork, Google Admin provides SAML settings,
+optional SAML attribute mappings, and service access controls, but does not show
+the SCIM fields OpenWork needs:
+
+- SCIM base URL or tenant URL
+- Bearer token or secret token
+- Create, update, deactivate, or reactivate user actions
+- Group push or group provisioning actions
+- SCIM attribute mappings such as `userName`, work email, given name, family
+  name, and display name
+
+Until Google adds OpenWork as a supported automated-provisioning app or exposes
+generic outbound SCIM settings for custom apps, Google Workspace can be used for
+OpenWork SSO but not for OpenWork SCIM lifecycle provisioning.
+
+## What still works with Google Workspace
+
+Google SAML SSO can authenticate OpenWork members and create first-login members
+through OpenWork's just-in-time SSO provisioning. JIT provisioning is not the
+same as SCIM:
+
+- It happens when a user signs in successfully.
+- It does not continuously sync profile changes from Google.
+- It does not deactivate OpenWork access when a Google user is suspended or
+  deleted.
+- It does not create SCIM-managed OpenWork teams from Google groups.
+
+Use OpenWork member management, invitations, or another supported SCIM identity
+provider for lifecycle automation.
+
+## How to confirm in Google Admin
+
+After setting up the OpenWork custom SAML app, open the Google Admin console and
+check:
+
+1. **Apps → Web and mobile apps → OpenWork**.
+2. The app's configuration sections and side navigation.
+3. Any settings named **Provisioning**, **Auto-provisioning**, **User
+   provisioning**, or **SCIM**.
+
+If those sections are not present, the app cannot consume the OpenWork SCIM base
+URL or bearer token.
+
+Google's general automated user provisioning page points administrators to
+app-specific provisioning guides for supported apps. If OpenWork appears in that
+supported app list in the future, follow the Google app-specific provisioning
+guide and enter the OpenWork SCIM values from **Settings → SCIM**.
+
+## Do not expose the SCIM token unnecessarily
+
+Only create or rotate an OpenWork SCIM connector when you have an identity
+provider that can use it. The bearer token is shown once and should be treated
+like a password. Do not paste it into Google, tickets, screenshots, logs, or
+documentation unless a provisioning screen explicitly asks for it.
+
+## Alternatives for SCIM lifecycle automation
+
+For automatic member lifecycle and team synchronization, use an identity provider
+that supports OpenWork's SCIM connector:
+
+- [Okta SCIM provisioning](/cloud/scim-okta)
+- [Microsoft Entra SCIM provisioning](/cloud/scim-microsoft-entra)
+
+Do not broaden SCIM assignment scope in the alternate provider until your chosen
+SSO and SCIM lifecycle tests pass and at least one OpenWork owner has a working
+recovery path.

--- a/packages/docs/cloud/scim-microsoft-entra.mdx
+++ b/packages/docs/cloud/scim-microsoft-entra.mdx
@@ -13,16 +13,18 @@ You need:
 
 - An OpenWork organization with Enterprise SSO and SCIM.
 - An OpenWork owner, or a member who can manage security configuration.
-- A working OpenWork SAML connection. Complete and test
+- A working, domain-verified, tested, and enabled OpenWork SAML connection.
+  Complete and test
   [Microsoft Entra SAML SSO](/cloud/sso-microsoft-entra) first.
 - A Microsoft Entra role that can manage enterprise applications and
   provisioning.
 - An Entra plan that supports assigning groups to enterprise applications if
   you want to synchronize groups.
 
-Keep SSO enforcement off until you have tested both SAML sign-in and SCIM. Make
-sure at least one OpenWork owner can sign in through SAML before relying on
-Entra as the identity source.
+Do not broaden SCIM assignment scope until you have tested both SAML sign-in and
+SCIM. Make sure at least one OpenWork owner can sign in through SAML and that
+the current SSO configuration has passed OpenWork's **Test SSO before enabling
+it** flow before relying on Entra as the identity source.
 
 ## 1. Get the OpenWork connection values
 

--- a/packages/docs/cloud/scim-okta.mdx
+++ b/packages/docs/cloud/scim-okta.mdx
@@ -10,14 +10,17 @@ OpenWork members. Okta groups can also become SCIM-managed OpenWork teams.
 
 You need:
 
-- A working and domain-verified [Okta SAML SSO](/cloud/sso-okta) connection.
+- A working, domain-verified, tested, and enabled
+  [Okta SAML SSO](/cloud/sso-okta) connection.
 - An OpenWork owner, or a member who can manage security configuration.
 - An Okta administrator who can configure provisioning for the SAML app.
 - An Okta plan that supports the provisioning and group-push features you
   intend to use.
 
-Keep OpenWork SSO enforcement off until both SAML and a narrowly scoped SCIM
-test pass. Make sure at least one OpenWork owner can sign in through Okta.
+Do not broaden SCIM assignment scope until both SAML and a narrowly scoped SCIM
+test pass. Make sure at least one OpenWork owner can sign in through Okta and
+that the current SSO configuration has passed OpenWork's **Test SSO before
+enabling it** flow.
 
 ## 1. Create the OpenWork SCIM connector
 
@@ -152,8 +155,9 @@ After the lifecycle and group tests pass:
 1. Assign the intended Okta users and groups to the application.
 2. Review Okta provisioning events for failures.
 3. Review OpenWork's SCIM health and unresolved-failure count.
-4. Confirm at least one owner has working Okta SAML access.
-5. Only then consider enabling **Require SSO for this organization**.
+4. Confirm at least one owner has working Okta SAML access through the enabled,
+   tested OpenWork SSO configuration.
+5. Keep password or other recovery access available until the rollout is stable.
 
 ## When to run reconciliation
 

--- a/packages/docs/cloud/sso-google-workspace.mdx
+++ b/packages/docs/cloud/sso-google-workspace.mdx
@@ -1,0 +1,188 @@
+---
+title: "Google Workspace SAML SSO"
+description: "Connect Google Workspace to OpenWork Cloud with SAML"
+---
+
+Use this guide when organization members should sign in to OpenWork through a
+Google Workspace custom SAML app.
+
+OpenWork keeps a new SSO configuration disabled until you verify the domain,
+complete a real authentication test, and explicitly enable SSO.
+
+## Before you start
+
+You need:
+
+- An OpenWork organization with the Enterprise SSO entitlement.
+- An OpenWork owner, or a member who can manage security configuration.
+- A Google Workspace super administrator who can create custom SAML apps.
+- Control of DNS for the email domain you will associate with the connection.
+- The final OpenWork auth origin, for example `https://app.openworklabs.com`.
+
+Keep password or existing recovery access available until an OpenWork owner has
+completed the Google SAML test and enabled SSO.
+
+<Note>
+For self-hosted deployments with separate web and API hosts, use the URLs that
+OpenWork shows in **Settings → SSO**. Do not replace them with a separate API
+origin unless your deployment or support guidance explicitly says to.
+</Note>
+
+## 1. Create the Google custom SAML app
+
+In the Google Admin console:
+
+1. Open **Apps → Web and mobile apps**.
+2. Select **Add app → Add custom SAML app**.
+3. Set **App name** to `OpenWork` or another recognizable workspace name.
+4. Select **Continue**.
+
+On **Google Identity Provider details**, keep the page open. You will copy these
+Google values into OpenWork:
+
+- **SSO URL**
+- **Entity ID**
+- **Certificate**
+
+Do not paste certificates, metadata, or setup secrets into tickets or shared
+notes.
+
+## 2. Copy Google values into OpenWork
+
+In OpenWork, open the organization dashboard, then **Settings → SSO**. Choose
+**SAML** and enter:
+
+| OpenWork field | Google value |
+| --- | --- |
+| IdP Issuer URL | Google **Entity ID**, for example `https://accounts.google.com/o/saml2?idpid=<idpid>` |
+| Domain | The Google Workspace email domain, for example `example.com` |
+| SAML Entry Point | Google **SSO URL** |
+| Audience URL | Leave blank so OpenWork uses the auth origin, unless support gives you a different audience |
+| IdP Certificate | Google **Certificate** |
+
+Save the SSO connection. OpenWork then shows setup values including:
+
+- **Sign-in URL**
+- **Redirect URL**
+- **ACS URL**
+- **Metadata URL**
+
+The saved configuration is still disabled at this point.
+
+## 3. Copy OpenWork values into Google
+
+Return to the Google custom SAML app setup. In **Service Provider Details**, set:
+
+| Google field | OpenWork value |
+| --- | --- |
+| ACS URL | OpenWork **ACS URL** |
+| Entity ID | The `entityID` from OpenWork **Metadata URL**, normally `https://app.openworklabs.com` for OpenWork Cloud |
+| Start URL | OpenWork **Sign-in URL** |
+| Signed response | Leave unchecked unless support asks you to sign the whole SAML response |
+| Name ID format | Email address |
+| Name ID value | Primary email |
+
+OpenWork requires Google to identify the user by a stable work email. Keep the
+Google **Name ID value** aligned with the email OpenWork should use for the
+member.
+
+<Warning>
+Google exposes two different SAML entity IDs. Use Google's IdP **Entity ID** in
+OpenWork's **IdP Issuer URL** field. Use OpenWork's metadata `entityID` in
+Google's **Service Provider Details → Entity ID** field. If you put the Google
+IdP entity ID into Google's service-provider Entity ID field, Google can reject
+SP-initiated login with `app_not_configured_for_user`.
+</Warning>
+
+To confirm the OpenWork service-provider entity ID, open the OpenWork
+**Metadata URL** and look for:
+
+```xml
+<EntityDescriptor entityID="https://app.openworklabs.com">
+```
+
+For OpenWork Cloud, that `entityID` is the same for the SSO test and for the
+real enabled login. The test uses the same saved SAML provider and ACS URL; only
+the post-authentication completion URL is test-specific.
+
+Select **Continue**.
+
+## 4. Skip optional mappings for the first SSO test
+
+On the Google mapping step, do not add custom attributes for the first SSO test
+unless your organization needs them. OpenWork's baseline SSO identity comes from
+NameID / primary email.
+
+If Google shows **Group membership (optional)**, leave it blank for the SSO
+test. Use SCIM-managed teams or another documented team-management process for
+authorization after SSO is working.
+
+Select **Finish**.
+
+## 5. Turn on the Google app for a test scope
+
+After the app is created, open **Apps → Web and mobile apps → OpenWork → User
+access** or **Service status**.
+
+Choose the narrowest safe test scope:
+
+- Turn the service on for a test group or organizational unit, when available.
+- Use **ON for everyone** only for a test Google Workspace or an intentional
+  rollout.
+
+Google's service-status page can show:
+
+- **ON for everyone**
+- **OFF for everyone**
+- **Groups**
+- **Organizational Units**
+
+Save the change. Google says most service changes take effect in a few minutes,
+but some can take longer to propagate.
+
+## 6. Verify the OpenWork domain
+
+In OpenWork **Settings → SSO**, select **Request token** under domain
+verification. Create a DNS TXT record for the email domain:
+
+| DNS field | Value |
+| --- | --- |
+| Type | `TXT` |
+| Host / name | The **Host / name** value OpenWork displays |
+| Value | The token OpenWork displays |
+
+Use the host value when your DNS provider appends the domain automatically. Use
+the full DNS name when your provider expects the complete record name.
+
+After the TXT record resolves publicly, select **Verify domain** in OpenWork.
+The token is a one-time proof and expires after seven days. After verification
+succeeds, you may remove the TXT record.
+
+## 7. Test and enable SSO in OpenWork
+
+After Google user access is on and OpenWork domain verification succeeds:
+
+1. In OpenWork **Settings → SSO**, select **Enable Config** or **Enable SSO**.
+2. In the **Test SSO before enabling it** dialog, select **SSO Login**.
+3. Complete Google authentication in the separate window.
+4. Return to OpenWork and confirm **Authentication test successful**.
+5. Select **Enable SSO**.
+
+SSO is not offered to organization members until you explicitly enable it after
+the successful test. If you edit the SSO configuration after a successful test,
+test it again before enabling. Test links expire after five minutes.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Google returns `403 app_not_configured_for_user` | Google's **Service Provider Details → Entity ID** does not exactly match the SAML request issuer from OpenWork | Open OpenWork **Metadata URL**, copy the `EntityDescriptor entityID` value, and paste that exact case-sensitive value into Google **Entity ID** |
+| Google returns `403 app_not_enabled_for_user` | The Google custom SAML app is not enabled for the test user | Open **User access** or **Service status** and turn the app on for the user's group, organizational unit, or everyone |
+| Google reports an ACS URL mismatch | Google's **ACS URL** differs from OpenWork's generated ACS URL | Copy OpenWork **ACS URL** into Google **Service Provider Details → ACS URL** exactly |
+| OpenWork shows **Verify the SSO domain before testing this configuration** | The DNS TXT proof has not passed yet | Create the TXT record shown by OpenWork, wait for DNS propagation, then select **Verify domain** |
+| The test dialog shows **The SSO authentication window was closed before the test completed** | The popup was closed or redirected away before OpenWork received the test result | Start a new test and keep the authentication window open until it returns or closes itself |
+| OpenWork will not enable SSO after editing settings | The current configuration has not been tested successfully | Run **SSO Login** again, then select **Enable SSO** after the successful test |
+| Google settings look correct but the same user still cannot test | Google service-status changes have not reached the user yet | Wait for propagation, confirm the user is in the enabled group or organizational unit, and retry |
+
+For member roles and access behavior after SSO sign-in, see
+[Members and RBAC](/cloud/members-and-rbac).

--- a/packages/docs/cloud/sso-microsoft-entra.mdx
+++ b/packages/docs/cloud/sso-microsoft-entra.mdx
@@ -19,6 +19,10 @@ You need:
 - Admin access to a Microsoft Entra enterprise application.
 - The final OpenWork auth origin, for example `https://app.openworklabs.com`.
 
+OpenWork keeps a new SSO configuration disabled until you verify the domain,
+complete a real authentication test, and explicitly enable SSO. Keep password or
+existing recovery access available during setup.
+
 ## 1. Create the Entra enterprise app
 
 In the Microsoft Azure portal, open **Microsoft Entra ID** and create a new
@@ -74,18 +78,53 @@ enter:
 | Audience URL | Leave blank so OpenWork uses the auth origin, unless support gives you a different audience |
 | IdP Certificate | The active **Certificate (Base64)** from Entra |
 
-Save the SSO connection. OpenWork then shows the generated ACS URL. Copy that
-ACS URL back into Entra's **Reply URL** if it was not available before the first
-save. Copy the OpenWork **Sign-in URL** into Entra's **Sign on URL** so the
-Entra tile can launch the same organization-scoped flow.
+Save the SSO connection. OpenWork then shows setup values including
+**Sign-in URL**, **Redirect URL**, **ACS URL**, and **Metadata URL**. Copy the
+generated **ACS URL** back into Entra's **Reply URL** if it was not available
+before the first save. Copy the OpenWork **Sign-in URL** into Entra's
+**Sign on URL** so the Entra tile can launch the same organization-scoped flow.
 
-## 5. Assign test users
+The saved configuration is still disabled at this point.
+
+## 5. Verify the email domain
+
+In OpenWork **Settings → SSO**, select **Request token** under domain
+verification. Create a DNS TXT record for the email domain:
+
+| DNS field | Value |
+| --- | --- |
+| Type | `TXT` |
+| Host / name | The **Host / name** value OpenWork displays |
+| Value | The token OpenWork displays |
+
+Use the host value when your DNS provider appends the domain automatically. Use
+the full DNS name when your provider expects the complete record name. After the
+TXT record resolves publicly, select **Verify domain** in OpenWork.
+
+The token is a one-time proof and expires after seven days. After verification
+succeeds, you may remove the TXT record.
+
+## 6. Assign test users
 
 In Entra, open the enterprise application's **Users and groups** page and assign
 the users who should be allowed to sign in.
 
 For external users, assign the guest identity shown by Entra, not only the
 original external email address.
+
+## 7. Test and enable SSO in OpenWork
+
+After the Entra assignment and domain verification are complete:
+
+1. In OpenWork **Settings → SSO**, select **Enable Config** or **Enable SSO**.
+2. In the **Test SSO before enabling it** dialog, select **SSO Login**.
+3. Complete Microsoft authentication in the separate window.
+4. Return to OpenWork and confirm **Authentication test successful**.
+5. Select **Enable SSO**.
+
+SSO is not offered to organization members until you explicitly enable it after
+the successful test. If you edit the SSO configuration after a successful test,
+test it again before enabling. Test links expire after five minutes.
 
 ## Troubleshooting
 
@@ -96,3 +135,6 @@ original external email address.
 | `/?error=unsolicited_response&error_description=IdP-initiated+SSO+not+allowed` | The deployment is running an older OpenWork version that rejects IdP-initiated SAML | Upgrade OpenWork, or launch from the org-specific OpenWork **Sign-in URL** |
 | User reaches Microsoft but cannot continue | The user is not assigned to the enterprise application | Add the user under **Users and groups** |
 | Reply URL mismatch | Entra's Reply URL does not match the OpenWork ACS URL exactly | Copy the ACS URL from OpenWork and paste it into Entra |
+| OpenWork shows **Verify the SSO domain before testing this configuration** | The DNS TXT proof has not passed yet | Create the TXT record shown by OpenWork, wait for DNS propagation, then select **Verify domain** |
+| The test dialog shows **The SSO authentication window was closed before the test completed** | The popup was closed or redirected away before OpenWork received the test result | Start a new test and keep the authentication window open until it returns or closes itself |
+| OpenWork will not enable SSO after editing settings | The current configuration has not been tested successfully | Run **SSO Login** again, then select **Enable SSO** after the successful test |

--- a/packages/docs/cloud/sso-okta.mdx
+++ b/packages/docs/cloud/sso-okta.mdx
@@ -20,9 +20,9 @@ You need:
 - The final HTTPS OpenWork web origin, for example
   `https://openwork.example.com`.
 
-Keep **Require SSO for this organization** off until an owner has completed a
-fresh SAML sign-in. Keep password access available as a recovery path during
-setup.
+OpenWork keeps a new SSO configuration disabled until you verify the domain,
+complete a real authentication test, and explicitly enable SSO. Keep password
+access available as a recovery path during setup.
 
 <Note>
 For a Helm deployment with separate web and API hosts, use the URLs OpenWork
@@ -105,9 +105,13 @@ In OpenWork, open **Settings → SSO**, select **SAML**, and enter:
 | Audience URL | Leave blank to use the configured OpenWork auth origin |
 | IdP Certificate | **X.509 Certificate** |
 
-Save the connection. Compare the generated **ACS URL** with Okta's
-**Single sign-on URL** character for character. Also copy the generated
-OpenWork **Sign-in URL**; use this URL for the first test.
+Save the connection. OpenWork then shows setup values including **Sign-in URL**,
+**Redirect URL**, **ACS URL**, and **Metadata URL**. Compare the generated
+**ACS URL** with Okta's **Single sign-on URL** character for character. Also
+copy the generated OpenWork **Sign-in URL** into Okta if you want the Okta tile
+to launch the same organization-scoped flow.
+
+The saved configuration is still disabled at this point.
 
 ## 5. Verify the email domain
 
@@ -142,10 +146,17 @@ In the Okta application:
 
 Do not assign broad groups until the test user can complete the full flow.
 
-## 7. Test SP-initiated sign-in
+## 7. Test and enable SSO in OpenWork
 
-Open the organization-specific OpenWork **Sign-in URL** in a fresh browser
-session. Confirm that:
+After the Okta assignment and domain verification are complete:
+
+1. In OpenWork **Settings → SSO**, select **Enable Config** or **Enable SSO**.
+2. In the **Test SSO before enabling it** dialog, select **SSO Login**.
+3. Complete Okta authentication in the separate window.
+4. Return to OpenWork and confirm **Authentication test successful**.
+5. Select **Enable SSO**.
+
+During the test, confirm that:
 
 1. OpenWork redirects to the expected Okta tenant.
 2. Okta authenticates the assigned user.
@@ -154,8 +165,11 @@ session. Confirm that:
 5. The member identity in OpenWork uses the same email that Okta sent as
    NameID.
 
-Only after this succeeds should you configure SCIM or enable
-**Require SSO for this organization**.
+SSO is not offered to organization members until you explicitly enable it after
+the successful test. If you edit the SSO configuration after a successful test,
+test it again before enabling. Test links expire after five minutes.
+
+Only after this succeeds should you configure SCIM.
 
 ## Troubleshooting
 
@@ -167,3 +181,6 @@ Only after this succeeds should you configure SCIM or enable
 | `invalid_destination` or `invalid_recipient` | Okta is posting to a different URL than OpenWork expects | Copy the generated OpenWork ACS URL into Okta and keep **Use this for Recipient URL and Destination URL** enabled |
 | `Invalid SAML response` | The assertion is unsigned, uses a deprecated algorithm, or the active Okta certificate differs from OpenWork | Sign the assertion with RSA-SHA256 and paste Okta's current active X.509 certificate into OpenWork |
 | Okta refuses access | The person is not assigned to the application | Assign the test user under **Assignments** |
+| OpenWork shows **Verify the SSO domain before testing this configuration** | The DNS TXT proof has not passed yet | Create the TXT record shown by OpenWork, wait for DNS propagation, then select **Verify domain** |
+| The test dialog shows **The SSO authentication window was closed before the test completed** | The popup was closed or redirected away before OpenWork received the test result | Start a new test and keep the authentication window open until it returns or closes itself |
+| OpenWork will not enable SSO after editing settings | The current configuration has not been tested successfully | Run **SSO Login** again, then select **Enable SSO** after the successful test |

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -157,6 +157,8 @@
             ]
           },
           "cloud/members-and-rbac",
+          "cloud/sso-google-workspace",
+          "cloud/scim-google-workspace",
           "cloud/sso-okta",
           "cloud/scim-okta",
           "cloud/sso-microsoft-entra",


### PR DESCRIPTION
## Summary
- add Google Workspace SAML SSO setup docs with the verified entity ID fix and test-before-enable flow
- document that Google Workspace custom SAML apps do not currently expose generic outbound SCIM provisioning for OpenWork
- update Okta and Microsoft Entra SSO/SCIM docs for the new explicit SSO test and enable flow

## Verification
- docs-only change; runtime proof skipped per repo guidance
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8')); console.log('docs.json ok')"`