### PR TITLE
feat(app): drop SheetJS from the artifact spreadsheet preview

### DIFF
--- a/.github/workflows/alpha-macos-aarch64.yml
+++ b/.github/workflows/alpha-macos-aarch64.yml
@@ -25,6 +25,7 @@ on:
       - packages/paths/**
       - packages/types/**
       - packages/ui/**
+      - packages/workbook/**
       - patches/**
       - scripts/release/**
       - constants.json

--- a/.github/workflows/build-electron-desktop.yml
+++ b/.github/workflows/build-electron-desktop.yml
@@ -9,6 +9,7 @@ on:
       - apps/app/**
       - apps/desktop/**
       - packages/ui/**
+      - packages/workbook/**
       - constants.json
       - pnpm-lock.yaml
       - package.json

--- a/.github/workflows/publish-ee-images.yml
+++ b/.github/workflows/publish-ee-images.yml
@@ -42,6 +42,7 @@ on:
       - "packages/mcp-apps/**"
       - "packages/types/**"
       - "packages/ui/**"
+      - "packages/workbook/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "package.json"

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -50,6 +50,7 @@
     "@openwork/install-config": "workspace:*",
     "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",
+    "@openwork/workbook": "workspace:*",
     "@paper-design/shaders-react": "0.0.72",
     "@pierre/diffs": "1.3.5",
     "@pierre/trees": "1.0.0-beta.6",
@@ -88,7 +89,6 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -39,7 +39,7 @@ export function isMarkdownPreviewSupported(extension: string) {
 }
 
 export function isSheetPreviewSupported(extension: string) {
-  return ["csv", "tsv", "xlsx", "xls", "ods"].includes(extension);
+  return ["csv", "tsv", "xlsx"].includes(extension);
 }
 
 export function isImagePreviewSupported(extension: string) {

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts
@@ -1,3 +1,5 @@
+import { cellInputFromText, openXlsxWorkbook, sheetGridRows, writeXlsxWorkbook } from "@openwork/workbook";
+
 import type { Data } from "./open-target";
 
 export type SpreadsheetRows = string[][];
@@ -83,12 +85,30 @@ function serializeDelimited(rows: SpreadsheetRows, delimiter: string) {
     .join("\n") + "\n";
 }
 
-function normalizeRows(rows: unknown[][]): SpreadsheetRows {
-  const next = rows.map((row) => row.map((cell) => cell == null ? "" : String(cell)));
-
-  return next.length ? next : [[""]];
+function unsupportedWorkbookMessage(ext: string) {
+  if (ext === "xls") return "Legacy .xls workbooks can't be edited here. Save the file as .xlsx and open it again.";
+  if (ext === "ods") return "OpenDocument spreadsheets can't be edited here. Export the file as .xlsx and open it again.";
+  return null;
 }
 
+function workbookBytes(content: Data): Uint8Array {
+  return new Uint8Array(content.kind === "binary" ? content.data : new ArrayBuffer(0));
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+
+  copy.set(bytes);
+
+  return copy.buffer;
+}
+
+/**
+ * Rows of the first sheet as a dense grid anchored at A1, so cell positions
+ * survive a save. Values are the stored values: numbers as written, booleans
+ * as TRUE/FALSE, date-formatted serials as ISO dates, formulas by their last
+ * calculated result.
+ */
 export async function parseSpreadsheet(input: { name: string; content: Data }): Promise<SpreadsheetRows> {
   const ext = extension(input.name);
 
@@ -96,19 +116,20 @@ export async function parseSpreadsheet(input: { name: string; content: Data }): 
     return parseDelimited(input.content.kind === "text" ? input.content.data : "", delimiterForName(input.name));
   }
 
-  const XLSX = await import("xlsx");
-  const workbook = XLSX.read(input.content.kind === "binary" ? input.content.data : new ArrayBuffer(0), { type: "array" });
-  const firstSheetName = workbook.SheetNames[0];
+  const unsupported = unsupportedWorkbookMessage(ext);
+  if (unsupported) throw new Error(unsupported);
 
-  if (!firstSheetName) { 
-    return [[""]]; 
-  }
+  const workbook = await openXlsxWorkbook(workbookBytes(input.content));
+  const sheet = await workbook.readSheet(workbook.sheets[0]);
 
