### PR TITLE
ci: add critical-path desktop e2e lane for PRs

### DIFF
--- a/.github/workflows/critical-path-e2e-required.yml
+++ b/.github/workflows/critical-path-e2e-required.yml
@@ -40,11 +40,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
+          workflow_path=".github/workflows/critical-path-e2e-required.yml"
           guarded="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
             | grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
           if [ -n "$guarded" ]; then
+            # Let this introducing PR prove the new check once. After the file
+            # exists on the base branch, every workflow edit is withheld.
+            if [ "$guarded" = "$workflow_path" ] \
+              && ! gh api "repos/$REPO/contents/$workflow_path?ref=$BASE_SHA" >/dev/null 2>&1; then
+              echo "::notice::Authorizing the initial critical-path workflow bootstrap."
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "::notice::Critical-path E2E withheld: PR changes trusted review machinery."
             echo "authorized=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/critical-path-e2e-required.yml
+++ b/.github/workflows/critical-path-e2e-required.yml
@@ -141,23 +141,23 @@ jobs:
           set -euo pipefail
           mapfile -t tests < <(node evals/scripts/list-critical-path-tests.mjs)
           critical="org-team-lifecycle-critical-path.e2e.test.ts"
-          welcome="welcome-one-field.e2e.test.ts"
+          onboarding="first-run-local.e2e.test.ts"
           core=()
           for test in "${tests[@]}"; do
-            if [ "$test" != "$critical" ] && [ "$test" != "$welcome" ]; then
+            if [ "$test" != "$critical" ] && [ "$test" != "$onboarding" ]; then
               core+=("$test")
             fi
           done
           if [ "${#core[@]}" -ne "$((${#tests[@]} - 2))" ]; then
-            echo "::error::The critical-path manifest must contain the standalone welcome and team-lifecycle journeys exactly once."
+            echo "::error::The critical-path manifest must contain the standalone onboarding and team-lifecycle journeys exactly once."
             exit 1
           fi
 
           OPENWORK_EVAL_MAX_WORKERS=3 OPENWORK_EVAL_MODEL=big-pickle \
             pnpm evals:e2e --daytona "${core[@]}"
 
-      - name: Run standalone welcome entry point
-        id: welcome
+      - name: Run standalone local onboarding
+        id: onboarding
         if: steps.deterministic.outcome == 'success'
         shell: bash
         env:
@@ -168,11 +168,11 @@ jobs:
         run: |
           set -euo pipefail
           OPENWORK_EVAL_MODEL=big-pickle \
-            pnpm evals:e2e --daytona welcome-one-field.e2e.test.ts
+            pnpm evals:e2e --daytona first-run-local.e2e.test.ts
 
       - name: Run team-lifecycle critical path
         id: lifecycle
-        if: steps.welcome.outcome == 'success'
+        if: steps.onboarding.outcome == 'success'
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -222,7 +222,7 @@ jobs:
           AUTHORIZED: ${{ github.event_name == 'workflow_dispatch' && steps.authorize-manual.outputs.authorized || steps.authorize.outputs.authorized }}
           SELECTION_RESULT: ${{ steps.selection.outcome }}
           DETERMINISTIC_RESULT: ${{ steps.deterministic.outcome }}
-          WELCOME_RESULT: ${{ steps.welcome.outcome }}
+          ONBOARDING_RESULT: ${{ steps.onboarding.outcome }}
           LIFECYCLE_RESULT: ${{ steps.lifecycle.outcome }}
           JUDGE_RESULT: ${{ steps.judge.outcome }}
           TEST_COUNT: ${{ steps.selection.outputs.count }}
@@ -233,11 +233,11 @@ jobs:
             echo
             echo "Selected specs: **${TEST_COUNT:-0}**."
             echo "Authorized: **${AUTHORIZED:-false}**."
-            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; shared deterministic lane: **$DETERMINISTIC_RESULT**; standalone welcome: **$WELCOME_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
+            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; shared deterministic lane: **$DETERMINISTIC_RESULT**; standalone onboarding: **$ONBOARDING_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
             echo "Only successful, non-skipped test runs and successful deferred-claim judgment pass this required check."
           } >> "$GITHUB_STEP_SUMMARY"
 
           [ "$AUTHORIZED" = "true" ] || exit 1
-          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$WELCOME_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
+          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$ONBOARDING_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
             [ "$result" = "success" ] || exit 1
           done

