### PR TITLE
fix(app): disable config providers on disconnect

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -2182,9 +2182,13 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       await removeProviderAuthCredentials(resolved);
       const updated = await refreshProviders({ dispose: true });
       if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {
-        // Provider is still connected (e.g. via env var). Just remove
-        // stored credentials; do NOT add to disabled_providers.
-        return `Removed stored credentials for ${resolved}${t("providers.still_connected_suffix")}`;
+        const provider = updated.all.find((entry) => entry.id === resolved);
+        if (provider?.source === "env") {
+          // Environment-backed providers are controlled outside OpenWork.
+          return `Removed stored credentials for ${resolved}${t("providers.still_connected_suffix")}`;
+        }
+        await ensureProjectProviderDisabledState(resolved, true);
+        await refreshProviders({ dispose: true });
       }
       removeProviderFromState(resolved);
       return `${t("providers.disconnected_prefix")} ${resolved}`;

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2403,6 +2403,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               const message = await providerAuthStore.disconnectProvider(providerId);
               if (typeof message === "string" && message.trim()) {
                 setConfigActionStatus(message);
+                toast.success(message);
               }
             }}
             canDisconnectProvider={(provider) =>

--- a/apps/app/tests/provider-auth-disconnect.test.ts
+++ b/apps/app/tests/provider-auth-disconnect.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createClient } from "../src/app/lib/opencode";
+import type { ProviderListItem, WorkspaceDisplay } from "../src/app/types";
+import { createProviderAuthStore } from "../src/react-app/domains/connections/provider-auth/store";
+
+const originalFetch = globalThis.fetch;
+const providerId = "litellm";
+
+type RecordedRequest = {
+  method: string;
+  path: string;
+  body: string | null;
+};
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function provider(source: ProviderListItem["source"]): ProviderListItem {
+  return {
+    id: providerId,
+    name: "LiteLLM",
+    env: [],
+    source,
+    models: {},
+  };
+}
+
+function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) return init.method;
+  return input instanceof Request ? input.method : "GET";
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof URL) return input;
+  return new URL(typeof input === "string" ? input : input.url);
+}
+
+async function requestBody(input: RequestInfo | URL, init?: RequestInit): Promise<string | null> {
+  if (typeof init?.body === "string") return init.body;
+  if (input instanceof Request) return await input.clone().text();
+  return null;
+}
+
+function disabledProvidersFromBody(body: BodyInit | null | undefined): string[] {
+  if (typeof body !== "string") return [];
+  const value: unknown = JSON.parse(body);
+  if (!value || typeof value !== "object" || !("disabled_providers" in value)) return [];
+  const disabled = value.disabled_providers;
+  return Array.isArray(disabled)
+    ? disabled.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function createDisconnectStore(options: {
+  connectedAfterCredentialRemoval: boolean;
+  source?: ProviderListItem["source"];
+}) {
+  const requests: RecordedRequest[] = [];
+  const item = provider(options.source ?? "config");
+  let providers = [item];
+  let connectedProviderIds = [providerId];
+  let providerDefaults: Record<string, string> = { [providerId]: "test-model" };
+  let disabledProviders: string[] = [];
+  let credentialsRemoved = false;
+
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestUrl(input);
+      const method = requestMethod(input, init);
+      const body = await requestBody(input, init);
+      requests.push({ method, path: url.pathname, body });
+
+      if (method === "DELETE" && url.pathname === `/auth/${providerId}`) {
+        credentialsRemoved = true;
+        return jsonResponse(true);
+      }
+      if (method === "PATCH" && url.pathname === "/config") {
+        disabledProviders = disabledProvidersFromBody(body);
+        return jsonResponse({ disabled_providers: disabledProviders });
+      }
+      if (method === "GET" && url.pathname === "/config") {
+        return jsonResponse({ disabled_providers: disabledProviders });
+      }
+      if (method === "GET" && url.pathname === "/provider") {
+        const connected = credentialsRemoved && !options.connectedAfterCredentialRemoval
+          ? []
+          : [providerId];
+        return jsonResponse({ all: [item], connected, default: providerDefaults });
+      }
+      if (url.pathname === "/global/health") {
+        return jsonResponse({ healthy: true, version: "test" });
+      }
+      return jsonResponse(true);
+    },
+  });
+
+  const client = createClient("https://engine.example", "/tmp/provider-auth-disconnect");
+  const workspace = {
+    id: "workspace_test",
+    name: "Test workspace",
+    path: "/tmp/provider-auth-disconnect",
+    preset: "default",
+    workspaceType: "local",
+  } satisfies WorkspaceDisplay;
+  const store = createProviderAuthStore({
+    client: () => client,
+    providers: () => providers,
+    providerDefaults: () => providerDefaults,
+    providerConnectedIds: () => connectedProviderIds,
+    disabledProviders: () => disabledProviders,
+    checkDesktopAppRestriction: () => false,
+    selectedWorkspaceDisplay: () => workspace,
+    providerBaseUrl: () => "https://engine.example",
+    selectedWorkspaceRoot: () => workspace.path,
+    runtimeWorkspaceId: () => workspace.id,
+    openworkServer: {
+      getSnapshot: () => ({
+        openworkServerStatus: "disconnected",
+        openworkServerClient: null,
+        openworkServerCapabilities: null,
+      }),
+    },
+    setProviders: (value) => {
+      providers = value;
+    },
+    setProviderDefaults: (value) => {
+      providerDefaults = value;
+    },
+    setProviderConnectedIds: (value) => {
+      connectedProviderIds = value;
+    },
+    setDisabledProviders: (value) => {
+      disabledProviders = value;
+    },
+    markOpencodeConfigReloadRequired: () => undefined,
+  });
+
+  return {
+    store,
+    requests,
+    connectedProviderIds: () => connectedProviderIds,
+    disabledProviders: () => disabledProviders,
+  };
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+});
+
+describe("provider disconnect", () => {
+  test("disables a config-defined provider that remains connected after credential removal", async () => {
+    const harness = createDisconnectStore({ connectedAfterCredentialRemoval: true });
+
+    const message = await harness.store.disconnectProvider(providerId);
+
+    expect(message).toBe("Disconnected litellm");
+    expect(harness.disabledProviders()).toEqual([providerId]);
+    expect(harness.connectedProviderIds()).toEqual([]);
+    expect(harness.store.getSnapshot().providerAuthProviders).toEqual([]);
+    const configWrites = harness.requests.filter(
+      (request) => request.method === "PATCH" && request.path === "/config",
+    );
+    expect(configWrites).toHaveLength(1);
+    expect(configWrites[0]?.body).toContain(providerId);
+  });
+
+  test("does not disable a provider when credential removal disconnects it", async () => {
+    const harness = createDisconnectStore({ connectedAfterCredentialRemoval: false });
+
+    const message = await harness.store.disconnectProvider(providerId);
+
+    expect(message).toBe("Disconnected litellm");
+    expect(harness.disabledProviders()).toEqual([]);
+    expect(harness.connectedProviderIds()).toEqual([]);
+    expect(harness.requests.some(
+      (request) => request.method === "PATCH" && request.path === "/config",
+    )).toBe(false);
+  });
+
+  test("leaves an environment-backed provider enabled when it remains connected", async () => {
+    const harness = createDisconnectStore({
+      connectedAfterCredentialRemoval: true,
+      source: "env",
+    });
+
+    const message = await harness.store.disconnectProvider(providerId);
+
+    expect(message).toContain("still reports it as connected");
+    expect(harness.disabledProviders()).toEqual([]);
+    expect(harness.connectedProviderIds()).toEqual([providerId]);
+    expect(harness.requests.some(
+      (request) => request.method === "PATCH" && request.path === "/config",
+    )).toBe(false);
+  });
+});

