### PR TITLE
ci: require owners and specs for protected surfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Desktop provider authentication, settings, policy, and credential sync
+/apps/app/src/react-app/domains/connections/provider-auth/** @benjaminshafii @reachjalil @OmarMcAdam
+/apps/app/src/react-app/domains/settings/pages/ai-view.tsx @benjaminshafii @reachjalil @OmarMcAdam
+/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx @benjaminshafii @reachjalil @OmarMcAdam
+/apps/app/src/app/cloud/desktop-app-restrictions.ts @benjaminshafii @reachjalil @OmarMcAdam
+/apps/server/src/cloud-provider-sync.ts @benjaminshafii @reachjalil @OmarMcAdam
+
+# Organization desktop policies
+/ee/apps/den-api/src/desktop-policies.ts @benjaminshafii @src-opn @OmarMcAdam
+/ee/apps/den-api/src/routes/org/desktop-policies.ts @benjaminshafii @src-opn @OmarMcAdam
+
+# Organization providers, connections, and SSO
+/ee/apps/den-api/src/llm/** @benjaminshafii @reachjalil @OmarMcAdam
+/ee/apps/den-api/src/routes/org/mcp-connections.ts @benjaminshafii @reachjalil @OmarMcAdam
+/ee/apps/den-api/src/**/sso* @OmarMcAdam @benjaminshafii @src-opn
+
+# CI guardrails and spec quarantine
+/.github/workflows/** @benjaminshafii @OmarMcAdam @reachjalil
+/evals/specs/quarantine.json @benjaminshafii @OmarMcAdam @reachjalil

--- a/.github/workflows/spec-impact.yml
+++ b/.github/workflows/spec-impact.yml
@@ -2,7 +2,7 @@ name: Spec Impact Snapshot
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -23,8 +23,14 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: >-
-          node evals/scripts/spec-impact.mjs
-          --base "$BASE_SHA"
-          --head "$HEAD_SHA"
-          --summary "$GITHUB_STEP_SUMMARY"
+          NO_RUNTIME_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'no-runtime-change') }}
+        run: |
+          args=()
+          if [[ "$NO_RUNTIME_CHANGE" != "true" ]]; then
+            args+=(--strict-paths evals/specs/spec-impact-strict-paths.json)
+          fi
+          node evals/scripts/spec-impact.mjs \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            "${args[@]}"

--- a/evals/scripts/spec-impact.mjs
+++ b/evals/scripts/spec-impact.mjs
@@ -11,6 +11,24 @@ function matches(pathname, pattern) {
   return pathname === pattern
 }
 
+function matchesGlob(pathname, pattern) {
+  let expression = "^"
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index]
+    if (character === "*" && pattern[index + 1] === "*") {
+      if (pattern[index + 2] === "/") {
+        expression += "(?:.*/)?"
+        index += 2
+      } else {
+        expression += ".*"
+        index += 1
+      }
+    } else if (character === "*") expression += "[^/]*"
+    else expression += character.replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+  }
+  return new RegExp(`${expression}$`).test(pathname)
+}
+
 function strings(value, label) {
   if (!Array.isArray(value) || value.length === 0 || value.some((entry) => typeof entry !== "string" || entry.length === 0)) {
     throw new Error(`${label} must be a non-empty string array`)
@@ -64,6 +82,22 @@ export function validateSnapshot(value) {
   return contracts
 }
 
+export function validateStrictPaths(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("strict paths must be an object")
+  if (Reflect.get(value, "version") !== 1) throw new Error("strict paths version must be 1")
+  return {
+    protectedPaths: strings(Reflect.get(value, "protectedPaths"), "strict paths protectedPaths"),
+    testPaths: strings(Reflect.get(value, "testPaths"), "strict paths testPaths"),
+  }
+}
+
+export function analyzeStrictImpact(config, changedFiles) {
+  const changed = [...new Set(changedFiles.map((entry) => entry.trim()).filter(Boolean))].sort()
+  const protectedFiles = changed.filter((pathname) => config.protectedPaths.some((pattern) => matchesGlob(pathname, pattern)))
+  const testFiles = changed.filter((pathname) => config.testPaths.some((pattern) => matchesGlob(pathname, pattern)))
+  return { protectedFiles, testFiles, required: protectedFiles.length > 0 && testFiles.length === 0 }
+}
+
 export function analyzeImpact(contracts, changedFiles) {
   const changed = [...new Set(changedFiles.map((entry) => entry.trim()).filter(Boolean))].sort()
   const changedE2eTests = changed.filter((pathname) => pathname.startsWith("evals/specs/") && pathname.endsWith(".e2e.test.ts"))
@@ -111,6 +145,14 @@ function annotation(value) {
   return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")
 }
 
+function strictMarkdown(result) {
+  const lines = ["### Strict spec-impact paths", ""]
+  if (result.protectedFiles.length === 0) lines.push("No protected path changed.", "")
+  else if (result.required) lines.push("Protected paths changed without a spec or test change:", ...result.protectedFiles.map((entry) => `- \`${entry}\``), "")
+  else lines.push("Protected path changes include a spec or test change.", "")
+  return lines.join("\n")
+}
+
 function parseArgs(args) {
   const options = { changedFiles: [] }
   for (let index = 0; index < args.length; index += 1) {
@@ -118,11 +160,12 @@ function parseArgs(args) {
     if (argument === "--strict") options.strict = true
     else if (argument === "--json") options.json = true
     else if (argument === "--matched-tests") options.matchedTests = true
-    else if (["--base", "--head", "--snapshot", "--summary", "--changed-file"].includes(argument)) {
+    else if (["--base", "--head", "--snapshot", "--summary", "--strict-paths", "--changed-file"].includes(argument)) {
       const value = args[index + 1]
       if (!value) throw new Error(`${argument} requires a value`)
       index += 1
       if (argument === "--changed-file") options.changedFiles.push(value)
+      else if (argument === "--strict-paths") options.strictPaths = value
       else options[argument.slice(2)] = value
     } else throw new Error(`unknown argument: ${argument}`)
   }
@@ -146,7 +189,10 @@ function main() {
     ? options.changedFiles
     : gitChangedFiles(options.base, options.head)
   const result = analyzeImpact(contracts, changedFiles)
-  const report = markdown(result)
+  const strictImpact = options.strictPaths
+    ? analyzeStrictImpact(validateStrictPaths(JSON.parse(readFileSync(resolve(repoRoot, options.strictPaths), "utf8"))), changedFiles)
+    : undefined
+  const report = [markdown(result), strictImpact && strictMarkdown(strictImpact)].filter(Boolean).join("\n")
   if (options.summary) appendFileSync(options.summary, report)
   if (options.matchedTests) {
     process.stdout.write(`${JSON.stringify(result.matchedTests)}\n`)
@@ -157,7 +203,10 @@ function main() {
   for (const contract of result.attention) {
     process.stdout.write(`::warning title=Spec impact snapshot::${annotation(`${contract.id} changed without a mapped E2E test change`)}\n`)
   }
-  if (options.strict && result.attention.length > 0) process.exitCode = 2
+  if (strictImpact?.required) {
+    process.stdout.write("::error title=Spec or test change required::Protected paths changed without a spec or test change\n")
+  }
+  if ((options.strict && result.attention.length > 0) || strictImpact?.required) process.exitCode = 2
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main()

--- a/evals/scripts/spec-impact.test.mjs
+++ b/evals/scripts/spec-impact.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+import { analyzeStrictImpact, validateStrictPaths } from "./spec-impact.mjs"
+
+const script = fileURLToPath(new URL("./spec-impact.mjs", import.meta.url))
+const configPath = fileURLToPath(new URL("../specs/spec-impact-strict-paths.json", import.meta.url))
+const config = validateStrictPaths(JSON.parse(readFileSync(configPath, "utf8")))
+const providerAuthStore = "apps/app/src/react-app/domains/connections/provider-auth/store.ts"
+
+test("strict paths require a spec or test change for protected surfaces", () => {
+  const run = (...changedFiles) => spawnSync(process.execPath, [
+    script,
+    "--strict-paths",
+    configPath,
+    ...changedFiles.flatMap((pathname) => ["--changed-file", pathname]),
+  ])
+  assert.equal(run(providerAuthStore).status, 2)
+  assert.equal(run(providerAuthStore, "evals/specs/provider-auth.test.ts").status, 0)
+  assert.equal(run("packages/docs/provider-auth.md").status, 0)
+  assert.equal(analyzeStrictImpact(config, ["ee/apps/den-api/src/routes/org/sso.ts"]).required, true)
+})

--- a/evals/specs/spec-impact-strict-paths.json
+++ b/evals/specs/spec-impact-strict-paths.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "protectedPaths": [
+    "apps/app/src/react-app/domains/connections/provider-auth/**",
+    "apps/app/src/react-app/domains/settings/pages/ai-view.tsx",
+    "apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx",
+    "apps/app/src/app/cloud/desktop-app-restrictions.ts",
+    "apps/server/src/cloud-provider-sync.ts",
+    "ee/apps/den-api/src/desktop-policies.ts",
+    "ee/apps/den-api/src/routes/org/desktop-policies.ts",
+    "ee/apps/den-api/src/llm/**",
+    "ee/apps/den-api/src/routes/org/mcp-connections.ts",
+    "ee/apps/den-api/src/**/sso*",
+    ".github/workflows/**",
+    "evals/specs/quarantine.json"
+  ],
+  "testPaths": [
+    "evals/specs/**",
+    "apps/**/tests/**",
+    "ee/**/test/**"
+  ]
+}


### PR DESCRIPTION
## Summary
- add CODEOWNERS coverage for provider auth, provider settings/sync, desktop policy, managed LLM, MCP connection, SSO, workflow, and quarantine surfaces
- make spec-impact fail for protected changes without a spec/test change, unless `no-runtime-change` is present
- rerun the check when the exemption label is added or removed

## Protected paths
- `apps/app/src/react-app/domains/connections/provider-auth/**`
- `apps/app/src/react-app/domains/settings/pages/ai-view.tsx`
- `apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx`
- `apps/app/src/app/cloud/desktop-app-restrictions.ts`
- `apps/server/src/cloud-provider-sync.ts`
- `ee/apps/den-api/src/desktop-policies.ts`
- `ee/apps/den-api/src/routes/org/desktop-policies.ts`
- `ee/apps/den-api/src/llm/**`
- `ee/apps/den-api/src/routes/org/mcp-connections.ts`
- `ee/apps/den-api/src/**/sso*`
- `.github/workflows/**`
- `evals/specs/quarantine.json`

## Owner mapping
Derived from 90-day path history and verified against repository collaborators and `gh api users/<handle>`:
- Benjamin Shafii / ben → `@benjaminshafii`
- Jalil → `@reachjalil`
- Omar McAdam → `@OmarMcAdam`
- Source Open → `@src-opn`

Uncertain mappings: none.

## Verification
- protected `provider-auth/store.ts`, no spec/test: exit 2
- same protected change plus `evals/specs/provider-auth.test.ts`: exit 0
- docs-only change: exit 0
- `node --test evals/scripts/spec-impact.test.mjs`: pass (1/1)
- CODEOWNERS errors API on pushed branch: `[]`
- `actionlint`: unavailable locally

Inert agent/CI configuration needs no runtime testkit proof.

**Verdict: Passed** — deterministic guardrail checks passed; runtime app proof is not applicable.