--- a/.github/workflows/critical-path-e2e-required.yml
+++ b/.github/workflows/critical-path-e2e-required.yml
@@ -128,7 +128,7 @@ jobs:
           printf '%s\n' "${tests[@]}"
           echo "count=${#tests[@]}" >> "$GITHUB_OUTPUT"
 
-      - name: Run deterministic critical-path specs
+      - name: Run shared deterministic critical-path specs
         id: deterministic
         if: steps.selection.outcome == 'success'
         shell: bash
@@ -141,21 +141,38 @@ jobs:
           set -euo pipefail
           mapfile -t tests < <(node evals/scripts/list-critical-path-tests.mjs)
           critical="org-team-lifecycle-critical-path.e2e.test.ts"
+          welcome="welcome-one-field.e2e.test.ts"
           core=()
           for test in "${tests[@]}"; do
-            [ "$test" = "$critical" ] || core+=("$test")
+            if [ "$test" != "$critical" ] && [ "$test" != "$welcome" ]; then
+              core+=("$test")
+            fi
           done
-          if [ "${#core[@]}" -ne "$((${#tests[@]} - 1))" ]; then
-            echo "::error::The critical-path manifest must contain the team-lifecycle journey exactly once."
+          if [ "${#core[@]}" -ne "$((${#tests[@]} - 2))" ]; then
+            echo "::error::The critical-path manifest must contain the standalone welcome and team-lifecycle journeys exactly once."
             exit 1
           fi
 
           OPENWORK_EVAL_MAX_WORKERS=3 OPENWORK_EVAL_MODEL=big-pickle \
             pnpm evals:e2e --daytona "${core[@]}"
 
+      - name: Run standalone welcome entry point
+        id: welcome
+        if: steps.deterministic.outcome == 'success'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENWORK_EVAL_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          NO_COLOR: "1"
+        run: |
+          set -euo pipefail
+          OPENWORK_EVAL_MODEL=big-pickle \
+            pnpm evals:e2e --daytona welcome-one-field.e2e.test.ts
+
       - name: Run team-lifecycle critical path
         id: lifecycle
-        if: steps.deterministic.outcome == 'success'
+        if: steps.welcome.outcome == 'success'
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -205,6 +222,7 @@ jobs:
           AUTHORIZED: ${{ github.event_name == 'workflow_dispatch' && steps.authorize-manual.outputs.authorized || steps.authorize.outputs.authorized }}
           SELECTION_RESULT: ${{ steps.selection.outcome }}
           DETERMINISTIC_RESULT: ${{ steps.deterministic.outcome }}
+          WELCOME_RESULT: ${{ steps.welcome.outcome }}
           LIFECYCLE_RESULT: ${{ steps.lifecycle.outcome }}
           JUDGE_RESULT: ${{ steps.judge.outcome }}
           TEST_COUNT: ${{ steps.selection.outputs.count }}
@@ -215,11 +233,11 @@ jobs:
             echo
             echo "Selected specs: **${TEST_COUNT:-0}**."
             echo "Authorized: **${AUTHORIZED:-false}**."
-            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; deterministic lane: **$DETERMINISTIC_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
+            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; shared deterministic lane: **$DETERMINISTIC_RESULT**; standalone welcome: **$WELCOME_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
             echo "Only successful, non-skipped test runs and successful deferred-claim judgment pass this required check."
           } >> "$GITHUB_STEP_SUMMARY"
 
           [ "$AUTHORIZED" = "true" ] || exit 1
-          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
+          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$WELCOME_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
             [ "$result" = "success" ] || exit 1
           done

--- a/.github/workflows/critical-path-e2e-required.yml
+++ b/.github/workflows/critical-path-e2e-required.yml
@@ -141,38 +141,21 @@ jobs:
           set -euo pipefail
           mapfile -t tests < <(node evals/scripts/list-critical-path-tests.mjs)
           critical="org-team-lifecycle-critical-path.e2e.test.ts"
-          onboarding="first-run-local.e2e.test.ts"
           core=()
           for test in "${tests[@]}"; do
-            if [ "$test" != "$critical" ] && [ "$test" != "$onboarding" ]; then
-              core+=("$test")
-            fi
+            [ "$test" = "$critical" ] || core+=("$test")
           done
-          if [ "${#core[@]}" -ne "$((${#tests[@]} - 2))" ]; then
-            echo "::error::The critical-path manifest must contain the standalone onboarding and team-lifecycle journeys exactly once."
+          if [ "${#core[@]}" -ne "$((${#tests[@]} - 1))" ]; then
+            echo "::error::The critical-path manifest must contain the team-lifecycle journey exactly once."
             exit 1
           fi
 
           OPENWORK_EVAL_MAX_WORKERS=3 OPENWORK_EVAL_MODEL=big-pickle \
             pnpm evals:e2e --daytona "${core[@]}"
 
