### PR TITLE
feat(app): scrollable, copyable command boxes in chat; double-click a running command to read it

### DIFF
--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -412,7 +412,7 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
                   <ReasoningBlock text={thought.text} isStreaming={thought.isStreaming} />
                 </div>
               ))}
-              <div className="flex min-w-0 flex-col gap-1.5 py-1">
+              <div data-tool-aggregate-row className="flex min-w-0 flex-col gap-1.5 py-1">
                 {!singleCommand ? (
                   <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
                   {status === "waiting" ? (

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,14 +1,15 @@
 "use client"
 
 import { Fragment, useState } from "react"
-import { AlertTriangle, ChevronUp, CircleHelp, CirclePause, MoreHorizontal } from "lucide-react"
+import { AlertTriangle, Check, ChevronUp, CircleHelp, CirclePause, Copy, MoreHorizontal } from "lucide-react"
 
 import { FileChip } from "@/components/chat/file-chip"
 import { ShellCommandText } from "@/components/chat/shell-command-text"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { useCurrentToolLifecycleResolver } from "@/components/chat/current-tool-lifecycle-context"
+import { Button } from "@/components/ui/button"
 import {
-  getAggregateNowLabel,
+  getAggregateNowPart,
   getAggregateCountSummary,
   getToolAggregateLifecycle,
   getAggregateRowFile,
@@ -56,45 +57,84 @@ type DetailBoxProps = {
   onToggle: () => void
 }
 
+function CopyCommandButton({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard access can be unavailable outside a secure browser context.
+    }
+  }
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      className="mr-1.5 mt-1.5 shrink-0 text-muted-foreground/70"
+      data-tool-aggregate-copy=""
+      title={copied ? "Copied" : "Copy command"}
+      aria-label={copied ? "Command copied" : "Copy command"}
+      onClick={() => void copy()}
+    >
+      {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+    </Button>
+  )
+}
+
 /**
  * Monospace detail (a command, a search pattern, an error) shown as one
- * clipped line; clicking reveals the whole text, wrapped, so nothing in
- * an expanded tool group is ever unreadable.
+ * clipped line; clicking reveals the whole text, wrapped inside a bounded
+ * scroll box, so nothing in an expanded tool group is ever unreadable and
+ * a long script never swallows the thread. A full command can be copied.
  */
-function DetailBox({ kind, text, expanded, onToggle }: DetailBoxProps) {
+export function DetailBox({ kind, text, expanded, onToggle }: DetailBoxProps) {
   const noun = kind === "command" ? "command" : kind === "pattern" ? "search pattern" : "error"
-  const textClassName = cn("min-w-0 flex-1", expanded ? "whitespace-pre-wrap break-all" : "line-clamp-1 break-all")
+  const textClassName = cn(
+    "min-w-0 flex-1 break-all",
+    expanded ? "max-h-60 overflow-y-auto whitespace-pre-wrap" : "line-clamp-1",
+  )
   return (
-    <button
-      type="button"
-      data-tool-aggregate-detail={kind}
-      data-tool-aggregate-command={kind === "command" ? "" : undefined}
-      data-command-expanded={expanded ? "true" : "false"}
-      aria-expanded={expanded}
-      aria-label={expanded ? `Collapse ${noun}` : `Show full ${noun}`}
-      onClick={onToggle}
+    <div
       className={cn(
-        "flex min-w-0 max-w-full cursor-pointer gap-2 rounded-xl border px-3 py-2 text-start font-mono transition-colors",
-        expanded ? "items-start [&>svg]:mt-0.5" : "items-center",
+        "flex min-w-0 max-w-full rounded-xl border font-mono transition-colors",
+        expanded ? "items-start" : "items-center",
         kind === "error"
           ? "border-destructive/30 bg-destructive/5 text-xs text-destructive hover:border-destructive/50"
           : "border-border/70 bg-gray-2/60 text-sm hover:border-border hover:bg-gray-3/60",
       )}
     >
-      {kind === "command" ? (
-        <>
-          <span className="shrink-0 text-muted-foreground/60">$</span>
-          <ShellCommandText command={text} className={textClassName} />
-        </>
-      ) : (
-        <code className={textClassName}>{text}</code>
-      )}
-      {expanded ? (
-        <ChevronUp aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
-      ) : (
-        <MoreHorizontal aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
-      )}
-    </button>
+      <button
+        type="button"
+        data-tool-aggregate-detail={kind}
+        data-tool-aggregate-command={kind === "command" ? "" : undefined}
+        data-command-expanded={expanded ? "true" : "false"}
+        aria-expanded={expanded}
+        aria-label={expanded ? `Collapse ${noun}` : `Show full ${noun}`}
+        onClick={onToggle}
+        className={cn(
+          "flex min-w-0 flex-1 cursor-pointer gap-2 rounded-xl px-3 py-2 text-start",
+          expanded ? "items-start [&>svg]:mt-0.5" : "items-center",
+        )}
+      >
+        {kind === "command" ? (
+          <>
+            <span className="shrink-0 text-muted-foreground/60">$</span>
+            <ShellCommandText command={text} className={textClassName} />
+          </>
+        ) : (
+          <code className={textClassName}>{text}</code>
+        )}
+        {expanded ? (
+          <ChevronUp aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
+        ) : (
+          <MoreHorizontal aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
+        )}
+      </button>
+      {expanded && kind === "command" ? <CopyCommandButton command={text} /> : null}
+    </div>
   )
 }
 
@@ -158,8 +198,9 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
   const [fullDetailKeys, setFullDetailKeys] = useState<ReadonlySet<string>>(() => new Set())
   const resolveLifecycle = useCurrentToolLifecycleResolver()
 
+  const detailKey = (toolCallId: string, kind: DetailBoxProps["kind"]) => `${toolCallId}:${kind}`
   const detailBox = (kind: DetailBoxProps["kind"], toolCallId: string, text: string) => {
-    const key = `${toolCallId}:${kind}`
+    const key = detailKey(toolCallId, kind)
     return (
       <DetailBox
         kind={kind}
@@ -200,7 +241,13 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
     : aggregateLifecycle === "unknown"
       ? `Status unknown · ${countSummary}`
       : getAggregateSummary(parts, visiblyRunning ? "present" : "past")
-  const nowLabel = visiblyRunning ? getAggregateNowLabel(parts) : null
+  const nowPart = visiblyRunning ? getAggregateNowPart(parts) : null
+  const nowLabel = nowPart ? getAggregateRowLabel(nowPart) : null
+  // A running command is clipped to one line; double-clicking swaps that
+  // line for the same scrollable, copyable box the history uses, so the
+  // whole command is readable while it is still running.
+  const nowCommand = nowPart && isBashToolPart(nowPart) ? nowPart.input?.command?.trim() ?? "" : ""
+  const nowCommandShown = Boolean(nowPart && nowCommand && fullDetailKeys.has(detailKey(nowPart.toolCallId, "command")))
   // The model is thinking mid-run: no tool is in flight but the run's
   // latest thought is still streaming. Show that instead of dead air.
   const lastThought = thoughts.at(-1)
@@ -311,8 +358,24 @@ export function ToolAggregateGroup({ parts, thoughts = [], className }: ToolAggr
         </div>
       ) : null}
 
-      {nowLabel ? (
-        <div data-tool-aggregate-now className="mt-1 min-w-0 text-sm text-muted-foreground">
+      {nowPart && nowCommandShown ? (
+        <div data-tool-aggregate-now className="mt-1.5 min-w-0">
+          {detailBox("command", nowPart.toolCallId, nowCommand)}
+        </div>
+      ) : nowLabel ? (
+        <div
+          data-tool-aggregate-now
+          className="mt-1 min-w-0 text-sm text-muted-foreground"
+          title={nowCommand ? "Double-click to show the full command" : undefined}
+          onDoubleClick={
+            nowPart && nowCommand
+              ? () =>
+                  setFullDetailKeys((current) =>
+                    new Set(current).add(detailKey(nowPart.toolCallId, "command")),
+                  )
+              : undefined
+          }
+        >
           <span className="ow-text-shimmer block min-w-0 truncate">
             {nowLabel}
           </span>

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -221,11 +221,11 @@ export function getAggregateRowLabel(part: AnyToolPart): string {
   return getToolActivityLabel(part)
 }
 
-/** Label for the single latest in-flight call — the self-replacing current-action line. */
-export function getAggregateNowLabel(parts: AnyToolPart[]): string | null {
+/** The single latest in-flight call — the one the self-replacing current-action line names. */
+export function getAggregateNowPart(parts: AnyToolPart[]): AnyToolPart | null {
   for (let index = parts.length - 1; index >= 0; index -= 1) {
     const part = parts[index]
-    if (part && isToolPartInFlight(part)) return getAggregateRowLabel(part)
+    if (part && isToolPartInFlight(part)) return part
   }
   return null
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -457,6 +457,57 @@ function createToolDetailsEvalMessages(sessionId: string): UIMessage[] {
   ];
 }
 
+// Long enough (well past the one-line clip and the box's max height) that
+// seeing its last line proves the whole running command is readable.
+const TOOL_DETAILS_EVAL_RUNNING_COMMAND = [
+  "cat <<'EOF' > /tmp/openwork-eval/release-check.sh",
+  "#!/usr/bin/env bash",
+  "set -euo pipefail",
+  "export OPENWORK_EVAL_E2E_TESTS=1",
+  "pnpm world up dev-headless --detach -- --replace --keep-tokens",
+  "for spec in \\",
+  "  chat-loading-shimmer \\",
+  "  chat-tool-details-expand \\",
+  "  chat-thought-chronology \\",
+  "  live-tool-visible-after-session-switch \\",
+  "  session-completion-reconciliation \\",
+  "  active-session-workspace-storm; do",
+  "  pnpm vitest run \"evals/specs/$spec.e2e.test.ts\" --reporter=verbose",
+  "done",
+  "pnpm --filter @openwork/app typecheck",
+  "pnpm --filter @openwork/app test",
+  "pnpm evals:typecheck",
+  "pnpm world down dev-headless",
+  "EOF",
+  "bash /tmp/openwork-eval/release-check.sh --reporter=verbose",
+].join("\n");
+
+function createToolDetailsRunningCommandEvalMessages(sessionId: string): UIMessage[] {
+  const now = Date.now();
+  return [
+    {
+      id: `${sessionId}:eval-tool-details-running-user`,
+      role: "user",
+      parts: [{ type: "text", text: "Write and run the release check." }],
+      metadata: { opencode: { created: now } },
+    },
+    {
+      id: `${sessionId}:eval-tool-details-running-assistant`,
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "bash",
+          toolCallId: "eval-tool-details-running-bash",
+          state: "input-available",
+          input: { command: TOOL_DETAILS_EVAL_RUNNING_COMMAND, description: "Run the release check" },
+        },
+      ],
+      metadata: { opencode: { created: now + 1 } },
+    },
+  ];
+}
+
 function createSubagentActivityEvalMessages(sessionId: string, childSessionId?: string): UIMessage[] {
   const now = Date.now();
   return [
@@ -1442,6 +1493,23 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId]);
   useControlAction(props.isControlTarget ? seedToolDetailsControlAction : null);
+  const seedRunningCommandControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.tool_details.seed_running_command",
+      label: "Seed a running long command",
+      description: "Dev-only eval hook that renders one in-flight multi-line command in an active session.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: () => {
+        setEvalMarkdownMessages(createToolDetailsRunningCommandEvalMessages(props.sessionId));
+        useSessionActivityStore.getState().setRunStatus(props.workspaceId, props.sessionId, { type: "busy" });
+        return { ok: true };
+      },
+    };
+  }, [props.sessionId, props.workspaceId]);
+  useControlAction(props.isControlTarget ? seedRunningCommandControlAction : null);
   const seedSessionLifecycleControlAction = useMemo<OpenworkControlAction | null>(() => {
     if (!import.meta.env.DEV) return null;
 

--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DynamicToolUIPart } from "ai";
 
-import { ToolAggregateGroup, buildAggregateRows } from "../src/components/chat/tool-aggregate-group";
-import { getAggregateRowSearch } from "../src/lib/tool-aggregate";
+import { DetailBox, ToolAggregateGroup, buildAggregateRows } from "../src/components/chat/tool-aggregate-group";
+import { getAggregateNowPart, getAggregateRowSearch } from "../src/lib/tool-aggregate";
 import { CurrentToolLifecycleProvider } from "../src/components/chat/current-tool-lifecycle-context";
 import { getToolAggregateLifecycle } from "../src/lib/tool-aggregate";
 
@@ -54,6 +54,46 @@ describe("tool aggregate running feedback", () => {
     expect(markup).not.toContain("Now:");
     expect(markup).toContain("ow-text-shimmer");
     expect(markup).not.toContain("animate-spin");
+  });
+
+  test("the running command line invites a double-click to show the whole command", () => {
+    const markup = renderToStaticMarkup(
+      <CurrentToolLifecycleProvider
+        activityStatus="responding"
+        currentToolCallIds={new Set([runningCommand.toolCallId])}
+      >
+        <ToolAggregateGroup parts={[completedCommand, runningCommand]} />
+      </CurrentToolLifecycleProvider>,
+    );
+
+    expect(getAggregateNowPart([completedCommand, runningCommand])).toBe(runningCommand);
+    expect(markup).toContain("data-tool-aggregate-now");
+    expect(markup).toContain('title="Double-click to show the full command"');
+    // Until double-clicked, the line stays the one-line shimmer, not the box.
+    expect(markup).not.toContain("data-tool-aggregate-copy");
+  });
+
+  test("a running file action's current line offers no command reveal", () => {
+    const runningRead: DynamicToolUIPart = {
+      type: "dynamic-tool",
+      toolName: "read",
+      toolCallId: "running-read",
+      state: "input-available",
+      input: { filePath: "/repo/brief.md" },
+    };
+
+    const markup = renderToStaticMarkup(
+      <CurrentToolLifecycleProvider
+        activityStatus="responding"
+        currentToolCallIds={new Set([runningCommand.toolCallId, runningRead.toolCallId])}
+      >
+        <ToolAggregateGroup parts={[runningCommand, runningRead]} />
+      </CurrentToolLifecycleProvider>,
+    );
+
+    expect(getAggregateNowPart([runningCommand, runningRead])).toBe(runningRead);
+    expect(markup).toContain("Reading brief.md");
+    expect(markup).not.toContain("Double-click to show the full command");
   });
 
   test("shimmers the whole active action without a Now prefix", () => {
@@ -197,6 +237,36 @@ describe("tool aggregate long details", () => {
       scope: null,
     });
     expect(getAggregateRowSearch(runningCommand)).toBeNull();
+  });
+
+  test("an expanded command is a bounded scroll box with a copy action; collapsed it is one line", () => {
+    const expanded = renderToStaticMarkup(
+      <DetailBox kind="command" text="git status --short --branch" expanded onToggle={() => {}} />,
+    );
+    expect(expanded).toContain('data-command-expanded="true"');
+    expect(expanded).toContain("max-h-60 overflow-y-auto whitespace-pre-wrap");
+    expect(expanded).toContain("data-tool-aggregate-copy");
+    expect(expanded).toContain('aria-label="Copy command"');
+
+    const collapsed = renderToStaticMarkup(
+      <DetailBox kind="command" text="git status --short --branch" expanded={false} onToggle={() => {}} />,
+    );
+    expect(collapsed).toContain('data-command-expanded="false"');
+    expect(collapsed).toContain("line-clamp-1");
+    expect(collapsed).not.toContain("overflow-y-auto");
+    expect(collapsed).not.toContain("data-tool-aggregate-copy");
+  });
+
+  test("only commands offer a copy action; errors and patterns do not", () => {
+    const error = renderToStaticMarkup(
+      <DetailBox kind="error" text={multiLineError} expanded onToggle={() => {}} />,
+    );
+    const pattern = renderToStaticMarkup(
+      <DetailBox kind="pattern" text={longPattern} expanded onToggle={() => {}} />,
+    );
+    expect(error).toContain("max-h-60 overflow-y-auto");
+    expect(error).not.toContain("data-tool-aggregate-copy");
+    expect(pattern).not.toContain("data-tool-aggregate-copy");
   });
 
   test("a failed solo file action exposes its whole error, not a clipped first line", () => {

--- a/evals/specs/chat-tool-details-expand.e2e.test.ts
+++ b/evals/specs/chat-tool-details-expand.e2e.test.ts
@@ -139,7 +139,7 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   // The search row names its scope in prose and does not clip the pattern in JS.
   const searchLabel = await evalIn(app, `(() => {
     const box = document.querySelector('[data-tool-aggregate-detail="pattern"]');
-    const row = box?.parentElement;
+    const row = box?.closest('[data-tool-aggregate-row]');
     return row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, ' ').trim() : '';
   })()`);
   if (typeof searchLabel !== "string") throw new Error(`Search row was not readable: ${JSON.stringify(searchLabel)}`);

--- a/evals/specs/chat-tool-details-expand.e2e.test.ts
+++ b/evals/specs/chat-tool-details-expand.e2e.test.ts
@@ -14,6 +14,11 @@ const title = enabled
 const COMMAND_TAIL = "chat-loading-shimmer.e2e.test.ts --reporter=verbose";
 const PATTERN_TAIL = "createSessionLifecycleEvalMessages|useControlAction";
 const ERROR_TAIL = "hint: use 'git fetch origin release/2026.09' first";
+// The running seed (eval.tool_details.seed_running_command) is a multi-line
+// script: its first line is inside the one-line clip, its last line is far
+// past it and past the box's max height, so it is only reachable by scrolling.
+const RUNNING_HEAD = "cat <<'EOF' > /tmp/openwork-eval/release-check.sh";
+const RUNNING_TAIL = "bash /tmp/openwork-eval/release-check.sh --reporter=verbose";
 
 type DetailKind = "command" | "pattern" | "error";
 
@@ -24,6 +29,9 @@ type DetailProbe = {
   isButton: boolean;
   visibleLines: number;
   clipped: boolean;
+  scrollable: boolean;
+  overflowY: string;
+  hasCopy: boolean;
   text: string;
 };
 
@@ -50,7 +58,34 @@ const probeScript = (kind: DetailKind, click: boolean) => `(() => {
     isButton: box.tagName === 'BUTTON',
     visibleLines: Math.round(code.getBoundingClientRect().height / lineHeight),
     clipped: code.scrollHeight > code.clientHeight + 1 || code.scrollWidth > code.clientWidth + 1,
+    scrollable: getComputedStyle(code).overflowY === 'auto' && code.scrollHeight > code.clientHeight + 1,
+    overflowY: getComputedStyle(code).overflowY,
+    hasCopy: Boolean(box.parentElement?.querySelector('[data-tool-aggregate-copy]')),
     text: code.textContent ?? '',
+  };
+})()`;
+
+type NowProbe = {
+  text: string;
+  hasShimmer: boolean;
+  oneLine: boolean;
+  showsBox: boolean;
+};
+
+function isNowProbe(value: unknown): value is NowProbe {
+  return typeof value === "object" && value !== null && "text" in value && "showsBox" in value;
+}
+
+const nowProbeScript = `(() => {
+  const row = document.querySelector('[data-tool-aggregate-now]');
+  if (!(row instanceof HTMLElement)) return null;
+  const label = row.querySelector('.ow-text-shimmer');
+  const lineHeight = label ? parseFloat(getComputedStyle(label).lineHeight) || 20 : 20;
+  return {
+    text: row.innerText,
+    hasShimmer: label !== null,
+    oneLine: label instanceof HTMLElement && Math.round(label.getBoundingClientRect().height / lineHeight) === 1,
+    showsBox: row.querySelector('[data-tool-aggregate-detail="command"]') !== null,
   };
 })()`;
 
@@ -130,6 +165,7 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
     expect(collapsed.ariaLabel).toBe(`Show full ${noun}`);
     expect(collapsed.visibleLines).toBe(1);
     expect(collapsed.clipped).toBe(true);
+    expect(collapsed.hasCopy).toBe(false);
     // The full value is in the DOM even while collapsed — nothing was cut in JS.
     expect(collapsed.text).toContain(tail);
 
@@ -137,7 +173,12 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
     expect(expanded.expanded).toBe("true");
     expect(expanded.ariaLabel).toBe(`Collapse ${noun}`);
     expect(expanded.visibleLines).toBeGreaterThan(1);
+    // Short details fit inside the box's height, so nothing is hidden...
     expect(expanded.clipped).toBe(false);
+    // ...but the box is a scroll container, ready for a long script.
+    expect(expanded.overflowY).toBe("auto");
+    // Only a command earns a copy action.
+    expect(expanded.hasCopy).toBe(kind === "command");
     expect(expanded.text).toContain(tail);
 
     const recollapsed = await probe(app, kind, true);
@@ -145,8 +186,8 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
     expect(recollapsed.visibleLines).toBe(1);
 
     evidence.recordAssertionEvidence(
-      `A long ${noun} is one clipped line until clicked, then fully readable, then collapsible again`,
-      `Collapsed: 1 visible line, clipped, labelled “Show full ${noun}”. Expanded: ${expanded.visibleLines} lines, not clipped, ending “${tail}”. Re-collapsed to 1 line.`,
+      `A long ${noun} is one clipped line until clicked, then fully readable inside a scroll box, then collapsible again`,
+      `Collapsed: 1 visible line, clipped, no copy action, labelled “Show full ${noun}”. Expanded: ${expanded.visibleLines} lines, overflow-y ${expanded.overflowY}, not clipped, copy action ${expanded.hasCopy ? "present" : "absent"}, ending “${tail}”. Re-collapsed to 1 line.`,
       true,
     );
   }
@@ -166,4 +207,88 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   // The old clipped-first-line "failed — …" summary is gone.
   const legacyFailedSummary = await evalIn(app, `document.body.innerText.includes('failed — ')`);
   expect(legacyFailedSummary).toBe(false);
+
+  // A command that is still running: its current-action line is one clipped
+  // shimmer line until double-clicked, then the same scrollable, copyable box.
+  await control(app, "eval.tool_details.seed_running_command");
+  await waitFor(app, `Boolean(document.querySelector('[data-tool-aggregate-now] .ow-text-shimmer'))`, {
+    timeoutMs: 15_000,
+    label: "running command shimmer line",
+  });
+  const runningLine = await evalIn(app, nowProbeScript);
+  if (!isNowProbe(runningLine)) throw new Error(`Running command line was not readable: ${JSON.stringify(runningLine)}`);
+  expect(runningLine.hasShimmer).toBe(true);
+  expect(runningLine.oneLine).toBe(true);
+  expect(runningLine.showsBox).toBe(false);
+  expect(runningLine.text).toContain(RUNNING_HEAD);
+  expect(runningLine.text).not.toContain(RUNNING_TAIL);
+
+  // A single click must not swap the line: only a double-click does.
+  await evalIn(app, `document.querySelector('[data-tool-aggregate-now]').click()`);
+  const afterClick = await evalIn(app, nowProbeScript);
+  if (!isNowProbe(afterClick)) throw new Error(`Running command line was not readable: ${JSON.stringify(afterClick)}`);
+  expect(afterClick.showsBox).toBe(false);
+
+  await evalIn(app, `document.querySelector('[data-tool-aggregate-now]').dispatchEvent(
+    new MouseEvent('dblclick', { bubbles: true, cancelable: true, view: window }),
+  )`);
+  await waitFor(app, `Boolean(document.querySelector('[data-tool-aggregate-now] [data-tool-aggregate-detail="command"][data-command-expanded="true"]'))`, {
+    timeoutMs: 15_000,
+    label: "running command box after double-click",
+  });
+  const runningBox = await probe(app, "command", false);
+  expect(runningBox.expanded).toBe("true");
+  expect(runningBox.scrollable).toBe(true);
+  expect(runningBox.hasCopy).toBe(true);
+  expect(runningBox.text).toContain(RUNNING_HEAD);
+  expect(runningBox.text).toContain(RUNNING_TAIL);
+  const headerStillRunning = await evalIn(app, `[...document.querySelectorAll('[data-tool-aggregate] > button')]
+    .some((button) => (button.textContent ?? '').includes('Running command'))`);
+  expect(headerStillRunning).toBe(true);
+  evidence.recordAssertionEvidence(
+    "Double-clicking a running command's line swaps it for the scrollable command box",
+    `Before: one shimmer line starting “${RUNNING_HEAD}” without the tail. A single click changed nothing. After dblclick: an expanded scroll box (overflow-y ${runningBox.overflowY}, content taller than the box) containing “${RUNNING_TAIL}”, with a copy action, under a header still reading “Running command”.`,
+    true,
+  );
+
+  // Copy hands the exact command to the clipboard (stubbed so the check does
+  // not depend on OS clipboard focus rules).
+  const copied = await evalIn(app, `(async () => {
+    const written = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: (text) => { written.push(text); return Promise.resolve(); } },
+    });
+    const button = document.querySelector('[data-tool-aggregate-now] [data-tool-aggregate-copy]');
+    if (!(button instanceof HTMLElement)) return null;
+    button.click();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return { written, label: button.getAttribute('aria-label') };
+  })()`, { awaitPromise: true });
+  if (!copied || typeof copied !== "object" || !("written" in copied) || !Array.isArray(copied.written)) {
+    throw new Error(`Copy action was not readable: ${JSON.stringify(copied)}`);
+  }
+  expect(copied.written).toHaveLength(1);
+  const [writtenCommand] = copied.written;
+  if (typeof writtenCommand !== "string") throw new Error(`Copied value was not text: ${JSON.stringify(copied)}`);
+  expect(writtenCommand.startsWith(RUNNING_HEAD)).toBe(true);
+  expect(writtenCommand.endsWith(RUNNING_TAIL)).toBe(true);
+  expect(writtenCommand.split("\n").length).toBeGreaterThan(12);
+  expect("label" in copied ? copied.label : null).toBe("Command copied");
+  evidence.recordAssertionEvidence(
+    "The copy action writes the whole running command, not the clipped label",
+    `One clipboard write of ${writtenCommand.split("\n").length} lines from “${RUNNING_HEAD}” to “${RUNNING_TAIL}”; the action then read “Command copied”.`,
+    true,
+  );
+
+  // Clicking the box collapses it back to the shimmer line.
+  await evalIn(app, `document.querySelector('[data-tool-aggregate-now] [data-tool-aggregate-detail="command"]').click()`);
+  await waitFor(app, `Boolean(document.querySelector('[data-tool-aggregate-now] .ow-text-shimmer'))`, {
+    timeoutMs: 15_000,
+    label: "running command shimmer line restored",
+  });
+  const restored = await evalIn(app, nowProbeScript);
+  if (!isNowProbe(restored)) throw new Error(`Running command line was not readable: ${JSON.stringify(restored)}`);
+  expect(restored.showsBox).toBe(false);
+  expect(restored.oneLine).toBe(true);
 });


### PR DESCRIPTION
## What changed

An expanded command in a chat tool group wrapped to its full height, so a long script could swallow the thread, and there was no way to copy it. While a command was still running, its current-action line was clipped to one line with no way to read the rest.

- **Expanded detail boxes are bounded scroll containers.** Command, search-pattern, and error boxes now open into a `max-h-60` scroll box instead of growing without limit. Short values still show completely; long ones scroll.
- **Commands get a copy action.** Beside the collapse chevron of an expanded command box, one click copies the exact command text (icon flips to a check, label reads "Command copied").
- **Double-click a running command to read it.** The one-line shimmer for an in-flight command swaps for the same scrollable, copyable box on double-click. A single click does nothing (it stays out of the way of the header toggle), and clicking the box returns to the shimmer line. If the command finishes while shown, the history box for it stays expanded.
- `getAggregateNowLabel` became `getAggregateNowPart` so the group can act on the current-action part, not just label it.
- Dev-only seed `eval.tool_details.seed_running_command` renders one in-flight 20-line command in an active session for the e2e proof.

## Proof

Lane: **Daytona** (`OPENWORK_EVAL_DAYTONA=1`, sandbox from `.devcontainer/test-on-daytona.sh feature/scrollable-command-preview`, checked out at the PR head).

```
OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_DAYTONA=1 pnpm evals:e2e chat-tool-details-expand --daytona
# exit 0 — 1 passed, 0 failed, 0 skipped — gitSha e8c2fdd (PR head)
```

`evals/specs/chat-tool-details-expand.e2e.test.ts` now asserts, on top of its existing claims:
- expanded boxes compute `overflow-y: auto`; only the command box has a copy action, collapsed boxes have none;
- a running command's line is one shimmer line without the tail; a single click changes nothing; after `dblclick` the line is an expanded scroll box (content taller than the box) containing the last line, under a header still reading "Running command";
- the copy action writes the whole 20-line command once and reads "Command copied";
- clicking the box restores the one-line shimmer.

Unit lane (`bun test --isolate tests/tool-aggregate-group.test.tsx tests/message-list-step-fold.test.tsx`): 17 pass. `pnpm --filter @openwork/app typecheck`: clean. `pnpm evals:pr specs/chat-thought-chronology.test.ts`: 1 passed.

Note: `pnpm evals:typecheck` reports 605 errors on pristine `dev` in this environment as well (email templates, headless-threads, other specs); none are in files this PR touches.

Verdict: **Passed**.
