### PR TITLE
docs: clarify SSO JIT provisioning behavior

### DIFF
--- a/packages/docs/cloud/scim-google-workspace.mdx
+++ b/packages/docs/cloud/scim-google-workspace.mdx
@@ -37,6 +37,10 @@ through OpenWork's just-in-time SSO provisioning. JIT provisioning is not the
 same as SCIM:
 
 - It happens when a user signs in successfully.
+- It can create the OpenWork organization membership with the default `Member`
+  role after successful SAML authentication.
+- A standalone email/password signup with the same verified domain does not add
+  the user to the organization or replace the SAML sign-in requirement.
 - It does not continuously sync profile changes from Google.
 - It does not deactivate OpenWork access when a Google user is suspended or
   deleted.

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -45,7 +45,7 @@ Use the Cloud member model as the source of truth for organization access:
 - Use custom roles only when the built-in roles are too broad.
 - Use teams for resource access to Collections and providers.
 
-SSO just-in-time provisioning uses `Member` as the safe default for first-login users. OpenWork does not convert IdP attributes such as `role`, `groups`, or `admin` into organization roles during SSO sign-in. Elevation to `Admin`, `Owner`, or a custom role should be an explicit, reviewed, and audited change in OpenWork.
+SSO just-in-time provisioning uses `Member` as the safe default for first-login users after successful SAML authentication. The standard sign-in flow routes email addresses from verified, enabled SSO domains to SSO. A standalone email/password signup with the same domain does not grant organization membership by itself. OpenWork does not convert IdP attributes such as `role`, `groups`, or `admin` into organization roles during SSO sign-in. Elevation to `Admin`, `Owner`, or a custom role should be an explicit, reviewed, and audited change in OpenWork.
 
 For access reviews, export the current member list, roles, teams, pending invitations, API keys, SSO configuration, and SCIM configuration on a regular cadence. Reconfirm that each member still needs their current role and team access.
 

--- a/packages/docs/cloud/sso-google-workspace.mdx
+++ b/packages/docs/cloud/sso-google-workspace.mdx
@@ -172,6 +172,23 @@ SSO is not offered to organization members until you explicitly enable it after
 the successful test. If you edit the SSO configuration after a successful test,
 test it again before enabling. Test links expire after five minutes.
 
+## Just-in-time provisioning and password signup
+
+After Google SAML SSO is enabled for a verified domain, OpenWork's standard
+sign-in flow routes users with that email domain to the organization SSO flow.
+When a user completes SAML sign-in successfully, OpenWork can create their
+organization membership just in time with the default `Member` role.
+
+JIT provisioning happens only after successful SAML authentication. Creating an
+email/password account with the same email domain does not add the user to the
+organization, does not create a SCIM-managed identity, and does not sync Google
+profile or suspension changes. If that user later completes SSO, OpenWork can
+link the matching account and provision the organization membership through SSO.
+
+OpenWork does not convert SAML attributes such as `role`, `groups`, or `admin`
+into elevated organization roles. Assign `Admin`, `Owner`, or custom roles in
+OpenWork after review, or through an invitation that grants the intended role.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/packages/docs/cloud/sso-microsoft-entra.mdx
+++ b/packages/docs/cloud/sso-microsoft-entra.mdx
@@ -126,6 +126,23 @@ SSO is not offered to organization members until you explicitly enable it after
 the successful test. If you edit the SSO configuration after a successful test,
 test it again before enabling. Test links expire after five minutes.
 
+## Just-in-time provisioning and password signup
+
+After Entra SAML SSO is enabled for a verified domain, OpenWork's standard
+sign-in flow routes users with that email domain to the organization SSO flow.
+When a user completes SAML sign-in successfully, OpenWork can create their
+organization membership just in time with the default `Member` role.
+
+JIT provisioning happens only after successful SAML authentication. Creating an
+email/password account with the same email domain does not add the user to the
+organization or create a SCIM-managed identity. If that user later completes
+SSO, OpenWork can link the matching account and provision the organization
+membership through SSO.
+
+OpenWork does not convert SAML attributes such as `role`, `groups`, or `admin`
+into elevated organization roles. Assign `Admin`, `Owner`, or custom roles in
+OpenWork after review, or through an invitation that grants the intended role.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/packages/docs/cloud/sso-okta.mdx
+++ b/packages/docs/cloud/sso-okta.mdx
@@ -171,6 +171,23 @@ test it again before enabling. Test links expire after five minutes.
 
 Only after this succeeds should you configure SCIM.
 
+## Just-in-time provisioning and password signup
+
+After Okta SAML SSO is enabled for a verified domain, OpenWork's standard
+sign-in flow routes users with that email domain to the organization SSO flow.
+When a user completes SAML sign-in successfully, OpenWork can create their
+organization membership just in time with the default `Member` role.
+
+JIT provisioning happens only after successful SAML authentication. Creating an
+email/password account with the same email domain does not add the user to the
+organization or create a SCIM-managed identity. If that user later completes
+SSO, OpenWork can link the matching account and provision the organization
+membership through SSO.
+
+OpenWork does not convert SAML attributes such as `role`, `groups`, or `admin`
+into elevated organization roles. Assign `Admin`, `Owner`, or custom roles in
+OpenWork after review, or through an invitation that grants the intended role.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |


### PR DESCRIPTION
## Summary
- document SAML just-in-time provisioning behavior for Google, Okta, and Microsoft Entra SSO
- clarify that verified-domain email/password signup alone does not grant organization membership
- note that the standard sign-in flow routes verified SSO domains to SSO and that JIT creates default Member access only after successful SAML auth

## Verification
- docs-only change; runtime proof skipped per repo guidance
- `node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8')); console.log('docs.json ok')"`
- `git diff --check`