### PR TITLE
fix(desktop): stop the blank initialize load from aborting browser.open_url

### DIFF
--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -153,7 +153,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       throw new Error(`Browser provider is not available yet: ${requestedProvider}`);
     }
     const url = normalizeBrowserUrl(rawUrl);
-    const tab = createBrowserTab("about:blank", { select: true });
+    // The marker page is loaded right away, so skip the blank initialize load:
+    // a queued about:blank navigation would abort this awaited load with
+    // ERR_ABORTED and fail the agent's request before the page ever opens.
+    const tab = createBrowserTab("about:blank", { select: true, initializeBlank: false });
     await tab.view.webContents.loadURL(browserTargetMarkerUrl(tab.tabId));
     const targetId = await resolveBrowserCdpTargetId(tab.tabId);
     await tab.view.webContents.loadURL(url);
@@ -472,7 +475,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     callback(browserProxy.username, browserProxy.password);
   });
 
-  function createBrowserTab(url = "about:blank", { select = true } = {}) {
+  function createBrowserTab(url = "about:blank", { select = true, initializeBlank = true } = {}) {
     const tabId = createBrowserTabId();
     const view = new WebContentsView({
       webPreferences: {
@@ -489,7 +492,11 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     browserTabOrder.push(tabId);
     // Load about:blank immediately to preempt persistent-session restore.
     // Cookies live on the session object, not the document — they survive this.
-    runDetachedTask("initialize browser tab", () => view.webContents.loadURL("about:blank"));
+    // Callers that load their own page synchronously opt out, because this
+    // queued navigation would otherwise abort theirs.
+    if (initializeBlank) {
+      runDetachedTask("initialize browser tab", () => view.webContents.loadURL("about:blank"));
+    }
     view.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
       runDetachedTask("open browser popup externally", () => shell.openExternal(targetUrl));
       return { action: "deny" };

--- a/evals/specs/browser-open-url-returns-target.e2e.test.ts
+++ b/evals/specs/browser-open-url-returns-target.e2e.test.ts
@@ -1,0 +1,129 @@
+import { expect } from "vitest";
+import { control, createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
+import { connect, debuggerUrlFor, evaluate, targetById } from "@openwork/cdp";
+import { desktop } from "@openwork/hosts";
+import { needs, test } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const title = e2eTestsEnabled
+  ? "browser.open_url opens the page and hands the agent a live CDP target for it"
+  : "browser.open_url target handoff skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1";
+
+// The desktop's own local OpenWork server answers GET /health without a token
+// on the app host's loopback, so the proof needs no public internet.
+const HEALTH_BODY_MARKER = '"ok":true';
+
+type Surface = Parameters<typeof evalIn>[0];
+type OpenUrlResult = { provider: string; browser_url: string; target_id: string; tab_id: string; url: string };
+
+function isOpenUrlResult(value: unknown): value is OpenUrlResult {
+  return typeof value === "object" && value !== null
+    && typeof Reflect.get(value, "provider") === "string"
+    && typeof Reflect.get(value, "browser_url") === "string"
+    && typeof Reflect.get(value, "target_id") === "string"
+    && typeof Reflect.get(value, "tab_id") === "string"
+    && typeof Reflect.get(value, "url") === "string";
+}
+
+function jsString(value: string): string {
+  return JSON.stringify(value);
+}
+
+async function localServerPort(app: Surface): Promise<number> {
+  const port = await evalIn(app, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return null;
+    return Number(new URL(String(info.baseUrl)).port) || null;
+  })()`, { awaitPromise: true });
+  if (typeof port !== "number") throw new Error(`Local OpenWork server is not running: ${JSON.stringify(port)}`);
+  return port;
+}
+
+/** The agent-facing control action — the exact path the OpenWork browser tool uses. */
+async function openUrl(app: Surface, url: string): Promise<OpenUrlResult> {
+  const result = await control(app, "browser.open_url", { url, provider: "builtin" });
+  if (!isOpenUrlResult(result)) throw new Error(`browser.open_url did not return a tab handle: ${JSON.stringify(result)}`);
+  return result;
+}
+
+async function waitForLoadedTab(app: Surface, tabId: string, url: string): Promise<void> {
+  await waitFor(
+    app,
+    `window.__OPENWORK_ELECTRON__.browser.getState().then((state) =>
+      (state?.tabs ?? []).some((tab) => tab.id === ${jsString(tabId)} && tab.url === ${jsString(url)} && tab.status === "ready"))`,
+    { awaitPromise: true, timeoutMs: 30_000, label: `tab ${tabId} loaded ${url}` },
+  );
+}
+
+async function waitForPageBody(client: Awaited<ReturnType<typeof connect>>, marker: string): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let last: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      last = await evaluate(client, "document.body ? document.body.innerText : null");
+      if (typeof last === "string" && last.includes(marker)) return;
+    } catch {
+      // Navigation in flight.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Page body never contained ${JSON.stringify(marker)}; last ${JSON.stringify(last)}.`);
+}
+
+test.skipIf(!e2eTestsEnabled)(title, async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using app = await desktop({ name: "browser-open-url-returns-target" });
+  await createAndSelectWorkspace(app, { path: `/tmp/openwork-browser-open-url-returns-target-${Date.now()}` });
+  const port = await localServerPort(app);
+  const pageUrl = (path: string) => `http://127.0.0.1:${port}/health?${path}`;
+
+  // Claim 1: the action resolves with a built-in browser handle instead of rejecting.
+  const first = await openUrl(app, pageUrl("first"));
+  expect(first.provider).toBe("builtin");
+  expect(first.url).toBe(pageUrl("first"));
+  evidence.recordAssertionEvidence(
+    "browser.open_url resolves with a built-in browser handle",
+    `The control action returned provider ${first.provider}, tab ${first.tab_id}, and CDP target ${first.target_id} for ${first.url}.`,
+    true,
+  );
+
+  // Claim 2: the tab it created finishes loading the requested page.
+  await waitForLoadedTab(app, first.tab_id, pageUrl("first"));
+  evidence.recordAssertionEvidence(
+    "The new tab loads the requested page",
+    `Tab ${first.tab_id} reports url ${pageUrl("first")} with status ready.`,
+    true,
+  );
+
+  // Claim 3: the returned target id is a live page target of the same Electron CDP
+  // endpoint the harness drives the app through, and it shows the loaded page.
+  // (`browser_url` is the app host's loopback, which a remote driver cannot dial.)
+  const appCdpPort = new URL(app.handle.cdpUrl).port;
+  if (appCdpPort) expect(new URL(first.browser_url).port).toBe(appCdpPort);
+  const target = await targetById(app.handle.cdpUrl, first.target_id);
+  const client = await connect(debuggerUrlFor(app.handle.cdpUrl, target));
+  try {
+    await waitForPageBody(client, HEALTH_BODY_MARKER);
+    const location = await evaluate(client, "window.location.href");
+    expect(location).toBe(pageUrl("first"));
+  } finally {
+    client.close();
+  }
+  evidence.recordAssertionEvidence(
+    "The returned CDP target is the loaded page",
+    `Target ${first.target_id} answered Runtime.evaluate with location ${pageUrl("first")} and a body containing ${HEALTH_BODY_MARKER}.`,
+    true,
+  );
+
+  // Claim 4: a second request opens a second tab; agents open many pages per task.
+  const second = await openUrl(app, pageUrl("second"));
+  expect(second.tab_id).not.toBe(first.tab_id);
+  expect(second.target_id).not.toBe(first.target_id);
+  await waitForLoadedTab(app, second.tab_id, pageUrl("second"));
+  evidence.recordAssertionEvidence(
+    "A second browser.open_url opens a second, independent tab",
+    `Tab ${second.tab_id} (target ${second.target_id}) loaded ${pageUrl("second")} while tab ${first.tab_id} stayed separate.`,
+    true,
+  );
+});

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -277,6 +277,17 @@
       ]
     },
     {
+      "id": "desktop.builtin-browser",
+      "description": "Built-in browser panel: tab lifecycle, agent-facing open_url handoff, and CDP target resolution",
+      "implementation": [
+        "apps/desktop/electron/browser-content-preload.cjs",
+        "apps/desktop/electron/browser-panel.mjs"
+      ],
+      "specs": [
+        "evals/specs/browser-open-url-returns-target.e2e.test.ts"
+      ]
+    },
+    {
       "id": "desktop.chat-composer",
       "description": "Desktop chat rendering, composer drafts, queued sends, attachments, and resend behavior",
       "implementation": [


### PR DESCRIPTION
## Problem

Since #4207 started loading `about:blank` on every new built-in browser tab (to preempt persistent-session restore), the agent-facing `browser.open_url` action has rejected every request with:

```
Error invoking remote method 'openwork:browser:openUrl': Error: ERR_ABORTED (-3) loading 'about:blank'
```

`openBrowserUrlForAutomation` creates the tab and immediately awaits the CDP marker-page load. The blank initialize load is queued as a detached task, so it starts *after* the marker load and aborts it; Electron's `loadURL` promise rejects with the aborting navigation's URL, the IPC call fails, and the tool never returns a target or opens the page. Every agent browser session that begins with `browser.open_url` has been failing on `dev` for a week.

Reproduced on clean `dev@e0ce31da9`: the spec added here fails there with exactly that error (`pnpm evals:e2e browser-open-url-returns-target`, exit 1, 0 passed / 1 failed).

## Change

- `createBrowserTab(url, { select, initializeBlank = true })`: callers that load their own page synchronously can opt out of the blank initialize load.
- `openBrowserUrlForAutomation` passes `initializeBlank: false`. The marker page it loads right away already preempts session restore, so nothing is lost.
- Every other tab-creation path keeps the blank load unchanged; their first navigation is queued the same way, so it was never aborted.

## Verification

Runtime proof — `evals/specs/browser-open-url-returns-target.e2e.test.ts`, mapped to a new `desktop.builtin-browser` contract (`browser-panel.mjs`, `browser-content-preload.cjs`). It drives the real control action against the desktop's own local server page (`/health`, no token, loopback), so nothing depends on the public internet. Claims: the action resolves with a built-in handle; the tab loads the requested page; the returned CDP target answers `Runtime.evaluate` for that page; a second request opens a second, independent tab.

**Daytona lane, exact head `08e83debf`:**

```
OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_DAYTONA_SANDBOX=<sandbox> OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e browser-open-url-returns-target
exit 0 · 1 passed, 0 failed, 0 skipped · 4/4 assertion claims (published below)
```

Negative control, identical spec on clean `dev@e0ce31da9`, local: exit 1, `ERR_ABORTED (-3) loading 'about:blank'`. The spec also passes locally on this branch (1/0/0).

Also green on this head:

```
pnpm --filter @openwork/desktop test              294 pass, 0 fail, 1 skipped (pre-existing)
pnpm evals:pr specs/daytona-e2e-singles-toolchain.test.ts specs/daytona-e2e-regression-{concurrency,schedule}.test.ts   8 pass
pnpm --dir evals run lint:layers                  no violations
node evals/scripts/spec-impact.mjs                desktop.builtin-browser covered by the changed E2E test
```

**Verdict: Passed.**

## Related

- #4207 introduced the blank initialize load.
- #4328 (browser URL allowlist policy) currently carries the same two-line fix so its own proof could run; it will drop it on rebase once this lands.
