### PR TITLE
fix(cloud): deliver managed provider credentials after a sandbox cold start

### DIFF
--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -10,7 +10,7 @@ import type { CloudMcpLiveStatusObserver } from "../cloud-mcp-health.js";
 import { readOpenWorkConnectSkillCatalog, renderOpenWorkConnectSkillInstruction } from "../connect-skill-catalog.js";
 import { readOpenWorkAutomationCatalog, renderOpenWorkAutomationInstruction } from "../connect-automation-catalog.js";
 import { EnvStoreReadError, InvalidEnvKeyError, isValidEnvKey, type EnvService } from "../env-file.js";
-import { syncManagedProviderAuth } from "../managed-provider-auth.js";
+import { syncManagedProviderAuth, type ManagedProviderAuthResult } from "../managed-provider-auth.js";
 import { ApiError } from "../errors.js";
 import { callExperimentalExtensionAction, listExperimentalExtensionActions } from "../extensions/index.js";
 import type { TokenService } from "../tokens.js";
@@ -44,6 +44,7 @@ interface RegisterCoreRoutesOptions {
   serializeWorkspace: (workspace: ServerConfig["workspaces"][number]) => unknown;
   resolveDevLogPath: () => string | null;
   createOpenAiRealtimeVoiceSession: (env: EnvService, input: unknown) => Promise<unknown>;
+  onManagedProviderAuthChanged?: (result: ManagedProviderAuthResult) => Promise<void>;
   managedProviderAuthLogger?: {
     warn: (message: string, attributes?: Record<string, unknown>) => void;
     error: (message: string, attributes?: Record<string, unknown>) => void;
@@ -105,6 +106,7 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     serializeWorkspace,
     resolveDevLogPath,
     createOpenAiRealtimeVoiceSession,
+    onManagedProviderAuthChanged,
     managedProviderAuthLogger,
   } = options;
   const envPendingChangesByRuntime = new Map<string, boolean>();
@@ -472,7 +474,10 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     }
     // A stored credential is useless until the engine holds it: deliver it now
     // rather than waiting for the next engine start.