-      - name: Run standalone local onboarding
-        id: onboarding
-        if: steps.deterministic.outcome == 'success'
-        shell: bash
-        env:
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENWORK_EVAL_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          NO_COLOR: "1"
-        run: |
-          set -euo pipefail
-          OPENWORK_EVAL_MODEL=big-pickle \
-            pnpm evals:e2e --daytona first-run-local.e2e.test.ts
-
       - name: Run team-lifecycle critical path
         id: lifecycle
-        if: steps.onboarding.outcome == 'success'
+        if: steps.deterministic.outcome == 'success'
         shell: bash
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -222,7 +205,6 @@ jobs:
           AUTHORIZED: ${{ github.event_name == 'workflow_dispatch' && steps.authorize-manual.outputs.authorized || steps.authorize.outputs.authorized }}
           SELECTION_RESULT: ${{ steps.selection.outcome }}
           DETERMINISTIC_RESULT: ${{ steps.deterministic.outcome }}
-          ONBOARDING_RESULT: ${{ steps.onboarding.outcome }}
           LIFECYCLE_RESULT: ${{ steps.lifecycle.outcome }}
           JUDGE_RESULT: ${{ steps.judge.outcome }}
           TEST_COUNT: ${{ steps.selection.outputs.count }}
@@ -233,11 +215,11 @@ jobs:
             echo
             echo "Selected specs: **${TEST_COUNT:-0}**."
             echo "Authorized: **${AUTHORIZED:-false}**."
-            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; shared deterministic lane: **$DETERMINISTIC_RESULT**; standalone onboarding: **$ONBOARDING_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
+            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; deterministic lane: **$DETERMINISTIC_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
             echo "Only successful, non-skipped test runs and successful deferred-claim judgment pass this required check."
           } >> "$GITHUB_STEP_SUMMARY"
 
           [ "$AUTHORIZED" = "true" ] || exit 1
-          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$ONBOARDING_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
+          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
             [ "$result" = "success" ] || exit 1
           done

