### PR TITLE
docs(cloud): describe OpenWork Web instead of shared workspaces

### DIFF
--- a/packages/docs/cloud/get-started.mdx
+++ b/packages/docs/cloud/get-started.mdx
@@ -69,6 +69,6 @@ After sign-in, pick your organization in `Settings > Account`. Organization-assi
 - Send members to [Connect your services](/start-here/connect-your-stack/connect-services) to sign in to team-approved accounts from the desktop app.
 - Use [Connectors](/cloud/share-with-your-team/shared-mcp-connections) to publish a managed service and grant member or team access.
 - Use [Publish and copy a skill](/start-here/do-work-with-it/publish-and-copy-a-skill) for the primary skill-sharing flow, or [Collections](/cloud/share-with-your-team/collections) to group and assign several plugins.
-- Use [Shared workspaces](/cloud/run-in-the-cloud/shared-workspace) to deploy hosted OpenWork runtimes that teammates can open from the desktop app.
+- Use [OpenWork Web](/cloud/run-in-the-cloud/shared-workspace) to give members a hosted OpenWork workspace in the browser, with nothing to install.
 - Use [LLM providers](/cloud/share-with-your-team/managed-llm-provider) or [custom LLM providers](/cloud/share-with-your-team/custom-llm-provider) to manage shared model access.
 - Use [Members and RBAC](/cloud/members-and-rbac) to invite people, create teams, and control access.

--- a/packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
@@ -9,29 +9,30 @@ description: "Run a full OpenWork workspace in the browser, hosted by OpenWork"
 
 OpenWork Web gives your team a full OpenWork workspace in the browser, hosted and managed for you — nothing to install. An organization owner or admin can purchase it directly from the organization dashboard.
 
-## Deploy a hosted workspace
+## Turn on OpenWork Web
 
-1. Open your org dashboard and go to `Shared Workspace`.
-2. Click `Add workspace`.
-3. Wait until the status becomes `Ready`.
-4. Click `Connect`.
+1. As an organization owner or admin, open your org dashboard and go to `OpenWork Web`.
+2. Click `Purchase OpenWork Web — $50 per member/month`.
+3. Complete Stripe checkout.
 
-From the connection drawer you can choose `Open in web` to use OpenWork Web directly in the browser, `Open in desktop`, or copy the `Connection URL` plus `Owner token` / `Client token`.
+If a platform admin has granted your organization complimentary access, you do not need to purchase OpenWork Web.
 
-## Open it from the desktop app
+## Open your workspace
 
-The same hosted workspace also opens in the desktop app. From the connection
-drawer, click `Connect` and copy the `Connection URL` plus `Owner token` /
-`Client token`. In the desktop app, choose `Add workspace -> Connect custom
-remote`, paste the connection URL and token, then click `Connect remote`.
+Any signed-in member can open the org dashboard, go to `OpenWork Web`, and click `Open OpenWork Web`. The first time you open it, OpenWork automatically provisions your instance.
+
+Each member gets one instance per organization. Work is not shared between members' instances. After 30 minutes of inactivity, your instance stops automatically and wakes the next time you open it. Your files persist across wakes.
+
+## OpenWork Web and the desktop app
+
+OpenWork Web runs in the browser and is not opened from the desktop app. The desktop app's `Add workspace -> Connect custom remote` flow is for a self-hosted `openwork-server`; see [Self-host OpenWork](/start-here/self-host).
 
 ## When to use OpenWork Web
 
-Use OpenWork Web when your team needs a hosted OpenWork runtime, a stable place for long-running tasks or messaging connectors, or one workspace that several people can open from the same org — especially for teammates who should not have to install anything.
+Use OpenWork Web for teammates who should not install anything, long-running tasks, or working from a machine without the desktop app.
 
 ## Notes
 
 - `DEN_OPENWORK_WEB_ENABLED=true` makes OpenWork Web available to every organization. Missing or false remains fail-closed except for an organization with an explicit complimentary grant from a platform admin in Den `/admin`; organization mode, Stripe-variable presence, and ordinary organization metadata do not act as rollout signals.
-- A workspace must be `Ready` before it can be opened.
-- Hosted workspace limits follow your OpenWork plan.
+- Each member has one OpenWork Web instance per organization; there is no option to add more.
 - If you prefer to self-host a runtime instead, run `openwork-server` and connect the desktop app to that server URL.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -135,7 +135,7 @@ OpenWork does not require many third-party services for the core runtime. These 
 
 Skip the server. [**OpenWork Cloud**](/cloud/get-started) runs hosted workers for your team.
 
-Cloud also gives you org-wide primitives you'd otherwise have to build: [Collections](/cloud/share-with-your-team/collections), [shared LLM providers](/cloud/share-with-your-team/managed-llm-provider), [RBAC](/cloud/members-and-rbac), and [shared workspaces](/cloud/run-in-the-cloud/shared-workspace).
+Cloud also gives you org-wide primitives you'd otherwise have to build: [Collections](/cloud/share-with-your-team/collections), [shared LLM providers](/cloud/share-with-your-team/managed-llm-provider), [RBAC](/cloud/members-and-rbac), and [OpenWork Web](/cloud/run-in-the-cloud/shared-workspace).
 
 ## Looking for support for a larger rollout?
 


### PR DESCRIPTION
## Why

An investor/customer (Mike Hinckley) reported "trouble adding multiple shared workspaces — the UI does not appear to allow it" and asked whether the desktop app can open them, noting the docs seemed out of date. He was right: `cloud/run-in-the-cloud/shared-workspace.mdx` still described a removed flow (`Shared Workspace` → `Add workspace` → `Ready` → `Connect` drawer with owner/client tokens, "one workspace several people can open", "open it from the desktop app").

## What the product actually does (verified in code)

- Sidebar item is **OpenWork Web** (`den-web …/org-dashboard-shell.tsx:446`); the page offers `Purchase OpenWork Web — $50 per member/month` or, once active, `Open OpenWork Web` + `View billing` (`dashboard/web/page.tsx`).
- **One instance per member per organization**, auto‑provisioned on first open; no way to add more (`den-api routes/cloud/index.ts:253-277, 463-492`). Members' instances are separate.
- Idle stop after 30 min (`CLOUD_IDLE_STOP_MINUTES`), automatic wake, files checkpointed.
- The page exposes no connection URL/token, so OpenWork Web is browser‑only; the desktop `Add workspace -> Connect custom remote` flow is for self‑hosted `openwork-server`.

## Changes

- `packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx`: rewrite body (Turn on OpenWork Web / Open your workspace / OpenWork Web and the desktop app / When to use / Notes). File name and URL unchanged (nav in `docs.json` references it).
- `packages/docs/cloud/get-started.mdx:72`, `packages/docs/start-here/self-host.mdx:138`: cross‑link text.

## Verification

Docs-only change; no runtime proof applies. Checked that no stale terms remain:
`rg -n "Shared Workspace|Click \`Add workspace\`|connection drawer|Owner token|Client token|becomes \`Ready\`" <3 files>` → no matches. There is no `packages/docs` lint/build script.

Follow-up to #4344 (the cold-start credential fix from the same report).