-    await syncManagedProviderAuth({ config, env, logger: managedProviderAuthLogger }).catch(() => undefined);
+    const authResult = await syncManagedProviderAuth({ config, env, logger: managedProviderAuthLogger }).catch(() => undefined);
+    if (authResult && (authResult.delivered.length > 0 || authResult.removed.length > 0)) {
+      await onManagedProviderAuthChanged?.(authResult).catch(() => undefined);
+    }
     return jsonResponse({ ok: true, count: entries.length });
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2153,6 +2153,15 @@ function createRoutes(
   cloudProviderSync: CloudProviderSync,
 ): Route[] {
   const routes: Route[] = [];
+  // A rollover-capable pool can apply this immediately without disposing
+  // the generation that owns live sessions. Legacy/external engines keep
+  // the established busy deferral.
+  const applyManagedProviderReload = async (workspace: WorkspaceInfo): Promise<"reloaded" | "deferred"> => {
+    const reloadDeferred = await shouldDeferInPlaceEngineReload(config, workspace, engineHasActiveSessions);
+    if (!reloadDeferred) await reloadOpencodeEngine(config, workspace, engineMcpServerState);
+    if (reloadDeferred) cloudProviderSync.markReloadPending();
+    return reloadDeferred ? "deferred" : "reloaded";
+  };
   registerCoreRoutes({
     routes,
     config,
@@ -2175,6 +2184,9 @@ function createRoutes(
     serializeWorkspace,
     resolveDevLogPath,
     createOpenAiRealtimeVoiceSession,
+    onManagedProviderAuthChanged: async () => {
+      await applyManagedProviderReload(resolveEngineRuntimeWorkspace(config));
+    },
   });
 
   registerWorkspaceRoutes({
@@ -2691,17 +2703,8 @@ function createRoutes(
       || fileResult.changed
       || authResult.delivered.length > 0
       || authResult.removed.length > 0;
-    // A rollover-capable pool can apply this immediately without disposing
-    // the generation that owns live sessions. Legacy/external engines keep
-    // the established busy deferral.
     const reloadDeferred = shouldReload
-      && (await shouldDeferInPlaceEngineReload(config, workspace, engineHasActiveSessions));
-    if (shouldReload && !reloadDeferred) {
-      await reloadOpencodeEngine(config, workspace, engineMcpServerState);
-    }
-    if (reloadDeferred) {
-      cloudProviderSync.markReloadPending();
-    }
+      && (await applyManagedProviderReload(workspace)) === "deferred";
     return jsonResponse({
       ok: true,
       changed: result.changed,

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -111,6 +111,8 @@ const requestTimeoutMs = 8_000
  * picker.
  */
 const materializedFingerprintByWorkerInstance = new Map<string, string>()
+// Only write-phase failures are cached. Read failures can occur while the
+// sandbox engine is booting and are safe to retry immediately.
 const materializationFailureByWorkerInstance = new Map<string, {
   failedAt: number
   result: Extract<CloudProviderMaterializationResult, { ok: false }>
@@ -952,6 +954,7 @@ export async function materializeCloudWorkerProviders(input: {
   const cacheKey = materializationCacheKey(input.workerId, instanceUrl)
   let fingerprint: string | null = null
   let providerCount = 0
+  let writePhaseStarted = false
 
   try {
     if (!instanceUrl) {
@@ -1009,6 +1012,7 @@ export async function materializeCloudWorkerProviders(input: {
     let providerPatched = false
 
     try {
+      writePhaseStarted = true
       await writeEnvEntries({
         fetchImpl,
         instanceUrl,
@@ -1101,7 +1105,9 @@ export async function materializeCloudWorkerProviders(input: {
       result,
       cause: error,
     })
-    materializationFailureByWorkerInstance.set(cacheKey, { failedAt: now(), result })
+    if (writePhaseStarted) {
+      materializationFailureByWorkerInstance.set(cacheKey, { failedAt: now(), result })
+    }
     return result
   }
 }

--- a/evals/specs/cloud-provider-materialization-read-retry.test.ts
+++ b/evals/specs/cloud-provider-materialization-read-retry.test.ts
@@ -1,0 +1,187 @@
+import { test } from "@openwork/testkit";
+import { expect } from "vitest";
+import { createDenTypeId } from "../../ee/packages/utils/src/typeid.js";
+import type {
+  CloudProviderMaterializationProvider,
+  CloudProviderMaterializationStore,
+} from "../../ee/apps/den-api/src/llm/cloud-provider-materialization.js";
+
+type MaterializerModule = typeof import("../../ee/apps/den-api/src/llm/cloud-provider-materialization.js");
+type MaterializeInput = Parameters<MaterializerModule["materializeCloudWorkerProviders"]>[0];
+type FetchImpl = NonNullable<MaterializeInput["fetchImpl"]>;
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test";
+  process.env.DEN_DB_ENCRYPTION_KEY ??= "x".repeat(32);
+  process.env.BETTER_AUTH_SECRET ??= "y".repeat(32);
+  process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790";
+  process.env.CORS_ORIGINS ??= "http://127.0.0.1:8790";
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBody(body: BodyInit | null | undefined): unknown {
+  return typeof body === "string" && body ? JSON.parse(body) : null;
+}
+
+function bodyEntries(body: unknown) {
+  if (!isRecord(body) || !Array.isArray(body.entries)) return [];
+  return body.entries.filter(isRecord);
+}
+
+function makeAnthropicProvider(): CloudProviderMaterializationProvider {
+  const modelId = "claude-fable-5";
+  return {
+    id: createDenTypeId("llmProvider"),
+    source: "models_dev",
+    providerId: "anthropic",
+    name: "Anthropic",
+    providerConfig: {
+      id: "anthropic",
+      name: "Anthropic",
+      npm: "@ai-sdk/anthropic",
+      env: ["ANTHROPIC_API_KEY"],
+    },
+    apiKey: "sk-anthropic",
+    models: [{
+      modelId,
+      name: modelId,
+      modelConfig: { id: modelId, name: modelId, tool_call: true },
+    }],
+  };
+}
+
+function makeInstance(input: { failConfigReads?: number; failEnvWrites?: number } = {}) {
+  const calls: string[] = [];
+  const envValues = new Map<string, string>();
+  const managedProviders: Record<string, unknown> = {};
+  let failConfigReads = input.failConfigReads ?? 0;
+  let failEnvWrites = input.failEnvWrites ?? 0;
+
+  const fetchImpl: FetchImpl = async (url, init) => {
+    const path = new URL(url).pathname;
+    const method = init?.method ?? "GET";
+    calls.push(`${method} ${path}`);
+
+    if (method === "GET" && path === "/opencode/config") {
+      if (failConfigReads > 0) {
+        failConfigReads -= 1;
+        return jsonResponse({ code: "opencode_unconfigured" }, 400);
+      }
+      return jsonResponse({ provider: managedProviders });
+    }
+
+    if (method === "GET" && path.startsWith("/env/")) {
+      const key = decodeURIComponent(path.slice("/env/".length));
+      const value = envValues.get(key);
+      return value === undefined
+        ? jsonResponse({ error: "env_not_found" }, 404)
+        : jsonResponse({ item: { key, value } });
+    }
+
+    if (method === "PUT" && path === "/env") {
+      if (failEnvWrites > 0) {
+        failEnvWrites -= 1;
+        return jsonResponse({ error: "env_write_failed" }, 500);
+      }
+      for (const entry of bodyEntries(parseBody(init?.body))) {
+        if (typeof entry.key === "string" && typeof entry.value === "string") {
+          envValues.set(entry.key, entry.value);
+        }
+      }
+      return jsonResponse({ ok: true });
+    }
+
+    if (method === "PATCH" && path === "/runtime-config/providers") {
+      const body = parseBody(init?.body);
+      const patch = isRecord(body) && isRecord(body.provider) ? body.provider : {};
+      for (const [providerId, value] of Object.entries(patch)) {
+        if (value === null) delete managedProviders[providerId];
+        else managedProviders[providerId] = value;
+      }
+      return jsonResponse({ updatedAt: Date.now() });
+    }
+
+    return jsonResponse({ error: "not_found" }, 404);
+  };
+
+  return { calls, fetchImpl };
+}
+
+test("read-phase failures retry immediately while write-phase failures cool down", async ({ evidence }) => {
+  seedRequiredEnv();
+  const { materializeCloudWorkerProviders } = await import(
+    "../../ee/apps/den-api/src/llm/cloud-provider-materialization.js"
+  );
+  const provider = makeAnthropicProvider();
+  const store: CloudProviderMaterializationStore = {
+    async listProviders() {
+      return [provider];
+    },
+    async getActiveTokens() {
+      return [];
+    },
+  };
+  const organizationId = createDenTypeId("organization");
+  const instanceUrl = "https://worker.example.test";
+  const now = () => 1_000;
+  const logger = { warn() {}, error() {} };
+  const materialize = (workerId: MaterializeInput["workerId"], fetchImpl: FetchImpl) =>
+    materializeCloudWorkerProviders({
+      organizationId,
+      workerId,
+      instanceUrl,
+      hostToken: "host-token",
+      clientToken: "client-token",
+      store,
+      fetchImpl,
+      logger,
+      now,
+    });
+
+  const readFailureInstance = makeInstance({ failConfigReads: 1 });
+  const workerId = createDenTypeId("worker");
+  const failedRead = await materialize(workerId, readFailureInstance.fetchImpl);
+
+  expect(failedRead.ok).toBe(false);
+  if (failedRead.ok) throw new Error("expected the first config read to fail");
+  expect(failedRead.reason).toBe("engine_config_read_failed_400");
+  expect(readFailureInstance.calls).not.toContain("PUT /env");
+  expect(readFailureInstance.calls).not.toContain("PATCH /runtime-config/providers");
+
+  const retriedRead = await materialize(workerId, readFailureInstance.fetchImpl);
+
+  expect(retriedRead.ok).toBe(true);
+  expect(retriedRead.status).toBe("applied");
+  expect(readFailureInstance.calls).toContain("PUT /env");
+  expect(readFailureInstance.calls).toContain("PATCH /runtime-config/providers");
+  evidence.recordAssertionEvidence(
+    "Read-phase materialization failures retry without a cooldown",
+    "The failed config read made no writes, and the same worker immediately retried through env and provider writes.",
+    true,
+  );
+
+  const writeFailureInstance = makeInstance({ failEnvWrites: 1 });
+  const writeWorkerId = createDenTypeId("worker");
+  const failedWrite = await materialize(writeWorkerId, writeFailureInstance.fetchImpl);
+  writeFailureInstance.calls.length = 0;
+  const cooledDownWrite = await materialize(writeWorkerId, writeFailureInstance.fetchImpl);
+
+  expect(failedWrite.ok).toBe(false);
+  expect(cooledDownWrite).toEqual(failedWrite);
+  expect(writeFailureInstance.calls).toEqual([]);
+  evidence.recordAssertionEvidence(
+    "Write-phase materialization failures retain their cooldown",
+    "The repeated call returned the same failure without making a fetch request.",
+    true,
+  );
+});

--- a/evals/specs/managed-provider-env-delivery-reload.test.ts
+++ b/evals/specs/managed-provider-env-delivery-reload.test.ts
@@ -1,0 +1,212 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eventually, test } from "@openwork/testkit";
+import { expect } from "vitest";
+
+import { resetManagedProviderAuthCache } from "../../apps/server/src/managed-provider-auth.js";
+import { openworkRuntimeConfigFilePath } from "../../apps/server/src/openwork-runtime-config.js";
+import { startServer } from "../../apps/server/src/server.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+
+const CLIENT_TOKEN = "owt_managed_provider_env_client";
+const HOST_TOKEN = "owt_managed_provider_env_host";
+
+function hostHeaders() {
+  return { "x-openwork-host-token": HOST_TOKEN, "content-type": "application/json" };
+}
+
+function managedProviderChanges(requests: string[]): string[] {
+  return requests.filter((entry) => entry.startsWith("PUT /auth/") || entry === "POST /instance/dispose");
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+async function handleEngineRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  config: ServerConfig,
+  requests: string[],
+): Promise<void> {
+  const method = request.method ?? "GET";
+  const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+  requests.push(`${method} ${path}`);
+  if (method === "GET" && path === "/config") {
+    const content = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(content);
+    return;
+  }
+  if (method === "POST" && path === "/instance/dispose") {
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+  if ((method === "PUT" || method === "DELETE") && path.startsWith("/auth/")) {
+    sendJson(response, 200, true);
+    return;
+  }
+  sendJson(response, 404, { error: "not_found" });
+}
+
+async function startFakeEngine(config: ServerConfig, requests: string[]) {
+  const engine = createServer((request, response) => {
+    void handleEngineRequest(request, response, config, requests).catch((error) => {
+      sendJson(response, 500, { error: error instanceof Error ? error.message : String(error) });
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    engine.once("error", reject);
+    engine.listen(0, "127.0.0.1", resolve);
+  });
+  const address = engine.address();
+  if (!address || typeof address === "string") throw new Error("Fake engine did not bind a TCP port");
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    stop: () => new Promise<void>((resolve, reject) => {
+      engine.close((error) => error ? reject(error) : resolve());
+      engine.closeAllConnections();
+    }),
+  };
+}
+
+test("stored managed provider credentials reload the engine after auth delivery", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwork-provider-env-reload-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  const previousEnvStore = process.env.OPENWORK_ENV_STORE;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_ENV_STORE = join(root, "env.json");
+  resetManagedProviderAuthCache();
+
+  const engineRequests: string[] = [];
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    approval: { mode: "auto", timeoutMs: 1_000 },
+    corsOrigins: ["*"],
+    workspaces: [{
+      id: "ws_managed_provider_env",
+      name: "Managed provider env",
+      path: root,
+      preset: "starter",
+      workspaceType: "local",
+    }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const provider = {
+    id: "anthropic",
+    name: "Managed",
+    env: ["MANAGED_TEST_API_KEY"],
+    npm: "@ai-sdk/anthropic",
+  };
+  let engine: Awaited<ReturnType<typeof startFakeEngine>> | undefined;
+  let server: Awaited<ReturnType<typeof startServer>> | undefined;
+
+  try {
+    engine = await startFakeEngine(config, engineRequests);
+    const workspace = config.workspaces[0];
+    if (!workspace) throw new Error("Expected one workspace");
+    workspace.baseUrl = engine.baseUrl;
+    server = await startServer(config);
+    const base = `http://127.0.0.1:${server.port}`;
+
+    const initialPatch = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_test: provider } }),
+    });
+    expect(initialPatch.status).toBe(200);
+    expect(await initialPatch.json()).toMatchObject({ changed: true, reload: "reloaded" });
+    expect(engineRequests.filter((entry) => entry === "POST /instance/dispose")).toHaveLength(1);
+    expect(engineRequests.some((entry) => entry === "PUT /auth/lpr_test")).toBe(false);
+    engineRequests.length = 0;
+
+    const firstPut = await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ entries: [{ key: "MANAGED_TEST_API_KEY", value: "sk-first" }] }),
+    });
+    expect(firstPut.status).toBe(200);
+    expect(await firstPut.json()).toEqual({ ok: true, count: 1 });
+    expect(await eventually(() => managedProviderChanges(engineRequests), {
+      within: 10_000,
+      intervalMs: 25,
+      until: (entries) => entries.length >= 2,
+      label: "managed auth delivery followed by engine reload",
+    })).toEqual(["PUT /auth/lpr_test", "POST /instance/dispose"]);
+    expect(engineRequests).toEqual(["PUT /auth/lpr_test", "GET /session/status", "POST /instance/dispose"]);
+
+    const stored = await fetch(`${base}/env/MANAGED_TEST_API_KEY`, { headers: hostHeaders() });
+    expect(stored.status).toBe(200);
+    expect(await stored.json()).toMatchObject({
+      item: { key: "MANAGED_TEST_API_KEY", value: "sk-first" },
+    });
+    engineRequests.length = 0;
+
+    const unrelatedPut = await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ entries: [{ key: "UNRELATED_KEY", value: "x" }] }),
+    });
+    expect(unrelatedPut.status).toBe(200);
+    expect(await unrelatedPut.json()).toEqual({ ok: true, count: 1 });
+    expect(managedProviderChanges(engineRequests)).toEqual([]);
+    engineRequests.length = 0;
+
+    const identicalPatch = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_test: provider } }),
+    });
+    expect(identicalPatch.status).toBe(200);
+    expect(await identicalPatch.json()).toMatchObject({ changed: false, reload: "skipped" });
+    expect(managedProviderChanges(engineRequests)).toEqual([]);
+    engineRequests.length = 0;
+
+    const identicalPut = await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ entries: [{ key: "MANAGED_TEST_API_KEY", value: "sk-first" }] }),
+    });
+    expect(identicalPut.status).toBe(200);
+    expect(await identicalPut.json()).toEqual({ ok: true, count: 1 });
+    expect(managedProviderChanges(engineRequests)).toEqual([]);
+    engineRequests.length = 0;
+
+    const rotatedPut = await fetch(`${base}/env`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ entries: [{ key: "MANAGED_TEST_API_KEY", value: "sk-second" }] }),
+    });
+    expect(rotatedPut.status).toBe(200);
+    expect(await rotatedPut.json()).toEqual({ ok: true, count: 1 });
+    expect(await eventually(() => managedProviderChanges(engineRequests), {
+      within: 10_000,
+      intervalMs: 25,
+      until: (entries) => entries.length >= 2,
+      label: "rotated managed auth delivery followed by engine reload",
+    })).toEqual(["PUT /auth/lpr_test", "POST /instance/dispose"]);
+    expect(engineRequests).toEqual(["PUT /auth/lpr_test", "GET /session/status", "POST /instance/dispose"]);
+  } finally {
+    await server?.stop();
+    await engine?.stop();
+    resetManagedProviderAuthCache();
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    if (previousEnvStore === undefined) delete process.env.OPENWORK_ENV_STORE;
+    else process.env.OPENWORK_ENV_STORE = previousEnvStore;
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

OpenWork Web users hit **"OpenRouter API key is missing. Pass it using the 'apiKey' parameter or the OPENROUTER_API_KEY environment variable."** when using `openwork/*` models (e.g. DeepSeek V4 Flash) after their sandbox woke from the 30‑minute idle stop. The `openwork` provider is built on `@openrouter/ai-sdk-provider` (`ee/apps/den-api/src/inference.ts:97`), so this is the SDK saying the **openwork provider has no credential** — nothing is routed to OpenRouter.

**Evidence (Sentry, den-api, last 7d):** 333× `cloud provider materialization failed` with `reason: engine_config_read_failed_400`, exactly one per sandbox wake (`CLOUD_IDLE_STOP_MINUTES=30`). Reproduced locally: a fresh `openwork-server` answers `GET /opencode/config` with `400 opencode_unconfigured` until its managed engine is spawned.

## Root cause

Two bugs compound:

1. **Boot race.** `cli.ts` starts listening before the managed engine spawns; `/health` is unconditionally 200. den-api's gateway resolve treats health as ready and materializes providers immediately. Its first step `GET /opencode/config` hits `proxyOpencodeRequest` with no pool and no `baseUrl` → 400 → den-api **cached the failure for 120 s**. Meanwhile the runtime config (with the `openwork` block) was restored from the checkpoint volume, so the model shows in the picker, but `auth.json`/env are deliberately not checkpointed → first prompt fails.
2. **Skipped reload.** When the retry finally ran, `PUT /env` delivered `PUT /auth/openwork` and recorded the fingerprint **without reloading** (`routes/core.ts`). The following identical `PATCH /runtime-config/providers` saw `changed=false` and `delivered=[]` → `shouldReload=false`. OpenCode caches SDK clients from config+auth together and `PUT /auth` does not rebuild them (`cloud-provider-sync.ts:967-985`), so the keyless instance persisted until the next restart — which re-raced.

## Fix

- `ee/apps/den-api/src/llm/cloud-provider-materialization.ts`: only cache a failure cooldown once the write phase has started. Read‑phase failures (no side effects) are retried on the next gateway resolve (≤15 s). Write‑phase and `unsupported` failures keep their cooldown.
- `apps/server/src/routes/core.ts` + `server.ts`: `PUT /env` applies the same reload/defer decision as the PATCH route when its auth sync delivers or removes a credential (extracted into `applyManagedProviderReload`; PATCH behavior unchanged).

## Proof

App‑less PR lane (both mechanisms are server/API‑level; no Den/desktop resources, so Daytona adds nothing):

- `evals/specs/cloud-provider-materialization-read-retry.test.ts` — read failure returns `engine_config_read_failed_400` with **no** `PUT /env`/`PATCH`; the next call (same worker+instance, no `force`) is `applied`; a write‑phase (`PUT /env` 500) failure **still** cools down (identical result, zero fetches).
- `evals/specs/managed-provider-env-delivery-reload.test.ts` — `PUT /env` for a managed key → `["PUT /auth/lpr_test", "POST /instance/dispose"]` in that order; unrelated key → no auth/no dispose; identical `PATCH` → `reload: "skipped"`, no dispose; same value re‑PUT → nothing; rotated value → auth then dispose.

Evidence is published in the sticky test‑evidence comment below.

## Not in scope (follow‑ups)

- Holding `/opencode/*` until the managed engine is up (would shrink the remaining first‑seconds window further). `/health` semantics are deliberately untouched: a non‑OK health triggers sandbox recovery in den-api.
- `packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx` is stale (describes `Shared Workspace` / `Add workspace` / `Connect` drawer; current product is one auto‑provisioned **OpenWork Web** instance per member with no desktop hand‑off on that page). Separate docs PR.