-  const sheet = workbook.Sheets[firstSheetName];
-
-  return normalizeRows(XLSX.utils.sheet_to_json(sheet, { header: 1, raw: false, blankrows: true }) as unknown[][]);
+  return sheetGridRows(sheet);
 }
 
+/**
+ * Writes the edited grid back. Delimited files stay text; workbooks become a
+ * single-sheet .xlsx whose cells keep their types (canonical numbers, TRUE and
+ * FALSE, and "=" formulas) instead of turning every value into text.
+ */
 export async function serializeSpreadsheet(name: string, rows: SpreadsheetRows): Promise<Data> {
   const ext = extension(name);
 
@@ -116,22 +137,12 @@ export async function serializeSpreadsheet(name: string, rows: SpreadsheetRows):
     return { kind: "text", data: serializeDelimited(rows, delimiterForName(name)) };
   }
 
-  const XLSX = await import("xlsx");
-  const workbook = XLSX.utils.book_new();
+  const unsupported = unsupportedWorkbookMessage(ext);
+  if (unsupported) throw new Error(unsupported);
 
-  XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet(rows), "Sheet1");
+  const { bytes } = await writeXlsxWorkbook([
+    { name: "Sheet1", header: false, rows: rows.map((row) => row.map((value) => cellInputFromText(String(value ?? "")))) },
+  ]);
 
-  const bookType = ext === "xls" ? "xls" : ext === "ods" ? "ods" : "xlsx";
-  const output = XLSX.write(workbook, { type: "array", bookType });
-
-  if (output instanceof ArrayBuffer) {
-    return { kind: "binary", data: output };
-  }
-
-  const view = output as Uint8Array;
-  const copy = new Uint8Array(view.byteLength);
-
-  copy.set(view);
-
-  return { kind: "binary", data: copy.buffer };
+  return { kind: "binary", data: toArrayBuffer(bytes) };
 }

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -106,7 +106,7 @@ function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPrev
   if (kind === "url") return "browser";
   const ext = extname(value);
   if ([".md", ".markdown", ".mdx", ".mmd"].includes(ext)) return "markdown";
-  if ([".csv", ".tsv", ".xlsx", ".xls", ".ods"].includes(ext)) return "sheet";
+  if ([".csv", ".tsv", ".xlsx"].includes(ext)) return "sheet";
   if ([".ppt", ".pptx", ".pptm", ".pot", ".potx", ".odp", ".key", ".sxi"].includes(ext)) return "slides";
   if (ext === ".docx") return "document";
   if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"].includes(ext)) return "image";

--- a/apps/app/tests/artifact-spreadsheet-model.test.ts
+++ b/apps/app/tests/artifact-spreadsheet-model.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { openXlsxWorkbook, writeXlsxWorkbook } from "@openwork/workbook";
+
+import { parseSpreadsheet, serializeSpreadsheet } from "../src/react-app/domains/session/artifacts/artifact-spreadsheet-model";
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+describe("artifact spreadsheet model", () => {
+  test("round-trips CSV edits", async () => {
+    const rows = await parseSpreadsheet({ name: "artifact-eval.csv", content: { kind: "text", data: "name,revenue\nAda,10\n" } });
+    rows[1][1] = "11";
+    expect(await serializeSpreadsheet("artifact-eval.csv", rows)).toEqual({ kind: "text", data: "name,revenue\nAda,11\n" });
+  });
+
+  test("shows a workbook as a dense grid anchored at A1 with stored values", async () => {
+    const { bytes } = await writeXlsxWorkbook([
+      { name: "Q3", header: false, rows: [[], ["", "Region", "Revenue", "Won"], ["", "EMEA", 1742.42, true], ["", "Total", "=SUM(C3:C3)", null]] },
+      { name: "Ignored second sheet", rows: [["x"]] },
+    ]);
+    const rows = await parseSpreadsheet({ name: "reports/q3.xlsx", content: { kind: "binary", data: toArrayBuffer(bytes) } });
+    expect(rows).toEqual([
+      ["", "", "", ""],
+      ["", "Region", "Revenue", "Won"],
+      ["", "EMEA", "1742.42", "TRUE"],
+      ["", "Total", "=SUM(C3:C3)", ""],
+    ]);
+  });
+
+  test("saves edited cells with their types instead of turning every value into text", async () => {
+    const saved = await serializeSpreadsheet("edited.xlsx", [
+      ["name", "revenue", "active", "zip", "growth"],
+      ["Ada", "11", "TRUE", "02134", "=B2/100"],
+      ["", "", "", "", ""],
+    ]);
+    if (saved.kind !== "binary") throw new Error("expected a binary workbook");
+    const workbook = await openXlsxWorkbook(new Uint8Array(saved.data));
+    expect(workbook.sheets.map((sheet) => sheet.name)).toEqual(["Sheet1"]);
+    const sheet = await workbook.readSheet(workbook.sheets[0]);
+    expect(sheet.cells.map((cell) => [cell.reference, cell.type, cell.displayedValue ?? cell.formula])).toEqual([
+      ["A1", "inline_string", "name"],
+      ["B1", "inline_string", "revenue"],
+      ["C1", "inline_string", "active"],
+      ["D1", "inline_string", "zip"],
+      ["E1", "inline_string", "growth"],
+      ["A2", "inline_string", "Ada"],
+      ["B2", "number", "11"],
+      ["C2", "boolean", "TRUE"],
+      ["D2", "inline_string", "02134"],
+      ["E2", "number", "B2/100"],
+    ]);
+    expect(sheet.lastRow).toBe(2);
+  });
+
+  test("explains legacy formats instead of failing to parse them", async () => {
+    await expect(parseSpreadsheet({ name: "old.xls", content: { kind: "binary", data: new ArrayBuffer(4) } })).rejects.toThrow("Legacy .xls workbooks can't be edited here");
+    await expect(serializeSpreadsheet("sheet.ods", [["a"]])).rejects.toThrow("OpenDocument spreadsheets can't be edited here");
+  });
+});

