### PR TITLE
fix(den): apply desktop policies through role hierarchy

### DIFF
--- a/ee/apps/den-api/src/desktop-policies.ts
+++ b/ee/apps/den-api/src/desktop-policies.ts
@@ -18,6 +18,7 @@ import {
   type DesktopPolicyValue,
 } from "@openwork/types/den/desktop-policies"
 import { db } from "./db.js"
+import { matchingDesktopPolicyAssignmentRoles } from "./desktop-policy-role-assignments.js"
 
 export type DesktopPolicyId = typeof DesktopPolicyTable.$inferSelect.id
 export type DesktopPolicyRow = typeof DesktopPolicyTable.$inferSelect
@@ -113,23 +114,17 @@ export async function calculateDesktopPolicyForOrgMember(input: {
     .limit(1)
   const memberRole = memberRows[0]?.role ?? null
   const teamIds = await listTeamIdsForOrgMember(input)
-  const assignedWhere = memberRole
-    ? teamIds.length > 0
-      ? or(
-          eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId),
-          inArray(DesktopPolicyMemberTable.teamId, teamIds),
-          eq(DesktopPolicyMemberTable.role, memberRole),
-        )
-      : or(
-          eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId),
-          eq(DesktopPolicyMemberTable.role, memberRole),
-        )
-    : teamIds.length > 0
-      ? or(
-          eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId),
-          inArray(DesktopPolicyMemberTable.teamId, teamIds),
-        )
-      : eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId)
+  const matchingRoles = memberRole ? matchingDesktopPolicyAssignmentRoles(memberRole) : []
+  const assignedWhere = teamIds.length > 0
+    ? or(
+        eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId),
+        inArray(DesktopPolicyMemberTable.teamId, teamIds),
+        inArray(DesktopPolicyMemberTable.role, matchingRoles),
+      )
+    : or(
+        eq(DesktopPolicyMemberTable.orgMemberId, input.orgMemberId),
+        inArray(DesktopPolicyMemberTable.role, matchingRoles),
+      )
 
   const assignedPolicies = assignedWhere
     ? await db

--- a/ee/apps/den-api/src/desktop-policy-role-assignments.ts
+++ b/ee/apps/den-api/src/desktop-policy-role-assignments.ts
@@ -1,0 +1,18 @@
+import {
+  ORGANIZATION_ADMIN_ROLE,
+  ORGANIZATION_MEMBER_ROLE,
+  ORGANIZATION_OWNER_ROLE,
+  organizationRoleValueSatisfies,
+} from "./organization-role-hierarchy.js"
+
+const desktopPolicyAssignmentRoles = [
+  ORGANIZATION_OWNER_ROLE,
+  ORGANIZATION_ADMIN_ROLE,
+  ORGANIZATION_MEMBER_ROLE,
+]
+
+export function matchingDesktopPolicyAssignmentRoles(memberRole: string) {
+  return desktopPolicyAssignmentRoles.filter((assignedRole) => (
+    organizationRoleValueSatisfies({ roleValue: memberRole, requiredRole: assignedRole })
+  ))
+}

--- a/ee/apps/den-api/test/desktop-policy-role-assignments.test.ts
+++ b/ee/apps/den-api/test/desktop-policy-role-assignments.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test"
+import { matchingDesktopPolicyAssignmentRoles } from "../src/desktop-policy-role-assignments.js"
+
+describe("desktop policy role assignments", () => {
+  test("matches role assignments through the organization hierarchy", () => {
+    expect(matchingDesktopPolicyAssignmentRoles("owner")).toEqual(["owner", "admin", "member"])
+    expect(matchingDesktopPolicyAssignmentRoles("super-admin")).toEqual(["admin", "member"])
+    expect(matchingDesktopPolicyAssignmentRoles("admin,member")).toEqual(["admin", "member"])
+    expect(matchingDesktopPolicyAssignmentRoles("member")).toEqual(["member"])
+  })
+})


### PR DESCRIPTION
## Summary

- Fix the customer-facing symptom where super admins do not see **Add Provider** despite an admin-assigned desktop-policy exception.
- Resolve role assignments through the organization hierarchy and support comma-joined member role values.

## Root cause

`ee/apps/den-api/src/desktop-policies.ts:115` compared `DesktopPolicyMemberTable.role` to the raw `MemberTable.role` string with exact equality. Consequently, `super-admin` did not match an `admin` assignment, and `admin,member` did not match either constituent assignment.

## Verification

- `cd ee/apps/den-api && bun test test/desktop-policy-role-assignments.test.ts` — exit 0; 1 pass, 0 fail, 4 assertions across 1 file.
- `cd ee/apps/den-api && pnpm run build:mcp-apps` — exit 0; all 3 MCP App bundles built.
- `cd ee/apps/den-api && pnpm exec tsc --noEmit -p .` — exit 0; no TypeScript diagnostics.
- The initial typecheck before building `@openwork/mcp-apps` exited 2 with three missing generated-module errors; the final typecheck above passed after the required dependency build.
- `models-available.e2e.test.ts` remains quarantined because `spec-quarantine.test.ts` requires the enabled inventory to be evidence-backed and its manifest entry says it is not yet verified green.

Verdict: Passed