--- a/evals/specs/contracts.snapshot.json
+++ b/evals/specs/contracts.snapshot.json
@@ -421,6 +421,7 @@
         "evals/specs/models-available.e2e.test.ts",
         "evals/specs/opencode-unconfigured-notification.e2e.test.ts",
         "evals/specs/org-model-analytics-desktop.e2e.test.ts",
+        "evals/specs/provider-disconnect-config-defined.e2e.test.ts",
         "evals/specs/session-model-availability.e2e.test.ts",
         "evals/specs/subagent-run-survives-provider-sync-storm.e2e.test.ts"
       ]

--- a/evals/specs/provider-disconnect-config-defined.e2e.test.ts
+++ b/evals/specs/provider-disconnect-config-defined.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   waitFor,
 } from "@openwork/behaviors";
 import { desktop } from "@openwork/hosts";
-import { eventually, needs, test } from "@openwork/testkit";
+import { needs, test } from "@openwork/testkit";
 
 const providerId = "litellm-disconnect-fixture";
 const providerName = "Config-defined LiteLLM";
@@ -31,6 +31,42 @@ const createOpencodeConfig = (baseURL: string) => ({
     },
   },
 });
+
+async function configureProvider(
+  app: Parameters<typeof evalIn>[0],
+  workspaceId: string,
+  config: ReturnType<typeof createOpencodeConfig>,
+): Promise<void> {
+  const result = await evalIn(app, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return "local_server_unavailable";
+    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const headers = {
+      Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
+      "Content-Type": "application/json",
+    };
+    const configured = await fetch(root + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/config", {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ opencode: ${JSON.stringify(config)} }),
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!configured.ok) return "config:" + configured.status + ":" + (await configured.text()).slice(0, 300);
+    const reloaded = await fetch(root + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/engine/reload", {
+      method: "POST",
+      headers,
+      signal: AbortSignal.timeout(60000),
+    });
+    return reloaded.ok ? "ok" : "reload:" + reloaded.status + ":" + (await reloaded.text()).slice(0, 300);
+  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  expect(result).toBe("ok");
+
+  await evalIn(app, "location.reload(); true");
+  await waitFor(app, "Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "desktop restored after provider configuration",
+  });
+}
 
 async function closeModelPicker(app: Parameters<typeof evalIn>[0]): Promise<void> {
   await evalIn(app, `(() => {
@@ -66,24 +102,51 @@ test("disconnect disables a config-defined provider", async ({ evidence }) => {
   const address = provider.address();
   if (!address || typeof address === "string") throw new Error("The provider fixture did not bind a TCP port.");
   const opencodeConfig = createOpencodeConfig(`http://127.0.0.1:${address.port}/v1`);
-  const profileDir = `/tmp/openwork-provider-disconnect-${process.pid}-${Date.now()}`;
-  const workspacePath = join(profileDir, "workspace");
-  const globalConfigDir = join(profileDir, "opencode-config");
-  onTestFinished(async () => rm(profileDir, { recursive: true, force: true }));
+  const workspacePath = `/tmp/openwork-provider-disconnect-${process.pid}-${Date.now()}`;
+  onTestFinished(async () => rm(workspacePath, { recursive: true, force: true }));
   await mkdir(workspacePath, { recursive: true });
-  await mkdir(globalConfigDir, { recursive: true });
   await writeFile(join(workspacePath, "opencode.json"), `${JSON.stringify(opencodeConfig, null, 2)}\n`, "utf8");
-  await writeFile(join(globalConfigDir, "opencode.json"), `${JSON.stringify(opencodeConfig, null, 2)}\n`, "utf8");
 
-  await using app = await desktop({ name: "provider-disconnect-config-defined", profileDir });
+  await using app = await desktop({ name: "provider-disconnect-config-defined" });
   const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
-  const beforeModels = await eventually(() => readAvailableModels(app), {
-    within: 90_000,
-    intervalMs: 2_000,
-    label: "config-defined LiteLLM model in picker",
-    until: (models) => models.some((model) => model.id === modelId && model.selectable),
+  await configureProvider(app, workspaceId, opencodeConfig);
+  await go(app, `/workspace/${workspaceId}/session`);
+  await readAvailableModels(app);
+  await waitFor(app, `(() => {
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    return Boolean(dialog && dialog.innerText.includes(${JSON.stringify(providerName)}));
+  })()`, {
+    timeoutMs: 60_000,
+    label: "config-defined LiteLLM provider in model picker",
   });
-  expect(beforeModels.some((model) => model.id === modelId && model.selectable)).toBe(true);
+  const expanded = await evalIn(app, `(() => {
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    const header = [...(dialog?.querySelectorAll('button') ?? [])]
+      .find((button) => (button.textContent ?? '').includes(${JSON.stringify(providerName)}));
+    header?.click();
+    return Boolean(header);
+  })()`);
+  expect(expanded).toBe(true);
+  await waitFor(app, `(() => {
+    const dialog = document.querySelector('[data-slot="dialog-content"]');
+    const header = [...(dialog?.querySelectorAll('button') ?? [])]
+      .find((button) => (button.textContent ?? '').includes(${JSON.stringify(providerName)}));
+    const group = header?.parentElement?.parentElement;
+    return Boolean(group && (group.textContent ?? '').includes(${JSON.stringify(modelId)}));
+  })()`, {
+    timeoutMs: 15_000,
+    label: "config-defined LiteLLM model row",
+  });
+  const beforeModels = await readAvailableModels(app);
+  const fixtureModels = beforeModels.filter(
+    (model) => model.providerName === providerName && model.id === modelId,
+  );
+  expect(fixtureModels, `beforeModels: ${JSON.stringify(beforeModels)}`).not.toHaveLength(0);
+  evidence.recordAssertionEvidence(
+    "The config-defined provider contributes its model before disconnect",
+    `Fixture models: ${JSON.stringify(fixtureModels)}`,
+    fixtureModels.length > 0,
+  );
   await closeModelPicker(app);
 
   await go(app, `/workspace/${workspaceId}/settings/ai`);
@@ -125,7 +188,9 @@ test("disconnect disables a config-defined provider", async ({ evidence }) => {
 
   await go(app, `/workspace/${workspaceId}/session`);
   const afterModels = await readAvailableModels(app);
-  const modelStillAvailable = afterModels.some((model) => model.id === modelId);
+  const modelStillAvailable = afterModels.some(
+    (model) => model.providerName === providerName,
+  );
   expect(modelStillAvailable).toBe(false);
   evidence.recordAssertionEvidence(
     "The disconnected provider no longer contributes models",

--- a/evals/specs/provider-disconnect-config-defined.e2e.test.ts
+++ b/evals/specs/provider-disconnect-config-defined.e2e.test.ts
@@ -1,0 +1,135 @@
+import { createServer } from "node:http";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import {
+  createAndSelectWorkspace,
+  evalIn,
+  go,
+  readAvailableModels,
+  waitFor,
+} from "@openwork/behaviors";
+import { desktop } from "@openwork/hosts";
+import { eventually, needs, test } from "@openwork/testkit";
+
+const providerId = "litellm-disconnect-fixture";
+const providerName = "Config-defined LiteLLM";
+const modelId = "litellm-disconnect-model";
+const createOpencodeConfig = (baseURL: string) => ({
+  $schema: "https://opencode.ai/config.json",
+  provider: {
+    [providerId]: {
+      npm: "@ai-sdk/openai-compatible",
+      name: providerName,
+      options: {
+        apiKey: "fixture-key",
+        baseURL,
+      },
+      models: {
+        [modelId]: { name: "LiteLLM disconnect model" },
+      },
+    },
+  },
+});
+
+async function closeModelPicker(app: Parameters<typeof evalIn>[0]): Promise<void> {
+  await evalIn(app, `(() => {
+    const close = document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]');
+    if (close instanceof HTMLElement) close.click();
+    return true;
+  })()`);
+  await waitFor(app, `!document.querySelector('[data-slot="dialog-content"]')`, {
+    timeoutMs: 15_000,
+    label: "model picker closed",
+  });
+}
+
+test("disconnect disables a config-defined provider", async ({ evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  const provider = createServer((request, response) => {
+    if (request.method === "GET" && request.url === "/v1/models") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "not found" } }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    provider.once("error", reject);
+    provider.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    provider.closeAllConnections();
+    await new Promise<void>((resolve, reject) => provider.close((error) => error ? reject(error) : resolve()));
+  });
+  const address = provider.address();
+  if (!address || typeof address === "string") throw new Error("The provider fixture did not bind a TCP port.");
+  const opencodeConfig = createOpencodeConfig(`http://127.0.0.1:${address.port}/v1`);
+  const profileDir = `/tmp/openwork-provider-disconnect-${process.pid}-${Date.now()}`;
+  const workspacePath = join(profileDir, "workspace");
+  const globalConfigDir = join(profileDir, "opencode-config");
+  onTestFinished(async () => rm(profileDir, { recursive: true, force: true }));
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(globalConfigDir, { recursive: true });
+  await writeFile(join(workspacePath, "opencode.json"), `${JSON.stringify(opencodeConfig, null, 2)}\n`, "utf8");
+  await writeFile(join(globalConfigDir, "opencode.json"), `${JSON.stringify(opencodeConfig, null, 2)}\n`, "utf8");
+
+  await using app = await desktop({ name: "provider-disconnect-config-defined", profileDir });
+  const { workspaceId } = await createAndSelectWorkspace(app, { path: workspacePath });
+  const beforeModels = await eventually(() => readAvailableModels(app), {
+    within: 90_000,
+    intervalMs: 2_000,
+    label: "config-defined LiteLLM model in picker",
+    until: (models) => models.some((model) => model.id === modelId && model.selectable),
+  });
+  expect(beforeModels.some((model) => model.id === modelId && model.selectable)).toBe(true);
+  await closeModelPicker(app);
+
+  await go(app, `/workspace/${workspaceId}/settings/ai`);
+  await waitFor(app, `document.body.innerText.includes(${JSON.stringify(providerName)})`, {
+    timeoutMs: 60_000,
+    label: "config-defined provider row",
+  });
+  const disconnected = await evalIn(app, `(() => {
+    const title = [...document.querySelectorAll('span')]
+      .find((element) => (element.textContent ?? '').trim() === ${JSON.stringify(providerName)});
+    let row = title;
+    while (row && ![...row.querySelectorAll('button')]
+      .some((button) => (button.textContent ?? '').trim() === 'Disconnect')) {
+      row = row.parentElement;
+    }
+    const button = [...(row?.querySelectorAll('button') ?? [])]
+      .find((element) => (element.textContent ?? '').trim() === 'Disconnect' && !element.disabled);
+    button?.click();
+    return Boolean(button);
+  })()`);
+  expect(disconnected).toBe(true);
+  await waitFor(app, `(() => {
+    const page = document.body.innerText;
+    const toastVisible = [...document.querySelectorAll('[data-sonner-toast]')]
+      .some((toast) => (toast.textContent ?? '').includes(${JSON.stringify(`Disconnected ${providerId}`)}));
+    return !page.includes(${JSON.stringify(providerName)}) && toastVisible;
+  })()`, { timeoutMs: 60_000, label: "provider removed with disconnect confirmation" });
+  const settingsState = await evalIn(app, `({
+    providerVisible: document.body.innerText.includes(${JSON.stringify(providerName)}),
+    providerEnabled: document.body.innerText.includes(${JSON.stringify(providerName)})
+      && document.body.innerText.includes('Enabled'),
+  })`);
+  expect(settingsState).toEqual({ providerVisible: false, providerEnabled: false });
+  evidence.recordAssertionEvidence(
+    "Disconnect removes the config-defined provider from AI Providers",
+    `Settings state after disconnect: ${JSON.stringify(settingsState)}`,
+    true,
+  );
+
+  await go(app, `/workspace/${workspaceId}/session`);
+  const afterModels = await readAvailableModels(app);
+  const modelStillAvailable = afterModels.some((model) => model.id === modelId);
+  expect(modelStillAvailable).toBe(false);
+  evidence.recordAssertionEvidence(
+    "The disconnected provider no longer contributes models",
+    `Models matching ${modelId}: ${JSON.stringify(afterModels.filter((model) => model.id === modelId))}`,
+    !modelStillAvailable,
+  );
+});

--- a/evals/specs/provider-disconnect-config-defined.e2e.test.ts
+++ b/evals/specs/provider-disconnect-config-defined.e2e.test.ts
@@ -4,12 +4,12 @@ import { join } from "node:path";
 import { expect, onTestFinished } from "vitest";
 import {
   createAndSelectWorkspace,
+  desktop,
   evalIn,
   go,
   readAvailableModels,
   waitFor,
-} from "@openwork/behaviors";
-import { desktop } from "@openwork/hosts";
+} from "@openwork/testkit/stack";
 import { needs, test } from "@openwork/testkit";
 
 const providerId = "litellm-disconnect-fixture";

--- a/evals/specs/spec-quarantine.test.ts
+++ b/evals/specs/spec-quarantine.test.ts
@@ -43,6 +43,7 @@ org-api-key-authenticates.e2e.test.ts
 org-model-analytics.e2e.test.ts
 org-team-lifecycle-critical-path.e2e.test.ts
 parent-child-permission-approval.e2e.test.ts
+provider-disconnect-config-defined.e2e.test.ts
 reliable-app-recovery.e2e.test.ts
 responsive-session-layout.e2e.test.ts
 saved-script-automations.e2e.test.ts


### PR DESCRIPTION
## Symptom
Disconnecting a provider defined only in OpenCode config removed no stored credential, left the provider connected, and gave no prominent confirmation.

## Root cause
`apps/app/src/react-app/domains/connections/provider-auth/store.ts:2184` treated every provider still connected after credential removal as environment-backed and returned before writing `disabled_providers`.

## Fix
- Preserve providers explicitly reported with `source: "env"`.
- Disable other still-connected providers, refresh them out of app state/model availability, and return the normal disconnected message.
- Surface successful disconnect messages as a toast.
- Cover config-defined, credential-backed, and environment-backed cases with unit tests and app-driving proof.

## Verification
- `cd apps/app && bun test --isolate tests/provider-auth-disconnect.test.ts` — pass (3 tests).
- `cd apps/app && pnpm exec tsc --noEmit` — pass.
- `node scripts/i18n-audit.mjs --ci` — pass.
- `OPENWORK_EVAL_E2E_TESTS=1 pnpm evals:e2e provider-disconnect-config-defined` — pass (1 test, local lane).

Verdict: Passed