### PR TITLE
docs(helm): hard-disable Automations in the starter examples

### DIFF
--- a/packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml
+++ b/packaging/helm/openwork-ee/examples/values.aws-load-balancer-http-smoke.yaml
@@ -39,11 +39,12 @@ config:
     webAppHosts: "pending-web-nlb"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "http://pending-web-nlb:3005"
-    # Automations are opt-in for self-hosted deployments and stay hidden until
-    # enabled. Set both values to "true" to turn them on. See the "Automations
-    # rollout" section in the chart README before changing either value.
+    # Automations are opt-in for self-hosted deployments. A fresh install has no
+    # legacy Desktop clients, so both values stay "false" and the routes,
+    # scheduler, and MCP resources are omitted. Set both to "true" to turn them
+    # on. See the "Automations rollout" section in the chart README first.
     automationsEnabled: "false"
-    automationsRuntimeEnabled: "true"
+    automationsRuntimeEnabled: "false"
   provisioner:
     mode: stub
 

--- a/packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
+++ b/packaging/helm/openwork-ee/examples/values.aws-load-balancer.yaml
@@ -39,11 +39,12 @@ config:
     webAppHosts: "REPLACE_WEB_HOST"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "https://REPLACE_WEB_HOST"
-    # Automations are opt-in for self-hosted deployments and stay hidden until
-    # enabled. Set both values to "true" to turn them on. See the "Automations
-    # rollout" section in the chart README before changing either value.
+    # Automations are opt-in for self-hosted deployments. A fresh install has no
+    # legacy Desktop clients, so both values stay "false" and the routes,
+    # scheduler, and MCP resources are omitted. Set both to "true" to turn them
+    # on. See the "Automations rollout" section in the chart README first.
     automationsEnabled: "false"
-    automationsRuntimeEnabled: "true"
+    automationsRuntimeEnabled: "false"
   provisioner:
     mode: stub
 

--- a/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.azure-ingress.yaml
@@ -41,11 +41,12 @@ config:
     webAppHosts: "REPLACE_WEB_HOST"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "https://REPLACE_WEB_HOST"
-    # Automations are opt-in for self-hosted deployments and stay hidden until
-    # enabled. Set both values to "true" to turn them on. See the "Automations
-    # rollout" section in the chart README before changing either value.
+    # Automations are opt-in for self-hosted deployments. A fresh install has no
+    # legacy Desktop clients, so both values stay "false" and the routes,
+    # scheduler, and MCP resources are omitted. Set both to "true" to turn them
+    # on. See the "Automations rollout" section in the chart README first.
     automationsEnabled: "false"
-    automationsRuntimeEnabled: "true"
+    automationsRuntimeEnabled: "false"
   provisioner:
     mode: stub
 

--- a/packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml
+++ b/packaging/helm/openwork-ee/examples/values.gcp-ingress.yaml
@@ -39,11 +39,12 @@ config:
     webAppHosts: "REPLACE_WEB_HOST"
     bootstrapAdminEmails: "REPLACE_ADMIN_EMAIL"
     authCallbackUrl: "https://REPLACE_WEB_HOST"
-    # Automations are opt-in for self-hosted deployments and stay hidden until
-    # enabled. Set both values to "true" to turn them on. See the "Automations
-    # rollout" section in the chart README before changing either value.
+    # Automations are opt-in for self-hosted deployments. A fresh install has no
+    # legacy Desktop clients, so both values stay "false" and the routes,
+    # scheduler, and MCP resources are omitted. Set both to "true" to turn them
+    # on. See the "Automations rollout" section in the chart README first.
     automationsEnabled: "false"
-    automationsRuntimeEnabled: "true"
+    automationsRuntimeEnabled: "false"
   provisioner:
     mode: stub
 


### PR DESCRIPTION
## Why

#4274 surfaced both Automations flags in every starter example, but copied the chart's `automationsRuntimeEnabled: "true"` default into them. That default exists for the staged Den upgrade path: it keeps routes and scheduling alive for Desktops older than v0.18.35 that predate the availability contract.

The starter examples target fresh installs, which have no legacy Desktop clients. There, `runtime: "true"` just leaves the Automations routes, scheduler, and MCP resources running for a feature the same file marks unavailable. The chart README already says new installations can hard-disable immediately by setting both values to `"false"`.

## What changed

- All four `packaging/helm/openwork-ee/examples/values.*.yaml` set `automationsEnabled: "false"` and `automationsRuntimeEnabled: "false"`.
- The inline comment explains why the pair differs from the chart default and still points to the README rollout section before enabling.
- `values.yaml` chart default is **unchanged**, so existing deployments keep the documented staged upgrade.

## Proof

Values/comments-only change; no runtime-observable behavior, so no testkit spec applies.

- `helm template openwork-ee . -f examples/<each>.yaml` renders `DEN_AUTOMATIONS_ENABLED: "false"` and `DEN_AUTOMATIONS_RUNTIME_ENABLED: "false"` for all four examples.
- `bash tests/automations-enabled.sh` passes (chart default still renders `RUNTIME_ENABLED: "true"`).