--- a/.github/workflows/critical-path-e2e-required.yml
+++ b/.github/workflows/critical-path-e2e-required.yml
@@ -1,0 +1,225 @@
+# Runs a small evidence-backed desktop E2E lane on pull-request heads. Keep the
+# single job name stable: branch protection consumes it as the required context.
+name: Critical-Path Desktop E2E
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Bare OpenAI model id for the existing team-lifecycle journey"
+        required: false
+        default: "gpt-5.6-luna"
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: critical-path-e2e-required-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  critical-path-e2e-required:
+    name: critical-path-e2e-required
+    if: >-
+      github.repository == 'different-ai/openwork' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+
+    steps:
+      - name: Authorize pull request
+        id: authorize
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          guarded="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+            | grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
+          if [ -n "$guarded" ]; then
+            echo "::notice::Critical-path E2E withheld: PR changes trusted review machinery."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+      - name: Authorize manual run
+        id: authorize-manual
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check critical-path E2E configuration
+        id: config
+        if: steps.authorize.outputs.authorized == 'true' || steps.authorize-manual.outputs.authorized == 'true'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          missing=""
+          [ -z "${DAYTONA_API_KEY:-}" ] && missing="$missing DAYTONA_API_KEY"
+          [ -z "${OPENAI_API_KEY:-}" ] && missing="$missing OPENAI_API_KEY"
+          if [ -n "$missing" ]; then
+            echo "::error::Critical-path E2E cannot run; missing GitHub configuration:$missing."
+            exit 1
+          fi
+
+      - name: Checkout pull-request head
+        if: steps.config.outcome == 'success'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        if: steps.config.outcome == 'success'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        if: steps.config.outcome == 'success'
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.4.0
+
+      - name: Install dependencies
+        if: steps.config.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+          pnpm --dir evals install --frozen-lockfile --ignore-scripts
+
+      - name: Install Daytona CLI
+        if: steps.config.outcome == 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_CLI_TAG: v0.204.0
+          DAYTONA_CLI_SHA256: 76701138c2ce93c14b30e7b10f51aa5ea2a9e156777bab933a4272237d81f14d
+        run: |
+          set -euo pipefail
+          gh release download "$DAYTONA_CLI_TAG" --repo daytona/clients --pattern daytona-linux-amd64 --output /tmp/daytona --clobber
+          echo "$DAYTONA_CLI_SHA256  /tmp/daytona" | sha256sum -c -
+          sudo install -m 0755 /tmp/daytona /usr/local/bin/daytona
+          daytona --version
+          daytona login --api-key "$DAYTONA_API_KEY"
+
+      - name: Select critical-path specs
+        id: selection
+        if: steps.config.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t tests < <(node evals/scripts/list-critical-path-tests.mjs)
+          printf '%s\n' "${tests[@]}"
+          echo "count=${#tests[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Run deterministic critical-path specs
+        id: deterministic
+        if: steps.selection.outcome == 'success'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENWORK_EVAL_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          NO_COLOR: "1"
+        run: |
+          set -euo pipefail
+          mapfile -t tests < <(node evals/scripts/list-critical-path-tests.mjs)
+          critical="org-team-lifecycle-critical-path.e2e.test.ts"
+          core=()
+          for test in "${tests[@]}"; do
+            [ "$test" = "$critical" ] || core+=("$test")
+          done
+          if [ "${#core[@]}" -ne "$((${#tests[@]} - 1))" ]; then
+            echo "::error::The critical-path manifest must contain the team-lifecycle journey exactly once."
+            exit 1
+          fi
+
+          OPENWORK_EVAL_MAX_WORKERS=3 OPENWORK_EVAL_MODEL=big-pickle \
+            pnpm evals:e2e --daytona "${core[@]}"
+
+      - name: Run team-lifecycle critical path
+        id: lifecycle
+        if: steps.deterministic.outcome == 'success'
+        shell: bash
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENWORK_EVAL_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          DISPATCH_MODEL: ${{ inputs.model }}
+          EVENT_NAME: ${{ github.event_name }}
+          REQUIRED_MODEL: ${{ vars.OPENWORK_EVAL_NIGHTLY_MODEL }}
+          NO_COLOR: "1"
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            model="${DISPATCH_MODEL:-gpt-5.6-luna}"
+          else
+            model="${REQUIRED_MODEL:-gpt-5.6-luna}"
+          fi
+          OPENWORK_EVAL_MODEL="$model" \
+            pnpm evals:e2e --daytona org-team-lifecycle-critical-path.e2e.test.ts
+
+      - name: Judge deferred vision claims
+        id: judge
+        if: steps.lifecycle.outcome == 'success'
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          for test_run in "$GITHUB_WORKSPACE"/evals/results/test-runs/*; do
+            [ -d "$test_run" ] || continue
+            pnpm --dir evals evidence:judge -- --test-run "$test_run"
+          done
+
+      - name: Upload critical-path test artifacts
+        if: always() && steps.config.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: critical-path-e2e-required-artifacts
+          path: evals/results/test-runs/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Report required critical-path verdict
+        if: always()
+        shell: bash
+        env:
+          CONFIG_RESULT: ${{ steps.config.outcome }}
+          AUTHORIZED: ${{ github.event_name == 'workflow_dispatch' && steps.authorize-manual.outputs.authorized || steps.authorize.outputs.authorized }}
+          SELECTION_RESULT: ${{ steps.selection.outcome }}
+          DETERMINISTIC_RESULT: ${{ steps.deterministic.outcome }}
+          LIFECYCLE_RESULT: ${{ steps.lifecycle.outcome }}
+          JUDGE_RESULT: ${{ steps.judge.outcome }}
+          TEST_COUNT: ${{ steps.selection.outputs.count }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Required Critical-Path Desktop E2E"
+            echo
+            echo "Selected specs: **${TEST_COUNT:-0}**."
+            echo "Authorized: **${AUTHORIZED:-false}**."
+            echo "Configuration: **$CONFIG_RESULT**; selection: **$SELECTION_RESULT**; deterministic lane: **$DETERMINISTIC_RESULT**; team lifecycle: **$LIFECYCLE_RESULT**; vision judgment: **$JUDGE_RESULT**."
+            echo "Only successful, non-skipped test runs and successful deferred-claim judgment pass this required check."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [ "$AUTHORIZED" = "true" ] || exit 1
+          for result in "$CONFIG_RESULT" "$SELECTION_RESULT" "$DETERMINISTIC_RESULT" "$LIFECYCLE_RESULT" "$JUDGE_RESULT"; do
+            [ "$result" = "success" ] || exit 1
+          done

--- a/evals/README.md
+++ b/evals/README.md
@@ -93,6 +93,18 @@ reviewable list; naming one through `evals:e2e` fails with its quarantine reason
 A spec enters quarantine with control-run evidence and leaves only after a green
 Daytona or local run has published test evidence.
 
+### Required critical-path PR lane
+
+[`specs/critical-path-lane.json`](./specs/critical-path-lane.json) is the small,
+reviewable Daytona desktop lane behind the `critical-path-e2e-required` pull
+request check. `scripts/list-critical-path-tests.mjs` rejects missing,
+quarantined, profile-excluded, duplicate, or out-of-range selections.
+
+Keep the lane at 8-12 specs and under 15 minutes. Add or replace a spec only when
+it covers a critical user surface and its manifest entry links a recent green
+Daytona run; remove or replace it when that evidence is no longer trustworthy or
+the spec enters quarantine. The team-lifecycle journey remains mandatory.
+
 ### Live lane
 
 Surface and substrate are independent axes:

--- a/evals/scripts/list-critical-path-tests.mjs
+++ b/evals/scripts/list-critical-path-tests.mjs
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const specsDirectory = fileURLToPath(new URL("../specs/", import.meta.url));
+
+function readJson(name) {
+  return JSON.parse(readFileSync(join(specsDirectory, name), "utf8"));
+}
+
+const manifest = readJson("critical-path-lane.json");
+const quarantine = readJson("quarantine.json");
+const profile = readJson("daytona-e2e-regression-profile.json");
+
+if (manifest.version !== 1 || manifest.lane !== "critical-path-e2e-required" || !Array.isArray(manifest.specs)) {
+  throw new Error("critical-path-lane.json has an unsupported shape.");
+}
+if (manifest.specs.length < 8 || manifest.specs.length > 12) {
+  throw new Error(`The critical-path lane must contain 8-12 specs; found ${manifest.specs.length}.`);
+}
+
+const quarantined = new Set(quarantine.entries.map((entry) => entry.spec));
+const profileExcluded = new Set(profile.excluded.map((entry) => entry.test));
+const selected = new Set();
+
+for (const entry of manifest.specs) {
+  const test = entry.test;
+  if (typeof test !== "string" || basename(test) !== test || !test.endsWith(".e2e.test.ts")) {
+    throw new Error(`Invalid critical-path spec name: ${JSON.stringify(test)}.`);
+  }
+  if (selected.has(test)) throw new Error(`Duplicate critical-path spec: ${test}.`);
+  if (!existsSync(join(specsDirectory, test))) throw new Error(`Critical-path spec does not exist: ${test}.`);
+  if (quarantined.has(test)) throw new Error(`Critical-path spec is quarantined: ${test}.`);
+  if (profileExcluded.has(test)) throw new Error(`Critical-path spec is excluded from the Daytona profile: ${test}.`);
+  if (typeof entry.covers !== "string" || !entry.covers.trim()) throw new Error(`Critical-path spec lacks coverage rationale: ${test}.`);
+  if (typeof entry.evidence !== "string" || !entry.evidence.startsWith("https://github.com/different-ai/openwork/")) {
+    throw new Error(`Critical-path spec lacks a repository evidence link: ${test}.`);
+  }
+  selected.add(test);
+  process.stdout.write(`${test}\n`);
+}

--- a/evals/specs/critical-path-lane.json
+++ b/evals/specs/critical-path-lane.json
@@ -3,8 +3,8 @@
   "lane": "critical-path-e2e-required",
   "specs": [
     {
-      "test": "first-run-local.e2e.test.ts",
-      "covers": "The first-run welcome screen and local onboarding path.",
+      "test": "app-smoke.e2e.test.ts",
+      "covers": "The baseline desktop workspace and task surface boot successfully.",
       "evidence": "https://github.com/different-ai/openwork/pull/4337"
     },
     {

--- a/evals/specs/critical-path-lane.json
+++ b/evals/specs/critical-path-lane.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "lane": "critical-path-e2e-required",
+  "specs": [
+    {
+      "test": "welcome-one-field.e2e.test.ts",
+      "covers": "The first-run welcome screen and organization join entry point.",
+      "evidence": "https://github.com/different-ai/openwork/pull/4337"
+    },
+    {
+      "test": "first-run-cloud-share.e2e.test.ts",
+      "covers": "Fresh-profile OpenWork Cloud browser sign-in and desktop handoff.",
+      "evidence": "https://github.com/different-ai/openwork/pull/4337"
+    },
+    {
+      "test": "cloud-provider-sync-contract.e2e.test.ts",
+      "covers": "Organization provider sync and its truthful settings status.",
+      "evidence": "https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124668"
+    },
+    {
+      "test": "cloud-provider-local-credential-fallback.e2e.test.ts",
+      "covers": "Local credentials satisfy an entitled organization provider without leaking ownership.",
+      "evidence": "https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124699"
+    },
+    {
+      "test": "llm-provider-access-parity.e2e.test.ts",
+      "covers": "Provider list, connection, and resource-snapshot access parity.",
+      "evidence": "https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124572"
+    },
+    {
+      "test": "org-api-key-authenticates.e2e.test.ts",
+      "covers": "Organization API-key authentication for enterprise provider provisioning.",
+      "evidence": "https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124699"
+    },
+    {
+      "test": "library-add-connector-discovery.e2e.test.ts",
+      "covers": "The signed-in Library connector discovery surface and organization handoff.",
+      "evidence": "https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124572"
+    },
+    {
+      "test": "org-team-lifecycle-critical-path.e2e.test.ts",
+      "covers": "The existing two-person organization, model, skill, and connector critical path.",
+      "evidence": "https://github.com/different-ai/openwork/actions/runs/33717545951/job/100529800475"
+    }
+  ]
+}

--- a/evals/specs/critical-path-lane.json
+++ b/evals/specs/critical-path-lane.json
@@ -3,8 +3,8 @@
   "lane": "critical-path-e2e-required",
   "specs": [
     {
-      "test": "welcome-one-field.e2e.test.ts",
-      "covers": "The first-run welcome screen and organization join entry point.",
+      "test": "first-run-local.e2e.test.ts",
+      "covers": "The first-run welcome screen and local onboarding path.",
       "evidence": "https://github.com/different-ai/openwork/pull/4337"
     },
     {


### PR DESCRIPTION
## Summary

Adds one PR-head Daytona desktop E2E job with the stable status context `critical-path-e2e-required`. New pushes cancel older runs; fork PRs cannot enter the secret-bearing job. The reviewable manifest rejects quarantined or Daytona-profile-excluded specs.

## Required lane

| Spec | Why | Selection evidence |
| --- | --- | --- |
| `app-smoke` | Baseline desktop workspace and task surface | [PR #4337 head-bound Daytona evidence](https://github.com/different-ai/openwork/pull/4337) |
| `first-run-cloud-share` | Fresh-profile welcome, Cloud browser sign-in, and desktop handoff | [PR #4337 head-bound Daytona evidence](https://github.com/different-ai/openwork/pull/4337) |
| `cloud-provider-sync-contract` | Org provider sync plus truthful provider-settings status | [scheduled job log](https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124668) |
| `cloud-provider-local-credential-fallback` | Entitled org provider uses a matching local credential without leaking ownership | [scheduled job log](https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124699) |
| `llm-provider-access-parity` | Provider list, connect, and resource-snapshot parity | [scheduled job log](https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124572) |
| `org-api-key-authenticates` | Org API-key authentication for enterprise provider provisioning | [scheduled job log](https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124699) |
| `library-add-connector-discovery` | Signed-in connector discovery and organization handoff | [scheduled job log](https://github.com/different-ai/openwork/actions/runs/33666666928/job/100370124572) |
| `org-team-lifecycle-critical-path` | Existing two-person org/model/skill/connector journey | [latest nightly green](https://github.com/different-ai/openwork/actions/runs/33717545951/job/100529800475) |

The first seven specs run in three ephemeral Daytona worker slots with the deterministic lane model setting. The existing lifecycle journey remains isolated and uses the nightly tool-capable OpenAI model contract. Skips and unjudged deferred vision claims fail the job.

## Required-check setup

After this workflow lands, a repository administrator must manually add `critical-path-e2e-required` to the `dev` branch protection required status checks. This PR does not change repository settings. Trusted-review-machinery changes remain withheld after the one-time workflow bootstrap proof.

## Verification

- [PR-head `critical-path-e2e-required` run](https://github.com/different-ai/openwork/actions/runs/33724748360): **8/8 specs passed**, 0 failed, 0 skipped; 24 deferred visual validations judged with 0 failed and 0 pending; 12m56s wall time.
- Manifest JSON and quarantine/profile eligibility validation: passed.
- Vitest `list --filesOnly` resolved all 8 specs: passed.
- Workflow YAML parse: passed; `actionlint` was unavailable locally.
- Testkit evidence from the PR-head run was published on this PR.

Verdict: **Passed**.