### PR TITLE
fix(server): fence browser policy checks during identity enrollment

### DIFF
--- a/apps/server/src/managed-desktop-policy.test.ts
+++ b/apps/server/src/managed-desktop-policy.test.ts
@@ -23,12 +23,13 @@ if (process.env.OPENWORK_MANAGED_POLICY_TEST_CHILD !== "1") {
   const delay = mock((ms: number) => { waiting.resolve(ms); return release.promise; });
   const externalFetch = mock(async (_url: string, _init?: RequestInit) => Response.json(policy));
   const parse = mock((_value: unknown) => policy);
+  const read = mock(async (): Promise<{ managedPolicy?: typeof policy }> => ({}));
   const write = mock(async (_config: ServerConfig, _policy: unknown) => ({ changed: false }));
   mock.module("node:timers/promises", () => ({ setTimeout: delay }));
   mock.module("./server-fetch.js", () => ({ externalFetch }));
   mock.module("@openwork/types/den/desktop-policies-runtime", () => ({ desktopConfigSchema: { parse } }));
   mock.module("./runtime-opencode-config-store.js", () => ({
-    readGlobalRuntimeOpencodeConfig: async () => ({}), writeManagedDesktopPolicy: write,
+    readGlobalRuntimeOpencodeConfig: read, writeManagedDesktopPolicy: write,
     runtimeProviderMap: () => ({}),
   }));
   mock.module("./workspace-kv-store.js", () => ({
@@ -50,10 +51,33 @@ if (process.env.OPENWORK_MANAGED_POLICY_TEST_CHILD !== "1") {
     delay.mockClear();
     externalFetch.mockReset().mockImplementation(async () => Response.json(policy));
     parse.mockReset().mockImplementation(() => policy);
+    read.mockReset().mockImplementation(async () => ({}));
     write.mockClear();
     service = managedDesktopPolicy({ ...config });
   });
   afterEach(() => { release.resolve(); });
+
+  test.each([false, true])("no-session browser evaluation fences identity installation during its persisted read (install=%s)", async (install) => {
+    const reading = Promise.withResolvers<void>();
+    const persisted = Promise.withResolvers<Awaited<ReturnType<typeof read>>>();
+    read.mockImplementationOnce(() => { reading.resolve(); return persisted.promise; });
+    const result = service.assert("browser", { url: "https://unapproved.example" }).catch((error: unknown) => error);
+    await reading.promise;
+    if (install) await service.setSession(session);
+    persisted.resolve({});
+    if (install) expect(await result).toMatchObject({ code: "policy_identity_changed", status: 409 });
+    else expect(await result).toBeUndefined();
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(externalFetch).toHaveBeenCalledTimes(install ? 1 : 0);
+    expect(write).toHaveBeenCalledTimes(install ? 1 : 0);
+  });
+
+  test("no-session browser evaluation keeps retained managed policy fail closed", async () => {
+    read.mockResolvedValue({ managedPolicy: policy });
+    await expect(service.assert("browser", { url: "https://unapproved.example" })).rejects.toMatchObject({ code: "policy_unavailable", status: 403 });
+    expect(externalFetch).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
 
   test("503 waits for the explicit 200ms release before the second read succeeds", async () => {
     externalFetch.mockImplementationOnce(async () => new Response(null, { status: 503 }));

--- a/apps/server/src/managed-desktop-policy.ts
+++ b/apps/server/src/managed-desktop-policy.ts
@@ -144,12 +144,14 @@ class ManagedDesktopPolicy {
   }
   private async fetchCurrent(): Promise<DesktopConfig | null> {
     const session = this.session;
+    const generation = this.generation;
     if (!session) {
       const persisted = await readGlobalRuntimeOpencodeConfig(this.config);
+      // A local-only read cannot grant access after a managed identity arrives.
+      this.identityChanged(generation);
       if (persisted.managedPolicy) throw new ApiError(403, "policy_unavailable", "Sign in to verify your organization's policy before continuing.");
       return null;
     }
-    const generation = this.generation;
     let policy: DesktopConfig;
     try {
       policy = desktopConfigSchema.parse(await this.readDenJson(session, "/v1/me/desktop-config", generation));

--- a/apps/server/src/managed-policy-rules.test.ts
+++ b/apps/server/src/managed-policy-rules.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import type { DesktopConfig } from "@openwork/types/den/desktop-policies";
+import { policyDenial } from "./managed-policy-rules.js";
+
+test("approved browser origins reject file URLs while allowing an approved HTTPS page", () => {
+  const policy: DesktopConfig = {
+    execution: { commands: "allow", blockedCommands: [], browserOrigins: ["https://approved.example"], blockBrowserUploads: false },
+  };
+  expect(policyDenial(policy, "browser", { url: "https://approved.example/page" })).toBeNull();
+  expect(policyDenial(policy, "browser", { url: "file:///tmp/browser-policy-witness.html" })).toBe("This website is not approved by your organization.");
+});

--- a/docs/desktop-app-policies.md
+++ b/docs/desktop-app-policies.md
@@ -12,6 +12,8 @@ Do not duplicate the list of policy IDs in app docs or feature code unless a fea
 
 `allowedDesktopVersions` is part of the desktop config response but is not a boolean policy item in `desktopPolicyDefinitions`.
 
+`execution.browserOrigins` is the canonical approved-site list. `desktopExecutionPolicySchema` validates exact HTTP(S) origins, and `resolveDesktopExecutionPolicy()` intersects matching lists; omission adds no restriction and `[]` denies every site. Enforcement is server-owned in `apps/server/src/managed-desktop-policy.ts` and `managed-policy-rules.ts`, called by the native request guard in `apps/desktop/electron/browser-panel.mjs`, not a renderer-pushed host list. See [Approved websites](../packages/docs/cloud/share-with-your-team/desktop-policies.mdx#approved-websites) for configuration and scope.
+
 For boolean policy keys, `false` means the feature is restricted or disabled. `true` or `undefined` means the app should not block the feature locally.
 
 ## Organization Prompt Suggestions

--- a/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
+++ b/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
@@ -20,6 +20,30 @@ Current desktop policy keys map to concrete product capabilities:
 
 Legacy desktop policies combine grants from the default policy and every assigned policy: any grant can allow a capability. Explicit Team Access blocks are applied afterward and take precedence over those grants. Restrict members by turning capabilities off in the default policy, then grant more to specific members or teams with assigned policies.
 
+## Approved websites
+
+Limit the built-in browser without turning off all built-in extensions:
+
+1. Open **Members > Teams > your team > Access** and expand **Browse websites**.
+2. Set **Website access** to **Approved sites only**, enter a complete site address, and choose **Add site** for each website.
+3. Choose **Review changes**, then **Save permissions**.
+
+In the general **Desktop policies** editor, the same setting is **Restrict browsing to approved sites** under **Commands & browser**, with one address per line.
+
+Approved websites are exact HTTP or HTTPS origins: the scheme, hostname, and port together. For example, `https://portal.example.com` permits pages on that origin, but not `http://portal.example.com`, `https://portal.example.com:8443`, or `https://docs.portal.example.com`. Default ports normalize to the same origin, so `https://portal.example.com:443` is equivalent to `https://portal.example.com`.
+
+- Add up to 100 complete site addresses per policy, without paths, sign-in credentials, queries, or fragments.
+- Add subdomains, sign-in sites, and resource sites separately. Wildcards do not grant access to subdomains.
+- Rules cover browser requests, including navigation, redirects, frames, and resources such as scripts and images. A resource from an unapproved origin is blocked even when the page itself is approved.
+- **Blocked**, or an empty approved-site list, denies all websites. Removing the final site does not turn restrictions off.
+- **All websites** removes this policy's approved-site restriction. It does not override restrictions from another applicable policy or the **Built-in Extensions** control.
+
+Unlike legacy boolean grants, approved-site restrictions **intersect** across the default policy and all matching member, team, and role policies. A site must appear in every applicable restricted list. A targeted policy can restrict browsing even when the default policy allows all websites. Policies without an approved-site list impose no additional origin restriction.
+
+The policy document stores these settings in `execution.browserOrigins`: an omitted field adds no origin restriction, while `[]` denies every website. The local policy service verifies managed browser requests independently of the desktop's cached display settings. If managed policy cannot be verified, requests are blocked; signing out does not clear retained managed restrictions into unrestricted browsing. This does not prevent genuinely unmanaged local use.
+
+Once approved-site policy has reached the managed engine, generated permissions block that engine's built-in `websearch` and `webfetch` tools. Changes can wait for an engine refresh; this is not a fresh Den check before every tool call and does not filter third-party MCP search or fetch traffic. **Upload files & submit forms** is a separate built-in-browser restriction: it blocks WebSocket connections, requests with upload data, and methods other than `GET`, `HEAD`, and `OPTIONS`. GET-based forms and other read URLs can still send data to approved sites. These controls are not device-wide data-loss prevention: allowed computer commands and third-party connections can use other network transports. Block computer commands too when members must not use that route.
+
 ## Restricted mode
 
 Every policy has a mode selector at the top of its editor:


### PR DESCRIPTION
## Current scope

This PR is reconstructed on current `dev` to finish browser-policy review findings. It no longer introduces `allowedBrowserHosts`: approved-site enforcement already landed through #4564 and later work as `execution.browserOrigins`.

The historical wildcard/subdomain expansion, union-of-host grants, renderer-pushed policy cache, and empty-means-unrestricted behavior are deliberately not restored. Current exact HTTP(S) origins, intersecting restrictions, empty-list denial, and server-owned enforcement remain authoritative.

## Fix

An evaluation that began without a managed identity could await an empty persisted-policy read, then return unrestricted after a managed identity had arrived. Extend the existing generation fence across that read so stale evaluations reject with `policy_identity_changed`.

- Add a deterministic enrollment-race regression, an unchanged-identity unmanaged control, and retained-managed-policy denial.
- Add a focused matcher regression for `file://` denial alongside approved HTTPS allowance.
- Document the current approved-website UI, exact-origin matching, intersecting restrictions, empty-list denial, engine-refresh timing, and upload/form/network limitations.

Genuinely unmanaged local browsing remains allowed. This does not redefine the enrollment boundary, restore retired engine hooks, replace already-open pages, or redesign the new-tab experience. #4836's merged shortcuts remain intact.

## Review reconciliation

- LZ8-9QN: the old startup policy push is replaced on dev. This change closes the remaining identity-installation race in the canonical evaluator.
- LR2-YZ3: current native interception uses `<all_urls>` and does not exempt `file:`; the canonical matcher only accepts approved HTTP(S) origins. The new matcher regression verifies denial, but is not native file-navigation proof.
- HDD-QBP: the old rollout finding concerns a superseded field and was already resolved. Current deployment order is not asserted by this source change.

## Verification

**Verdict: Incomplete — native enrollment/file-request evidence and the CI-pinned runtime check remain outstanding.**

Current head: `03820db8a7519878206131f3e8d96d3f5b340d5a`, based on `dev@23143497940c871bda4a9aaebb82bd86c3f95530`.

Passed from `apps/server`:

- `bun --conditions=development test src/managed-desktop-policy.test.ts` — exit 0; **10 service tests passed**, 52 assertions, plus the passing isolation-wrapper test. The same new regression failed before the production fix (9 pass / 1 fail inside the wrapper).
- `bun test --conditions=development --preload ../../../browser-policy-test-deps.mjs ./src/managed-policy-rules.test.ts` — exit 0; **1 passed**, 2 assertions. The temporary preload aliases the real installed Zod 4.3.6 dependency without replacing its implementation. Omit the preload in a normally installed workspace.
- `git diff --check origin/dev...HEAD` — exit 0.

No successful test was skipped. Local Bun was **1.3.4**, not CI's pinned 1.3.14; that runtime check is deferred. Initial dependency setup for the matcher test failed to resolve Zod and was corrected before the passing run.

Not run: native Electron/Den journey, package builds, or whole-package typechecks. The runtime owner remains `evals/specs/desktop-policy-restricted-mode.e2e.test.ts`; its first-enrollment and native file-request assertions are still missing. A page-context `fetch(file://...)` would not distinguish policy denial from Chromium restrictions, so it is not used as substitute proof. Historical allowlist evidence on the old head is not evidence for this reconstruction.
