### PR TITLE
fix(den): report MCP connection connected only after callback validation succeeds

### DIFF
--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -359,6 +359,15 @@ test("connect start keeps the shared callback for a pre-registered confidential 
   let expectedRedirectUri = ""
   let initializeRequests = 0
   let toolsListRequests = 0
+  let validationMode: "hold" | "succeed" | "fail" = "hold"
+  let markValidationStarted = () => {}
+  let releaseValidation = () => {}
+  const validationStarted = new Promise<void>((resolve) => {
+    markValidationStarted = resolve
+  })
+  const validationReleased = new Promise<void>((resolve) => {
+    releaseValidation = resolve
+  })
   const server = Bun.serve({
     port: 0,
     async fetch(incoming) {
@@ -403,6 +412,14 @@ test("connect start keeps the shared callback for a pre-registered confidential 
       }
       if (url.pathname === "/mcp") {
         if (incoming.headers.get("authorization") === "Bearer shared-access-token") {
+          if (validationMode === "hold") {
+            markValidationStarted()
+            await validationReleased
+            validationMode = "succeed"
+          }
+          if (validationMode === "fail") {
+            return Response.json({ error: "post_authorization_validation_failed" }, { status: 500 })
+          }
           if (incoming.method !== "POST") return new Response(null, { status: 405 })
           const rpc: unknown = await incoming.json()
           if (!isRecord(rpc)) return Response.json({ error: "invalid_request" }, { status: 400 })
@@ -516,7 +533,20 @@ test("connect start keeps the shared callback for a pre-registered confidential 
     )
     callbackUrl.searchParams.set("code", "shared-authorization-code")
     callbackUrl.searchParams.set("state", signedState)
-    const callbackResponse = await app.fetch(new Request(callbackUrl))
+    const callbackPending = app.fetch(new Request(callbackUrl))
+    await validationStarted
+
+    const pendingListResponse = await request("/v1/mcp-connections?scope=manageable")
+    expect(pendingListResponse.status).toBe(200)
+    const pendingList: unknown = await pendingListResponse.json()
+    if (!isRecord(pendingList) || !Array.isArray(pendingList.connections)) {
+      throw new Error("Expected manageable connections during callback validation.")
+    }
+    const pendingConnection = pendingList.connections.find((entry) => isRecord(entry) && entry.id === connection.id)
+    expect(pendingConnection).toMatchObject({ connected: false, connectedForMe: false })
+
+    releaseValidation()
+    const callbackResponse = await callbackPending
     expect(callbackResponse.status).toBe(200)
     expect(await callbackResponse.text()).toContain("You're connected")
 
@@ -530,6 +560,53 @@ test("connect start keeps the shared callback for a pre-registered confidential 
     expect(connectedRows[0]?.scope).toBe("mcp_server")
     expect(initializeRequests).toBeGreaterThan(0)
     expect(toolsListRequests).toBeGreaterThan(0)
+
+    const connectedListResponse = await request("/v1/mcp-connections?scope=manageable")
+    expect(connectedListResponse.status).toBe(200)
+    const connectedList: unknown = await connectedListResponse.json()
+    if (!isRecord(connectedList) || !Array.isArray(connectedList.connections)) {
+      throw new Error("Expected manageable connections after callback validation.")
+    }
+    expect(connectedList.connections.find((entry) => isRecord(entry) && entry.id === connection.id))
+      .toMatchObject({ connected: true, connectedForMe: true, credentialHealth: "ready" })
+
+    const disconnectResponse = await principalRequest(
+      userId,
+      `/v1/mcp-connections/${connection.id}/disconnect`,
+      "POST",
+    )
+    expect(disconnectResponse.status).toBe(200)
+    validationMode = "fail"
+
+    const restarted = await request(`/v1/mcp-connections/${connection.id}/connect/start`)
+    expect(restarted.status).toBe(200)
+    const restartedBody: unknown = await restarted.json()
+    if (!isRecord(restartedBody) || typeof restartedBody.authorizeUrl !== "string") {
+      throw new Error("Expected a fresh OAuth authorize URL after disconnect.")
+    }
+    const restartedAuthorizeUrl = new URL(restartedBody.authorizeUrl)
+    expectedCodeChallenge = restartedAuthorizeUrl.searchParams.get("code_challenge") ?? ""
+    const failedCallbackUrl = new URL(
+      "/v1/mcp-connections/oauth/callback",
+      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
+    )
+    failedCallbackUrl.searchParams.set("code", "shared-authorization-code")
+    failedCallbackUrl.searchParams.set("state", restartedAuthorizeUrl.searchParams.get("state") ?? "")
+    const failedCallbackResponse = await app.fetch(new Request(failedCallbackUrl))
+    expect(failedCallbackResponse.status).toBe(400)
+
+    const failedListResponse = await request("/v1/mcp-connections?scope=manageable")
+    expect(failedListResponse.status).toBe(200)
+    const failedList: unknown = await failedListResponse.json()
+    if (!isRecord(failedList) || !Array.isArray(failedList.connections)) {
+      throw new Error("Expected manageable connections after callback validation failed.")
+    }
+    expect(failedList.connections.find((entry) => isRecord(entry) && entry.id === connection.id)).toMatchObject({
+      connected: false,
+      connectedForMe: false,
+      credentialHealth: "reconnect_required",
+      credentialHealthReason: "post_authorization_validation_failed",
+    })
   } finally {
     server.stop(true)
   }

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -550,6 +550,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
             if (session.client.getServerCapabilities()?.tools) {
               await session.client.listTools(undefined, session.requestOptions)
             }
+            await session.oauthProvider?.commitPendingAuthorizationCodeCredential()
           } catch (error) {
             operationFailed = true
             let credentialCleanupError: unknown = null

--- a/packages/enterprise-mcp-client/src/oauth-provider.ts
+++ b/packages/enterprise-mcp-client/src/oauth-provider.ts
@@ -85,6 +85,12 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
   private loadedDiscovery: OAuthDiscoveryState | undefined
   private verifiedAuthorizationServerMetadata: AuthorizationServerMetadata | undefined
   private authorizationHandle: EnterpriseMcpOAuthAuthorizationHandle | undefined
+  private pendingAuthorizationCodeCredential: {
+    tokens: StoredOAuthTokens
+    expiresAt?: number
+    authorization: EnterpriseMcpOAuthAuthorizationHandle
+    clientRegistrationRevision?: string
+  } | undefined
   authorizeUrl: string | null = null
 
   constructor(input: {
@@ -373,6 +379,9 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
   }
 
   async tokens(context?: OAuthClientInformationContext): Promise<StoredOAuthTokens | undefined> {
+    if (this.pendingAuthorizationCodeCredential) {
+      return this.pendingAuthorizationCodeCredential.tokens
+    }
     const record = await this.persistence.credentials.load(this.context())
     if (!record) {
       this.loadedCredential = undefined
@@ -401,22 +410,53 @@ export class EnterpriseMcpOAuthProvider implements OAuthClientProvider {
 
   async saveTokens(tokens: StoredOAuthTokens, context?: OAuthClientInformationContext): Promise<void> {
     const validated = this.storedTokens(tokens, context)
-    const source = this.authorizationHandle ? "authorization-code" : "refresh"
+    const authorization = this.authorizationHandle
+    const source = authorization ? "authorization-code" : "refresh"
     const existing = source === "refresh"
       ? (this.loadedCredential ?? await this.persistence.credentials.load(this.context()))
       : undefined
     const merged = source === "refresh" && !validated.refresh_token && existing?.tokens.refresh_token
       ? { ...validated, refresh_token: existing.tokens.refresh_token }
       : validated
+    const expiresAt = tokenExpiration(merged, this.clock.now())
+    if (authorization) {
+      this.pendingAuthorizationCodeCredential = {
+        tokens: merged,
+        expiresAt,
+        authorization,
+        clientRegistrationRevision: this.loadedClient?.revision,
+      }
+      this.loadedCredential = undefined
+      return
+    }
     await this.persistence.credentials.save({
       context: this.context(),
       tokens: merged,
-      expiresAt: tokenExpiration(merged, this.clock.now()),
-      source,
-      authorization: this.authorizationHandle,
+      expiresAt,
+      source: "refresh",
       clientRegistrationRevision: this.loadedClient?.revision,
-      expectedCredentialRevision: source === "refresh" ? existing?.revision : undefined,
+      expectedCredentialRevision: existing?.revision,
     })
+    this.loadedCredential = undefined
+  }
+
+  async commitPendingAuthorizationCodeCredential(): Promise<void> {
+    const pending = this.pendingAuthorizationCodeCredential
+    if (!pending) {
+      throw new EnterpriseMcpOAuthContractError(
+        "MCP_OAUTH_PERSISTENCE_INVALID",
+        "The OAuth callback completed without a pending credential.",
+      )
+    }
+    await this.persistence.credentials.save({
+      context: this.context(),
+      tokens: pending.tokens,
+      expiresAt: pending.expiresAt,
+      source: "authorization-code",
+      authorization: pending.authorization,
+      clientRegistrationRevision: pending.clientRegistrationRevision,
+    })
+    this.pendingAuthorizationCodeCredential = undefined
     this.loadedCredential = undefined
   }
 


### PR DESCRIPTION
## Symptom
OAuth connector flips to Connected on failed callback until refresh.

## Root cause
`packages/enterprise-mcp-client/src/oauth-provider.ts:410-439` persisted authorization-code tokens while `finishAuth` was still running. Den connection status derives connectivity from those persisted tokens (`ee/apps/den-api/src/routes/org/mcp-connections.ts:1068-1094`), so a concurrent status read could report Connected before post-callback MCP initialization and tool discovery finished. Failed validation then cleared the token, making a later refresh appear disconnected.

## Fix
- Hold authorization-code tokens inside the callback-scoped OAuth provider.
- Persist them only after MCP initialization and tool discovery succeed (`packages/enterprise-mcp-client/src/enterprise-mcp-client.ts:553`).
- Preserve the existing invalidation path and `post_authorization_validation_failed` reason on failure.
- Extend the Den route test to assert disconnected during validation, connected after success, and disconnected with an error reason after failure.

## Verification
- `pnpm run build:mcp-apps` — passed.
- `pnpm --filter @openwork/enterprise-mcp-client typecheck` — passed.
- `pnpm --filter @openwork/enterprise-mcp-client test` — 85 passed, 0 failed.
- `pnpm exec bun test --conditions development --timeout=15000 test/mcp-connections-connect-start.test.ts` (from `ee/apps/den-api`) — 21 passed, 0 failed.
- `pnpm exec tsc --noEmit -p .` (from `ee/apps/den-api`) — passed.

Verdict: Passed