--- a/apps/app/tests/spreadsheet-workbook-interop.test.ts
+++ b/apps/app/tests/spreadsheet-workbook-interop.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import * as XLSX from "xlsx";
+import { openXlsxWorkbook, writeXlsxWorkbook } from "@openwork/workbook";
 
 import { parseSpreadsheet, serializeSpreadsheet } from "../src/react-app/domains/session/artifacts/artifact-spreadsheet-model";
-import { openXlsxWorkbook, writeXlsxWorkbook } from "../../../packages/workbook/src/index";
 
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   const copy = new Uint8Array(bytes.byteLength);
@@ -10,19 +9,12 @@ function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return copy.buffer;
 }
 
-describe("spreadsheet tools and the artifact panel share one workbook format", () => {
+describe("spreadsheet tools and the artifact preview share one workbook engine", () => {
   test("a workbook written by spreadsheet_write opens in the artifact spreadsheet preview", async () => {
     const { bytes } = await writeXlsxWorkbook([
       { name: "Summary", rows: [["Region", "Revenue", "Active"], ["EMEA", 1742.42, true], ["APAC", 871.21, false]] },
       { name: "Detail", rows: [["id", "amount"], [1, 10]] },
     ]);
-
-    const workbook = XLSX.read(toArrayBuffer(bytes), { type: "array" });
-    expect(workbook.SheetNames).toEqual(["Summary", "Detail"]);
-    expect(workbook.Sheets.Summary["!ref"]).toBe("A1:C3");
-    expect(workbook.Sheets.Summary.B2).toMatchObject({ t: "n", v: 1742.42 });
-    expect(workbook.Sheets.Summary.C2).toMatchObject({ t: "b", v: true });
-    expect(workbook.Sheets.Detail.B2).toMatchObject({ t: "n", v: 10 });
 
     const previewRows = await parseSpreadsheet({ name: "reports/q3.xlsx", content: { kind: "binary", data: toArrayBuffer(bytes) } });
     expect(previewRows).toEqual([

--- a/apps/server/src/supply-chain-lockfile.test.ts
+++ b/apps/server/src/supply-chain-lockfile.test.ts
@@ -3,31 +3,33 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
- * The xlsx dependency is fetched from cdn.sheetjs.com rather than the npm
- * registry, and some pnpm versions drop its `integrity` field when rewriting
- * the lockfile. Without that hash the tarball is trusted on faith. This canary
- * pins the integrity line so any lockfile rewrite that loses it fails fast.
+ * Every dependency must resolve from the npm registry. A tarball fetched from
+ * any other host is trusted on faith: some pnpm versions drop its `integrity`
+ * field when rewriting the lockfile, and the host can change the bytes at will.
+ * The last such dependency (SheetJS from cdn.sheetjs.com) was replaced by
+ * @openwork/workbook; this canary keeps the door shut.
  */
 describe("root pnpm lockfile supply chain", () => {
-  test("the xlsx CDN tarball keeps its integrity hash", async () => {
+  test("no dependency resolves from a tarball outside the npm registry", async () => {
     const lockfile = await readFile(join(import.meta.dir, "..", "..", "..", "pnpm-lock.yaml"), "utf8");
 
-    const resolutionLines = lockfile
+    const offRegistry = lockfile
       .split("\n")
-      .filter((line) => {
-        if (!line.includes("resolution:")) return false;
+      .filter((line) => line.includes("resolution:") && line.includes("tarball:"))
+      .map((line) => {
         const tarballMatch = line.match(/tarball:\s*([^,\s}]+)/);
-        if (!tarballMatch) return false;
+        return tarballMatch ? tarballMatch[1] : "";
+      })
+      .filter((tarball) => {
+        if (!tarball) return false;
         try {
-          return new URL(tarballMatch[1]).hostname === "cdn.sheetjs.com";
+          return new URL(tarball).hostname !== "registry.npmjs.org";
         } catch {
-          return false;
+          return true;
         }
       });
 
-    expect(resolutionLines.length).toBeGreaterThan(0);
-    for (const line of resolutionLines) {
-      expect(line).toContain("integrity: sha512-");
-    }
+    expect(offRegistry).toEqual([]);
+    expect(lockfile).not.toContain("cdn.sheetjs.com");
   });
 });

--- a/evals/specs/artifact-spreadsheet-preview-native-workbook.test.ts
+++ b/evals/specs/artifact-spreadsheet-preview-native-workbook.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import { parseSpreadsheet, serializeSpreadsheet } from "../../apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model";
+import { openTargetFromWorkspaceFile } from "../../apps/app/src/react-app/domains/session/artifacts/open-target";
+import { OpenWorkSpreadsheets } from "../../apps/server/src/opencode-plugins/openwork-spreadsheets";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+async function sourceFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...await sourceFiles(path));
+    else if (/\.(ts|tsx|js|mjs)$/.test(entry.name)) files.push(path);
+  }
+  return files;
+}
+
+test("the artifact spreadsheet preview and the agent's workbook tools share one engine", async ({ evidence }) => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-preview-workbook-"));
+  try {
+    const tools = await OpenWorkSpreadsheets({ directory: root });
+    await tools.tool.spreadsheet_write.execute({
+      path: "reports/pipeline.xlsx",
+      sheets: [{ name: "Pipeline", header: false, rows: [[], ["", "Account", "Amount", "Won"], ["", "Northstar", 1742.42, true]] }],
+    });
+
+    // Claim: what the agent writes, the preview shows as a grid anchored at A1
+    // with the stored values, not shifted to the first used cell.
+    const bytes = await readFile(join(root, "reports", "pipeline.xlsx"));
+    const rows = await parseSpreadsheet({ name: "reports/pipeline.xlsx", content: { kind: "binary", data: toArrayBuffer(bytes) } });
+    expect(rows).toEqual([
+      ["", "", "", ""],
+      ["", "Account", "Amount", "Won"],
+      ["", "Northstar", "1742.42", "TRUE"],
+    ]);
+
+    // Claim: an edit saved from the preview keeps cell types, so the agent's
+    // read tool sees numbers, booleans, formulas, and text exactly as typed.
+    rows[2][2] = "1800";
+    rows.push(["", "Total", "=SUM(C3:C3)", "FALSE"]);
+    rows.push(["", "Zip", "02134", ""]);
+    const saved = await serializeSpreadsheet("reports/pipeline.xlsx", rows);
+    if (saved.kind !== "binary") throw new Error("expected a binary workbook");
+    await writeFile(join(root, "reports", "pipeline.xlsx"), new Uint8Array(saved.data));
+    const read = await tools.tool.spreadsheet_read.execute({ path: "reports/pipeline.xlsx", formulas: true });
+    expect(read).toContain("| 3 | Northstar | 1800 | TRUE |");
+    expect(read).toContain("| 4 | Total | =SUM(C3:C3) | FALSE |");
+    expect(read).toContain("| 5 | Zip | 02134 |  |");
+    const inspected: unknown = JSON.parse(await tools.tool.spreadsheet_inspect.execute({ path: "reports/pipeline.xlsx" }));
+    expect(inspected).toMatchObject({ sheets: [expect.objectContaining({ usedRange: "B2:D5", formulas: 1 })] });
+
+    // Negative half: legacy formats no longer route into the in-app editor and
+    // the editor says why instead of failing to parse them.
+    expect(openTargetFromWorkspaceFile("reports/pipeline.xlsx")?.preview).toBe("sheet");
+    expect(openTargetFromWorkspaceFile("reports/table.csv")?.preview).toBe("sheet");
+    expect(openTargetFromWorkspaceFile("reports/legacy.xls")?.preview).toBe("external");
+    expect(openTargetFromWorkspaceFile("reports/sheet.ods")?.preview).toBe("external");
+    await expect(parseSpreadsheet({ name: "legacy.xls", content: { kind: "binary", data: new ArrayBuffer(8) } })).rejects.toThrow("Legacy .xls workbooks can't be edited here");
+
+    evidence.recordAssertionEvidence(
+      "The preview shows and saves the same workbook format the agent tools use",
+      "A workbook written by spreadsheet_write rendered as an A1-anchored grid with stored values; an edit saved from the preview came back through spreadsheet_read with a number, a formula, a boolean, and a leading-zero text cell intact; .xls and .ods route to an external opener with an explanation.",
+      true,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the desktop renderer no longer depends on SheetJS", async ({ evidence }) => {
+  // Claim: no app source imports xlsx, the app manifest does not declare it,
+  // and no dependency in the root lockfile resolves from a tarball outside the
+  // npm registry.
+  const appSources = await sourceFiles(join(repoRoot, "apps/app/src"));
+  const importers: string[] = [];
+  for (const file of appSources) {
+    const source = await readFile(file, "utf8");
+    if (/from\s+["']xlsx["']|import\(\s*["']xlsx["']\s*\)|require\(\s*["']xlsx["']\s*\)/.test(source)) importers.push(file.slice(repoRoot.length));
+  }
+  expect(importers).toEqual([]);
+  expect(appSources.some((file) => file.endsWith("artifact-spreadsheet-model.ts"))).toBe(true);
+
+  const manifest: unknown = JSON.parse(await readFile(join(repoRoot, "apps/app/package.json"), "utf8"));
+  const dependencies = typeof manifest === "object" && manifest !== null && "dependencies" in manifest ? manifest.dependencies : undefined;
+  expect(dependencies).toBeTypeOf("object");
+  expect(dependencies).not.toHaveProperty("xlsx");
+  expect(dependencies).toHaveProperty("@openwork/workbook", "workspace:*");
+
+  const lockfile = await readFile(join(repoRoot, "pnpm-lock.yaml"), "utf8");
+  const offRegistry = lockfile.split("\n").filter((line) => {
+    if (!line.includes("resolution:") || !line.includes("tarball:")) return false;
+    const tarball = line.match(/tarball:\s*([^,\s}]+)/)?.[1] ?? "";
+    try {
+      return new URL(tarball).hostname !== "registry.npmjs.org";
+    } catch {
+      return true;
+    }
+  });
+  expect(offRegistry).toEqual([]);
+  expect(lockfile).not.toContain("cdn.sheetjs.com");
+
+  evidence.recordAssertionEvidence(
+    "SheetJS is gone from the desktop app",
+    "No file under apps/app/src imports xlsx, apps/app/package.json declares @openwork/workbook instead of the cdn.sheetjs.com tarball, and the root lockfile has no dependency resolved from a non-registry tarball.",
+    true,
+  );
+});

--- a/packaging/docker/Dockerfile.den-gateway
+++ b/packaging/docker/Dockerfile.den-gateway
@@ -25,6 +25,7 @@ RUN node -e "const fs = require('node:fs'); fs.appendFileSync('/app/pnpm-workspa
 COPY packages/types/package.json /app/packages/types/package.json
 COPY packages/ui/package.json /app/packages/ui/package.json
 COPY packages/install-config/package.json /app/packages/install-config/package.json
+COPY packages/workbook/package.json /app/packages/workbook/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/apps/den-gateway/package.json /app/ee/apps/den-gateway/package.json
 COPY apps/app/package.json /app/apps/app/package.json
@@ -34,6 +35,7 @@ RUN pnpm install --frozen-lockfile --trust-lockfile
 COPY packages/types /app/packages/types
 COPY packages/ui /app/packages/ui
 COPY packages/install-config /app/packages/install-config
+COPY packages/workbook /app/packages/workbook
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/apps/den-gateway /app/ee/apps/den-gateway
 COPY apps/app /app/apps/app

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@openwork/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@openwork/workbook':
+        specifier: workspace:*
+        version: link:../../packages/workbook
       '@paper-design/shaders-react':
         specifier: 0.0.72
         version: 0.0.72(@types/react@19.2.14)(react@19.2.8)
@@ -274,9 +277,6 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
-      xlsx:
-        specifier: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
-        version: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -9272,12 +9272,6 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz:
-    resolution: {integrity: sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz}
-    version: 0.20.2
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   xml-crypto@6.1.2:
     resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
     engines: {node: '>=16'}
@@ -17974,8 +17968,6 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
-
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz: {}
 
   xml-crypto@6.1.2:
     dependencies:


### PR DESCRIPTION
Stacked on #4327 (`feature/excel-workbook-tools`), which introduces `@openwork/workbook`. This PR carries only its own commit (`eca825be9`); review the diff against that branch. Once #4327 merges this will be retargeted to `dev`, rebased, and its evidence re-run.

## Problem

`xlsx` (SheetJS) was the only dependency in the repository not resolved from the npm registry — it was fetched as a tarball from `cdn.sheetjs.com`, which is why `supply-chain-lockfile.test.ts` existed: some pnpm versions silently drop that entry's `integrity` hash on a lockfile rewrite, leaving the tarball trusted on faith. The package is also the one flagged in the Dependabot backlog as abandoned on npm.

Its only consumer was the artifact spreadsheet preview (`artifact-spreadsheet-model.ts`), which used it to show the first sheet of a `.xlsx` and to write edits back. That path had its own problems: it read cells as *formatted text* and wrote every edited cell back as text (a `1742.42` cell became the string `"1742.42"` on save), and it started the grid at the first used cell, so a sheet with data at `B2` was rewritten with that data at `A1`.

## Change

- **`artifact-spreadsheet-model.ts`** keeps its public API (`parseSpreadsheet`, `serializeSpreadsheet`, `SpreadsheetRows`) and swaps the engine for `@openwork/workbook`:
  - `parseSpreadsheet` returns the first sheet as a dense grid anchored at A1 (`sheetGridRows`), so positions survive a save. Values are the stored values: numbers as written, `TRUE`/`FALSE`, ISO dates for date-formatted serials, a formula's last calculated result.
  - `serializeSpreadsheet` writes typed cells via `cellInputFromText`: canonical numbers become numbers, `TRUE`/`FALSE` booleans, `=`-prefixed text formulas; anything else (including `02134` and `1,000`) stays text.
  - `.xls` and `.ods` throw a one-line explanation instead of a parse error.
- **`open-target.ts` / `artifacts.ts`** — `.xls` and `.ods` are no longer classified as in-app `sheet` previews; they open externally like other unsupported files. `.xlsx`, `.csv`, `.tsv` are unchanged.
- **`apps/app/package.json` / `pnpm-lock.yaml`** — `xlsx` removed, `@openwork/workbook` added. The lockfile diff is the two importer lines plus the removal of the tarball entries; nothing else was re-resolved.
- **`packaging/docker/Dockerfile.den-gateway`** — the gateway image bakes the web build from a pruned workspace that copies packages one by one; `packages/workbook` is now copied in (no build step needed). `packages/workbook/**` is also listed in the path filters of `publish-ee-images.yml`, `alpha-macos-aarch64.yml`, and `build-electron-desktop.yml`.
- **`apps/server/src/supply-chain-lockfile.test.ts`** — the canary now asserts that *no* dependency resolves from a tarball outside `registry.npmjs.org` (and that `cdn.sheetjs.com` is gone), which is the property the old test was protecting.

Not in this PR: the editor component itself (`artifact-spreadsheet-editor.tsx`) is untouched because #3360 is rewriting it. It still edits the first sheet only and a save still writes a single-sheet workbook; the multi-sheet tabs and sheet-preserving save that this engine makes possible are a follow-up on top of #3360.

## Behavior changes to be aware of

- Formatted numbers show their stored value in the preview (`0.12`, not `12%`; `1742.42`, not `$1,742.42`). This matches what the agent sees through `spreadsheet_read`, and it is what makes numbers round-trip as numbers.
- Dates show as ISO (`2023-03-15`) rather than a locale string; an edited date is still saved as text, as before.
- `.xls`/`.ods` are no longer previewed in-app.

## Tests

- `apps/app/tests/artifact-spreadsheet-model.test.ts` — CSV round trip; A1-anchored grid with stored values and a second sheet ignored; typed save (number, boolean, formula, leading-zero text) read back by the shared reader; legacy-format explanations.
- `apps/app/tests/spreadsheet-workbook-interop.test.ts` — preview parses a workbook from `spreadsheet_write`; a preview-saved workbook is readable by the tool reader.
- `apps/server/src/supply-chain-lockfile.test.ts` — rewritten as above.
- `evals/specs/artifact-spreadsheet-preview-native-workbook.test.ts` — two PR-lane claims: (1) a workbook written by the agent's `spreadsheet_write` renders as an A1-anchored grid, and an edit saved from the preview comes back through `spreadsheet_read`/`spreadsheet_inspect` with a number, a formula, a boolean, and a leading-zero text cell intact, while `.xls`/`.ods` route to an external opener; (2) no file under `apps/app/src` imports `xlsx`, the manifest declares `@openwork/workbook` and not `xlsx`, and the lockfile has no off-registry tarball.

## Verification

Lane: **local** (app-less `pr` project; no resources launched). Head `ca8e13fad` (two commits: the swap, plus the gateway image fix after the first CI run of `Publish EE Artifacts` failed to resolve `@openwork/workbook` inside the image) on `feature/excel-workbook-tools@862732568`.

```
pnpm evals:pr specs/artifact-spreadsheet-preview-native-workbook.test.ts
```
exit 0 — Test Files 1 passed, Tests **2 passed**, 0 failed, 0 skipped. The test-evidence comment shows the engine-sharing run; the other head-matching run is `…-the-desktop-renderer-no-longer-depends-on-sheetjs`.

```
cd apps/app && bun test --isolate tests/artifact-spreadsheet-model.test.ts tests/spreadsheet-workbook-interop.test.ts tests/office-attachment-ui.test.ts tests/attachment-artifacts.test.ts && bun test scripts/open-target.test.ts
```
exit 0 — 6 pass + 9 pass + 22 pass, 0 fail.

```
cd apps/app && bun test --isolate tests/
```
exit 1 — **1144 pass, 5 fail**. The five (`connect-capability-inventory`, `cloud-workspace-overlay`, `session-provider-auth-server-sync`, `extensions-sidebar-header`) are the same order-dependent failures already recorded on `dev` in #4299; each file passes when run alone (6/7/26/3 pass).

```
cd apps/server && bun --conditions=development test src/supply-chain-lockfile.test.ts   # 1 pass
pnpm --dir apps/app typecheck && pnpm --dir evals lint:layers                           # clean
pnpm install --frozen-lockfile --prefer-offline                                          # lockfile consistent
```

```
cd apps/app && pnpm exec vite build --outDir /tmp/app-dist
```
exit 0 — the lazy `artifact-spreadsheet-editor-*.js` chunk is 80 KB with the engine inlined; `grep -ril sheetjs /tmp/app-dist/assets` finds nothing.

```
docker build -f packaging/docker/Dockerfile.den-gateway .
```
exit 0 locally after the fix — `build:web` succeeds inside the image (`✓ built in 15.73s`), `/opt/openwork/web/assets` contains the spreadsheet-editor chunk and no SheetJS.

```
soffice --headless --convert-to csv edited.xlsx
```
on a workbook produced by `serializeSpreadsheet`: LibreOffice reads `11`/`12.5` as numbers, `TRUE`/`FALSE` as booleans, keeps `02134` as text, and recalculates `=B2/100` to `0.11`.

Verdict: **Passed**.

## Notes

- `apps/app/scripts/artifact-spreadsheet.test.ts` already calls the model with a stale argument shape on `dev` and is not part of `pnpm test`; #3360 touches that file, so it is left alone here.
- The Dependabot `xlsx` follow-up (replace or dismiss the abandoned-package advisory) is resolved by removal rather than replacement.
