### PR TITLE
domínio Engenharia + EAP real (81 nós) + Planejamento + Core navigation

### DIFF
--- a/.clinerules/visao-produto-engenharia.md
+++ b/.clinerules/visao-produto-engenharia.md
@@ -1,0 +1,89 @@
+# OpenWork — Plataforma de Engenharia (visão de produto)
+
+> Regra permanente do Cline. Complementa `AGENTS.md` (verificação/PR) — não a
+> substitui. Aplica-se a todo trabalho sobre os **Domínios de negócio** do app
+> (atualmente: Engenharia → Obras → Obra → módulos/capacidades).
+
+## 1. Produto
+
+O OpenWork é uma **plataforma de Engenharia** para estruturar, planejar,
+acompanhar, analisar e controlar **obras**, usando o modelo estruturado da obra
+como base para suas ferramentas e para a futura inteligência especializada.
+**Não** tratar o domínio como CRUD genérico ou coleção de telas desconexas.
+
+## 2. Hierarquia de referência
+
+```text
+Core (genérico)
+└── Domínio (ex.: Engenharia)
+    └── Entidade operacional (ex.: Obra)
+        └── Modelo da Obra
+            ├── EAP · serviços · atividades · predecessoras · rede de precedências
+            ├── calendário · duração · produtividade · equipes · restrições · marcos
+            ├── frentes de serviço · pavimentos · unidades
+            └── planejamento · execução/produção · controle · histórico
+                └── Análise → Inteligência (Agente Planejador — FUTURO)
+```
+
+## 3. Modelo da Obra
+
+- Considerar as estruturas existentes (EAP, serviços, atividades, redes, calendário,
+  produção, frentes, planejamento, histórico) quando houver trabalho de
+  planejamento/controle.
+- **Não criar estruturas paralelas** sem antes procurar as estruturas já existentes
+  (fonte única; ver §6).
+- Nenhum conceito de Obra pertence ao Core: ele permanece genérico.
+
+## 4. Ferramentas de planejamento
+
+Gantt, CPM, Rede de Precedências, Linha de Balanço, Produção, Frentes de Serviço,
+acompanhamento, restrições e replanejamento são **capacidades do mesmo contexto
+operacional da obra** — nunca sistemas independentes desconectados entre si.
+
+## 5. Inteligência futura (requisito arquitetural)
+
+Prever um **Agente Planejador** especialista em planejamento de obras, que trabalhará
+sobre: modelo estruturado, memória da obra, planejamento, produção, histórico,
+restrições, CPM, Gantt, Linha de Balanço e produtividade. Sua função: **analisar,
+diagnosticar, propor alternativas e justificar replanejamentos**.
+Alterações críticas **não** serão feitas automaticamente pelo agente sem decisão
+humana.
+
+## 6. Separação Core/Domínio e fragmentação
+
+- O Core deve permanecer genérico. Especialização (Engenharia → Obra → módulos/
+  capacidades) vive no **domínio**.
+- Antes de criar entidade, campo, tabela, módulo, serviço, estado, API ou estrutura
+  de dados: **procurar se o conceito já existe**. Evitar múltiplas fontes de verdade.
+
+## 7. Processo de trabalho (fases relevantes)
+
+```text
+Entender → Inspecionar → Relacionar ao modelo da obra → Verificar estruturas
+existentes → Auditar impacto arquitetural → Propor solução → Implementar →
+Testar → Validar → Documentar
+```
+
+## 8. Regra contra invenção
+
+- **Nunca inventar** arquivos, APIs, entidades, contratos ou comportamentos.
+- Sem evidência → **INSPECIONAR**. Ainda incerto → **REPORTAR A INCERTEZA** (não
+  assumir).
+- Distinguir sempre: `IMPLEMENTADO` vs. `FUTURO` vs. `FORA DE ESCOPO` vs.
+  `DOCUMENTAÇÃO`.
+
+## 9. Papel do Cline
+
+Atuar como engenheiro de software responsável pela evolução de uma **plataforma de
+Engenharia**: cada solicitação é avaliada em relação à arquitetura, ao modelo da
+obra, à integração entre módulos (planejamento/execução/controle) e à evolução
+futura (inteligência). Não tratar solicitações como tarefas isoladas.
+
+## 10. Limites de atuação
+
+- Fases **read-only** (auditoria): nenhuma alteração de código/rotas/banco/testes;
+  somente documentação.
+- Implementações de visão (regras/configuração do Cline): código de produção
+  inalterado.
+- Sempre executar as validações aplicáveis (typecheck/build/testes) e **não fazer
+  commit** salvo autorização explícita.

--- a/apps/app/src/react-app/domains/domain-back-button.tsx
+++ b/apps/app/src/react-app/domains/domain-back-button.tsx
@@ -1,0 +1,68 @@
+/** @jsxImportSource react */
+import { ChevronLeft } from "lucide-react";
+import { useLocation, useNavigate } from "react-router";
+
+import { Button } from "@/components/ui/button";
+import type { NavigationNode } from "./navigation/navigation-types";
+import { resolveNavigationUpLevel } from "./navigation/navigation-utils";
+
+/**
+ * Ação de "Voltar ao nível anterior" da navegação de domínios (Core genérico).
+ *
+ * Aparece apenas dentro do conteúdo de um domínio (`/dominios/:domainId[...]`)
+ * e quando existe um nível anterior válido, derivado SOMENTE da rota atual
+ * (useLocation) + árvore declarativa (NavigationNode[]) — sem estado duplicado:
+ *  - nível interno (ex.: módulo dentro de uma entidade) → volta ao ancestral
+ *    imediatamente acima com rota própria (rótulo dinâmico);
+ *  - topo do domínio (home/raiz) → volta para fora da navegação de domínios
+ *    (exitRoute, por padrão a área principal `/session`);
+ *  - rota sem correspondência na árvore → não renderiza nada.
+ *
+ * NÃO conhece Engenharia/Obra/EAP — funciona para qualquer domínio futuro.
+ */
+
+const EXTERNAL_LABEL = "Voltar para a visão principal";
+
+export type DomainBackButtonProps = {
+  /** Árvore de navegação do domínio atual (dados declarativos). */
+  navigation: NavigationNode[];
+  /** Rota usada quando o nível anterior é externo ao domínio. */
+  exitRoute?: string;
+};
+
+export function DomainBackButton({
+  navigation,
+  exitRoute = "/session",
+}: DomainBackButtonProps) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const target = resolveNavigationUpLevel(navigation, pathname);
+  if (target.kind === "none") return null;
+
+  const isInternal = target.kind === "internal";
+  const accessibleLabel = isInternal
+    ? `Voltar para ${target.label}`
+    : EXTERNAL_LABEL;
+  const destination = isInternal ? target.route : exitRoute;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      data-domain-back-button
+      data-domain-back-target={isInternal ? "internal" : "external"}
+      className="group/back h-7 w-fit gap-1 px-1.5 text-muted-foreground hover:text-foreground"
+      onClick={() => navigate(destination)}
+      aria-label={accessibleLabel}
+      title={accessibleLabel}
+    >
+      <ChevronLeft
+        className="size-4 transition-transform duration-150 group-hover/back:-translate-x-0.5"
+        aria-hidden="true"
+      />
+      <span>Voltar</span>
+    </Button>
+  );
+}

--- a/apps/app/src/react-app/domains/domain-bootstrap.ts
+++ b/apps/app/src/react-app/domains/domain-bootstrap.ts
@@ -1,0 +1,11 @@
+// Bootstrap de Domínios — ponto único de registro.
+// Para adicionar um novo domínio (Administração, Medicina, Direito...) basta registrar um
+// novo módulo aqui (import side-effect) — NENHUMA alteração no Core é necessária.
+import "./engenharia/domain";
+
+export {
+  listDomains,
+  getDomain,
+  registerDomain,
+  type DomainDefinition,
+} from "./domain-registry";

--- a/apps/app/src/react-app/domains/domain-registry.ts
+++ b/apps/app/src/react-app/domains/domain-registry.ts
@@ -1,0 +1,31 @@
+// Registro de Domínios (Core → Domínio → Entidade).
+// O Core conhece APENAS esta interface. Domínios específicos (Engenharia, Administração,
+// Medicina, Direito...) registram-se via registerDomain (side-effect), sem tocar no Core.
+import type { ReactNode } from "react";
+import type { NavigationNode } from "./navigation/navigation-types";
+
+export type DomainDefinition = {
+  id: string;
+  label: string;
+  /** Rota inicial do domínio (primeira entidade). */
+  homeRoute: string;
+  /** Árvore de navegação declarativa (data-driven). O Core apenas interpreta os nós. */
+  navigation: NavigationNode[];
+  /** Renderiza a rota /dominios/:domainId<path> (ex.: "/obras/:obraId/eap"). */
+  renderRoute: (path: string) => ReactNode;
+};
+
+const registry = new Map<string, DomainDefinition>();
+
+export function registerDomain(domain: DomainDefinition): void {
+  registry.set(domain.id, domain);
+}
+
+export function listDomains(): DomainDefinition[] {
+  return [...registry.values()];
+}
+
+export function getDomain(id: string): DomainDefinition | null {
+  return registry.get(id) ?? null;
+}
+

--- a/apps/app/src/react-app/domains/domain-route.tsx
+++ b/apps/app/src/react-app/domains/domain-route.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource react */
+import { useParams } from "react-router";
+import { getDomain } from "./domain-bootstrap";
+import { DomainBackButton } from "./domain-back-button";
+
+/**
+ * Rota genérica de domínios: /dominios/:domainId/* (Core).
+ * O Core delega a renderização ao domínio registrado; não conhece Engenharia nem Obra.
+ *
+ * Header genérico: enquanto o usuário está DENTRO de um domínio, expõe uma ação
+ * clara de "Voltar ao nível anterior" (derivada da rota + árvore de navegação).
+ */
+export function DomainRoute() {
+  const params = useParams();
+  const domainId = params.domainId ?? "";
+  const rest = params["*"] ?? "";
+  const domain = getDomain(domainId);
+
+  if (!domain) {
+    return (
+      <div className="flex min-h-[60vh] w-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <p className="text-lg font-semibold">Domínio não encontrado</p>
+        <p className="text-sm text-muted-foreground">{domainId}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <header className="shrink-0 px-3 pt-2">
+        <DomainBackButton navigation={domain.navigation} />
+      </header>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {domain.renderRoute(rest)}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/domain-sidebar-group.tsx
+++ b/apps/app/src/react-app/domains/domain-sidebar-group.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource react */
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+} from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+import {
+  SIDEBAR_SECTION_LABEL,
+  SIDEBAR_SECTION_LANE,
+} from "@/react-app/domains/session/sidebar/sidebar-lanes";
+import { listDomains } from "./domain-bootstrap";
+import { SidebarNavigationList } from "./navigation/sidebar-navigation";
+
+/**
+ * Seção "DOMÍNIOS" da sidebar (Core genérico).
+ * Para cada domínio registrado, renderiza a árvore declarativa (navigation: NavigationNode[])
+ * usando o renderer genérico de navegação. Nenhum conceito de Engenharia/Obra existe aqui.
+ */
+export function DomainsSidebarGroup() {
+  const domains = listDomains();
+  if (domains.length === 0) return null;
+
+  return (
+    <SidebarGroup>
+      <div className={cn("flex h-6 items-center", SIDEBAR_SECTION_LANE)}>
+        <span className={SIDEBAR_SECTION_LABEL}>DOMÍNIOS</span>
+      </div>
+      <SidebarGroupContent>
+        {domains.map((domain) => (
+          <div key={domain.id} data-domain-id={domain.id} className="mb-1 last:mb-0">
+            <SidebarNavigationList nodes={domain.navigation} depth={0} />
+          </div>
+        ))}
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+

--- a/apps/app/src/react-app/domains/engenharia/domain.tsx
+++ b/apps/app/src/react-app/domains/engenharia/domain.tsx
@@ -15,6 +15,7 @@ import {
 } from "./obra/obra-repository";
 import { ObraListaPage } from "./obra/pages/obra-lista";
 import { ObraNovaPage } from "./obra/pages/obra-nova";
+import { ObraEditarPage } from "./obra/pages/obra-editar";
 import { ObraShellRoute } from "./obra/obra-shell-route";
 import { initializeObraEapRepository } from "./obra/obra-eap-repository";
 
@@ -42,6 +43,10 @@ export function buildEngenhariaDomain(): DomainDefinition {
         if (segment === "nova") {
           // /obras/nova → criação
           return <ObraNovaPage />;
+        }
+        if (segments[2] === "editar") {
+          // /obras/:obraId/editar → edição de identificação
+          return <ObraEditarPage obraId={segment} />;
         }
         // /obras/:obraId[/:modulo]
         const modulo = isObraModule(segments[2]) ? segments[2] : null;

--- a/apps/app/src/react-app/domains/engenharia/domain.tsx
+++ b/apps/app/src/react-app/domains/engenharia/domain.tsx
@@ -1,0 +1,70 @@
+/** @jsxImportSource react */
+import { Navigate } from "react-router";
+
+import { registerDomain, type DomainDefinition } from "../domain-registry";
+import {
+  DOMAIN_ENGENHARIA_ID,
+  isObraModule,
+  obrasListRoute,
+} from "./obra/obra-routes";
+import { buildEngenhariaNavigation } from "./obra/obra-navigation";
+import {
+  initializeObraRepository,
+  listObras,
+  useObraRepository,
+} from "./obra/obra-repository";
+import { ObraListaPage } from "./obra/pages/obra-lista";
+import { ObraNovaPage } from "./obra/pages/obra-nova";
+import { ObraShellRoute } from "./obra/obra-shell-route";
+import { initializeObraEapRepository } from "./obra/obra-eap-repository";
+
+/**
+ * Domínio ENGENHARIA.
+ * A navegação é fornecida como DADOS (NavigationNode[]) montados a partir do
+ * repositório de obras (fonte única). O Core apenas interpreta; a Obra pertence
+ * ao domínio, nunca ao Core.
+ */
+export function buildEngenhariaDomain(): DomainDefinition {
+  const obras = listObras();
+  return {
+    id: DOMAIN_ENGENHARIA_ID,
+    label: "Engenharia",
+    homeRoute: obrasListRoute(),
+    navigation: buildEngenhariaNavigation(obras),
+    renderRoute: (path) => {
+      const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
+      if (segments[0] === "obras") {
+        const segment = segments[1] ? decodeURIComponent(segments[1]) : "";
+        if (!segment) {
+          // /obras → lista de obras
+          return <ObraListaPage />;
+        }
+        if (segment === "nova") {
+          // /obras/nova → criação
+          return <ObraNovaPage />;
+        }
+        // /obras/:obraId[/:modulo]
+        const modulo = isObraModule(segments[2]) ? segments[2] : null;
+        return <ObraShellRoute obraId={segment} modulo={modulo} />;
+      }
+      return <Navigate to={obrasListRoute()} replace />;
+    },
+  };
+}
+
+/** Registra (ou re-registra) o domínio com a navegação atual do repositório. */
+export function registerEngenhariaDomain(): void {
+  registerDomain(buildEngenhariaDomain());
+}
+
+// Inicialização (side-effect no import): hidrata do armazenamento local e
+// registra a primeira versão. Mudanças posteriores (ex.: criar obra) re-registram
+// o domínio para a sidebar consumir a navegação atualizada ao remontar.
+initializeObraRepository();
+initializeObraEapRepository();
+registerEngenhariaDomain();
+useObraRepository.subscribe(() => {
+  registerEngenhariaDomain();
+});
+
+

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-ares-referencia.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-ares-referencia.ts
@@ -1,0 +1,134 @@
+// Domínio Engenharia — DATASET DE REFERÊNCIA ARES/PIEMARTA (FASE 20.x).
+//
+// ⚠️ SEPARAÇÃO DE FONTES (decisão do usuário 2026-09-03):
+//   - Obra real (OBRA-MODELO-EAP-001) → EAP real de 81 nós + cronograma derivado.
+//   - ARES/Piemarta → dataset de REFERÊNCIA/DEMONSTRAÇÃO para validar a estrutura
+//     de Planejamento, Gantt e LOB. NÃO é o cronograma da obra real.
+//
+// Este arquivo NÃO é consumido pelo módulo Planejamento/Gantt/LOB da obra real.
+// Ele existe para (a) documentar o modelo ARES e (b) servir de base a testes que
+// validam que a estrutura de Planejamento/Gantt/LOB consegue consumir um
+// cronograma com datas explícitas, predecessoras, %plan/%real e status.
+//
+// Fonte: aba PLANEJAMENTO (modelo legado, 15 atividades) + REDE (18 elos) +
+// LINHA DE BALANÇO (11 serviços) da planilha ARES_MODELO_EXCEL_NATIVO_MVP_LOB.
+
+/** Status de uma atividade no modelo ARES. */
+export type AresStatusAtividade =
+  | "concluido"
+  | "em_andamento"
+  | "planejado"
+  | "atrasado";
+
+/** Atividade de cronograma do dataset de referência ARES/Piemarta. */
+export type AresAtividadeReferencia = {
+  codigo: string;
+  atividade: string;
+  servico: string;
+  frente: string;
+  local: string;
+  equipe: string;
+  quantidade: number;
+  duracao: number;
+  inicio: string; // ISO yyyy-mm-dd
+  fim: string; // ISO yyyy-mm-dd
+  predecessora: string | null;
+  percentualPlan: number; // 0–100
+  percentualReal: number; // 0–100
+  status: AresStatusAtividade;
+};
+
+/** Elo da rede de precedências do dataset de referência. */
+export type AresEloRede = {
+  id: string;
+  predecessora: string;
+  sucessora: string;
+  tipoRelacao: "FS";
+  defasagem: number;
+  origem: string;
+};
+
+/** Identificação do dataset de referência (nunca confundir com a obra real). */
+export const ARES_REFERENCIA = {
+  obra: "Piemarta",
+  empresa: "Empresa B",
+  tipo: "Edificação vertical",
+  natureza: "DATASET DE REFERÊNCIA/DEMONSTRAÇÃO — NÃO é a obra real",
+  fonte: "ARES_MODELO_EXCEL_NATIVO_MVP_LOB_PROFISSIONAL_FINAL_WORK.xlsx",
+} as const;
+
+/** 15 atividades do cronograma ARES/Piemarta (aba PLANEJAMENTO, modelo legado). */
+export const ARES_ATIVIDADES_REFERENCIA: AresAtividadeReferencia[] = [
+  { codigo: "LOC-ATV", atividade: "Locação e implantação do canteiro", servico: "Locação de obra", frente: "FRENTE-000", local: "LOCAL-T1", equipe: "EQUIPE-001", quantidade: 1, duracao: 10, inicio: "2026-01-05", fim: "2026-01-16", predecessora: null, percentualPlan: 100, percentualReal: 100, status: "concluido" },
+  { codigo: "FUN-ATV", atividade: "Blocos, baldrames e fundação", servico: "Fundação", frente: "FRENTE-001", local: "LOCAL-T1", equipe: "EQUIPE-002", quantidade: 1200, duracao: 40, inicio: "2026-01-19", fim: "2026-03-13", predecessora: "LOC-ATV", percentualPlan: 100, percentualReal: 100, status: "concluido" },
+  { codigo: "EST-ATV1", atividade: "Estrutura - subsolo e pilotis", servico: "Estrutura", frente: "FRENTE-002", local: "LOCAL-T1", equipe: "EQUIPE-003", quantidade: 1800, duracao: 25, inicio: "2026-03-16", fim: "2026-04-17", predecessora: "FUN-ATV", percentualPlan: 100, percentualReal: 100, status: "concluido" },
+  { codigo: "EST-ATV2", atividade: "Estrutura - pisos 1 a 5", servico: "Estrutura", frente: "FRENTE-002", local: "LOCAL-T1", equipe: "EQUIPE-003", quantidade: 2400, duracao: 35, inicio: "2026-04-20", fim: "2026-06-05", predecessora: "EST-ATV1", percentualPlan: 100, percentualReal: 100, status: "concluido" },
+  { codigo: "EST-ATV3", atividade: "Estrutura - pisos 6 a 14", servico: "Estrutura", frente: "FRENTE-002", local: "LOCAL-T1", equipe: "EQUIPE-003", quantidade: 2300, duracao: 40, inicio: "2026-06-08", fim: "2026-07-31", predecessora: "EST-ATV2", percentualPlan: 55, percentualReal: 60, status: "em_andamento" },
+  { codigo: "ALV-ATV1", atividade: "Alvenaria - pisos 1 a 7", servico: "Alvenaria", frente: "FRENTE-003", local: "LOCAL-T1", equipe: "EQUIPE-004", quantidade: 2500, duracao: 60, inicio: "2026-06-08", fim: "2026-08-28", predecessora: "EST-ATV2", percentualPlan: 100, percentualReal: 100, status: "concluido" },
+  { codigo: "ALV-ATV2", atividade: "Alvenaria - pisos 8 a 14", servico: "Alvenaria", frente: "FRENTE-003", local: "LOCAL-T1", equipe: "EQUIPE-004", quantidade: 2500, duracao: 45, inicio: "2026-08-31", fim: "2026-10-30", predecessora: "ALV-ATV1", percentualPlan: 20, percentualReal: 28, status: "em_andamento" },
+  { codigo: "REV-ATV1", atividade: "Revestimento interno - pisos 1 a 7", servico: "Revestimento interno", frente: "FRENTE-004", local: "LOCAL-T1", equipe: "EQUIPE-005", quantidade: 2400, duracao: 50, inicio: "2026-06-29", fim: "2026-09-04", predecessora: "ALV-ATV1", percentualPlan: 10, percentualReal: 5, status: "em_andamento" },
+  { codigo: "REV-ATV2", atividade: "Revestimento interno - pisos 8 a 14", servico: "Revestimento interno", frente: "FRENTE-004", local: "LOCAL-T1", equipe: "EQUIPE-005", quantidade: 2100, duracao: 45, inicio: "2026-09-14", fim: "2026-11-13", predecessora: "ALV-ATV2", percentualPlan: 0, percentualReal: 0, status: "planejado" },
+  { codigo: "CON-ATV", atividade: "Contrapiso de regularização", servico: "Contrapiso", frente: "FRENTE-004", local: "LOCAL-T1", equipe: "EQUIPE-011", quantidade: 4200, duracao: 45, inicio: "2026-08-03", fim: "2026-10-02", predecessora: "EST-ATV3", percentualPlan: 15, percentualReal: 4, status: "atrasado" },
+  { codigo: "ELE-ATV", atividade: "Instalações elétricas", servico: "Instalações elétricas", frente: "FRENTE-005", local: "LOCAL-T1", equipe: "EQUIPE-006", quantidade: 8400, duracao: 50, inicio: "2026-06-08", fim: "2026-08-14", predecessora: "EST-ATV2", percentualPlan: 55, percentualReal: 55, status: "em_andamento" },
+  { codigo: "HID-ATV", atividade: "Instalações hidráulicas", servico: "Instalações hidráulicas", frente: "FRENTE-005", local: "LOCAL-T1", equipe: "EQUIPE-007", quantidade: 2800, duracao: 45, inicio: "2026-06-08", fim: "2026-08-07", predecessora: "EST-ATV2", percentualPlan: 60, percentualReal: 70, status: "em_andamento" },
+  { codigo: "IMP-ATV", atividade: "Impermeabilização", servico: "Impermeabilização", frente: "FRENTE-006", local: "LOCAL-T1", equipe: "EQUIPE-008", quantidade: 2400, duracao: 35, inicio: "2026-08-03", fim: "2026-09-18", predecessora: "EST-ATV3", percentualPlan: 0, percentualReal: 0, status: "planejado" },
+  { codigo: "PIN-ATV", atividade: "Pintura de paredes e tetos", servico: "Pintura", frente: "FRENTE-006", local: "LOCAL-T1", equipe: "EQUIPE-009", quantidade: 6800, duracao: 50, inicio: "2026-11-16", fim: "2027-01-22", predecessora: "REV-ATV2", percentualPlan: 0, percentualReal: 0, status: "planejado" },
+  { codigo: "ESQ-ATV", atividade: "Instalação de esquadrias", servico: "Esquadrias", frente: "FRENTE-006", local: "LOCAL-T1", equipe: "EQUIPE-010", quantidade: 504, duracao: 45, inicio: "2026-11-02", fim: "2027-01-01", predecessora: "ALV-ATV2", percentualPlan: 0, percentualReal: 0, status: "planejado" },
+];
+
+/** 18 elos da rede de precedências ARES/Piemarta (aba REDE). */
+export const ARES_REDE_REFERENCIA: AresEloRede[] = [
+  { id: "REDE-001", predecessora: "PLAN-001", sucessora: "ALV-ATV2", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-002", predecessora: "EST-ATV3", sucessora: "CON-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-003", predecessora: "EST-ATV2", sucessora: "ELE-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-004", predecessora: "ALV-ATV2", sucessora: "ESQ-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-005", predecessora: "FUN-ATV", sucessora: "EST-ATV1", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-006", predecessora: "EST-ATV1", sucessora: "EST-ATV2", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-007", predecessora: "EST-ATV2", sucessora: "EST-ATV3", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-008", predecessora: "LOC-ATV", sucessora: "FUN-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-009", predecessora: "EST-ATV2", sucessora: "HID-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-010", predecessora: "EST-ATV3", sucessora: "IMP-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-011", predecessora: "REV-ATV2", sucessora: "PIN-ATV", tipoRelacao: "FS", defasagem: 3, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-012", predecessora: "EST-ATV2", sucessora: "PLAN-001", tipoRelacao: "FS", defasagem: 59, origem: "R1-SUBST: precedente herdado pelo substituto" },
+  { id: "REDE-013", predecessora: "HID-ATV", sucessora: "PLAN-002", tipoRelacao: "FS", defasagem: 3, origem: "R6: mesma EQUIPE_ID" },
+  { id: "REDE-014", predecessora: "PLAN-001", sucessora: "PLAN-002", tipoRelacao: "FS", defasagem: 0, origem: "R1-ATIVO: PREDECESSORA_ID" },
+  { id: "REDE-015", predecessora: "ELE-ATV", sucessora: "PLAN-003", tipoRelacao: "FS", defasagem: 24, origem: "R6: mesma EQUIPE_ID" },
+  { id: "REDE-016", predecessora: "PLAN-002", sucessora: "PLAN-003", tipoRelacao: "FS", defasagem: 3, origem: "R1-ATIVO: PREDECESSORA_ID" },
+  { id: "REDE-017", predecessora: "PLAN-001", sucessora: "REV-ATV1", tipoRelacao: "FS", defasagem: 0, origem: "R1: precedente explicito do legado" },
+  { id: "REDE-018", predecessora: "ALV-ATV2", sucessora: "REV-ATV2", tipoRelacao: "FS", defasagem: 0, origem: "R1: precedente explicito do legado" },
+];
+
+/** 11 serviços da grade LOB ARES/Piemarta (aba LINHA DE BALANÇO). */
+export const ARES_SERVICOS_LOB_REFERENCIA: string[] = [
+  "Locação de obra",
+  "Fundação",
+  "Estrutura",
+  "Alvenaria",
+  "Revestimento interno",
+  "Contrapiso",
+  "Instalações elétricas",
+  "Instalações hidráulicas",
+  "Impermeabilização",
+  "Pintura",
+  "Esquadrias",
+];
+
+/** Duração total do cronograma de referência (dias) — derivada das atividades. */
+export function aresDuracaoTotalReferencia(): number {
+  if (ARES_ATIVIDADES_REFERENCIA.length === 0) return 0;
+  const fim = new Date(ARES_ATIVIDADES_REFERENCIA[ARES_ATIVIDADES_REFERENCIA.length - 1].fim);
+  const inicio = new Date(ARES_ATIVIDADES_REFERENCIA[0].inicio);
+  return Math.round((fim.getTime() - inicio.getTime()) / 86400000);
+}
+
+/** Contagem de atividades por status no dataset de referência. */
+export function aresResumoStatusReferencia(): Record<AresStatusAtividade, number> {
+  const resumo: Record<AresStatusAtividade, number> = {
+    concluido: 0,
+    em_andamento: 0,
+    planejado: 0,
+    atrasado: 0,
+  };
+  for (const atv of ARES_ATIVIDADES_REFERENCIA) resumo[atv.status] += 1;
+  return resumo;
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-dashboard.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-dashboard.tsx
@@ -1,0 +1,121 @@
+/** @jsxImportSource react */
+import { useState, type ReactNode } from "react";
+import { Maximize2, Minimize2, RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Dashboard de widgets da Obra (FASE 22).
+ *
+ * Compõe widgets (KPIs + cards de contexto) numa grade. Cada widget pode ser
+ * EXPANDIDO para tela cheia (overlay) e possui estrutura preparada para
+ * filtros/período/atualização (via `actions` e `onRefresh`).
+ *
+ * NÃO implementa drag-and-drop (fase posterior). Os dados dos widgets são
+ * sempre fornecidos pelo chamador (derivados de dados reais).
+ */
+export type DashboardWidget = {
+  id: string;
+  title: string;
+  description?: string;
+  content: ReactNode;
+  /** Ações opcionais do widget (ex.: filtro, período). */
+  actions?: ReactNode;
+  /** Callback de atualização (recalcular). Quando ausente, não mostra o botão. */
+  onRefresh?: () => void;
+};
+
+export function ObraDashboard({ widgets }: { widgets: DashboardWidget[] }) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const expanded = widgets.find((w) => w.id === expandedId) ?? null;
+
+  return (
+    <div className="flex w-full flex-col gap-4" data-obra-dashboard>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {widgets.map((widget) => (
+          <DashboardWidgetCard
+            key={widget.id}
+            widget={widget}
+            onExpand={() => setExpandedId(widget.id)}
+          />
+        ))}
+      </div>
+
+      {expanded ? (
+        <div
+          className="fixed inset-0 z-50 flex flex-col bg-background"
+          data-obra-dashboard-expanded
+          data-widget={expanded.id}
+        >
+          <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+            <div className="min-w-0">
+              <h3 className="text-lg font-semibold">{expanded.title}</h3>
+              {expanded.description ? (
+                <p className="text-xs text-muted-foreground">{expanded.description}</p>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2">
+              {expanded.onRefresh ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={expanded.onRefresh}
+                  aria-label="Atualizar"
+                >
+                  <RefreshCw className="size-4" aria-hidden="true" />
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => setExpandedId(null)}
+                aria-label="Fechar visualização ampliada"
+              >
+                <Minimize2 className="size-4" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-4">{expanded.content}</div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DashboardWidgetCard({
+  widget,
+  onExpand,
+}: {
+  widget: DashboardWidget;
+  onExpand: () => void;
+}) {
+  return (
+    <Card className="min-w-0" data-widget={widget.id}>
+      <CardHeader className="flex flex-row items-start justify-between gap-3">
+        <div className="min-w-0">
+          <CardTitle>{widget.title}</CardTitle>
+          {widget.description ? (
+            <CardDescription>{widget.description}</CardDescription>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {widget.actions}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={onExpand}
+            aria-label={`Expandir ${widget.title}`}
+            data-widget-expand={widget.id}
+          >
+            <Maximize2 className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>{widget.content}</CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-data.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-data.ts
@@ -1,0 +1,179 @@
+// Domínio Engenharia — dados da EAP real da Obra Modelo EAP (FASE 06.2-B).
+//
+// FONTE DE ORIGEM (proveniência): arquivo oficial externo
+//   C:\Users\Correta Engenharia\OBRAS-MODELO\OBRA-MODELO-EAP-001\data\eap\OBRA-MODELO-EAP-001-eap.json
+//   (versão FASE-19.5, 81 nós, status PROPOSTA).
+//
+// Esta representação integrada passa a ser a FONTE OPERACIONAL da Obra dentro
+// do OpenWork. O arquivo externo NÃO é lido em runtime; ele é apenas a origem
+// desta migração. Nenhum campo foi descartado: todos os metadados e todos os
+// campos de cada nó (wbs, nome, nivel, tipo, pai, fundamentacao, condicao) são
+// preservados integralmente. A ordem dos nós é a ordem de ocorrência na fonte
+// (pré-order), usada como `ordem` entre irmãos.
+import type { ObraEap, ObraEapMetadata, ObraEapNode } from "./obra-eap-types";
+
+export const OBRA_MODELO_EAP_ID = "OBRA-MODELO-EAP-001";
+
+/** Nós da EAP real da Obra Modelo EAP (81 nós = 10/24/47). */
+export const OBRA_MODELO_EAP_NODES: ObraEapNode[] = [
+  // ---------------------------------------------------------------- //
+  // 1 — Preparação, Projetos e Canteiro
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1", nome: "Preparação, Projetos e Canteiro", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 1, fundamentacao: "Antecede a execução física; agrupa projetos, licenças e canteiro.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.1", nome: "Projetos e Aprovações", nivel: 2, tipo: "PACOTE", pai: "1", ordem: 1, fundamentacao: "Reunião de projeto executivo e licenças como entregáveis de planejamento.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.1.1", nome: "Projetos executivos", nivel: 3, tipo: "TRABALHO", pai: "1.1", ordem: 1, fundamentacao: "Base para execução e compatibilização.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.1.2", nome: "Licenças e aprovações", nivel: 3, tipo: "TRABALHO", pai: "1.1", ordem: 2, fundamentacao: "Requisitos legais para início da obra.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.2", nome: "Implantação do Canteiro", nivel: 2, tipo: "PACOTE", pai: "1", ordem: 2, fundamentacao: "Infraestrutura de apoio à execução.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.2.1", nome: "Instalações provisórias", nivel: 3, tipo: "TRABALHO", pai: "1.2", ordem: 1, fundamentacao: "Alojamento, escritório e apoio administrativo.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.2.2", nome: "Infraestrutura do canteiro", nivel: 3, tipo: "TRABALHO", pai: "1.2", ordem: 2, fundamentacao: "Acessos, energia, água e esgoto provisórios.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "1.2.3", nome: "Mobilização", nivel: 3, tipo: "TRABALHO", pai: "1.2", ordem: 3, fundamentacao: "Chegada de equipamentos e equipes.", condicao: null },
+
+  // ---------------------------------------------------------------- //
+  // 2 — Infraestrutura e Fundações
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2", nome: "Infraestrutura e Fundações", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 2, fundamentacao: "Suporte estrutural da edificação.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2.1", nome: "Escavações e Contenções", nivel: 2, tipo: "PACOTE", pai: "2", ordem: 1, fundamentacao: "Preparação do terreno para fundação. Sem subsolo (subsolos=0); escavação limitada à fundação.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2.1.1", nome: "Escavação", nivel: 3, tipo: "TRABALHO", pai: "2.1", ordem: 1, fundamentacao: "Cava para elementos de fundação (sem subsolo).", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2.1.2", nome: "Contenções provisórias", nivel: 3, tipo: "TRABALHO", pai: "2.1", ordem: 2, fundamentacao: "Estabilidade das escavações; tipo depende de estudo geotécnico.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (tipo e necessidade)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2.2", nome: "Estruturas de Fundação", nivel: 2, tipo: "PACOTE", pai: "2", ordem: 2, fundamentacao: "Elementos que transferem cargas ao solo.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2.2.1", nome: "Elementos de fundação", nivel: 3, tipo: "TRABALHO", pai: "2.2", ordem: 1, fundamentacao: "Elementos de fundação (escopo genérico). A solução específica (sapatas/estacas/radier) depende de estudo geotécnico não informado.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (tipo de fundação)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "2.2.2", nome: "Baldrame e cinta de fundação", nivel: 3, tipo: "TRABALHO", pai: "2.2", ordem: 2, fundamentacao: "Travamento entre elementos de fundação. A necessidade e o tipo dependem da solução de fundação (não definida).", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (depende da solução de fundação)" },
+
+  // ---------------------------------------------------------------- //
+  // 3 — Superestrutura
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3", nome: "Superestrutura", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 3, fundamentacao: "Estrutura portante vertical em concreto armado. Inclui pilotis, sobresolo, pavimentos tipo e cobertura.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.1", nome: "Estrutura do Pilotis", nivel: 2, tipo: "PACOTE", pai: "3", ordem: 1, fundamentacao: "Nível térreo aberto com pilares. Caracterizado como presente.", condicao: "CONFIRMADO (pilotis)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.1.1", nome: "Estrutura de pilares e laje do pilotis", nivel: 3, tipo: "TRABALHO", pai: "3.1", ordem: 1, fundamentacao: "Pilares do pilotis e laje de cobertura do nível de pilotis.", condicao: "CONFIRMADO (pilotis)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.2", nome: "Estrutura do Sobresolo", nivel: 2, tipo: "PACOTE", pai: "3", ordem: 2, fundamentacao: "Nível acima do pilotis. Caracterizado como presente.", condicao: "CONFIRMADO (sobresolo)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.2.1", nome: "Estrutura de pilares, vigas e laje do sobresolo", nivel: 3, tipo: "TRABALHO", pai: "3.2", ordem: 1, fundamentacao: "Estrutura do pavimento de sobresolo.", condicao: "CONFIRMADO (sobresolo)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.3", nome: "Estrutura dos Pavimentos Tipo", nivel: 2, tipo: "PACOTE", pai: "3", ordem: 3, fundamentacao: "Estrutura dos pavimentos residenciais. 14 lajes no total; pavimentos tipo repetitivos (1 apto/andar).", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.3.1", nome: "Estrutura de pilares, vigas e lajes dos pavimentos residenciais", nivel: 3, tipo: "TRABALHO", pai: "3.3", ordem: 1, fundamentacao: "Estrutura dos pavimentos residenciais acima do sobresolo. 1 apto por andar favorece repetição.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.4", nome: "Estrutura da Caixa de Escada e Elevador", nivel: 2, tipo: "PACOTE", pai: "3", ordem: 4, fundamentacao: "Núcleo rígido de verticalidade e acesso. A escada é componente típico; a caixa de elevador depende da existência do elevador (não confirmada).", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (caixa de elevador depende da existência do elevador)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.4.1", nome: "Estrutura da caixa de escada e elevador", nivel: 3, tipo: "TRABALHO", pai: "3.4", ordem: 1, fundamentacao: "Núcleo rígido, escada e shaft de elevador. A parcela relativa ao elevador é hipótese, pois a existência do elevador não está confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (parcela do elevador)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.5", nome: "Estrutura do Reservatório Superior", nivel: 2, tipo: "PACOTE", pai: "3", ordem: 5, fundamentacao: "Apoio estrutural para reservatório de água na cobertura. A cobertura prevista NÃO comprova a existência de reservatório superior.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (existência de reservatório superior)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "3.5.1", nome: "Estrutura do reservatório superior", nivel: 3, tipo: "TRABALHO", pai: "3.5", ordem: 1, fundamentacao: "Elemento estrutural para apoio do reservatório. Existência do reservatório é hipótese.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (existência de reservatório superior)" },
+
+  // ---------------------------------------------------------------- //
+  // 4 — Vedações e Esquadrias
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4", nome: "Vedações e Esquadrias", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 4, fundamentacao: "Fechamentos verticais e aberturas.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4.1", nome: "Alvenarias", nivel: 2, tipo: "PACOTE", pai: "4", ordem: 1, fundamentacao: "Vedações internas e externas. O sistema de vedação não é determinado pela estrutura de concreto armado; alvenaria é hipótese provável.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (sistema de vedação)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4.1.1", nome: "Alvenaria interna", nivel: 3, tipo: "TRABALHO", pai: "4.1", ordem: 1, fundamentacao: "Divisórias internas das unidades e áreas comuns. Sistema de vedação é hipótese.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (sistema de vedação)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4.1.2", nome: "Alvenaria externa", nivel: 3, tipo: "TRABALHO", pai: "4.1", ordem: 2, fundamentacao: "Fechamento externo da edificação. Sistema de vedação é hipótese.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (sistema de vedação)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4.2", nome: "Esquadrias", nivel: 2, tipo: "PACOTE", pai: "4", ordem: 2, fundamentacao: "Janelas e portas.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (material/tipo)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4.2.1", nome: "Esquadrias de alumínio (janelas)", nivel: 3, tipo: "TRABALHO", pai: "4.2", ordem: 1, fundamentacao: "Esquadrias externas de referência.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "4.2.2", nome: "Portas internas e fechaduras", nivel: 3, tipo: "TRABALHO", pai: "4.2", ordem: 2, fundamentacao: "Portas internas das unidades.", condicao: null },
+
+  // ---------------------------------------------------------------- //
+  // 5 — Cobertura e Impermeabilização
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5", nome: "Cobertura e Impermeabilização", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 5, fundamentacao: "Proteção superior e estanqueidade.", condicao: "Cobertura prevista" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.1", nome: "Cobertura", nivel: 2, tipo: "PACOTE", pai: "5", ordem: 1, fundamentacao: "Fechamento superior da edificação.", condicao: "Cobertura prevista" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.1.1", nome: "Estrutura e laje de cobertura", nivel: 3, tipo: "TRABALHO", pai: "5.1", ordem: 1, fundamentacao: "Suporte do sistema de cobertura.", condicao: "Cobertura prevista" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.1.2", nome: "Telhamento ou cobertura impermeabilizada", nivel: 3, tipo: "TRABALHO", pai: "5.1", ordem: 2, fundamentacao: "Sistema de vedação superior final.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (tipo de cobertura)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.2", nome: "Impermeabilização", nivel: 2, tipo: "PACOTE", pai: "5", ordem: 2, fundamentacao: "Tratamento de áreas sob umidade.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.2.1", nome: "Impermeabilização do sobresolo", nivel: 3, tipo: "TRABALHO", pai: "5.2", ordem: 1, fundamentacao: "Estanqueidade do sobresolo, se aplicável.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (sobresolo pode demandar impermeabilização)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.2.2", nome: "Impermeabilização da cobertura", nivel: 3, tipo: "TRABALHO", pai: "5.2", ordem: 2, fundamentacao: "Estanqueidade da cobertura.", condicao: "Cobertura prevista" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "5.2.3", nome: "Impermeabilização de áreas molhadas", nivel: 3, tipo: "TRABALHO", pai: "5.2", ordem: 3, fundamentacao: "Banheiros, copas e áreas frias. A existência e localização de áreas molhadas não está confirmada na caracterização.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (existência de áreas molhadas)" },
+
+  // ---------------------------------------------------------------- //
+  // 6 — Instalações Prediais
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6", nome: "Instalações Prediais", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 6, fundamentacao: "Infraestrutura de serviços da edificação.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.1", nome: "Instalações Hidrossanitárias", nivel: 2, tipo: "PACOTE", pai: "6", ordem: 1, fundamentacao: "Água, esgoto e águas pluviais.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.1.1", nome: "Água fria", nivel: 3, tipo: "TRABALHO", pai: "6.1", ordem: 1, fundamentacao: "Distribuição de água fria às unidades.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.1.2", nome: "Esgoto e ventilação", nivel: 3, tipo: "TRABALHO", pai: "6.1", ordem: 2, fundamentacao: "Coleta e destinação de esgoto.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.1.3", nome: "Águas pluviais", nivel: 3, tipo: "TRABALHO", pai: "6.1", ordem: 3, fundamentacao: "Captação e condução de águas de chuva.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.1.4", nome: "Reservatórios de água", nivel: 3, tipo: "TRABALHO", pai: "6.1", ordem: 4, fundamentacao: "Reservação inferior/superior. A existência de reservatório superior é hipótese.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (reservatório superior)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.1.5", nome: "Água quente", nivel: 3, tipo: "TRABALHO", pai: "6.1", ordem: 5, fundamentacao: "Distribuição de água quente. Existência não confirmada na caracterização.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (existência de água quente)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.2", nome: "Instalações Elétricas", nivel: 2, tipo: "PACOTE", pai: "6", ordem: 2, fundamentacao: "Fornecimento e distribuição de energia.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.2.1", nome: "Quadros e distribuição", nivel: 3, tipo: "TRABALHO", pai: "6.2", ordem: 1, fundamentacao: "Quadros, medidores e proteção por unidade.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.2.2", nome: "Circuitos, pontos de luz e tomadas", nivel: 3, tipo: "TRABALHO", pai: "6.2", ordem: 2, fundamentacao: "Rede elétrica final das unidades.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.3", nome: "Outros Sistemas Prediais", nivel: 2, tipo: "PACOTE", pai: "6", ordem: 3, fundamentacao: "Sistemas complementares.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.3.1", nome: "Gás", nivel: 3, tipo: "TRABALHO", pai: "6.3", ordem: 1, fundamentacao: "Rede de gás, se prevista no projeto.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "6.3.2", nome: "Comunicação e dados", nivel: 3, tipo: "TRABALHO", pai: "6.3", ordem: 2, fundamentacao: "Infraestrutura de telecom/dados. Existência não confirmada na caracterização.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (existência de telecom/dados)" },
+
+  // ---------------------------------------------------------------- //
+  // 7 — Elevadores
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "7", nome: "Elevadores", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 7, fundamentacao: "Transporte vertical.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (necessário p/ 14 lajes; quantidade a validar)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "7.1", nome: "Fornecimento e Instalação", nivel: 2, tipo: "PACOTE", pai: "7", ordem: 1, fundamentacao: "Aquisição e montagem do elevador.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "7.1.1", nome: "Fornecimento do elevador", nivel: 3, tipo: "TRABALHO", pai: "7.1", ordem: 1, fundamentacao: "Equipamento e componentes.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "7.1.2", nome: "Instalação e comissionamento", nivel: 3, tipo: "TRABALHO", pai: "7.1", ordem: 2, fundamentacao: "Montagem, testes e liberação.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+
+  // ---------------------------------------------------------------- //
+  // 8 — Acabamentos
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8", nome: "Acabamentos", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 8, fundamentacao: "Revestimentos e acabamento final.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.1", nome: "Revestimentos", nivel: 2, tipo: "PACOTE", pai: "8", ordem: 1, fundamentacao: "Revestimento de pisos e paredes. Escopo provável de residencial; especificação não confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (especificação de acabamentos)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.1.1", nome: "Revestimento de pisos", nivel: 3, tipo: "TRABALHO", pai: "8.1", ordem: 1, fundamentacao: "Piso das unidades e áreas comuns. Escopo provável; especificação não confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (especificação de acabamentos)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.1.2", nome: "Revestimento de paredes", nivel: 3, tipo: "TRABALHO", pai: "8.1", ordem: 2, fundamentacao: "Revestimento de paredes internas/áreas molhadas. Escopo provável; especificação não confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (especificação de acabamentos)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.2", nome: "Pintura", nivel: 2, tipo: "PACOTE", pai: "8", ordem: 2, fundamentacao: "Acabamento superficial.", condicao: "Pintura — usual em residencial; detalhe a validar" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.2.1", nome: "Pintura interna", nivel: 3, tipo: "TRABALHO", pai: "8.2", ordem: 1, fundamentacao: "Pintura de unidades e áreas internas.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.2.2", nome: "Pintura externa", nivel: 3, tipo: "TRABALHO", pai: "8.2", ordem: 2, fundamentacao: "Pintura de fachada.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.3", nome: "Forros e Acabamentos Diversos", nivel: 2, tipo: "PACOTE", pai: "8", ordem: 3, fundamentacao: "Forros e arremates. Escopo provável de residencial; especificação não confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (especificação de acabamentos)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.3.1", nome: "Forros", nivel: 3, tipo: "TRABALHO", pai: "8.3", ordem: 1, fundamentacao: "Forros de áreas comuns e unidades. Escopo provável; especificação não confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (especificação de acabamentos)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "8.3.2", nome: "Rodapés, soleiras e arremates", nivel: 3, tipo: "TRABALHO", pai: "8.3", ordem: 2, fundamentacao: "Acabamentos de fechamento. Escopo provável; especificação não confirmada.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (especificação de acabamentos)" },
+
+  // ---------------------------------------------------------------- //
+  // 9 — Sistemas de Proteção e Segurança
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "9", nome: "Sistemas de Proteção e Segurança", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 9, fundamentacao: "Proteção da edificação e ocupantes.", condicao: null },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "9.1", nome: "SPDA", nivel: 2, tipo: "PACOTE", pai: "9", ordem: 1, fundamentacao: "Proteção contra descargas atmosféricas.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "9.1.1", nome: "Sistema de proteção contra descargas atmosféricas", nivel: 3, tipo: "TRABALHO", pai: "9.1", ordem: 1, fundamentacao: "Captação, descida e aterramento.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "9.2", nome: "Segurança Contra Incêndio", nivel: 2, tipo: "PACOTE", pai: "9", ordem: 2, fundamentacao: "Proteção e resposta a incêndio.", condicao: "CONFIRMADO (existência mínima); HIPÓTESE/NECESSITA VALIDAÇÃO (escopo)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "9.2.1", nome: "Sistema de combate a incêndio", nivel: 3, tipo: "TRABALHO", pai: "9.2", ordem: 1, fundamentacao: "Hidrantes/extintores/SPRINKLER conforme projeto.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (escopo)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "9.2.2", nome: "Sinalização e iluminação de emergência", nivel: 3, tipo: "TRABALHO", pai: "9.2", ordem: 2, fundamentacao: "Rotas de fuga e sinalização.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (escopo)" },
+
+  // ---------------------------------------------------------------- //
+  // 10 — Áreas Externas
+  // ---------------------------------------------------------------- //
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10", nome: "Áreas Externas", nivel: 1, tipo: "DISCIPLINA", pai: null, ordem: 10, fundamentacao: "Urbanização e ligações externas.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO (escopo)" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10.1", nome: "Urbanização e Paisagismo", nivel: 2, tipo: "PACOTE", pai: "10", ordem: 1, fundamentacao: "Espaços externos do terreno.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10.1.1", nome: "Pavimentação externa", nivel: 3, tipo: "TRABALHO", pai: "10.1", ordem: 1, fundamentacao: "Piso de áreas externas.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10.1.2", nome: "Paisagismo", nivel: 3, tipo: "TRABALHO", pai: "10.1", ordem: 2, fundamentacao: "Áreas verdes e ajardinamento.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10.2", nome: "Infraestrutura de Ligação", nivel: 2, tipo: "PACOTE", pai: "10", ordem: 2, fundamentacao: "Ligações de concessionárias e fechamentos.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10.2.1", nome: "Ligações de água, esgoto e energia", nivel: 3, tipo: "TRABALHO", pai: "10.2", ordem: 1, fundamentacao: "Conexões externas de serviços.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+  { obraId: OBRA_MODELO_EAP_ID, wbs: "10.2.2", nome: "Muros e fechamentos externos", nivel: 3, tipo: "TRABALHO", pai: "10.2", ordem: 2, fundamentacao: "Divisas e fechamento do terreno.", condicao: "HIPÓTESE / NECESSITA VALIDAÇÃO" },
+];
+
+/** Metadados da EAP real da Obra Modelo EAP (preservados da fonte oficial). */
+export const OBRA_MODELO_EAP_METADATA: ObraEapMetadata = {
+  obraId: OBRA_MODELO_EAP_ID,
+  obraNome: "Edifício Residencial Modelo EAP",
+  status: "PROPOSTA",
+  versao: "FASE-19.5",
+  caracterizacaoRef: "data/caracterizacao/OBRA-MODELO-EAP-001.json",
+  regraAlocacaoEstruturaCobertura:
+    "A estrutura e laje de cobertura (5.1.1) é alocada na disciplina 5 (Cobertura e Impermeabilização), não na disciplina 3 (Superestrutura). Esta é a regra de alocação adotada para evitar ambiguidade e sobreposição semântica entre as disciplinas 3 e 5.",
+  niveisTipos: { "1": "DISCIPLINA", "2": "PACOTE", "3": "TRABALHO" },
+  principios: [
+    "regra_100_porcento",
+    "exclusividade_mutua",
+    "orientacao_a_entregaveis",
+    "decomposicao_progressiva",
+    "work_packages",
+    "rastreabilidade",
+    "separacao_eap_do_cronograma",
+  ],
+  noTemplate:
+    "Cronograma fora da EAP; sem duracao, predecessoras ou atividades de cronograma.",
+  caracterizacaoResumo: {
+    torres: 1,
+    lajes: 14,
+    pilotis: true,
+    sobresolo: true,
+    unidades_por_pavimento: 1,
+    subsolos: 0,
+    sistema_construtivo: "concreto_armado",
+    cobertura_prevista: true,
+  },
+};
+
+/** EAP completa da Obra Modelo EAP (metadados + nós). */
+export const OBRA_MODELO_EAP: ObraEap = {
+  obraId: OBRA_MODELO_EAP_ID,
+  metadata: OBRA_MODELO_EAP_METADATA,
+  nodes: OBRA_MODELO_EAP_NODES,
+};

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-reference.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-reference.ts
@@ -1,0 +1,62 @@
+// Domínio Engenharia — referência reutilizável de EAP (EapReference).
+//
+// A Obra Modelo EAP é a PRIMEIRA referência da biblioteca de EAPs modelo.
+// A referência NÃO substitui a EAP operacional da Obra: ela aponta para a
+// origem (origemObraId) e expõe os nós por identidade, evitando duplicação.
+//
+// Futuramente, Skills/Agents/MCPs poderão selecionar, analisar e adaptar estas
+// referências para criar EAPs de novas obras. A Obra Modelo NÃO é um template
+// universal nem fonte operacional das outras obras.
+import type { EapReference, ObraEapNode } from "./obra-eap-types";
+import { getEapNodesForObra } from "./obra-eap-repository";
+
+/** Primeira referência de EAP: EAP Residencial Completo (Obra Modelo EAP). */
+export const REF_EAP_RES_001: EapReference = {
+  id: "REF-EAP-RES-001",
+  nome: "EAP Residencial Completo",
+  descricao:
+    "EAP completa de um edifício residencial de concreto armado (1 torre, 14 lajes, pilotis, sobresolo, 1 unidade por pavimento, sem subsolo), com 81 nós distribuídos em 10 disciplinas, 24 pacotes e 47 trabalhos.",
+  origem: "Obra Modelo EAP",
+  versaoOrigem: "FASE-19.5",
+  origemObraId: "OBRA-MODELO-EAP-001",
+  caracterizacao: {
+    torres: 1,
+    lajes: 14,
+    pilotis: true,
+    sobresolo: true,
+    unidades_por_pavimento: 1,
+    subsolos: 0,
+    sistema_construtivo: "concreto_armado",
+    cobertura_prevista: true,
+  },
+  principios: [
+    "regra_100_porcento",
+    "exclusividade_mutua",
+    "orientacao_a_entregaveis",
+    "decomposicao_progressiva",
+    "work_packages",
+    "rastreabilidade",
+    "separacao_eap_do_cronograma",
+  ],
+  regrasObservadas: [
+    "A estrutura e laje de cobertura (5.1.1) é alocada na disciplina 5 (Cobertura e Impermeabilização), não na disciplina 3 (Superestrutura).",
+  ],
+  metadados: {
+    status: "PROPOSTA",
+    quantidade_nos: 81,
+    distribuicao: { DISCIPLINA: 10, PACOTE: 24, TRABALHO: 47 },
+  },
+};
+
+/** Catálogo de referências de EAP disponíveis (biblioteca). */
+export const EAP_REFERENCES: EapReference[] = [REF_EAP_RES_001];
+
+/** Resolve os nós de uma referência a partir da EAP operacional da origem. */
+export function resolveReferenceNodes(reference: EapReference): ObraEapNode[] {
+  return getEapNodesForObra(reference.origemObraId);
+}
+
+/** Busca uma referência por id. */
+export function findEapReference(id: string): EapReference | undefined {
+  return EAP_REFERENCES.find((reference) => reference.id === id);
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-repository.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-repository.ts
@@ -109,8 +109,15 @@ export type EapValidation = {
   foraDaObra: string[];
 };
 
-/** Valida a integridade estrutural da EAP (espelha o verificador oficial). */
-export function validateEap(nodes: readonly ObraEapNode[]): EapValidation {
+/**
+ * Valida a integridade estrutural da EAP (espelha o verificador oficial).
+ * Desacoplado da Obra Modelo (D8): recebe o `obraId` real e considera
+ * `foraDaObra` todo nó cujo `node.obraId` difere da obra validada.
+ */
+export function validateEap(
+  nodes: readonly ObraEapNode[],
+  obraId: string,
+): EapValidation {
   const byWbs = new Map<string, ObraEapNode>();
   const wbsDuplicados: string[] = [];
   for (const node of nodes) {
@@ -144,7 +151,7 @@ export function validateEap(nodes: readonly ObraEapNode[]): EapValidation {
   }
 
   const foraDaObra = nodes
-    .filter((node) => node.obraId !== OBRA_MODELO_EAP_ID)
+    .filter((node) => node.obraId !== obraId)
     .map((node) => node.wbs);
 
   return {

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-repository.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-repository.ts
@@ -1,0 +1,225 @@
+// Domínio Engenharia — repositório da EAP (FASE 06.2-B).
+// Arquitetura: UI → repository → storage. A UI nunca toca em localStorage.
+// A EAP pertence à Obra e é persistida por obraId (identidade obraId + wbs).
+//
+// Fonte única: os nós reais da Obra Modelo EAP vivem aqui (obra-eap-data.ts),
+// hidratados no store. O resumo (ObraEapSummary) é SEMPRE derivado dos nós via
+// deriveEapSummary — nunca uma fonte independente de números.
+import { create } from "zustand";
+
+import { OBRA_MODELO_EAP, OBRA_MODELO_EAP_ID } from "./obra-eap-data";
+import type { ObraEap, ObraEapNode, ObraEapSummary } from "./obra-eap-types";
+import type { EapRow } from "./obra-eap-tree";
+import {
+  clearEapStorage,
+  loadEapFromStorage,
+  saveEapToStorage,
+} from "./obra-eap-storage";
+
+// ------------------------------------------------------------------ //
+// Helpers puros (derivação e validação) — testáveis sem DOM
+// ------------------------------------------------------------------ //
+
+/** Deriva o resumo estrutural a partir dos nós reais. */
+export function deriveEapSummary(nodes: readonly ObraEapNode[]): ObraEapSummary {
+  let raizes = 0;
+  let pacotes = 0;
+  let trabalhos = 0;
+  for (const node of nodes) {
+    if (node.nivel === 1) raizes += 1;
+    else if (node.nivel === 2) pacotes += 1;
+    else if (node.nivel === 3) trabalhos += 1;
+  }
+  return {
+    status: "PROPOSTA",
+    total: nodes.length,
+    raizes,
+    pacotes,
+    trabalhos,
+  };
+}
+
+/** Conta as folhas (nós sem filhos) da EAP. */
+export function countEapLeaves(nodes: readonly ObraEapNode[]): number {
+  const hasChildren = new Set<string>();
+  for (const node of nodes) {
+    if (node.pai) hasChildren.add(node.pai);
+  }
+  return nodes.filter((node) => !hasChildren.has(node.wbs)).length;
+}
+
+/** Mapa pai -> filhos na ordem declarada (ordem entre irmãos preservada). */
+export function buildEapChildrenIndex(
+  nodes: readonly ObraEapNode[],
+): Map<string, ObraEapNode[]> {
+  const byParent = new Map<string, ObraEapNode[]>();
+  for (const node of nodes) {
+    const key = node.pai ?? "";
+    const list = byParent.get(key) ?? [];
+    list.push(node);
+    byParent.set(key, list);
+  }
+  return byParent;
+}
+
+/** WBS dos nós raiz (sem pai). */
+export function eapRootWbs(nodes: readonly ObraEapNode[]): string[] {
+  return nodes.filter((node) => !node.pai).map((node) => node.wbs);
+}
+
+/**
+ * Linhas visíveis em ordem de árvore (DFS, pré-order) respeitando o conjunto de
+ * nós recolhidos. A ordem entre irmãos é a ordem declarada (ordem da fonte).
+ */
+export function deriveEapRows(
+  nodes: readonly ObraEapNode[],
+  collapsedWbs: ReadonlySet<string>,
+): EapRow[] {
+  const byWbs = new Map(nodes.map((node) => [node.wbs, node]));
+  const children = buildEapChildrenIndex(nodes);
+  const rows: EapRow[] = [];
+
+  const visit = (wbs: string) => {
+    const node = byWbs.get(wbs);
+    if (!node) return;
+    const kids = children.get(wbs) ?? [];
+    const expanded = !collapsedWbs.has(wbs);
+    rows.push({
+      node,
+      depth: node.nivel - 1,
+      hasChildren: kids.length > 0,
+      expanded,
+    });
+    if (kids.length > 0 && expanded) {
+      for (const kid of kids) visit(kid.wbs);
+    }
+  };
+
+  for (const rootWbs of eapRootWbs(nodes)) visit(rootWbs);
+  return rows;
+}
+
+export type EapValidation = {
+  ok: boolean;
+  total: number;
+  wbsDuplicados: string[];
+  paisInexistentes: string[];
+  raizesComPai: string[];
+  ciclos: string[];
+  foraDaObra: string[];
+};
+
+/** Valida a integridade estrutural da EAP (espelha o verificador oficial). */
+export function validateEap(nodes: readonly ObraEapNode[]): EapValidation {
+  const byWbs = new Map<string, ObraEapNode>();
+  const wbsDuplicados: string[] = [];
+  for (const node of nodes) {
+    if (byWbs.has(node.wbs)) wbsDuplicados.push(node.wbs);
+    else byWbs.set(node.wbs, node);
+  }
+
+  const paisInexistentes: string[] = [];
+  const raizesComPai: string[] = [];
+  for (const node of nodes) {
+    if (node.pai) {
+      if (!byWbs.has(node.pai)) paisInexistentes.push(node.wbs);
+    } else if (node.nivel !== 1) {
+      raizesComPai.push(node.wbs);
+    }
+  }
+
+  // Detecção de ciclo: percorre a cadeia de pais com limite de profundidade.
+  const ciclos: string[] = [];
+  for (const node of nodes) {
+    const visitados = new Set<string>();
+    let atual: ObraEapNode | undefined = node;
+    while (atual && atual.pai) {
+      if (visitados.has(atual.wbs)) {
+        ciclos.push(node.wbs);
+        break;
+      }
+      visitados.add(atual.wbs);
+      atual = byWbs.get(atual.pai);
+    }
+  }
+
+  const foraDaObra = nodes
+    .filter((node) => node.obraId !== OBRA_MODELO_EAP_ID)
+    .map((node) => node.wbs);
+
+  return {
+    ok:
+      wbsDuplicados.length === 0 &&
+      paisInexistentes.length === 0 &&
+      raizesComPai.length === 0 &&
+      ciclos.length === 0 &&
+      foraDaObra.length === 0,
+    total: nodes.length,
+    wbsDuplicados,
+    paisInexistentes,
+    raizesComPai,
+    ciclos,
+    foraDaObra,
+  };
+}
+
+// ------------------------------------------------------------------ //
+// Store (Zustand) — EAP por obraId
+// ------------------------------------------------------------------ //
+
+type ObraEapRepositoryState = {
+  /** EAPs por obraId (fonte única operacional). */
+  eaps: Record<string, ObraEap>;
+  /** Registra/substitui a EAP de uma obra (idempotente por obraId). */
+  setEap: (eap: ObraEap) => void;
+  /** Reset explícito (testes). */
+  resetEaps: (eaps: Record<string, ObraEap>) => void;
+};
+
+const SEED_EAPS: Record<string, ObraEap> = {
+  [OBRA_MODELO_EAP_ID]: OBRA_MODELO_EAP,
+};
+
+export const useObraEapRepository = create<ObraEapRepositoryState>((set, get) => ({
+  eaps: SEED_EAPS,
+  setEap: (eap) => {
+    set((state) => ({ eaps: { ...state.eaps, [eap.obraId]: eap } }));
+    saveEapToStorage(get().eaps);
+  },
+  resetEaps: (eaps) => {
+    set({ eaps });
+    saveEapToStorage(eaps);
+  },
+}));
+
+// ------------------------------------------------------------------ //
+// Helpers não-reativos
+// ------------------------------------------------------------------ //
+
+/** Retorna a EAP completa de uma obra (ou undefined se não existir). */
+export function getEapForObra(obraId: string): ObraEap | undefined {
+  return useObraEapRepository.getState().eaps[obraId];
+}
+
+/** Retorna os nós da EAP de uma obra (ou [] se não existir). */
+export function getEapNodesForObra(obraId: string): ObraEapNode[] {
+  return getEapForObra(obraId)?.nodes ?? [];
+}
+
+/** Resumo derivado dos nós reais da obra. */
+export function getEapSummaryForObra(obraId: string): ObraEapSummary | null {
+  const nodes = getEapNodesForObra(obraId);
+  return nodes.length > 0 ? deriveEapSummary(nodes) : null;
+}
+
+/** Hidrata o repositório a partir do armazenamento local (inicialização). */
+export function initializeObraEapRepository(): void {
+  const stored = loadEapFromStorage();
+  if (stored) useObraEapRepository.setState({ eaps: stored });
+}
+
+/** Remove a persistência e restaura os seeds (testes). */
+export function resetObraEapRepository(): void {
+  clearEapStorage();
+  useObraEapRepository.setState({ eaps: SEED_EAPS });
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-storage.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-storage.ts
@@ -1,0 +1,64 @@
+// Domínio Engenharia — camada de armazenamento local da EAP (FASE 06.2-B).
+// A UI NUNCA acessa localStorage diretamente: ela fala com o repository
+// (obra-eap-repository.ts), que por sua vez usa este módulo. Trocar por backend
+// depois = substituir apenas esta camada.
+import type { ObraEap } from "./obra-eap-types";
+
+export const OBRA_EAP_STORAGE_KEY = "openwork.obra-eap.v1";
+const STORAGE_VERSION = 1;
+
+function isObraEap(value: unknown): value is ObraEap {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.obraId === "string" &&
+    typeof record.metadata === "object" &&
+    record.metadata !== null &&
+    Array.isArray(record.nodes)
+  );
+}
+
+/** Carrega e valida o mapa de EAPs persistido; null quando não há dado utilizável. */
+export function loadEapFromStorage(): Record<string, ObraEap> | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(OBRA_EAP_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const record = parsed as { version?: unknown; eaps?: unknown };
+    if (record.version !== STORAGE_VERSION) return null;
+    if (!record.eaps || typeof record.eaps !== "object") return null;
+    const eaps = record.eaps as Record<string, unknown>;
+    const result: Record<string, ObraEap> = {};
+    for (const [obraId, eap] of Object.entries(eaps)) {
+      if (isObraEap(eap) && eap.obraId === obraId) result[obraId] = eap;
+    }
+    return Object.keys(result).length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persiste o mapa de EAPs. Nunca lança para a UI. */
+export function saveEapToStorage(eaps: Record<string, ObraEap>): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(
+      OBRA_EAP_STORAGE_KEY,
+      JSON.stringify({ version: STORAGE_VERSION, eaps }),
+    );
+  } catch {
+    // Armazenamento indisponível: mantém estado em memória (best-effort).
+  }
+}
+
+/** Remove os dados persistidos (útil em testes/reset). */
+export function clearEapStorage(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(OBRA_EAP_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-tree.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-tree.tsx
@@ -1,0 +1,105 @@
+// Domínio Engenharia — árvore navegável da EAP (FASE 06.2-B).
+// Componente presentacional: recebe linhas prontas (deriveEapRows) e eventos.
+// Nenhuma hierarquia é derivada aqui; nenhum domínio externo é conhecido.
+/** @jsxImportSource react */
+import { ChevronRight } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ObraEapNode, ObraEapTipo } from "./obra-eap-types";
+
+export type EapRow = {
+  node: ObraEapNode;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+};
+
+const TIPO_LABEL: Record<ObraEapTipo, string> = {
+  DISCIPLINA: "Disciplina",
+  PACOTE: "Pacote",
+  TRABALHO: "Trabalho",
+};
+
+const TIPO_TONE: Record<ObraEapTipo, string> = {
+  DISCIPLINA: "border-sky-500/40 bg-sky-500/10 text-sky-700",
+  PACOTE: "border-violet-500/40 bg-violet-500/10 text-violet-700",
+  TRABALHO: "border-slate-400/40 bg-slate-400/10 text-slate-600",
+};
+
+export function EapTree({
+  rows,
+  selectedWbs,
+  onSelect,
+  onToggle,
+}: {
+  rows: EapRow[];
+  selectedWbs?: string | null;
+  onSelect: (wbs: string) => void;
+  onToggle: (wbs: string) => void;
+}) {
+  return (
+    <div role="tree" aria-label="Estrutura Analítica do Projeto" data-eap-tree className="min-w-full">
+      {rows.map((row) => {
+        const { node } = row;
+        const active = selectedWbs === node.wbs;
+        return (
+          <div
+            key={node.wbs}
+            role="treeitem"
+            aria-level={node.nivel}
+            aria-expanded={row.hasChildren ? row.expanded : undefined}
+            aria-selected={active}
+            data-eap-row
+            data-eap-wbs={node.wbs}
+            className={cn(
+              "group/row flex cursor-pointer items-center gap-2 border-b border-border/40 py-1.5 pr-2 text-sm transition-colors",
+              active
+                ? "bg-sidebar-accent font-medium text-foreground"
+                : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
+            )}
+            onClick={() => onSelect(node.wbs)}
+          >
+            <span
+              aria-hidden="true"
+              className="shrink-0"
+              style={{ width: (node.nivel - 1) * 16 + 4 }}
+            />
+            {row.hasChildren ? (
+              <button
+                type="button"
+                aria-label={row.expanded ? "Recolher" : "Expandir"}
+                data-eap-toggle={node.wbs}
+                className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-sidebar-accent"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggle(node.wbs);
+                }}
+              >
+                <ChevronRight
+                  className={cn(
+                    "size-3.5 transition-transform duration-150",
+                    row.expanded && "rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+            ) : (
+              <span aria-hidden="true" className="size-5 shrink-0" />
+            )}
+            <span className="w-12 shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+              {node.wbs}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-left">{node.nome}</span>
+            <Badge
+              variant="outline"
+              className={cn("shrink-0 text-[10px] font-medium", TIPO_TONE[node.tipo])}
+            >
+              {TIPO_LABEL[node.tipo]}
+            </Badge>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-eap-types.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-eap-types.ts
@@ -1,0 +1,84 @@
+// Domínio Engenharia — modelo de domínio da EAP (Estrutura Analítica do Projeto).
+// A EAP é um conceito PRÓPRIO da Obra (não reutiliza PlanningItem).
+// Identidade natural de um nó: obraId + wbs (o mesmo WBS em obras diferentes
+// NÃO representa o mesmo nó operacional).
+//
+// FASE 06.2-B: modelo de domínio criado para receber o EAP real (81 nós) da
+// Obra Modelo EAP, preservando integralmente os dados da fonte oficial.
+
+export type ObraEapTipo = "DISCIPLINA" | "PACOTE" | "TRABALHO";
+
+/** Nó da EAP — preserva todos os campos da fonte oficial. */
+export type ObraEapNode = {
+  /** Obra à qual o nó pertence (identidade composta obraId + wbs). */
+  obraId: string;
+  /** Identificador hierárquico oficial (ex.: "1", "1.1", "1.1.1"). */
+  wbs: string;
+  nome: string;
+  /** Nível hierárquico (1 = DISCIPLINA, 2 = PACOTE, 3 = TRABALHO). */
+  nivel: number;
+  tipo: ObraEapTipo;
+  /** WBS do nó pai; null/undefined para raízes (nível 1). */
+  pai: string | null;
+  /** Ordem entre irmãos (ordem de ocorrência na fonte, pré-order). */
+  ordem: number;
+  /** Fundamentação do nó (preservada da fonte oficial). */
+  fundamentacao?: string | null;
+  /** Condição/hipótese do nó (preservada da fonte oficial). */
+  condicao?: string | null;
+};
+
+/** Metadados da EAP — preserva os metadados do documento oficial. */
+export type ObraEapMetadata = {
+  obraId: string;
+  obraNome: string;
+  status: string;
+  versao: string;
+  caracterizacaoRef?: string | null;
+  regraAlocacaoEstruturaCobertura?: string | null;
+  niveisTipos?: Record<string, string> | null;
+  principios?: string[] | null;
+  noTemplate?: string | null;
+  caracterizacaoResumo?: Record<string, unknown> | null;
+};
+
+/** EAP completa de uma Obra: metadados + nós. */
+export type ObraEap = {
+  obraId: string;
+  metadata: ObraEapMetadata;
+  nodes: ObraEapNode[];
+};
+
+/** Resumo estrutural derivado dos nós (nunca fonte independente). */
+export type ObraEapSummary = {
+  status: string;
+  total: number;
+  raizes: number;
+  pacotes: number;
+  trabalhos: number;
+};
+
+// ------------------------------------------------------------------ //
+// Referência reutilizável de EAP (EapReference)
+// ------------------------------------------------------------------ //
+
+/**
+ * Referência reutilizável de EAP — estrutura que permite a futura Skill/Agent
+ * selecionar, analisar e adaptar EAPs modelo para novas obras.
+ *
+ * A referência NÃO substitui a EAP operacional da Obra. Ela aponta para a
+ * origem (obraId) e expõe os nós por identidade, evitando duplicação de dados.
+ */
+export type EapReference = {
+  id: string;
+  nome: string;
+  descricao: string;
+  origem: string;
+  versaoOrigem: string;
+  /** Obra cuja EAP operacional é a fonte desta referência (proveniência). */
+  origemObraId: string;
+  caracterizacao?: Record<string, unknown> | null;
+  principios?: string[] | null;
+  regrasObservadas?: string[] | null;
+  metadados?: Record<string, unknown> | null;
+};

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-escopo-repository.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-escopo-repository.ts
@@ -1,0 +1,44 @@
+// Domínio Engenharia — repositório de Escopo/Serviço por obra (P0b).
+//
+// Desacopla o escopo de quantidades/produtividades por WBS (antes o mapa global
+// `OBRA_SCOPE_REF`) para um registro por `obraId`. A obra-modelo é semeada com
+// os MESMOS dados de `OBRA_SCOPE_REF` (paridade preservada); outras obras
+// começam sem escopo (resolvem a "sem escopo" → duração 0).
+//
+// Direção D3 (P1): este registro evolui para o cadastro de Serviço
+// (EAP × Frente × Local). Aqui mantemos apenas o registro de quantidades/
+// produtividades por obra, sem criar a entidade Serviço completa.
+import { OBRA_MODELO_EAP_ID } from "./obra-eap-data";
+import { OBRA_SCOPE_REF, type ObraEapScopeRef } from "./obra-planejamento-data";
+
+/** Escopo de um WBS dentro de uma obra (quantidade/produtividade). */
+export type ObraEscopo = ObraEapScopeRef & {
+  obraId: string;
+  wbs: string;
+};
+
+/** Mapa de escopo por obra: obraId → (wbs → ObraEscopo). */
+type EscopoStore = Record<string, Record<string, ObraEscopo>>;
+
+/** Seed da obra-modelo: migra `OBRA_SCOPE_REF` para o registro por obra. */
+function seedObraModelo(): Record<string, ObraEscopo> {
+  const mapa: Record<string, ObraEscopo> = {};
+  for (const [wbs, ref] of Object.entries(OBRA_SCOPE_REF)) {
+    mapa[wbs] = { obraId: OBRA_MODELO_EAP_ID, wbs, ...ref };
+  }
+  return mapa;
+}
+
+const escopoStore: EscopoStore = {
+  [OBRA_MODELO_EAP_ID]: seedObraModelo(),
+};
+
+/** Retorna o escopo (wbs → ObraEscopo) de uma obra; `{}` se não houver. */
+export function getEscopo(obraId: string): Record<string, ObraEscopo> {
+  return escopoStore[obraId] ?? {};
+}
+
+/** Define/substitui o escopo de uma obra. */
+export function setEscopo(obraId: string, mapa: Record<string, ObraEscopo>): void {
+  escopoStore[obraId] = mapa;
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-help.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-help.tsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource react */
+import { Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+/**
+ * Ajuda contextual da gestão de Obras (domínio Engenharia).
+ * Textos definidos na FASE 04.2-B; componentes nativos (Popover/Button).
+ */
+
+export function ObraHelpButton() {
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={<Button type="button" variant="ghost" size="icon" />}
+        aria-label="Ajuda: Obras"
+      >
+        <Info className="size-4" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent className="w-80" align="start">
+        <div className="flex flex-col gap-3">
+          <div className="text-sm font-semibold">Obras</div>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Obras são os projetos de trabalho registrados neste domínio.
+          </p>
+          <div className="text-sm font-semibold">Nova obra</div>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Crie a identificação básica da obra. Informações técnicas
+            detalhadas podem ser preenchidas posteriormente.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-kpi-bar.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-kpi-bar.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource react */
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+/**
+ * Barra de KPIs reutilizável (FASE 21 / FASE 22).
+ *
+ * Renderiza uma grade de cartões de indicador. Os VALORES são sempre fornecidos
+ * pelo chamador (derivados de dados reais do domínio) — este componente é um
+ * primitivo de UI neutro, sem regras de negócio.
+ *
+ * FASE 22: cada KPI pode ter um `target` (rota do módulo de origem). Quando
+ * presente E `onNavigate` é fornecido, o card torna-se clicável e navega para
+ * o módulo (drill-down). A navegação é injetada pelo chamador (evita dependência
+ * de Router neste primitivo, mantendo-o SSR-testável).
+ */
+export type KpiItem = {
+  id: string;
+  label: string;
+  value: number | string;
+  /** Classe de cor opcional para o valor (ex.: "text-emerald-600"). */
+  tone?: string;
+  /** Detalhe opcional exibido abaixo do valor. */
+  hint?: string;
+  /** Rota do módulo de origem (drill-down). Quando presente, o card é clicável. */
+  target?: string;
+};
+
+export function KpiBar({
+  items,
+  onNavigate,
+}: {
+  items: KpiItem[];
+  onNavigate?: (target: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div
+      data-kpi-bar
+      className="grid grid-cols-2 gap-2 lg:grid-cols-4 xl:grid-cols-5"
+      aria-label="Indicadores"
+    >
+      {items.map((kpi) => {
+        const clickable = Boolean(kpi.target) && Boolean(onNavigate);
+        const inner = (
+          <>
+            <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {kpi.label}
+            </span>
+            <span
+              className={cn("text-2xl font-bold tabular-nums", kpi.tone)}
+              data-kpi={kpi.id}
+            >
+              {kpi.value}
+            </span>
+            {kpi.hint ? (
+              <span className="truncate text-[11px] text-muted-foreground">
+                {kpi.hint}
+              </span>
+            ) : null}
+          </>
+        );
+        return (
+          <Card
+            key={kpi.id}
+            className={cn("min-w-0", clickable && "cursor-pointer transition-colors hover:bg-sidebar-accent/40")}
+            data-kpi-target={kpi.target}
+          >
+            <CardContent
+              className={cn("flex flex-col gap-0.5 py-3", clickable && "h-full")}
+              {...(clickable
+                ? {
+                    role: "button",
+                    tabIndex: 0,
+                    onClick: () => onNavigate?.(kpi.target!),
+                    onKeyDown: (e: React.KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onNavigate?.(kpi.target!);
+                      }
+                    },
+                    "aria-label": `Ver detalhes de ${kpi.label}`,
+                  }
+                : {})}
+            >
+              {inner}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-lob-data.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-lob-data.ts
@@ -1,84 +1,84 @@
-// Domínio Engenharia — dados da grade Linha de Balanço (FASE 20.x).
+// Domínio Engenharia — adapter da grade Linha de Balanço (FASE 20.x / FASE 21).
 //
-// Deriva a grade tempo × serviço (como a aba LINHA DE BALANÇO (GRADE) da
-// planilha nativa) a partir das linhas de planejamento. Tudo é DERIVADO dos
-// nós reais + datas — nunca uma fonte independente.
-import type { ObraEapNode } from "./obra-eap-types";
+// FASE 21: a capacidade genérica de LOB foi extraída para domains/linha-de-balanco.
+// Este arquivo agora é um ADAPTER que traduz os nós reais da EAP + o planejamento
+// derivado para o contrato genérico `LobGradeData`, delegando a derivação à
+// capacidade reutilizável. Nenhuma fonte de verdade é criada aqui.
+import type { LobAtividade, LobGradeData, LobSemana } from "../../linha-de-balanco/lob-types";
 import {
-  DATA_INICIO_OBRA,
+  atividadeParaLobLinha as lobAtividadeParaLobLinha,
+  derivarGradeLob as lobDerivarGradeLob,
+  gerarSemanas as lobGerarSemanas,
+} from "../../linha-de-balanco/lob-data";
+import type { ObraEapNode } from "./obra-eap-types";
+import type { ObraEapScopeRef } from "./obra-planejamento-data";
+import {
+  DATA_INICIO_DEFAULT,
   derivarPlanejamentoCompleto,
-  diaParaDataIso,
   duracaoTotalDasLinhas,
 } from "./obra-planejamento-data";
 import type { ObraPlanejamentoLinha } from "./obra-planejamento-data";
 
-/** Uma semana do eixo temporal (segunda a domingo). */
-export type LobSemana = {
-  /** Índice 0-based da semana. */
-  index: number;
-  /** Data ISO do início (segunda). */
-  inicio: string;
-  /** Data ISO do fim (domingo). */
-  fim: string;
-  /** Rótulo curto (ex.: "SEM 1"). */
-  label: string;
-};
+/** Data de início da obra em ISO (base do eixo temporal da LOB). */
+export const DATA_INICIO_OBRA_ISO = DATA_INICIO_DEFAULT.toISOString().slice(0, 10);
 
-/** Linha da grade LOB: serviço + semanas ativas. */
-export type LobLinha = {
-  node: ObraEapNode;
-  duracao: number;
-  critico: "CRÍTICO" | "Sequencial" | "—";
-  /** Índices das semanas em que o serviço está ativo. */
-  semanasAtivas: number[];
-};
+/** Linha da grade LOB (re-export do contrato genérico). */
+export type LobLinha = import("../../linha-de-balanco/lob-types").LobLinha;
+
+/** Formata uma Date como ISO local (yyyy-mm-dd), consistente com diaParaDataIso. */
+function dataParaIsoLocal(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
 
 /** Gera as semanas (segunda a domingo) cobrindo a duração total da obra. */
-export function gerarSemanas(duracaoTotal: number): LobSemana[] {
-  const semanas: LobSemana[] = [];
-  const cursor = new Date(DATA_INICIO_OBRA);
-  let index = 0;
-  while (index * 7 <= duracaoTotal) {
-    const inicio = new Date(cursor);
-    const fim = new Date(cursor);
-    fim.setDate(fim.getDate() + 6);
-    semanas.push({
-      index,
-      inicio: diaParaDataIso(index * 7),
-      fim: diaParaDataIso(index * 7 + 6),
-      label: `SEM ${index + 1}`,
-    });
-    cursor.setDate(cursor.getDate() + 7);
-    index += 1;
-  }
-  return semanas;
+export function gerarSemanas(
+  duracaoTotal: number,
+  startDate: Date = DATA_INICIO_DEFAULT,
+): LobSemana[] {
+  return lobGerarSemanas(dataParaIsoLocal(startDate), duracaoTotal);
 }
 
-/** Converte uma linha de planejamento em linha da grade (semanas ativas). */
+/** Converte uma linha de planejamento da obra em linha da grade LOB. */
 export function linhaParaLobLinha(linha: ObraPlanejamentoLinha): LobLinha {
-  const semanasAtivas: number[] = [];
-  if (linha.duracao > 0) {
-    const semanaInicio = Math.floor(linha.inicio / 7);
-    const semanaFim = Math.floor((linha.fim - 1) / 7);
-    for (let s = semanaInicio; s <= semanaFim; s += 1) semanasAtivas.push(s);
-  }
-  return {
-    node: linha.node,
+  return lobAtividadeParaLobLinha({
+    id: linha.node.wbs,
+    nome: linha.node.nome,
+    codigo: linha.node.wbs,
+    inicio: linha.inicio,
+    fim: linha.fim,
     duracao: linha.duracao,
     critico: linha.critico,
-    semanasAtivas,
-  };
+  });
 }
 
-/** Grade LOB completa: semanas + linhas (serviços com duração). */
+/** Converte as linhas de planejamento da obra em atividades genéricas de LOB. */
+function linhasParaAtividades(
+  linhas: readonly ObraPlanejamentoLinha[],
+): LobAtividade[] {
+  return linhas.map((linha) => ({
+    id: linha.node.wbs,
+    nome: linha.node.nome,
+    codigo: linha.node.wbs,
+    inicio: linha.inicio,
+    fim: linha.fim,
+    duracao: linha.duracao,
+    critico: linha.critico,
+  }));
+}
+
+/** Grade LOB completa da obra: semanas + linhas (serviços com duração). */
 export function derivarGradeLob(
   nodes: readonly ObraEapNode[],
-): { semanas: LobSemana[]; linhas: LobLinha[] } {
-  const linhas = derivarPlanejamentoCompleto(nodes);
+  escopo: Record<string, ObraEapScopeRef>,
+  startDate: Date = DATA_INICIO_DEFAULT,
+): LobGradeData {
+  const linhas = derivarPlanejamentoCompleto(nodes, escopo, startDate);
   const duracaoTotal = duracaoTotalDasLinhas(linhas);
-  const semanas = gerarSemanas(duracaoTotal);
-  const linhasGrade = linhas
-    .filter((l) => l.duracao > 0)
-    .map(linhaParaLobLinha);
-  return { semanas, linhas: linhasGrade };
+  const semanas = gerarSemanas(duracaoTotal, startDate);
+  const atividades = linhasParaAtividades(linhas);
+  const grade = lobDerivarGradeLob(atividades, dataParaIsoLocal(startDate));
+  return { semanas, linhas: grade.linhas };
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-lob-data.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-lob-data.ts
@@ -1,0 +1,84 @@
+// Domínio Engenharia — dados da grade Linha de Balanço (FASE 20.x).
+//
+// Deriva a grade tempo × serviço (como a aba LINHA DE BALANÇO (GRADE) da
+// planilha nativa) a partir das linhas de planejamento. Tudo é DERIVADO dos
+// nós reais + datas — nunca uma fonte independente.
+import type { ObraEapNode } from "./obra-eap-types";
+import {
+  DATA_INICIO_OBRA,
+  derivarPlanejamentoCompleto,
+  diaParaDataIso,
+  duracaoTotalDasLinhas,
+} from "./obra-planejamento-data";
+import type { ObraPlanejamentoLinha } from "./obra-planejamento-data";
+
+/** Uma semana do eixo temporal (segunda a domingo). */
+export type LobSemana = {
+  /** Índice 0-based da semana. */
+  index: number;
+  /** Data ISO do início (segunda). */
+  inicio: string;
+  /** Data ISO do fim (domingo). */
+  fim: string;
+  /** Rótulo curto (ex.: "SEM 1"). */
+  label: string;
+};
+
+/** Linha da grade LOB: serviço + semanas ativas. */
+export type LobLinha = {
+  node: ObraEapNode;
+  duracao: number;
+  critico: "CRÍTICO" | "Sequencial" | "—";
+  /** Índices das semanas em que o serviço está ativo. */
+  semanasAtivas: number[];
+};
+
+/** Gera as semanas (segunda a domingo) cobrindo a duração total da obra. */
+export function gerarSemanas(duracaoTotal: number): LobSemana[] {
+  const semanas: LobSemana[] = [];
+  const cursor = new Date(DATA_INICIO_OBRA);
+  let index = 0;
+  while (index * 7 <= duracaoTotal) {
+    const inicio = new Date(cursor);
+    const fim = new Date(cursor);
+    fim.setDate(fim.getDate() + 6);
+    semanas.push({
+      index,
+      inicio: diaParaDataIso(index * 7),
+      fim: diaParaDataIso(index * 7 + 6),
+      label: `SEM ${index + 1}`,
+    });
+    cursor.setDate(cursor.getDate() + 7);
+    index += 1;
+  }
+  return semanas;
+}
+
+/** Converte uma linha de planejamento em linha da grade (semanas ativas). */
+export function linhaParaLobLinha(linha: ObraPlanejamentoLinha): LobLinha {
+  const semanasAtivas: number[] = [];
+  if (linha.duracao > 0) {
+    const semanaInicio = Math.floor(linha.inicio / 7);
+    const semanaFim = Math.floor((linha.fim - 1) / 7);
+    for (let s = semanaInicio; s <= semanaFim; s += 1) semanasAtivas.push(s);
+  }
+  return {
+    node: linha.node,
+    duracao: linha.duracao,
+    critico: linha.critico,
+    semanasAtivas,
+  };
+}
+
+/** Grade LOB completa: semanas + linhas (serviços com duração). */
+export function derivarGradeLob(
+  nodes: readonly ObraEapNode[],
+): { semanas: LobSemana[]; linhas: LobLinha[] } {
+  const linhas = derivarPlanejamentoCompleto(nodes);
+  const duracaoTotal = duracaoTotalDasLinhas(linhas);
+  const semanas = gerarSemanas(duracaoTotal);
+  const linhasGrade = linhas
+    .filter((l) => l.duracao > 0)
+    .map(linhaParaLobLinha);
+  return { semanas, linhas: linhasGrade };
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-modules.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-modules.ts
@@ -1,0 +1,65 @@
+// Catálogo declarativo de módulos da Obra (FASE 22).
+//
+// Este arquivo representa APENAS a DECLARAÇÃO/CAPACIDADE de cada módulo:
+// id, label, fase, ordem, opcionalidade e descrição. NÃO contém componentes
+// React, roteamento, estado, regras de negócio nem dados — a resolução da
+// tela/renderização fica na camada apropriada (obra-shell-route.tsx).
+//
+// Objetivo (decisão FASE 22): adicionar um módulo novo = adicionar uma entrada
+// aqui + o render no shell. Sem alterar 3+ arquivos estruturais e sem criar um
+// "plugin system" complexo.
+import type { ObraFase, ObraModule } from "./obra-types";
+
+export type ObraModuleDef = {
+  /** Identificador estável do módulo (mesmo valor do tipo ObraModule). */
+  id: ObraModule;
+  /** Rótulo exibido na navegação. */
+  label: string;
+  /** Fase do ciclo de vida à qual o módulo pertence. */
+  fase: ObraFase;
+  /** Ordem de exibição dentro da fase (ordem = fluxo real). */
+  ordem: number;
+  /** Módulo opcional (não padrão). Quando ausente, é módulo padrão. */
+  opcional?: boolean;
+  /** Descrição curta (metadado para catálogo/help). */
+  descricao?: string;
+};
+
+/**
+ * Catálogo declarativo dos módulos da Obra — FONTE ÚNICA de metadados.
+ * A ordem de exibição é derivada de (fase, ordem).
+ */
+export const OBRA_MODULES: ObraModuleDef[] = [
+  // ---- Preparação ----
+  { id: "visao-geral", label: "Visão Geral", fase: "preparacao", ordem: 1, descricao: "Dashboard executiva da obra." },
+  { id: "caracterizacao", label: "Caracterização", fase: "preparacao", ordem: 2, descricao: "Informações estruturais da obra." },
+  { id: "eap", label: "EAP", fase: "preparacao", ordem: 3, descricao: "Estrutura Analítica do Projeto (81 nós)." },
+  { id: "disciplinas", label: "Disciplinas", fase: "preparacao", ordem: 4, descricao: "Disciplinas (nível 1) da EAP." },
+  { id: "servicos", label: "Serviços", fase: "preparacao", ordem: 5, descricao: "Serviços derivados da EAP." },
+  { id: "planejamento", label: "Planejamento", fase: "preparacao", ordem: 6, descricao: "Cronograma derivado da EAP." },
+  { id: "linha-de-balanco", label: "Linha de Balanço", fase: "preparacao", ordem: 7, descricao: "Grade LOB derivada do planejamento." },
+  // ---- Execução ----
+  { id: "frentes", label: "Frentes de Serviço", fase: "execucao", ordem: 1, descricao: "Frentes derivadas das disciplinas raiz." },
+  { id: "producao", label: "Produção", fase: "execucao", ordem: 2, descricao: "Acompanhamento planejado × realizado." },
+  { id: "rdo", label: "RDO", fase: "execucao", ordem: 3, descricao: "Registro Diário de Obra (fase futura)." },
+  // ---- Suporte ----
+  { id: "ia", label: "IA", fase: "suporte", ordem: 1, descricao: "Assistência de IA da obra (fase futura)." },
+];
+
+/** Módulos ordenados por (fase, ordem) — ordem de exibição nas abas. */
+export function listModulesByFase(fase: ObraFase): ObraModuleDef[] {
+  return OBRA_MODULES.filter((m) => m.fase === fase).sort((a, b) => a.ordem - b.ordem);
+}
+
+/** Todas as fases na ordem canônica (Preparação, Execução, Suporte). */
+export const OBRA_FASES_ORDER: ObraFase[] = ["preparacao", "execucao", "suporte"];
+
+/** Rótulo de um módulo a partir do catálogo (fallback para o id). */
+export function moduleLabel(id: ObraModule): string {
+  return OBRA_MODULES.find((m) => m.id === id)?.label ?? id;
+}
+
+/** Fase de um módulo a partir do catálogo (fallback: preparação). */
+export function moduleFase(id: ObraModule): ObraFase {
+  return OBRA_MODULES.find((m) => m.id === id)?.fase ?? "preparacao";
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-navigation.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-navigation.ts
@@ -1,0 +1,71 @@
+// Configuração declarativa de navegação do domínio Engenharia.
+// Produz NavigationNode[] (dados) a partir do REPOSITÓRIO de obras (fonte única).
+// O Core apenas interpreta/renderiza — sem regras de Engenharia no Core.
+import type { NavigationNode } from "../../navigation/navigation-types";
+import type { Obra } from "./obra-types";
+import { SEED_OBRAS } from "./obra-repository";
+import {
+  DOMAIN_ENGENHARIA_ID,
+  OBRA_FASES,
+  OBRA_MODULE_LABEL,
+  obraNovaRoute,
+  obrasListRoute,
+  obraRoute,
+} from "./obra-routes";
+
+function moduleNodes(obra: Obra): NavigationNode[] {
+  return OBRA_FASES.map((fase) => ({
+    id: `domain:${DOMAIN_ENGENHARIA_ID}:obra:${obra.id}:fase:${fase.id}`,
+    label: fase.label,
+    type: "group",
+    children: fase.modules.map((module) => ({
+      id: `domain:${DOMAIN_ENGENHARIA_ID}:obra:${obra.id}:${module}`,
+      label: OBRA_MODULE_LABEL[module],
+      type: "module",
+      route: obraRoute(obra.id, module),
+    })),
+  }));
+}
+
+function obraNode(obra: Obra): NavigationNode {
+  return {
+    id: `domain:${DOMAIN_ENGENHARIA_ID}:obra:${obra.id}`,
+    label: obra.nome,
+    type: "entity",
+    route: obraRoute(obra.id),
+    children: moduleNodes(obra),
+  };
+}
+
+/**
+ * Monta a árvore DOMÍNIOS → Engenharia → Obras a partir da lista de obras.
+ * Inclui a ação "+ Nova obra". Sem estado estático: as obras vêm dos dados.
+ */
+export function buildEngenhariaNavigation(
+  obras: readonly Obra[] = SEED_OBRAS,
+): NavigationNode[] {
+  const novaObra: NavigationNode = {
+    id: `domain:${DOMAIN_ENGENHARIA_ID}:obras:nova`,
+    label: "+ Nova obra",
+    type: "entity",
+    route: obraNovaRoute(),
+  };
+
+  return [
+    {
+      id: `domain:${DOMAIN_ENGENHARIA_ID}`,
+      label: "Engenharia",
+      type: "domain",
+      route: obrasListRoute(),
+      children: [
+        {
+          id: `domain:${DOMAIN_ENGENHARIA_ID}:obras`,
+          label: "Obras",
+          type: "group",
+          children: [novaObra, ...obras.map(obraNode)],
+        },
+      ],
+    },
+  ];
+}
+

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-adapter.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-adapter.ts
@@ -6,8 +6,9 @@
 // da Obra, sem tocar na Dashboard (que permanece neutra / anti-hardcode).
 import type { PlanningDashboardData, PlanningItem } from "../../planejamento/planning-types";
 import type { ObraEapNode } from "./obra-eap-types";
+import type { ObraEapScopeRef } from "./obra-planejamento-data";
 import {
-  DATA_INICIO_OBRA,
+  DATA_INICIO_DEFAULT,
   derivarPlanejamentoCompleto,
   diaParaDataIso,
   duracaoTotalDasLinhas,
@@ -34,23 +35,27 @@ export function eapNodeParaPlanningItem(
 
 /**
  * Produz o PlanningDashboardData da Obra a partir dos nós reais da EAP.
- * Datas são derivadas deterministicamente (mesma lógica da planilha nativa).
+ * Datas são derivadas deterministicamente (mesma lógica da planilha nativa),
+ * a partir do escopo da obra (`escopo`) e da data de início (`startDate`;
+ * fallback 05/01/2026).
  */
 export function obraEapParaPlanningDashboard(
   nodes: readonly ObraEapNode[],
   obraNome: string,
+  escopo: Record<string, ObraEapScopeRef>,
+  startDate: Date = DATA_INICIO_DEFAULT,
 ): PlanningDashboardData {
-  const linhas = derivarPlanejamentoCompleto(nodes);
+  const linhas = derivarPlanejamentoCompleto(nodes, escopo, startDate);
   const duracaoTotal = duracaoTotalDasLinhas(linhas);
-  const fimObraIso = diaParaDataIso(duracaoTotal);
+  const fimObraIso = diaParaDataIso(duracaoTotal, startDate);
 
   const items: PlanningItem[] = linhas.map((linha) => {
     const { node, duracao } = linha;
     const temData = node.tipo === "TRABALHO" && duracao > 0;
     return eapNodeParaPlanningItem(
       node,
-      temData ? diaParaDataIso(linha.inicio) : null,
-      temData ? diaParaDataIso(linha.fim) : null,
+      temData ? diaParaDataIso(linha.inicio, startDate) : null,
+      temData ? diaParaDataIso(linha.fim, startDate) : null,
     );
   });
 
@@ -58,7 +63,7 @@ export function obraEapParaPlanningDashboard(
     context: {
       title: "Planejamento",
       subtitle: `${obraNome} · Cronograma derivado da EAP (${nodes.length} nós)`,
-      referenceDate: DATA_INICIO_OBRA.toISOString().slice(0, 10),
+      referenceDate: diaParaDataIso(0, startDate),
     },
     items,
   };

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-adapter.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-adapter.ts
@@ -1,0 +1,65 @@
+// Domínio Engenharia — adapter do Planejamento (FASE 20.x).
+//
+// Traduz os 81 nós reais da EAP + as datas derivadas de planejamento para o
+// contrato genérico `PlanningDashboardData` do domínio `planejamento/`.
+// Substitui o dataset demonstrativo (PLANNING_DEMO_DATA) no módulo Planejamento
+// da Obra, sem tocar na Dashboard (que permanece neutra / anti-hardcode).
+import type { PlanningDashboardData, PlanningItem } from "../../planejamento/planning-types";
+import type { ObraEapNode } from "./obra-eap-types";
+import {
+  DATA_INICIO_OBRA,
+  derivarPlanejamentoCompleto,
+  diaParaDataIso,
+  duracaoTotalDasLinhas,
+} from "./obra-planejamento-data";
+
+/** Constrói um PlanningItem a partir de um nó da EAP (datas opcionais). */
+export function eapNodeParaPlanningItem(
+  node: ObraEapNode,
+  inicioIso: string | null,
+  fimIso: string | null,
+): PlanningItem {
+  return {
+    id: node.wbs,
+    parentId: node.pai,
+    name: node.nome,
+    // Planning usa 0 = raiz; EAP usa nivel 1 = raiz.
+    level: node.nivel - 1,
+    status: "planejado",
+    progress: 0,
+    start: inicioIso,
+    end: fimIso,
+  };
+}
+
+/**
+ * Produz o PlanningDashboardData da Obra a partir dos nós reais da EAP.
+ * Datas são derivadas deterministicamente (mesma lógica da planilha nativa).
+ */
+export function obraEapParaPlanningDashboard(
+  nodes: readonly ObraEapNode[],
+  obraNome: string,
+): PlanningDashboardData {
+  const linhas = derivarPlanejamentoCompleto(nodes);
+  const duracaoTotal = duracaoTotalDasLinhas(linhas);
+  const fimObraIso = diaParaDataIso(duracaoTotal);
+
+  const items: PlanningItem[] = linhas.map((linha) => {
+    const { node, duracao } = linha;
+    const temData = node.tipo === "TRABALHO" && duracao > 0;
+    return eapNodeParaPlanningItem(
+      node,
+      temData ? diaParaDataIso(linha.inicio) : null,
+      temData ? diaParaDataIso(linha.fim) : null,
+    );
+  });
+
+  return {
+    context: {
+      title: "Planejamento",
+      subtitle: `${obraNome} · Cronograma derivado da EAP (${nodes.length} nós)`,
+      referenceDate: DATA_INICIO_OBRA.toISOString().slice(0, 10),
+    },
+    items,
+  };
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-data.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-data.ts
@@ -1,0 +1,260 @@
+// Domínio Engenharia — dados de planejamento da Obra (FASE 20.x).
+//
+// FONTE ÚNICA de datas/durações do cronograma da Obra Modelo EAP. Deriva o
+// planejamento a partir dos 81 nós reais da EAP (obra-eap-data.ts) + as
+// quantidades/produtividades de escopo (SCOPE_REF), espelhando a lógica usada
+// na geração da planilha nativa (aba PLANEJAMENTO / LINHA DE BALANÇO).
+//
+// Princípio: NADA é inventado aqui. As datas são derivadas deterministicamente
+// dos nós + escopo. O resumo (duração total, críticos) é sempre derivado.
+import type { ObraEapNode } from "./obra-eap-types";
+
+/** Data de início da obra (05/01/2026) — base do cronograma. */
+export const DATA_INICIO_OBRA = new Date(2026, 0, 5);
+
+/** Quantidade e produtividade por WBS (escopo de referência da Obra Modelo). */
+export type ObraEapScopeRef = {
+  unidade: string;
+  quantidade: number;
+  produtividade: string;
+};
+
+/** Escopo de referência por WBS (espelha a fonte da planilha). */
+export const OBRA_SCOPE_REF: Record<string, ObraEapScopeRef> = {
+  // Disciplina 1 — Preparação, Projetos e Canteiro
+  "1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.1.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.1.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.2.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.2.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "1.2.3": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  // Disciplina 2 — Infraestrutura e Fundações
+  "2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "2.1": { unidade: "m³", quantidade: 120, produtividade: "8 m³/dia" },
+  "2.1.1": { unidade: "m³", quantidade: 120, produtividade: "8 m³/dia" },
+  "2.1.2": { unidade: "m²", quantidade: 80, produtividade: "6 m²/dia" },
+  "2.2": { unidade: "m³", quantidade: 90, produtividade: "6 m³/dia" },
+  "2.2.1": { unidade: "m³", quantidade: 70, produtividade: "6 m³/dia" },
+  "2.2.2": { unidade: "m³", quantidade: 20, produtividade: "5 m³/dia" },
+  // Disciplina 3 — Superestrutura
+  "3": { unidade: "m³", quantidade: 420, produtividade: "—" },
+  "3.1": { unidade: "m³", quantidade: 40, produtividade: "6 m³/dia" },
+  "3.1.1": { unidade: "m³", quantidade: 40, produtividade: "6 m³/dia" },
+  "3.2": { unidade: "m³", quantidade: 35, produtividade: "6 m³/dia" },
+  "3.2.1": { unidade: "m³", quantidade: 35, produtividade: "6 m³/dia" },
+  "3.3": { unidade: "m³", quantidade: 280, produtividade: "6 m³/dia" },
+  "3.3.1": { unidade: "m³", quantidade: 280, produtividade: "6 m³/dia" },
+  "3.4": { unidade: "m³", quantidade: 40, produtividade: "5 m³/dia" },
+  "3.4.1": { unidade: "m³", quantidade: 40, produtividade: "5 m³/dia" },
+  "3.5": { unidade: "m³", quantidade: 25, produtividade: "5 m³/dia" },
+  "3.5.1": { unidade: "m³", quantidade: 25, produtividade: "5 m³/dia" },
+  // Disciplina 4 — Vedações e Esquadrias
+  "4": { unidade: "m²", quantidade: 1800, produtividade: "—" },
+  "4.1": { unidade: "m²", quantidade: 1500, produtividade: "12 m²/dia" },
+  "4.1.1": { unidade: "m²", quantidade: 900, produtividade: "12 m²/dia" },
+  "4.1.2": { unidade: "m²", quantidade: 600, produtividade: "10 m²/dia" },
+  "4.2": { unidade: "un", quantidade: 60, produtividade: "—" },
+  "4.2.1": { unidade: "un", quantidade: 30, produtividade: "2 un/dia" },
+  "4.2.2": { unidade: "un", quantidade: 30, produtividade: "3 un/dia" },
+  // Disciplina 5 — Cobertura e Impermeabilização
+  "5": { unidade: "m²", quantidade: 400, produtividade: "—" },
+  "5.1": { unidade: "m²", quantidade: 250, produtividade: "—" },
+  "5.1.1": { unidade: "m²", quantidade: 150, produtividade: "6 m²/dia" },
+  "5.1.2": { unidade: "m²", quantidade: 100, produtividade: "8 m²/dia" },
+  "5.2": { unidade: "m²", quantidade: 150, produtividade: "—" },
+  "5.2.1": { unidade: "m²", quantidade: 50, produtividade: "10 m²/dia" },
+  "5.2.2": { unidade: "m²", quantidade: 60, produtividade: "10 m²/dia" },
+  "5.2.3": { unidade: "m²", quantidade: 40, produtividade: "8 m²/dia" },
+  // Disciplina 6 — Instalações Prediais
+  "6": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "6.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "6.1.1": { unidade: "pt", quantidade: 30, produtividade: "2 pt/dia" },
+  "6.1.2": { unidade: "pt", quantidade: 30, produtividade: "2 pt/dia" },
+  "6.1.3": { unidade: "pt", quantidade: 15, produtividade: "2 pt/dia" },
+  "6.1.4": { unidade: "un", quantidade: 2, produtividade: "1 un/dia" },
+  "6.1.5": { unidade: "pt", quantidade: 15, produtividade: "2 pt/dia" },
+  "6.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "6.2.1": { unidade: "un", quantidade: 15, produtividade: "1 un/dia" },
+  "6.2.2": { unidade: "pt", quantidade: 60, produtividade: "3 pt/dia" },
+  "6.3": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "6.3.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "6.3.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  // Disciplina 7 — Elevadores
+  "7": { unidade: "un", quantidade: 1, produtividade: "—" },
+  "7.1": { unidade: "un", quantidade: 1, produtividade: "—" },
+  "7.1.1": { unidade: "un", quantidade: 1, produtividade: "—" },
+  "7.1.2": { unidade: "un", quantidade: 1, produtividade: "—" },
+  // Disciplina 8 — Acabamentos
+  "8": { unidade: "m²", quantidade: 2500, produtividade: "—" },
+  "8.1": { unidade: "m²", quantidade: 1800, produtividade: "—" },
+  "8.1.1": { unidade: "m²", quantidade: 900, produtividade: "15 m²/dia" },
+  "8.1.2": { unidade: "m²", quantidade: 900, produtividade: "12 m²/dia" },
+  "8.2": { unidade: "m²", quantidade: 2200, produtividade: "—" },
+  "8.2.1": { unidade: "m²", quantidade: 1500, produtividade: "25 m²/dia" },
+  "8.2.2": { unidade: "m²", quantidade: 700, produtividade: "20 m²/dia" },
+  "8.3": { unidade: "m²", quantidade: 400, produtividade: "—" },
+  "8.3.1": { unidade: "m²", quantidade: 250, produtividade: "15 m²/dia" },
+  "8.3.2": { unidade: "m", quantidade: 300, produtividade: "20 m/dia" },
+  // Disciplina 9 — Sistemas de Proteção e Segurança
+  "9": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "9.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "9.1.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "9.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "9.2.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "9.2.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  // Disciplina 10 — Áreas Externas
+  "10": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "10.1": { unidade: "m²", quantidade: 200, produtividade: "—" },
+  "10.1.1": { unidade: "m²", quantidade: 150, produtividade: "15 m²/dia" },
+  "10.1.2": { unidade: "m²", quantidade: 50, produtividade: "10 m²/dia" },
+  "10.2": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "10.2.1": { unidade: "vb", quantidade: 1, produtividade: "—" },
+  "10.2.2": { unidade: "m", quantidade: 60, produtividade: "10 m/dia" },
+};
+
+/** Resolve a disciplina raiz de um nó (nome da DISCIPLINA nível 1). */
+export function resolveDisciplina(
+  node: ObraEapNode,
+  nodes: readonly ObraEapNode[],
+): string {
+  if (node.nivel === 1) return node.nome;
+  const pai = nodes.find((n) => n.wbs === node.pai);
+  if (!pai) return "";
+  if (pai.nivel === 1) return pai.nome;
+  const avo = nodes.find((n) => n.wbs === pai.pai);
+  return avo ? avo.nome : "";
+}
+
+/** Extrai a taxa diária de uma produtividade "N un/dia" (ou null). */
+function taxaDiaria(produtividade: string): number | null {
+  const match = /([\d.]+)\s*([^\s]+)\/dia/.exec(produtividade);
+  if (!match) return null;
+  const rate = Number(match[1]);
+  return rate && rate > 0 ? rate : null;
+}
+
+/** Duração estimada (dias) de um nó TRABALHO com produtividade; senão 0. */
+export function calcDuracao(node: ObraEapNode): number {
+  if (node.tipo !== "TRABALHO") return 0;
+  const ref = OBRA_SCOPE_REF[node.wbs];
+  if (!ref || ref.produtividade === "—") return 0;
+  const rate = taxaDiaria(ref.produtividade);
+  if (rate === null) return 0;
+  return Math.ceil(ref.quantidade / rate);
+}
+
+/** Número da disciplina raiz de um nó (para ordenação por disciplina). */
+function disciplinaOrdem(node: ObraEapNode, nodes: readonly ObraEapNode[]): number {
+  if (node.nivel === 1) return Number(node.wbs);
+  const pai = nodes.find((n) => n.wbs === node.pai);
+  if (pai && pai.nivel === 1) return Number(pai.wbs);
+  const avo = nodes.find((n) => n.wbs === pai?.pai);
+  return avo ? Number(avo.wbs) : 0;
+}
+
+/** Linha de planejamento derivada de um nó (datas em dias acumulados). */
+export type ObraPlanejamentoLinha = {
+  node: ObraEapNode;
+  disciplina: string;
+  duracao: number;
+  inicio: number;
+  fim: number;
+  ritmo: number | "";
+  critico: "CRÍTICO" | "Sequencial" | "—";
+  predecessora: string;
+};
+
+/** Sequencia os nós por disciplina (depois pré-order) e calcula datas. */
+export function derivarPlanejamento(
+  nodes: readonly ObraEapNode[],
+): ObraPlanejamentoLinha[] {
+  const indiceOriginal = new Map(nodes.map((n, i) => [n.wbs, i]));
+  const sequenciados = [...nodes].sort((a, b) => {
+    const da = disciplinaOrdem(a, nodes);
+    const db = disciplinaOrdem(b, nodes);
+    if (da !== db) return da - db;
+    return (indiceOriginal.get(a.wbs) ?? 0) - (indiceOriginal.get(b.wbs) ?? 0);
+  });
+
+  let diaAtual = 0;
+  const linhas: ObraPlanejamentoLinha[] = [];
+  for (const node of sequenciados) {
+    const ref = OBRA_SCOPE_REF[node.wbs];
+    const duracao = calcDuracao(node);
+    const inicio = diaAtual;
+    const fim = inicio + duracao;
+    diaAtual = fim;
+    const ritmo =
+      duracao > 0 && ref && ref.quantidade
+        ? Math.round((ref.quantidade / duracao) * 100) / 100
+        : "";
+    linhas.push({
+      node,
+      disciplina: resolveDisciplina(node, nodes),
+      duracao,
+      inicio,
+      fim,
+      ritmo,
+      critico: "—",
+      predecessora: "",
+    });
+  }
+  return linhas;
+}
+
+/** Duração total da obra (dias) a partir das linhas derivadas. */
+export function duracaoTotalDasLinhas(linhas: readonly ObraPlanejamentoLinha[]): number {
+  return linhas.length > 0 ? linhas[linhas.length - 1].fim : 0;
+}
+
+/** Limiar crítico: 60% da maior duração entre trabalhos com duração. */
+export function limiarCriticoDasLinhas(
+  linhas: readonly ObraPlanejamentoLinha[],
+): number {
+  const trabalhosComDuracao = linhas.filter((l) => l.duracao > 0);
+  if (trabalhosComDuracao.length === 0) return 0;
+  const maxDuracao = Math.max(...trabalhosComDuracao.map((l) => l.duracao));
+  return maxDuracao * 0.6;
+}
+
+/** Preenche crítico e predecessora nas linhas (TRABALHO com duração). */
+export function marcarCriticoEPredecessora(
+  linhas: ObraPlanejamentoLinha[],
+): ObraPlanejamentoLinha[] {
+  const limiar = limiarCriticoDasLinhas(linhas);
+  let ultimoTrabalho: string | null = null;
+  return linhas.map((l) => {
+    const node = l.node;
+    const critico =
+      node.tipo === "TRABALHO" && l.duracao > 0
+        ? l.duracao >= limiar
+          ? "CRÍTICO"
+          : "Sequencial"
+        : "—";
+    const predecessora =
+      node.tipo === "TRABALHO" && l.duracao > 0 && ultimoTrabalho
+        ? ultimoTrabalho
+        : "";
+    if (node.tipo === "TRABALHO" && l.duracao > 0) ultimoTrabalho = node.wbs;
+    return { ...l, critico, predecessora };
+  });
+}
+
+/** Converte dia acumulado em data ISO (yyyy-mm-dd) a partir do início da obra. */
+export function diaParaDataIso(dia: number): string {
+  const d = new Date(DATA_INICIO_OBRA);
+  d.setDate(d.getDate() + dia);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Planejamento completo derivado dos nós reais da EAP. */
+export function derivarPlanejamentoCompleto(
+  nodes: readonly ObraEapNode[],
+): ObraPlanejamentoLinha[] {
+  return marcarCriticoEPredecessora(derivarPlanejamento(nodes));
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-data.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-data.ts
@@ -9,8 +9,37 @@
 // dos nós + escopo. O resumo (duração total, críticos) é sempre derivado.
 import type { ObraEapNode } from "./obra-eap-types";
 
-/** Data de início da obra (05/01/2026) — base do cronograma. */
-export const DATA_INICIO_OBRA = new Date(2026, 0, 5);
+/** Data de início padrão da obra (05/01/2026) — fallback do cronograma. */
+export const DATA_INICIO_DEFAULT = new Date(2026, 0, 5);
+
+/**
+ * Data de início da obra (05/01/2026) — base do cronograma.
+ * Mantida como alias de `DATA_INICIO_DEFAULT` para compatibilidade; o
+ * cronograma agora deriva a data de início da obra via `dataInicioEfetiva`.
+ */
+export const DATA_INICIO_OBRA = DATA_INICIO_DEFAULT;
+
+/**
+ * Resolve a data de início efetiva do cronograma a partir do cadastro da obra
+ * (`obra.dataInicio`, string ISO "yyyy-mm-dd" | null | undefined).
+ * Se ausente/vazia/inválida, usa o fallback `DATA_INICIO_DEFAULT` (05/01/2026),
+ * preservando as seeds da Obra Modelo (que não definem `dataInicio`).
+ * Parse local (não UTC) para manter consistência com `diaParaDataIso`.
+ */
+export function dataInicioEfetiva(obraDataInicio?: string | null): Date {
+  if (obraDataInicio) {
+    const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(obraDataInicio.trim());
+    if (match) {
+      const year = Number(match[1]);
+      const month = Number(match[2]);
+      const day = Number(match[3]);
+      if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+        return new Date(year, month - 1, day);
+      }
+    }
+  }
+  return new Date(DATA_INICIO_DEFAULT);
+}
 
 /** Quantidade e produtividade por WBS (escopo de referência da Obra Modelo). */
 export type ObraEapScopeRef = {
@@ -135,10 +164,16 @@ function taxaDiaria(produtividade: string): number | null {
   return rate && rate > 0 ? rate : null;
 }
 
-/** Duração estimada (dias) de um nó TRABALHO com produtividade; senão 0. */
-export function calcDuracao(node: ObraEapNode): number {
+/**
+ * Duração estimada (dias) de um nó TRABALHO com produtividade; senão 0.
+ * Recebe o escopo da obra (wbs → ref); sem escopo resolve a "sem escopo" (0).
+ */
+export function calcDuracao(
+  node: ObraEapNode,
+  escopo: Record<string, ObraEapScopeRef>,
+): number {
   if (node.tipo !== "TRABALHO") return 0;
-  const ref = OBRA_SCOPE_REF[node.wbs];
+  const ref = escopo[node.wbs];
   if (!ref || ref.produtividade === "—") return 0;
   const rate = taxaDiaria(ref.produtividade);
   if (rate === null) return 0;
@@ -169,6 +204,8 @@ export type ObraPlanejamentoLinha = {
 /** Sequencia os nós por disciplina (depois pré-order) e calcula datas. */
 export function derivarPlanejamento(
   nodes: readonly ObraEapNode[],
+  escopo: Record<string, ObraEapScopeRef>,
+  _startDate: Date = DATA_INICIO_DEFAULT,
 ): ObraPlanejamentoLinha[] {
   const indiceOriginal = new Map(nodes.map((n, i) => [n.wbs, i]));
   const sequenciados = [...nodes].sort((a, b) => {
@@ -181,8 +218,8 @@ export function derivarPlanejamento(
   let diaAtual = 0;
   const linhas: ObraPlanejamentoLinha[] = [];
   for (const node of sequenciados) {
-    const ref = OBRA_SCOPE_REF[node.wbs];
-    const duracao = calcDuracao(node);
+    const ref = escopo[node.wbs];
+    const duracao = calcDuracao(node, escopo);
     const inicio = diaAtual;
     const fim = inicio + duracao;
     diaAtual = fim;
@@ -243,8 +280,8 @@ export function marcarCriticoEPredecessora(
 }
 
 /** Converte dia acumulado em data ISO (yyyy-mm-dd) a partir do início da obra. */
-export function diaParaDataIso(dia: number): string {
-  const d = new Date(DATA_INICIO_OBRA);
+export function diaParaDataIso(dia: number, startDate: Date = DATA_INICIO_DEFAULT): string {
+  const d = new Date(startDate);
   d.setDate(d.getDate() + dia);
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -255,6 +292,8 @@ export function diaParaDataIso(dia: number): string {
 /** Planejamento completo derivado dos nós reais da EAP. */
 export function derivarPlanejamentoCompleto(
   nodes: readonly ObraEapNode[],
+  escopo: Record<string, ObraEapScopeRef>,
+  startDate: Date = DATA_INICIO_DEFAULT,
 ): ObraPlanejamentoLinha[] {
-  return marcarCriticoEPredecessora(derivarPlanejamento(nodes));
+  return marcarCriticoEPredecessora(derivarPlanejamento(nodes, escopo, startDate));
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-repository.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-repository.ts
@@ -1,0 +1,133 @@
+// Repositório de Obras do domínio Engenharia (FASE 04.2-B) — FONTE ÚNICA.
+// Arquitetura: UI → repository → storage. A UI nunca toca em localStorage.
+// A navegação (obra-navigation) e as páginas consomem esta mesma fonte.
+import { create } from "zustand";
+
+import type { CreateObraInput, Obra } from "./obra-types";
+import {
+  clearObrasStorage,
+  loadObrasFromStorage,
+  saveObrasToStorage,
+} from "./obra-storage";
+
+// ------------------------------------------------------------------ //
+// Seeds (FASE 04.2-B): a obra demonstrativa é PRESERVADA para não quebrar
+// módulos/rotas existentes; duas obras neutras adicionais ilustram a lista.
+// ------------------------------------------------------------------ //
+
+/** ID da obra demonstrativa original (compatibilidade com rotas/módulos/EAP). */
+export const OBRA_MODELO_ID = "OBRA-MODELO-EAP-001";
+
+export const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_ID,
+  nome: OBRA_MODELO_ID,
+  status: "PROPOSTA",
+  caracterizacao: {
+    torres: 1,
+    lajes: 14,
+    apartamentosPorPavimento: 1,
+    subsolos: 0,
+    sistemaConstrutivo: "concreto armado",
+  },
+  eap: {
+    status: "PROPOSTA",
+    total: 81,
+    raizes: 10,
+    pacotes: 24,
+    trabalhos: 47,
+  },
+};
+
+const OBRA_DEMO_01: Obra = {
+  id: "OBRA-DEMO-001",
+  nome: "Obra Demonstrativa 01",
+  status: "PROPOSTA",
+};
+
+const OBRA_DEMO_02: Obra = {
+  id: "OBRA-DEMO-002",
+  nome: "Obra Demonstrativa 02",
+  status: "PROPOSTA",
+};
+
+export const SEED_OBRAS: Obra[] = [OBRA_MODELO, OBRA_DEMO_01, OBRA_DEMO_02];
+
+// ------------------------------------------------------------------ //
+// Geração de ID estável
+// ------------------------------------------------------------------ //
+
+const OBRA_ID_PREFIX = "OBRA-";
+
+/** Gera um ID estável e único (não depende do nome nem de índice do array). */
+export function createObraId(existing: ReadonlySet<string> = new Set()): string {
+  let id = "";
+  do {
+    const time = Date.now().toString(36);
+    const random =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID().replace(/-/g, "").slice(0, 6)
+        : Math.random().toString(36).slice(2, 8);
+    id = `${OBRA_ID_PREFIX}${(time + random).toUpperCase()}`;
+  } while (existing.has(id));
+  return id;
+}
+
+// ------------------------------------------------------------------ //
+// Store (Zustand) — estado + ações; persistência encapsulada no repository
+// ------------------------------------------------------------------ //
+
+type ObraRepositoryState = {
+  obras: Obra[];
+  createObra: (input: CreateObraInput) => Obra;
+  /** Reset explícito (testes). */
+  resetObras: (obras: Obra[]) => void;
+};
+
+export const useObraRepository = create<ObraRepositoryState>((set, get) => ({
+  obras: SEED_OBRAS,
+  createObra: (input) => {
+    const nome = (input.nome ?? "").trim();
+    const existingIds = new Set(get().obras.map((obra) => obra.id));
+    const obra: Obra = {
+      id: createObraId(existingIds),
+      nome,
+      status: input.status ?? "PROPOSTA",
+    };
+    set((state) => ({ obras: [obra, ...state.obras] }));
+    saveObrasToStorage(get().obras);
+    return obra;
+  },
+  resetObras: (obras) => {
+    set({ obras });
+    saveObrasToStorage(obras);
+  },
+}));
+
+// ------------------------------------------------------------------ //
+// Helpers não-reativos (para módulos que leem uma vez: domain/navigation)
+// ------------------------------------------------------------------ //
+
+export function listObras(): Obra[] {
+  return useObraRepository.getState().obras;
+}
+
+export function findObraById(id: string): Obra | undefined {
+  return listObras().find((obra) => obra.id === id);
+}
+
+/** Alias de compatibilidade mantido para consumidores existentes. */
+export function findObraModelo(id: string): Obra | undefined {
+  return findObraById(id);
+}
+
+/** Hidrata o repositório a partir do armazenamento local (inicialização). */
+export function initializeObraRepository(): void {
+  const stored = loadObrasFromStorage();
+  if (stored) useObraRepository.setState({ obras: stored });
+}
+
+/** Remove a persistência e restaura os seeds (testes). */
+export function resetObraRepository(): void {
+  clearObrasStorage();
+  useObraRepository.setState({ obras: SEED_OBRAS });
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-repository.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-repository.ts
@@ -3,12 +3,21 @@
 // A navegação (obra-navigation) e as páginas consomem esta mesma fonte.
 import { create } from "zustand";
 
-import type { CreateObraInput, Obra } from "./obra-types";
+import type { CreateObraInput, Obra, ObraStatus } from "./obra-types";
 import {
   clearObrasStorage,
   loadObrasFromStorage,
   saveObrasToStorage,
 } from "./obra-storage";
+
+/**
+ * Status efetivo de uma obra (FASE 22).
+ * `ARQUIVADA` é DERIVADO de `Obra.arquivada` (soft-delete) — nunca persistido
+ * separadamente, evitando segunda fonte de verdade.
+ */
+export function statusEfetivo(obra: Pick<Obra, "status" | "arquivada">): ObraStatus {
+  return obra.arquivada ? "ARQUIVADA" : obra.status;
+}
 
 // ------------------------------------------------------------------ //
 // Seeds (FASE 04.2-B): a obra demonstrativa é PRESERVADA para não quebrar
@@ -79,6 +88,14 @@ export function createObraId(existing: ReadonlySet<string> = new Set()): string 
 type ObraRepositoryState = {
   obras: Obra[];
   createObra: (input: CreateObraInput) => Obra;
+  /** Atualiza campos de identificação/status/datas/localização/responsável. */
+  updateObra: (id: string, patch: Partial<Obra>) => void;
+  /** Soft-delete: marca a obra como arquivada (não aparece na lista ativa). */
+  archiveObra: (id: string) => void;
+  /** Restaura uma obra arquivada. */
+  unarchiveObra: (id: string) => void;
+  /** Exclusão definitiva (sempre precedida de confirmação em duas etapas na UI). */
+  deleteObra: (id: string) => void;
   /** Reset explícito (testes). */
   resetObras: (obras: Obra[]) => void;
 };
@@ -92,10 +109,42 @@ export const useObraRepository = create<ObraRepositoryState>((set, get) => ({
       id: createObraId(existingIds),
       nome,
       status: input.status ?? "PROPOSTA",
+      dataInicio: input.dataInicio ?? null,
+      dataFim: input.dataFim ?? null,
+      localizacao: input.localizacao ?? null,
+      responsavel: input.responsavel ?? null,
     };
     set((state) => ({ obras: [obra, ...state.obras] }));
     saveObrasToStorage(get().obras);
     return obra;
+  },
+  updateObra: (id, patch) => {
+    set((state) => ({
+      obras: state.obras.map((obra) =>
+        obra.id === id ? { ...obra, ...patch, id: obra.id } : obra,
+      ),
+    }));
+    saveObrasToStorage(get().obras);
+  },
+  archiveObra: (id) => {
+    set((state) => ({
+      obras: state.obras.map((obra) =>
+        obra.id === id ? { ...obra, arquivada: true } : obra,
+      ),
+    }));
+    saveObrasToStorage(get().obras);
+  },
+  unarchiveObra: (id) => {
+    set((state) => ({
+      obras: state.obras.map((obra) =>
+        obra.id === id ? { ...obra, arquivada: false } : obra,
+      ),
+    }));
+    saveObrasToStorage(get().obras);
+  },
+  deleteObra: (id) => {
+    set((state) => ({ obras: state.obras.filter((obra) => obra.id !== id) }));
+    saveObrasToStorage(get().obras);
   },
   resetObras: (obras) => {
     set({ obras });
@@ -113,6 +162,16 @@ export function listObras(): Obra[] {
 
 export function findObraById(id: string): Obra | undefined {
   return listObras().find((obra) => obra.id === id);
+}
+
+/** Obras ativas (não arquivadas) — usadas na lista padrão da Central de Obras. */
+export function listObrasAtivas(): Obra[] {
+  return listObras().filter((obra) => !obra.arquivada);
+}
+
+/** Obras arquivadas (soft-delete) — visíveis apenas na visão "arquivadas". */
+export function listObrasArquivadas(): Obra[] {
+  return listObras().filter((obra) => obra.arquivada);
 }
 
 /** Alias de compatibilidade mantido para consumidores existentes. */

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-routes.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-routes.ts
@@ -1,0 +1,79 @@
+// Domínio Engenharia — rotas da entidade Obra (helpers puros, testáveis).
+// Padrão de rota: /dominios/:domainId/obras[/:obraId[/:modulo]]
+// FASE 04.2-B: adicionadas rotas de LISTA (/obras) e de NOVA OBRA (/obras/nova).
+// FASE 20.x: módulos reorganizados por FASES do fluxo real da obra (sidebar).
+import type { ObraFase, ObraModule } from "./obra-types";
+
+export const DOMAIN_ENGENHARIA_ID = "engenharia";
+
+/** Fases do ciclo de vida da obra, com seus módulos (ordem = fluxo real). */
+export const OBRA_FASES: { id: ObraFase; label: string; modules: ObraModule[] }[] = [
+  {
+    id: "preparacao",
+    label: "Preparação",
+    modules: [
+      "visao-geral",
+      "caracterizacao",
+      "eap",
+      "disciplinas",
+      "servicos",
+      "planejamento",
+      "linha-de-balanco",
+    ],
+  },
+  {
+    id: "execucao",
+    label: "Execução",
+    modules: ["frentes", "producao", "rdo"],
+  },
+  {
+    id: "suporte",
+    label: "Suporte",
+    modules: ["ia"],
+  },
+];
+
+/** Módulos da casca da obra (ordem de exibição nas abas internas). */
+export const OBRA_MODULES: ObraModule[] = OBRA_FASES.flatMap((fase) => fase.modules);
+
+export const OBRA_MODULE_LABEL: Record<ObraModule, string> = {
+  "visao-geral": "Visão Geral",
+  caracterizacao: "Caracterização",
+  eap: "EAP",
+  disciplinas: "Disciplinas",
+  servicos: "Serviços",
+  planejamento: "Planejamento",
+  "linha-de-balanco": "Linha de Balanço",
+  frentes: "Frentes de Serviço",
+  producao: "Produção",
+  rdo: "RDO",
+  ia: "IA",
+};
+
+/** Rota da LISTA de obras do domínio Engenharia. */
+export function obrasListRoute(): string {
+  return `/dominios/${DOMAIN_ENGENHARIA_ID}/obras`;
+}
+
+/** Rota da ação "+ Nova obra". */
+export function obraNovaRoute(): string {
+  return `${obrasListRoute()}/nova`;
+}
+
+/** Rota inicial do domínio Engenharia (lista de obras). */
+export function engenhariaDomainHome(): string {
+  return obrasListRoute();
+}
+
+/** Rota de uma obra (e, opcionalmente, de um módulo da obra). */
+export function obraRoute(obraId: string, modulo?: ObraModule | null): string {
+  const id = encodeURIComponent(obraId.trim());
+  const base = `${obrasListRoute()}/${id}`;
+  return modulo ? `${base}/${modulo}` : base;
+}
+
+/** Guarda de tipo: "eap" | "frentes" | ... vale como ObraModule. */
+export function isObraModule(value: string | null | undefined): value is ObraModule {
+  return typeof value === "string" && (OBRA_MODULES as string[]).includes(value);
+}
+

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-routes.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-routes.ts
@@ -2,53 +2,35 @@
 // Padrão de rota: /dominios/:domainId/obras[/:obraId[/:modulo]]
 // FASE 04.2-B: adicionadas rotas de LISTA (/obras) e de NOVA OBRA (/obras/nova).
 // FASE 20.x: módulos reorganizados por FASES do fluxo real da obra (sidebar).
+// FASE 22: OBRA_FASES e OBRA_MODULE_LABEL passam a ser DERIVADOS do catálogo
+// declarativo (obra-modules.ts) — fonte única de metadados dos módulos.
 import type { ObraFase, ObraModule } from "./obra-types";
+import {
+  OBRA_FASES_ORDER,
+  listModulesByFase,
+  moduleLabel,
+} from "./obra-modules";
 
 export const DOMAIN_ENGENHARIA_ID = "engenharia";
 
 /** Fases do ciclo de vida da obra, com seus módulos (ordem = fluxo real). */
-export const OBRA_FASES: { id: ObraFase; label: string; modules: ObraModule[] }[] = [
-  {
-    id: "preparacao",
-    label: "Preparação",
-    modules: [
-      "visao-geral",
-      "caracterizacao",
-      "eap",
-      "disciplinas",
-      "servicos",
-      "planejamento",
-      "linha-de-balanco",
-    ],
-  },
-  {
-    id: "execucao",
-    label: "Execução",
-    modules: ["frentes", "producao", "rdo"],
-  },
-  {
-    id: "suporte",
-    label: "Suporte",
-    modules: ["ia"],
-  },
-];
+export const OBRA_FASES: { id: ObraFase; label: string; modules: ObraModule[] }[] =
+  OBRA_FASES_ORDER.map((fase) => ({
+    id: fase,
+    label: fase === "preparacao" ? "Preparação" : fase === "execucao" ? "Execução" : "Suporte",
+    modules: listModulesByFase(fase).map((m) => m.id),
+  }));
 
 /** Módulos da casca da obra (ordem de exibição nas abas internas). */
 export const OBRA_MODULES: ObraModule[] = OBRA_FASES.flatMap((fase) => fase.modules);
 
-export const OBRA_MODULE_LABEL: Record<ObraModule, string> = {
-  "visao-geral": "Visão Geral",
-  caracterizacao: "Caracterização",
-  eap: "EAP",
-  disciplinas: "Disciplinas",
-  servicos: "Serviços",
-  planejamento: "Planejamento",
-  "linha-de-balanco": "Linha de Balanço",
-  frentes: "Frentes de Serviço",
-  producao: "Produção",
-  rdo: "RDO",
-  ia: "IA",
-};
+export const OBRA_MODULE_LABEL: Record<ObraModule, string> = OBRA_MODULES.reduce(
+  (acc, id) => {
+    acc[id] = moduleLabel(id);
+    return acc;
+  },
+  {} as Record<ObraModule, string>,
+);
 
 /** Rota da LISTA de obras do domínio Engenharia. */
 export function obrasListRoute(): string {
@@ -58,6 +40,11 @@ export function obrasListRoute(): string {
 /** Rota da ação "+ Nova obra". */
 export function obraNovaRoute(): string {
   return `${obrasListRoute()}/nova`;
+}
+
+/** Rota de edição de uma obra. */
+export function obraEditarRoute(obraId: string): string {
+  return `${obrasListRoute()}/${encodeURIComponent(obraId.trim())}/editar`;
 }
 
 /** Rota inicial do domínio Engenharia (lista de obras). */

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-servicos-adapter.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-servicos-adapter.ts
@@ -1,0 +1,48 @@
+// Domínio Engenharia — adapter de Serviços (FASE 21).
+//
+// Traduz os nós reais da EAP + o planejamento derivado para o contrato genérico
+// `ServicosData` do domínio `servicos/`. Delega a renderização à capacidade
+// reutilizável. Nenhuma fonte de verdade é criada aqui.
+import type { ServicoItem, ServicosData } from "../../servicos/servicos-types";
+import type { ObraEapNode } from "./obra-eap-types";
+import type { ObraEapScopeRef } from "./obra-planejamento-data";
+import {
+  DATA_INICIO_DEFAULT,
+  derivarPlanejamentoCompleto,
+  diaParaDataIso,
+} from "./obra-planejamento-data";
+
+/** Constrói um ServicoItem a partir de uma linha de planejamento da obra. */
+export function obraLinhaParaServicoItem(
+  linha: ReturnType<typeof derivarPlanejamentoCompleto>[number],
+  startDate: Date = DATA_INICIO_DEFAULT,
+): ServicoItem {
+  const temData = linha.duracao > 0;
+  return {
+    id: linha.node.wbs,
+    codigo: linha.node.wbs,
+    nome: linha.node.nome,
+    duracao: linha.duracao,
+    inicio: temData ? diaParaDataIso(linha.inicio, startDate) : null,
+    fim: temData ? diaParaDataIso(linha.fim, startDate) : null,
+    status: linha.critico,
+  };
+}
+
+/** Produz o ServicosData da obra a partir dos nós reais da EAP. */
+export function obraEapParaServicos(
+  nodes: readonly ObraEapNode[],
+  obraNome: string,
+  escopo: Record<string, ObraEapScopeRef>,
+  startDate: Date = DATA_INICIO_DEFAULT,
+): ServicosData {
+  const linhas = derivarPlanejamentoCompleto(nodes, escopo, startDate);
+  const items = linhas
+    .filter((l) => l.node.tipo === "TRABALHO")
+    .map((l) => obraLinhaParaServicoItem(l, startDate));
+  return {
+    title: "Serviços",
+    subtitle: `${obraNome} · ${items.length} trabalhos (nível 3) da EAP com duração, datas e caminho crítico derivados do planejamento.`,
+    items,
+  };
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-shell-route.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-shell-route.tsx
@@ -1,34 +1,61 @@
 /** @jsxImportSource react */
+import type { ReactNode } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { OBRA_MODULES, OBRA_MODULE_LABEL, obraRoute } from "./obra-routes";
+import { OBRA_FASES, OBRA_MODULE_LABEL, obraRoute } from "./obra-routes";
+import { listModulesByFase, moduleFase } from "./obra-modules";
 import { useObraStore } from "./obra-store";
 import { useObraRepository } from "./obra-repository";
-import type { ObraModule } from "./obra-types";
+import type { Obra, ObraFase, ObraModule } from "./obra-types";
 import { ObraCaracterizacao } from "./pages/obra-caracterizacao";
 import { ObraDisciplinas } from "./pages/obra-disciplinas";
 import { ObraEap } from "./pages/obra-eap";
+import { ObraFrentes } from "./pages/obra-frentes";
 import { ObraLobGrade } from "./pages/obra-lob-grade";
 import { ObraModuloPlaceholder } from "./pages/obra-modulo-placeholder";
 import { ObraPlanejamento } from "./pages/obra-planejamento";
+import { ObraProducao } from "./pages/obra-producao";
 import { ObraServicos } from "./pages/obra-servicos";
 import { ObraVisaoGeral } from "./pages/obra-visao-geral";
 
-const MODULE_DESCRIPTIONS: Record<
-  Exclude<ObraModule, "visao-geral" | "caracterizacao" | "eap" | "disciplinas" | "servicos" | "planejamento" | "linha-de-balanco">,
-  string
-> = {
-  frentes:
-    "A estrutura deste módulo será vinculada posteriormente aos elementos da EAP (elemento_eap_id).",
-  producao: "Produção da obra será vinculada aos elementos da EAP em fase futura.",
-  rdo: "Registro Diário de Obra (RDO) será vinculado aos elementos da EAP em fase futura.",
-  ia: "Assistência de IA da obra será vinculada aos elementos da EAP em fase futura.",
+/**
+ * Resolução de TELA dos módulos (FASE 22).
+ * Camada de renderização: mapeia cada id de módulo para o componente que o
+ * renderiza. O catálogo (obra-modules.ts) permanece declarativo (sem React);
+ * esta é a camada apropriada para a resolução da tela.
+ */
+const MODULE_RENDERERS: Record<ObraModule, (obra: Obra) => ReactNode> = {
+  "visao-geral": (obra) => <ObraVisaoGeral obra={obra} />,
+  caracterizacao: (obra) => <ObraCaracterizacao obra={obra} />,
+  eap: (obra) => <ObraEap obra={obra} />,
+  disciplinas: (obra) => <ObraDisciplinas obra={obra} />,
+  servicos: (obra) => <ObraServicos obra={obra} />,
+  planejamento: (obra) => <ObraPlanejamento obra={obra} />,
+  "linha-de-balanco": (obra) => <ObraLobGrade obra={obra} />,
+  frentes: (obra) => <ObraFrentes obra={obra} />,
+  producao: (obra) => <ObraProducao obra={obra} />,
+  rdo: (obra) => (
+    <ObraModuloPlaceholder
+      titulo="RDO"
+      descricao="Registro Diário de Obra (RDO) será vinculado aos elementos da EAP em fase futura."
+    />
+  ),
+  ia: (obra) => (
+    <ObraModuloPlaceholder
+      titulo="IA"
+      descricao="Assistência de IA da obra será vinculada aos elementos da EAP em fase futura."
+    />
+  ),
 };
 
 /**
- * Casca da entidade Obra (domínio Engenharia): navegação interna entre os módulos
- * (Visão Geral, EAP, Frentes, Planejamento, Produção, RDO, IA).
+ * Casca da entidade Obra (domínio Engenharia) — FASE 21 / FASE 22.
+ * Navegação em TABS POR FASE com subitens: uma barra de fases (Preparação,
+ * Execução, Suporte) e, dentro da fase ativa, as abas dos módulos (subitens).
+ * FASE 22: a navegação e o conteúdo são derivados do catálogo declarativo
+ * (obra-modules.ts) + mapa de renderização — sem switch hardcoded.
  */
 export function ObraShellRoute({
   obraId,
@@ -39,9 +66,15 @@ export function ObraShellRoute({
 }) {
   const navigate = useNavigate();
   const selectModule = useObraStore((state) => state.selectModule);
+  const setActiveObra = useObraStore((state) => state.setActiveObra);
   const obra = useObraRepository((state) =>
     state.obras.find((candidate) => candidate.id === obraId),
   );
+
+  // Contexto da obra ativa: ao abrir uma obra, registra-a como ativa.
+  useEffect(() => {
+    if (obra) setActiveObra(obra.id);
+  }, [obra, setActiveObra]);
 
   if (!obra) {
     return (
@@ -53,31 +86,15 @@ export function ObraShellRoute({
   }
 
   const activeModule: ObraModule = modulo ?? "visao-geral";
+  const activeFase: ObraFase = moduleFase(activeModule);
+  const activeModules = listModulesByFase(activeFase);
 
-  const content =
-    activeModule === "eap" ? (
-      <ObraEap obra={obra} />
-    ) : activeModule === "caracterizacao" ? (
-      <ObraCaracterizacao obra={obra} />
-    ) : activeModule === "disciplinas" ? (
-      <ObraDisciplinas obra={obra} />
-    ) : activeModule === "servicos" ? (
-      <ObraServicos obra={obra} />
-    ) : activeModule === "frentes" ? (
-      <ObraModuloPlaceholder titulo="Frentes de Serviço" descricao={MODULE_DESCRIPTIONS.frentes} />
-    ) : activeModule === "planejamento" ? (
-      <ObraPlanejamento obra={obra} />
-    ) : activeModule === "linha-de-balanco" ? (
-      <ObraLobGrade obra={obra} />
-    ) : activeModule === "producao" ? (
-      <ObraModuloPlaceholder titulo="Produção" descricao={MODULE_DESCRIPTIONS.producao} />
-    ) : activeModule === "rdo" ? (
-      <ObraModuloPlaceholder titulo="RDO" descricao={MODULE_DESCRIPTIONS.rdo} />
-    ) : activeModule === "ia" ? (
-      <ObraModuloPlaceholder titulo="IA" descricao={MODULE_DESCRIPTIONS.ia} />
-    ) : (
-      <ObraVisaoGeral obra={obra} />
-    );
+  const content = MODULE_RENDERERS[activeModule](obra);
+
+  const goToModule = (module: ObraModule) => {
+    selectModule(obraId, module);
+    navigate(obraRoute(obraId, module));
+  };
 
   return (
     <div className="flex h-full w-full flex-col gap-4 overflow-auto p-4">
@@ -88,23 +105,53 @@ export function ObraShellRoute({
         <h1 className="text-xl font-bold">{obra.nome}</h1>
       </div>
 
-      <nav className="flex flex-wrap items-center gap-1.5" aria-label="Módulos da obra">
-        {OBRA_MODULES.map((module) => {
-          const active = module === activeModule;
+      {/* Tabs por fase (nível 1) */}
+      <nav
+        className="flex flex-wrap items-center gap-1.5 border-b border-border pb-2"
+        aria-label="Fases da obra"
+        data-obra-fases
+      >
+        {OBRA_FASES.map((fase) => {
+          const active = fase.id === activeFase;
           return (
             <Button
-              key={module}
+              key={fase.id}
               type="button"
               size="sm"
               variant={active ? "default" : "ghost"}
               className={cn(active && "text-primary-foreground")}
-              data-obra-module={module}
+              data-obra-fase={fase.id}
               onClick={() => {
-                selectModule(obraId, module);
-                navigate(obraRoute(obraId, module));
+                // Ao trocar de fase, navega para o primeiro módulo da fase.
+                const primeiro = fase.modules[0];
+                if (primeiro) goToModule(primeiro);
               }}
             >
-              {OBRA_MODULE_LABEL[module]}
+              {fase.label}
+            </Button>
+          );
+        })}
+      </nav>
+
+      {/* Subitens da fase ativa (nível 2) */}
+      <nav
+        className="flex flex-wrap items-center gap-1.5"
+        aria-label={`Módulos da fase ${activeFase}`}
+        data-obra-modulos
+      >
+        {activeModules.map((module) => {
+          const active = module.id === activeModule;
+          return (
+            <Button
+              key={module.id}
+              type="button"
+              size="sm"
+              variant={active ? "secondary" : "ghost"}
+              className={cn(active && "font-medium")}
+              data-obra-module={module.id}
+              onClick={() => goToModule(module.id)}
+            >
+              {OBRA_MODULE_LABEL[module.id]}
             </Button>
           );
         })}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-shell-route.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-shell-route.tsx
@@ -1,0 +1,116 @@
+/** @jsxImportSource react */
+import { useNavigate } from "react-router";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { OBRA_MODULES, OBRA_MODULE_LABEL, obraRoute } from "./obra-routes";
+import { useObraStore } from "./obra-store";
+import { useObraRepository } from "./obra-repository";
+import type { ObraModule } from "./obra-types";
+import { ObraCaracterizacao } from "./pages/obra-caracterizacao";
+import { ObraDisciplinas } from "./pages/obra-disciplinas";
+import { ObraEap } from "./pages/obra-eap";
+import { ObraLobGrade } from "./pages/obra-lob-grade";
+import { ObraModuloPlaceholder } from "./pages/obra-modulo-placeholder";
+import { ObraPlanejamento } from "./pages/obra-planejamento";
+import { ObraServicos } from "./pages/obra-servicos";
+import { ObraVisaoGeral } from "./pages/obra-visao-geral";
+
+const MODULE_DESCRIPTIONS: Record<
+  Exclude<ObraModule, "visao-geral" | "caracterizacao" | "eap" | "disciplinas" | "servicos" | "planejamento" | "linha-de-balanco">,
+  string
+> = {
+  frentes:
+    "A estrutura deste módulo será vinculada posteriormente aos elementos da EAP (elemento_eap_id).",
+  producao: "Produção da obra será vinculada aos elementos da EAP em fase futura.",
+  rdo: "Registro Diário de Obra (RDO) será vinculado aos elementos da EAP em fase futura.",
+  ia: "Assistência de IA da obra será vinculada aos elementos da EAP em fase futura.",
+};
+
+/**
+ * Casca da entidade Obra (domínio Engenharia): navegação interna entre os módulos
+ * (Visão Geral, EAP, Frentes, Planejamento, Produção, RDO, IA).
+ */
+export function ObraShellRoute({
+  obraId,
+  modulo,
+}: {
+  obraId: string;
+  modulo: ObraModule | null;
+}) {
+  const navigate = useNavigate();
+  const selectModule = useObraStore((state) => state.selectModule);
+  const obra = useObraRepository((state) =>
+    state.obras.find((candidate) => candidate.id === obraId),
+  );
+
+  if (!obra) {
+    return (
+      <div className="flex min-h-[60vh] w-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <p className="text-lg font-semibold">Obra não encontrada</p>
+        <p className="text-sm text-muted-foreground">{obraId}</p>
+      </div>
+    );
+  }
+
+  const activeModule: ObraModule = modulo ?? "visao-geral";
+
+  const content =
+    activeModule === "eap" ? (
+      <ObraEap obra={obra} />
+    ) : activeModule === "caracterizacao" ? (
+      <ObraCaracterizacao obra={obra} />
+    ) : activeModule === "disciplinas" ? (
+      <ObraDisciplinas obra={obra} />
+    ) : activeModule === "servicos" ? (
+      <ObraServicos obra={obra} />
+    ) : activeModule === "frentes" ? (
+      <ObraModuloPlaceholder titulo="Frentes de Serviço" descricao={MODULE_DESCRIPTIONS.frentes} />
+    ) : activeModule === "planejamento" ? (
+      <ObraPlanejamento obra={obra} />
+    ) : activeModule === "linha-de-balanco" ? (
+      <ObraLobGrade obra={obra} />
+    ) : activeModule === "producao" ? (
+      <ObraModuloPlaceholder titulo="Produção" descricao={MODULE_DESCRIPTIONS.producao} />
+    ) : activeModule === "rdo" ? (
+      <ObraModuloPlaceholder titulo="RDO" descricao={MODULE_DESCRIPTIONS.rdo} />
+    ) : activeModule === "ia" ? (
+      <ObraModuloPlaceholder titulo="IA" descricao={MODULE_DESCRIPTIONS.ia} />
+    ) : (
+      <ObraVisaoGeral obra={obra} />
+    );
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 overflow-auto p-4">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Engenharia · Obra
+        </span>
+        <h1 className="text-xl font-bold">{obra.nome}</h1>
+      </div>
+
+      <nav className="flex flex-wrap items-center gap-1.5" aria-label="Módulos da obra">
+        {OBRA_MODULES.map((module) => {
+          const active = module === activeModule;
+          return (
+            <Button
+              key={module}
+              type="button"
+              size="sm"
+              variant={active ? "default" : "ghost"}
+              className={cn(active && "text-primary-foreground")}
+              data-obra-module={module}
+              onClick={() => {
+                selectModule(obraId, module);
+                navigate(obraRoute(obraId, module));
+              }}
+            >
+              {OBRA_MODULE_LABEL[module]}
+            </Button>
+          );
+        })}
+      </nav>
+
+      <div className="min-h-0 flex-1">{content}</div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-storage.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-storage.ts
@@ -1,0 +1,60 @@
+// Camada de armazenamento local do repositório de Obras (FASE 04.2-B).
+// A UI NUNCA acessa localStorage diretamente: ela fala com o repository
+// (obra-repository.ts), que por sua vez usa este módulo. Trocar por backend
+// depois = substituir apenas esta camada.
+import type { Obra } from "./obra-types";
+
+export const OBRA_STORAGE_KEY = "openwork.obra-repository.v1";
+const STORAGE_VERSION = 1;
+
+function isObra(value: unknown): value is Obra {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.nome === "string" &&
+    typeof record.status === "string"
+  );
+}
+
+/** Carrega e valida a lista persistida; null quando não há dado utilizável. */
+export function loadObrasFromStorage(): Obra[] | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(OBRA_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const record = parsed as { version?: unknown; obras?: unknown };
+    if (record.version !== STORAGE_VERSION) return null;
+    if (!Array.isArray(record.obras)) return null;
+    const obras = record.obras.filter(isObra);
+    if (obras.length === 0 && record.obras.length > 0) return null;
+    return obras;
+  } catch {
+    return null;
+  }
+}
+
+/** Persiste a lista. Nunca lança para a UI. */
+export function saveObrasToStorage(obras: Obra[]): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(
+      OBRA_STORAGE_KEY,
+      JSON.stringify({ version: STORAGE_VERSION, obras }),
+    );
+  } catch {
+    // Armazenamento indisponível: mantém estado em memória (best-effort).
+  }
+}
+
+/** Remove os dados persistidos (útil em testes/reset). */
+export function clearObrasStorage(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(OBRA_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-store.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-store.ts
@@ -10,6 +10,9 @@ type ObraStoreState = {
   /** Módulo selecionado por obraId (lembrança de UI; não decide a rota). */
   selectedModules: Record<string, ObraModule | null>;
   selectModule: (obraId: string, module: ObraModule | null) => void;
+  /** Obra atualmente aberta (contexto da obra ativa; não decide a rota). */
+  activeObraId: string | null;
+  setActiveObra: (obraId: string | null) => void;
 };
 
 export const useObraStore = create<ObraStoreState>()(
@@ -23,6 +26,8 @@ export const useObraStore = create<ObraStoreState>()(
             [obraId]: module,
           },
         })),
+      activeObraId: null,
+      setActiveObra: (obraId) => set({ activeObraId: obraId }),
     }),
     {
       name: "openwork-obra-store",

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-store.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-store.ts
@@ -1,0 +1,33 @@
+// Domínio Engenharia — estado de UI da Obra (Zustand, persist localStorage).
+// FASE 04.2-B: o módulo selecionado passa a ser ESCOPO POR OBRA (obraId) para
+// evitar vazamento de estado entre obras. A obra aberta continua vinda da URL
+// (obraId), nunca deste store.
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { ObraModule } from "./obra-types";
+
+type ObraStoreState = {
+  /** Módulo selecionado por obraId (lembrança de UI; não decide a rota). */
+  selectedModules: Record<string, ObraModule | null>;
+  selectModule: (obraId: string, module: ObraModule | null) => void;
+};
+
+export const useObraStore = create<ObraStoreState>()(
+  persist(
+    (set) => ({
+      selectedModules: {},
+      selectModule: (obraId, module) =>
+        set((state) => ({
+          selectedModules: {
+            ...state.selectedModules,
+            [obraId]: module,
+          },
+        })),
+    }),
+    {
+      name: "openwork-obra-store",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-types.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-types.ts
@@ -18,7 +18,17 @@ export type ObraModule =
 /** Fase do ciclo de vida real da obra (agrupa módulos na sidebar). */
 export type ObraFase = "preparacao" | "execucao" | "suporte";
 
-export type ObraStatus = "PROPOSTA";
+/**
+ * Status do ciclo de vida da obra (FASE 22).
+ * `ARQUIVADA` é derivado de `Obra.arquivada` (soft-delete) — não é um valor
+ * persistido separadamente para evitar segunda fonte de verdade.
+ */
+export type ObraStatus =
+  | "PROPOSTA"
+  | "PLANEJAMENTO"
+  | "EM_EXECUCAO"
+  | "CONCLUIDA"
+  | "ARQUIVADA";
 
 export type ObraEapSummary = {
   status: ObraStatus;
@@ -40,6 +50,22 @@ export type Obra = {
   id: string;
   nome: string;
   status: ObraStatus;
+  /**
+   * Metadado da obra/cadastro (FASE 22). Fonte única do CADASTRO.
+   * NÃO é sobrescrito pelo Planejamento: as datas das atividades são fonte de
+   * verdade do Planejamento (DATA_INICIO_OBRA). Se uma data derivada do
+   * cronograma for apresentada, usa-se `inicioPlanejamento` (derivada), nunca
+   * este campo.
+   */
+  dataInicio?: string | null;
+  /** Data de fim como metadado opcional do cadastro (não derivada do cronograma). */
+  dataFim?: string | null;
+  /** Localização da obra (opcional). */
+  localizacao?: string | null;
+  /** Responsável pela obra (opcional). */
+  responsavel?: string | null;
+  /** Soft-delete: obra arquivada não aparece na lista ativa por padrão. */
+  arquivada?: boolean;
   /** Preenchido quando a caracterização existir (etapa posterior ao cadastro). */
   caracterizacao?: ObraCaracterizacao | null;
   /** Resumo estrutural da EAP (preenchido quando a EAP da obra existir). */
@@ -50,5 +76,9 @@ export type Obra = {
 export type CreateObraInput = {
   nome: string;
   status?: ObraStatus;
+  dataInicio?: string | null;
+  dataFim?: string | null;
+  localizacao?: string | null;
+  responsavel?: string | null;
 };
 

--- a/apps/app/src/react-app/domains/engenharia/obra/obra-types.ts
+++ b/apps/app/src/react-app/domains/engenharia/obra/obra-types.ts
@@ -1,0 +1,54 @@
+// Domínio Engenharia — entidade Obra (tipos).
+// A Obra NÃO pertence ao Core: pertence ao domínio Engenharia (Core → Domínio → Entidade).
+// FASE 04.2-B: caracterizacao/eap tornam-se OPCIONAIS — uma obra nova nasce apenas com
+// identificação; caracterização e EAP são etapas posteriores (não fazem parte do cadastro V1).
+export type ObraModule =
+  | "visao-geral"
+  | "caracterizacao"
+  | "eap"
+  | "disciplinas"
+  | "servicos"
+  | "planejamento"
+  | "linha-de-balanco"
+  | "frentes"
+  | "producao"
+  | "rdo"
+  | "ia";
+
+/** Fase do ciclo de vida real da obra (agrupa módulos na sidebar). */
+export type ObraFase = "preparacao" | "execucao" | "suporte";
+
+export type ObraStatus = "PROPOSTA";
+
+export type ObraEapSummary = {
+  status: ObraStatus;
+  total: number;
+  raizes: number;
+  pacotes: number;
+  trabalhos: number;
+};
+
+export type ObraCaracterizacao = {
+  torres: number;
+  lajes: number;
+  apartamentosPorPavimento: number;
+  subsolos: number;
+  sistemaConstrutivo: string;
+};
+
+export type Obra = {
+  id: string;
+  nome: string;
+  status: ObraStatus;
+  /** Preenchido quando a caracterização existir (etapa posterior ao cadastro). */
+  caracterizacao?: ObraCaracterizacao | null;
+  /** Resumo estrutural da EAP (preenchido quando a EAP da obra existir). */
+  eap?: ObraEapSummary | null;
+};
+
+/** Entrada mínima de criação de obra (FASE 04.2-B). */
+export type CreateObraInput = {
+  nome: string;
+  status?: ObraStatus;
+};
+

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-caracterizacao.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-caracterizacao.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource react */
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Obra, ObraCaracterizacao } from "../obra-types";
+
+const CAMPOS_CARACTERIZACAO: Array<{
+  label: string;
+  value: (c: ObraCaracterizacao) => string;
+}> = [
+  { label: "Torres", value: (c) => String(c.torres) },
+  { label: "Lajes", value: (c) => String(c.lajes) },
+  { label: "Apartamentos por pavimento", value: (c) => String(c.apartamentosPorPavimento) },
+  { label: "Subsolos", value: (c) => String(c.subsolos) },
+  { label: "Sistema construtivo", value: (c) => c.sistemaConstrutivo },
+];
+
+/**
+ * Página Caracterização da casca (FASE 20.x).
+ * Dados estruturais da obra (torres, lajes, subsolos, sistema construtivo),
+ * extraídos da Visão Geral para um módulo próprio na fase Preparação.
+ */
+export function ObraCaracterizacao({ obra }: { obra: Obra }) {
+  return (
+    <Card variant="outline" className="w-full">
+      <CardHeader>
+        <CardTitle>Caracterização</CardTitle>
+        <CardDescription>
+          Informações estruturais da obra (somente dados existentes no projeto).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2 text-sm">
+        {obra.caracterizacao ? (
+          CAMPOS_CARACTERIZACAO.map((campo) => (
+            <div
+              key={campo.label}
+              className="flex items-center justify-between border-b border-border/60 pb-2 last:border-b-0 last:pb-0"
+            >
+              <span className="text-muted-foreground">{campo.label}</span>
+              <span className="font-medium">{campo.value(obra.caracterizacao!)}</span>
+            </div>
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Caracterização ainda não preenchida para esta obra.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-disciplinas.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-disciplinas.tsx
@@ -1,0 +1,79 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getEapNodesForObra } from "../obra-eap-repository";
+import type { Obra } from "../obra-types";
+
+/**
+ * Página Disciplinas da casca (FASE 20.x).
+ * As 10 DISCIPLINA (nível 1) da EAP com a contagem de pacotes e trabalhos
+ * agregados. Tudo DERIVADO dos nós reais — nunca uma fonte independente.
+ */
+export function ObraDisciplinas({ obra }: { obra: Obra }) {
+  const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
+
+  const disciplinas = useMemo(() => {
+    const raizes = nodes.filter((n) => n.nivel === 1);
+    return raizes.map((raiz) => {
+      const filhos = nodes.filter((n) => n.pai === raiz.wbs);
+      const pacotes = filhos.filter((n) => n.tipo === "PACOTE").length;
+      const trabalhos = filhos.reduce((acc, filho) => {
+        const netos = nodes.filter((n) => n.pai === filho.wbs);
+        return acc + netos.filter((n) => n.tipo === "TRABALHO").length;
+      }, 0);
+      return {
+        wbs: raiz.wbs,
+        nome: raiz.nome,
+        ordem: raiz.ordem,
+        pacotes,
+        trabalhos,
+      };
+    });
+  }, [nodes]);
+
+  if (disciplinas.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Disciplinas</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Esta obra ainda não possui EAP definida.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Disciplinas</CardTitle>
+          <CardDescription>
+            As {disciplinas.length} disciplinas (nível 1) da EAP com seus pacotes
+            e trabalhos agregados.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2 text-sm">
+          {disciplinas.map((d) => (
+            <div
+              key={d.wbs}
+              className="flex items-center justify-between border-b border-border/60 pb-2 last:border-b-0 last:pb-0"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="font-mono text-xs text-muted-foreground">{d.wbs}</span>
+                <span className="truncate font-medium">{d.nome}</span>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Badge variant="outline">{d.pacotes} pacotes</Badge>
+                <Badge variant="outline">{d.trabalhos} trabalhos</Badge>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-eap.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-eap.tsx
@@ -11,6 +11,7 @@ import {
   deriveEapSummary,
   getEapForObra,
 } from "../obra-eap-repository";
+import { KpiBar, type KpiItem } from "../obra-kpi-bar";
 import type { Obra } from "../obra-types";
 
 const LINHAS_EAP: Array<{ label: string; value: number }> = [];
@@ -67,8 +68,19 @@ export function ObraEap({ obra }: { obra: Obra }) {
       ]
     : LINHAS_EAP;
 
+  const kpis: KpiItem[] = summary
+    ? [
+        { id: "kpi-total", label: "Total de nós", value: summary.total },
+        { id: "kpi-disciplinas", label: "Disciplinas", value: summary.raizes },
+        { id: "kpi-pacotes", label: "Pacotes", value: summary.pacotes },
+        { id: "kpi-trabalhos", label: "Trabalhos", value: summary.trabalhos },
+        { id: "kpi-folhas", label: "Folhas", value: leaves },
+      ]
+    : [];
+
   return (
     <div className="flex w-full flex-col gap-4">
+      <KpiBar items={kpis} />
       <Card>
         <CardHeader>
           <CardTitle>EAP — Estrutura Analítica do Projeto</CardTitle>

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-eap.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-eap.tsx
@@ -1,0 +1,147 @@
+/** @jsxImportSource react */
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { EapTree } from "../obra-eap-tree";
+import {
+  countEapLeaves,
+  deriveEapRows,
+  deriveEapSummary,
+  getEapForObra,
+} from "../obra-eap-repository";
+import type { Obra } from "../obra-types";
+
+const LINHAS_EAP: Array<{ label: string; value: number }> = [];
+
+/**
+ * Página EAP da casca (FASE 06.2-B).
+ * Exibe o EAP REAL da obra: árvore navegável (expandir/recolher/selecionar) com
+ * WBS, nome, tipo e nível, além do resumo estrutural DERIVADO dos nós reais.
+ * O resumo nunca é uma fonte independente de números — vem de deriveEapSummary.
+ */
+export function ObraEap({ obra }: { obra: Obra }) {
+  const [collapsedWbs, setCollapsedWbs] = useState<ReadonlySet<string>>(new Set());
+  const [selectedWbs, setSelectedWbs] = useState<string | null>(null);
+
+  const eap = useMemo(() => getEapForObra(obra.id), [obra.id]);
+  const nodes = eap?.nodes ?? [];
+
+  const summary = useMemo(() => (nodes.length > 0 ? deriveEapSummary(nodes) : null), [nodes]);
+  const leaves = useMemo(() => countEapLeaves(nodes), [nodes]);
+  const rows = useMemo(() => deriveEapRows(nodes, collapsedWbs), [nodes, collapsedWbs]);
+
+  const selectedNode = selectedWbs ? nodes.find((node) => node.wbs === selectedWbs) ?? null : null;
+
+  const toggleCollapse = (wbs: string) => {
+    setCollapsedWbs((prev) => {
+      const next = new Set(prev);
+      if (next.has(wbs)) next.delete(wbs);
+      else next.add(wbs);
+      return next;
+    });
+  };
+
+  if (!eap || nodes.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>EAP — Estrutura Analítica do Projeto</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Esta obra ainda não possui EAP definida. A estrutura será criada em
+          etapa posterior.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const summaryLines = summary
+    ? [
+        { label: "Nós nível 1 (disciplinas)", value: summary.raizes },
+        { label: "Pacotes nível 2", value: summary.pacotes },
+        { label: "Trabalhos nível 3", value: summary.trabalhos },
+        { label: "Total de nós", value: summary.total },
+        { label: "Folhas", value: leaves },
+      ]
+    : LINHAS_EAP;
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>EAP — Estrutura Analítica do Projeto</CardTitle>
+          <CardDescription>
+            {eap.metadata.obraNome} · versão {eap.metadata.versao} · status{" "}
+            {eap.metadata.status}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Status</span>
+            <Badge variant="outline">{eap.metadata.status}</Badge>
+          </div>
+          <div className="flex flex-col gap-2">
+            {summaryLines.map((linha) => (
+              <div
+                key={linha.label}
+                className="flex items-center justify-between border-b border-border/60 pb-2 last:border-b-0 last:pb-0"
+              >
+                <span className="text-muted-foreground">{linha.label}</span>
+                <span className="font-medium">{linha.value}</span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card variant="outline">
+        <CardHeader>
+          <CardTitle>Árvore da EAP</CardTitle>
+          <CardDescription>
+            Clique para expandir/recolher e selecionar nós. WBS, nome, tipo e
+            nível são preservados da fonte oficial.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="max-h-[60vh] overflow-auto">
+          <EapTree
+            rows={rows}
+            selectedWbs={selectedWbs}
+            onSelect={setSelectedWbs}
+            onToggle={toggleCollapse}
+          />
+        </CardContent>
+      </Card>
+
+      {selectedNode ? (
+        <Card variant="outline">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span className="font-mono text-sm">{selectedNode.wbs}</span>
+              <span>{selectedNode.nome}</span>
+            </CardTitle>
+            <CardDescription>
+              Nível {selectedNode.nivel} · {selectedNode.tipo}
+              {selectedNode.pai ? ` · pai ${selectedNode.pai}` : " · raiz"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2 text-sm">
+            {selectedNode.fundamentacao ? (
+              <div>
+                <span className="text-muted-foreground">Fundamentação: </span>
+                {selectedNode.fundamentacao}
+              </div>
+            ) : null}
+            {selectedNode.condicao ? (
+              <div className={cn("rounded-md border px-2 py-1 text-xs", "border-amber-500/40 bg-amber-500/5")}>
+                <span className="font-medium">Condição: </span>
+                {selectedNode.condicao}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-editar.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-editar.tsx
@@ -7,8 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useObraRepository } from "../obra-repository";
-import { obraNovaRoute, obraRoute, obrasListRoute } from "../obra-routes";
-import type { ObraStatus } from "../obra-types";
+import { obraRoute, obrasListRoute } from "../obra-routes";
+import type { Obra, ObraStatus } from "../obra-types";
 
 const STATUS_OPTIONS: { value: ObraStatus; label: string }[] = [
   { value: "PROPOSTA", label: "Proposta" },
@@ -18,21 +18,34 @@ const STATUS_OPTIONS: { value: ObraStatus; label: string }[] = [
 ];
 
 /**
- * Cadastro de obra (FASE 04.2-B / FASE 22).
- * Identificação (nome) + metadados opcionais (status, dataInicio, localização,
- * responsável). Caracterização/EAP/planejamento ficam para etapas posteriores.
- * Após criar, abre a nova obra (contexto da obra = obraId na URL).
+ * Edição de identificação da obra (FASE 22).
+ * Edita nome, status, dataInicio, dataFim, localização e responsável.
+ * `dataInicio` é metadado do cadastro (fonte única do cadastro) — NÃO é
+ * sobrescrito pelo Planejamento.
  */
-export function ObraNovaPage() {
+export function ObraEditarPage({ obraId }: { obraId: string }) {
   const navigate = useNavigate();
-  const createObra = useObraRepository((state) => state.createObra);
-  const [nome, setNome] = useState("");
-  const [status, setStatus] = useState<ObraStatus>("PROPOSTA");
-  const [dataInicio, setDataInicio] = useState("");
-  const [localizacao, setLocalizacao] = useState("");
-  const [responsavel, setResponsavel] = useState("");
+  const obra = useObraRepository((state) =>
+    state.obras.find((candidate) => candidate.id === obraId),
+  );
+  const updateObra = useObraRepository((state) => state.updateObra);
+
+  const [nome, setNome] = useState(obra?.nome ?? "");
+  const [status, setStatus] = useState<ObraStatus>(obra?.status ?? "PROPOSTA");
+  const [dataInicio, setDataInicio] = useState(obra?.dataInicio ?? "");
+  const [dataFim, setDataFim] = useState(obra?.dataFim ?? "");
+  const [localizacao, setLocalizacao] = useState(obra?.localizacao ?? "");
+  const [responsavel, setResponsavel] = useState(obra?.responsavel ?? "");
   const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+
+  if (!obra) {
+    return (
+      <div className="flex min-h-[60vh] w-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <p className="text-lg font-semibold">Obra não encontrada</p>
+        <p className="text-sm text-muted-foreground">{obraId}</p>
+      </div>
+    );
+  }
 
   const trimmed = nome.trim();
 
@@ -43,16 +56,15 @@ export function ObraNovaPage() {
       return;
     }
     setError(null);
-    setSubmitting(true);
-    const obra = createObra({
+    updateObra(obra.id, {
       nome: trimmed,
       status,
       dataInicio: dataInicio || null,
+      dataFim: dataFim || null,
       localizacao: localizacao.trim() || null,
       responsavel: responsavel.trim() || null,
     });
-    // Preferência da fase: após criar, abrir a nova obra.
-    navigate(obraRoute(obra.id), { replace: false });
+    navigate(obraRoute(obra.id));
   };
 
   return (
@@ -60,14 +72,14 @@ export function ObraNovaPage() {
       <div className="max-w-lg">
         <Card>
           <CardHeader>
-            <CardTitle>Nova obra</CardTitle>
+            <CardTitle>Editar obra</CardTitle>
             <CardDescription>
-              Identificação básica. Informações técnicas podem ser preenchidas
-              posteriormente.
+              Identificação e metadados da obra. Informações técnicas continuam
+              nos módulos específicos.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <form className="flex flex-col gap-4" onSubmit={handleSubmit} data-obra-nova>
+            <form className="flex flex-col gap-4" onSubmit={handleSubmit} data-obra-editar>
               <div className="flex flex-col gap-1.5">
                 <Label htmlFor="obra-nome">Nome</Label>
                 <Input
@@ -77,13 +89,9 @@ export function ObraNovaPage() {
                     setNome(event.target.value);
                     if (error) setError(null);
                   }}
-                  placeholder="Ex.: Obra Demonstrativa 03"
-                  autoFocus
                   maxLength={120}
                 />
-                {error ? (
-                  <p className="text-xs text-destructive">{error}</p>
-                ) : null}
+                {error ? <p className="text-xs text-destructive">{error}</p> : null}
               </div>
 
               <div className="flex flex-col gap-1.5">
@@ -102,14 +110,25 @@ export function ObraNovaPage() {
                 </select>
               </div>
 
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="obra-data-inicio">Data de início</Label>
-                <Input
-                  id="obra-data-inicio"
-                  type="date"
-                  value={dataInicio}
-                  onChange={(e) => setDataInicio(e.target.value)}
-                />
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="obra-data-inicio">Data de início</Label>
+                  <Input
+                    id="obra-data-inicio"
+                    type="date"
+                    value={dataInicio}
+                    onChange={(e) => setDataInicio(e.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="obra-data-fim">Data de fim</Label>
+                  <Input
+                    id="obra-data-fim"
+                    type="date"
+                    value={dataFim}
+                    onChange={(e) => setDataFim(e.target.value)}
+                  />
+                </div>
               </div>
 
               <div className="flex flex-col gap-1.5">
@@ -142,17 +161,14 @@ export function ObraNovaPage() {
                 >
                   Cancelar
                 </Button>
-                <Button type="submit" disabled={!trimmed || submitting}>
-                  {submitting ? "Criando…" : "Criar obra"}
+                <Button type="submit" disabled={!trimmed}>
+                  Salvar
                 </Button>
               </div>
             </form>
           </CardContent>
         </Card>
       </div>
-      <p className="mt-2 text-xs text-muted-foreground">
-        Rota atual: <span className="font-mono">{obraNovaRoute()}</span>
-      </p>
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-frentes.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-frentes.tsx
@@ -1,0 +1,89 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getEapNodesForObra } from "../obra-eap-repository";
+import type { Obra } from "../obra-types";
+
+/**
+ * Página Frentes de Serviço da casca (FASE 20.x).
+ *
+ * Frente = natureza/especialidade do trabalho. Para a obra real, as frentes são
+ * DERIVADAS das disciplinas raiz da EAP real (81 nós) — nunca de outra obra.
+ * Cada disciplina raiz vira uma frente, com a contagem de pacotes/trabalhos.
+ */
+export function ObraFrentes({ obra }: { obra: Obra }) {
+  const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
+
+  const frentes = useMemo(() => {
+    const raizes = nodes.filter((n) => n.nivel === 1);
+    return raizes.map((raiz) => {
+      const filhos = nodes.filter((n) => n.pai === raiz.wbs);
+      const pacotes = filhos.filter((n) => n.tipo === "PACOTE").length;
+      const trabalhos = filhos.filter((n) => n.tipo === "TRABALHO").length;
+      return {
+        wbs: raiz.wbs,
+        nome: raiz.nome,
+        pacotes,
+        trabalhos,
+        total: filhos.length,
+      };
+    });
+  }, [nodes]);
+
+  if (frentes.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Frentes de Serviço</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Esta obra ainda não possui EAP definida.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Frentes de Serviço</CardTitle>
+          <CardDescription>
+            As {frentes.length} frentes (disciplinas raiz) da EAP real da obra,
+            com a quantidade de pacotes e trabalhos vinculados.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="max-h-[70vh] overflow-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-1.5 pr-2 font-medium">WBS</th>
+                <th className="py-1.5 pr-2 font-medium">Frente</th>
+                <th className="py-1.5 pr-2 font-medium">Pacotes</th>
+                <th className="py-1.5 pr-2 font-medium">Trabalhos</th>
+                <th className="py-1.5 font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {frentes.map((f) => (
+                <tr key={f.wbs} className="border-b border-border/40">
+                  <td className="py-1.5 pr-2 font-mono text-xs text-muted-foreground">
+                    {f.wbs}
+                  </td>
+                  <td className="py-1.5 pr-2 font-medium">{f.nome}</td>
+                  <td className="py-1.5 pr-2 tabular-nums">{f.pacotes}</td>
+                  <td className="py-1.5 pr-2 tabular-nums">{f.trabalhos}</td>
+                  <td className="py-1.5">
+                    <Badge variant="outline">{f.total}</Badge>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lista.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lista.tsx
@@ -1,0 +1,90 @@
+/** @jsxImportSource react */
+import { Plus } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ObraHelpButton } from "../obra-help";
+import { useObraRepository } from "../obra-repository";
+import { obraNovaRoute, obraRoute } from "../obra-routes";
+import type { Obra } from "../obra-types";
+
+/**
+ * Conteúdo presentacional da lista (testável via SSR com qualquer lista de obras).
+ * A mesma fonte (ObraRepository) alimenta esta superfície e a navegação.
+ */
+export function ObraListaContent({ obras }: { obras: readonly Obra[] }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 overflow-auto p-4">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold leading-tight">Obras</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Projetos de trabalho registrados no domínio.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ObraHelpButton />
+          <Button type="button" size="sm" onClick={() => navigate(obraNovaRoute())}>
+            <Plus className="size-4" aria-hidden="true" />
+            Nova obra
+          </Button>
+        </div>
+      </header>
+
+      {obras.length === 0 ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>Nenhuma obra</EmptyTitle>
+          </EmptyHeader>
+          <EmptyDescription>
+            Crie a primeira obra para começar a trabalhar neste domínio.
+          </EmptyDescription>
+        </Empty>
+      ) : (
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3">
+          {obras.map((obra) => (
+            <Card key={obra.id} data-obra-card={obra.id} className="min-w-0">
+              <CardContent className="flex items-center justify-between gap-3 py-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{obra.nome}</div>
+                  <div className="mt-1 flex items-center gap-2">
+                    <Badge variant="outline">{obra.status}</Badge>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {obra.id}
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => navigate(obraRoute(obra.id))}
+                  aria-label={`Abrir ${obra.nome}`}
+                >
+                  Abrir
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Conector: lista de obras a partir da fonte única (repositório reativo). */
+export function ObraListaPage() {
+  const obras = useObraRepository((state) => state.obras);
+  return <ObraListaContent obras={obras} />;
+}
+

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lista.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lista.tsx
@@ -1,90 +1,320 @@
 /** @jsxImportSource react */
-import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Archive, ArchiveRestore, Pencil, Plus, Trash2 } from "lucide-react";
 import { useNavigate } from "react-router";
 
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyTitle,
-} from "@/components/ui/empty";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { ObraHelpButton } from "../obra-help";
-import { useObraRepository } from "../obra-repository";
-import { obraNovaRoute, obraRoute } from "../obra-routes";
-import type { Obra } from "../obra-types";
+import { statusEfetivo, useObraRepository } from "../obra-repository";
+import { obraEditarRoute, obraNovaRoute, obraRoute } from "../obra-routes";
+import { useObraStore } from "../obra-store";
+import type { Obra, ObraStatus } from "../obra-types";
+
+const STATUS_OPTIONS: { value: ObraStatus | "TODOS"; label: string }[] = [
+  { value: "TODOS", label: "Todos os status" },
+  { value: "PROPOSTA", label: "Proposta" },
+  { value: "PLANEJAMENTO", label: "Planejamento" },
+  { value: "EM_EXECUCAO", label: "Em execução" },
+  { value: "CONCLUIDA", label: "Concluída" },
+  { value: "ARQUIVADA", label: "Arquivada" },
+];
+
+const STATUS_TONE: Record<ObraStatus, string> = {
+  PROPOSTA: "border-sky-500/40 bg-sky-500/10 text-sky-700",
+  PLANEJAMENTO: "border-violet-500/40 bg-violet-500/10 text-violet-700",
+  EM_EXECUCAO: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700",
+  CONCLUIDA: "border-slate-400/40 bg-slate-400/10 text-slate-600",
+  ARQUIVADA: "border-muted-foreground/40 bg-muted-foreground/10 text-muted-foreground",
+};
 
 /**
- * Conteúdo presentacional da lista (testável via SSR com qualquer lista de obras).
- * A mesma fonte (ObraRepository) alimenta esta superfície e a navegação.
+ * Conteúdo presentacional da Central de Obras (testável via SSR).
+ * Recebe obras + estado + callbacks; a página conecta ao repositório/store.
+ * FASE 22: busca, filtro por status, ações por card (editar/arquivar/excluir
+ * com confirmação em duas etapas) e destaque da obra ativa.
  */
-export function ObraListaContent({ obras }: { obras: readonly Obra[] }) {
-  const navigate = useNavigate();
+export function ObraListaContent({
+  obras,
+  activeObraId,
+  onAbrir,
+  onEditar,
+  onArquivar,
+  onRestaurar,
+  onExcluir,
+}: {
+  obras: readonly Obra[];
+  activeObraId?: string | null;
+  onAbrir: (obra: Obra) => void;
+  onEditar: (obra: Obra) => void;
+  onArquivar: (obra: Obra) => void;
+  onRestaurar: (obra: Obra) => void;
+  onExcluir: (obra: Obra) => void;
+}) {
+  const [busca, setBusca] = useState("");
+  const [filtroStatus, setFiltroStatus] = useState<ObraStatus | "TODOS">("TODOS");
+
+  const termo = busca.trim().toLowerCase();
+  const filtradas = obras.filter((obra) => {
+    const status = statusEfetivo(obra);
+    if (filtroStatus !== "TODOS" && status !== filtroStatus) return false;
+    if (termo) {
+      const alvo = `${obra.nome} ${obra.id} ${obra.localizacao ?? ""}`.toLowerCase();
+      if (!alvo.includes(termo)) return false;
+    }
+    return true;
+  });
 
   return (
     <div className="flex h-full w-full flex-col gap-4 overflow-auto p-4">
       <header className="flex items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold leading-tight">Obras</h2>
+          <h2 className="text-lg font-semibold leading-tight">Central de Obras</h2>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            Projetos de trabalho registrados no domínio.
+            Projetos de trabalho registrados no domínio Engenharia.
           </p>
         </div>
         <div className="flex items-center gap-2">
           <ObraHelpButton />
-          <Button type="button" size="sm" onClick={() => navigate(obraNovaRoute())}>
+          <Button type="button" size="sm" onClick={() => onAbrir({ id: "nova" } as Obra)} data-obra-nova>
             <Plus className="size-4" aria-hidden="true" />
             Nova obra
           </Button>
         </div>
       </header>
 
-      {obras.length === 0 ? (
+      {/* Busca + filtro */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center" data-obra-filtros>
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="obra-busca" className="text-xs text-muted-foreground">
+            Buscar
+          </Label>
+          <Input
+            id="obra-busca"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+            placeholder="Nome, ID ou localização…"
+            data-obra-busca
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="obra-status" className="text-xs text-muted-foreground">
+            Status
+          </Label>
+          <select
+            id="obra-status"
+            value={filtroStatus}
+            onChange={(e) => setFiltroStatus(e.target.value as ObraStatus | "TODOS")}
+            data-obra-status-filtro
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {filtradas.length === 0 ? (
         <Empty>
           <EmptyHeader>
             <EmptyTitle>Nenhuma obra</EmptyTitle>
           </EmptyHeader>
           <EmptyDescription>
-            Crie a primeira obra para começar a trabalhar neste domínio.
+            {obras.length === 0
+              ? "Crie a primeira obra para começar a trabalhar neste domínio."
+              : "Nenhuma obra corresponde aos filtros atuais."}
           </EmptyDescription>
         </Empty>
       ) : (
         <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3">
-          {obras.map((obra) => (
-            <Card key={obra.id} data-obra-card={obra.id} className="min-w-0">
-              <CardContent className="flex items-center justify-between gap-3 py-3">
-                <div className="min-w-0">
-                  <div className="truncate text-sm font-medium">{obra.nome}</div>
-                  <div className="mt-1 flex items-center gap-2">
-                    <Badge variant="outline">{obra.status}</Badge>
-                    <span className="truncate text-xs text-muted-foreground">
+          {filtradas.map((obra) => {
+            const status = statusEfetivo(obra);
+            const ativa = obra.id === activeObraId;
+            return (
+              <Card
+                key={obra.id}
+                data-obra-card={obra.id}
+                data-obra-ativa={ativa || undefined}
+                className="min-w-0"
+              >
+                <CardContent className="flex flex-col gap-2 py-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">{obra.nome}</div>
+                      <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                        <Badge variant="outline" className={STATUS_TONE[status]}>
+                          {status}
+                        </Badge>
+                        {ativa ? (
+                          <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
+                            Ativa
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </div>
+                    <span className="shrink-0 truncate text-xs text-muted-foreground">
                       {obra.id}
                     </span>
                   </div>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => navigate(obraRoute(obra.id))}
-                  aria-label={`Abrir ${obra.nome}`}
-                >
-                  Abrir
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+
+                  {(obra.dataInicio || obra.localizacao || obra.responsavel) ? (
+                    <div className="flex flex-col gap-0.5 text-xs text-muted-foreground">
+                      {obra.dataInicio ? <span>Início: {obra.dataInicio}</span> : null}
+                      {obra.localizacao ? <span>Local: {obra.localizacao}</span> : null}
+                      {obra.responsavel ? <span>Responsável: {obra.responsavel}</span> : null}
+                    </div>
+                  ) : null}
+
+                  <div className="flex items-center gap-1 pt-1">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="default"
+                      onClick={() => onAbrir(obra)}
+                      aria-label={`Abrir ${obra.nome}`}
+                    >
+                      Abrir
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onEditar(obra)}
+                      aria-label={`Editar ${obra.nome}`}
+                      data-obra-editar={obra.id}
+                    >
+                      <Pencil className="size-3.5" aria-hidden="true" />
+                    </Button>
+                    {obra.arquivada ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => onRestaurar(obra)}
+                        aria-label={`Restaurar ${obra.nome}`}
+                        data-obra-restaurar={obra.id}
+                      >
+                        <ArchiveRestore className="size-3.5" aria-hidden="true" />
+                      </Button>
+                    ) : (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => onArquivar(obra)}
+                        aria-label={`Arquivar ${obra.nome}`}
+                        data-obra-arquivar={obra.id}
+                      >
+                        <Archive className="size-3.5" aria-hidden="true" />
+                      </Button>
+                    )}
+                    <DeleteObraButton obra={obra} onExcluir={onExcluir} />
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       )}
     </div>
   );
 }
 
-/** Conector: lista de obras a partir da fonte única (repositório reativo). */
-export function ObraListaPage() {
-  const obras = useObraRepository((state) => state.obras);
-  return <ObraListaContent obras={obras} />;
+/** Exclusão com confirmação em duas etapas (segurança contra exclusão acidental). */
+function DeleteObraButton({ obra, onExcluir }: { obra: Obra; onExcluir: (obra: Obra) => void }) {
+  const [confirmado, setConfirmado] = useState(false);
+  return (
+    <AlertDialog
+      open={confirmado}
+      onOpenChange={(open) => {
+        if (!open) setConfirmado(false);
+      }}
+    >
+      <AlertDialogTrigger
+        render={
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label={`Excluir ${obra.nome}`}
+            data-obra-excluir={obra.id}
+          >
+            <Trash2 className="size-3.5" aria-hidden="true" />
+          </Button>
+        }
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Excluir obra definitivamente?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Esta ação exclui permanentemente a obra <strong>{obra.nome}</strong> e sua EAP.
+            Para evitar exclusão acidental, confirme digitando o nome da obra abaixo.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="confirmar-exclusao" className="text-xs text-muted-foreground">
+            Digite o nome da obra para confirmar
+          </Label>
+          <Input
+            id="confirmar-exclusao"
+            value={confirmado ? "" : ""}
+            onChange={(e) => setConfirmado(e.target.value === obra.nome)}
+            placeholder={obra.nome}
+            data-obra-excluir-confirmacao
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            render={<Button type="button" variant="ghost">Cancelar</Button>}
+          />
+          <AlertDialogAction
+            disabled={!confirmado}
+            render={
+              <Button type="button" variant="destructive" disabled={!confirmado}>
+                Excluir definitivamente
+              </Button>
+            }
+          >
+            Excluir definitivamente
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }
 
+/** Conector: Central de Obras a partir da fonte única (repositório + store). */
+export function ObraListaPage() {
+  const navigate = useNavigate();
+  const obras = useObraRepository((state) => state.obras);
+  const activeObraId = useObraStore((state) => state.activeObraId);
+  const archiveObra = useObraRepository((state) => state.archiveObra);
+  const unarchiveObra = useObraRepository((state) => state.unarchiveObra);
+  const deleteObra = useObraRepository((state) => state.deleteObra);
+
+  return (
+    <ObraListaContent
+      obras={obras}
+      activeObraId={activeObraId}
+      onAbrir={(obra) => {
+        if (obra.id === "nova") {
+          navigate(obraNovaRoute());
+          return;
+        }
+        navigate(obraRoute(obra.id));
+      }}
+      onEditar={(obra) => navigate(obraEditarRoute(obra.id))}
+      onArquivar={(obra) => archiveObra(obra.id)}
+      onRestaurar={(obra) => unarchiveObra(obra.id)}
+      onExcluir={(obra) => deleteObra(obra.id)}
+    />
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lob-grade.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lob-grade.tsx
@@ -1,29 +1,51 @@
 /** @jsxImportSource react */
 import { useMemo } from "react";
 
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
+import { LobGrade } from "@/react-app/domains/linha-de-balanco/lob-grade";
 import { getEapNodesForObra } from "../obra-eap-repository";
+import { getEscopo } from "../obra-escopo-repository";
 import { derivarGradeLob } from "../obra-lob-data";
+import { dataInicioEfetiva } from "../obra-planejamento-data";
+import { KpiBar, type KpiItem } from "../obra-kpi-bar";
 import type { Obra } from "../obra-types";
 
 /**
- * Grade Linha de Balanço (FASE 20.x).
- * Visualização tempo × serviço (como a aba LINHA DE BALANÇO (GRADE) da
- * planilha nativa): semanas na horizontal, serviços na vertical, célula ativa
- * quando o serviço está em execução. Tudo DERIVADO dos nós reais + datas.
+ * Página Linha de Balanço da casca (FASE 20.x / FASE 21).
+ * Adapter: deriva a grade LOB dos nós reais da EAP + planejamento e delega a
+ * renderização à capacidade genérica `LobGrade`. KPIs derivados dos dados reais.
  */
 export function ObraLobGrade({ obra }: { obra: Obra }) {
   const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
-  const { semanas, linhas } = useMemo(() => derivarGradeLob(nodes), [nodes]);
+  const { semanas, linhas } = useMemo(
+    () => derivarGradeLob(nodes, getEscopo(obra.id), dataInicioEfetiva(obra.dataInicio)),
+    [nodes, obra.dataInicio, obra.id],
+  );
+
+  const kpis = useMemo<KpiItem[]>(() => {
+    const criticos = linhas.filter((l) => l.critico === "CRÍTICO").length;
+    return [
+      { id: "kpi-semanas", label: "Semanas", value: semanas.length },
+      { id: "kpi-servicos", label: "Serviços", value: linhas.length },
+      { id: "kpi-criticos", label: "Críticos", value: criticos, tone: "text-destructive" },
+      {
+        id: "kpi-inicio",
+        label: "Início",
+        value: semanas[0]?.inicio ?? "—",
+        hint: "Data de início",
+      },
+      {
+        id: "kpi-fim",
+        label: "Fim",
+        value: semanas[semanas.length - 1]?.fim ?? "—",
+        hint: "Data de fim",
+      },
+    ];
+  }, [semanas, linhas]);
 
   if (linhas.length === 0) {
     return (
       <Card className="w-full">
-        <CardHeader>
-          <CardTitle>Linha de Balanço</CardTitle>
-        </CardHeader>
         <CardContent className="text-sm text-muted-foreground">
           Esta obra ainda não possui EAP definida.
         </CardContent>
@@ -31,93 +53,10 @@ export function ObraLobGrade({ obra }: { obra: Obra }) {
     );
   }
 
-  const criticos = linhas.filter((l) => l.critico === "CRÍTICO").length;
-
   return (
     <div className="flex w-full flex-col gap-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Linha de Balanço</CardTitle>
-          <CardDescription>
-            {semanas.length} semanas · {linhas.length} serviços com duração ·{" "}
-            {criticos} críticos. Tempo na horizontal, serviços na vertical.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span>Início {semanas[0]?.inicio}</span>
-            <span>·</span>
-            <span>Fim {semanas[semanas.length - 1]?.fim}</span>
-          </div>
-
-          <div className="max-h-[70vh] overflow-auto rounded-lg border border-border">
-            <div className="min-w-max">
-              {/* Cabeçalho de semanas */}
-              <div className="sticky top-0 z-10 flex border-b border-border bg-background/95 backdrop-blur">
-                <div className="sticky left-0 z-20 w-64 shrink-0 border-r border-border bg-background px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Serviço
-                </div>
-                <div className="flex">
-                  {semanas.map((semana) => (
-                    <div
-                      key={semana.index}
-                      className="flex w-8 shrink-0 items-center justify-center border-r border-border/40 px-0.5 text-[10px] font-medium text-muted-foreground"
-                      title={`${semana.inicio} → ${semana.fim}`}
-                    >
-                      {semana.label.replace("SEM ", "")}
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Linhas de serviço */}
-              {linhas.map((linha) => (
-                <div
-                  key={linha.node.wbs}
-                  className="flex border-b border-border/40 last:border-b-0"
-                >
-                  <div className="sticky left-0 z-10 flex w-64 shrink-0 items-center gap-2 border-r border-border bg-background px-3 py-1.5">
-                    <span className="font-mono text-[10px] text-muted-foreground">
-                      {linha.node.wbs}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-xs font-medium">
-                      {linha.node.nome}
-                    </span>
-                    {linha.critico === "CRÍTICO" ? (
-                      <Badge variant="destructive" className="shrink-0 px-1.5 text-[10px]">
-                        C
-                      </Badge>
-                    ) : null}
-                  </div>
-                  <div className="flex">
-                    {semanas.map((semana) => {
-                      const ativa = linha.semanasAtivas.includes(semana.index);
-                      return (
-                        <div
-                          key={semana.index}
-                          className={cn(
-                            "h-7 w-8 shrink-0 border-r border-border/40",
-                            ativa
-                              ? linha.critico === "CRÍTICO"
-                                ? "bg-destructive/70"
-                                : "bg-primary/70"
-                              : "bg-transparent",
-                          )}
-                          title={
-                            ativa
-                              ? `${linha.node.nome} · ${semana.label}`
-                              : undefined
-                          }
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <KpiBar items={kpis} />
+      <LobGrade data={{ semanas, linhas }} />
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lob-grade.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-lob-grade.tsx
@@ -1,0 +1,123 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { getEapNodesForObra } from "../obra-eap-repository";
+import { derivarGradeLob } from "../obra-lob-data";
+import type { Obra } from "../obra-types";
+
+/**
+ * Grade Linha de Balanço (FASE 20.x).
+ * Visualização tempo × serviço (como a aba LINHA DE BALANÇO (GRADE) da
+ * planilha nativa): semanas na horizontal, serviços na vertical, célula ativa
+ * quando o serviço está em execução. Tudo DERIVADO dos nós reais + datas.
+ */
+export function ObraLobGrade({ obra }: { obra: Obra }) {
+  const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
+  const { semanas, linhas } = useMemo(() => derivarGradeLob(nodes), [nodes]);
+
+  if (linhas.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Linha de Balanço</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Esta obra ainda não possui EAP definida.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const criticos = linhas.filter((l) => l.critico === "CRÍTICO").length;
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Linha de Balanço</CardTitle>
+          <CardDescription>
+            {semanas.length} semanas · {linhas.length} serviços com duração ·{" "}
+            {criticos} críticos. Tempo na horizontal, serviços na vertical.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>Início {semanas[0]?.inicio}</span>
+            <span>·</span>
+            <span>Fim {semanas[semanas.length - 1]?.fim}</span>
+          </div>
+
+          <div className="max-h-[70vh] overflow-auto rounded-lg border border-border">
+            <div className="min-w-max">
+              {/* Cabeçalho de semanas */}
+              <div className="sticky top-0 z-10 flex border-b border-border bg-background/95 backdrop-blur">
+                <div className="sticky left-0 z-20 w-64 shrink-0 border-r border-border bg-background px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Serviço
+                </div>
+                <div className="flex">
+                  {semanas.map((semana) => (
+                    <div
+                      key={semana.index}
+                      className="flex w-8 shrink-0 items-center justify-center border-r border-border/40 px-0.5 text-[10px] font-medium text-muted-foreground"
+                      title={`${semana.inicio} → ${semana.fim}`}
+                    >
+                      {semana.label.replace("SEM ", "")}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Linhas de serviço */}
+              {linhas.map((linha) => (
+                <div
+                  key={linha.node.wbs}
+                  className="flex border-b border-border/40 last:border-b-0"
+                >
+                  <div className="sticky left-0 z-10 flex w-64 shrink-0 items-center gap-2 border-r border-border bg-background px-3 py-1.5">
+                    <span className="font-mono text-[10px] text-muted-foreground">
+                      {linha.node.wbs}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                      {linha.node.nome}
+                    </span>
+                    {linha.critico === "CRÍTICO" ? (
+                      <Badge variant="destructive" className="shrink-0 px-1.5 text-[10px]">
+                        C
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <div className="flex">
+                    {semanas.map((semana) => {
+                      const ativa = linha.semanasAtivas.includes(semana.index);
+                      return (
+                        <div
+                          key={semana.index}
+                          className={cn(
+                            "h-7 w-8 shrink-0 border-r border-border/40",
+                            ativa
+                              ? linha.critico === "CRÍTICO"
+                                ? "bg-destructive/70"
+                                : "bg-primary/70"
+                              : "bg-transparent",
+                          )}
+                          title={
+                            ativa
+                              ? `${linha.node.nome} · ${semana.label}`
+                              : undefined
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-modulo-placeholder.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-modulo-placeholder.tsx
@@ -1,0 +1,19 @@
+/** @jsxImportSource react */
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Placeholder funcional dos módulos futuros da obra
+ * (Frentes de Serviço, Planejamento, Produção, RDO, IA).
+ * Cada módulo será vinculado aos elementos da EAP em fases posteriores.
+ */
+export function ObraModuloPlaceholder({ titulo, descricao }: { titulo: string; descricao: string }) {
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>{titulo}</CardTitle>
+        <CardDescription>Módulo em construção.</CardDescription>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">{descricao}</CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-nova.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-nova.tsx
@@ -1,0 +1,91 @@
+/** @jsxImportSource react */
+import { useState } from "react";
+import { useNavigate } from "react-router";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useObraRepository } from "../obra-repository";
+import { obraNovaRoute, obraRoute, obrasListRoute } from "../obra-routes";
+
+/**
+ * Cadastro mínimo de obra (FASE 04.2-B).
+ * Apenas identificação (nome). Caracterização/EAP/planejamento ficam para etapas
+ * posteriores. Após criar, abre a nova obra (contexto da obra = obraId na URL).
+ */
+export function ObraNovaPage() {
+  const navigate = useNavigate();
+  const createObra = useObraRepository((state) => state.createObra);
+  const [nome, setNome] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const trimmed = nome.trim();
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!trimmed) {
+      setError("Informe o nome da obra.");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    const obra = createObra({ nome: trimmed });
+    // Preferência da fase: após criar, abrir a nova obra.
+    navigate(obraRoute(obra.id), { replace: false });
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-auto p-4">
+      <div className="max-w-lg">
+        <Card>
+          <CardHeader>
+            <CardTitle>Nova obra</CardTitle>
+            <CardDescription>
+              Identificação básica. Informações técnicas podem ser preenchidas
+              posteriormente.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="flex flex-col gap-4" onSubmit={handleSubmit} data-obra-nova>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="obra-nome">Nome</Label>
+                <Input
+                  id="obra-nome"
+                  value={nome}
+                  onChange={(event) => {
+                    setNome(event.target.value);
+                    if (error) setError(null);
+                  }}
+                  placeholder="Ex.: Obra Demonstrativa 03"
+                  autoFocus
+                  maxLength={120}
+                />
+                {error ? (
+                  <p className="text-xs text-destructive">{error}</p>
+                ) : null}
+              </div>
+
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => navigate(obrasListRoute())}
+                >
+                  Cancelar
+                </Button>
+                <Button type="submit" disabled={!trimmed || submitting}>
+                  {submitting ? "Criando…" : "Criar obra"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Rota atual: <span className="font-mono">{obraNovaRoute()}</span>
+      </p>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-planejamento.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-planejamento.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { PlanningDashboard } from "@/react-app/domains/planejamento/planning-dashboard";
+import type { PlanningDashboardData } from "@/react-app/domains/planejamento/planning-types";
+import { getEapNodesForObra } from "../obra-eap-repository";
+import { obraEapParaPlanningDashboard } from "../obra-planejamento-adapter";
+import type { Obra } from "../obra-types";
+
+/**
+ * Consumer/Adapter do módulo Planejamento no domínio Engenharia.
+ *
+ * Responsabilidade: traduzir o contexto do domínio para o contrato genérico
+ * `PlanningDashboardData` e delegar à capacidade reutilizável de Planejamento.
+ * Nenhum conceito de Obra existe dentro de domains/planejamento.
+ *
+ * Alimenta a Dashboard com os 81 nós reais da EAP + datas derivadas de
+ * planejamento (substituindo o dataset demonstrativo).
+ */
+export function ObraPlanejamento({ obra }: { obra: Obra }) {
+  const data = useMemo<PlanningDashboardData>(() => {
+    const nodes = getEapNodesForObra(obra.id);
+    return obraEapParaPlanningDashboard(nodes, obra.nome);
+  }, [obra]);
+
+  return <PlanningDashboard data={data} />;
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-planejamento.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-planejamento.tsx
@@ -4,7 +4,10 @@ import { useMemo } from "react";
 import { PlanningDashboard } from "@/react-app/domains/planejamento/planning-dashboard";
 import type { PlanningDashboardData } from "@/react-app/domains/planejamento/planning-types";
 import { getEapNodesForObra } from "../obra-eap-repository";
+import { getEscopo } from "../obra-escopo-repository";
+import { KpiBar, type KpiItem } from "../obra-kpi-bar";
 import { obraEapParaPlanningDashboard } from "../obra-planejamento-adapter";
+import { dataInicioEfetiva, derivarPlanejamentoCompleto, duracaoTotalDasLinhas } from "../obra-planejamento-data";
 import type { Obra } from "../obra-types";
 
 /**
@@ -15,13 +18,39 @@ import type { Obra } from "../obra-types";
  * Nenhum conceito de Obra existe dentro de domains/planejamento.
  *
  * Alimenta a Dashboard com os 81 nós reais da EAP + datas derivadas de
- * planejamento (substituindo o dataset demonstrativo).
+ * planejamento (substituindo o dataset demonstrativo). KPIs derivados dos dados
+ * reais (FASE 21).
  */
 export function ObraPlanejamento({ obra }: { obra: Obra }) {
   const data = useMemo<PlanningDashboardData>(() => {
     const nodes = getEapNodesForObra(obra.id);
-    return obraEapParaPlanningDashboard(nodes, obra.nome);
+    return obraEapParaPlanningDashboard(
+      nodes,
+      obra.nome,
+      getEscopo(obra.id),
+      dataInicioEfetiva(obra.dataInicio),
+    );
   }, [obra]);
 
-  return <PlanningDashboard data={data} />;
+  const kpis = useMemo<KpiItem[]>(() => {
+    const nodes = getEapNodesForObra(obra.id);
+    const linhas = derivarPlanejamentoCompleto(nodes, getEscopo(obra.id));
+    const duracaoTotal = duracaoTotalDasLinhas(linhas);
+    const comDuracao = linhas.filter((l) => l.duracao > 0).length;
+    const criticos = linhas.filter((l) => l.critico === "CRÍTICO").length;
+    const sequenciais = linhas.filter((l) => l.critico === "Sequencial").length;
+    return [
+      { id: "kpi-duracao", label: "Duração (dias)", value: duracaoTotal },
+      { id: "kpi-com-duracao", label: "Com duração", value: comDuracao },
+      { id: "kpi-criticos", label: "Críticos", value: criticos, tone: "text-destructive" },
+      { id: "kpi-sequenciais", label: "Sequenciais", value: sequenciais },
+    ];
+  }, [obra.id]);
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <KpiBar items={kpis} />
+      <PlanningDashboard data={data} />
+    </div>
+  );
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-producao.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-producao.tsx
@@ -1,0 +1,99 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getEapNodesForObra } from "../obra-eap-repository";
+import { getEscopo } from "../obra-escopo-repository";
+import { dataInicioEfetiva, derivarPlanejamentoCompleto, diaParaDataIso } from "../obra-planejamento-data";
+import type { Obra } from "../obra-types";
+
+/**
+ * Página Produção da casca (FASE 20.x).
+ *
+ * Acompanhamento planejado × realizado. Para a obra real, a produção é derivada
+ * do cronograma da EAP real (81 nós): cada TRABALHO com duração mostra a
+ * quantidade planejada e o ritmo. Os dados de produção REAL (quantidade
+ * executada) ainda não existem para a obra real — ficam marcados como pendentes.
+ */
+export function ObraProducao({ obra }: { obra: Obra }) {
+  const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
+  const escopo = useMemo(() => getEscopo(obra.id), [obra.id]);
+  const startDate = useMemo(() => dataInicioEfetiva(obra.dataInicio), [obra.dataInicio]);
+  const linhas = useMemo(
+    () => derivarPlanejamentoCompleto(nodes, escopo, startDate),
+    [nodes, escopo, startDate],
+  );
+
+  const producao = useMemo(
+    () => linhas.filter((l) => l.node.tipo === "TRABALHO" && l.duracao > 0),
+    [linhas],
+  );
+
+  if (producao.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Produção</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Esta obra ainda não possui EAP definida.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Produção</CardTitle>
+          <CardDescription>
+            {producao.length} trabalhos com duração do cronograma da EAP real.
+            Quantidade planejada e ritmo derivados; produção real (executada)
+            pendente de registro.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="max-h-[70vh] overflow-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-1.5 pr-2 font-medium">WBS</th>
+                <th className="py-1.5 pr-2 font-medium">Serviço</th>
+                <th className="py-1.5 pr-2 font-medium">Un</th>
+                <th className="py-1.5 pr-2 font-medium">Qtd. planejada</th>
+                <th className="py-1.5 pr-2 font-medium">Ritmo</th>
+                <th className="py-1.5 pr-2 font-medium">Início</th>
+                <th className="py-1.5 pr-2 font-medium">Fim</th>
+                <th className="py-1.5 font-medium">Produção real</th>
+              </tr>
+            </thead>
+            <tbody>
+              {producao.map((l) => {
+                const ref = escopo[l.node.wbs];
+                return (
+                  <tr key={l.node.wbs} className="border-b border-border/40">
+                    <td className="py-1.5 pr-2 font-mono text-xs text-muted-foreground">
+                      {l.node.wbs}
+                    </td>
+                    <td className="py-1.5 pr-2 font-medium">{l.node.nome}</td>
+                    <td className="py-1.5 pr-2 tabular-nums">{ref?.unidade ?? "—"}</td>
+                    <td className="py-1.5 pr-2 tabular-nums">{ref?.quantidade ?? "—"}</td>
+                    <td className="py-1.5 pr-2 tabular-nums">
+                      {l.ritmo !== "" ? `${l.ritmo}/dia` : "—"}
+                    </td>
+                    <td className="py-1.5 pr-2 tabular-nums">{diaParaDataIso(l.inicio, startDate)}</td>
+                    <td className="py-1.5 pr-2 tabular-nums">{diaParaDataIso(l.fim, startDate)}</td>
+                    <td className="py-1.5">
+                      <Badge variant="outline">Pendente</Badge>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-servicos.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-servicos.tsx
@@ -1,0 +1,95 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getEapNodesForObra } from "../obra-eap-repository";
+import { derivarPlanejamentoCompleto, diaParaDataIso } from "../obra-planejamento-data";
+import type { Obra } from "../obra-types";
+
+/**
+ * Página Serviços da casca (FASE 20.x).
+ * Os 47 TRABALHO (nível 3) da EAP com duração, datas e caminho crítico,
+ * DERIVADOS do planejamento (mesma lógica da planilha nativa).
+ */
+export function ObraServicos({ obra }: { obra: Obra }) {
+  const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
+  const linhas = useMemo(() => derivarPlanejamentoCompleto(nodes), [nodes]);
+
+  const servicos = useMemo(
+    () => linhas.filter((l) => l.node.tipo === "TRABALHO"),
+    [linhas],
+  );
+
+  if (servicos.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Serviços</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Esta obra ainda não possui EAP definida.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Serviços</CardTitle>
+          <CardDescription>
+            Os {servicos.length} trabalhos (nível 3) da EAP com duração, datas e
+            caminho crítico derivados do planejamento.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="max-h-[70vh] overflow-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-1.5 pr-2 font-medium">WBS</th>
+                <th className="py-1.5 pr-2 font-medium">Serviço</th>
+                <th className="py-1.5 pr-2 font-medium">Duração</th>
+                <th className="py-1.5 pr-2 font-medium">Início</th>
+                <th className="py-1.5 pr-2 font-medium">Fim</th>
+                <th className="py-1.5 font-medium">Crítico</th>
+              </tr>
+            </thead>
+            <tbody>
+              {servicos.map((l) => {
+                const temData = l.duracao > 0;
+                return (
+                  <tr key={l.node.wbs} className="border-b border-border/40">
+                    <td className="py-1.5 pr-2 font-mono text-xs text-muted-foreground">
+                      {l.node.wbs}
+                    </td>
+                    <td className="py-1.5 pr-2 font-medium">{l.node.nome}</td>
+                    <td className="py-1.5 pr-2 tabular-nums">
+                      {l.duracao > 0 ? `${l.duracao} d` : "—"}
+                    </td>
+                    <td className="py-1.5 pr-2 tabular-nums">
+                      {temData ? diaParaDataIso(l.inicio) : "—"}
+                    </td>
+                    <td className="py-1.5 pr-2 tabular-nums">
+                      {temData ? diaParaDataIso(l.fim) : "—"}
+                    </td>
+                    <td className="py-1.5">
+                      {l.critico === "CRÍTICO" ? (
+                        <Badge variant="destructive">Crítico</Badge>
+                      ) : l.critico === "Sequencial" ? (
+                        <Badge variant="outline">Sequencial</Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-servicos.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-servicos.tsx
@@ -1,95 +1,23 @@
 /** @jsxImportSource react */
 import { useMemo } from "react";
 
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ServicosTable } from "@/react-app/domains/servicos/servicos-table";
 import { getEapNodesForObra } from "../obra-eap-repository";
-import { derivarPlanejamentoCompleto, diaParaDataIso } from "../obra-planejamento-data";
+import { getEscopo } from "../obra-escopo-repository";
+import { dataInicioEfetiva } from "../obra-planejamento-data";
+import { obraEapParaServicos } from "../obra-servicos-adapter";
 import type { Obra } from "../obra-types";
 
 /**
- * Página Serviços da casca (FASE 20.x).
- * Os 47 TRABALHO (nível 3) da EAP com duração, datas e caminho crítico,
- * DERIVADOS do planejamento (mesma lógica da planilha nativa).
+ * Página Serviços da casca (FASE 20.x / FASE 21).
+ * Adapter: deriva os serviços dos nós reais da EAP + planejamento e delega a
+ * renderização à capacidade genérica `ServicosTable`. Preparada para a FASE 22.
  */
 export function ObraServicos({ obra }: { obra: Obra }) {
-  const nodes = useMemo(() => getEapNodesForObra(obra.id), [obra.id]);
-  const linhas = useMemo(() => derivarPlanejamentoCompleto(nodes), [nodes]);
+  const data = useMemo(() => {
+    const nodes = getEapNodesForObra(obra.id);
+    return obraEapParaServicos(nodes, obra.nome, getEscopo(obra.id), dataInicioEfetiva(obra.dataInicio));
+  }, [obra]);
 
-  const servicos = useMemo(
-    () => linhas.filter((l) => l.node.tipo === "TRABALHO"),
-    [linhas],
-  );
-
-  if (servicos.length === 0) {
-    return (
-      <Card className="w-full">
-        <CardHeader>
-          <CardTitle>Serviços</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          Esta obra ainda não possui EAP definida.
-        </CardContent>
-      </Card>
-    );
-  }
-
-  return (
-    <div className="flex w-full flex-col gap-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Serviços</CardTitle>
-          <CardDescription>
-            Os {servicos.length} trabalhos (nível 3) da EAP com duração, datas e
-            caminho crítico derivados do planejamento.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="max-h-[70vh] overflow-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
-                <th className="py-1.5 pr-2 font-medium">WBS</th>
-                <th className="py-1.5 pr-2 font-medium">Serviço</th>
-                <th className="py-1.5 pr-2 font-medium">Duração</th>
-                <th className="py-1.5 pr-2 font-medium">Início</th>
-                <th className="py-1.5 pr-2 font-medium">Fim</th>
-                <th className="py-1.5 font-medium">Crítico</th>
-              </tr>
-            </thead>
-            <tbody>
-              {servicos.map((l) => {
-                const temData = l.duracao > 0;
-                return (
-                  <tr key={l.node.wbs} className="border-b border-border/40">
-                    <td className="py-1.5 pr-2 font-mono text-xs text-muted-foreground">
-                      {l.node.wbs}
-                    </td>
-                    <td className="py-1.5 pr-2 font-medium">{l.node.nome}</td>
-                    <td className="py-1.5 pr-2 tabular-nums">
-                      {l.duracao > 0 ? `${l.duracao} d` : "—"}
-                    </td>
-                    <td className="py-1.5 pr-2 tabular-nums">
-                      {temData ? diaParaDataIso(l.inicio) : "—"}
-                    </td>
-                    <td className="py-1.5 pr-2 tabular-nums">
-                      {temData ? diaParaDataIso(l.fim) : "—"}
-                    </td>
-                    <td className="py-1.5">
-                      {l.critico === "CRÍTICO" ? (
-                        <Badge variant="destructive">Crítico</Badge>
-                      ) : l.critico === "Sequencial" ? (
-                        <Badge variant="outline">Sequencial</Badge>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ServicosTable data={data} />;
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-visao-geral.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-visao-geral.tsx
@@ -1,6 +1,15 @@
 /** @jsxImportSource react */
+import { useMemo } from "react";
+import { useNavigate } from "react-router";
+
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getEapSummaryForObra } from "../obra-eap-repository";
+import { KpiBar, type KpiItem } from "../obra-kpi-bar";
+import { ObraDashboard, type DashboardWidget } from "../obra-dashboard";
+import { obraRoute } from "../obra-routes";
+import { statusEfetivo } from "../obra-repository";
+import { dataInicioEfetiva, diaParaDataIso } from "../obra-planejamento-data";
 import type { Obra, ObraCaracterizacao } from "../obra-types";
 
 const CAMPOS_CARACTERIZACAO: Array<{
@@ -15,45 +24,107 @@ const CAMPOS_CARACTERIZACAO: Array<{
 ];
 
 export function ObraVisaoGeral({ obra }: { obra: Obra }) {
+  const navigate = useNavigate();
+  const eapSummary = useMemo(() => getEapSummaryForObra(obra.id), [obra.id]);
+
+  const kpis: KpiItem[] = useMemo(() => {
+    const items: KpiItem[] = [];
+    const c = obra.caracterizacao;
+    if (c) {
+      items.push({
+        id: "kpi-torres",
+        label: "Torres",
+        value: c.torres,
+        target: obraRoute(obra.id, "caracterizacao"),
+      });
+      items.push({
+        id: "kpi-lajes",
+        label: "Lajes",
+        value: c.lajes,
+        target: obraRoute(obra.id, "caracterizacao"),
+      });
+      items.push({
+        id: "kpi-apartamentos",
+        label: "Aptos/pavimento",
+        value: c.apartamentosPorPavimento,
+        target: obraRoute(obra.id, "caracterizacao"),
+      });
+      items.push({
+        id: "kpi-subsolos",
+        label: "Subsolos",
+        value: c.subsolos,
+        target: obraRoute(obra.id, "caracterizacao"),
+      });
+    }
+    if (eapSummary) {
+      items.push({
+        id: "kpi-eap-nos",
+        label: "Nós EAP",
+        value: eapSummary.total,
+        hint: `${eapSummary.raizes} disciplinas`,
+        target: obraRoute(obra.id, "eap"),
+      });
+    }
+    return items;
+  }, [obra, eapSummary]);
+
+  const widgets: DashboardWidget[] = useMemo(() => {
+    const status = statusEfetivo(obra);
+    const inicioPlanejamento = diaParaDataIso(0, dataInicioEfetiva(obra.dataInicio));
+    return [
+      {
+        id: "widget-identidade",
+        title: obra.nome,
+        description: "Identificação e metadados da obra.",
+        content: (
+          <div className="flex flex-col gap-2 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Status</span>
+              <Badge variant="outline">{status}</Badge>
+            </div>
+            <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+              {obra.dataInicio ? <span>Início (cadastro): {obra.dataInicio}</span> : null}
+              {obra.dataFim ? <span>Fim (cadastro): {obra.dataFim}</span> : null}
+              {obra.localizacao ? <span>Local: {obra.localizacao}</span> : null}
+              {obra.responsavel ? <span>Responsável: {obra.responsavel}</span> : null}
+              <span>
+                Início do cronograma (derivado): {inicioPlanejamento}
+              </span>
+            </div>
+          </div>
+        ),
+      },
+      {
+        id: "widget-caracterizacao",
+        title: "Caracterização",
+        description: "Informações estruturais da obra (somente dados existentes).",
+        content: (
+          <div className="flex flex-col gap-2 text-sm">
+            {obra.caracterizacao ? (
+              CAMPOS_CARACTERIZACAO.map((campo) => (
+                <div
+                  key={campo.label}
+                  className="flex items-center justify-between border-b border-border/60 pb-2 last:border-b-0 last:pb-0"
+                >
+                  <span className="text-muted-foreground">{campo.label}</span>
+                  <span className="font-medium">{campo.value(obra.caracterizacao!)}</span>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Caracterização ainda não preenchida para esta obra.
+              </p>
+            )}
+          </div>
+        ),
+      },
+    ];
+  }, [obra]);
+
   return (
     <div className="flex w-full flex-col gap-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>{obra.nome}</CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-center gap-2 text-sm">
-          <span className="text-muted-foreground">Status</span>
-          <Badge variant="outline">{obra.status}</Badge>
-        </CardContent>
-      </Card>
-
-      <Card variant="outline">
-        <CardHeader>
-          <CardTitle>Caracterização</CardTitle>
-          <CardDescription>
-            Informações estruturais da obra (somente dados existentes no projeto).
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-2 text-sm">
-          {obra.caracterizacao ? (
-            CAMPOS_CARACTERIZACAO.map((campo) => (
-              <div
-                key={campo.label}
-                className="flex items-center justify-between border-b border-border/60 pb-2 last:border-b-0 last:pb-0"
-              >
-                <span className="text-muted-foreground">{campo.label}</span>
-                <span className="font-medium">
-                  {campo.value(obra.caracterizacao!)}
-                </span>
-              </div>
-            ))
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Caracterização ainda não preenchida para esta obra.
-            </p>
-          )}
-        </CardContent>
-      </Card>
+      <KpiBar items={kpis} onNavigate={(target) => navigate(target)} />
+      <ObraDashboard widgets={widgets} />
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/engenharia/obra/pages/obra-visao-geral.tsx
+++ b/apps/app/src/react-app/domains/engenharia/obra/pages/obra-visao-geral.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource react */
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Obra, ObraCaracterizacao } from "../obra-types";
+
+const CAMPOS_CARACTERIZACAO: Array<{
+  label: string;
+  value: (c: ObraCaracterizacao) => string;
+}> = [
+  { label: "Torres", value: (c) => String(c.torres) },
+  { label: "Lajes", value: (c) => String(c.lajes) },
+  { label: "Apartamentos por pavimento", value: (c) => String(c.apartamentosPorPavimento) },
+  { label: "Subsolos", value: (c) => String(c.subsolos) },
+  { label: "Sistema construtivo", value: (c) => c.sistemaConstrutivo },
+];
+
+export function ObraVisaoGeral({ obra }: { obra: Obra }) {
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>{obra.nome}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Status</span>
+          <Badge variant="outline">{obra.status}</Badge>
+        </CardContent>
+      </Card>
+
+      <Card variant="outline">
+        <CardHeader>
+          <CardTitle>Caracterização</CardTitle>
+          <CardDescription>
+            Informações estruturais da obra (somente dados existentes no projeto).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2 text-sm">
+          {obra.caracterizacao ? (
+            CAMPOS_CARACTERIZACAO.map((campo) => (
+              <div
+                key={campo.label}
+                className="flex items-center justify-between border-b border-border/60 pb-2 last:border-b-0 last:pb-0"
+              >
+                <span className="text-muted-foreground">{campo.label}</span>
+                <span className="font-medium">
+                  {campo.value(obra.caracterizacao!)}
+                </span>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Caracterização ainda não preenchida para esta obra.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/linha-de-balanco/lob-data.ts
+++ b/apps/app/src/react-app/domains/linha-de-balanco/lob-data.ts
@@ -1,0 +1,104 @@
+// Helpers puros da capacidade de Linha de Balanço (LOB) — sem DOM, testáveis.
+// Tudo aqui é DERIVADO dos dados fornecidos pelo adapter; nada é inventado.
+// FASE 21: capacidade genérica extraída para um domínio reutilizável.
+import type { LobAtividade, LobGradeData, LobLinha, LobSemana } from "./lob-types";
+
+const DAY_MS = 86_400_000;
+
+/** Converte "yyyy-mm-dd" em Date (timezone local). Retorna null se inválido. */
+export function parseIsoDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(value.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function toIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Gera as semanas (segunda a domingo) cobrindo a duração total, a partir de uma
+ * data de início ISO. A primeira semana começa na data de início.
+ */
+export function gerarSemanas(inicioIso: string, duracaoTotal: number): LobSemana[] {
+  const inicio = parseIsoDate(inicioIso);
+  if (!inicio || duracaoTotal < 0) return [];
+  const semanas: LobSemana[] = [];
+  let index = 0;
+  while (index * 7 <= duracaoTotal) {
+    const cursor = new Date(inicio);
+    cursor.setDate(cursor.getDate() + index * 7);
+    const fim = new Date(cursor);
+    fim.setDate(fim.getDate() + 6);
+    semanas.push({
+      index,
+      inicio: toIso(cursor),
+      fim: toIso(fim),
+      label: `SEM ${index + 1}`,
+    });
+    index += 1;
+  }
+  return semanas;
+}
+
+/** Converte uma atividade genérica em linha da grade (semanas ativas). */
+export function atividadeParaLobLinha(atividade: LobAtividade): LobLinha {
+  const semanasAtivas: number[] = [];
+  if (atividade.duracao > 0) {
+    const semanaInicio = Math.floor(atividade.inicio / 7);
+    const semanaFim = Math.floor((atividade.fim - 1) / 7);
+    for (let s = semanaInicio; s <= semanaFim; s += 1) semanasAtivas.push(s);
+  }
+  return {
+    id: atividade.id,
+    nome: atividade.nome,
+    codigo: atividade.codigo,
+    duracao: atividade.duracao,
+    critico: atividade.critico,
+    semanasAtivas,
+  };
+}
+
+/** Duração total (dias) a partir das atividades (fim da última). */
+export function duracaoTotalDasAtividades(
+  atividades: readonly LobAtividade[],
+): number {
+  return atividades.length > 0 ? atividades[atividades.length - 1].fim : 0;
+}
+
+/** Grade LOB completa: semanas + linhas (atividades com duração). */
+export function derivarGradeLob(
+  atividades: readonly LobAtividade[],
+  inicioIso: string,
+): LobGradeData {
+  const duracaoTotal = duracaoTotalDasAtividades(atividades);
+  const semanas = gerarSemanas(inicioIso, duracaoTotal);
+  const linhas = atividades
+    .filter((a) => a.duracao > 0)
+    .map(atividadeParaLobLinha);
+  return { semanas, linhas };
+}
+
+/** Dias corridos entre duas datas ISO (inclusive início). Negativo se fora de ordem. */
+export function diasEntre(startIso: string, endIso: string): number {
+  const start = parseIsoDate(startIso);
+  const end = parseIsoDate(endIso);
+  if (!start || !end) return 0;
+  return Math.round((end.getTime() - start.getTime()) / DAY_MS);
+}

--- a/apps/app/src/react-app/domains/linha-de-balanco/lob-grade.tsx
+++ b/apps/app/src/react-app/domains/linha-de-balanco/lob-grade.tsx
@@ -1,0 +1,120 @@
+/** @jsxImportSource react */
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { LobGradeData } from "./lob-types";
+
+/**
+ * Grade Linha de Balanço — capacidade genérica (FASE 21).
+ * Visualização tempo × serviço: semanas na horizontal, serviços na vertical,
+ * célula ativa quando o serviço está em execução. Consome QUALQUER LobGradeData
+ * fornecido por um adapter do domínio (não conhece Obra/EAP).
+ */
+export function LobGrade({ data }: { data: LobGradeData }) {
+  const { semanas, linhas } = data;
+
+  if (linhas.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Linha de Balanço</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Nenhum serviço com duração para exibir.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const criticos = linhas.filter((l) => l.critico === "CRÍTICO").length;
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Linha de Balanço</CardTitle>
+          <CardDescription>
+            {semanas.length} semanas · {linhas.length} serviços com duração ·{" "}
+            {criticos} críticos. Tempo na horizontal, serviços na vertical.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>Início {semanas[0]?.inicio}</span>
+            <span>·</span>
+            <span>Fim {semanas[semanas.length - 1]?.fim}</span>
+          </div>
+
+          <div className="max-h-[70vh] overflow-auto rounded-lg border border-border">
+            <div className="min-w-max">
+              {/* Cabeçalho de semanas */}
+              <div className="sticky top-0 z-10 flex border-b border-border bg-background/95 backdrop-blur">
+                <div className="sticky left-0 z-20 w-64 shrink-0 border-r border-border bg-background px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Serviço
+                </div>
+                <div className="flex">
+                  {semanas.map((semana) => (
+                    <div
+                      key={semana.index}
+                      className="flex w-8 shrink-0 items-center justify-center border-r border-border/40 px-0.5 text-[10px] font-medium text-muted-foreground"
+                      title={`${semana.inicio} → ${semana.fim}`}
+                    >
+                      {semana.label.replace("SEM ", "")}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Linhas de serviço */}
+              {linhas.map((linha) => (
+                <div
+                  key={linha.id}
+                  className="flex border-b border-border/40 last:border-b-0"
+                >
+                  <div className="sticky left-0 z-10 flex w-64 shrink-0 items-center gap-2 border-r border-border bg-background px-3 py-1.5">
+                    {linha.codigo ? (
+                      <span className="font-mono text-[10px] text-muted-foreground">
+                        {linha.codigo}
+                      </span>
+                    ) : null}
+                    <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                      {linha.nome}
+                    </span>
+                    {linha.critico === "CRÍTICO" ? (
+                      <Badge variant="destructive" className="shrink-0 px-1.5 text-[10px]">
+                        C
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <div className="flex">
+                    {semanas.map((semana) => {
+                      const ativa = linha.semanasAtivas.includes(semana.index);
+                      return (
+                        <div
+                          key={semana.index}
+                          className={cn(
+                            "h-7 w-8 shrink-0 border-r border-border/40",
+                            ativa
+                              ? linha.critico === "CRÍTICO"
+                                ? "bg-destructive/70"
+                                : "bg-primary/70"
+                              : "bg-transparent",
+                          )}
+                          title={
+                            ativa
+                              ? `${linha.nome} · ${semana.label}`
+                              : undefined
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/linha-de-balanco/lob-help.tsx
+++ b/apps/app/src/react-app/domains/linha-de-balanco/lob-help.tsx
@@ -1,0 +1,55 @@
+/** @jsxImportSource react */
+import { Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+/** Seções de ajuda da capacidade de Linha de Balanço (genérica). */
+export const LOB_HELP_SECTIONS = [
+  {
+    question: "O que é?",
+    answer:
+      "A Linha de Balanço (LOB) é uma visão tempo × serviço que mostra, em semanas, quando cada serviço da obra está em execução.",
+  },
+  {
+    question: "Para que serve?",
+    answer:
+      "Permite visualizar o ritmo e a continuidade dos serviços ao longo do tempo, identificando serviços críticos e sobreposições.",
+  },
+  {
+    question: "Como funciona?",
+    answer:
+      "Cada linha representa um serviço com duração; as células ativas indicam as semanas em que o serviço está em execução. Serviços críticos são destacados.",
+  },
+  {
+    question: "O que devo fazer?",
+    answer:
+      "Os dados são derivados automaticamente do planejamento da obra. Não há entrada manual nesta visão.",
+  },
+] as const;
+
+export function LobHelp() {
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={<Button type="button" variant="ghost" size="icon" />}
+        aria-label="Ajuda: Linha de Balanço"
+      >
+        <Info className="size-4" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent className="w-80" align="start">
+        <div className="flex flex-col gap-3">
+          <div className="text-sm font-semibold">Linha de Balanço</div>
+          {LOB_HELP_SECTIONS.map((section) => (
+            <div key={section.question} className="flex flex-col gap-0.5">
+              <div className="text-xs font-semibold">{section.question}</div>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {section.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/react-app/domains/linha-de-balanco/lob-types.ts
+++ b/apps/app/src/react-app/domains/linha-de-balanco/lob-types.ts
@@ -1,0 +1,52 @@
+// Capacidade genérica de Linha de Balanço (LOB) — contrato reutilizável.
+// Este módulo NÃO conhece nenhum domínio consumidor nem entidade específica.
+// A grade renderiza QUALQUER LobGradeData fornecido por um adapter do domínio.
+//
+// FASE 21: extraída para uma capacidade reutilizável, seguindo o mesmo padrão
+// da capacidade de Planejamento (domains/planejamento).
+// Nenhuma fonte de verdade é criada aqui: os dados vêm do adapter do domínio.
+
+/** Uma semana do eixo temporal (segunda a domingo). */
+export type LobSemana = {
+  /** Índice 0-based da semana. */
+  index: number;
+  /** Data ISO do início (segunda). */
+  inicio: string;
+  /** Data ISO do fim (domingo). */
+  fim: string;
+  /** Rótulo curto (ex.: "SEM 1"). */
+  label: string;
+};
+
+/** Linha da grade LOB: serviço + semanas ativas. */
+export type LobLinha = {
+  /** Identificador estável da linha (ex.: WBS). */
+  id: string;
+  /** Nome exibido do serviço. */
+  nome: string;
+  /** Código curto opcional (ex.: WBS). */
+  codigo?: string;
+  duracao: number;
+  critico: "CRÍTICO" | "Sequencial" | "—";
+  /** Índices das semanas em que o serviço está ativo. */
+  semanasAtivas: number[];
+};
+
+/** Atividade genérica com duração — entrada para derivar a grade. */
+export type LobAtividade = {
+  id: string;
+  nome: string;
+  codigo?: string;
+  /** Dia acumulado de início (0-based). */
+  inicio: number;
+  /** Dia acumulado de fim (exclusivo). */
+  fim: number;
+  duracao: number;
+  critico: "CRÍTICO" | "Sequencial" | "—";
+};
+
+/** Contrato consumido pela grade LOB. */
+export type LobGradeData = {
+  semanas: LobSemana[];
+  linhas: LobLinha[];
+};

--- a/apps/app/src/react-app/domains/navigation/navigation-state.ts
+++ b/apps/app/src/react-app/domains/navigation/navigation-state.ts
@@ -1,0 +1,46 @@
+// Estado de navegação hierárquica (Core) — Zustand + persist localStorage.
+// Guarda APENAS o estado de expansão/recolhimento por id de nó.
+// A seleção e o contexto são derivados da rota (useLocation), não duplicados aqui.
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type NavigationState = {
+  expandedNodeIds: string[];
+  toggleNode: (id: string) => void;
+  expandNode: (id: string) => void;
+  collapseNode: (id: string) => void;
+};
+
+export const useNavigationState = create<NavigationState>()(
+  persist(
+    (set) => ({
+      expandedNodeIds: [],
+      toggleNode: (id) =>
+        set((state) => ({
+          expandedNodeIds: state.expandedNodeIds.includes(id)
+            ? state.expandedNodeIds.filter((n) => n !== id)
+            : [...state.expandedNodeIds, id],
+        })),
+      expandNode: (id) =>
+        set((state) =>
+          state.expandedNodeIds.includes(id)
+            ? state
+            : { expandedNodeIds: [...state.expandedNodeIds, id] },
+        ),
+      collapseNode: (id) =>
+        set((state) => ({
+          expandedNodeIds: state.expandedNodeIds.filter((n) => n !== id),
+        })),
+    }),
+    {
+      name: "openwork-navigation-state",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+/** True se o nó está expandido. Nós ancestrais do caminho ativo abrem por padrão
+ *  (expandidos se ainda não foram tocados — ver isNodeExpanded em sidebar-navigation). */
+export function isNodeExpanded(state: NavigationState, id: string): boolean {
+  return state.expandedNodeIds.includes(id);
+}

--- a/apps/app/src/react-app/domains/navigation/navigation-types.ts
+++ b/apps/app/src/react-app/domains/navigation/navigation-types.ts
@@ -1,0 +1,15 @@
+// Navegação genérica do Core — modelo data-driven.
+// O Core não conhece Engenharia/Obra/EAP: apenas nós hierárquicos.
+export type NavigationNodeType = "domain" | "entity" | "group" | "module";
+
+export type NavigationNode = {
+  /** Identificador estável do nó (usado no estado de expansão). */
+  id: string;
+  label: string;
+  type: NavigationNodeType;
+  /** Rota de navegação (clique). Nós agrupadores ("group") podem omitir. */
+  route?: string;
+  children?: NavigationNode[];
+  /** Metadados opcionais do domínio (livre). */
+  metadata?: Record<string, unknown>;
+};

--- a/apps/app/src/react-app/domains/navigation/navigation-utils.ts
+++ b/apps/app/src/react-app/domains/navigation/navigation-utils.ts
@@ -1,0 +1,105 @@
+// Helpers puros de navegação hierárquica (Core) — testáveis, sem DOM.
+import type { NavigationNode } from "./navigation-types";
+
+/** Ativo quando a rota atual casa com o nó (module: igual; pai: prefixo). */
+export function isNodeRouteActive(node: NavigationNode, pathname: string): boolean {
+  if (!node.route) return false;
+  const route = node.route.replace(/\/+$/, "");
+  if (node.type === "module") return pathname === route;
+  return pathname === route || pathname.startsWith(`${route}/`);
+}
+
+/** Algum descendente (direto ou indireto) está ativo na rota atual. */
+export function hasActiveDescendant(node: NavigationNode, pathname: string): boolean {
+  if (!node.children?.length) return false;
+  return node.children.some(
+    (child) => isNodeRouteActive(child, pathname) || hasActiveDescendant(child, pathname),
+  );
+}
+
+/** O nó (ou um descendente) está ativo — usado para destacar e auto-expandir. */
+export function isNodeActive(node: NavigationNode, pathname: string): boolean {
+  return isNodeRouteActive(node, pathname) || hasActiveDescendant(node, pathname);
+}
+
+/** Achata ids de todos os nós (útil para debug/tests). */
+export function collectNodeIds(nodes: NavigationNode[]): string[] {
+  const out: string[] = [];
+  for (const node of nodes) {
+    out.push(node.id);
+    if (node.children?.length) out.push(...collectNodeIds(node.children));
+  }
+  return out;
+}
+
+/**
+ * Nível de retorno da navegação de um domínio (Core genérico).
+ *  - "internal": existe um nível anterior DENTRO do domínio (ancestral com rota própria).
+ *  - "external": o nível atual já é o topo do domínio; voltar = sair da navegação de domínios.
+ *  - "none": a rota atual não corresponde a nenhum nó do domínio (sem nível anterior válido).
+ */
+export type DomainNavigationBackTarget =
+  | { kind: "none" }
+  | { kind: "internal"; label: string; route: string }
+  | { kind: "external" };
+
+function normalizePath(value: string): string {
+  const trimmed = value.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+}
+
+/**
+ * Caminho da raiz até o nó mais profundo cuja rota "hospeda" a rota atual
+ * (casamento exato primeiro; quando não há exato, o prefixo mais profundo).
+ * Nós agrupadores sem rota (group) nunca são o nó ativo terminal.
+ */
+export function findActiveNavigationPath(
+  nodes: NavigationNode[],
+  pathname: string,
+): NavigationNode[] {
+  const target = normalizePath(pathname);
+  let best: NavigationNode[] = [];
+
+  const visit = (list: NavigationNode[], trail: NavigationNode[]) => {
+    for (const node of list) {
+      const nextTrail = trail.length === 0 ? [node] : [...trail, node];
+      const route = node.route?.replace(/\/+$/, "");
+      if (route) {
+        const hosts =
+          route === target || (target.length > route.length && target.startsWith(`${route}/`));
+        if (hosts && nextTrail.length > best.length) best = nextTrail;
+      }
+      if (node.children?.length) visit(node.children, nextTrail);
+    }
+  };
+
+  visit(nodes, []);
+  return best;
+}
+
+/**
+ * Determina o nível anterior de uma rota de domínio a partir APENAS da árvore
+ * declarativa e da rota atual (sem estado duplicado). Sobe do nó ativo até o
+ * ancestral mais próximo que possua rota própria distinta da rota atual:
+ *  - módulo/entidade interna → "internal" (rota do ancestral);
+ *  - topo do domínio (raiz/home, sem ancestral navegável distinto) → "external";
+ *  - rota sem nó correspondente → "none".
+ */
+export function resolveNavigationUpLevel(
+  nodes: NavigationNode[],
+  pathname: string,
+): DomainNavigationBackTarget {
+  const path = findActiveNavigationPath(nodes, pathname);
+  if (path.length === 0) return { kind: "none" };
+
+  const activeRoute = normalizePath(path[path.length - 1].route ?? "");
+  for (let index = path.length - 2; index >= 0; index -= 1) {
+    const ancestor = path[index];
+    const ancestorRoute = ancestor.route?.replace(/\/+$/, "");
+    if (ancestorRoute && ancestorRoute !== activeRoute) {
+      return { kind: "internal", label: ancestor.label, route: ancestorRoute };
+    }
+  }
+
+  return { kind: "external" };
+}

--- a/apps/app/src/react-app/domains/navigation/sidebar-navigation.tsx
+++ b/apps/app/src/react-app/domains/navigation/sidebar-navigation.tsx
@@ -1,0 +1,119 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import { ChevronRight } from "lucide-react";
+import { useLocation, useNavigate } from "react-router";
+import { cn } from "@/lib/utils";
+import { useNavigationState } from "./navigation-state";
+import type { NavigationNode, NavigationNodeType } from "./navigation-types";
+import { isNodeActive, hasActiveDescendant } from "./navigation-utils";
+
+/**
+ * RENDERER GENÉRICO da árvore de navegação do Core.
+ *
+ * Fluxo: Navigation Data (NavigationNode[]) → SidebarNavigationList (recursivo) → DOM nativo
+ * da sidebar (tokens de sidebar do OpenWork). NÃO conhece Engenharia/Obra/EAP.
+ *
+ * FASE 04.2-D (correção VISUAL): a hierarquia é reforçada de forma GENÉRICA —
+ *  - tipografia/ênfase por tipo de nó (domain / group / entity / module);
+ *  - indentação com guia vertical crescente por profundidade;
+ *  - item ativo sempre destacado, independente do tipo.
+ * Nenhuma regra de domínio foi adicionada; a diferenciação vem da estrutura de dados.
+ */
+
+const NAV_ROW_CLASS =
+  "group/navrow flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+
+/** Estilo dos nós INATIVOS por tipo (propriedades genéricas de apresentação). */
+const TYPED_TEXT_CLASS: Record<NavigationNodeType, string> = {
+  domain: "text-[13px] font-semibold text-sidebar-foreground",
+  group: "text-[11px] font-semibold uppercase tracking-[0.14em] text-sidebar-foreground/70",
+  entity: "text-[13px] font-medium text-sidebar-foreground/90",
+  module: "text-[13px] text-sidebar-foreground/80",
+};
+
+/** Item ativo: destaque uniforme em qualquer nível. */
+const ACTIVE_TEXT_CLASS = "font-semibold text-foreground";
+
+export function SidebarNavigationList({
+  nodes,
+  depth = 0,
+}: {
+  nodes: NavigationNode[];
+  depth?: number;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5" data-nav-depth={depth}>
+      {nodes.map((node) => (
+        <SidebarNavNode key={node.id} node={node} depth={depth} />
+      ))}
+    </div>
+  );
+}
+
+function SidebarNavNode({ node, depth }: { node: NavigationNode; depth: number }) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const expandedNodeIds = useNavigationState((s) => s.expandedNodeIds);
+  const toggleNode = useNavigationState((s) => s.toggleNode);
+  const expandNode = useNavigationState((s) => s.expandNode);
+
+  const hasChildren = Boolean(node.children?.length);
+  const active = isNodeActive(node, pathname);
+  const expanded = expandedNodeIds.includes(node.id);
+
+  // Auto-expande nós com descendente ativo (ex.: rota recarregada /obra/.../eap).
+  React.useEffect(() => {
+    if (hasChildren && hasActiveDescendant(node, pathname) && !expanded) {
+      expandNode(node.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, hasChildren, node.id]);
+
+  const handleClick = () => {
+    if (hasChildren) {
+      toggleNode(node.id);
+      return;
+    }
+    if (node.route) navigate(node.route);
+  };
+
+  const textClass = active ? ACTIVE_TEXT_CLASS : TYPED_TEXT_CLASS[node.type];
+
+  const rowClassName = cn(
+    NAV_ROW_CLASS,
+    textClass,
+    // FASE 04.2-D: nós agrupadores/domínio ganham leve separação superior quando
+    // aninhados (diferencia visualmente coletivo/entidade sem tocar nos dados).
+    depth === 0 && "mt-1 first:mt-0",
+    active && "bg-sidebar-accent",
+  );
+
+  return (
+    <div data-nav-node={node.id} data-nav-type={node.type}>
+      <button
+        type="button"
+        aria-expanded={hasChildren ? expanded : undefined}
+        className={rowClassName}
+        onClick={handleClick}
+        title={node.route ? node.label : `${node.label} (grupo)`}
+      >
+        <span className="min-w-0 flex-1 truncate text-left">{node.label}</span>
+        {hasChildren ? (
+          <ChevronRight
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform duration-200",
+              expanded && "rotate-90",
+            )}
+          />
+        ) : null}
+      </button>
+
+      {hasChildren && expanded ? (
+        <div className="ms-2.5 border-l-2 border-sidebar-border/60 ps-2.5">
+          <SidebarNavigationList nodes={node.children ?? []} depth={depth + 1} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+

--- a/apps/app/src/react-app/domains/planejamento/planning-dashboard.tsx
+++ b/apps/app/src/react-app/domains/planejamento/planning-dashboard.tsx
@@ -1,0 +1,277 @@
+/** @jsxImportSource react */
+import { useMemo, useRef, useState } from "react";
+import { Search } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import {
+  derivePlanningAlerts,
+  derivePlanningRows,
+  derivePlanningSummary,
+  planningRowsForQuery,
+  resolvePlanningPeriods,
+} from "./planning-data";
+import { PlanningItemDetails } from "./planning-details";
+import { PlanningHelp } from "./planning-help";
+import { PlanningTimeline } from "./planning-timeline";
+import { PlanningTree } from "./planning-tree";
+import type {
+  PlanningAlert,
+  PlanningDashboardData,
+  PlanningSummary,
+} from "./planning-types";
+
+/** Alturas fixas compartilhadas (árvore/timeline alinhadas linha a linha). */
+export const PLANNING_ROW_HEIGHT = 36;
+export const PLANNING_AXIS_HEIGHT = 30;
+
+function KpiCard({ label, value, tone }: { label: string; value: number; tone?: string }) {
+  return (
+    <Card className="min-w-0">
+      <CardContent className="flex items-baseline justify-between gap-3 py-3">
+        <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </span>
+        <span className={cn("text-2xl font-bold tabular-nums", tone)}>{value}</span>
+      </CardContent>
+    </Card>
+  );
+}
+
+function summaryToCards(summary: PlanningSummary) {
+  return [
+    { id: "kpi-total", label: "Total", value: summary.total, tone: undefined },
+    { id: "kpi-em-andamento", label: "Em andamento", value: summary.emAndamento, tone: "text-sky-600" },
+    { id: "kpi-atencao", label: "Atenção", value: summary.atencao, tone: "text-amber-600" },
+    { id: "kpi-concluidos", label: "Concluídos", value: summary.concluidos, tone: "text-emerald-600" },
+  ] as const;
+}
+
+const ALERT_TONE: Record<PlanningAlert["severity"], { label: string; className: string }> = {
+  warning: { label: "Atenção", className: "border-amber-500/40 bg-amber-500/5" },
+  info: { label: "Info", className: "border-sky-500/40 bg-sky-500/5" },
+  success: { label: "OK", className: "border-emerald-500/40 bg-emerald-500/5" },
+};
+
+export function PlanningDashboard({
+  data,
+  className,
+}: {
+  data: PlanningDashboardData;
+  className?: string;
+}) {
+  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(new Set());
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const treeScrollRef = useRef<HTMLDivElement | null>(null);
+  const timelineScrollRef = useRef<HTMLDivElement | null>(null);
+
+  const items = data.items;
+  const periods = useMemo(() => resolvePlanningPeriods(data), [data]);
+  const collapsedRows = useMemo(
+    () => derivePlanningRows(items, collapsedIds),
+    [items, collapsedIds],
+  );
+  const rows = useMemo(() => {
+    const q = query.trim();
+    return q ? planningRowsForQuery(items, q) : collapsedRows;
+  }, [items, query, collapsedRows]);
+  const summary = useMemo(() => derivePlanningSummary(data), [data]);
+  const alerts = useMemo(() => derivePlanningAlerts(data), [data]);
+  const byId = useMemo(
+    () => new Map(items.map((item) => [item.id, item])),
+    [items],
+  );
+
+  const selectedItem = selectedId ? byId.get(selectedId) ?? null : null;
+  const parentName = selectedItem?.parentId
+    ? byId.get(selectedItem.parentId)?.name ?? null
+    : null;
+
+  const toggleCollapse = (id: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const syncScrollToTree = (scrollTop: number) => {
+    if (treeScrollRef.current) treeScrollRef.current.scrollTop = scrollTop;
+  };
+  const syncScrollToTimeline = (scrollTop: number) => {
+    if (timelineScrollRef.current) timelineScrollRef.current.scrollTop = scrollTop;
+  };
+
+  const kpiCards = summaryToCards(summary);
+  const empty = items.length === 0;
+
+  return (
+    <div
+      data-planning-dashboard
+      className={cn("flex h-full w-full min-h-0 flex-col gap-3", className)}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-lg font-semibold leading-tight">
+            {data.context.title}
+          </h2>
+          {data.context.subtitle ? (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {data.context.subtitle}
+            </p>
+          ) : null}
+        </div>
+        <PlanningHelp />
+      </header>
+
+      {empty ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>Sem itens de planejamento</EmptyTitle>
+          </EmptyHeader>
+          <EmptyDescription>
+            Este planejamento ainda não possui itens para exibir.
+          </EmptyDescription>
+        </Empty>
+      ) : (
+        <>
+          {/* Resumo (KPIs derivados) */}
+          <div className="grid grid-cols-2 gap-2 lg:grid-cols-4" aria-label="Resumo">
+            {kpiCards.map((kpi) => (
+              <div key={kpi.id} data-kpi={kpi.id}>
+                <KpiCard label={kpi.label} value={kpi.value} tone={kpi.tone} />
+              </div>
+            ))}
+          </div>
+
+          {/* Busca por nome */}
+          <div className="relative max-w-sm">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+            <Input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Buscar por nome…"
+              aria-label="Buscar no planejamento"
+              className="pl-8"
+            />
+          </div>
+          {/* Árvore + Timeline (linhas sincronizadas) */}
+          <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
+            <div className="flex h-full min-h-0">
+              <div
+                ref={treeScrollRef}
+                data-planning-tree-scroll
+                className="w-[320px] min-w-[220px] max-w-[45%] shrink-0 overflow-y-auto border-r border-border/70"
+                onScroll={(event) => syncScrollToTimeline(event.currentTarget.scrollTop)}
+              >
+                <PlanningTree
+                  rows={rows}
+                  selectedId={selectedId}
+                  onSelect={setSelectedId}
+                  onToggle={toggleCollapse}
+                  rowHeight={PLANNING_ROW_HEIGHT}
+                  axisHeight={PLANNING_AXIS_HEIGHT}
+                />
+              </div>
+              <div
+                ref={timelineScrollRef}
+                data-planning-timeline-scroll
+                className="min-w-0 flex-1 overflow-auto"
+                onScroll={(event) => syncScrollToTree(event.currentTarget.scrollTop)}
+              >
+                <PlanningTimeline
+                  rows={rows}
+                  periods={periods}
+                  selectedId={selectedId}
+                  onSelect={setSelectedId}
+                  rowHeight={PLANNING_ROW_HEIGHT}
+                  axisHeight={PLANNING_AXIS_HEIGHT}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Alertas derivados */}
+          <section className="shrink-0" aria-label="Alertas do planejamento">
+            <div className="mb-1 flex items-center gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Alertas
+              </h3>
+              {alerts.length > 0 ? <Badge variant="outline">{alerts.length}</Badge> : null}
+            </div>
+            {alerts.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                Nenhum alerta derivado dos dados.
+              </p>
+            ) : (
+              <div className="flex max-h-28 flex-col gap-1 overflow-y-auto pr-1">
+                {alerts.map((alert) => {
+                  const tone = ALERT_TONE[alert.severity];
+                  return (
+                    <div
+                      key={alert.id}
+                      data-alert={alert.id}
+                      className={cn(
+                        "flex items-start gap-2 rounded-md border px-2.5 py-1.5 text-xs",
+                        tone.className,
+                      )}
+                    >
+                      <span className="mt-0.5 shrink-0 font-semibold uppercase tracking-wide">
+                        {tone.label}
+                      </span>
+                      <span className="min-w-0">
+                        <span className="font-medium">{alert.title}</span>
+                        <span className="text-muted-foreground"> — {alert.detail}</span>
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+          {/* Detalhes do item selecionado */}
+          <Sheet
+            open={selectedItem !== null}
+            onOpenChange={(open) => {
+              if (!open) setSelectedId(null);
+            }}
+          >
+            <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
+              {selectedItem ? (
+                <>
+                  <SheetHeader>
+                    <SheetTitle>{selectedItem.name}</SheetTitle>
+                    <SheetDescription>
+                      Detalhes do item selecionado no planejamento.
+                    </SheetDescription>
+                  </SheetHeader>
+                  <div className="px-4 py-4">
+                    <PlanningItemDetails item={selectedItem} parentName={parentName} />
+                  </div>
+                </>
+              ) : null}
+            </SheetContent>
+          </Sheet>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/planejamento/planning-data.ts
+++ b/apps/app/src/react-app/domains/planejamento/planning-data.ts
@@ -1,0 +1,327 @@
+// Helpers puros da capacidade de Planejamento (V1) — sem DOM, testáveis.
+// Tudo aqui é DERIVADO dos dados; nada é inventado pelo componente.
+import type {
+  PlanningAlert,
+  PlanningDashboardData,
+  PlanningItem,
+  PlanningPeriod,
+  PlanningRow,
+  PlanningSummary,
+} from "./planning-types";
+
+/** Converte "yyyy-mm-dd" em Date (timezone local). Retorna null se inválido. */
+export function parseIsoDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(value.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function toIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+const DAY_MS = 86_400_000;
+
+/** Data de referência para alertas (contexto → hoje). */
+export function planningReferenceDate(data: PlanningDashboardData): Date {
+  return parseIsoDate(data.context.referenceDate) ?? new Date();
+}
+
+// ------------------------------------------------------------------ //
+// Hierarquia / linhas visíveis
+// ------------------------------------------------------------------ //
+
+/** Mapa parentId -> filhos na ordem declarada. */
+export function buildPlanningChildrenIndex(
+  items: PlanningItem[],
+): Map<string, PlanningItem[]> {
+  const byParent = new Map<string, PlanningItem[]>();
+  for (const item of items) {
+    const key = item.parentId ?? "";
+    const list = byParent.get(key) ?? [];
+    list.push(item);
+    byParent.set(key, list);
+  }
+  return byParent;
+}
+
+/** Ids dos nós raiz (parentId ausente ou sem nó correspondente). */
+export function planningRootIds(
+  items: PlanningItem[],
+  byParent?: Map<string, PlanningItem[]>,
+): string[] {
+  const children = byParent ?? buildPlanningChildrenIndex(items);
+  const ids = new Set(items.map((item) => item.id));
+  const roots: string[] = [];
+  for (const item of items) {
+    const parentMissing =
+      !item.parentId || !ids.has(item.parentId) || !children.has(item.parentId);
+    if (parentMissing) roots.push(item.id);
+  }
+  return roots;
+}
+
+/**
+ * Linhas visíveis em ordem de árvore (DFS, pré-order) respeitando o conjunto de
+ * nós recolhidos. Árvore e timeline consomem a MESMA lista (alinhamento 1:1).
+ */
+export function derivePlanningRows(
+  items: PlanningItem[],
+  collapsedIds: ReadonlySet<string>,
+): PlanningRow[] {
+  const byId = new Map(items.map((item) => [item.id, item]));
+  const children = buildPlanningChildrenIndex(items);
+  const rows: PlanningRow[] = [];
+
+  const visit = (id: string) => {
+    const item = byId.get(id);
+    if (!item) return;
+    const kids = children.get(id) ?? [];
+    const expanded = !collapsedIds.has(id);
+    rows.push({
+      item,
+      depth: item.level,
+      hasChildren: kids.length > 0,
+      expanded,
+    });
+    if (kids.length > 0 && expanded) {
+      for (const kid of kids) visit(kid.id);
+    }
+  };
+
+  for (const rootId of planningRootIds(items, children)) visit(rootId);
+  return rows;
+}
+
+/**
+ * Filtro de busca por nome mantendo a hierarquia: um nó só aparece se ele
+ * (ou algum descendente) casa com o texto; ancestrais de nós casados também
+ * são mantidos. Durante a busca a estrutura é revelada (colapso ignorado).
+ */
+export function planningRowsForQuery(
+  items: PlanningItem[],
+  query: string,
+): PlanningRow[] {
+  const q = query.trim().toLocaleLowerCase();
+  if (!q) return derivePlanningRows(items, new Set());
+  const children = buildPlanningChildrenIndex(items);
+  const byId = new Map(items.map((item) => [item.id, item]));
+
+  const matches: Record<string, boolean> = {};
+  for (const item of items) {
+    matches[item.id] = item.name.toLocaleLowerCase().includes(q);
+  }
+
+  const hasMatchBelow = (id: string): boolean => {
+    if (matches[id]) return true;
+    const kids = children.get(id) ?? [];
+    return kids.some((kid) => hasMatchBelow(kid.id));
+  };
+
+  const visibleIds = new Set<string>();
+  const propagateUp = (id: string) => {
+    if (visibleIds.has(id)) return;
+    visibleIds.add(id);
+    const item = byId.get(id);
+    if (item?.parentId) propagateUp(item.parentId);
+  };
+  for (const item of items) {
+    if (matches[item.id]) propagateUp(item.id);
+  }
+
+  const rows: PlanningRow[] = [];
+  const visit = (id: string) => {
+    const item = byId.get(id);
+    if (!item) return;
+    const kids = (children.get(id) ?? []).filter((kid) => visibleIds.has(kid.id));
+    rows.push({
+      item,
+      depth: item.level,
+      hasChildren: kids.length > 0,
+      expanded: true,
+    });
+    for (const kid of kids) visit(kid.id);
+  };
+  for (const rootId of planningRootIds(items, children)) {
+    if (visibleIds.has(rootId) || hasMatchBelow(rootId)) visit(rootId);
+  }
+  return rows;
+}
+
+// ------------------------------------------------------------------ //
+// Resumo (KPIs derivados)
+// ------------------------------------------------------------------ //
+
+export function derivePlanningSummary(
+  data: PlanningDashboardData,
+  referenceDate?: Date,
+): PlanningSummary {
+  const ref = referenceDate ?? planningReferenceDate(data);
+  const items = data.items;
+  const emAndamento = items.filter((item) => item.status === "em_andamento").length;
+  const concluidos = items.filter((item) => item.status === "concluido").length;
+  const atencao = items.filter((item) => {
+    if (item.status === "atrasado") return true;
+    if (item.status !== "em_andamento") return false;
+    const end = parseIsoDate(item.end);
+    return end !== null && ref !== null && end.getTime() < ref.getTime();
+  }).length;
+  return {
+    total: items.length,
+    emAndamento,
+    atencao,
+    concluidos,
+  };
+}
+
+// ------------------------------------------------------------------ //
+// Alertas (derivados dos dados)
+// ------------------------------------------------------------------ //
+
+export function derivePlanningAlerts(
+  data: PlanningDashboardData,
+  referenceDate?: Date,
+): PlanningAlert[] {
+  const ref = referenceDate ?? planningReferenceDate(data);
+  const children = buildPlanningChildrenIndex(data.items);
+  const alerts: PlanningAlert[] = [];
+
+  for (const item of data.items) {
+    const hasChildren = (children.get(item.id) ?? []).length > 0;
+    const start = parseIsoDate(item.start);
+    const end = parseIsoDate(item.end);
+
+    if (!hasChildren && !start && !end) {
+      alerts.push({
+        id: `sem-periodo:${item.id}`,
+        severity: "warning",
+        title: "Sem período",
+        detail: `"${item.name}" não possui início e fim definidos.`,
+        itemId: item.id,
+      });
+      continue;
+    }
+    if (item.status === "atrasado") {
+      alerts.push({
+        id: `atrasado:${item.id}`,
+        severity: "warning",
+        title: "Atrasado",
+        detail: `"${item.name}" está marcado como atrasado.`,
+        itemId: item.id,
+      });
+    } else if (
+      item.status === "em_andamento" &&
+      end !== null &&
+      ref !== null &&
+      end.getTime() < ref.getTime()
+    ) {
+      alerts.push({
+        id: `atencao:${item.id}`,
+        severity: "warning",
+        title: "Em atenção",
+        detail: `"${item.name}" tem fim previsto em ${item.end} e ainda não foi concluído.`,
+        itemId: item.id,
+      });
+    }
+    if (item.status === "concluido") {
+      alerts.push({
+        id: `concluido:${item.id}`,
+        severity: "success",
+        title: "Concluído",
+        detail: `"${item.name}" foi concluído.`,
+        itemId: item.id,
+      });
+    } else if (item.progress >= 100) {
+      alerts.push({
+        id: `progresso-sem-conclusao:${item.id}`,
+        severity: "info",
+        title: "Progresso sem conclusão",
+        detail: `"${item.name}" está com progresso 100% mas não marcado como concluído.`,
+        itemId: item.id,
+      });
+    }
+  }
+
+  const order: Record<PlanningAlert["severity"], number> = {
+    warning: 0,
+    info: 1,
+    success: 2,
+  };
+  return alerts.sort((a, b) => order[a.severity] - order[b.severity]);
+}
+
+// ------------------------------------------------------------------ //
+// Períodos / eixo temporal
+// ------------------------------------------------------------------ //
+
+/**
+ * Deriva o eixo mensal que cobre o intervalo [menor início, maior fim] dos
+ * itens com datas. Quando não há datas, retorna []. Rótulo = mês curto.
+ */
+export function derivePlanningPeriods(items: PlanningItem[]): PlanningPeriod[] {
+  const starts: Date[] = [];
+  const ends: Date[] = [];
+  for (const item of items) {
+    const start = parseIsoDate(item.start);
+    const end = parseIsoDate(item.end);
+    if (start) starts.push(start);
+    if (end) ends.push(end);
+  }
+  if (starts.length === 0 || ends.length === 0) return [];
+
+  const min = new Date(Math.min(...starts.map((d) => d.getTime())));
+  const max = new Date(Math.max(...ends.map((d) => d.getTime())));
+  const first = new Date(min.getFullYear(), min.getMonth(), 1);
+  const last = new Date(max.getFullYear(), max.getMonth() + 1, 0);
+
+  const months: PlanningPeriod[] = [];
+  const cursor = new Date(first);
+  const MONTH_LABELS = [
+    "Jan", "Fev", "Mar", "Abr", "Mai", "Jun",
+    "Jul", "Ago", "Set", "Out", "Nov", "Dez",
+  ];
+  while (cursor.getTime() <= last.getTime()) {
+    const monthEnd = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0);
+    months.push({
+      id: `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`,
+      label: MONTH_LABELS[cursor.getMonth()],
+      start: toIso(cursor),
+      end: toIso(monthEnd),
+    });
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+  return months;
+}
+
+/** Normaliza o eixo: usa os períodos do contrato ou deriva dos itens. */
+export function resolvePlanningPeriods(
+  data: PlanningDashboardData,
+): PlanningPeriod[] {
+  return data.periods && data.periods.length > 0
+    ? data.periods
+    : derivePlanningPeriods(data.items);
+}
+
+/** Dias corridos entre duas datas ISO (inclusive início). Negativo se fora de ordem. */
+export function daysBetween(startIso: string, endIso: string): number {
+  const start = parseIsoDate(startIso);
+  const end = parseIsoDate(endIso);
+  if (!start || !end) return 0;
+  return Math.round((end.getTime() - start.getTime()) / DAY_MS);
+}

--- a/apps/app/src/react-app/domains/planejamento/planning-demo-data.ts
+++ b/apps/app/src/react-app/domains/planejamento/planning-demo-data.ts
@@ -1,0 +1,142 @@
+// Dados DEMONSTRATIVOS da capacidade de Planejamento (V1).
+// Declarativos, locais, determinísticos e NEUTROS — nenhum conceito específico
+// de construção ou de um domínio consumidor aparece aqui. Este arquivo será
+// substituído por dados reais (adapter do domínio) em fase futura, sem tocar
+// na Dashboard.
+import type { PlanningDashboardData } from "./planning-types";
+
+/**
+ * Dataset ilustrativo: hierarquia Grupo → Pacote → Atividade com datas no
+ * período Jun–Set de 2026 e data de referência fixa (alertas determinísticos).
+ */
+export const PLANNING_DEMO_DATA: PlanningDashboardData = {
+  context: {
+    title: "Planejamento",
+    subtitle: "Cronograma ilustrativo (dados de demonstração)",
+    referenceDate: "2026-08-15",
+  },
+  items: [
+    // Grupo A
+    {
+      id: "grupo-a",
+      parentId: null,
+      name: "Grupo A",
+      level: 0,
+      status: "planejado",
+      progress: 0,
+    },
+    {
+      id: "pacote-a-1",
+      parentId: "grupo-a",
+      name: "Pacote A.1",
+      level: 1,
+      status: "em_andamento",
+      progress: 55,
+      start: "2026-06-15",
+      end: "2026-08-20",
+    },
+    {
+      id: "atividade-01",
+      parentId: "pacote-a-1",
+      name: "Atividade 01",
+      level: 2,
+      status: "em_andamento",
+      progress: 80,
+      start: "2026-06-15",
+      end: "2026-07-30",
+    },
+    {
+      id: "atividade-02",
+      parentId: "pacote-a-1",
+      name: "Atividade 02",
+      level: 2,
+      status: "concluido",
+      progress: 100,
+      start: "2026-07-01",
+      end: "2026-07-25",
+    },
+    {
+      id: "atividade-03",
+      parentId: "pacote-a-1",
+      name: "Atividade 03",
+      level: 2,
+      status: "atrasado",
+      progress: 40,
+      start: "2026-07-20",
+      end: "2026-08-10",
+    },
+    {
+      id: "pacote-a-2",
+      parentId: "grupo-a",
+      name: "Pacote A.2",
+      level: 1,
+      status: "planejado",
+      progress: 0,
+      start: "2026-08-05",
+      end: "2026-09-30",
+    },
+    {
+      id: "atividade-04",
+      parentId: "pacote-a-2",
+      name: "Atividade 04",
+      level: 2,
+      status: "planejado",
+      progress: 0,
+      start: "2026-08-05",
+      end: "2026-09-05",
+    },
+    {
+      id: "atividade-05",
+      parentId: "pacote-a-2",
+      name: "Atividade 05",
+      level: 2,
+      status: "planejado",
+      progress: 0,
+    },
+    // Grupo B
+    {
+      id: "grupo-b",
+      parentId: null,
+      name: "Grupo B",
+      level: 0,
+      status: "planejado",
+      progress: 0,
+    },
+    {
+      id: "pacote-b-1",
+      parentId: "grupo-b",
+      name: "Pacote B.1",
+      level: 1,
+      status: "concluido",
+      progress: 100,
+      start: "2026-06-01",
+      end: "2026-06-30",
+    },
+    {
+      id: "atividade-06",
+      parentId: "pacote-b-1",
+      name: "Atividade 06",
+      level: 2,
+      status: "concluido",
+      progress: 100,
+      start: "2026-06-01",
+      end: "2026-06-28",
+    },
+    {
+      id: "pacote-b-2",
+      parentId: "grupo-b",
+      name: "Pacote B.2",
+      level: 1,
+      status: "planejado",
+      progress: 0,
+    },
+    {
+      id: "atividade-07",
+      parentId: "pacote-b-2",
+      name: "Atividade 07",
+      level: 2,
+      status: "em_andamento",
+      progress: 35,
+    },
+  ],
+};

--- a/apps/app/src/react-app/domains/planejamento/planning-details.tsx
+++ b/apps/app/src/react-app/domains/planejamento/planning-details.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource react */
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import type { PlanningItem, PlanningItemStatus } from "./planning-types";
+
+/** Rótulos neutros de status (genéricos, sem domínio). */
+export const PLANNING_STATUS_LABELS: Record<PlanningItemStatus, string> = {
+  planejado: "Planejado",
+  em_andamento: "Em andamento",
+  atrasado: "Atrasado",
+  concluido: "Concluído",
+};
+
+export function formatPlanningDate(iso?: string | null): string {
+  if (!iso) return "—";
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(iso);
+  if (!match) return iso;
+  return `${match[3]}/${match[2]}/${match[1]}`;
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-border/60 py-2 text-sm last:border-b-0">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Conteúdo do painel de detalhes de um item (V1, somente leitura).
+ * Exportado separadamente para testes SSR independentes do Sheet.
+ */
+export function PlanningItemDetails({
+  item,
+  parentName,
+}: {
+  item: PlanningItem;
+  parentName?: string | null;
+}) {
+  return (
+    <div data-planning-details className="flex flex-col">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {parentName ? `Nível ${item.level + 1} · em ${parentName}` : `Nível ${item.level + 1}`}
+        </span>
+        <Badge variant="outline">{PLANNING_STATUS_LABELS[item.status]}</Badge>
+      </div>
+
+      <div className="py-2">
+        <div className="mb-1.5 flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Progresso</span>
+          <span className="tabular-nums font-medium">{Math.round(item.progress)}%</span>
+        </div>
+        <Progress value={Math.round(item.progress)} className="w-full" />
+      </div>
+
+      <div className="flex flex-col">
+        <DetailRow label="Nome" value={item.name} />
+        <DetailRow label="Status" value={PLANNING_STATUS_LABELS[item.status]} />
+        <DetailRow label="Progresso" value={`${Math.round(item.progress)}%`} />
+        <DetailRow label="Início" value={formatPlanningDate(item.start)} />
+        <DetailRow label="Fim" value={formatPlanningDate(item.end)} />
+        <DetailRow label="Nível" value={String(item.level + 1)} />
+        {parentName ? <DetailRow label="Pai" value={parentName} /> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/planejamento/planning-help.tsx
+++ b/apps/app/src/react-app/domains/planejamento/planning-help.tsx
@@ -1,0 +1,70 @@
+/** @jsxImportSource react */
+import { Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+/**
+ * Ajuda contextual da capacidade de Planejamento (V1).
+ * O conteúdo é fornecido como DADOS (PlanningHelpSection[]) — o componente é
+ * genérico e não conhece domínios. Em fases futuras, cada módulo poderá
+ * fornecer o próprio conteúdo sem o Core conhecer o domínio.
+ */
+
+export type PlanningHelpSection = {
+  question: string;
+  answer: string;
+};
+
+export const PLANNING_HELP_SECTIONS: PlanningHelpSection[] = [
+  {
+    question: "O que é?",
+    answer: "Uma visão integrada do planejamento.",
+  },
+  {
+    question: "Para que serve?",
+    answer:
+      "Para acompanhar estrutura, andamento, período e pontos de atenção.",
+  },
+  {
+    question: "Como funciona?",
+    answer:
+      "A árvore mostra a estrutura; a timeline mostra o período; o resumo mostra indicadores; os alertas destacam situações que merecem atenção.",
+  },
+  {
+    question: "O que devo fazer?",
+    answer: "Selecionar um item para consultar seus detalhes.",
+  },
+];
+
+export function PlanningHelp({
+  sections = PLANNING_HELP_SECTIONS,
+}: {
+  sections?: PlanningHelpSection[];
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={<Button type="button" variant="ghost" size="icon" />}
+        aria-label="Ajuda: Planejamento"
+      >
+        <Info className="size-4" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent className="w-80" align="start">
+        <div className="flex flex-col gap-3">
+          <div className="text-sm font-semibold">Planejamento</div>
+          {sections.map((section) => (
+            <div key={section.question} className="flex flex-col gap-0.5">
+              <div className="text-xs font-medium text-foreground">
+                {section.question}
+              </div>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {section.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/react-app/domains/planejamento/planning-timeline.tsx
+++ b/apps/app/src/react-app/domains/planejamento/planning-timeline.tsx
@@ -1,0 +1,139 @@
+/** @jsxImportSource react */
+import { cn } from "@/lib/utils";
+import {
+  daysBetween,
+  parseIsoDate,
+} from "./planning-data";
+import type { PlanningPeriod, PlanningRow } from "./planning-types";
+
+/**
+ * Timeline simples da capacidade de Planejamento (V1).
+ * Visualização temporal derivada de start/end/periods — NÃO é um Gantt e não
+ * contém dependências, arraste ou agendamento. O conteúdo possui largura
+ * proporcional aos dias; o scroll é controlado pelo contêiner da Dashboard.
+ */
+
+const BAR_CLASSES: Record<PlanningRow["item"]["status"], string> = {
+  planejado: "bg-slate-400/80",
+  em_andamento: "bg-primary",
+  atrasado: "bg-destructive",
+  concluido: "bg-emerald-500",
+};
+
+function barClass(status: PlanningRow["item"]["status"]): string {
+  return BAR_CLASSES[status];
+}
+
+export function PlanningTimeline({
+  rows,
+  periods,
+  selectedId,
+  onSelect,
+  rowHeight,
+  axisHeight,
+  dayWidth = 3,
+}: {
+  rows: PlanningRow[];
+  periods: PlanningPeriod[];
+  selectedId?: string | null;
+  onSelect: (id: string) => void;
+  rowHeight: number;
+  axisHeight: number;
+  dayWidth?: number;
+}) {
+  const axisStart = periods.length > 0 ? parseIsoDate(periods[0].start) : null;
+  const axisEnd = periods.length > 0 ? parseIsoDate(periods[periods.length - 1].end) : null;
+  if (!axisStart || !axisEnd) {
+    return (
+      <div
+        data-planning-timeline
+        className="flex items-center justify-center text-xs text-muted-foreground"
+        style={{ height: 120 }}
+      >
+        Nenhum período com data para exibir.
+      </div>
+    );
+  }
+
+  const axisDays = daysBetween(
+    periods[0].start,
+    periods[periods.length - 1].end,
+  );
+  const contentWidth = Math.max(1, (axisDays + 1) * dayWidth + 12);
+
+  const xOf = (iso: string): number => daysBetween(periods[0].start, iso) * dayWidth;
+
+  return (
+    <div
+      data-planning-timeline
+      className="relative"
+      style={{ width: contentWidth }}
+    >
+      {/* Eixo temporal (meses) */}
+      <div
+        aria-hidden="true"
+        className="sticky top-0 z-10 border-b border-border bg-background/95 backdrop-blur"
+        style={{ height: axisHeight }}
+      >
+        {periods.map((period) => {
+          const width = (daysBetween(period.start, period.end) + 1) * dayWidth;
+          return (
+            <div
+              key={period.id}
+              className="absolute top-0 flex h-full items-center justify-center overflow-hidden border-r border-border/60 px-1 text-[11px] font-medium text-muted-foreground"
+              style={{ left: xOf(period.start), width }}
+            >
+              {period.label}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Linhas com barras por item (mesma ordem das linhas da árvore) */}
+      {rows.map((row, index) => {
+        const { item } = row;
+        const start = parseIsoDate(item.start);
+        const end = parseIsoDate(item.end);
+        const hasPeriod = start !== null && end !== null;
+        const active = selectedId === item.id;
+        return (
+          <div
+            key={item.id}
+            data-planning-period-row={item.id}
+            className="relative border-b border-border/30"
+            style={{ height: rowHeight }}
+          >
+            {hasPeriod ? (
+              <button
+                type="button"
+                data-planning-bar={item.id}
+                aria-label={`${item.name}: ${item.start ?? ""} até ${item.end ?? ""}`}
+                className={cn(
+                  "absolute top-1/2 z-[1] -translate-y-1/2 cursor-pointer rounded-sm",
+                  barClass(item.status),
+                  active && "z-[2] ring-2 ring-ring ring-offset-1",
+                )}
+                style={{
+                  left: xOf(item.start ?? ""),
+                  width: Math.max(
+                    dayWidth,
+                    (daysBetween(item.start ?? "", item.end ?? "") + 1) * dayWidth,
+                  ),
+                  height: Math.max(10, rowHeight - 10),
+                }}
+                onClick={() => onSelect(item.id)}
+                title={`${item.name} · ${item.start} → ${item.end}`}
+              />
+            ) : null}
+            {index % 2 === 1 ? (
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-y-0 w-full bg-muted/20"
+              />
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/planejamento/planning-tree.tsx
+++ b/apps/app/src/react-app/domains/planejamento/planning-tree.tsx
@@ -1,0 +1,96 @@
+/** @jsxImportSource react */
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { PlanningRow } from "./planning-types";
+
+/**
+ * Árvore hierárquica da capacidade de Planejamento (V1).
+ * Recebe APENAS linhas prontas (derivePlanningRows) e eventos — nenhuma
+ * hierarquia é derivada aqui e nenhum domínio é conhecido.
+ */
+
+export function PlanningTree({
+  rows,
+  selectedId,
+  onSelect,
+  onToggle,
+  rowHeight,
+  axisHeight,
+}: {
+  rows: PlanningRow[];
+  selectedId?: string | null;
+  onSelect: (id: string) => void;
+  onToggle: (id: string) => void;
+  rowHeight: number;
+  /** Espaço reservado no topo para alinhar com o eixo da timeline. */
+  axisHeight: number;
+}) {
+  return (
+    <div
+      role="tree"
+      aria-label="Estrutura do planejamento"
+      data-planning-tree
+      className="min-w-full"
+    >
+      <div style={{ height: axisHeight }} aria-hidden="true" />
+      {rows.map((row) => {
+        const { item } = row;
+        const active = selectedId === item.id;
+        return (
+          <div
+            key={item.id}
+            role="treeitem"
+            aria-level={item.level + 1}
+            aria-expanded={row.hasChildren ? row.expanded : undefined}
+            aria-selected={active}
+            data-planning-row
+            data-planning-id={item.id}
+            style={{ height: rowHeight }}
+            className={cn(
+              "group/row flex cursor-pointer items-center gap-1 border-b border-border/40 pr-2 text-sm transition-colors",
+              active
+                ? "bg-sidebar-accent font-medium text-foreground"
+                : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
+            )}
+            onClick={() => onSelect(item.id)}
+          >
+            <span
+              aria-hidden="true"
+              className="shrink-0"
+              style={{ width: item.level * 14 + 4 }}
+            />
+            {row.hasChildren ? (
+              <button
+                type="button"
+                aria-label={row.expanded ? "Recolher" : "Expandir"}
+                data-planning-toggle={item.id}
+                className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-sidebar-accent"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggle(item.id);
+                }}
+              >
+                <ChevronRight
+                  className={cn(
+                    "size-3.5 transition-transform duration-150",
+                    row.expanded && "rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+            ) : (
+              <span aria-hidden="true" className="size-5 shrink-0" />
+            )}
+            <span className="min-w-0 flex-1 truncate text-left">{item.name}</span>
+            {item.progress > 0 ? (
+              <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                {Math.round(item.progress)}%
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/planejamento/planning-types.ts
+++ b/apps/app/src/react-app/domains/planejamento/planning-types.ts
@@ -1,0 +1,81 @@
+// Contrato da capacidade de Planejamento (V1) — genérico e reutilizável.
+// Este módulo NÃO conhece nenhum domínio consumidor nem entidade específica.
+// A Dashboard renderiza QUALQUER PlanningDashboardData fornecido por um adapter.
+
+export type PlanningItemStatus =
+  | "planejado"
+  | "em_andamento"
+  | "atrasado"
+  | "concluido";
+
+/** Item mínimo exibido na superfície V1. Datas opcionais: ausência vira alerta. */
+export type PlanningItem = {
+  id: string;
+  /** Pai na hierarquia (null/undefined = raiz). */
+  parentId?: string | null;
+  name: string;
+  /** Profundidade declarada (0 = raiz). Mantida do contrato para casos onde
+   *  o nível não pode ser derivado apenas de parentId. */
+  level: number;
+  status: PlanningItemStatus;
+  /** Progresso 0..100 (número já fornecido pelo adapter; nunca calculado aqui). */
+  progress: number;
+  /** ISO yyyy-mm-dd (inclusive). */
+  start?: string | null;
+  /** ISO yyyy-mm-dd (inclusive). */
+  end?: string | null;
+};
+
+/** Período do eixo temporal (ex.: um mês). */
+export type PlanningPeriod = {
+  id: string;
+  label: string;
+  start: string;
+  end: string;
+};
+
+export type PlanningContext = {
+  /** Título principal (ex.: "Planejamento"). */
+  title: string;
+  /** Detalhe do contexto fornecido pelo adapter do domínio. */
+  subtitle?: string;
+  /** Data de referência ISO para derivar alertas (default: hoje). */
+  referenceDate?: string;
+};
+
+/** Contrato V1 consumido pela Dashboard (ver docs da FASE 04.1). */
+export type PlanningDashboardData = {
+  context: PlanningContext;
+  items: PlanningItem[];
+  /** Eixo temporal opcional; quando ausente é derivado dos itens. */
+  periods?: PlanningPeriod[];
+};
+
+// ------------------------------------------------------------------ //
+// Estruturas DERIVADAS (produzidas por helpers puros, nunca no contrato)
+// ------------------------------------------------------------------ //
+
+export type PlanningSummary = {
+  total: number;
+  emAndamento: number;
+  atencao: number;
+  concluidos: number;
+};
+
+export type PlanningAlertSeverity = "info" | "warning" | "success";
+
+export type PlanningAlert = {
+  id: string;
+  severity: PlanningAlertSeverity;
+  title: string;
+  detail: string;
+  itemId?: string;
+};
+
+/** Linha pronta para renderização (árvore/timeline compartilham a mesma ordem). */
+export type PlanningRow = {
+  item: PlanningItem;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+};

--- a/apps/app/src/react-app/domains/servicos/servicos-data.ts
+++ b/apps/app/src/react-app/domains/servicos/servicos-data.ts
@@ -1,0 +1,22 @@
+// Helpers puros da capacidade de Serviços — sem DOM, testáveis.
+// Tudo aqui é DERIVADO dos dados fornecidos pelo adapter; nada é inventado.
+// FASE 21: contrato preparado para a FASE 22 (orçamento, medição, indicadores).
+import type { ServicosData, ServicosSummary } from "./servicos-types";
+
+/** Deriva o resumo (KPIs) a partir dos itens reais. */
+export function deriveServicosSummary(data: ServicosData): ServicosSummary {
+  let criticos = 0;
+  let sequenciais = 0;
+  let comDuracao = 0;
+  for (const item of data.items) {
+    if (item.status === "CRÍTICO") criticos += 1;
+    else if (item.status === "Sequencial") sequenciais += 1;
+    if (item.duracao > 0) comDuracao += 1;
+  }
+  return {
+    total: data.items.length,
+    criticos,
+    sequenciais,
+    comDuracao,
+  };
+}

--- a/apps/app/src/react-app/domains/servicos/servicos-help.tsx
+++ b/apps/app/src/react-app/domains/servicos/servicos-help.tsx
@@ -1,0 +1,55 @@
+/** @jsxImportSource react */
+import { Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+/** Seções de ajuda da capacidade de Serviços (genérica). */
+export const SERVICOS_HELP_SECTIONS = [
+  {
+    question: "O que é?",
+    answer:
+      "Serviços são os trabalhos (nível 3) da EAP com duração, datas e caminho crítico derivados do planejamento.",
+  },
+  {
+    question: "Para que serve?",
+    answer:
+      "Permite acompanhar cada serviço da obra, sua duração, período de execução e se é crítico para o cronograma.",
+  },
+  {
+    question: "Como funciona?",
+    answer:
+      "Os dados são derivados automaticamente da EAP e do planejamento da obra. Não há entrada manual nesta visão.",
+  },
+  {
+    question: "O que devo fazer?",
+    answer:
+      "Nesta fase, apenas visualize. Orçamento, medição e indicadores completos serão adicionados em fase futura.",
+  },
+] as const;
+
+export function ServicosHelp() {
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={<Button type="button" variant="ghost" size="icon" />}
+        aria-label="Ajuda: Serviços"
+      >
+        <Info className="size-4" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent className="w-80" align="start">
+        <div className="flex flex-col gap-3">
+          <div className="text-sm font-semibold">Serviços</div>
+          {SERVICOS_HELP_SECTIONS.map((section) => (
+            <div key={section.question} className="flex flex-col gap-0.5">
+              <div className="text-xs font-semibold">{section.question}</div>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {section.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/react-app/domains/servicos/servicos-table.tsx
+++ b/apps/app/src/react-app/domains/servicos/servicos-table.tsx
@@ -1,0 +1,122 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { deriveServicosSummary } from "./servicos-data";
+import { ServicosHelp } from "./servicos-help";
+import type { ServicosData } from "./servicos-types";
+
+/**
+ * Tabela de Serviços — capacidade genérica (FASE 21).
+ * Consome QUALQUER ServicosData fornecido por um adapter do domínio. KPIs
+ * derivados dos dados reais. Preparada para a FASE 22 (orçamento, medição).
+ */
+export function ServicosTable({ data }: { data: ServicosData }) {
+  const summary = useMemo(() => deriveServicosSummary(data), [data]);
+
+  if (data.items.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>{data.title}</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Nenhum serviço para exibir.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const kpis = [
+    { id: "kpi-total", label: "Total", value: summary.total },
+    { id: "kpi-com-duracao", label: "Com duração", value: summary.comDuracao },
+    { id: "kpi-criticos", label: "Críticos", value: summary.criticos, tone: "text-destructive" },
+    { id: "kpi-sequenciais", label: "Sequenciais", value: summary.sequenciais },
+  ];
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle>{data.title}</CardTitle>
+            {data.subtitle ? (
+              <CardDescription>{data.subtitle}</CardDescription>
+            ) : null}
+          </div>
+          <ServicosHelp />
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div
+            data-kpi-bar
+            className="grid grid-cols-2 gap-2 lg:grid-cols-4"
+            aria-label="Indicadores"
+          >
+            {kpis.map((kpi) => (
+              <Card key={kpi.id} className="min-w-0">
+                <CardContent className="flex flex-col gap-0.5 py-3">
+                  <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {kpi.label}
+                  </span>
+                  <span
+                    className={`text-2xl font-bold tabular-nums ${kpi.tone ?? ""}`}
+                    data-kpi={kpi.id}
+                  >
+                    {kpi.value}
+                  </span>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <div className="max-h-[70vh] overflow-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="py-1.5 pr-2 font-medium">WBS</th>
+                  <th className="py-1.5 pr-2 font-medium">Serviço</th>
+                  <th className="py-1.5 pr-2 font-medium">Duração</th>
+                  <th className="py-1.5 pr-2 font-medium">Início</th>
+                  <th className="py-1.5 pr-2 font-medium">Fim</th>
+                  <th className="py-1.5 font-medium">Crítico</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.items.map((item) => {
+                  const temData = item.duracao > 0;
+                  return (
+                    <tr key={item.id} className="border-b border-border/40">
+                      <td className="py-1.5 pr-2 font-mono text-xs text-muted-foreground">
+                        {item.codigo}
+                      </td>
+                      <td className="py-1.5 pr-2 font-medium">{item.nome}</td>
+                      <td className="py-1.5 pr-2 tabular-nums">
+                        {item.duracao > 0 ? `${item.duracao} d` : "—"}
+                      </td>
+                      <td className="py-1.5 pr-2 tabular-nums">
+                        {temData ? item.inicio : "—"}
+                      </td>
+                      <td className="py-1.5 pr-2 tabular-nums">
+                        {temData ? item.fim : "—"}
+                      </td>
+                      <td className="py-1.5">
+                        {item.status === "CRÍTICO" ? (
+                          <Badge variant="destructive">Crítico</Badge>
+                        ) : item.status === "Sequencial" ? (
+                          <Badge variant="outline">Sequencial</Badge>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/servicos/servicos-types.ts
+++ b/apps/app/src/react-app/domains/servicos/servicos-types.ts
@@ -1,0 +1,53 @@
+// Capacidade genérica de Serviços — contrato reutilizável (FASE 21).
+// Este módulo NÃO conhece nenhum domínio consumidor nem entidade específica.
+// A tabela renderiza QUALQUER ServicosData fornecido por um adapter do domínio.
+//
+// FASE 21: contrato criado PREPARADO para a FASE 22 (orçamento, medição,
+// indicadores). Os campos opcionais abaixo antecipam essas necessidades, mas
+// NENHUM número fictício é inventado: só são preenchidos quando houver dado real.
+
+/** Status de um serviço (derivado dos dados; nunca inventado). */
+export type ServicoStatus = "CRÍTICO" | "Sequencial" | "—";
+
+/** Item de serviço exibido na tabela. */
+export type ServicoItem = {
+  /** Identificador estável (ex.: WBS). */
+  id: string;
+  /** Código curto (ex.: WBS). */
+  codigo: string;
+  /** Nome do serviço. */
+  nome: string;
+  /** Duração em dias (0 = sem duração definida). */
+  duracao: number;
+  /** Data ISO de início (null = sem data). */
+  inicio: string | null;
+  /** Data ISO de fim (null = sem data). */
+  fim: string | null;
+  status: ServicoStatus;
+  // --- Campos preparados para FASE 22 (opcionais; só preenchidos com dado real) ---
+  /** Unidade de medida (ex.: "m²", "m³", "un"). */
+  unidade?: string | null;
+  /** Quantidade de escopo. */
+  quantidade?: number | null;
+  /** Produtividade declarada (ex.: "8 m³/dia"). */
+  produtividade?: string | null;
+  /** Predecessora (WBS) quando existir. */
+  predecessora?: string | null;
+};
+
+/** Contrato consumido pela tabela de Serviços. */
+export type ServicosData = {
+  /** Título do contexto (ex.: "Serviços"). */
+  title: string;
+  /** Detalhe do contexto fornecido pelo adapter. */
+  subtitle?: string;
+  items: ServicoItem[];
+};
+
+/** Resumo derivado dos itens (KPIs). */
+export type ServicosSummary = {
+  total: number;
+  criticos: number;
+  sequenciais: number;
+  comDuracao: number;
+};

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -108,6 +108,7 @@ import {
 } from "@/components/ui/select";
 
 import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
+import { DomainsSidebarGroup } from "../../../domains/domain-sidebar-group";
 import { AccountStatusMenu, type AccountStatusMenuProps } from "./account-status-menu";
 import { usePlatform } from "../../../kernel/platform";
 import {
@@ -1228,6 +1229,8 @@ export function AppSidebar(props: AppSidebarProps) {
             data-session-number-modifier-held={props.sessionNumberShortcuts.modifierHeld ? "true" : undefined}
             className="no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto [--radius:var(--radius-md)] group-data-[collapsible=icon]:overflow-hidden"
           >
+            {/* Domínios de negócio (Core → Domínio → Entidade) — genérico, sem conceito de Engenharia. */}
+            <DomainsSidebarGroup />
             {pinnedSessions.length > 0 ? (
               <GlobalPinnedSessions entries={pinnedSessions} />
             ) : null}

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -48,6 +48,9 @@ import { ShellConfigProvider } from "./shell-config";
 import { WelcomeRoute } from "./welcome-route";
 import { readOrgSelectionPending } from "../../app/lib/den-sign-in-intent";
 import { signedInRoute } from "./den-signin-routing";
+import { DomainRoute } from "@/react-app/domains/domain-route";
+// Side-effect: registra os domínios de negócio (Core → Domínio → Entidade).
+import "@/react-app/domains/domain-bootstrap";
 
 
 type DenSigninGateProps = {
@@ -493,6 +496,24 @@ export function AppRoot() {
                 element={
                   <DevProfiler id="SettingsRoute">
                     <SettingsRoute />
+                  </DevProfiler>
+                }
+              />
+              {/* Rotas genéricas de domínios: /dominios/:domainId/* (Core desconhece o
+                  domínio específico; o domínio registrado renderiza a rota). */}
+              <Route
+                path="/dominios/:domainId"
+                element={
+                  <DevProfiler id="DomainRoute">
+                    <DomainRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
+                path="/dominios/:domainId/*"
+                element={
+                  <DevProfiler id="DomainRoute">
+                    <DomainRoute />
                   </DevProfiler>
                 }
               />

--- a/apps/app/tests/domain-back-button.test.tsx
+++ b/apps/app/tests/domain-back-button.test.tsx
@@ -1,0 +1,55 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { buildEngenhariaNavigation } from "../src/react-app/domains/engenharia/obra/obra-navigation";
+import { SEED_OBRAS } from "../src/react-app/domains/engenharia/obra/obra-repository";
+import { obrasListRoute } from "../src/react-app/domains/engenharia/obra/obra-routes";
+import { DomainBackButton } from "../src/react-app/domains/domain-back-button";
+
+const tree = buildEngenhariaNavigation(SEED_OBRAS);
+function primeiraObraRoute(): string {
+  const group = tree[0].children?.[0];
+  const entity = (group?.children ?? []).find(
+    (n) => n.type === "entity" && n.label !== "+ Nova obra",
+  );
+  return entity?.route ?? "";
+}
+const HOME_ROUTE = obrasListRoute();
+const EAP_ROUTE = `${primeiraObraRoute()}/eap`;
+
+describe("DomainBackButton — ação de voltar genérica do Core (SSR)", () => {
+  test("módulo interno renderiza botão voltar para o nível anterior (internal)", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={[EAP_ROUTE]}>
+        <DomainBackButton navigation={tree} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("data-domain-back-button");
+    expect(html).toContain('data-domain-back-target="internal"');
+    expect(html).toContain("aria-label=\"Voltar para OBRA-MODELO-EAP-001\"");
+    expect(html).toContain("Voltar");
+  });
+
+  test("topo do domínio (lista de obras) renderiza voltar externo", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={[HOME_ROUTE]}>
+        <DomainBackButton navigation={tree} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("data-domain-back-button");
+    expect(html).toContain('data-domain-back-target="external"');
+    expect(html).toContain("aria-label=\"Voltar para a visão principal\"");
+  });
+
+  test("rota sem correspondência não renderiza o botão", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/dominios/engenharia/desconhecido"]}>
+        <DomainBackButton navigation={tree} />
+      </MemoryRouter>,
+    );
+    expect(html).toBe("");
+  });
+});
+

--- a/apps/app/tests/engenharia-navigation.test.ts
+++ b/apps/app/tests/engenharia-navigation.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildEngenhariaNavigation } from "../src/react-app/domains/engenharia/obra/obra-navigation";
+import {
+  DOMAIN_ENGENHARIA_ID,
+  OBRA_MODULES,
+  obraNovaRoute,
+  obrasListRoute,
+} from "../src/react-app/domains/engenharia/obra/obra-routes";
+import {
+  OBRA_MODELO_ID,
+  SEED_OBRAS,
+} from "../src/react-app/domains/engenharia/obra/obra-repository";
+import {
+  collectNodeIds,
+  findActiveNavigationPath,
+  hasActiveDescendant,
+  isNodeActive,
+  isNodeRouteActive,
+  resolveNavigationUpLevel,
+} from "../src/react-app/domains/navigation/navigation-utils";
+
+function obrasEntities(tree: ReturnType<typeof buildEngenhariaNavigation>) {
+  const group = tree[0].children?.[0];
+  return (group?.children ?? []).filter(
+    (n) => n.type === "entity" && n.label !== "+ Nova obra",
+  );
+}
+
+describe("navegação do domínio Engenharia (data-driven a partir do repositório)", () => {
+  const tree = buildEngenhariaNavigation(SEED_OBRAS);
+
+  test("raiz é um único nó de domínio apontando para a lista de obras", () => {
+    expect(tree).toHaveLength(1);
+    const domain = tree[0];
+    expect(domain.type).toBe("domain");
+    expect(domain.id).toBe(`domain:${DOMAIN_ENGENHARIA_ID}`);
+    expect(domain.label).toBe("Engenharia");
+    expect(domain.route).toBe(obrasListRoute());
+  });
+
+  test("estrutura domain → group(Obras) → (+ Nova obra + obras entity)", () => {
+    const domain = tree[0];
+    const obras = domain.children?.[0];
+    expect(obras?.type).toBe("group");
+    expect(obras?.label).toBe("Obras");
+    expect(obras?.children?.[0]?.label).toBe("+ Nova obra");
+    expect(obras?.children?.[0]?.route).toBe(obraNovaRoute());
+
+    const entities = obrasEntities(tree);
+    expect(entities.length).toBe(SEED_OBRAS.length);
+    const modelo = entities[0];
+    expect(modelo?.label).toBe("OBRA-MODELO-EAP-001");
+    // A obra agora agrupa os módulos por FASES (grupos) na sidebar.
+    const fases = modelo?.children ?? [];
+    expect(fases.length).toBeGreaterThanOrEqual(3);
+    const faseLabels = fases.map((n) => n.label);
+    expect(faseLabels).toContain("Preparação");
+    expect(faseLabels).toContain("Execução");
+    expect(faseLabels).toContain("Suporte");
+    // Os módulos vivem dentro das fases.
+    const allModuleLabels = fases.flatMap((f) => f.children?.map((c) => c.label) ?? []);
+    expect(allModuleLabels).toContain("Visão Geral");
+    expect(allModuleLabels).toContain("EAP");
+    expect(allModuleLabels).toContain("Disciplinas");
+    expect(allModuleLabels).toContain("Serviços");
+    expect(allModuleLabels).toContain("Linha de Balanço");
+  });
+
+  test("múltiplas obras aparecem com rotas próprias (derivadas dos dados)", () => {
+    const entities = obrasEntities(tree);
+    const names = entities.map((n) => n.label);
+    expect(names).toContain("OBRA-MODELO-EAP-001");
+    expect(names).toContain("Obra Demonstrativa 01");
+    expect(names).toContain("Obra Demonstrativa 02");
+    for (const entity of entities) {
+      expect(entity.route).toContain("/obras/");
+    }
+  });
+
+  test("obra nova na lista aparece na navegação", () => {
+    const extra: (typeof SEED_OBRAS)[number] = {
+      id: "OBRA-NOVA-TESTE",
+      nome: "Obra de Teste",
+      status: "PROPOSTA",
+    };
+    const comNova = buildEngenhariaNavigation([...SEED_OBRAS, extra]);
+    const entities = obrasEntities(comNova);
+    expect(entities.some((n) => n.id.includes("OBRA-NOVA-TESTE"))).toBe(true);
+    expect(entities.some((n) => n.label === "Obra de Teste")).toBe(true);
+  });
+
+  test("todos os módulos da obra-modelo possuem rota própria e tipo module", () => {
+    const entities = obrasEntities(tree);
+    const fases = entities[0]?.children ?? [];
+    const modules = fases.flatMap((fase) => fase.children ?? []);
+    expect(modules.length).toBeGreaterThanOrEqual(11);
+    for (const module of modules) {
+      expect(module.type).toBe("module");
+      expect(module.route).toMatch(
+        /^\/dominios\/engenharia\/obras\/OBRA-MODELO-EAP-001\//,
+      );
+    }
+  });
+
+  test("collectNodeIds percorre todos os nós", () => {
+    const ids = collectNodeIds(tree);
+    expect(ids.length).toBeGreaterThanOrEqual(1 + 1 + 1 + SEED_OBRAS.length);
+    expect(ids).toContain(`domain:${DOMAIN_ENGENHARIA_ID}`);
+  });
+
+  test("OBRA_MODULES ainda expõe os módulos da casca", () => {
+    expect(OBRA_MODULES.length).toBe(11);
+    expect(OBRA_MODELO_ID).toBe("OBRA-MODELO-EAP-001");
+  });
+});
+
+describe("navigation-utils (Core genérico)", () => {
+  const moduleNode = {
+    id: "m",
+    label: "EAP",
+    type: "module" as const,
+    route: "/dominios/x/obras/O1/eap",
+  };
+  const entityNode = {
+    id: "e",
+    label: "Obra",
+    type: "entity" as const,
+    route: "/dominios/x/obras/O1",
+    children: [moduleNode],
+  };
+
+  test("isNodeRouteActive: module casa exato; pai casa prefixo", () => {
+    expect(isNodeRouteActive(moduleNode, "/dominios/x/obras/O1/eap")).toBe(true);
+    expect(isNodeRouteActive(moduleNode, "/dominios/x/obras/O1")).toBe(false);
+    expect(isNodeRouteActive(entityNode, "/dominios/x/obras/O1/eap")).toBe(true);
+  });
+
+  test("hasActiveDescendant / isNodeActive", () => {
+    expect(hasActiveDescendant(entityNode, "/dominios/x/obras/O1/eap")).toBe(true);
+    expect(isNodeActive(entityNode, "/dominios/x/obras/O1/eap")).toBe(true);
+    expect(isNodeActive(entityNode, "/outro")).toBe(false);
+  });
+});
+
+describe("resolveNavigationUpLevel — nível anterior derivado da rota (multi-obra)", () => {
+  const tree = buildEngenhariaNavigation(SEED_OBRAS);
+  const primeiraObra = obrasEntities(tree)[0];
+  const obraRoute = primeiraObra?.route ?? "";
+  const eapRoute = `${obraRoute}/eap`;
+  const listaRoute = obrasListRoute();
+
+  test("módulo interno retorna caminho completo até o módulo", () => {
+    const path = findActiveNavigationPath(tree, eapRoute);
+    expect(path.map((n) => n.type)).toEqual([
+      "domain",
+      "group",
+      "entity",
+      "group",
+      "module",
+    ]);
+    expect(path[path.length - 1].route).toBe(eapRoute);
+  });
+
+  test("módulo → internal (volta para a entidade/pai)", () => {
+    expect(resolveNavigationUpLevel(tree, eapRoute)).toEqual({
+      kind: "internal",
+      label: "OBRA-MODELO-EAP-001",
+      route: obraRoute,
+    });
+  });
+
+  test("rota da obra (visão geral) → internal (volta para a lista de obras)", () => {
+    expect(resolveNavigationUpLevel(tree, obraRoute)).toEqual({
+      kind: "internal",
+      label: "Engenharia",
+      route: listaRoute,
+    });
+  });
+
+  test("rota da lista (topo do domínio) → external", () => {
+    expect(resolveNavigationUpLevel(tree, listaRoute)).toEqual({ kind: "external" });
+  });
+
+  test("rota sem correspondência na árvore → none", () => {
+    expect(resolveNavigationUpLevel(tree, "/dominios/engenharia/desconhecido")).toEqual({
+      kind: "none",
+    });
+  });
+
+  test("domínio de nível único (raiz sem filhos) → external", () => {
+    const flat = [
+      { id: "d", label: "D", type: "domain" as const, route: "/dominios/d/home" },
+    ];
+    expect(resolveNavigationUpLevel(flat, "/dominios/d/home")).toEqual({ kind: "external" });
+  });
+});

--- a/apps/app/tests/engenharia-obra-domain.test.ts
+++ b/apps/app/tests/engenharia-obra-domain.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OBRA_MODELO,
+  OBRA_MODELO_ID,
+  findObraModelo,
+} from "../src/react-app/domains/engenharia/obra/obra-repository";
+import {
+  DOMAIN_ENGENHARIA_ID,
+  OBRA_MODULES,
+  OBRA_MODULE_LABEL,
+  engenhariaDomainHome,
+  isObraModule,
+  obraRoute,
+  obrasListRoute,
+} from "../src/react-app/domains/engenharia/obra/obra-routes";
+
+describe("domínio Engenharia — entidade Obra", () => {
+  test("obra-modelo existe com identidade e status PROPOSTA", () => {
+    expect(OBRA_MODELO.id).toBe("OBRA-MODELO-EAP-001");
+    expect(OBRA_MODELO.nome).toBe("OBRA-MODELO-EAP-001");
+    expect(OBRA_MODELO.status).toBe("PROPOSTA");
+  });
+
+  test("caracterização contém somente dados reais do projeto", () => {
+    expect(OBRA_MODELO.caracterizacao).toEqual({
+      torres: 1,
+      lajes: 14,
+      apartamentosPorPavimento: 1,
+      subsolos: 0,
+      sistemaConstrutivo: "concreto armado",
+    });
+  });
+
+  test("resumo estrutural da EAP preserva 81 nós (10/24/47) e status PROPOSTA", () => {
+    expect(OBRA_MODELO.eap.status).toBe("PROPOSTA");
+    expect(OBRA_MODELO.eap.total).toBe(81);
+    expect(OBRA_MODELO.eap.raizes).toBe(10);
+    expect(OBRA_MODELO.eap.pacotes).toBe(24);
+    expect(OBRA_MODELO.eap.trabalhos).toBe(47);
+  });
+
+  test("findObraModelo resolve a obra-modelo e rejeita ids desconhecidos", () => {
+    expect(findObraModelo(OBRA_MODELO_ID)?.id).toBe(OBRA_MODELO_ID);
+    expect(findObraModelo("OBRA-NAO-EXISTE")).toBeUndefined();
+  });
+});
+
+describe("domínio Engenharia — rotas da Obra", () => {
+  test("obraRoute gera as rotas nativas do domínio", () => {
+    expect(obraRoute(OBRA_MODELO_ID)).toBe(
+      `/dominios/${DOMAIN_ENGENHARIA_ID}/obras/OBRA-MODELO-EAP-001`,
+    );
+    expect(obraRoute(OBRA_MODELO_ID, "eap")).toBe(
+      `/dominios/${DOMAIN_ENGENHARIA_ID}/obras/OBRA-MODELO-EAP-001/eap`,
+    );
+    expect(obraRoute(OBRA_MODELO_ID, "frentes")).toBe(
+      `/dominios/${DOMAIN_ENGENHARIA_ID}/obras/OBRA-MODELO-EAP-001/frentes`,
+    );
+  });
+
+  test("home do domínio aponta para a lista de obras", () => {
+    expect(engenhariaDomainHome()).toBe(obrasListRoute());
+    expect(obrasListRoute()).toBe(`/dominios/${DOMAIN_ENGENHARIA_ID}/obras`);
+  });
+
+  test("OBRA_MODULES expõe os módulos da casca (por fases)", () => {
+    expect(OBRA_MODULES).toEqual([
+      "visao-geral",
+      "caracterizacao",
+      "eap",
+      "disciplinas",
+      "servicos",
+      "planejamento",
+      "linha-de-balanco",
+      "frentes",
+      "producao",
+      "rdo",
+      "ia",
+    ]);
+    for (const module of OBRA_MODULES) {
+      expect(typeof OBRA_MODULE_LABEL[module]).toBe("string");
+    }
+  });
+
+  test("isObraModule valida módulos conhecidos e rejeita os demais", () => {
+    expect(isObraModule("eap")).toBe(true);
+    expect(isObraModule("rdo")).toBe(true);
+    expect(isObraModule("orcamento")).toBe(false);
+    expect(isObraModule(null)).toBe(false);
+    expect(isObraModule(undefined)).toBe(false);
+  });
+});

--- a/apps/app/tests/lob-data.test.ts
+++ b/apps/app/tests/lob-data.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  atividadeParaLobLinha,
+  derivarGradeLob,
+  gerarSemanas,
+} from "../src/react-app/domains/linha-de-balanco/lob-data";
+import type { LobAtividade } from "../src/react-app/domains/linha-de-balanco/lob-types";
+
+/**
+ * Auditoria anti-hardcode da capacidade genérica de Linha de Balanço (FASE 21).
+ * Garante que a pasta domains/linha-de-balanco (contrato + componentes) NÃO
+ * dependa de conceitos de um domínio/obra específica.
+ */
+const LOB_DIR = join(
+  import.meta.dir,
+  "..",
+  "src",
+  "react-app",
+  "domains",
+  "linha-de-balanco",
+);
+
+const FORBIDDEN_TERMS = [
+  "OBRA-MODELO-EAP-001",
+  "torre",
+  "apartamento",
+  "pavimento",
+  "engenharia",
+  "obra-001",
+  "Escavação",
+];
+
+describe("linha-de-balanco — auditoria anti-hardcode", () => {
+  const files = readdirSync(LOB_DIR).filter((name) => /\.(ts|tsx)$/.test(name));
+
+  test("arquivos da capacidade existem e são auditáveis", () => {
+    expect(files).toContain("lob-types.ts");
+    expect(files).toContain("lob-data.ts");
+    expect(files).toContain("lob-grade.tsx");
+    expect(files).toContain("lob-help.tsx");
+  });
+
+  test("nenhum termo específico de domínio/obra aparece na capacidade genérica", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const content = readFileSync(join(LOB_DIR, file), "utf8").toLowerCase();
+      for (const term of FORBIDDEN_TERMS) {
+        if (content.includes(term.toLowerCase())) {
+          offenders.push(`${file} -> ${term}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("lob-data — helpers genéricos (FASE 21)", () => {
+  test("gerarSemanas cobre a duração a partir da data de início", () => {
+    const semanas = gerarSemanas("2026-01-05", 698);
+    expect(semanas.length).toBe(100);
+    expect(semanas[0].inicio).toBe("2026-01-05");
+    expect(semanas[0].fim).toBe("2026-01-11");
+    expect(semanas[99].inicio).toBe("2027-11-29");
+    expect(semanas[99].fim).toBe("2027-12-05");
+  });
+
+  test("gerarSemanas retorna [] para duração negativa", () => {
+    expect(gerarSemanas("2026-01-05", -1)).toEqual([]);
+  });
+
+  test("atividadeParaLobLinha converte atividade em semanas ativas", () => {
+    const atividade: LobAtividade = {
+      id: "A",
+      nome: "Serviço A",
+      inicio: 0,
+      fim: 16,
+      duracao: 16,
+      critico: "CRÍTICO",
+    };
+    const linha = atividadeParaLobLinha(atividade);
+    expect(linha.semanasAtivas).toEqual([0, 1, 2]);
+    expect(linha.critico).toBe("CRÍTICO");
+  });
+
+  test("atividade sem duração não entra na grade", () => {
+    const atividades: LobAtividade[] = [
+      { id: "A", nome: "Sem duração", inicio: 0, fim: 0, duracao: 0, critico: "—" },
+      { id: "B", nome: "Com duração", inicio: 0, fim: 7, duracao: 7, critico: "Sequencial" },
+    ];
+    const grade = derivarGradeLob(atividades, "2026-01-05");
+    expect(grade.linhas.length).toBe(1);
+    expect(grade.linhas[0].id).toBe("B");
+  });
+});

--- a/apps/app/tests/obra-ares-referencia.test.ts
+++ b/apps/app/tests/obra-ares-referencia.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ARES_ATIVIDADES_REFERENCIA,
+  ARES_REDE_REFERENCIA,
+  ARES_REFERENCIA,
+  ARES_SERVICOS_LOB_REFERENCIA,
+  aresDuracaoTotalReferencia,
+  aresResumoStatusReferencia,
+} from "../src/react-app/domains/engenharia/obra/obra-ares-referencia";
+import { OBRA_MODELO_EAP_NODES } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+
+describe("obra-ares-referencia — dataset de referência ARES/Piemarta (FASE 20.x)", () => {
+  test("identifica o dataset como REFERÊNCIA, não como obra real", () => {
+    expect(ARES_REFERENCIA.obra).toBe("Piemarta");
+    expect(ARES_REFERENCIA.natureza).toContain("REFERÊNCIA");
+    expect(ARES_REFERENCIA.natureza).toContain("NÃO é a obra real");
+  });
+
+  test("contém 15 atividades de cronograma com datas/predecessoras/%plan/%real/status", () => {
+    expect(ARES_ATIVIDADES_REFERENCIA.length).toBe(15);
+    for (const atv of ARES_ATIVIDADES_REFERENCIA) {
+      expect(atv.inicio).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(atv.fim).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(atv.duracao).toBeGreaterThan(0);
+      expect(atv.percentualPlan).toBeGreaterThanOrEqual(0);
+      expect(atv.percentualPlan).toBeLessThanOrEqual(100);
+      expect(atv.percentualReal).toBeGreaterThanOrEqual(0);
+      expect(atv.percentualReal).toBeLessThanOrEqual(100);
+    }
+  });
+
+  test("contém 18 elos de rede de precedências", () => {
+    expect(ARES_REDE_REFERENCIA.length).toBe(18);
+    for (const elo of ARES_REDE_REFERENCIA) {
+      expect(elo.tipoRelacao).toBe("FS");
+      expect(elo.defasagem).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("contém 11 serviços na grade LOB", () => {
+    expect(ARES_SERVICOS_LOB_REFERENCIA.length).toBe(11);
+  });
+
+  test("resumo de status soma 15 atividades", () => {
+    const resumo = aresResumoStatusReferencia();
+    const total = Object.values(resumo).reduce((a, b) => a + b, 0);
+    expect(total).toBe(15);
+    expect(resumo.concluido).toBe(5);
+    expect(resumo.em_andamento).toBe(5);
+    expect(resumo.planejado).toBe(4);
+    expect(resumo.atrasado).toBe(1);
+  });
+
+  test("duração total do cronograma de referência é coerente (2026-01-05 → 2027-01-22)", () => {
+    const dias = aresDuracaoTotalReferencia();
+    expect(dias).toBeGreaterThan(300);
+    expect(dias).toBeLessThan(400);
+  });
+});
+
+describe("SEPARAÇÃO DE FONTES — obra real ≠ dataset ARES/Piemarta", () => {
+  test("a EAP real tem 81 nós, NÃO os 85 da ARES", () => {
+    expect(OBRA_MODELO_EAP_NODES.length).toBe(81);
+    expect(OBRA_MODELO_EAP_NODES.length).not.toBe(85);
+  });
+
+  test("a EAP real tem 10 disciplinas raiz, NÃO as 20 da ARES", () => {
+    const raizes = OBRA_MODELO_EAP_NODES.filter((n) => n.nivel === 1);
+    expect(raizes.length).toBe(10);
+    expect(raizes.length).not.toBe(20);
+  });
+
+  test("nenhuma atividade de referência usa WBS da EAP real (não há mistura)", () => {
+    const wbsReais = new Set(OBRA_MODELO_EAP_NODES.map((n) => n.wbs));
+    // As atividades de referência usam códigos próprios (LOC-ATV, FUN-ATV...),
+    // nunca os WBS da EAP real (1, 1.1, 2.1.1...).
+    for (const atv of ARES_ATIVIDADES_REFERENCIA) {
+      expect(wbsReais.has(atv.codigo)).toBe(false);
+    }
+  });
+});

--- a/apps/app/tests/obra-dashboard.test.tsx
+++ b/apps/app/tests/obra-dashboard.test.tsx
@@ -1,0 +1,124 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { ObraDashboard, type DashboardWidget } from "../src/react-app/domains/engenharia/obra/obra-dashboard";
+import { KpiBar, type KpiItem } from "../src/react-app/domains/engenharia/obra/obra-kpi-bar";
+import { ObraVisaoGeral } from "../src/react-app/domains/engenharia/obra/pages/obra-visao-geral";
+import { OBRA_MODELO_EAP_ID } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { resetObraEapRepository } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_EAP_ID,
+  nome: OBRA_MODELO_EAP_ID,
+  status: "PROPOSTA",
+  caracterizacao: {
+    torres: 1,
+    lajes: 14,
+    apartamentosPorPavimento: 1,
+    subsolos: 0,
+    sistemaConstrutivo: "concreto_armado",
+  },
+};
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraEapRepository();
+});
+
+describe("KpiBar — drill-down (FASE 22)", () => {
+  test("KPI com target e onNavigate é clicável e expõe a rota de origem", () => {
+    const items: KpiItem[] = [
+      { id: "kpi-a", label: "Torres", value: 3, target: "/obras/X/caracterizacao" },
+      { id: "kpi-b", label: "Nós", value: 81 },
+    ];
+    const html = renderToStaticMarkup(
+      <KpiBar items={items} onNavigate={() => undefined} />,
+    );
+    expect(html).toContain('data-kpi-target="/obras/X/caracterizacao"');
+    expect(html).toContain('role="button"');
+    // KPI sem target não é clicável (apenas um card com role=button).
+    expect(html.match(/role="button"/g)?.length).toBe(1);
+  });
+
+  test("sem onNavigate, KPI com target não é clicável (primitivo SSR-testável)", () => {
+    const items: KpiItem[] = [
+      { id: "kpi-a", label: "Torres", value: 3, target: "/obras/X/caracterizacao" },
+    ];
+    const html = renderToStaticMarkup(<KpiBar items={items} />);
+    expect(html).not.toContain('role="button"');
+  });
+});
+
+describe("ObraDashboard — widgets e expansão (FASE 22)", () => {
+  const widgets: DashboardWidget[] = [
+    {
+      id: "widget-a",
+      title: "Identidade",
+      content: <span data-widget-content="a">Conteúdo A</span>,
+    },
+    {
+      id: "widget-b",
+      title: "Caracterização",
+      content: <span data-widget-content="b">Conteúdo B</span>,
+    },
+  ];
+
+  test("renderiza widgets em grade com botão de expandir", () => {
+    const html = renderToStaticMarkup(<ObraDashboard widgets={widgets} />);
+    expect(html).toContain("data-obra-dashboard");
+    expect(html).toContain('data-widget="widget-a"');
+    expect(html).toContain('data-widget="widget-b"');
+    expect(html).toContain('data-widget-expand="widget-a"');
+    expect(html).toContain('data-widget-expand="widget-b"');
+    expect(html).toContain("Conteúdo A");
+    expect(html).toContain("Conteúdo B");
+  });
+
+  test("sem widget expandido, não renderiza overlay de tela cheia", () => {
+    const html = renderToStaticMarkup(<ObraDashboard widgets={widgets} />);
+    expect(html).not.toContain("data-obra-dashboard-expanded");
+  });
+});
+
+describe("Visão Geral — dashboard com KPIs clicáveis (FASE 22)", () => {
+  test("KPIs de caracterização e EAP apontam para o módulo de origem", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraVisaoGeral obra={OBRA_MODELO} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("data-obra-dashboard");
+    expect(html).toContain('data-kpi="kpi-torres"');
+    expect(html).toContain('data-kpi="kpi-eap-nos"');
+    // drill-down para o módulo de origem
+    expect(html).toContain(`data-kpi-target="/dominios/engenharia/obras/${OBRA_MODELO_EAP_ID}/caracterizacao"`);
+    expect(html).toContain(`data-kpi-target="/dominios/engenharia/obras/${OBRA_MODELO_EAP_ID}/eap"`);
+    // widgets de identidade e caracterização
+    expect(html).toContain('data-widget="widget-identidade"');
+    expect(html).toContain('data-widget="widget-caracterizacao"');
+  });
+
+  test("início do cronograma é apresentado como derivado (não sobrescreve cadastro)", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraVisaoGeral obra={OBRA_MODELO} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Início do cronograma (derivado)");
+  });
+});

--- a/apps/app/tests/obra-eap-ui.test.tsx
+++ b/apps/app/tests/obra-eap-ui.test.tsx
@@ -1,0 +1,107 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ObraEap } from "../src/react-app/domains/engenharia/obra/pages/obra-eap";
+import { EapTree } from "../src/react-app/domains/engenharia/obra/obra-eap-tree";
+import { OBRA_MODELO_EAP_ID } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import {
+  deriveEapRows,
+  resetObraEapRepository,
+} from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_EAP_ID,
+  nome: OBRA_MODELO_EAP_ID,
+  status: "PROPOSTA",
+};
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraEapRepository();
+});
+
+describe("ObraEap — página EAP real (SSR)", () => {
+  test("renderiza o EAP real da Obra Modelo (81 nós, resumo derivado)", () => {
+    const html = renderToStaticMarkup(<ObraEap obra={OBRA_MODELO} />);
+    expect(html).toContain("EAP — Estrutura Analítica do Projeto");
+    expect(html).toContain("Edifício Residencial Modelo EAP");
+    expect(html).toContain("FASE-19.5");
+    expect(html).toContain("data-eap-tree");
+    // Resumo derivado dos nós reais
+    expect(html).toContain("Total de nós");
+    expect(html).toContain(">81<");
+    expect(html).toContain(">10<");
+    expect(html).toContain(">24<");
+    expect(html).toContain(">47<");
+    expect(html).toContain("Folhas");
+    expect(html).toContain(">47<");
+  });
+
+  test("renderiza a árvore com WBS, nome e tipo dos nós reais", () => {
+    const html = renderToStaticMarkup(<ObraEap obra={OBRA_MODELO} />);
+    expect(html).toContain("Preparação, Projetos e Canteiro");
+    expect(html).toContain("data-eap-row");
+    expect(html).toContain('data-eap-wbs="1"');
+    expect(html).toContain('data-eap-wbs="1.1.1"');
+    expect(html).toContain("Disciplina");
+    expect(html).toContain("Pacote");
+    expect(html).toContain("Trabalho");
+  });
+
+  test("trata obra sem EAP sem quebrar", () => {
+    const obraSemEap: Obra = { id: "OBRA-SEM-EAP", nome: "Sem EAP", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraEap obra={obraSemEap} />);
+    expect(html).toContain("ainda não possui EAP definida");
+  });
+});
+
+describe("EapTree — árvore navegável (SSR)", () => {
+  test("renderiza linhas com WBS, nome e tipo", () => {
+    const rows = deriveEapRows(
+      [
+        {
+          obraId: OBRA_MODELO_EAP_ID,
+          wbs: "1",
+          nome: "Disciplina 1",
+          nivel: 1,
+          tipo: "DISCIPLINA" as const,
+          pai: null,
+          ordem: 1,
+        },
+        {
+          obraId: OBRA_MODELO_EAP_ID,
+          wbs: "1.1",
+          nome: "Pacote 1.1",
+          nivel: 2,
+          tipo: "PACOTE" as const,
+          pai: "1",
+          ordem: 1,
+        },
+      ],
+      new Set(),
+    );
+    const html = renderToStaticMarkup(
+      <EapTree rows={rows} onSelect={() => {}} onToggle={() => {}} />,
+    );
+    expect(html).toContain("data-eap-tree");
+    expect(html).toContain("Disciplina 1");
+    expect(html).toContain("Pacote 1.1");
+    expect(html).toContain('data-eap-wbs="1"');
+    expect(html).toContain("Disciplina");
+    expect(html).toContain("Pacote");
+  });
+});

--- a/apps/app/tests/obra-eap.test.ts
+++ b/apps/app/tests/obra-eap.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OBRA_MODELO_EAP,
+  OBRA_MODELO_EAP_ID,
+  OBRA_MODELO_EAP_METADATA,
+  OBRA_MODELO_EAP_NODES,
+} from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import {
+  EAP_REFERENCES,
+  REF_EAP_RES_001,
+  findEapReference,
+  resolveReferenceNodes,
+} from "../src/react-app/domains/engenharia/obra/obra-eap-reference";
+import {
+  countEapLeaves,
+  deriveEapRows,
+  deriveEapSummary,
+  eapRootWbs,
+  getEapForObra,
+  getEapNodesForObra,
+  getEapSummaryForObra,
+  validateEap,
+} from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+
+describe("EAP real da Obra Modelo — fonte × destino (FASE 06.2-B)", () => {
+  test("81 nós preservados (10 DISCIPLINA / 24 PACOTE / 47 TRABALHO)", () => {
+    const nodes = OBRA_MODELO_EAP_NODES;
+    expect(nodes.length).toBe(81);
+    const disciplinas = nodes.filter((n) => n.tipo === "DISCIPLINA").length;
+    const pacotes = nodes.filter((n) => n.tipo === "PACOTE").length;
+    const trabalhos = nodes.filter((n) => n.tipo === "TRABALHO").length;
+    expect(disciplinas).toBe(10);
+    expect(pacotes).toBe(24);
+    expect(trabalhos).toBe(47);
+  });
+
+  test("10 raízes e 47 folhas", () => {
+    expect(eapRootWbs(OBRA_MODELO_EAP_NODES).length).toBe(10);
+    expect(countEapLeaves(OBRA_MODELO_EAP_NODES)).toBe(47);
+  });
+
+  test("todos os nós pertencem a OBRA-MODELO-EAP-001", () => {
+    for (const node of OBRA_MODELO_EAP_NODES) {
+      expect(node.obraId).toBe(OBRA_MODELO_EAP_ID);
+    }
+  });
+
+  test("WBS preservados no formato hierárquico (1, 1.1, 1.1.1)", () => {
+    const wbs = OBRA_MODELO_EAP_NODES.map((n) => n.wbs);
+    expect(wbs).toContain("1");
+    expect(wbs).toContain("1.1");
+    expect(wbs).toContain("1.1.1");
+    expect(wbs).toContain("10.2.2");
+  });
+
+  test("nomes, tipos, fundamentação e condição preservados", () => {
+    const n1 = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "1");
+    expect(n1?.nome).toBe("Preparação, Projetos e Canteiro");
+    expect(n1?.tipo).toBe("DISCIPLINA");
+    expect(n1?.nivel).toBe(1);
+    expect(n1?.pai).toBeNull();
+    expect(n1?.fundamentacao).toContain("Antecede a execução física");
+
+    const n211 = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.1");
+    expect(n211?.nome).toBe("Escavação");
+    expect(n211?.tipo).toBe("TRABALHO");
+    expect(n211?.pai).toBe("2.1");
+
+    const n212 = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.2");
+    expect(n212?.condicao).toContain("HIPÓTESE");
+  });
+
+  test("ordem entre irmãos preservada (ordem declarada da fonte)", () => {
+    const filhosDe1 = OBRA_MODELO_EAP_NODES.filter((n) => n.pai === "1");
+    expect(filhosDe1.map((n) => n.wbs)).toEqual(["1.1", "1.2"]);
+    expect(filhosDe1.map((n) => n.ordem)).toEqual([1, 2]);
+  });
+
+  test("metadados preservados (versão FASE-19.5, status PROPOSTA)", () => {
+    expect(OBRA_MODELO_EAP_METADATA.versao).toBe("FASE-19.5");
+    expect(OBRA_MODELO_EAP_METADATA.status).toBe("PROPOSTA");
+    expect(OBRA_MODELO_EAP_METADATA.obraNome).toBe("Edifício Residencial Modelo EAP");
+    expect(OBRA_MODELO_EAP_METADATA.niveisTipos).toEqual({
+      "1": "DISCIPLINA",
+      "2": "PACOTE",
+      "3": "TRABALHO",
+    });
+    expect(OBRA_MODELO_EAP_METADATA.principios).toContain("regra_100_porcento");
+    expect(OBRA_MODELO_EAP_METADATA.regraAlocacaoEstruturaCobertura).toContain("5.1.1");
+  });
+});
+
+describe("EAP — integridade estrutural", () => {
+  test("nenhum WBS duplicado, pai inexistente, raiz com pai ou ciclo", () => {
+    const result = validateEap(OBRA_MODELO_EAP_NODES);
+    expect(result.ok).toBe(true);
+    expect(result.total).toBe(81);
+    expect(result.wbsDuplicados).toEqual([]);
+    expect(result.paisInexistentes).toEqual([]);
+    expect(result.raizesComPai).toEqual([]);
+    expect(result.ciclos).toEqual([]);
+    expect(result.foraDaObra).toEqual([]);
+  });
+
+  test("validação detecta WBS duplicado", () => {
+    const nodes = [
+      ...OBRA_MODELO_EAP_NODES.slice(0, 2),
+      { ...OBRA_MODELO_EAP_NODES[1] },
+    ];
+    const result = validateEap(nodes);
+    expect(result.ok).toBe(false);
+    expect(result.wbsDuplicados).toContain("1.1");
+  });
+
+  test("validação detecta pai inexistente", () => {
+    const nodes = OBRA_MODELO_EAP_NODES.map((n) =>
+      n.wbs === "1.1.1" ? { ...n, pai: "99.99" } : n,
+    );
+    const result = validateEap(nodes);
+    expect(result.ok).toBe(false);
+    expect(result.paisInexistentes).toContain("1.1.1");
+  });
+});
+
+describe("EAP — resumo derivado dos nós reais", () => {
+  test("deriveEapSummary produz 81/10/24/47 a partir dos nós", () => {
+    const summary = deriveEapSummary(OBRA_MODELO_EAP_NODES);
+    expect(summary.total).toBe(81);
+    expect(summary.raizes).toBe(10);
+    expect(summary.pacotes).toBe(24);
+    expect(summary.trabalhos).toBe(47);
+    expect(summary.status).toBe("PROPOSTA");
+  });
+
+  test("getEapSummaryForObra deriva do repositório por obraId", () => {
+    const summary = getEapSummaryForObra(OBRA_MODELO_EAP_ID);
+    expect(summary?.total).toBe(81);
+    expect(getEapSummaryForObra("OBRA-NAO-EXISTE")).toBeNull();
+  });
+
+  test("getEapForObra / getEapNodesForObra resolvem por obraId", () => {
+    expect(getEapForObra(OBRA_MODELO_EAP_ID)?.nodes.length).toBe(81);
+    expect(getEapNodesForObra(OBRA_MODELO_EAP_ID).length).toBe(81);
+    expect(getEapNodesForObra("OBRA-NAO-EXISTE")).toEqual([]);
+  });
+});
+
+describe("EAP — árvore derivada (deriveEapRows)", () => {
+  test("pré-order: pai antes do filho, ordem entre irmãos preservada", () => {
+    const rows = deriveEapRows(OBRA_MODELO_EAP_NODES, new Set());
+    const order = rows.map((r) => r.node.wbs);
+    expect(order.indexOf("1")).toBeLessThan(order.indexOf("1.1"));
+    expect(order.indexOf("1.1")).toBeLessThan(order.indexOf("1.1.1"));
+    expect(order.indexOf("1.1.1")).toBeLessThan(order.indexOf("1.1.2"));
+    expect(order.indexOf("1.1.2")).toBeLessThan(order.indexOf("1.2"));
+    expect(rows.find((r) => r.node.wbs === "1")?.depth).toBe(0);
+    expect(rows.find((r) => r.node.wbs === "1.1.1")?.depth).toBe(2);
+  });
+
+  test("recolher um nó oculta descendentes e expandir restaura", () => {
+    const collapsed = deriveEapRows(OBRA_MODELO_EAP_NODES, new Set(["1"]));
+    const ids = collapsed.map((r) => r.node.wbs);
+    expect(ids).toContain("1");
+    expect(ids).not.toContain("1.1");
+    const expanded = deriveEapRows(OBRA_MODELO_EAP_NODES, new Set());
+    expect(expanded.map((r) => r.node.wbs)).toContain("1.1");
+  });
+
+  test("todas as 81 linhas são produzidas quando nada está recolhido", () => {
+    const rows = deriveEapRows(OBRA_MODELO_EAP_NODES, new Set());
+    expect(rows.length).toBe(81);
+  });
+});
+
+describe("EAP — referência reutilizável (EapReference)", () => {
+  test("REF-EAP-RES-001 registrada com origem e versão corretas", () => {
+    expect(REF_EAP_RES_001.id).toBe("REF-EAP-RES-001");
+    expect(REF_EAP_RES_001.nome).toBe("EAP Residencial Completo");
+    expect(REF_EAP_RES_001.origem).toBe("Obra Modelo EAP");
+    expect(REF_EAP_RES_001.versaoOrigem).toBe("FASE-19.5");
+    expect(REF_EAP_RES_001.origemObraId).toBe(OBRA_MODELO_EAP_ID);
+  });
+
+  test("catálogo contém a primeira referência", () => {
+    expect(EAP_REFERENCES.map((r) => r.id)).toContain("REF-EAP-RES-001");
+    expect(findEapReference("REF-EAP-RES-001")?.nome).toBe("EAP Residencial Completo");
+    expect(findEapReference("NAO-EXISTE")).toBeUndefined();
+  });
+
+  test("referência resolve os 81 nós da origem por identidade (sem duplicar)", () => {
+    const nodes = resolveReferenceNodes(REF_EAP_RES_001);
+    expect(nodes.length).toBe(81);
+    // A referência não embute os nós: aponta para a EAP operacional da origem.
+    expect("nodes" in REF_EAP_RES_001).toBe(false);
+  });
+
+  test("EAP completa exposta pelo repositório é a mesma da referência", () => {
+    expect(OBRA_MODELO_EAP.nodes.length).toBe(81);
+    expect(OBRA_MODELO_EAP.obraId).toBe(OBRA_MODELO_EAP_ID);
+  });
+});

--- a/apps/app/tests/obra-eap.test.ts
+++ b/apps/app/tests/obra-eap.test.ts
@@ -93,7 +93,7 @@ describe("EAP real da Obra Modelo — fonte × destino (FASE 06.2-B)", () => {
 
 describe("EAP — integridade estrutural", () => {
   test("nenhum WBS duplicado, pai inexistente, raiz com pai ou ciclo", () => {
-    const result = validateEap(OBRA_MODELO_EAP_NODES);
+    const result = validateEap(OBRA_MODELO_EAP_NODES, OBRA_MODELO_EAP_ID);
     expect(result.ok).toBe(true);
     expect(result.total).toBe(81);
     expect(result.wbsDuplicados).toEqual([]);
@@ -108,7 +108,7 @@ describe("EAP — integridade estrutural", () => {
       ...OBRA_MODELO_EAP_NODES.slice(0, 2),
       { ...OBRA_MODELO_EAP_NODES[1] },
     ];
-    const result = validateEap(nodes);
+    const result = validateEap(nodes, OBRA_MODELO_EAP_ID);
     expect(result.ok).toBe(false);
     expect(result.wbsDuplicados).toContain("1.1");
   });
@@ -117,7 +117,7 @@ describe("EAP — integridade estrutural", () => {
     const nodes = OBRA_MODELO_EAP_NODES.map((n) =>
       n.wbs === "1.1.1" ? { ...n, pai: "99.99" } : n,
     );
-    const result = validateEap(nodes);
+    const result = validateEap(nodes, OBRA_MODELO_EAP_ID);
     expect(result.ok).toBe(false);
     expect(result.paisInexistentes).toContain("1.1.1");
   });

--- a/apps/app/tests/obra-editar.test.tsx
+++ b/apps/app/tests/obra-editar.test.tsx
@@ -1,0 +1,67 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { ObraEditarPage } from "../src/react-app/domains/engenharia/obra/pages/obra-editar";
+import { OBRA_MODELO_ID, resetObraRepository, useObraRepository } from "../src/react-app/domains/engenharia/obra/obra-repository";
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraRepository();
+});
+
+describe("Edição de obra (FASE 22)", () => {
+  test("renderiza formulário de edição com campos de identificação e metadados", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={[`/dominios/engenharia/obras/${OBRA_MODELO_ID}/editar`]}>
+        <ObraEditarPage obraId={OBRA_MODELO_ID} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Editar obra");
+    expect(html).toContain('id="obra-nome"');
+    expect(html).toContain('id="obra-status"');
+    expect(html).toContain('id="obra-data-inicio"');
+    expect(html).toContain('id="obra-data-fim"');
+    expect(html).toContain('id="obra-localizacao"');
+    expect(html).toContain('id="obra-responsavel"');
+    expect(html).toContain("Salvar");
+  });
+
+  test("obra inexistente mostra estado de não encontrada", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/dominios/engenharia/obras/NAO-EXISTE/editar"]}>
+        <ObraEditarPage obraId="NAO-EXISTE" />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Obra não encontrada");
+  });
+
+  test("updateObra persiste alterações na fonte única", () => {
+    const obra = useObraRepository.getState().createObra({
+      nome: "Obra Editável",
+      status: "PROPOSTA",
+    });
+    useObraRepository.getState().updateObra(obra.id, {
+      nome: "Obra Renomeada",
+      status: "PLANEJAMENTO",
+      localizacao: "Belo Horizonte, MG",
+    });
+    const atualizada = useObraRepository.getState().obras.find((o) => o.id === obra.id);
+    expect(atualizada?.nome).toBe("Obra Renomeada");
+    expect(atualizada?.status).toBe("PLANEJAMENTO");
+    expect(atualizada?.localizacao).toBe("Belo Horizonte, MG");
+  });
+});

--- a/apps/app/tests/obra-frentes-producao-ui.test.tsx
+++ b/apps/app/tests/obra-frentes-producao-ui.test.tsx
@@ -1,0 +1,67 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ObraFrentes } from "../src/react-app/domains/engenharia/obra/pages/obra-frentes";
+import { ObraProducao } from "../src/react-app/domains/engenharia/obra/pages/obra-producao";
+import { OBRA_MODELO_EAP_ID } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { resetObraEapRepository } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_EAP_ID,
+  nome: OBRA_MODELO_EAP_ID,
+  status: "PROPOSTA",
+};
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraEapRepository();
+});
+
+describe("ObraFrentes — frentes derivadas da EAP real (SSR)", () => {
+  test("renderiza as 10 frentes (disciplinas raiz) com contagem", () => {
+    const html = renderToStaticMarkup(<ObraFrentes obra={OBRA_MODELO} />);
+    expect(html).toContain("Frentes de Serviço");
+    expect(html).toContain("Preparação, Projetos e Canteiro");
+    expect(html).toContain("Superestrutura");
+    expect(html).toContain("Áreas Externas");
+    expect(html).toContain("Pacotes");
+    expect(html).toContain("Trabalhos");
+  });
+
+  test("trata obra sem EAP sem quebrar", () => {
+    const semEap: Obra = { id: "OBRA-X", nome: "X", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraFrentes obra={semEap} />);
+    expect(html).toContain("ainda não possui EAP definida");
+  });
+});
+
+describe("ObraProducao — produção derivada do cronograma real (SSR)", () => {
+  test("renderiza os trabalhos com quantidade planejada e ritmo", () => {
+    const html = renderToStaticMarkup(<ObraProducao obra={OBRA_MODELO} />);
+    expect(html).toContain("Produção");
+    expect(html).toContain("Escavação");
+    expect(html).toContain("Qtd. planejada");
+    expect(html).toContain("Ritmo");
+    expect(html).toContain("Pendente");
+  });
+
+  test("trata obra sem EAP sem quebrar", () => {
+    const semEap: Obra = { id: "OBRA-X", nome: "X", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraProducao obra={semEap} />);
+    expect(html).toContain("ainda não possui EAP definida");
+  });
+});

--- a/apps/app/tests/obra-gestao.test.tsx
+++ b/apps/app/tests/obra-gestao.test.tsx
@@ -1,0 +1,110 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { ObraListaContent, ObraListaPage } from "../src/react-app/domains/engenharia/obra/pages/obra-lista";
+import { ObraNovaPage } from "../src/react-app/domains/engenharia/obra/pages/obra-nova";
+import { ObraPlanejamento } from "../src/react-app/domains/engenharia/obra/pages/obra-planejamento";
+import { OBRA_MODELO_ID, listObras, resetObraRepository, useObraRepository } from "../src/react-app/domains/engenharia/obra/obra-repository";
+import { useObraStore } from "../src/react-app/domains/engenharia/obra/obra-store";
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraRepository();
+  useObraStore.setState({ selectedModules: {} });
+});
+
+describe("Gestão de Obras V1 — lista (SSR)", () => {
+  test("renderiza múltiplas obras a partir do repositório", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/dominios/engenharia/obras"]}>
+        <ObraListaPage />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Obras");
+    expect(html).toContain('data-obra-card="OBRA-MODELO-EAP-001"');
+    expect(html).toContain('data-obra-card="OBRA-DEMO-001"');
+    expect(html).toContain("Obra Demonstrativa 01");
+    expect(html).toContain("Obra Demonstrativa 02");
+    expect(html).toContain("Abrir");
+    expect(html).toContain("Nova obra");
+  });
+
+  test("obra criada aparece na lista (mesma fonte do repositório)", () => {
+    useObraRepository.getState().createObra({ nome: "Obra Criada Na Lista" });
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/dominios/engenharia/obras"]}>
+        <ObraListaContent obras={listObras()} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Obra Criada Na Lista");
+  });
+
+  test("estado vazio é tratado", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/dominios/engenharia/obras"]}>
+        <ObraListaContent obras={[]} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Nenhuma obra");
+  });
+});
+
+describe("Gestão de Obras V1 — criação (SSR)", () => {
+  test("formulário mínimo renderiza nome e valida (botão desabilitado sem nome)", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/dominios/engenharia/obras/nova"]}>
+        <ObraNovaPage />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Nova obra");
+    expect(html).toContain('id="obra-nome"');
+    expect(html).toContain("Criar obra");
+    // botão desabilitado enquanto o nome estiver vazio (validação mínima)
+    expect(html).toContain("disabled");
+  });
+});
+
+describe("Gestão de Obras V1 — compatibilidade e isolamento", () => {
+  test("obra-modelo continua disponível com caracterização e EAP (compat)", () => {
+    const obra = listObras().find((o) => o.id === OBRA_MODELO_ID);
+    expect(obra?.caracterizacao?.torres).toBe(1);
+    expect(obra?.eap?.total).toBe(81);
+  });
+
+  test("planejamento recebe contexto dinâmico da obra (sem hardcode)", () => {
+    const obra = {
+      id: "OBRA-XYZ",
+      nome: "Obra Especial 99",
+      status: "PROPOSTA" as const,
+    };
+    const html = renderToStaticMarkup(<ObraPlanejamento obra={obra} />);
+    expect(html).toContain("Obra Especial 99");
+    expect(html).not.toContain("OBRA-MODELO-EAP-001");
+  });
+
+  test("estado de módulo selecionado é isolado por obra", () => {
+    useObraStore.getState().selectModule("OBRA-A", "eap");
+    useObraStore.getState().selectModule("OBRA-B", "ia");
+    const state = useObraStore.getState();
+    expect(state.selectedModules["OBRA-A"]).toBe("eap");
+    expect(state.selectedModules["OBRA-B"]).toBe("ia");
+    // Mudar a obra B não altera a obra A
+    useObraStore.getState().selectModule("OBRA-B", null);
+    expect(useObraStore.getState().selectedModules["OBRA-A"]).toBe("eap");
+    expect(useObraStore.getState().selectedModules["OBRA-B"]).toBeNull();
+  });
+});

--- a/apps/app/tests/obra-kpi-bar.test.tsx
+++ b/apps/app/tests/obra-kpi-bar.test.tsx
@@ -1,0 +1,101 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { ObraEap } from "../src/react-app/domains/engenharia/obra/pages/obra-eap";
+import { ObraLobGrade } from "../src/react-app/domains/engenharia/obra/pages/obra-lob-grade";
+import { ObraPlanejamento } from "../src/react-app/domains/engenharia/obra/pages/obra-planejamento";
+import { ObraServicos } from "../src/react-app/domains/engenharia/obra/pages/obra-servicos";
+import { ObraVisaoGeral } from "../src/react-app/domains/engenharia/obra/pages/obra-visao-geral";
+import { OBRA_MODELO_EAP_ID } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { resetObraEapRepository } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_EAP_ID,
+  nome: OBRA_MODELO_EAP_ID,
+  status: "PROPOSTA",
+  caracterizacao: {
+    torres: 1,
+    lajes: 14,
+    apartamentosPorPavimento: 1,
+    subsolos: 0,
+    sistemaConstrutivo: "concreto_armado",
+  },
+};
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraEapRepository();
+});
+
+describe("KPI bars nos módulos principais (FASE 21) — derivados de dados reais", () => {
+  test("Visão Geral: KPIs de caracterização + EAP", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraVisaoGeral obra={OBRA_MODELO} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("data-kpi-bar");
+    expect(html).toContain("data-kpi=\"kpi-torres\"");
+    expect(html).toContain("data-kpi=\"kpi-lajes\"");
+    expect(html).toContain("data-kpi=\"kpi-eap-nos\"");
+    expect(html).toContain(">1<"); // torres
+    expect(html).toContain(">14<"); // lajes
+    expect(html).toContain(">81<"); // nós EAP
+  });
+
+  test("EAP: KPIs derivados dos 81 nós reais", () => {
+    const html = renderToStaticMarkup(<ObraEap obra={OBRA_MODELO} />);
+    expect(html).toContain("data-kpi-bar");
+    expect(html).toContain("data-kpi=\"kpi-total\"");
+    expect(html).toContain("data-kpi=\"kpi-disciplinas\"");
+    expect(html).toContain("data-kpi=\"kpi-pacotes\"");
+    expect(html).toContain("data-kpi=\"kpi-trabalhos\"");
+    expect(html).toContain("data-kpi=\"kpi-folhas\"");
+    expect(html).toContain(">81<"); // total
+    expect(html).toContain(">10<"); // disciplinas
+    expect(html).toContain(">24<"); // pacotes
+    expect(html).toContain(">47<"); // trabalhos
+  });
+
+  test("Planejamento: KPIs de duração, críticos e sequenciais", () => {
+    const html = renderToStaticMarkup(<ObraPlanejamento obra={OBRA_MODELO} />);
+    expect(html).toContain("data-kpi-bar");
+    expect(html).toContain("data-kpi=\"kpi-duracao\"");
+    expect(html).toContain("data-kpi=\"kpi-criticos\"");
+    expect(html).toContain("data-kpi=\"kpi-sequenciais\"");
+  });
+
+  test("Linha de Balanço: KPIs de semanas, serviços e críticos", () => {
+    const html = renderToStaticMarkup(<ObraLobGrade obra={OBRA_MODELO} />);
+    expect(html).toContain("data-kpi-bar");
+    expect(html).toContain("data-kpi=\"kpi-semanas\"");
+    expect(html).toContain("data-kpi=\"kpi-servicos\"");
+    expect(html).toContain("data-kpi=\"kpi-criticos\"");
+    expect(html).toContain(">100<"); // semanas
+    expect(html).toContain(">34<"); // serviços
+  });
+
+  test("Serviços: KPIs de total, críticos e sequenciais", () => {
+    const html = renderToStaticMarkup(<ObraServicos obra={OBRA_MODELO} />);
+    expect(html).toContain("data-kpi-bar");
+    expect(html).toContain("data-kpi=\"kpi-total\"");
+    expect(html).toContain("data-kpi=\"kpi-criticos\"");
+    expect(html).toContain("data-kpi=\"kpi-sequenciais\"");
+    expect(html).toContain(">47<"); // total de trabalhos
+  });
+});

--- a/apps/app/tests/obra-lista-fase22.test.tsx
+++ b/apps/app/tests/obra-lista-fase22.test.tsx
@@ -1,0 +1,139 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { ObraListaContent } from "../src/react-app/domains/engenharia/obra/pages/obra-lista";
+import { resetObraRepository, useObraRepository } from "../src/react-app/domains/engenharia/obra/obra-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraRepository();
+});
+
+const noop = () => undefined;
+
+describe("Central de Obras — FASE 22 (busca, filtro, soft-delete, obra ativa)", () => {
+  test("renderiza busca, filtro de status e ações por card", () => {
+    const obras = useObraRepository.getState().obras;
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraListaContent
+          obras={obras}
+          onAbrir={noop}
+          onEditar={noop}
+          onArquivar={noop}
+          onRestaurar={noop}
+          onExcluir={noop}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Central de Obras");
+    expect(html).toContain('data-obra-busca');
+    expect(html).toContain('data-obra-status-filtro');
+    expect(html).toContain('data-obra-editar');
+    expect(html).toContain('data-obra-arquivar');
+    expect(html).toContain('data-obra-excluir');
+    expect(html).toContain("Abrir");
+  });
+
+  test("obra ativa recebe badge 'Ativa' e atributo data-obra-ativa", () => {
+    const obras = useObraRepository.getState().obras;
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraListaContent
+          obras={obras}
+          activeObraId="OBRA-DEMO-001"
+          onAbrir={noop}
+          onEditar={noop}
+          onArquivar={noop}
+          onRestaurar={noop}
+          onExcluir={noop}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('data-obra-ativa');
+    expect(html).toContain("Ativa");
+  });
+
+  test("obra arquivada mostra ação de restaurar em vez de arquivar", () => {
+    const obras: Obra[] = [
+      { id: "OBRA-ARQ", nome: "Obra Arquivada", status: "PROPOSTA", arquivada: true },
+    ];
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraListaContent
+          obras={obras}
+          onAbrir={noop}
+          onEditar={noop}
+          onArquivar={noop}
+          onRestaurar={noop}
+          onExcluir={noop}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('data-obra-restaurar="OBRA-ARQ"');
+    expect(html).not.toContain('data-obra-arquivar="OBRA-ARQ"');
+    expect(html).toContain("ARQUIVADA");
+  });
+
+  test("badge de status reflete statusEfetivo (ARQUIVADA derivado)", () => {
+    const obras: Obra[] = [
+      { id: "OBRA-EM", nome: "Obra Execução", status: "EM_EXECUCAO" },
+    ];
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraListaContent
+          obras={obras}
+          onAbrir={noop}
+          onEditar={noop}
+          onArquivar={noop}
+          onRestaurar={noop}
+          onExcluir={noop}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("EM_EXECUCAO");
+  });
+
+  test("metadados opcionais (dataInicio/localização/responsável) aparecem no card", () => {
+    const obras: Obra[] = [
+      {
+        id: "OBRA-META",
+        nome: "Obra com Metadados",
+        status: "PROPOSTA",
+        dataInicio: "2026-01-05",
+        localizacao: "Curitiba, PR",
+        responsavel: "Eng. Bruno",
+      },
+    ];
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ObraListaContent
+          obras={obras}
+          onAbrir={noop}
+          onEditar={noop}
+          onArquivar={noop}
+          onRestaurar={noop}
+          onExcluir={noop}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Início: 2026-01-05");
+    expect(html).toContain("Local: Curitiba, PR");
+    expect(html).toContain("Responsável: Eng. Bruno");
+  });
+});

--- a/apps/app/tests/obra-lob-grade.test.tsx
+++ b/apps/app/tests/obra-lob-grade.test.tsx
@@ -1,0 +1,99 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  OBRA_MODELO_EAP_ID,
+  OBRA_MODELO_EAP_NODES,
+} from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { resetObraEapRepository } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import { getEscopo } from "../src/react-app/domains/engenharia/obra/obra-escopo-repository";
+import {
+  derivarGradeLob,
+  gerarSemanas,
+  linhaParaLobLinha,
+} from "../src/react-app/domains/engenharia/obra/obra-lob-data";
+import { derivarPlanejamentoCompleto } from "../src/react-app/domains/engenharia/obra/obra-planejamento-data";
+import { ObraLobGrade } from "../src/react-app/domains/engenharia/obra/pages/obra-lob-grade";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+const ESCOPO_MODELO = getEscopo(OBRA_MODELO_EAP_ID);
+
+const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_EAP_ID,
+  nome: OBRA_MODELO_EAP_ID,
+  status: "PROPOSTA",
+};
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraEapRepository();
+});
+
+describe("obra-lob-data — grade Linha de Balanço (FASE 20.x)", () => {
+  test("gera 100 semanas cobrindo a obra (05/01/2026 → 04/12/2027)", () => {
+    const semanas = gerarSemanas(698);
+    expect(semanas.length).toBe(100);
+    expect(semanas[0].inicio).toBe("2026-01-05");
+    expect(semanas[0].fim).toBe("2026-01-11");
+    expect(semanas[99].inicio).toBe("2027-11-29");
+    expect(semanas[99].fim).toBe("2027-12-05");
+  });
+
+  test("grade deriva 34 serviços com duração e 6 críticos", () => {
+    const { semanas, linhas } = derivarGradeLob(
+      // usa os nós reais via repositório? Não — usa a fonte direta.
+      // Importamos os nós reais abaixo.
+      OBRA_MODELO_EAP_NODES,
+      ESCOPO_MODELO,
+    );
+    expect(semanas.length).toBe(100);
+    expect(linhas.length).toBe(34);
+    expect(linhas.filter((l) => l.critico === "CRÍTICO").length).toBe(6);
+  });
+
+  test("Escavação (2.1.1) ativa nas semanas 1–3 (dias 0–15)", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    const escavacao = linhas.find((l) => l.node.wbs === "2.1.1")!;
+    const lob = linhaParaLobLinha(escavacao);
+    expect(lob.semanasAtivas).toEqual([0, 1, 2]);
+  });
+
+  test("serviço sem duração não entra na grade", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    const disciplina = linhas.find((l) => l.node.wbs === "2")!;
+    const lob = linhaParaLobLinha(disciplina);
+    expect(lob.duracao).toBe(0);
+    expect(lob.semanasAtivas).toEqual([]);
+  });
+});
+
+describe("ObraLobGrade — grade LOB (SSR)", () => {
+  test("renderiza semanas, serviços e células ativas", () => {
+    const html = renderToStaticMarkup(<ObraLobGrade obra={OBRA_MODELO} />);
+    expect(html).toContain("Linha de Balanço");
+    expect(html).toContain("100 semanas");
+    expect(html).toContain("34 serviços");
+    expect(html).toContain("6 críticos");
+    expect(html).toContain("Escavação");
+    expect(html).toContain("SEM");
+  });
+
+  test("trata obra sem EAP sem quebrar", () => {
+    const semEap: Obra = { id: "OBRA-X", nome: "X", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraLobGrade obra={semEap} />);
+    expect(html).toContain("ainda não possui EAP definida");
+  });
+});

--- a/apps/app/tests/obra-modules-catalog.test.ts
+++ b/apps/app/tests/obra-modules-catalog.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OBRA_FASES_ORDER,
+  OBRA_MODULES,
+  listModulesByFase,
+  moduleFase,
+  moduleLabel,
+} from "../src/react-app/domains/engenharia/obra/obra-modules";
+import type { ObraFase, ObraModule } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+describe("Catálogo declarativo de módulos (FASE 22)", () => {
+  test("declara todos os módulos com id, label, fase e ordem", () => {
+    const ids = OBRA_MODULES.map((m) => m.id);
+    expect(ids).toContain("visao-geral");
+    expect(ids).toContain("caracterizacao");
+    expect(ids).toContain("eap");
+    expect(ids).toContain("disciplinas");
+    expect(ids).toContain("servicos");
+    expect(ids).toContain("planejamento");
+    expect(ids).toContain("linha-de-balanco");
+    expect(ids).toContain("frentes");
+    expect(ids).toContain("producao");
+    expect(ids).toContain("rdo");
+    expect(ids).toContain("ia");
+    for (const m of OBRA_MODULES) {
+      expect(m.label.length).toBeGreaterThan(0);
+      expect(OBRA_FASES_ORDER).toContain(m.fase);
+      expect(typeof m.ordem).toBe("number");
+    }
+  });
+
+  test("ids do catálogo são únicos", () => {
+    const ids = OBRA_MODULES.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("listModulesByFase retorna módulos da fase ordenados por ordem", () => {
+    const preparacao = listModulesByFase("preparacao");
+    expect(preparacao.map((m) => m.id)).toEqual([
+      "visao-geral",
+      "caracterizacao",
+      "eap",
+      "disciplinas",
+      "servicos",
+      "planejamento",
+      "linha-de-balanco",
+    ]);
+    const execucao = listModulesByFase("execucao");
+    expect(execucao.map((m) => m.id)).toEqual(["frentes", "producao", "rdo"]);
+    const suporte = listModulesByFase("suporte");
+    expect(suporte.map((m) => m.id)).toEqual(["ia"]);
+  });
+
+  test("OBRA_FASES_ORDER é a ordem canônica Preparação → Execução → Suporte", () => {
+    expect(OBRA_FASES_ORDER).toEqual(["preparacao", "execucao", "suporte"]);
+  });
+
+  test("moduleLabel resolve rótulo; moduleFase resolve fase", () => {
+    expect(moduleLabel("eap")).toBe("EAP");
+    expect(moduleLabel("linha-de-balanco")).toBe("Linha de Balanço");
+    expect(moduleFase("eap")).toBe("preparacao");
+    expect(moduleFase("producao")).toBe("execucao");
+    expect(moduleFase("ia")).toBe("suporte");
+  });
+
+  test("catálogo é a fonte única de metadados (sem React/routing/estado/dados)", () => {
+    // Garante que o catálogo permanece declarativo: nenhum componente/rota/estado.
+    const source = OBRA_MODULES;
+    expect(Array.isArray(source)).toBe(true);
+    // Cada entrada é um objeto plano de metadados.
+    for (const m of source) {
+      expect(typeof m.id).toBe("string");
+      expect(typeof m.label).toBe("string");
+    }
+  });
+
+  test("todos os ids do catálogo são ObraModule válidos", () => {
+    const valid: ObraModule[] = [
+      "visao-geral",
+      "caracterizacao",
+      "eap",
+      "disciplinas",
+      "servicos",
+      "planejamento",
+      "linha-de-balanco",
+      "frentes",
+      "producao",
+      "rdo",
+      "ia",
+    ];
+    for (const m of OBRA_MODULES) {
+      expect(valid).toContain(m.id);
+    }
+  });
+
+  test("fases do catálogo são ObraFase válidas", () => {
+    const valid: ObraFase[] = ["preparacao", "execucao", "suporte"];
+    for (const m of OBRA_MODULES) {
+      expect(valid).toContain(m.fase);
+    }
+  });
+});

--- a/apps/app/tests/obra-modulos-ui.test.tsx
+++ b/apps/app/tests/obra-modulos-ui.test.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ObraCaracterizacao } from "../src/react-app/domains/engenharia/obra/pages/obra-caracterizacao";
+import { ObraDisciplinas } from "../src/react-app/domains/engenharia/obra/pages/obra-disciplinas";
+import { ObraServicos } from "../src/react-app/domains/engenharia/obra/pages/obra-servicos";
+import { OBRA_MODELO_EAP_ID } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { resetObraEapRepository } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+const OBRA_MODELO: Obra = {
+  id: OBRA_MODELO_EAP_ID,
+  nome: OBRA_MODELO_EAP_ID,
+  status: "PROPOSTA",
+  caracterizacao: {
+    torres: 1,
+    lajes: 14,
+    apartamentosPorPavimento: 1,
+    subsolos: 0,
+    sistemaConstrutivo: "concreto_armado",
+  },
+};
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraEapRepository();
+});
+
+describe("ObraCaracterizacao — módulo próprio (SSR)", () => {
+  test("renderiza os campos estruturais da obra", () => {
+    const html = renderToStaticMarkup(<ObraCaracterizacao obra={OBRA_MODELO} />);
+    expect(html).toContain("Caracterização");
+    expect(html).toContain("Torres");
+    expect(html).toContain("Lajes");
+    expect(html).toContain("Subsolos");
+    expect(html).toContain("Sistema construtivo");
+    expect(html).toContain("concreto_armado");
+  });
+
+  test("trata obra sem caracterização sem quebrar", () => {
+    const semCarac: Obra = { id: "OBRA-X", nome: "X", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraCaracterizacao obra={semCarac} />);
+    expect(html).toContain("ainda não preenchida");
+  });
+});
+
+describe("ObraDisciplinas — 10 disciplinas derivadas (SSR)", () => {
+  test("renderiza as 10 disciplinas com contagem de pacotes e trabalhos", () => {
+    const html = renderToStaticMarkup(<ObraDisciplinas obra={OBRA_MODELO} />);
+    expect(html).toContain("Disciplinas");
+    expect(html).toContain("Preparação, Projetos e Canteiro");
+    expect(html).toContain("Superestrutura");
+    expect(html).toContain("Áreas Externas");
+    expect(html).toContain("pacotes");
+    expect(html).toContain("trabalhos");
+  });
+
+  test("trata obra sem EAP sem quebrar", () => {
+    const semEap: Obra = { id: "OBRA-X", nome: "X", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraDisciplinas obra={semEap} />);
+    expect(html).toContain("ainda não possui EAP definida");
+  });
+});
+
+describe("ObraServicos — 47 trabalhos com datas e crítico (SSR)", () => {
+  test("renderiza os trabalhos com duração, datas e caminho crítico", () => {
+    const html = renderToStaticMarkup(<ObraServicos obra={OBRA_MODELO} />);
+    expect(html).toContain("Serviços");
+    expect(html).toContain("Escavação");
+    expect(html).toContain("2026-01-05");
+    expect(html).toContain("Crítico");
+    expect(html).toContain("Sequencial");
+  });
+
+  test("trata obra sem EAP sem quebrar", () => {
+    const semEap: Obra = { id: "OBRA-X", nome: "X", status: "PROPOSTA" };
+    const html = renderToStaticMarkup(<ObraServicos obra={semEap} />);
+    expect(html).toContain("Nenhum serviço para exibir");
+  });
+});

--- a/apps/app/tests/obra-p0a-desacoplamento.test.ts
+++ b/apps/app/tests/obra-p0a-desacoplamento.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { OBRA_MODELO_EAP_ID, OBRA_MODELO_EAP_NODES } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { validateEap } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import {
+  DATA_INICIO_DEFAULT,
+  dataInicioEfetiva,
+  diaParaDataIso,
+} from "../src/react-app/domains/engenharia/obra/obra-planejamento-data";
+
+describe("P0a D8 — validateEap desacoplado da Obra Modelo", () => {
+  test("valida EAP de outra obra (OBRA-DEMO-001) com todos os nós pertencentes a ela", () => {
+    const nodes = OBRA_MODELO_EAP_NODES.map((n) => ({ ...n, obraId: "OBRA-DEMO-001" }));
+    const result = validateEap(nodes, "OBRA-DEMO-001");
+    expect(result.ok).toBe(true);
+    expect(result.total).toBe(81);
+    expect(result.foraDaObra).toEqual([]);
+  });
+
+  test("marca como foraDaObra nó de obra diferente da validada", () => {
+    const nodes = OBRA_MODELO_EAP_NODES.map((n) =>
+      n.wbs === "2.1.1" ? { ...n, obraId: "OBRA-DEMO-001" } : n,
+    );
+    const result = validateEap(nodes, OBRA_MODELO_EAP_ID);
+    expect(result.ok).toBe(false);
+    expect(result.foraDaObra).toEqual(["2.1.1"]);
+  });
+
+  test("obra-modelo continua válida via seed (todos os nós pertencem a ela)", () => {
+    const result = validateEap(OBRA_MODELO_EAP_NODES, OBRA_MODELO_EAP_ID);
+    expect(result.ok).toBe(true);
+    expect(result.foraDaObra).toEqual([]);
+  });
+});
+
+describe("P0a D9 — dataInicioEfetiva vincula o cronograma à obra", () => {
+  test("dataInicioEfetiva('2026-06-01') retorna 01/06/2026", () => {
+    const d = dataInicioEfetiva("2026-06-01");
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(5);
+    expect(d.getDate()).toBe(1);
+  });
+
+  test("dataInicioEfetiva(null) cai no fallback 05/01/2026", () => {
+    const d = dataInicioEfetiva(null);
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(0);
+    expect(d.getDate()).toBe(5);
+  });
+
+  test("dataInicioEfetiva(undefined) cai no fallback 05/01/2026", () => {
+    const d = dataInicioEfetiva(undefined);
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(0);
+    expect(d.getDate()).toBe(5);
+  });
+
+  test("DATA_INICIO_DEFAULT é 05/01/2026 (preserva a seed da obra-modelo)", () => {
+    expect(DATA_INICIO_DEFAULT.getFullYear()).toBe(2026);
+    expect(DATA_INICIO_DEFAULT.getMonth()).toBe(0);
+    expect(DATA_INICIO_DEFAULT.getDate()).toBe(5);
+  });
+
+  test("diaParaDataIso respeita a data de início efetiva da obra", () => {
+    expect(diaParaDataIso(0, dataInicioEfetiva("2026-06-01"))).toBe("2026-06-01");
+    expect(diaParaDataIso(0, dataInicioEfetiva(null))).toBe("2026-01-05");
+  });
+});

--- a/apps/app/tests/obra-p0b-escopo.test.ts
+++ b/apps/app/tests/obra-p0b-escopo.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { OBRA_MODELO_EAP_ID, OBRA_MODELO_EAP_NODES } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { getEscopo } from "../src/react-app/domains/engenharia/obra/obra-escopo-repository";
+import {
+  OBRA_SCOPE_REF,
+  calcDuracao,
+  derivarPlanejamentoCompleto,
+  duracaoTotalDasLinhas,
+} from "../src/react-app/domains/engenharia/obra/obra-planejamento-data";
+
+const ESCOPO_MODELO = getEscopo(OBRA_MODELO_EAP_ID);
+
+describe("P0b — repositório de escopo por obra (obra-escopo-repository)", () => {
+  test("getEscopo(OBRA_MODELO_EAP_ID) tem paridade com OBRA_SCOPE_REF (WBS com quantidade>0)", () => {
+    const comQtdRef = Object.values(OBRA_SCOPE_REF).filter((r) => r.quantidade > 0).length;
+    const comQtdEscopo = Object.values(ESCOPO_MODELO).filter((e) => e.quantidade > 0).length;
+    expect(comQtdEscopo).toBe(comQtdRef);
+    expect(Object.keys(ESCOPO_MODELO).length).toBe(Object.keys(OBRA_SCOPE_REF).length);
+  });
+
+  test("getEscopo(OBRA_MODELO_EAP_ID) preserva unidade/quantidade/produtividade por WBS", () => {
+    const escavacao = ESCOPO_MODELO["2.1.1"];
+    expect(escavacao).toBeDefined();
+    expect(escavacao.obraId).toBe(OBRA_MODELO_EAP_ID);
+    expect(escavacao.wbs).toBe("2.1.1");
+    expect(escavacao.unidade).toBe("m³");
+    expect(escavacao.quantidade).toBe(120);
+    expect(escavacao.produtividade).toBe("8 m³/dia");
+  });
+
+  test("getEscopo(OBRA-DEMO-001) retorna vazio (outra obra sem escopo)", () => {
+    expect(getEscopo("OBRA-DEMO-001")).toEqual({});
+  });
+});
+
+describe("P0b — calcDuracao parametrizado pelo escopo da obra", () => {
+  test("com escopo da obra-modelo → mesmo valor que OBRA_SCOPE_REF (paridade)", () => {
+    const escavacao = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.1")!;
+    const ref = OBRA_SCOPE_REF["2.1.1"];
+    const rate = Number(/([\d.]+)/.exec(ref.produtividade)![1]);
+    expect(calcDuracao(escavacao, ESCOPO_MODELO)).toBe(Math.ceil(ref.quantidade / rate));
+    expect(calcDuracao(escavacao, ESCOPO_MODELO)).toBe(15);
+  });
+
+  test("com escopo vazio → 0 (sem escopo, sem duração)", () => {
+    const escavacao = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.1")!;
+    expect(calcDuracao(escavacao, {})).toBe(0);
+  });
+
+  test("derivarPlanejamentoCompleto com escopo vazio → duração total 0", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, {});
+    expect(duracaoTotalDasLinhas(linhas)).toBe(0);
+  });
+});

--- a/apps/app/tests/obra-planejamento-adapter.test.ts
+++ b/apps/app/tests/obra-planejamento-adapter.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+
+import { OBRA_MODELO_EAP_ID, OBRA_MODELO_EAP_NODES } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { getEscopo } from "../src/react-app/domains/engenharia/obra/obra-escopo-repository";
+import {
+  DATA_INICIO_OBRA,
+  calcDuracao,
+  derivarPlanejamentoCompleto,
+  diaParaDataIso,
+  duracaoTotalDasLinhas,
+  limiarCriticoDasLinhas,
+  resolveDisciplina,
+} from "../src/react-app/domains/engenharia/obra/obra-planejamento-data";
+import {
+  eapNodeParaPlanningItem,
+  obraEapParaPlanningDashboard,
+} from "../src/react-app/domains/engenharia/obra/obra-planejamento-adapter";
+import { derivePlanningRows } from "../src/react-app/domains/planejamento/planning-data";
+
+const ESCOPO_MODELO = getEscopo(OBRA_MODELO_EAP_ID);
+
+describe("obra-planejamento-data — derivação do cronograma (FASE 20.x)", () => {
+  test("duração total da obra é 698 dias (início 05/01/2026)", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    expect(duracaoTotalDasLinhas(linhas)).toBe(698);
+    expect(DATA_INICIO_OBRA.getFullYear()).toBe(2026);
+    expect(DATA_INICIO_OBRA.getMonth()).toBe(0);
+    expect(DATA_INICIO_OBRA.getDate()).toBe(5);
+  });
+
+  test("34 trabalhos têm duração estimada; 47 nós sem duração", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    const comDuracao = linhas.filter((l) => l.duracao > 0).length;
+    const semDuracao = linhas.filter((l) => l.duracao === 0).length;
+    expect(comDuracao).toBe(34);
+    expect(semDuracao).toBe(47);
+  });
+
+  test("limiar crítico é 45 dias (60% da maior duração)", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    expect(limiarCriticoDasLinhas(linhas)).toBe(45);
+  });
+
+  test("6 trabalhos são CRÍTICOS", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    const criticos = linhas.filter((l) => l.critico === "CRÍTICO").length;
+    expect(criticos).toBe(6);
+  });
+
+  test("Escavação (2.1.1) dura 15 dias e ocupa as semanas 1–3", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    const escavacao = linhas.find((l) => l.node.wbs === "2.1.1");
+    expect(escavacao?.duracao).toBe(15);
+    expect(escavacao?.inicio).toBe(0);
+    expect(escavacao?.fim).toBe(15);
+    // Semana 1 = dias 0..6, semana 2 = 7..13, semana 3 = 14..20
+    expect(escavacao?.fim).toBeGreaterThan(13);
+  });
+
+  test("predecessora encadeia os trabalhos com duração", () => {
+    const linhas = derivarPlanejamentoCompleto(OBRA_MODELO_EAP_NODES, ESCOPO_MODELO);
+    const trabalhos = linhas.filter((l) => l.node.tipo === "TRABALHO" && l.duracao > 0);
+    for (let i = 1; i < trabalhos.length; i += 1) {
+      expect(trabalhos[i].predecessora).toBe(trabalhos[i - 1].node.wbs);
+    }
+  });
+
+  test("resolveDisciplina devolve o nome da disciplina raiz", () => {
+    const n211 = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.1");
+    expect(resolveDisciplina(n211!, OBRA_MODELO_EAP_NODES)).toBe(
+      "Infraestrutura e Fundações",
+    );
+  });
+
+  test("diaParaDataIso converte dia acumulado em data ISO", () => {
+    expect(diaParaDataIso(0)).toBe("2026-01-05");
+    expect(diaParaDataIso(698)).toBe("2027-12-04");
+  });
+
+  test("calcDuracao usa quantidade/produtividade (ceil)", () => {
+    const escavacao = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.1");
+    expect(calcDuracao(escavacao!, ESCOPO_MODELO)).toBe(15); // 120 / 8
+    const disciplina = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2");
+    expect(calcDuracao(disciplina!, ESCOPO_MODELO)).toBe(0); // não é TRABALHO
+  });
+});
+
+describe("obra-planejamento-adapter — EAP → PlanningDashboardData", () => {
+  test("produz 81 itens com hierarquia preservada", () => {
+    const data = obraEapParaPlanningDashboard(OBRA_MODELO_EAP_NODES, "Obra Modelo EAP", ESCOPO_MODELO);
+    expect(data.items.length).toBe(81);
+    const rows = derivePlanningRows(data.items, new Set());
+    expect(rows.length).toBe(81);
+    // Raiz primeiro, filho depois (pré-order)
+    const order = rows.map((r) => r.item.id);
+    expect(order.indexOf("1")).toBeLessThan(order.indexOf("1.1"));
+    expect(order.indexOf("1.1")).toBeLessThan(order.indexOf("1.1.1"));
+  });
+
+  test("níveis mapeados: EAP nivel 1 → planning level 0", () => {
+    const data = obraEapParaPlanningDashboard(OBRA_MODELO_EAP_NODES, "Obra Modelo EAP", ESCOPO_MODELO);
+    const raiz = data.items.find((i) => i.id === "1");
+    const trabalho = data.items.find((i) => i.id === "2.1.1");
+    expect(raiz?.level).toBe(0);
+    expect(trabalho?.level).toBe(2);
+  });
+
+  test("trabalhos com duração têm datas; demais não", () => {
+    const data = obraEapParaPlanningDashboard(OBRA_MODELO_EAP_NODES, "Obra Modelo EAP", ESCOPO_MODELO);
+    const escavacao = data.items.find((i) => i.id === "2.1.1");
+    expect(escavacao?.start).toBe("2026-01-05");
+    expect(escavacao?.end).toBe("2026-01-20");
+    const disciplina = data.items.find((i) => i.id === "2");
+    expect(disciplina?.start).toBeNull();
+    expect(disciplina?.end).toBeNull();
+  });
+
+  test("contexto reflete a obra e a fonte (81 nós)", () => {
+    const data = obraEapParaPlanningDashboard(OBRA_MODELO_EAP_NODES, "Edifício Modelo", ESCOPO_MODELO);
+    expect(data.context.title).toBe("Planejamento");
+    expect(data.context.subtitle).toContain("Edifício Modelo");
+    expect(data.context.subtitle).toContain("81 nós");
+  });
+
+  test("eapNodeParaPlanningItem mapeia campos individualmente", () => {
+    const node = OBRA_MODELO_EAP_NODES.find((n) => n.wbs === "2.1.1")!;
+    const item = eapNodeParaPlanningItem(node, "2026-01-05", "2026-01-20");
+    expect(item.id).toBe("2.1.1");
+    expect(item.parentId).toBe("2.1");
+    expect(item.name).toBe("Escavação");
+    expect(item.status).toBe("planejado");
+    expect(item.progress).toBe(0);
+  });
+});

--- a/apps/app/tests/obra-repository-fase22.test.ts
+++ b/apps/app/tests/obra-repository-fase22.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  OBRA_MODELO_ID,
+  listObras,
+  listObrasArquivadas,
+  listObrasAtivas,
+  resetObraRepository,
+  statusEfetivo,
+  useObraRepository,
+} from "../src/react-app/domains/engenharia/obra/obra-repository";
+import type { Obra } from "../src/react-app/domains/engenharia/obra/obra-types";
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraRepository();
+});
+
+describe("ObraRepository — FASE 22 (CRUD, soft-delete, status)", () => {
+  test("createObra aceita metadados opcionais (status, datas, localização, responsável)", () => {
+    const obra = useObraRepository.getState().createObra({
+      nome: "Obra Completa",
+      status: "EM_EXECUCAO",
+      dataInicio: "2026-01-05",
+      dataFim: "2026-12-20",
+      localizacao: "São Paulo, SP",
+      responsavel: "Eng. Ana",
+    });
+    expect(obra.status).toBe("EM_EXECUCAO");
+    expect(obra.dataInicio).toBe("2026-01-05");
+    expect(obra.dataFim).toBe("2026-12-20");
+    expect(obra.localizacao).toBe("São Paulo, SP");
+    expect(obra.responsavel).toBe("Eng. Ana");
+    expect(obra.arquivada).toBeUndefined();
+  });
+
+  test("createObra sem metadados usa defaults (status PROPOSTA, campos nulos)", () => {
+    const obra = useObraRepository.getState().createObra({ nome: "Obra Mínima" });
+    expect(obra.status).toBe("PROPOSTA");
+    expect(obra.dataInicio).toBeNull();
+    expect(obra.dataFim).toBeNull();
+    expect(obra.localizacao).toBeNull();
+    expect(obra.responsavel).toBeNull();
+  });
+
+  test("updateObra altera campos preservando id", () => {
+    const obra = useObraRepository.getState().createObra({ nome: "Antes" });
+    useObraRepository.getState().updateObra(obra.id, {
+      nome: "Depois",
+      status: "CONCLUIDA",
+      localizacao: "Rio de Janeiro, RJ",
+    });
+    const atualizada = listObras().find((o) => o.id === obra.id);
+    expect(atualizada?.nome).toBe("Depois");
+    expect(atualizada?.status).toBe("CONCLUIDA");
+    expect(atualizada?.localizacao).toBe("Rio de Janeiro, RJ");
+    expect(atualizada?.id).toBe(obra.id);
+  });
+
+  test("statusEfetivo deriva ARQUIVADA de arquivada (soft-delete), nunca persistido", () => {
+    const obra = useObraRepository.getState().createObra({ nome: "Obra Status" });
+    expect(statusEfetivo(obra)).toBe("PROPOSTA");
+    useObraRepository.getState().archiveObra(obra.id);
+    const arquivada = listObras().find((o) => o.id === obra.id)!;
+    expect(statusEfetivo(arquivada)).toBe("ARQUIVADA");
+    // O campo `status` original não é alterado (ARQUIVADA é derivado).
+    expect(arquivada.status).toBe("PROPOSTA");
+  });
+
+  test("archiveObra/unarchiveObra alternam soft-delete", () => {
+    const obra = useObraRepository.getState().createObra({ nome: "Obra Arquivável" });
+    useObraRepository.getState().archiveObra(obra.id);
+    expect(listObras().find((o) => o.id === obra.id)?.arquivada).toBe(true);
+    useObraRepository.getState().unarchiveObra(obra.id);
+    expect(listObras().find((o) => o.id === obra.id)?.arquivada).toBe(false);
+  });
+
+  test("deleteObra remove definitivamente da fonte única", () => {
+    const obra = useObraRepository.getState().createObra({ nome: "Obra Excluída" });
+    expect(listObras().some((o) => o.id === obra.id)).toBe(true);
+    useObraRepository.getState().deleteObra(obra.id);
+    expect(listObras().some((o) => o.id === obra.id)).toBe(false);
+  });
+
+  test("listObrasAtivas exclui arquivadas; listObrasArquivadas retorna só arquivadas", () => {
+    const ativa = useObraRepository.getState().createObra({ nome: "Ativa" });
+    const arquivada = useObraRepository.getState().createObra({ nome: "Arquivada" });
+    useObraRepository.getState().archiveObra(arquivada.id);
+    expect(listObrasAtivas().map((o) => o.id)).toContain(ativa.id);
+    expect(listObrasAtivas().map((o) => o.id)).not.toContain(arquivada.id);
+    expect(listObrasArquivadas().map((o) => o.id)).toContain(arquivada.id);
+    expect(listObrasArquivadas().map((o) => o.id)).not.toContain(ativa.id);
+  });
+
+  test("obra-modelo permanece ativa e com caracterização/EAP (compatibilidade)", () => {
+    const modelo = listObras().find((o) => o.id === OBRA_MODELO_ID) as Obra;
+    expect(statusEfetivo(modelo)).toBe("PROPOSTA");
+    expect(modelo.caracterizacao?.torres).toBe(1);
+    expect(modelo.eap?.total).toBe(81);
+  });
+});

--- a/apps/app/tests/obra-repository.test.ts
+++ b/apps/app/tests/obra-repository.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  OBRA_MODELO_ID,
+  SEED_OBRAS,
+  createObraId,
+  findObraById,
+  initializeObraRepository,
+  listObras,
+  resetObraRepository,
+  useObraRepository,
+} from "../src/react-app/domains/engenharia/obra/obra-repository";
+import { loadObrasFromStorage } from "../src/react-app/domains/engenharia/obra/obra-storage";
+
+beforeEach(() => {
+  // Em ambiente Bun (node-like) não existe localStorage global: injetamos um
+  // storage em memória para validar a camada de persistência do repositório.
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraRepository();
+});
+
+describe("ObraRepository — fonte única de obras (FASE 04.2-B)", () => {
+  test("inicia com pelo menos duas obras demonstrativas + obra-modelo preservada", () => {
+    const obras = listObras();
+    expect(obras.length).toBeGreaterThanOrEqual(3);
+    expect(obras.map((o) => o.id)).toContain(OBRA_MODELO_ID);
+    expect(findObraById(OBRA_MODELO_ID)?.nome).toBe(OBRA_MODELO_ID);
+    expect(obras.some((o) => o.id === "OBRA-DEMO-001")).toBe(true);
+    expect(obras.some((o) => o.id === "OBRA-DEMO-002")).toBe(true);
+  });
+
+  test("listObras reflete o estado atual", () => {
+    const antes = listObras().length;
+    useObraRepository.getState().createObra({ nome: "Obra Lista" });
+    expect(listObras().length).toBe(antes + 1);
+  });
+
+  test("findObraById resolve e rejeita ids desconhecidos", () => {
+    expect(findObraById(OBRA_MODELO_ID)?.id).toBe(OBRA_MODELO_ID);
+    expect(findObraById("OBRA-NAO-EXISTE")).toBeUndefined();
+  });
+
+  test("createObra gera id estável e único (não depende do nome)", () => {
+    const a = useObraRepository.getState().createObra({ nome: "Alfa" });
+    const b = useObraRepository.getState().createObra({ nome: "Beta" });
+    expect(a.id).toMatch(/^OBRA-/);
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).not.toContain("Alfa");
+    expect(b.id).not.toContain("Beta");
+    const nova = findObraById(a.id);
+    expect(nova?.nome).toBe("Alfa");
+    expect(nova?.status).toBe("PROPOSTA");
+    expect(nova?.caracterizacao).toBeUndefined();
+  });
+
+  test("createObraId gera ids distintos para um conjunto", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 20; i += 1) ids.add(createObraId(ids));
+    expect(ids.size).toBe(20);
+  });
+
+  test("persistência local: obra criada sobrevive a um reload (re-hidratação)", () => {
+    const nova = useObraRepository.getState().createObra({
+      nome: "Obra Sobrevive Ao Reload",
+    });
+    // 1) o armazenamento local contém a obra criada
+    const persisted = loadObrasFromStorage();
+    expect(persisted?.some((o) => o.id === nova.id)).toBe(true);
+
+    // 2) simula reload: zera a memória (preservando o storage) e re-hidrata
+    useObraRepository.setState({ obras: [] });
+    initializeObraRepository();
+
+    const aposReload = findObraById(nova.id);
+    expect(aposReload?.nome).toBe("Obra Sobrevive Ao Reload");
+    expect(listObras().length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("resetObraRepository restaura os seeds", () => {
+    useObraRepository.getState().createObra({ nome: "Temporária" });
+    resetObraRepository();
+    expect(listObras().map((o) => o.id)).toEqual(SEED_OBRAS.map((o) => o.id));
+  });
+});

--- a/apps/app/tests/obra-shell-fases.test.tsx
+++ b/apps/app/tests/obra-shell-fases.test.tsx
@@ -1,0 +1,86 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { ObraShellRoute } from "../src/react-app/domains/engenharia/obra/obra-shell-route";
+import { OBRA_MODELO_EAP_ID } from "../src/react-app/domains/engenharia/obra/obra-eap-data";
+import { resetObraEapRepository } from "../src/react-app/domains/engenharia/obra/obra-eap-repository";
+import { resetObraRepository } from "../src/react-app/domains/engenharia/obra/obra-repository";
+import { useObraStore } from "../src/react-app/domains/engenharia/obra/obra-store";
+
+beforeEach(() => {
+  const memory = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+  resetObraRepository();
+  resetObraEapRepository();
+  useObraStore.setState({ selectedModules: {} });
+});
+
+function renderShell(modulo?: string) {
+  return renderToStaticMarkup(
+    <MemoryRouter
+      initialEntries={[
+        `/dominios/engenharia/obras/${OBRA_MODELO_EAP_ID}${modulo ? `/${modulo}` : ""}`,
+      ]}
+    >
+      <ObraShellRoute obraId={OBRA_MODELO_EAP_ID} modulo={(modulo as never) ?? null} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ObraShellRoute — Tabs por fase com subitens (FASE 21)", () => {
+  test("renderiza as três fases (Preparação, Execução, Suporte)", () => {
+    const html = renderShell();
+    expect(html).toContain("data-obra-fases");
+    expect(html).toContain('data-obra-fase="preparacao"');
+    expect(html).toContain('data-obra-fase="execucao"');
+    expect(html).toContain('data-obra-fase="suporte"');
+    expect(html).toContain("Preparação");
+    expect(html).toContain("Execução");
+    expect(html).toContain("Suporte");
+  });
+
+  test("fase Preparação ativa por padrão mostra seus subitens", () => {
+    const html = renderShell();
+    expect(html).toContain("data-obra-modulos");
+    expect(html).toContain('data-obra-module="visao-geral"');
+    expect(html).toContain('data-obra-module="eap"');
+    expect(html).toContain('data-obra-module="planejamento"');
+    expect(html).toContain('data-obra-module="linha-de-balanco"');
+    expect(html).toContain('data-obra-module="servicos"');
+  });
+
+  test("módulo de Execução (frentes) mostra os subitens da fase Execução", () => {
+    const html = renderShell("frentes");
+    expect(html).toContain('data-obra-module="frentes"');
+    expect(html).toContain('data-obra-module="producao"');
+    expect(html).toContain('data-obra-module="rdo"');
+  });
+
+  test("módulo de Suporte (ia) mostra os subitens da fase Suporte", () => {
+    const html = renderShell("ia");
+    expect(html).toContain('data-obra-module="ia"');
+  });
+
+  test("renderiza o conteúdo do módulo ativo (EAP)", () => {
+    const html = renderShell("eap");
+    expect(html).toContain("EAP — Estrutura Analítica do Projeto");
+  });
+
+  test("renderiza o conteúdo do módulo ativo (Linha de Balanço)", () => {
+    const html = renderShell("linha-de-balanco");
+    expect(html).toContain("Linha de Balanço");
+  });
+});

--- a/apps/app/tests/planning-anti-hardcode.test.ts
+++ b/apps/app/tests/planning-anti-hardcode.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Auditoria anti-hardcode da capacidade genérica de Planejamento (V1).
+ * Garante que a pasta domains/planejamento (contrato + componentes + dados
+ * demonstrativos) NÃO dependa de conceitos de um domínio/obra específica.
+ */
+
+const PLANNING_DIR = join(
+  import.meta.dir,
+  "..",
+  "src",
+  "react-app",
+  "domains",
+  "planejamento",
+);
+
+const FORBIDDEN_TERMS = [
+  "OBRA-MODELO-EAP-001",
+  "torre",
+  "apartamento",
+  "pavimento",
+  "engenharia",
+  "obra-001",
+];
+
+describe("planejamento — auditoria anti-hardcode", () => {
+  const files = readdirSync(PLANNING_DIR).filter((name) =>
+    /\.(ts|tsx)$/.test(name),
+  );
+
+  test("arquivos da capacidade existem e são auditáveis", () => {
+    expect(files).toContain("planning-types.ts");
+    expect(files).toContain("planning-data.ts");
+    expect(files).toContain("planning-dashboard.tsx");
+  });
+
+  test("nenhum termo específico de domínio/obra aparece na capacidade genérica", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const content = readFileSync(join(PLANNING_DIR, file), "utf8").toLowerCase();
+      for (const term of FORBIDDEN_TERMS) {
+        if (content.includes(term.toLowerCase())) {
+          offenders.push(`${file} -> ${term}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("nomes do dataset demonstrativo são neutros", () => {
+    const demo = readFileSync(join(PLANNING_DIR, "planning-demo-data.ts"), "utf8");
+    expect(demo).toContain("Grupo A");
+    expect(demo).toContain("Atividade 01");
+    expect(demo).toContain("Pacote B.2");
+  });
+});

--- a/apps/app/tests/planning-dashboard.test.tsx
+++ b/apps/app/tests/planning-dashboard.test.tsx
@@ -1,0 +1,77 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PlanningDashboard } from "../src/react-app/domains/planejamento/planning-dashboard";
+import { PlanningItemDetails } from "../src/react-app/domains/planejamento/planning-details";
+import { PLANNING_DEMO_DATA } from "../src/react-app/domains/planejamento/planning-demo-data";
+import {
+  PLANNING_HELP_SECTIONS,
+  PlanningHelp,
+} from "../src/react-app/domains/planejamento/planning-help";
+import type { PlanningDashboardData } from "../src/react-app/domains/planejamento/planning-types";
+
+describe("PlanningDashboard — SSR (capacidade genérica)", () => {
+  test("renderiza título, contexto e KPIs derivados", () => {
+    const html = renderToStaticMarkup(<PlanningDashboard data={PLANNING_DEMO_DATA} />);
+    expect(html).toContain("Planejamento");
+    expect(html).toContain("data-planning-dashboard");
+    expect(html).toContain("data-kpi=\"kpi-total\"");
+    expect(html).toContain("data-kpi=\"kpi-atencao\"");
+    expect(html).toContain("data-kpi=\"kpi-concluidos\"");
+    expect(html).toContain("Total");
+    expect(html).toContain("Atenção");
+    expect(html).toContain("Em andamento");
+  });
+
+  test("renderiza árvore e timeline com os itens da hierarquia", () => {
+    const html = renderToStaticMarkup(<PlanningDashboard data={PLANNING_DEMO_DATA} />);
+    expect(html).toContain("data-planning-tree");
+    expect(html).toContain("data-planning-timeline");
+    expect(html).toContain("Grupo A");
+    expect(html).toContain("Atividade 01");
+    expect(html).toContain("data-planning-row");
+    expect(html).toContain("data-planning-bar");
+  });
+
+  test("deriva alertas a partir dos dados (estado preenchido)", () => {
+    const html = renderToStaticMarkup(<PlanningDashboard data={PLANNING_DEMO_DATA} />);
+    expect(html).toContain("data-alert");
+    expect(html).toContain("Atrasado");
+    expect(html).toContain("Sem período");
+  });
+
+  test("trata estado vazio sem quebrar", () => {
+    const empty: PlanningDashboardData = {
+      context: { title: "Planejamento" },
+      items: [],
+    };
+    const html = renderToStaticMarkup(<PlanningDashboard data={empty} />);
+    expect(html).toContain("Sem itens de planejamento");
+  });
+
+  test("painel de detalhes renderiza os campos do item", () => {
+    const item = PLANNING_DEMO_DATA.items.find((i) => i.id === "atividade-01");
+    expect(item).toBeDefined();
+    const html = renderToStaticMarkup(
+      <PlanningItemDetails item={item!} parentName="Pacote A.1" />,
+    );
+    expect(html).toContain("data-planning-details");
+    expect(html).toContain("Atividade 01");
+    expect(html).toContain("Em andamento");
+    expect(html).toContain("80%");
+    expect(html).toContain("15/06/2026");
+    expect(html).toContain("Pacote A.1");
+  });
+
+  test("conteúdo da ajuda contextual cobre as perguntas da V1", () => {
+    expect(PLANNING_HELP_SECTIONS.map((s) => s.question)).toEqual([
+      "O que é?",
+      "Para que serve?",
+      "Como funciona?",
+      "O que devo fazer?",
+    ]);
+    const html = renderToStaticMarkup(<PlanningHelp />);
+    expect(html).toContain("Planejamento");
+  });
+});

--- a/apps/app/tests/planning-data.test.ts
+++ b/apps/app/tests/planning-data.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  daysBetween,
+  derivePlanningAlerts,
+  derivePlanningPeriods,
+  derivePlanningRows,
+  derivePlanningSummary,
+  parseIsoDate,
+  planningRootIds,
+  planningRowsForQuery,
+} from "../src/react-app/domains/planejamento/planning-data";
+import { PLANNING_DEMO_DATA } from "../src/react-app/domains/planejamento/planning-demo-data";
+
+describe("planning-data — derivações puras (V1)", () => {
+  test("parseIsoDate valida datas reais e rejeita inválidas", () => {
+    expect(parseIsoDate("2026-08-15")?.getFullYear()).toBe(2026);
+    expect(parseIsoDate("2026-13-01")).toBeNull();
+    expect(parseIsoDate("2026-02-30")).toBeNull();
+    expect(parseIsoDate(null)).toBeNull();
+    expect(parseIsoDate("")).toBeNull();
+  });
+
+  test("resumo derivado do dataset demonstrativo", () => {
+    const summary = derivePlanningSummary(PLANNING_DEMO_DATA);
+    expect(summary.total).toBe(13);
+    expect(summary.emAndamento).toBe(3);
+    expect(summary.concluidos).toBe(3);
+    // atencao = atrasado + em_andamento com fim < data de referência
+    expect(summary.atencao).toBe(2);
+  });
+
+  test("alertas derivados cobrem atraso, sem período e concluído", () => {
+    const alerts = derivePlanningAlerts(PLANNING_DEMO_DATA);
+    const titles = alerts.map((alert) => alert.title);
+    expect(titles).toContain("Atrasado");
+    expect(titles).toContain("Sem período");
+    expect(titles).toContain("Concluído");
+    const atrasado = alerts.find((alert) => alert.title === "Atrasado");
+    expect(atrasado?.detail).toContain("Atividade 03");
+    const semPeriodo = alerts.filter((alert) => alert.title === "Sem período");
+    expect(semPeriodo.length).toBe(2);
+  });
+
+  test("linhas preservam hierarquia pai antes do filho (pré-order)", () => {
+    const rows = derivePlanningRows(PLANNING_DEMO_DATA.items, new Set());
+    const order = rows.map((row) => row.item.id);
+    expect(order.indexOf("grupo-a")).toBeLessThan(order.indexOf("pacote-a-1"));
+    expect(order.indexOf("pacote-a-1")).toBeLessThan(order.indexOf("atividade-01"));
+    expect(rows.find((row) => row.item.id === "grupo-a")?.depth).toBe(0);
+    expect(rows.find((row) => row.item.id === "atividade-01")?.depth).toBe(2);
+  });
+
+  test("recolher um grupo oculta descendentes e expandir restaura", () => {
+    const collapsed = derivePlanningRows(PLANNING_DEMO_DATA.items, new Set(["grupo-a"]));
+    const ids = collapsed.map((row) => row.item.id);
+    expect(ids).toContain("grupo-a");
+    expect(ids).not.toContain("pacote-a-1");
+    const expanded = derivePlanningRows(PLANNING_DEMO_DATA.items, new Set());
+    expect(expanded.map((row) => row.item.id)).toContain("pacote-a-1");
+  });
+
+  test("planningRootIds devolve nós sem pai válido", () => {
+    const roots = planningRootIds(PLANNING_DEMO_DATA.items);
+    expect(roots).toEqual(["grupo-a", "grupo-b"]);
+  });
+
+  test("busca por nome preserva ancestrais e não revela itens sem match", () => {
+    const rows = planningRowsForQuery(PLANNING_DEMO_DATA.items, "atividade 01");
+    const names = rows.map((row) => row.item.name);
+    expect(names).toContain("Grupo A");
+    expect(names).toContain("Pacote A.1");
+    expect(names).toContain("Atividade 01");
+    expect(names).not.toContain("Atividade 02");
+  });
+
+  test("períodos mensais cobrem o intervalo das datas", () => {
+    const periods = derivePlanningPeriods(PLANNING_DEMO_DATA.items);
+    expect(periods.length).toBeGreaterThanOrEqual(3);
+    expect(periods[0].label).toBe("Jun");
+    expect(periods[0].start).toMatch(/^2026-06-01$/);
+    expect(periods[periods.length - 1].label).toBe("Set");
+  });
+
+  test("daysBetween conta dias corridos entre datas", () => {
+    expect(daysBetween("2026-06-01", "2026-06-01")).toBe(0);
+    expect(daysBetween("2026-06-01", "2026-06-30")).toBe(29);
+  });
+});

--- a/apps/app/tests/servicos-data.test.ts
+++ b/apps/app/tests/servicos-data.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { deriveServicosSummary } from "../src/react-app/domains/servicos/servicos-data";
+import type { ServicosData } from "../src/react-app/domains/servicos/servicos-types";
+
+/**
+ * Auditoria anti-hardcode da capacidade genérica de Serviços (FASE 21).
+ * Garante que a pasta domains/servicos (contrato + componentes) NÃO dependa de
+ * conceitos de um domínio/obra específica.
+ */
+const SERVICOS_DIR = join(
+  import.meta.dir,
+  "..",
+  "src",
+  "react-app",
+  "domains",
+  "servicos",
+);
+
+const FORBIDDEN_TERMS = [
+  "OBRA-MODELO-EAP-001",
+  "torre",
+  "apartamento",
+  "pavimento",
+  "engenharia",
+  "obra-001",
+  "Escavação",
+];
+
+describe("servicos — auditoria anti-hardcode", () => {
+  const files = readdirSync(SERVICOS_DIR).filter((name) => /\.(ts|tsx)$/.test(name));
+
+  test("arquivos da capacidade existem e são auditáveis", () => {
+    expect(files).toContain("servicos-types.ts");
+    expect(files).toContain("servicos-data.ts");
+    expect(files).toContain("servicos-table.tsx");
+    expect(files).toContain("servicos-help.tsx");
+  });
+
+  test("nenhum termo específico de domínio/obra aparece na capacidade genérica", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const content = readFileSync(join(SERVICOS_DIR, file), "utf8").toLowerCase();
+      for (const term of FORBIDDEN_TERMS) {
+        if (content.includes(term.toLowerCase())) {
+          offenders.push(`${file} -> ${term}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("servicos-data — helpers genéricos (FASE 21)", () => {
+  test("deriveServicosSummary conta totais, críticos, sequenciais e com duração", () => {
+    const data: ServicosData = {
+      title: "Serviços",
+      items: [
+        { id: "1", codigo: "1", nome: "A", duracao: 10, inicio: "2026-01-05", fim: "2026-01-16", status: "CRÍTICO" },
+        { id: "2", codigo: "2", nome: "B", duracao: 5, inicio: "2026-01-19", fim: "2026-01-23", status: "Sequencial" },
+        { id: "3", codigo: "3", nome: "C", duracao: 0, inicio: null, fim: null, status: "—" },
+      ],
+    };
+    const summary = deriveServicosSummary(data);
+    expect(summary.total).toBe(3);
+    expect(summary.criticos).toBe(1);
+    expect(summary.sequenciais).toBe(1);
+    expect(summary.comDuracao).toBe(2);
+  });
+
+  test("deriveServicosSummary trata lista vazia", () => {
+    const data: ServicosData = { title: "Serviços", items: [] };
+    const summary = deriveServicosSummary(data);
+    expect(summary).toEqual({ total: 0, criticos: 0, sequenciais: 0, comDuracao: 0 });
+  });
+});

--- a/apps/app/tests/sidebar-navigation.test.tsx
+++ b/apps/app/tests/sidebar-navigation.test.tsx
@@ -1,0 +1,42 @@
+/** @jsxImportSource react */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+
+import { buildEngenhariaNavigation } from "../src/react-app/domains/engenharia/obra/obra-navigation";
+import { useNavigationState } from "../src/react-app/domains/navigation/navigation-state";
+import { SidebarNavigationList } from "../src/react-app/domains/navigation/sidebar-navigation";
+
+const EAP_ROUTE = "/dominios/engenharia/obras/OBRA-MODELO-EAP-001/eap";
+
+beforeEach(() => {
+  useNavigationState.setState({ expandedNodeIds: [] });
+});
+
+describe("SidebarNavigationList — renderer genérico do Core (SSR)", () => {
+  test("renderiza o nó raiz de domínio com markup data-driven sem erro", () => {
+    const tree = buildEngenhariaNavigation();
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={[EAP_ROUTE]}>
+        <SidebarNavigationList nodes={tree} depth={0} />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("Engenharia");
+    expect(html).toContain("data-nav-node=\"domain:engenharia\"");
+    expect(html).toContain("data-nav-type=\"domain\"");
+    expect(html).toContain("aria-expanded=\"false\"");
+  });
+
+  test("nó raiz recolhido não renderiza descendentes (expansão condicionada ao estado)", () => {
+    const tree = buildEngenhariaNavigation();
+    const html = renderToStaticMarkup(
+      <MemoryRouter initialEntries={[EAP_ROUTE]}>
+        <SidebarNavigationList nodes={tree} depth={0} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Engenharia");
+    expect(html).not.toContain("OBRA-MODELO-EAP-001");
+  });
+});
+

--- a/docs/FASE-20.0-AUDITORIA-ARQUITETURAL-OBRA.md
+++ b/docs/FASE-20.0-AUDITORIA-ARQUITETURAL-OBRA.md
@@ -1,0 +1,312 @@
+# FASE 20.0 — AUDITORIA ARQUITETURAL DO CLONE OPENWORK (CRIAÇÃO DA INTERFACE DE OBRA)
+
+> **Data:** 2026-09-01 · **Tipo:** Auditoria READ-ONLY (INSPEÇÃO → MAPEAMENTO → EVIDÊNCIA → ARQUITETURA PROPOSTA).
+> **Escopo:** clone `OPENWORK-LAB\openwork` (tag v0.18.40). Nenhum arquivo de código alterado;
+> somente este documento foi criado.
+> **Objetivo:** responder **onde e como** criar a entidade `Obra` com navegação própria
+> (`/obra/:id`, `/obra/:id/eap|frentes|planejamento|producao|rdo|ia`), com EAP como espinha
+> dorsal.
+
+---
+
+## 1. Stack (evidência)
+
+| Camada | Tecnologia | Evidência |
+|---|---|---|
+| Monorepo | **pnpm@11.4.0 + Turbo 2.10.7** | `package.json` (`packageManager`), `pnpm-workspace.yaml`, `turbo` devDep |
+| Frontend | **React 19.2.8 + TypeScript 5.9** | `pnpm-workspace.yaml` catalog; `apps/app/package.json` |
+| Build frontend | **Vite 6.4.3 + @vitejs/plugin-react + Tailwind 4 + shadcn/ui** | `apps/app/package.json`; `apps/app/tsconfig.json` |
+| Roteamento | **react-router 8.3.0** (`<Routes>` declarativos) | `apps/app/src/react-app/shell/app-root.tsx` |
+| Estado | **Zustand 5** (stores + `persist` localStorage) + **TanStack Query 5** + Context | `session-management-store.ts`, `query-client.ts` |
+| UI | `@/components/ui/*` (shadcn) + `@/packages/ui` + `lucide-react` + `@base-ui/react` | `app-sidebar.tsx`, `apps/app/package.json` |
+| Backend | **Node/Bun + SQLite (`node:sqlite`/`bun:sqlite`) + drizzle-orm** | `apps/server/src/runtime-db.ts`, `workspace-kv-store.ts` |
+| Server HTTP | Router próprio (`routes/registry.ts` — `addRoute`/`matchRoute` com `:param` → regex) | `apps/server/src/routes/*.ts` |
+| Desktop | **Electron** (`apps/desktop`) + sidecars (opencode) | `apps/desktop`, `engine-instances.json` |
+| Autenticação | Tokens (`TokenService`), **Den/Better-Auth** (enterprise `ee/`) | `apps/server/src/tokens.ts`, `ee/apps/den-api` |
+| IA/engine | **OpenCode SDK (`@opencode-ai/sdk` 1.18.15)** gerenciado via `EnginePool` | `apps/server/src/engine-pool.ts`, `apps/app/src/app/lib/opencode.ts` |
+| Plugins/extensão | Plugins + Skills + Commands + MCP gerenciados pelo server | `apps/server/src/plugins.ts`, `skills.ts`, `commands.ts`, `mcp.ts` |
+
+## 2. Arquitetura atual
+
+```
+apps/app (React SPA, Vite) ── HTTP ──▶ apps/server (Node/Bun, router próprio)
+   ├─ react-app/shell/        (app-root.tsx, session-route, settings-route, workspace-routes)
+   ├─ react-app/domains/      (session, workspace, settings, dashboard, connections, cloud, automations, onboarding)
+   ├─ react-app/kernel/       (server-provider, local-provider, global-sdk-provider, platform)
+   ├─ react-app/infra/        (query-client, workspace-server-client)
+   └─ app/lib/                (opencode.ts, openwork-server.ts, workspace-endpoint.ts, desktop.ts)
+apps/desktop (Electron) ── IPC ──▶ apps/server (embedded)
+apps/server ── gera/gerencia engines OpenCode (EnginePool) + config OpenCode por workspace
+```
+
+- **Separação Core/Domains:** o app já separa `shell` (estrutura) de `domains` (negócio) —
+  padrão que favorece novos módulos.
+- **Client SDK:** o app consome o OpenCode via `@opencode-ai/sdk` e o OpenWork via
+  `OpenworkServerClient` (`app/lib/openwork-server.ts`), com endpoint resolvido por
+  workspace (`app/lib/workspace-endpoint.ts`).
+
+## 3. Sidebar (evidência)
+
+```
+Arquivo:      apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+              + app-sidebar-provider.tsx (SidebarContext)
+              + sidebar-lanes.tsx / sidebar-lane-metrics.tsx (layout de rails/glyphs)
+              + session-management-store.ts (estado Zustand)
+Componente:   shadcn <Sidebar> (de @/components/ui/sidebar) com SidebarGroup/Menu/
+              Collapsible/ContextMenu; ícones lucide-react
+Estado:       Zustand `useSessionManagementStore` (persist localStorage): ordem,
+              pins, groups, collapsed; `SidebarContextValue` (app-sidebar-provider):
+              selectedWorkspaceId, selectedSessionId, expandedWorkspaceIds, callbacks
+Dados:        `useWorkspaceGroups(workspaceId)` (store) → WorkspaceGroupState
+              (groups/assignments); sessões via Session SDK (listRouteSessions)
+Rota/ação:    onSelectWorkspace(id), onOpenSession(ws, session) → navega via
+              react-router (session-route); cria/renomeia/arquiva/apaga sessões
+Persistência: localStorage (Zustand persist) + estado de sessões no server (OpenCode)
+```
+
+**Ponto crítico:** a sidebar é **hardcoded para workspaces/sessões** (a estrutura de
+"Obras" não existe). Adicionar uma seção "OBRAS" exigirá estender `app-sidebar.tsx` ou —
+melhor — **introduzir uma fonte de dados de navegação** (ver seção 11).
+
+## 4. Workspace
+
+```
+Modelo:   WorkspaceInfo = WorkspaceWire (apps/app/src/app/lib/desktop-types.ts)
+          id, name, path, displayName, workspaceType (local|remote), baseUrl,
+          openworkHostUrl/Token, openworkWorkspaceId ...
+Store:    openwork_workspace_configs no runtime.sqlite (server) + authorizedRoots
+Criação:  POST /workspaces/local|remote (routes/workspaces.ts) → diretório + seed
+          (workspace-init.ts: ensureWorkspaceFiles, opencode.jsonc)
+Abertura: app/lib/workspace-endpoint.ts resolve endpoint do workspace
+          (baseUrl/token/workspaceId + mount /workspace/:id)
+Troca:    session-route.tsx (workspaceSetSelected, resolveWorkspaceListSelectedId)
+Sessões:  WorkspaceSessionGroup { workspace, sessions, status } (app/types.ts)
+Relacionamento: sessões pertencem a workspaces; rota /workspace/:workspaceId/session
+```
+
+> **Viabilidade da entidade Obra:** SIM — há dois caminhos técnicos: (a) **Obra como
+> workspace** (herda infraestrutura pronta de navegação/rota/endpoint, mas acopla a
+> conceitos de sessão/IA do OpenWork); (b) **Obra como entidade própria** (novo domínio +
+> rotas + tabelas) — recomendado, para manter a separação Core/Domain e não contaminar o
+> conceito de workspace.
+
+## 5. Rotas e páginas
+
+**Frontend (react-router 8) — `shell/app-root.tsx` (`<Routes>`):**
+```
+/ → redirect /session
+/session, /session/:sessionId                     (legacy)
+/workspace/:workspaceId/session[/:sessionId]      (sessão por workspace)
+/automations, /dashboard
+/workspace/:workspaceId/extensions/*, /extensions/*
+/workspace/:workspaceId/settings/*, /settings/*
+```
+- Helpers: `shell/workspace-routes.ts` (`workspaceSessionRoute`, `workspaceSettingsRoute`,
+  `workspaceExtensionsRoute`, `legacySessionRoute`).
+- Layout: `shell/app-root.tsx` monta providers (DenAuth, ShellConfig, AppMenu,
+  OpenworkControl) e `<Routes>`.
+
+**Backend (router próprio) — `routes/*.ts` (`addRoute`):**
+```
+core:  /health, /w/:id/status, /w/:id/capabilities, /w/:id/workspaces, /status, /whoami,
+       /capabilities, /workspaces, /tokens, /env/...
+files: /workspace/:id/inbox|artifacts|files/content|stat|raw|sessions
+ops:   /workspace/:id/events, /workspace/:id/engine/reload, /approvals
+groups: /workspace/:id/session-groups[...]
+ws:    /workspaces/local, /workspaces/remote, /workspaces/:id/display-name|activate
+cloud: /workspace/:id/mcp/openwork-cloud/...
+```
+
+> **Conclusão para rotas futuras:** é **totalmente viável** adicionar
+> `/obra/:id[/eap|frentes|planejamento|producao|rdo|ia]` no frontend (novas `<Route>` no
+> `app-root.tsx`) e `/workspace/:id/obra/...` ou `/obra/...` no server (`registerObraRoutes`
+> seguindo `routes/workspaces.ts`).
+
+## 6. Persistência
+
+| Camada | Mecanismo | Arquivos |
+|---|---|---|
+| Server (estado) | **SQLite** `runtime.sqlite` via `node:sqlite`/`bun:sqlite` + **drizzle-orm** | `apps/server/src/runtime-db.ts` (path: `openworkConfigDir()/runtime.sqlite`), `workspace-kv-store.ts`, `runtime-opencode-config-store.ts`, `connect-state.ts` |
+| Workspaces | `openwork_workspace_configs` (SQLite) + diretório no disco + `opencode.jsonc`/`.opencode/` no workspace | `openwork-workspace-config-store.ts`, `workspace-init.ts` |
+| Sessões (IA) | OpenCode engine (arquivos/transcripts; server-side `session.time.archived`) | `apps/server/src/file-sessions.ts`, SDK |
+| App (UI) | **localStorage** via Zustand persist (ordem/pins/grupos/colapsados) | `session-management-store.ts`, `ui-state-store.ts` |
+| Config OpenCode | `opencode.jsonc` por workspace + config global + `runtime-opencode-config.json` | `apps/server/src/jsonc.ts`, `runtime-opencode-config-store.ts` |
+
+> **Futura entidade `Obra`:** recomendado persistir em **SQLite** (novas tabelas
+> `obras`, `obra_eap`, `obra_frentes`, ...) via novas rotas no server — seguindo o padrão
+> `workspace-kv-store.ts`/`runtime-db.ts` com drizzle. O módulo Engenharia (Workspace
+> oficial) já tem a lógica de domínio pronta (`_store.mjs`/`_eap_models.mjs`) que poderá ser
+> **reimplementada como rotas server** (não copiada como duplicata).
+
+## 7. Extensibilidade
+
+- **Plugins:** `apps/server/src/plugins.ts` — lista plugins por config (`opencode.jsonc`
+  `plugin: [...]`) + diretório de plugins do projeto (`projectPluginsDir`); adiciona/remove
+  via `addPlugin/removePlugin`. Suporta `file:`/`http:`/`git:`/npm specs.
+- **Skills:** `apps/server/src/skills.ts` (`listSkills/upsertSkill/deleteSkill`) — skills
+  são arquivos `SKILL.md` no workspace (`projectSkillsDir`) + globais.
+- **Commands:** `apps/server/src/commands.ts` (`listCommands/upsertCommand/repairCommands`).
+- **MCP:** `apps/server/src/mcp.ts`, `local-managed-mcp.ts`, `mcp-app-host.ts` — servidores
+  MCP por workspace e apps MCP.
+- **UI extensions:** rotas `/extensions/*` no app (Settings → Extensions; MCP/Plugins).
+- **OpenCode config:** `opencode.jsonc` por workspace (permissions, agents, skills,
+  commands, plugins) — o mecanismo nativo que o OpenWork usa.
+
+> **Conclusão:** o clone **já tem mecanismos de extensão** (plugins/skills/commands/mcp),
+> porém **não existe um "domain registry" no frontend** que permita plugar um módulo de UI
+> novo (ex.: Obra) sem editar `app-root.tsx` e `app-sidebar.tsx`. Esse é o principal ponto a
+> criar/refatorar.
+
+## 8. Fluxo atual (nomes reais)
+
+```
+usuário
+  → app-sidebar.tsx (shadcn Sidebar, ícones lucide)
+  → session-management-store.ts (Zustand; seleção)
+  → session-route.tsx (useNavigate; react-router)
+  → app-root.tsx (<Routes>) → <SessionRoute>
+  → WorkspaceProvider (shell/workspace-provider.ts) [client, workspaceId, selectedWorkspaceRoot]
+  → workspace-endpoint.ts (resolve baseUrl/token/mount /workspace/:id)
+  → apps/server (routes: core/files/operations/session-groups)
+  → EnginePool → engine OpenCode (sdk) → dados (SQLite runtime.sqlite + transcripts)
+  → session-surface.tsx / session-page.tsx (renderização)
+```
+
+## 9. Pontos de extensão (onde alterar para a Obra)
+
+| O quê | Onde (arquivo real) |
+|---|---|
+| Nova rota frontend | `apps/app/src/react-app/shell/app-root.tsx` (novas `<Route path="/obra/...">`) |
+| Helper de rotas | `apps/app/src/react-app/shell/workspace-routes.ts` (novos helpers `obraRoute`) |
+| Nova página/layout | novo `apps/app/src/react-app/domains/obra/` (seguindo padrão `domains/session`) |
+| Nova seção na sidebar | `domains/session/sidebar/app-sidebar.tsx` + `app-sidebar-provider.tsx` (fonte de dados de navegação) |
+| Estado | novo store Zustand `domains/obra/obra-store.ts` (padrão `session-management-store.ts`) |
+| API client | `apps/app/src/app/lib/` (novo `obra-client.ts` + `openwork-server.ts` client) |
+| Rotas server | novo `apps/server/src/routes/obras.ts` + `registerObraRoutes` em `server.ts` |
+| Persistência | novas tabelas via `apps/server/src/runtime-db.ts`/`workspace-kv-store.ts` (drizzle) |
+| Domínio determinístico | reutilizar a lógica do módulo Engenharia (EAP `_store`/`_eap_models`) como serviço server |
+
+## 10. Riscos
+
+1. **Sidebar monolítica:** `app-sidebar.tsx` concentra toda a navegação (workspaces +
+   sessões + ações). Adicionar "Obras" inline aumenta complexidade — mitigar com **fonte de
+   dados de navegação** (registry).
+2. **Acoplar Obra ao workspace:** se a Obra for implementada "por dentro" de workspace,
+   herda sessões/IA/conceitos do OpenWork e mistura domínio com plataforma (viola a
+   separação Core/Domain do nosso contrato).
+3. **Duplicar lógica de EAP:** não copiar `_store.mjs`/`_eap_models.mjs` para o app — deve
+   virar **serviço server** (rotas + SQLite) reutilizando as regras existentes.
+4. **Estado fragmentado:** app usa Zustand + Query + Context — novos módulos devem seguir um
+   padrão único (Zustand p/ UI, Query p/ server).
+5. **Router server customizado:** `addRoute`/`matchRoute` é simples e sem middlewares —
+   validação/erros precisam ser consistentes nos novos `routes/obras.ts`.
+6. **EAP como espinha dorsal:** todos os módulos futuros (Frentes, Planejamento, Produção,
+   RDO, IA) devem referenciar **`elemento_eap_id`** (não duplicar a árvore) — risco de
+   desvio se não for estabelecido como contrato de tabelas desde o início.
+
+## 11. Arquitetura futura proposta (referência — NÃO implementar nesta fase)
+
+```text
+FRONTEND (apps/app)
+├─ shell/app-root.tsx            + rotas /obra/:id e /obra/:id/{eap,frentes,planejamento,producao,rdo,ia}
+├─ react-app/domains/obra/       (novo domain: obra-shell.tsx, obra-store.ts (Zustand),
+│                                 pages: visao-geral, eap, frentes, planejamento, producao, rdo, ia)
+├─ app/lib/obra-client.ts        (client → server /obra...)
+└─ app-sidebar.tsx               (seção "OBRAS" alimentada por fonte de dados — registry)
+
+BACKEND (apps/server)
+├─ routes/obras.ts               (registerObraRoutes: CRUD obra + submódulos)
+├─ runtime-db.ts                 (novas tabelas drizzle: obras, obra_eap, obra_frentes,
+│                                 obra_planejamento, obra_producao, obra_rdo)
+└─ services/obra-eap.ts          (reimplementa as regras de EAP do módulo Engenharia —
+                                  validação de árvore, ciclos, unicidade — como serviço)
+
+DADOS (relacionamento — EAP como espinha dorsal)
+obras (obra_id) ─ 1:N ─ obra_eap (eap_id) ─ 1:N ─ obra_eap_elemento (elemento_eap_id)
+                                  ▲        ▲        ▲        ▲
+                            frentes   planej.   producao   rdo   (referenciam elemento_eap_id)
+```
+
+**Princípios:**
+- **Baixo acoplamento:** novo domain `obra/` no app; rotas e tabelas próprias; nenhuma
+  alteração no fluxo de sessões/workspaces existente.
+- **Reutilização:** UI via `@/components/ui/*` (shadcn); layout reaproveita `Sidebar`;
+  regras de EAP reimplementadas como serviço (sem duplicação).
+- **Separação Core/Domain:** o Core continua sendo plataforma (workspaces, sessões, IA); a
+  Obra é **entidade de domínio** na camada `domains/obra` + `routes/obras.ts`.
+- **Multi-domínio futuro:** o mesmo padrão serve para outros domínios além de Engenharia
+  (basta criar `domains/<dominio>` + `routes/<dominio>.ts` + tabelas).
+- **Preservação do existente:** nada do fluxo atual (sidebar de workspaces, sessões,
+  settings, extensions) é removido; "Obras" é **aditivo**.
+
+## 12. Arquivos relevantes (mapa de alteração futura)
+
+| Função | Arquivo |
+|---|---|
+| Rotas frontend | `apps/app/src/react-app/shell/app-root.tsx` |
+| Helpers de rota | `apps/app/src/react-app/shell/workspace-routes.ts` |
+| Sidebar | `apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx` · `app-sidebar-provider.tsx` |
+| Estado sidebar | `apps/app/src/react-app/domains/session/sidebar/session-management-store.ts` |
+| Workspace provider | `apps/app/src/react-app/shell/workspace-provider.ts` |
+| Endpoint/API | `apps/app/src/app/lib/workspace-endpoint.ts` · `openwork-server.ts` |
+| Server rotas | `apps/server/src/routes/workspaces.ts` (padrão) · `server.ts` (registro) |
+| Persistência | `apps/server/src/runtime-db.ts` · `workspace-kv-store.ts` |
+| Skills/Commands/Plugins/MCP | `apps/server/src/skills.ts` · `commands.ts` · `plugins.ts` · `mcp.ts` |
+| Modelo de sessões | `apps/app/src/app/types.ts` (WorkspaceSessionGroup, Client, SettingsTab) |
+| Lógica de domínio EAP (fonte) | Módulo Engenharia (Workspace oficial) — `_store.mjs`/`_eap_models.mjs` |
+
+## 13. Evidências
+
+1. `pnpm-workspace.yaml` — React 19.2.8 catalog; pnpm 11.4; packages `apps/*`, `packages/*`.
+2. `apps/app/package.json` — react-router 8.3.0, zustand 5.0.12, react-query, vite 6.4.3,
+   tailwind 4, shadcn.
+3. `apps/app/src/react-app/shell/app-root.tsx` — `<Routes>` declarativas (session/settings/
+   extensions/dashboard/automations/workspace).
+4. `apps/app/src/react-app/shell/workspace-routes.ts` — helpers de rota por workspace.
+5. `apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx` + `app-sidebar-provider.tsx`
+   — shadcn Sidebar; `SidebarContextValue` com callbacks de seleção.
+6. `session-management-store.ts` — Zustand + persist localStorage (`useWorkspaceGroups`).
+7. `apps/server/src/routes/registry.ts` — router próprio (`addRoute`/`matchRoute`).
+8. `apps/server/src/routes/workspaces.ts` + `core.ts` + `files.ts` + `session-groups.ts` —
+   conjunto real de rotas `/workspace/:id/...`.
+9. `apps/server/src/runtime-db.ts` + `workspace-kv-store.ts` — SQLite `runtime.sqlite`
+   (node:sqlite/bun:sqlite + drizzle).
+10. `apps/server/src/plugins.ts` · `skills.ts` · `commands.ts` · `mcp.ts` — extensibilidade.
+
+## 14. Conclusão
+
+### ARQUITETURA ADEQUADA COM REFATORAÇÃO
+
+**Por quê (evidência):**
+- O clone tem **base sólida para evolução**: React 19 + react-router 8 + Zustand + Query;
+  separação `shell/`×`domains/`; server com router registrável; SQLite/drizzle; mecanismos
+  de extensão (plugins/skills/commands/mcp). Isso sustenta a criação da entidade `Obra`
+  **sem** reescrever a plataforma.
+- **Refatoração necessária (mínima e localizada):**
+  1. **Introduzir um "domain registry" de navegação** no app (fonte de dados da sidebar +
+     registro de rotas) para não crescer `app-sidebar.tsx`/`app-root.tsx` de forma
+     monolítica a cada novo módulo.
+  2. **Criar o domain `obra/`** (rotas + páginas + store + client) como bloco **aditivo**,
+     sem tocar o fluxo de workspaces/sessões.
+  3. **Criar rotas server `obras.ts` + tabelas SQLite** seguindo o padrão existente.
+  4. **Reimplementar as regras de EAP como serviço server** (reutilizando a lógica do módulo
+     Engenharia), mantendo a **EAP como espinha dorsal**: todos os módulos futuros
+     referenciam `elemento_eap_id`.
+
+**Recomendação de sequência futura (após decisão humana):**
+```
+1. Domain registry (navegação) no app
+2. Domain obra/ (rotas + store + páginas básicas + sidebar "OBRAS")
+3. Rotas server obras.ts + tabelas (obras, obra_eap, obra_eap_elemento)
+4. Serviço EAP (validação determinística) reutilizando regras do módulo
+5. Módulos referenciais: frentes/planejamento/producao/rdo/ia apontando para elemento_eap_id
+```
+
+> **Se quisermos transformar este clone no sistema de gestão de obras:** os arquivos a
+> alterar são os da seção 12; o padrão a seguir é o da seção 11; e a condição estrutural é
+> criar o **domain registry** + **domain `obra/`** como bloco aditivo, sem duplicar EAP.
+
+---
+
+*Relatório gerado em 2026-09-01 · FASE 20.0 · auditoria somente leitura · único arquivo
+criado: este documento em `docs/` · nenhum código/arquitetura alterado.*

--- a/docs/FASE-20.1-CASCA-APLICACAO-OBRA.md
+++ b/docs/FASE-20.1-CASCA-APLICACAO-OBRA.md
@@ -1,0 +1,188 @@
+# FASE 20.1 — CASCA NATIVA DA APLICAÇÃO DE OBRA (DOMÍNIO ENGENHARIA)
+
+> **Data:** 2026-09-01 · **Tipo:** Implementação da casca (navegação nativa + rotas + entidade).
+> **Escopo:** clone `OPENWORK-LAB\openwork`. **Nenhum módulo de negócio completo foi implementado.**
+
+---
+
+## 1. Objetivo
+
+Criar a primeira casca funcional da aplicação de obra **dentro** do OpenWork (navegação
+nativa, sem iframe/página externa), com a arquitetura corrigida:
+
+```text
+OPENWORK (Core — genérico)
+├── SESSÕES (existente)
+└── DOMÍNIOS (registro genérico)
+    └── ENGENHARIA (domínio)
+        └── OBRA-MODELO-EAP-001 (entidade do domínio)
+            ├── Visão Geral · EAP · Frentes de Serviço · Planejamento · Produção · RDO · IA
+```
+
+## 2. Correção arquitetural aplicada (Core → Domínio → Entidade)
+
+- **Não** foi criada `Obra` como entidade raiz do Core.
+- Foi criado um **registro de domínios genérico** (`react-app/domains/domain-registry.ts`):
+  o Core conhece apenas a interface `DomainDefinition` (id, label, homeRoute,
+  renderSidebarItems, renderRoute). **Engenharia** registra-se por side-effect
+  (`domain-bootstrap.ts`), e **Obra** pertence a Engenharia (`domains/engenharia/obra/`).
+- **Não foi inventado um framework novo**: o padrão de registro por side-effect é o mesmo já
+  usado pelo projeto em `settings/extension-registry.tsx` (Map global + register). A rota
+  genérica `/dominios/:domainId/*` segue o padrão react-router 8 já existente em
+  `shell/app-root.tsx`.
+
+## 3. Arquitetura implementada
+
+```text
+apps/app/src/react-app/domains/
+├── domain-registry.ts         registro genérico de domínios (Core não conhece Engenharia)
+├── domain-bootstrap.ts        ponto único de registro (import side-effect dos domínios)
+├── domain-route.tsx           rota genérica /dominios/:domainId/* (delega ao domínio)
+├── domain-sidebar-group.tsx   seção "DOMÍNIOS" da sidebar (itera o registro)
+└── engenharia/
+    ├── domain.tsx             definição do domínio Engenharia (registerDomain)
+    └── obra/
+        ├── obra-types.ts      tipos (Obra, ObraModule, ObraEapSummary)
+        ├── obra-data.ts       OBRA-MODELO-EAP-001 (fonte única de dados da casca)
+        ├── obra-routes.ts     helpers de rota (/dominios/engenharia/obras/:id[/:modulo])
+        ├── obra-store.ts      estado Zustand (módulo selecionado; persist localStorage)
+        ├── obra-shell-route.tsx  casca da obra (header + navegação interna + página)
+        ├── obra-sidebar-items.tsx  itens da sidebar (Engenharia → Obra → módulos)
+        └── pages/
+            ├── obra-visao-geral.tsx        (Visão Geral)
+            ├── obra-eap.tsx                (EAP — resumo estrutural real)
+            └── obra-modulo-placeholder.tsx (Frentes/Planejamento/Produção/RDO/IA)
+```
+
+## 4. Rotas criadas (nativas, react-router 8 — `shell/app-root.tsx`)
+
+```text
+/dominios/:domainId                      → DomainRoute (rota genérica do Core)
+/dominios/:domainId/*                    → DomainRoute
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001                     → ObraShellRoute (Visão Geral)
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001/eap                 → EAP
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001/frentes             → placeholder
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001/planejamento        → placeholder
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001/producao            → placeholder
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001/rdo                 → placeholder
+/dominios/engenharia/obras/OBRA-MODELO-EAP-001/ia                  → placeholder
+/dominios/engenharia                         → redirect para a home do domínio (obra-modelo)
+```
+
+## 5. Entidade Obra — persistência
+
+- **Obra** é entidade do domínio Engenharia (tipos em `obra-types.ts`; dados em
+  `obra-data.ts`).
+- **Persistência nesta fase:** a obra-modelo é a **fonte única declarativa** no clone
+  (`obra-data.ts`) — dados estruturais reais e mínimos (id, nome, status PROPOSTA,
+  caracterização 1 torre / 14 lajes / 1 apartamento por pavimento / 0 subsolos / concreto
+  armado; EAP resumo 81 nós = 10/24/47, PROPOSTA). Nenhuma informação fictícia adicional.
+- O estado de UI (módulo selecionado) usa o padrão do projeto: **Zustand + persist
+  (localStorage)** (`obra-store.ts`), análogo a `session-management-store.ts`.
+- **Persistência em servidor (SQLite via `createWorkspaceKvStore`/`runtime-db.ts`) é FUTURO**
+  — a casca não cria tabelas nem rotas de servidor (evita persistência especulativa,
+  conforme regra da FASE 20.1 §11).
+
+## 6. Sidebar — integração
+
+- `app-sidebar.tsx` (modificado): a seção genérica **DOMÍNIOS** foi adicionada ao conteúdo
+  (`<DomainsSidebarGroup />`), logo acima das sessões/workspaces existentes.
+- `domain-sidebar-group.tsx` itera o registro de domínios e renderiza os itens de cada um.
+- `obra-sidebar-items.tsx` renderiza a árvore: **Engenharia** (expansível, padrão Base UI
+  `Collapsible` com `render`) → **OBRA-MODELO-EAP-001** → os 7 módulos
+  (`SidebarMenuSub`), com navegação real via `useNavigate`.
+- **Nenhuma funcionalidade existente foi removida** (workspaces, sessões, pins, grupos,
+  settings, extensions continuam intactos — regressão validada).
+
+## 7. EAP — como foi tratada
+
+- **Resumo estrutural real preservado:** 81 nós = 10 raízes (nível 1) + 24 pacotes (nível 2)
+  + 47 trabalhos (nível 3), status **PROPOSTA** — exibidos na página EAP **sem alterar,
+  aprovar, recalcular ou reinterpretar**.
+- **Nós individuais (81): NÃO VERIFICADO** — a árvore real da OBRA-MODELO-EAP-001 vive em
+  fonte isolada (outro workspace); a regra de isolamento da FASE 20.1 proíbe importar de
+  fora. A página EAP deixa explícito que o carregamento da fonte real é **FUTURO**.
+- **Fonte única:** a EAP não é duplicada (nenhum banco/JSON/frontend replicado); a casca
+  guarda apenas o resumo estrutural.
+
+## 8. Placeholders
+
+Frentes de Serviço, Planejamento, Produção, RDO e IA são **páginas placeholders funcionais**
+(`obra-modulo-placeholder.tsx`) com o aviso de que serão vinculadas aos elementos da EAP
+(`elemento_eap_id`) em fases futuras. Nenhuma lógica de negócio foi implementada.
+
+## 9. Testes executados
+
+| Teste | Resultado |
+|---|---|
+| `bun test tests/engenharia-obra-domain.test.ts` (entidade, rotas, módulos) | ✅ **8 PASS / 0 FAIL** (28 expect) |
+| `bun test tests/workspace-routes.test.ts` (regressão do fluxo existente) | ✅ **18 PASS / 0 FAIL** (51 expect) |
+| `tsc -p tsconfig.json --noEmit` (typecheck do app) | ✅ **EXIT 0** |
+| Build de produção (`vite build`) | **NÃO VERIFICADO** — não executado nesta fase (validado por typecheck + testes); recomenda-se rodar antes de release |
+
+## 10. Arquivos
+
+**Criados (14):**
+```
+apps/app/src/react-app/domains/domain-registry.ts
+apps/app/src/react-app/domains/domain-bootstrap.ts
+apps/app/src/react-app/domains/domain-route.tsx
+apps/app/src/react-app/domains/domain-sidebar-group.tsx
+apps/app/src/react-app/domains/engenharia/domain.tsx
+apps/app/src/react-app/domains/engenharia/obra/obra-types.ts
+apps/app/src/react-app/domains/engenharia/obra/obra-data.ts
+apps/app/src/react-app/domains/engenharia/obra/obra-routes.ts
+apps/app/src/react-app/domains/engenharia/obra/obra-store.ts
+apps/app/src/react-app/domains/engenharia/obra/obra-shell-route.tsx
+apps/app/src/react-app/domains/engenharia/obra/obra-sidebar-items.tsx
+apps/app/src/react-app/domains/engenharia/obra/pages/obra-visao-geral.tsx
+apps/app/src/react-app/domains/engenharia/obra/pages/obra-eap.tsx
+apps/app/src/react-app/domains/engenharia/obra/pages/obra-modulo-placeholder.tsx
+apps/app/tests/engenharia-obra-domain.test.ts
+docs/FASE-20.1-CASCA-APLICACAO-OBRA.md   (este relatório)
+```
+
+**Modificados (2):**
+```
+apps/app/src/react-app/shell/app-root.tsx        (rotas /dominios/:domainId/* + bootstrap)
+apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx   (seção DOMÍNIOS)
+```
+
+## 11. Limitações
+
+- **EAP de 81 nós:** apenas o resumo estrutural (10/24/47, PROPOSTA) é exibido; os nós
+  individuais não foram importados (isolamento) → carregamento real **FUTURO**.
+- **Persistência:** obra-modelo declarativa (fonte única no frontend); servidor/SQLite
+  **FUTURO** (a entidade e os módulos serão persistidos quando os módulos de negócio forem
+  implementados, seguindo `createWorkspaceKvStore`/`runtime-db.ts`).
+- **Verificação visual interativa** (abrir o app e clicar na sidebar): **NÃO VERIFICADO**
+  nesta sessão — a validação foi por typecheck + testes + build não executado. Para
+  confirmação visual, rodar `pnpm --filter @openwork/app dev` e navegar até
+  `/dominios/engenharia/obras/OBRA-MODELO-EAP-001`.
+- **Extensibilidade futura:** adicionar novo domínio (Administração, Medicina, Direito)
+  requer apenas registrar em `domain-bootstrap.ts` + criar a pasta do domínio — **sem
+  alterar o Core**.
+
+## 12. Veredito
+
+```text
+ARQUITETURA:   Core → Domínio → Entidade (Obra NÃO é entidade raiz do Core)  ✅
+CASCA:         IMPLEMENTADA (sidebar nativa + rotas nativas + páginas)         ✅
+ENTIDADE:      OBRA-MODELO-EAP-001 (status PROPOSTA)                           ✅
+ROTAS:         /dominios/engenharia/obras/OBRA-MODELO-EAP-001[/{modulo}]      ✅
+SIDEBAR:       DOMÍNIOS → Engenharia → Obra → 7 módulos                        ✅
+EAP:           resumo estrutural real (81 = 10/24/47, PROPOSTA)                ✅ (nós: FUTURO)
+PLACEHOLDERS:  Frentes/Planejamento/Produção/RDO/IA                            ✅
+PERSISTÊNCIA:  declarativa (frontend); servidor/SQLite = FUTURO                ✅
+TESTES:        8/0 (obra) + 18/0 (regressão) + typecheck 0                     ✅
+CORE:          não conhece Engenharia/Obra (registro genérico)                 ✅
+```
+
+> **A casca está pronta para validação visual.** As próximas fases construirão os módulos de
+> Engenharia sobre esta base, vinculando Frentes/Planejamento/Produção/RDO/IA aos elementos
+> da EAP (`elemento_eap_id`), sem alterar o Core.
+
+---
+
+*Relatório gerado em 2026-09-01 · FASE 20.1 · casca nativa do domínio Engenharia ·
+Core → Domínio → Entidade · nenhum commit realizado.*

--- a/docs/features/auditoria-editabilidade-modelo-obra.md
+++ b/docs/features/auditoria-editabilidade-modelo-obra.md
@@ -1,0 +1,808 @@
+# Auditoria Profunda — Editabilidade, Configurabilidade e Rigidez do Modelo de Obra
+
+> **Status: AUDITORIA (somente leitura — nenhum código funcional alterado).**
+> Data: 2026-09-03 · Domínio: Engenharia · Obra de referência: `OBRA-MODELO-EAP-001`
+> Escopo: mapear o que é fixo/derivado/configurável/editável/somente-leitura e responder
+> **"Se amanhã eu cadastrar uma obra completamente diferente, consigo configurar o sistema sem alterar código?"**
+>
+> **Regra de evidência:** cada conclusão cita os arquivos/tipos/funções analisados.
+> Conclusões que não puderem ser comprovadas pelo código atual são marcadas como `NÃO VERIFICADO`.
+
+---
+
+## 1. Objetivo e pergunta central da auditoria
+
+### Objetivo
+Auditar, **sem alterar código**, o modelo de Obra do domínio Engenharia para mapear:
+1. O que é **fixo** (hardcoded em código).
+2. O que é **derivado** (calculado a partir de outra fonte).
+3. O que é **configurável** (dado por obra, editável via UI).
+4. O que é **somente leitura** (exibido, nunca editado).
+5. O que é **fonte de verdade** (origem dos dados) vs **fonte duplicada/concorrente**.
+6. As **dependências da obra-modelo** (`OBRA-MODELO-EAP-001`).
+7. A **arquitetura conceitual** necessária para suportar múltiplas obras diferentes.
+
+### Pergunta central
+> **"Se amanhã eu cadastrar uma obra completamente diferente, consigo configurar o sistema sem precisar alterar código?"**
+
+### Método
+- Leitura integral dos arquivos do domínio `engenharia/obra/` + capacidades genéricas (`planejamento`, `servicos`, `linha-de-balanco`).
+- Busca de padrões hardcoded (`OBRA_MODELO_ID`, `OBRA_MODELO_EAP_ID`, `OBRA_SCOPE_REF`, `DATA_INICIO_OBRA`, `STATUS_OPTIONS`, `CAMPOS_CARACTERIZACAO`, `torres/lajes/subsolos`).
+- Classificação de cada dado em: **ESTRUTURAL / EDITÁVEL / CONFIGURÁVEL / DERIVADO / CALCULADO / SOMENTE LEITURA**.
+- Nenhuma alteração de código, refatoração ou implementação.
+
+---
+
+## 2. Diagnóstico geral do estado atual
+
+### O que está bem (a preservar)
+- **Fonte única de verdade por repositório** — `obra-repository.ts` (obras) e `obra-eap-repository.ts` (EAP por obraId). A UI nunca toca em `localStorage` (arquitetura UI → repository → storage).
+- **Derivação correta** — EAP → planejamento → LOB/serviços/produção são **calculados**, nunca duplicados.
+- **Capacidades genéricas reutilizáveis** — `domains/planejamento`, `domains/servicos`, `domains/linha-de-balanco` são neutras, sem conceito de Obra.
+- **Adapters** traduzem o domínio para os contratos genéricos — bom padrão.
+- **Separação ARES/Piemarta** isolada em `obra-ares-referencia.ts`, **não consumida** pela obra real.
+- **Catálogo declarativo de módulos** — `obra-modules.ts` (adicionar módulo = 1 entrada + 1 render no shell).
+- **EAP real de 81 nós** preservada integralmente; resumo sempre derivado (`deriveEapSummary`).
+- **Referência reutilizável de EAP** — `obra-eap-reference.ts` aponta para a origem sem duplicar.
+
+### O que está rígido (o problema)
+1. **EAP é fixa em código** — `obra-eap-data.ts` hardcoda 81 nós com `obraId: OBRA_MODELO_EAP_ID`. Não há UI para criar/editar EAP de outra obra.
+2. **Escopo é fixo em código** — `OBRA_SCOPE_REF` é um mapa hardcoded por WBS com `{unidade, quantidade, produtividade}`. Sem ele, não há duração → não há planejamento/LOB/serviços/produção.
+3. **Data de início é fixa** — `DATA_INICIO_OBRA = new Date(2026, 0, 5)`.
+4. **Caracterização tem shape fixo** — torres/lajes/aptos/subsolos/sistema construtivo (específico de edifício residencial).
+5. **Disciplinas e Frentes são derivadas, não entidades** — não há cadastro/configuração por obra.
+6. **Serviços são derivados, não cadastráveis** — não há cadastro/edição.
+7. **Produção é derivada/simulada, não registrada** — não há registro de produção real.
+8. **Planejamento é derivado, não editável** — não há edição de datas/durações/predecessoras.
+9. **Validação EAP depende da obra-modelo** — `validateEap` marca como inválido qualquer nó cujo `obraId !== OBRA_MODELO_EAP_ID`.
+10. **Status é union fixa** — não há status configuráveis por obra.
+
+---
+
+## 3. Resposta objetiva: uma nova obra pode ser configurada sem alterar código?
+
+> **NÃO.**
+
+Uma obra nova pode ser **criada** (nome/status/datas/localização/responsável) e **aberta**, mas **não pode ser configurada** para representar uma obra diferente da obra-modelo:
+
+| Capacidade | Funciona hoje? | Evidência |
+|-----------|:---:|-----------|
+| Criar obra (identificação) | ✅ | `obra-repository.ts` → `createObra`; `obra-nova.tsx` |
+| Abrir obra (contexto) | ✅ | `obra-shell-route.tsx` → `setActiveObra` |
+| EAP própria da nova obra | ❌ | `obra-eap-data.ts` → 81 nós com `obraId: OBRA_MODELO_EAP_ID`; seed só contém a obra-modelo |
+| Escopo (qtd/prod) da nova obra | ❌ | `OBRA_SCOPE_REF` em `obra-planejamento-data.ts` → mapa hardcoded por WBS |
+| Data de início da nova obra | ❌ | `DATA_INICIO_OBRA` fixa em 05/01/2026 |
+| Caracterização da nova obra | ❌ | `ObraCaracterizacao` shape fixo (torres/lajes/aptos/subsolos) |
+| Disciplinas/Frentes da nova obra | ❌ | Derivadas do EAP nível 1; sem entidade |
+| Serviços da nova obra | ❌ | Derivados dos nós TRABALHO; sem cadastro |
+| Produção da nova obra | ❌ | Derivada/simulada; sem registro real |
+| Planejamento da nova obra | ❌ | Derivado deterministicamente; sem edição |
+| LOB da nova obra | ❌ | Derivada do planejamento (herda a rigidez da fonte) |
+
+**Conclusão:** a arquitetura de **derivação** está correta, mas a **fonte de dados** (EAP + escopo + caracterização + data) está **fixa em código** e **específica da obra-modelo**. Para cadastrar uma obra diferente, é preciso **editar código**.
+
+---
+
+## 4. Mapa completo de rigidez do sistema
+
+| Camada | Rigidez | Onde | Impacto |
+|--------|---------|------|---------|
+| **EAP** | ALTA — fixa em código | `obra-eap-data.ts` | Nova obra não tem EAP própria |
+| **Escopo (qtd/prod)** | ALTA — fixa em código | `OBRA_SCOPE_REF` em `obra-planejamento-data.ts` | Sem escopo, sem duração/planejamento |
+| **Data de início** | ALTA — fixa | `DATA_INICIO_OBRA` em `obra-planejamento-data.ts` | Todas as obras usam 05/01/2026 |
+| **Caracterização** | MÉDIA-ALTA — shape fixo | `ObraCaracterizacao` em `obra-types.ts` | Não representa obra não-residencial |
+| **Disciplinas** | ALTA — derivada, sem entidade | `obra-disciplinas.tsx` | Não pode crescer/reduzir/ordenar |
+| **Frentes** | ALTA — derivada, sem entidade | `obra-frentes.tsx` | Não pode criar/editar/encerrar |
+| **Serviços** | ALTA — derivado, sem cadastro | `obra-servicos-adapter.ts` | Não pode cadastrar/editar |
+| **Produção** | ALTA — derivada/simulada | `obra-producao.tsx` | Não registra produção real |
+| **Planejamento** | ALTA — derivado, sem edição | `obra-planejamento-data.ts` | Não evolui cronograma |
+| **LOB** | BAIXA — derivada corretamente | `obra-lob-data.ts` | Representação/calculadora (correto) |
+| **Status** | MÉDIA — union fixa | `ObraStatus` em `obra-types.ts` | Não configura status por obra |
+| **Módulos** | BAIXA — catálogo declarativo | `obra-modules.ts` | Adicionar módulo = 1 entrada + 1 render |
+| **Validação EAP** | ALTA — depende da obra-modelo | `validateEap` em `obra-eap-repository.ts` | Bloqueia EAP de outra obra |
+
+---
+
+## 5. Matriz de editabilidade
+
+### 5.1 Obra (entidade raiz)
+
+| Campo | Tipo | Classificação | Editável via UI? | Evidência |
+|-------|------|---------------|:---:|-----------|
+| `id` | string | **ESTRUTURAL / SOMENTE LEITURA** | ❌ | `obra-types.ts`; `createObraId` em `obra-repository.ts` |
+| `nome` | string | **EDITÁVEL** | ✅ | `obra-editar.tsx` |
+| `status` | `ObraStatus` | **EDITÁVEL** (union fixa) | ✅ (valores fixos) | `obra-editar.tsx` → `STATUS_OPTIONS` |
+| `dataInicio?` | string | **EDITÁVEL** (metadado cadastro) | ✅ | `obra-editar.tsx` |
+| `dataFim?` | string | **EDITÁVEL** (metadado cadastro) | ✅ | `obra-editar.tsx` |
+| `localizacao?` | string | **EDITÁVEL** | ✅ | `obra-editar.tsx` |
+| `responsavel?` | string | **EDITÁVEL** | ✅ | `obra-editar.tsx` |
+| `arquivada?` | boolean | **EDITÁVEL** (soft-delete) | ✅ | `obra-lista.tsx` → `archiveObra`/`unarchiveObra` |
+| `caracterizacao?` | `ObraCaracterizacao` | **CONFIGURÁVEL** (shape fixo) | ❌ (somente leitura) | `obra-caracterizacao.tsx`; `obra-visao-geral.tsx` |
+| `eap?` | `ObraEapSummary` | **DERIVADO** | ❌ | `obra-eap-repository.ts` → `deriveEapSummary` |
+
+### 5.2 Status
+
+| Valor | Classificação | Evidência |
+|-------|---------------|-----------|
+| `PROPOSTA` | Union fixa | `obra-types.ts` → `ObraStatus` |
+| `PLANEJAMENTO` | Union fixa | idem |
+| `EM_EXECUCAO` | Union fixa | idem |
+| `CONCLUIDA` | Union fixa | idem |
+| `ARQUIVADA` | **DERIVADO** de `arquivada` | `obra-repository.ts` → `statusEfetivo` |
+
+**Rigidez:** não há como configurar status custom por obra/tipo de obra.
+
+### 5.3 Datas
+- `dataInicio`/`dataFim` são **metadados do cadastro** (editáveis) — `obra-editar.tsx`.
+- `DATA_INICIO_OBRA` (planejamento) é **fixa em código** — `obra-planejamento-data.ts:13`.
+- **Não vinculada** ao `obra.dataInicio` (o comentário em `obra-types.ts:54-59` confirma que `dataInicio` é metadado do cadastro e NÃO é sobrescrito pelo planejamento).
+
+### 5.4 Suporte a múltiplas obras
+- O repositório é uma **lista** (`obras: Obra[]`) — `obra-repository.ts`.
+- `obra-eap-repository` é um **mapa por obraId** (`eaps: Record<string, ObraEap>`) — `obra-eap-repository.ts:172`.
+- **PORÉM:** o seed só contém a obra-modelo; não há UI para criar EAP/escopo de outra obra. **A infraestrutura suporta, mas o produto não expõe.**
+
+---
+
+## 6. Inventário de dados hardcoded
+
+| # | Dado | Arquivo | Origem atual | Deveria ser | Risco |
+|---|------|---------|--------------|-------------|-------|
+| 1 | 81 nós EAP | `obra-eap-data.ts` | Obra-modelo (fonte oficial) | Dado por obra (cadastro/importação) | **ALTO** |
+| 2 | `OBRA_SCOPE_REF` (qtd/prod por WBS) | `obra-planejamento-data.ts` | Obra-modelo | Dado por obra (cadastro) | **ALTO** |
+| 3 | `DATA_INICIO_OBRA` (05/01/2026) | `obra-planejamento-data.ts` | Obra-modelo | Dado por obra (`obra.dataInicio`) | **ALTO** |
+| 4 | Caracterização (torres/lajes/aptos/subsolos) | `obra-types.ts` + seeds | Obra-modelo | Configurável por tipo de obra | **MÉDIO-ALTO** |
+| 5 | `validateEap.foraDaObra` (obraId fixo) | `obra-eap-repository.ts` | Obra-modelo | Validar contra a própria obra | **ALTO** |
+| 6 | `OBRA_MODELO_ID`/`OBRA_MODELO_EAP_ID` | `obra-repository.ts`/`obra-eap-data.ts` | Obra-modelo | Referência (não fonte operacional) | **MÉDIO** |
+| 7 | `REF_EAP_RES_001` | `obra-eap-reference.ts` | Obra-modelo | Biblioteca de referências | **BAIXO** |
+| 8 | ARES/Piemarta (15 atv, 18 elos, 11 serv) | `obra-ares-referencia.ts` | Dataset de referência | Isolado (não consumido pela obra real) | **BAIXO** |
+| 9 | `STATUS_OPTIONS` (lista/editar/nova) | `obra-lista.tsx`/`obra-editar.tsx`/`obra-nova.tsx` | Union fixa | Configurável | **BAIXO** |
+| 10 | `CAMPOS_CARACTERIZACAO` | `obra-caracterizacao.tsx`/`obra-visao-geral.tsx` | Shape fixo | Configurável | **MÉDIO** |
+| 11 | `OBRA_MODULES` (11 módulos) | `obra-modules.ts` | Catálogo declarativo | Catálogo (ok) | **BAIXO** |
+| 12 | `OBRA_FASES_ORDER` | `obra-modules.ts` | Fixo | Fixo (ok) | **BAIXO** |
+
+---
+
+## 7. Arquivos onde cada dado hardcoded está localizado
+
+| Dado | Arquivo(s) | Linha(s) relevante(s) |
+|------|-----------|----------------------|
+| 81 nós EAP | `obra-eap-data.ts` | `OBRA_MODELO_EAP_NODES` (linha 18+); `OBRA_MODELO_EAP_ID` (linha 15) |
+| Escopo (qtd/prod) | `obra-planejamento-data.ts` | `OBRA_SCOPE_REF` (linha 23–115) |
+| Data de início | `obra-planejamento-data.ts` | `DATA_INICIO_OBRA` (linha 13) |
+| Caracterização (seed) | `obra-repository.ts` | `OBRA_MODELO.caracterizacao` (linha 34–40) |
+| Caracterização (metadata EAP) | `obra-eap-data.ts` | metadata (linha 163–168) |
+| Caracterização (referência) | `obra-eap-reference.ts` | `REF_EAP_RES_001.caracterizacao` (linha 22–31) |
+| Caracterização (shape) | `obra-types.ts` | `ObraCaracterizacao` (linha 41–47) |
+| Caracterização (UI) | `obra-caracterizacao.tsx` / `obra-visao-geral.tsx` | `CAMPOS_CARACTERIZACAO` |
+| Validação obra-modelo | `obra-eap-repository.ts` | `validateEap.foraDaObra` (linha 146–148) |
+| Status options | `obra-lista.tsx` / `obra-editar.tsx` / `obra-nova.tsx` | `STATUS_OPTIONS` |
+| Status tone | `obra-lista.tsx` | `STATUS_TONE` (linha 28–34) |
+| Módulos | `obra-modules.ts` | `OBRA_MODULES` (linha 32–47) |
+| Renderers | `obra-shell-route.tsx` | `MODULE_RENDERERS` (linha 29–51) |
+| ARES/Piemarta | `obra-ares-referencia.ts` | `ARES_ATIVIDADES_REFERENCIA`, `ARES_REDE_REFERENCIA`, `ARES_SERVICOS_LOB_REFERENCIA` |
+
+---
+
+## 8. Fonte atual de cada informação
+
+| Informação | Fonte atual | Arquivo |
+|-----------|-------------|---------|
+| Obras | `useObraRepository` (lista) | `obra-repository.ts` |
+| EAP | `useObraEapRepository` (mapa por obraId) | `obra-eap-repository.ts` + `obra-eap-data.ts` |
+| Escopo (qtd/prod) | `OBRA_SCOPE_REF` (hardcoded) | `obra-planejamento-data.ts` |
+| Data de início do cronograma | `DATA_INICIO_OBRA` (hardcoded) | `obra-planejamento-data.ts` |
+| Caracterização | `Obra.caracterizacao` (shape fixo) | `obra-types.ts` + seeds |
+| Disciplinas | Derivada do EAP nível 1 | `obra-disciplinas.tsx` |
+| Frentes | Derivada do EAP nível 1 | `obra-frentes.tsx` |
+| Serviços | Derivada dos nós TRABALHO + planejamento | `obra-servicos-adapter.ts` |
+| Produção | Derivada do planejamento + `OBRA_SCOPE_REF` | `obra-producao.tsx` |
+| Planejamento | Derivada do EAP + `OBRA_SCOPE_REF` + `DATA_INICIO_OBRA` | `obra-planejamento-data.ts` |
+| LOB | Derivada do planejamento | `obra-lob-data.ts` |
+| Módulos | `OBRA_MODULES` (catálogo) | `obra-modules.ts` |
+| Status | `ObraStatus` (union fixa) | `obra-types.ts` |
+
+---
+
+## 9. Fonte de verdade recomendada
+
+| Informação | Fonte de verdade recomendada | Justificativa |
+|-----------|------------------------------|---------------|
+| Obras | `obra-repository.ts` (lista) | Já é fonte única ✅ |
+| EAP | `obra-eap-repository.ts` (mapa por obraId) | Já é fonte única ✅; falta expor UI |
+| Escopo (qtd/prod) | **Por obra** (cadastro de serviço) | Desacoplar de `OBRA_SCOPE_REF` global |
+| Data de início | **`obra.dataInicio`** (metadado cadastro) | Vincular ao cadastro, não a constante |
+| Caracterização | **Por obra** (configurável por tipo) | Desacoplar do shape fixo |
+| Disciplinas | **Entidade por obra** | Não derivar do EAP |
+| Frentes | **Entidade por obra** | Não derivar do EAP |
+| Serviços | **Cadastro por obra** (EAP × frente × local) | Não derivar dos nós TRABALHO |
+| Produção | **Registro por obra** (realizado) | Não derivar/simular |
+| Planejamento | **Baseline derivado + overrides editáveis** | Evoluir cronograma |
+| LOB | **Derivada do planejamento** (calculadora) | Já é derivada ✅ |
+| Módulos | `obra-modules.ts` (catálogo) | Já é fonte única ✅ |
+
+---
+
+## 10. Possíveis duplicidades / fontes de verdade concorrentes
+
+| Dado | Duplicado em | Risco |
+|------|--------------|-------|
+| Caracterização (torres/lajes) | `obra-repository.ts` (seed) + `obra-eap-data.ts` (metadata) + `obra-eap-reference.ts` (caracterizacao) | **MÉDIO** — 3 lugares com os mesmos números (1 torre, 14 lajes) |
+| Status options | `obra-lista.tsx` + `obra-editar.tsx` + `obra-nova.tsx` | **BAIXO** — UI, mas duplicado |
+| Campos caracterização | `obra-caracterizacao.tsx` + `obra-visao-geral.tsx` | **BAIXO** — UI, mas duplicado |
+| `DATA_INICIO_OBRA` | `obra-planejamento-data.ts` + `obra-lob-data.ts` (re-export) | **BAIXO** — re-export, não duplicação |
+
+**Nota:** a caracterização aparece em 3 lugares (seed da obra, metadata da EAP, referência). Isso é **duplicação de fato** — os números (1 torre, 14 lajes) estão repetidos. Deveria haver uma única fonte (a obra) e os demais deveriam referenciar ou derivar.
+
+---
+
+## 11. Dependências da `OBRA-MODELO-EAP-001`
+
+| Dependência | Onde | Efeito |
+|-------------|------|--------|
+| EAP de 81 nós | `obra-eap-data.ts` | Nova obra sem EAP própria |
+| `OBRA_SCOPE_REF` por WBS | `obra-planejamento-data.ts` | Nova obra sem escopo → sem duração |
+| `DATA_INICIO_OBRA` | `obra-planejamento-data.ts` | Nova obra usa data fixa |
+| `validateEap.foraDaObra` | `obra-eap-repository.ts` | Nova obra com EAP própria é "inválida" |
+| Caracterização shape | `obra-types.ts` | Nova obra não-residencial não representável |
+| `REF_EAP_RES_001` | `obra-eap-reference.ts` | Referência aponta para a obra-modelo (ok, mas única) |
+
+**Conclusão:** qualquer obra nova que não seja um edifício residencial de 1 torre/14 lajes **não pode ser representada** sem alterar código.
+
+---
+
+## 12. Auditoria completa do EAP
+
+### Estado atual
+- `obra-eap-data.ts` hardcoda **81 nós** com `obraId: OBRA_MODELO_EAP_ID` (10 disciplinas / 24 pacotes / 47 trabalhos).
+- `obra-eap-repository.ts` seed: `{ [OBRA_MODELO_EAP_ID]: OBRA_MODELO_EAP }` (linha 179–181).
+- `setEap(eap)` permite registrar EAP de outra obra **programaticamente** (linha 185–188), mas **não há UI**.
+- `validateEap` tem `foraDaObra` que marca como inválido qualquer nó cujo `obraId !== OBRA_MODELO_EAP_ID` (linha 146–148).
+
+### O EAP é modelo estrutural reutilizável ou estrutura fixa do produto?
+**Hoje é estrutura fixa do produto** (da obra-modelo), embora a **intenção** (documentada em `obra-eap-reference.ts`) seja de modelo reutilizável. A referência `REF_EAP_RES_001` existe e aponta para a origem, mas **não há mecanismo para instanciar uma EAP de referência numa nova obra**.
+
+### Capacidades de edição (todas AUSENTES hoje)
+
+| Operação | Existe? | Onde estaria |
+|----------|:---:|--------------|
+| Criar disciplina | ❌ | — |
+| Editar disciplina | ❌ | — |
+| Excluir/arquivar disciplina | ❌ | — |
+| Criar subdisciplina | ❌ | — |
+| Criar serviço | ❌ | — |
+| Alterar hierarquia | ❌ | — |
+| Mover nó | ❌ | — |
+| Editar código/WBS | ❌ | — |
+| Ordenar | ❌ | — |
+| Expandir (adicionar nó) | ❌ | — |
+| Nós folha | ❌ | — |
+| Dependências | ❌ | — |
+
+### Como permitir EAPs diferentes sem quebrar a arquitetura
+A arquitetura **já suporta** EAP por obraId (`eaps: Record<string, ObraEap>`). O que falta:
+1. **Remover a dependência da obra-modelo na validação** (`validateEap.foraDaObra`).
+2. **Expor UI de criação/edição de EAP** (ou importação de referência → instância).
+3. **Vincular o escopo (qtd/prod) à EAP da obra**, não a um mapa global por WBS.
+
+---
+
+## 13. Auditoria de Disciplinas
+
+### Estado atual
+- `obra-disciplinas.tsx` **deriva** as disciplinas dos nós nível 1 da EAP (`nodes.filter((n) => n.nivel === 1)`).
+- Não há entidade/configuração de disciplina por obra.
+
+### Análise conceitual: `Disciplina → EAP` vs `EAP → Disciplina`
+- **Hoje:** `EAP → Disciplina` (disciplina = nó nível 1 da EAP).
+- **Conceitualmente correto para o domínio:** a **Disciplina é a fonte de verdade** (especialidade/área do conhecimento), e a **EAP é a decomposição de entregáveis** que **referencia** disciplinas. Ou seja, o correto é `Disciplina → EAP` (a disciplina existe primeiro; os nós da EAP são associados a ela).
+- **Por quê:** uma disciplina (ex.: "Estrutura") pode ter múltiplos pacotes/trabalhos na EAP, mas também pode existir sem EAP (ex.: disciplina planejada, ainda sem decomposição). Derivar disciplina do EAP impede ter disciplina sem EAP e impede configurar cor/ícone/ordem/código independentes.
+
+### Proposta (não implementar)
+- Criar **entidade/configuração de disciplinas por obra** (`Disciplina` com `{id, codigo, nome, ordem, cor?, icone?, arquivada?}`).
+- Permitir: adicionar, editar, arquivar, reativar, ordenar, definir código/nome, configurar cor/ícone.
+- **Associar elementos do EAP** a disciplinas (nó nível 1 referencia a disciplina, ou a disciplina referencia os WBS).
+- **Migração:** para a obra-modelo, as 10 disciplinas atuais (nível 1 da EAP) viram o seed de disciplinas.
+
+---
+
+## 14. Auditoria de Frentes
+
+### Estado atual
+- `obra-frentes.tsx` **deriva** as frentes das disciplinas raiz da EAP (`nodes.filter((n) => n.nivel === 1)`).
+- Frente = natureza/especialidade do trabalho (documentado no código).
+
+### Classificação
+- **Hoje:** derivação do EAP (frente = disciplina raiz).
+- **Deveria ser:** **entidade operacional** (cadastro/configuração), pois uma frente tem ciclo de vida próprio (criar, editar, encerrar) e atributos operacionais que não vêm do EAP.
+
+### Atributos propostos (somente os com justificativa)
+
+| Atributo | Justificativa | Deveria ser |
+|----------|---------------|-------------|
+| `nome` | Identificação | **EDITÁVEL** |
+| `codigo` | Referência operacional | **EDITÁVEL** |
+| `disciplina` | Vínculo à disciplina | **EDITÁVEL** (referência) |
+| `responsavel` | Gestão da frente | **EDITÁVEL** |
+| `equipe` | Composição da frente | **EDITÁVEL** |
+| `status` | Ciclo de vida (ativa/encerrada) | **EDITÁVEL** |
+| `localizacao` | Onde atua | **EDITÁVEL** |
+| `capacidade` | Planejamento de recursos | **EDITÁVEL** (opcional) |
+| `produtividade` | Base de cálculo | **EDITÁVEL** (opcional) |
+| `inicio`/`término` | Período de atuação | **EDITÁVEL** |
+| `observacoes` | Notas | **EDITÁVEL** |
+
+**Nota:** nem todos precisam existir agora. `capacidade`/`produtividade` podem ficar para depois. O essencial é `nome`, `codigo`, `disciplina`, `status`, `responsavel`, `equipe`.
+
+---
+
+## 15. Auditoria de Serviços
+
+### Estado atual
+- `obra-servicos-adapter.ts` **deriva** os serviços dos nós TRABALHO (nível 3) da EAP + planejamento.
+- `ServicoItem` tem `{id, codigo, nome, duracao, inicio, fim, status}` + campos opcionais preparados (`unidade`, `quantidade`, `produtividade`, `predecessora`).
+
+### Conceito `SERVIÇO = EAP × FRENTE × LOCALIZAÇÃO`
+- **Hoje NÃO está representado.** O serviço é apenas um nó TRABALHO da EAP com datas derivadas. **Não há dimensão de frente nem de localização** no serviço.
+- O conceito correto (presente no dataset ARES, mas não na obra real) é que um serviço é a **interseção** de um elemento de escopo (EAP), uma frente (quem executa) e uma localização (onde). Isso permite, por exemplo, "Alvenaria interna — Frente 3 — Torre A, pavimentos 1-7".
+
+### O que identifica um serviço
+- **Hoje:** o WBS do nó TRABALHO.
+- **Deveria ser:** uma identidade composta (ex.: `obraId + eapWbs + frenteId + localizacaoId`), pois o mesmo trabalho pode ocorrer em múltiplas frentes/locais.
+
+### O que pode ser editado vs derivado
+
+| Dado | Pertence a | Editável? |
+|------|-----------|-----------|
+| `quantidade` | **Cadastro/base** (escopo) | **EDITÁVEL** |
+| `unidade` | **Cadastro/base** | **EDITÁVEL** |
+| `produtividade` | **Cadastro/base** (referência) | **EDITÁVEL** |
+| `predecessora` | **Cadastro/base** (rede) | **EDITÁVEL** |
+| `duracao` | **DERIVADO** (qtd / produtividade) | Calculado |
+| `inicio`/`fim` | **DERIVADO** (cronograma) | Calculado |
+| `localizacao` | **Cadastro** (dimensão) | **EDITÁVEL** |
+| `frente` | **Cadastro** (dimensão) | **EDITÁVEL** |
+| `disciplina` | **Cadastro** (dimensão) | **EDITÁVEL** |
+
+---
+
+## 16. Auditoria de Produção
+
+### Estado atual
+- `obra-producao.tsx` **deriva** a produção dos nós TRABALHO com duração + `OBRA_SCOPE_REF`.
+- Mostra: WBS, serviço, un, qtd planejada, ritmo, início, fim, e **"Pendente"** para produção real.
+
+### Classificação
+- **Hoje:** **derivada/simulada** — a produção é calculada do EAP + escopo, e a produção real é marcada como "Pendente" (não registrada).
+- **Problema:** o sistema **não registra produção real** — trata produção como se fosse um valor calculado do EAP. Isso é **incorreto** para gestão real.
+
+### Separação necessária
+
+| Categoria | Dados | Editável? |
+|-----------|-------|-----------|
+| **Planejado** | quantidade planejada, produtividade planejada, ritmo, meta, período | **EDITÁVEL** (cadastro) |
+| **Realizado** | quantidade produzida, data, equipe, frente, responsável, observação | **EDITÁVEL** (registro) |
+| **Derivado** | avanço, produtividade real, desvio, projeção, tendência | **CALCULADO** |
+
+**Conclusão:** Produção precisa de uma **entidade de registro de produção real** (apontamentos diários/periódicos), separada do planejado. O avanço/desvio/projeção são **derivados** da comparação planejado × realizado.
+
+---
+
+## 17. Auditoria de Planejamento
+
+### Estado atual
+- `obra-planejamento-data.ts` **deriva** o cronograma dos nós EAP + `OBRA_SCOPE_REF` + `DATA_INICIO_OBRA`.
+- `derivarPlanejamento` sequencia por disciplina, calcula duração (qtd/prod), datas acumuladas, crítico (limiar 60%), predecessora (sequencial).
+- **Não há edição** — tudo é derivado deterministicamente.
+
+### Cadastrado/Editável vs Derivado/Calculado
+
+| Elemento | Deveria ser | Observação |
+|----------|-------------|------------|
+| `atividade` | **CADASTRADA** | Nome/escopo |
+| `duracao` | **DERIVADA** (qtd/prod) OU **EDITÁVEL** (override) | Pode ser calculada ou manual |
+| `inicio` | **DERIVADO** (cronograma) | Calculado |
+| `término` | **DERIVADO** | Calculado |
+| `predecessoras` | **CADASTRADAS** | Rede de precedência |
+| `calendário` | **CONFIGURÁVEL** | Dias úteis/feriados |
+| `percentual planejado` | **DERIVADO** | Curva S |
+| `percentual realizado` | **CADASTRADO** | Vem da produção real |
+| `status` | **DERIVADO** (datas × realizado) | Calculado |
+| `tipo de atividade` | **CONFIGURÁVEL** | Marco/tarefa/duração |
+| `marcos` | **CADASTRADOS** | |
+| `restrições` | **CADASTRADAS** | |
+
+**Conclusão:** o planejamento atual é **excessivamente dependente de dados de referência** (escopo hardcoded). Para evoluir o cronograma real, é preciso permitir **cadastro de atividades, rede de precedência, calendário e overrides de duração**, mantendo a derivação como ponto de partida (baseline).
+
+---
+
+## 18. Auditoria da Linha de Balanço
+
+### Estado atual
+- `obra-lob-data.ts` **deriva** a grade LOB dos nós EAP + planejamento.
+- `domains/linha-de-balanco/lob-data.ts` é a **capacidade genérica** (calculadora pura).
+
+### Confirmação
+- **A LOB é uma representação/calculadora derivada dos dados operacionais** (planejamento), **NÃO uma segunda fonte de dados.** ✅ **Correto.**
+- Depende de: planejamento (datas/durações), serviço (linhas), localização (eixo temporal), produtividade (via duração).
+- **Nenhum dado é fonte própria na LOB** — tudo vem do adapter.
+
+### O que deveria ser configurável
+- **Nada na LOB em si** — ela é derivada. O que precisa ser configurável é a **fonte** (planejamento/serviços), não a LOB.
+
+---
+
+## 19. Auditoria de Locais/Unidades
+
+### Estado atual
+- **Não existe entidade de Locais/Unidades** no domínio Obra.
+- A caracterização tem `torres`, `lajes`, `apartamentosPorPavimento`, `subsolos` — mas são **números agregados**, não uma estrutura hierárquica de locais.
+- O dataset ARES (`obra-ares-referencia.ts`) tem `local: "LOCAL-T1"` e `frente`/`equipe` por atividade, mas **não é consumido pela obra real**.
+
+### Classificação
+- **Hoje:** Locais/Unidades **NÃO existem** como entidade. Apenas números agregados na caracterização.
+- **Deveria ser:** **entidade hierárquica por obra** (torres → pavimentos → unidades; ou trechos → km para rodoviária).
+
+### Proposta (não implementar)
+- Criar **entidade de Locais por obra** (`Local` com `{id, nome, tipo, pai?, ordem}`), hierárquica.
+- Permitir: adicionar, editar, arquivar, ordenar, definir hierarquia.
+- **Vincular serviços** a locais (dimensão `LOCALIZAÇÃO` do conceito `SERVIÇO = EAP × FRENTE × LOCALIZAÇÃO`).
+- **Migração:** para a obra-modelo, os locais seriam derivados da caracterização (1 torre, 14 lajes, 1 apto/pavimento).
+
+---
+
+## 20. Auditoria de Caracterização da Obra
+
+### Estado atual
+- `ObraCaracterizacao` em `obra-types.ts` tem shape **fixo**: `{torres, lajes, apartamentosPorPavimento, subsolos, sistemaConstrutivo}`.
+- Exibida **somente leitura** em `obra-caracterizacao.tsx` e `obra-visao-geral.tsx` (via `CAMPOS_CARACTERIZACAO`).
+- Seed em `obra-repository.ts` (1 torre, 14 lajes, 1 apto/pav, 0 subsolos, concreto armado).
+
+### Classificação
+- **Hoje:** shape fixo, somente leitura, específico de edifício residencial.
+- **Deveria ser:** **configurável por tipo de obra** (campos dinâmicos). Uma obra rodoviária não tem torres/lajes; tem trechos/km, tipo de pavimento, etc.
+
+### Proposta (não implementar)
+- Tornar a caracterização **dinâmica** (lista de campos `{chave, rotulo, tipo, valor}` por obra/tipo de obra).
+- Permitir **edição** da caracterização via UI.
+- **Migração:** para a obra-modelo, os 5 campos atuais viram o seed de campos.
+
+---
+
+## 21. Auditoria de Recursos/Equipes/Calendários
+
+### Estado atual
+- **Não existe entidade de Recursos, Equipes ou Calendários** no domínio Obra.
+- O dataset ARES (`obra-ares-referencia.ts`) tem `equipe: "EQUIPE-001"` por atividade, mas **não é consumido pela obra real**.
+- O planejamento (`obra-planejamento-data.ts`) **não considera calendário** — datas são dias corridos acumulados a partir de `DATA_INICIO_OBRA`.
+
+### Classificação
+- **Hoje:** Recursos/Equipes/Calendários **NÃO existem** como entidade.
+- **Deveria ser:** **entidades por obra** (fases futuras).
+
+### Proposta (não implementar)
+- **Equipes:** entidade por obra (`{id, nome, frenteId?, responsavel?, membros?}`).
+- **Recursos:** entidade por obra (`{id, nome, tipo, unidade, custo?}`).
+- **Calendários:** entidade por obra (`{id, nome, diasUteis, feriados}`), usada no cálculo de datas do planejamento.
+
+---
+
+## 22. Arquitetura conceitual recomendada para suportar múltiplas obras diferentes
+
+### Princípio central
+> **A Obra é a raiz de um grafo de dados configuráveis. Cada obra tem seu próprio EAP, escopo, disciplinas, frentes, serviços, locais, planejamento e produção. Nada é global/hardcoded.**
+
+### Modelo proposto (conceitual)
+
+```
+Obra
+ ├── Caracterização (configurável por tipo de obra — campos dinâmicos)
+ ├── Disciplinas (entidade por obra: codigo, nome, ordem, cor, icone, arquivada)
+ ├── EAP (por obra: nós com wbs, nome, nivel, tipo, pai, ordem, disciplinaId)
+ ├── Locais (entidade por obra: torres, pavimentos, blocos, trechos — hierárquico)
+ ├── Frentes (entidade por obra: nome, codigo, disciplinaId, responsavel, equipe, status)
+ ├── Serviços (cadastro: eapWbs × frenteId × localId, quantidade, unidade, produtividade, predecessora)
+ ├── Planejamento (atividades: serviçoId, duracao/override, datas, rede, calendario, marcos)
+ ├── Produção (registro: serviçoId, data, quantidade, equipe, frente, responsavel, observacao)
+ └── LOB (DERIVADA do planejamento — calculadora, nunca fonte)
+```
+
+### Como suportar Obra A / B / C sem alterar código
+
+| Obra | Torres | Disciplinas | Frentes | Como o sistema representa |
+|------|:---:|:---:|:---:|---------------------------|
+| **A** (3 torres, 12 disc, 40 frentes) | 3 | 12 | 40 | Locais com 3 torres; 12 disciplinas cadastradas; 40 frentes cadastradas; EAP própria; escopo por serviço |
+| **B** (1 torre, 7 disc, 18 frentes) | 1 | 7 | 18 | Mesma estrutura, valores diferentes |
+| **C** (rodoviária) | — | diferentes | diferentes | Caracterização dinâmica (sem torres/lajes); locais = trechos/km; disciplinas = terraplenagem/pavimentação/etc.; EAP própria |
+
+**Requisitos para isso:**
+1. **Caracterização dinâmica** (campos por tipo de obra, não shape fixo).
+2. **EAP por obra** (cadastro/importação de referência → instância).
+3. **Escopo por obra** (qtd/prod por serviço, não mapa global).
+4. **Disciplinas/Frentes/Locais/Serviços como entidades por obra**.
+5. **Planejamento editável** (baseline derivado + overrides).
+6. **Produção registrada** (realizado separado do planejado).
+7. **Remover dependência da obra-modelo na validação** (`validateEap`).
+
+---
+
+## 23. Classificação das mudanças
+
+### P0 — Obrigatório antes de continuar
+| # | Mudança | Justificativa |
+|---|---------|---------------|
+| P0-1 | Remover dependência da obra-modelo na validação (`validateEap.foraDaObra`) | Bloqueia qualquer obra nova |
+| P0-2 | EAP por obra (cadastro/importação) | Sem EAP própria, nada funciona |
+| P0-3 | Escopo por obra (qtd/prod por serviço) | Sem escopo, sem duração/planejamento |
+| P0-4 | `DATA_INICIO_OBRA` vinculada ao `obra.dataInicio` | Data fixa invalida qualquer obra |
+
+### P1 — Núcleo operacional
+| # | Mudança | Justificativa |
+|---|---------|---------------|
+| P1-1 | Disciplinas como entidade por obra | Crescer/reduzir/ordenar |
+| P1-2 | Frentes como entidade operacional | Criar/editar/encerrar |
+| P1-3 | Serviços como cadastro (EAP × frente × local) | Conceito correto |
+| P1-4 | Produção registrada (realizado) | Gestão real |
+
+### P2 — Evolução
+| # | Mudança | Justificativa |
+|---|---------|---------------|
+| P2-1 | Caracterização dinâmica | Obra não-residencial |
+| P2-2 | Planejamento editável (baseline + overrides) | Evolução do cronograma |
+| P2-3 | Locais como entidade | Torres/pavimentos/blocos/trechos |
+
+### P3 — Posterior
+| # | Mudança | Justificativa |
+|---|---------|---------------|
+| P3-1 | Equipes | Composição de frentes |
+| P3-2 | Recursos | Planejamento de recursos |
+| P3-3 | Calendários | Dias úteis/feriados |
+| P3-4 | Tipos de atividade | Marco/tarefa/duração |
+| P3-5 | Status custom | Configuração por obra |
+
+---
+
+## 24. Riscos de não corrigir cada problema
+
+| Problema | Risco de não corrigir |
+|----------|----------------------|
+| EAP fixa em código | Impossibilidade de cadastrar obra diferente; sistema preso à obra-modelo |
+| Escopo fixo (`OBRA_SCOPE_REF`) | Sem escopo, sem duração/planejamento/LOB/serviços/produção para obra nova |
+| Data fixa (`DATA_INICIO_OBRA`) | Todas as obras usam a mesma data de início |
+| Caracterização shape fixo | Obra não-residencial não representável |
+| Disciplinas/Frentes derivadas | Não podem crescer/reduzir/ordenar; sem ciclo de vida |
+| Serviços derivados | Conceito `EAP × FRENTE × LOCALIZAÇÃO` não representado |
+| Produção derivada/simulada | Dados fictícios tratados como reais; sem gestão real |
+| Planejamento derivado | Cronograma não evolui; sem rede/calendário/overrides |
+| Validação obra-modelo | Bloqueia EAP de outra obra, impedindo uso da infraestrutura existente |
+| Duplicação de caracterização | 3 lugares com os mesmos números; risco de divergência |
+| Status union fixa | Não configura status por obra |
+
+---
+
+## 25. Impacto das mudanças sobre a arquitetura existente
+
+### O que NÃO muda (impacto baixo)
+- **Repositórios** (`obra-repository`, `obra-eap-repository`) — já são fonte única por obraId.
+- **Capacidades genéricas** (`planejamento`, `servicos`, `linha-de-balanco`) — já são neutras.
+- **Adapters** — padrão já existente, apenas ganham novas fontes.
+- **Catálogo de módulos** (`obra-modules.ts`) — permanece declarativo.
+- **Derivação** (EAP → planejamento → LOB) — permanece como calculadora.
+
+### O que muda (impacto médio)
+- **`OBRA_SCOPE_REF`** deixa de ser mapa global e vira dado por obra (cadastro de serviço).
+- **`DATA_INICIO_OBRA`** deixa de ser constante e vira `obra.dataInicio`.
+- **`validateEap`** deixa de depender de `OBRA_MODELO_EAP_ID`.
+- **Caracterização** deixa de ser shape fixo e vira campos dinâmicos.
+
+### O que muda (impacto alto)
+- **Disciplinas/Frentes/Locais/Serviços** deixam de ser derivações e viram **entidades por obra**.
+- **Produção** ganha **entidade de registro real** (realizado).
+- **Planejamento** ganha **edição** (baseline + overrides, rede, calendário).
+
+**Nota:** as mudanças P0 são **desacoplamentos** (remover hardcodes), não reescritas. As mudanças P1/P2/P3 adicionam **entidades novas** sem quebrar as existentes (a obra-modelo continua funcionando via seed).
+
+---
+
+## 26. O que deve ser preservado exatamente como está
+
+| Item | Evidência | Por quê |
+|------|-----------|---------|
+| EAP real de 81 nós | `obra-eap-data.ts` | Fonte oficial; não alterar |
+| Separação ARES/Piemarta | `obra-ares-referencia.ts` | Dataset de referência isolado; não consumido pela obra real |
+| Fonte única por repositório | `obra-repository.ts`, `obra-eap-repository.ts` | Arquitetura correta |
+| Derivação EAP → planejamento → LOB | `obra-planejamento-data.ts`, `obra-lob-data.ts` | Calculadora correta |
+| Capacidades genéricas | `domains/planejamento`, `servicos`, `linha-de-balanco` | Neutras, reutilizáveis |
+| Catálogo declarativo de módulos | `obra-modules.ts` | Adicionar módulo = 1 entrada + 1 render |
+| `ARQUIVADA` derivado de `arquivada` | `obra-repository.ts` → `statusEfetivo` | Sem segunda fonte |
+| `dataInicio` como metadado do cadastro | `obra-types.ts` | Fonte única do cadastro; NÃO sobrescrito pelo planejamento |
+| Referência reutilizável de EAP | `obra-eap-reference.ts` | Aponta para origem sem duplicar |
+
+---
+
+## 27. O que deve ser desacoplado
+
+| Item | De | Para | Evidência |
+|------|----|------|-----------|
+| EAP | `obra-eap-data.ts` (fixa) | Dado por obra | `obra-eap-repository.ts` já suporta `eaps: Record<string, ObraEap>` |
+| Escopo | `OBRA_SCOPE_REF` (global) | Dado por obra (cadastro de serviço) | `obra-planejamento-data.ts` |
+| Data de início | `DATA_INICIO_OBRA` (constante) | `obra.dataInicio` | `obra-types.ts` |
+| Caracterização | Shape fixo | Campos dinâmicos por tipo | `obra-types.ts` |
+| Validação | `OBRA_MODELO_EAP_ID` | A própria obra | `obra-eap-repository.ts` → `validateEap` |
+| Disciplinas | EAP nível 1 | Entidade por obra | `obra-disciplinas.tsx` |
+| Frentes | EAP nível 1 | Entidade por obra | `obra-frentes.tsx` |
+| Serviços | Nós TRABALHO | Cadastro por obra | `obra-servicos-adapter.ts` |
+| Produção | Derivada/simulada | Registro real | `obra-producao.tsx` |
+| Planejamento | Derivado deterministicamente | Baseline + overrides | `obra-planejamento-data.ts` |
+
+---
+
+## 28. O que deve virar entidade
+
+| Entidade | De onde vem hoje | Evidência |
+|----------|------------------|-----------|
+| **Disciplina** | Derivada do EAP nível 1 | `obra-disciplinas.tsx` |
+| **Frente** | Derivada do EAP nível 1 | `obra-frentes.tsx` |
+| **Local/Unidade** | Não existe (números agregados) | `obra-types.ts` → `ObraCaracterizacao` |
+| **Serviço** | Derivado dos nós TRABALHO | `obra-servicos-adapter.ts` |
+| **Produção (realizado)** | Derivada/simulada | `obra-producao.tsx` |
+| **Equipe** | Não existe (só no dataset ARES) | `obra-ares-referencia.ts` |
+| **Recurso** | Não existe | — |
+| **Calendário** | Não existe (dias corridos) | `obra-planejamento-data.ts` |
+
+---
+
+## 29. O que deve permanecer derivado
+
+| Item | Derivado de | Evidência |
+|------|-------------|-----------|
+| Resumo EAP (`ObraEapSummary`) | Nós reais | `obra-eap-repository.ts` → `deriveEapSummary` |
+| Duração de serviço | qtd / produtividade | `obra-planejamento-data.ts` → `calcDuracao` |
+| Datas de início/fim | Cronograma | `obra-planejamento-data.ts` → `derivarPlanejamento` |
+| Caminho crítico | Durações | `obra-planejamento-data.ts` → `marcarCriticoEPredecessora` |
+| LOB | Planejamento | `obra-lob-data.ts` → `derivarGradeLob` |
+| `ARQUIVADA` | `arquivada` | `obra-repository.ts` → `statusEfetivo` |
+| Avanço/desvio/projeção | Planejado × Realizado | (futuro) |
+
+---
+
+## 30. O que deve ser editável
+
+| Item | Evidência atual |
+|------|-----------------|
+| Nome da obra | `obra-editar.tsx` |
+| Status da obra | `obra-editar.tsx` (valores fixos) |
+| `dataInicio`/`dataFim` | `obra-editar.tsx` |
+| Localização | `obra-editar.tsx` |
+| Responsável | `obra-editar.tsx` |
+| Arquivar/restaurar | `obra-lista.tsx` |
+| **Disciplinas** (criar/editar/arquivar/ordenar) | ❌ hoje derivado |
+| **Frentes** (criar/editar/encerrar) | ❌ hoje derivado |
+| **Serviços** (quantidade/unidade/produtividade/predecessora) | ❌ hoje derivado |
+| **Produção real** (quantidade/data/equipe) | ❌ hoje derivado |
+| **Planejamento** (overrides de duração, rede, marcos) | ❌ hoje derivado |
+| **Caracterização** | ❌ hoje somente leitura |
+
+---
+
+## 31. O que deve ser configurável
+
+| Item | Evidência atual |
+|------|-----------------|
+| Caracterização (campos por tipo de obra) | ❌ hoje shape fixo |
+| Status (custom por obra) | ❌ hoje union fixa |
+| Calendário (dias úteis/feriados) | ❌ hoje não existe |
+| Tipo de atividade (marco/tarefa/duração) | ❌ hoje não existe |
+| Produtividade (por serviço) | ❌ hoje `OBRA_SCOPE_REF` hardcoded |
+| Unidades de medida | ❌ hoje hardcoded no escopo |
+
+---
+
+## 32. O que deve ser somente leitura
+
+| Item | Evidência |
+|------|-----------|
+| `Obra.id` | `obra-types.ts`; `createObraId` |
+| Resumo EAP | `obra-eap-repository.ts` → `deriveEapSummary` |
+| LOB (grade) | `obra-lob-data.ts` → `derivarGradeLob` |
+| Caminho crítico | `obra-planejamento-data.ts` → `marcarCriticoEPredecessora` |
+| Datas derivadas do cronograma | `obra-planejamento-data.ts` → `derivarPlanejamento` |
+| `ARQUIVADA` (derivado) | `obra-repository.ts` → `statusEfetivo` |
+
+---
+
+## 33. O que deve ser calculado
+
+| Item | Calculado de | Evidência |
+|------|--------------|-----------|
+| Duração de serviço | qtd / produtividade | `obra-planejamento-data.ts` → `calcDuracao` |
+| Datas de início/fim | Cronograma acumulado | `obra-planejamento-data.ts` → `derivarPlanejamento` |
+| Caminho crítico | Durações (limiar 60%) | `obra-planejamento-data.ts` → `marcarCriticoEPredecessora` |
+| Ritmo | qtd / duração | `obra-planejamento-data.ts` → `derivarPlanejamento` |
+| Resumo EAP | Nós reais | `obra-eap-repository.ts` → `deriveEapSummary` |
+| LOB | Planejamento | `obra-lob-data.ts` → `derivarGradeLob` |
+| Avanço/desvio/projeção | Planejado × Realizado | (futuro) |
+
+---
+
+## 34. Proposta de cadeia de dependências futura (fontes de verdade explícitas)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        FONTES DE VERDADE (dado por obra)            │
+│                                                                     │
+│  Obra (obra-repository.ts)                                          │
+│   ├── id, nome, status, dataInicio, dataFim, localizacao,           │
+│   │   responsavel, arquivada                                        │
+│   ├── Caracterização (campos dinâmicos por tipo)                    │
+│   ├── Disciplinas (entidade)                                        │
+│   ├── EAP (obra-eap-repository.ts — nós por obraId)                 │
+│   ├── Locais (entidade hierárquica)                                 │
+│   ├── Frentes (entidade)                                            │
+│   ├── Serviços (cadastro: eapWbs × frenteId × localId,              │
+│   │   quantidade, unidade, produtividade, predecessora)             │
+│   ├── Planejamento (atividades: serviçoId, duracao/override,        │
+│   │   datas, rede, calendario, marcos)                              │
+│   └── Produção (registro: serviçoId, data, quantidade, equipe)      │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        DERIVADOS (calculados, nunca fonte)          │
+│                                                                     │
+│  Duração        = qtd / produtividade                               │
+│  Datas          = cronograma acumulado                              │
+│  Caminho crítico= durações (limiar)                                 │
+│  Resumo EAP     = deriveEapSummary(nós)                             │
+│  LOB            = derivarGradeLob(planejamento)                     │
+│  Avanço/desvio  = planejado × realizado                             │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        CAPACIDADES GENÉRICAS (neutras)              │
+│                                                                     │
+│  domains/planejamento  → PlanningDashboardData                      │
+│  domains/servicos      → ServicosData                               │
+│  domains/linha-de-balanco → LobGradeData                            │
+│  (adapters traduzem o domínio para estes contratos)                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Onde fica cada fonte de verdade (futuro):**
+
+| Fonte de verdade | Onde | Evidência |
+|------------------|------|-----------|
+| Obra | `obra-repository.ts` | Já é fonte única ✅ |
+| EAP | `obra-eap-repository.ts` (por obraId) | Já é fonte única ✅ |
+| Caracterização | `Obra.caracterizacao` (dinâmico) | Hoje shape fixo |
+| Disciplinas | Entidade por obra | Hoje derivado |
+| Locais | Entidade por obra | Hoje não existe |
+| Frentes | Entidade por obra | Hoje derivado |
+| Serviços | Cadastro por obra | Hoje derivado |
+| Planejamento | Baseline + overrides | Hoje derivado |
+| Produção | Registro por obra | Hoje derivado |
+| LOB | **NUNCA fonte** — derivada | ✅ correto |
+
+---
+
+## Conclusão
+
+A arquitetura de **derivação** (EAP → planejamento → LOB/serviços/produção) e a **separação de capacidades genéricas** estão **corretas e bem feitas**. O problema está na **fonte de dados**: EAP, escopo, data de início e caracterização estão **fixos em código e específicos da obra-modelo**.
+
+A infraestrutura **já suporta** múltiplas obras (repositórios por obraId), mas o **produto não expõe** a capacidade de configurar uma obra diferente. Para responder à pergunta central: **hoje NÃO é possível cadastrar uma obra completamente diferente sem alterar código.**
+
+A correção prioritária (P0) é **desacoplar a fonte de dados da obra-modelo**: EAP por obra, escopo por obra, data por obra, e remover a dependência na validação. Isso destrava o restante (disciplinas, frentes, serviços, produção, planejamento) sem quebrar a arquitetura de derivação já existente.
+
+---
+
+## Verificação do documento
+
+- [x] Arquivo existe: `docs/features/auditoria-editabilidade-modelo-obra.md`
+- [x] Conteúdo completo (34 seções obrigatórias)
+- [x] Nenhuma seção obrigatória ausente
+- [x] Nenhuma alteração de código funcional (auditoria somente leitura)
+
+---
+
+*AUDITORIA DOCUMENTADA — AGUARDANDO APROVAÇÃO*

--- a/docs/features/mapeamento-ares-app.md
+++ b/docs/features/mapeamento-ares-app.md
@@ -1,0 +1,124 @@
+# Mapeamento ARES (19 abas) → App OBRA-MODELO-EAP
+
+> Documento de decisão — comparação entre a planilha **ARES_MODELO_EXCEL_NATIVO_MVP_LOB_PROFISSIONAL_FINAL_WORK.xlsx** (19 abas) e o que está implementado no app hoje.
+> Objetivo: dar visibilidade completa antes de decidir o escopo de expansão.
+
+## Resumo executivo
+
+A planilha ARES é um **modelo de engenharia completo e multi-dimensional**. O app hoje implementa uma **versão reduzida** (7 abas equivalentes), focada na EAP + Planejamento + Linha de Balanço. Há **10 abas da ARES que ainda não existem no app** (Orçamento, Rede, Caminho Crítico, Recursos, Medição, Controle, Indicadores, Gráficos, Fórmulas, Configurações) e **2 que existem só como placeholder** (Frentes, Produção).
+
+A diferença conceitual mais importante: a ARES define **SERVIÇO = EAP × FRENTE × LOCALIZAÇÃO** (unidade operacional de cruzamento), e o **PLANEJAMENTO** é um cronograma real com datas/predecessoras/%plan/%real/status. O app hoje deriva o cronograma dos nós da EAP, sem essa dimensão de cruzamento.
+
+---
+
+## Mapeamento aba a aba
+
+Legenda de estado no app:
+- ✅ **Implementado** — módulo real com dados derivados
+- 🟡 **Parcial** — existe, mas simplificado ou com placeholder
+- ⬜ **Não existe** — falta criar
+
+| # | Aba ARES | O que é (ARES) | Estado no app | O que falta / observação |
+|---|----------|----------------|---------------|--------------------------|
+| 1 | **DASHBOARD** | Painel executivo: progresso físico, status da obra, prazo, equipes, resumo de serviços, evolução mensal planejado×realizado | 🟡 Visão Geral | Visão Geral existe mas não tem os indicadores financeiros/equipes/evolução mensal da ARES |
+| 2 | **CADASTRO** | Dados da obra + hierarquia de locais (empreendimento→torres→pavimentos→apartamentos) + tipologias | 🟡 Caracterização | Caracterização existe (dados básicos), mas **não tem a hierarquia de locais** (LOCAL-E01, LOCAL-T1-P01-AP01...) nem tipologias |
+| 3 | **FRENTES** | Natureza/especialidade do trabalho (16 frentes) + equipes | ✅ Frentes | Frentes derivadas das 10 disciplinas raiz da EAP real (com contagem de pacotes/trabalhos). **Não usa** as 16 frentes da ARES (separação de fontes) |
+| 4 | **EAP** | 20 disciplinas, 85 nós (DISCIPLINA/PACOTE/TRABALHO) | ✅ EAP | App tem **10 disciplinas / 81 nós**. A ARES tem **20 disciplinas / 85 nós** (mais granular: Pisos, Gesso/drywall, Fachada, Apartamentos, Áreas comuns, Áreas externas, Equipamentos, Comissionamento) |
+| 5 | **SERVIÇOS** | Unidade operacional = EAP × FRENTE × LOCAL (12 serviços exemplo) | 🟡 Serviços | App mostra os 47 TRABALHO da EAP com duração/datas/crítico. **Não tem a dimensão de cruzamento** EAP×FRENTE×LOCAL nem quantidade/preço/status |
+| 6 | **ORÇAMENTO** | Formação de custos: EAP→SERVIÇO→ITEM→COMPOSIÇÃO→RECURSOS→CUSTO→BDI→PREÇO | ⬜ Não existe | Falta módulo completo de orçamento (itens, composições, BDI) |
+| 7 | **PLANEJAMENTO** | Cronograma real: 15 atividades legadas + modelo A2 (PLAN-xxx com TIPO_ATIVIDADE SERVIÇO/ESPECIAL/MARCO), datas, predecessoras, %plan/%real, status | 🟡 Planejamento | App deriva datas dos nós EAP. **Não tem** o cronograma real da ARES (datas explícitas, %plan/%real, status, TIPO_ATIVIDADE) |
+| 8 | **REDE** | Rede de precedências (18 elos FS com defasagem) | ⬜ Não existe | Falta visualização da rede de precedências |
+| 9 | **LINHA DE BALANÇO** | Grade tempo×serviço (11 serviços, semanas, células ativas) | ✅ Linha de Balanço | App tem a grade LOB em React. **Diferença de fonte**: ARES deriva das 15 atividades do PLANEJAMENTO; app deriva dos 81 nós EAP |
+| 10 | **CAMINHO CRÍTICO** | Cálculo de folgas (início/término cedo/tarde, folga total/livre, crítica) | ⬜ Não existe | Falta módulo de caminho crítico/folgas |
+| 11 | **GANTT** | Cronograma de barras (15 atividades, %real) | 🟡 Planejamento (timeline) | O PlanningDashboard tem Gantt, mas alimentado pelos nós EAP, não pelo cronograma real |
+| 12 | **RECURSOS** | Mão de obra/equipamento/material (custo unitário, capacidade/dia) | ⬜ Não existe | Falta módulo de recursos |
+| 13 | **PRODUÇÃO** | Acompanhamento diário planejado×realizado×acumulado | 🟡 Produção | Produção derivada do cronograma da EAP real (qtd. planejada + ritmo). Produção real (executada) ainda pendente de registro |
+| 14 | **MEDIÇÃO** | Processo financeiro/contratual (valor contrato, medido, saldo, %medido) | ⬜ Não existe | Falta módulo de medição |
+| 15 | **CONTROLE** | Planejado×realizado (estrutura vazia na ARES) | ⬜ Não existe | Falta módulo de controle |
+| 16 | **INDICADORES** | 7 indicadores com valor/referência/status/leitura | ⬜ Não existe | Falta módulo de indicadores |
+| 17 | **GRÁFICOS** | 5 gráficos ligados aos dados (evolução mensal, produção acumulada, medição, serviços por status, produtividade) | ⬜ Não existe | Falta módulo de gráficos |
+| 18 | **FÓRMULAS** | Documentação das fórmulas do modelo | ⬜ Não existe | Falta documentação das fórmulas |
+| 19 | **CONFIGURAÇÕES** | Parâmetros globais, listas de validação, BDI composto | ⬜ Não existe | Falta módulo de configurações |
+
+---
+
+## O que o app já tem (implementado)
+
+| Módulo app | Fase | Fonte de dados | Status |
+|------------|------|----------------|--------|
+| Visão Geral | Preparação | Derivado | 🟡 parcial |
+| Caracterização | Preparação | Dados da obra | 🟡 parcial |
+| EAP | Preparação | 81 nós reais | ✅ |
+| Disciplinas | Preparação | Derivado da EAP | ✅ |
+| Serviços | Preparação | Derivado da EAP + planejamento | 🟡 parcial |
+| Planejamento | Preparação | Derivado da EAP | 🟡 parcial |
+| Linha de Balanço | Preparação | Derivado da EAP | ✅ |
+| Frentes | Execução | Derivado da EAP real | ✅ |
+| Produção | Execução | Derivado da EAP real | 🟡 parcial |
+| RDO | Execução | — | 🟡 placeholder |
+| IA | Suporte | — | 🟡 placeholder |
+
+---
+
+## Diferenças conceituais-chave
+
+1. **SERVIÇO = EAP × FRENTE × LOCALIZAÇÃO** — a ARES cruza três dimensões para formar a unidade operacional. O app hoje trata "Serviços" como os TRABALHO da EAP, sem essa dimensão de cruzamento.
+
+2. **PLANEJAMENTO é um cronograma real** — com datas explícitas, predecessoras, %plan/%real, status e TIPO_ATIVIDADE (SERVIÇO/ESPECIAL/MARCO/MOBILIZAÇÃO/ADMINISTRAÇÃO). O app deriva as datas dos nós EAP.
+
+3. **EAP mais granular** — a ARES tem 20 disciplinas / 85 nós; o app tem 10 disciplinas / 81 nós.
+
+4. **Cadeia completa de engenharia** — a ARES documenta a cadeia EAP → SERVIÇO → PLANEJAMENTO → PRODUÇÃO → MEDIÇÃO → INDICADORES → GRÁFICOS, com ORÇAMENTO e RECURSOS no meio. O app só cobre a parte de EAP/Planejamento/LOB.
+
+---
+
+## Opções de escopo
+
+### Opção A — Expandir para as 19 abas (fiel à ARES)
+Criar os módulos que faltam: Orçamento, Rede, Caminho Crítico, Recursos, Medição, Controle, Indicadores, Gráficos, Fórmulas, Configurações + completar Frentes/Produção + expandir EAP para 20 disciplinas + usar o cronograma real da ARES.
+- **Esforço**: alto (várias fases)
+- **Fidelidade**: máxima
+
+### Opção B — Ajustar o atual com dados reais da ARES
+Manter a estrutura atual (7 abas), mas:
+- Usar o **cronograma real da ARES** (15 atividades com datas/predecessoras/%real) no Planejamento/Gantt/LOB
+- Expandir a EAP para as 20 disciplinas da ARES
+- Completar Frentes (lista real) e Produção (registro real)
+- **Esforço**: médio
+- **Fidelidade**: alta no que existe, sem as abas financeiras
+
+### Opção C — Manter o atual
+Não expandir. Manter a versão reduzida atual.
+- **Esforço**: zero
+- **Fidelidade**: baixa (só EAP/Planejamento/LOB)
+
+---
+
+## Recomendação
+
+A **Opção B** é o melhor equilíbrio: corrige a maior divergência (usar o cronograma real da ARES em vez de datas derivadas) e expande a EAP para a granularidade correta, sem o esforço de construir todo o módulo financeiro (Orçamento/Medição/Indicadores) de uma vez. A Opção A pode ser feita depois, em fases, sobre a base da Opção B.
+
+---
+
+## Decisão do usuário (2026-09-03) — separação de fontes
+
+O usuário definiu uma **regra de separação explícita** entre as duas obras, que **não podem ser misturadas**:
+
+> **Obra real → EAP real de 81 nós**
+> **ARES/Piemarta → dataset de referência para cronograma e validação**
+
+Consequências práticas:
+
+1. **A EAP real de 81 nós é preservada integralmente.** Ela representa os dados reais da obra e **não pode ser substituída** pela EAP pedagógica da Piemarta (20 disciplinas/85 nós).
+
+2. **O cronograma da ARES/Piemarta (15 atividades) é um dataset de referência/demonstração**, usado para **validar a estrutura** de Planejamento, Gantt e LOB. **Não deve ser apresentado como cronograma da obra real.**
+
+3. **Não misturar os dados das duas obras.** A separação deve ficar explícita no modelo e na documentação.
+
+### Escopo da Opção B (revisado)
+
+- ✅ Manter a EAP real de 81 nós e seu cronograma derivado (sem alteração).
+- ✅ Criar um **dataset de referência ARES/Piemarta** (15 atividades com datas/predecessoras/%plan/%real/status) claramente separado, para validar a estrutura de Planejamento/Gantt/LOB.
+- ✅ Completar Frentes (16 frentes + equipes) e Produção (registro real).
+- ❌ **Não** substituir a EAP real pela da ARES.
+- ❌ **Não** apresentar o cronograma da ARES como cronograma da obra real.

--- a/docs/features/modelo-canonico-planejamento.md
+++ b/docs/features/modelo-canonico-planejamento.md
@@ -1,0 +1,560 @@
+# Modelo Canônico de Planejamento de Obras — Especificação Arquitetural
+
+> **Status: ESPECIFICAÇÃO PARA APROVAÇÃO (somente análise e arquitetura — nenhum código alterado).**
+> Data: 2026-09-03 · Domínio: Engenharia · Obra de referência: `OBRA-MODELO-EAP-001`
+> Base: auditoria aprovada `docs/features/auditoria-editabilidade-modelo-obra.md`
+>
+> **Regra de evidência:** cada conclusão foi validada contra o código real
+> (`apps/app/src/react-app/domains/engenharia/obra/**` e `domains/{planejamento,servicos,linha-de-balanco}/**`).
+> Conclusões que não puderem ser comprovadas pelo código são marcadas como `NÃO VERIFICADO`.
+
+---
+
+## 0. Objetivo e princípios
+
+### Objetivo
+Definir o **núcleo canônico de planejamento de obras** que futuramente sustentará o
+OpenWork/ARES, permitindo trabalhar com **obras diferentes sem criar código específico
+para cada tipo de obra**.
+
+### Princípios norteadores (validados no código)
+1. **A Obra é a raiz de um grafo de dados configuráveis.** Nada é global/hardcoded.
+2. **Fonte única de verdade por entidade.** Nunca duplicar; derivar quando possível.
+3. **Derivação é calculadora, nunca fonte.** Gantt/CPM/LOB são derivados do planejamento.
+4. **Capacidades genéricas neutras** (`domains/planejamento`, `servicos`, `linha-de-balanco`)
+   não conhecem Obra; adapters traduzem o domínio para os contratos genéricos.
+5. **Preservar** a EAP real de 81 nós, `OBRA-MODELO-EAP-001`, o isolamento ARES/Piemarta,
+   as FASES 21/22 e a arquitetura de derivação correta.
+
+---
+
+## 1. OBRA — o que pertence à entidade Obra
+
+### Situação atual (validado)
+`Obra` em `obra-types.ts` contém: `id`, `nome`, `status` (union fixa), `dataInicio`/`dataFim`
+(metadado do cadastro), `localizacao`, `responsavel`, `arquivada`, `caracterizacao` (shape fixo),
+`eap` (resumo derivado). `ARQUIVADA` é derivado de `arquivada` (`statusEfetivo` em `obra-repository.ts`).
+
+### O que pertence à Obra (fonte de verdade)
+| Campo | Classificação | Observação |
+|-------|---------------|------------|
+| `id` | ESTRUTURAL / somente leitura | `createObraId` |
+| `nome` | EDITÁVEL | `obra-editar.tsx` |
+| `status` | EDITÁVEL (union fixa hoje) | Futuro: configurável por obra |
+| `dataInicio` | EDITÁVEL (metadado cadastro) | **NÃO** é a data do cronograma |
+| `dataFim` | EDITÁVEL (metadado cadastro) | idem |
+| `localizacao` | EDITÁVEL | |
+| `responsavel` | EDITÁVEL | |
+| `arquivada` | EDITÁVEL (soft-delete) | |
+| `tipoObra` | CONFIGURÁVEL (novo) | residencial/comercial/infraestrutura — **não assumir torre/laje** |
+
+### O que NÃO pertence à Obra (fica em outras entidades)
+- **EAP** → entidade própria por obra (`obra-eap-repository.ts` já é mapa por obraId).
+- **Disciplinas** → entidade própria por obra.
+- **Frentes** → entidade operacional por obra.
+- **Locais** → entidade hierárquica por obra.
+- **Serviços** → cadastro por obra.
+- **Planejamento** → entidade por obra (baseline + overrides).
+- **Produção** → registro por obra.
+- **Caracterização** → campos dinâmicos por tipo de obra (não shape fixo).
+
+**Decisão:** a Obra é a **raiz de identidade** (quem é a obra), não o contêiner de todos os
+dados. Cada subdomínio é uma entidade própria vinculada por `obraId`.
+
+---
+
+## 2. EAP
+
+### Situação atual (validado)
+- `obra-eap-data.ts` hardcoda 81 nós com `obraId: OBRA_MODELO_EAP_ID` (10/24/47).
+- `obra-eap-repository.ts` suporta `eaps: Record<string, ObraEap>` mas só seeda a obra-modelo.
+- `validateEap.foraDaObra` (linha 146–148) marca como inválido qualquer nó cujo
+  `obraId !== OBRA_MODELO_EAP_ID`.
+- `obra-eap-reference.ts` define `REF_EAP_RES_001` (referência reutilizável, aponta para origem).
+
+### Definição conceitual
+| Aspecto | Definição |
+|---------|-----------|
+| **Identidade** | `obraId + wbs` (o mesmo WBS em obras diferentes NÃO é o mesmo nó) |
+| **Vínculo com obra** | `obraId` em cada nó; repositório por obraId |
+| **Hierarquia** | `wbs`, `nivel` (1/2/3), `pai`, `ordem` — árvore pré-order |
+| **Edição/importação** | Cadastro por obra OU importação de referência → instância |
+| **Relacionamento com serviços** | Nó TRABALHO (nível 3) é a base do serviço; serviço adiciona frente × local |
+| **Relacionamento com atividades** | Atividade de planejamento referencia o serviço (que referencia o nó EAP) |
+| **Versionamento** | Possível: `versao` já existe em `ObraEapMetadata`; baseline de EAP |
+
+### Preservar
+- **EAP real de 81 nós** da `OBRA-MODELO-EAP-001` — **NÃO alterar**.
+- `obra-eap-reference.ts` como biblioteca de referências (não fonte operacional).
+
+### Mudança necessária (P0, da auditoria)
+- Remover a dependência da obra-modelo na validação (`validateEap.foraDaObra`).
+- Expor UI de criação/edição/importação de EAP por obra.
+
+---
+
+## 3. DISCIPLINAS
+
+### Situação atual (validado)
+`obra-disciplinas.tsx` **deriva** as disciplinas dos nós nível 1 da EAP
+(`nodes.filter((n) => n.nivel === 1)`). Não há entidade/configuração por obra.
+
+### Análise conceitual
+- **Hoje:** `EAP → Disciplina` (disciplina = nó nível 1).
+- **Correto para o domínio:** `Disciplina → EAP`. A **Disciplina é a fonte de verdade**
+  (especialidade/área do conhecimento); a EAP é a decomposição de entregáveis que
+  **referencia** disciplinas. Uma disciplina pode existir sem EAP (ex.: planejada, ainda
+  sem decomposição) e pode ter cor/ícone/ordem/código independentes.
+
+### Definição conceitual
+`Disciplina` por obra: `{ id, codigo, nome, ordem, cor?, icone?, arquivada? }`.
+- **Entidade própria por obra** (não derivada).
+- Nós do EAP (nível 1) **referenciam** a disciplina (ou a disciplina referencia os WBS).
+- **Migração:** para a obra-modelo, as 10 disciplinas atuais (nível 1) viram o seed.
+
+---
+
+## 4. FRENTES
+
+### Situação atual (validado)
+`obra-frentes.tsx` **deriva** as frentes das disciplinas raiz da EAP
+(`nodes.filter((n) => n.nivel === 1)`). Frente = natureza/especialidade do trabalho.
+
+### Definição conceitual
+`Frente` é uma **entidade operacional** por obra, com ciclo de vida próprio
+(criar, editar, encerrar) e atributos que não vêm do EAP.
+
+| Atributo | Relação | Classificação |
+|----------|---------|---------------|
+| `nome` | — | EDITÁVEL |
+| `codigo` | — | EDITÁVEL |
+| `disciplina` | → Disciplina | EDITÁVEL (referência) |
+| `responsavel` | → (pessoa) | EDITÁVEL |
+| `equipe` | → Equipe | EDITÁVEL (referência) |
+| `status` | — | EDITÁVEL (ativa/encerrada) |
+| `localizacao` | → Local | EDITÁVEL (referência) |
+| `inicio`/`término` | — | EDITÁVEL |
+
+**Relações:** Frente ↔ Disciplina (uma frente atua numa disciplina); Frente ↔ EAP
+(indireta, via serviço); Frente ↔ Serviço (dimensão do serviço); Frente ↔ Local (onde atua);
+Frente ↔ Equipe (quem executa).
+
+---
+
+## 5. LOCAIS
+
+### Situação atual (validado)
+**Não existe entidade de Locais/Unidades** no domínio Obra. A caracterização tem
+`torres`, `lajes`, `apartamentosPorPavimento`, `subsolos` — **números agregados**, não
+estrutura hierárquica. O dataset ARES tem `local: "LOCAL-T1"` mas não é consumido pela obra real.
+
+### Definição conceitual
+`Local` é uma **entidade hierárquica por obra**, genérica — **não assumir torre/laje/apartamento
+como estrutura universal**.
+
+```
+Local = { id, nome, tipo, pai?, ordem }
+```
+
+| Tipo de obra | Exemplo de hierarquia de locais |
+|--------------|---------------------------------|
+| Residencial vertical | Torre → Pavimento → Unidade |
+| Comercial | Bloco → Andar → Sala |
+| Infraestrutura (rodoviária) | Trecho → Subtrecho → Km |
+| Infraestrutura (hidráulica) | Trecho → Estação → Ponto |
+
+**Relações:** Local ↔ Serviço (dimensão `LOCALIZAÇÃO`); Local ↔ Frente (onde atua);
+Local ↔ Produção (onde foi executado).
+
+**Migração:** para a obra-modelo, os locais seriam derivados da caracterização
+(1 torre, 14 lajes, 1 apto/pavimento).
+
+---
+
+## 6. SERVIÇOS
+
+### Situação atual (validado)
+`obra-servicos-adapter.ts` **deriva** os serviços dos nós TRABALHO (nível 3) da EAP +
+planejamento. `ServicoItem` tem `{id, codigo, nome, duracao, inicio, fim, status}` + campos
+opcionais preparados (`unidade`, `quantidade`, `produtividade`, `predecessora`).
+
+### Conceito `SERVIÇO = EAP × FRENTE × LOCALIZAÇÃO`
+**Hoje NÃO está representado.** O serviço é apenas um nó TRABALHO com datas derivadas.
+**Não há dimensão de frente nem de localização** no serviço.
+
+### Definição conceitual
+`Serviço` é o **principal elemento operacional da execução** — a interseção de um elemento
+de escopo (EAP), uma frente (quem executa) e uma localização (onde).
+
+```
+Serviço = { id, obraId, eapWbs, frenteId, localId, quantidade, unidade, produtividade, predecessora }
+```
+
+- **Identidade composta:** `obraId + eapWbs + frenteId + localId` (o mesmo trabalho pode
+  ocorrer em múltiplas frentes/locais).
+- **Editável:** `quantidade`, `unidade`, `produtividade`, `predecessora`, `frenteId`, `localId`.
+- **Derivado:** `duracao` (qtd/prod), `inicio`/`fim` (cronograma).
+
+**Decisão:** **SIM** — o Serviço deve ser o principal elemento operacional da execução,
+pois é onde escopo, responsabilidade e localização se encontram.
+
+---
+
+## 7. ATIVIDADES
+
+### Definição conceitual
+`Atividade` é a **entidade de planejamento** que representa uma unidade de trabalho no
+cronograma. Ela referencia um Serviço (que referencia EAP × Frente × Local).
+
+| Campo | Classificação | Observação |
+|-------|---------------|------------|
+| `id` | ESTRUTURAL | |
+| `descricao` | EDITÁVEL | |
+| `servicoId` | EDITÁVEL (referência) | vínculo com EAP/serviço |
+| `quantidade` | EDITÁVEL | escopo |
+| `unidade` | EDITÁVEL | |
+| `produtividade` | EDITÁVEL | base de cálculo |
+| `duracao` | DERIVADO (qtd/prod) OU EDITÁVEL (override) | |
+| `inicio` | DERIVADO (cronograma) | |
+| `termino` | DERIVADO | |
+| `predecessoras` | EDITÁVEL | rede de precedência |
+| `tipoRelacao` | EDITÁVEL | FS/SS/FF/SF |
+| `calendario` | CONFIGURÁVEL (referência) | |
+| `equipe/recurso` | EDITÁVEL (referência) | |
+| `status` | DERIVADO (datas × realizado) | |
+| `percentualPlan` | DERIVADO (curva S) | |
+| `percentualReal` | CADASTRADO (vem da produção) | |
+
+---
+
+## 8. PLANEJAMENTO
+
+### Situação atual (validado)
+`obra-planejamento-data.ts` **deriva** o cronograma dos nós EAP + `OBRA_SCOPE_REF` +
+`DATA_INICIO_OBRA`. `derivarPlanejamento` sequencia por disciplina, calcula duração
+(qtd/prod), datas acumuladas, crítico (limiar 60%), predecessora (sequencial).
+**Não há edição** — tudo é derivado deterministicamente.
+
+### Definição conceitual
+| Elemento | Classificação |
+|----------|---------------|
+| **Baseline** | DERIVADO (ponto de partida, do EAP + escopo) |
+| **Planejamento atual** | EDITÁVEL (baseline + overrides) |
+| **Alterações/overrides** | EDITÁVEL (duração, datas, rede) |
+| **Datas** | DERIVADO (cronograma) OU EDITÁVEL (override) |
+| **Duração** | DERIVADO (qtd/prod) OU EDITÁVEL (override) |
+| **Predecessoras** | EDITÁVEL (rede) |
+| **Calendário** | CONFIGURÁVEL |
+| **Status** | DERIVADO |
+
+### QUAL É A ÚNICA FONTE DE VERDADE DO CRONOGRAMA?
+> **O PLANEJAMENTO (entidade de Atividades por obra) é a ÚNICA fonte de verdade do
+> cronograma.** Gantt, CPM e LOB são **derivados** dele e **nunca** mantêm cronogramas
+> independentes. A derivação atual (EAP + escopo → planejamento) é o **baseline**; o
+> planejamento editável (com overrides) é a fonte operacional.
+
+---
+
+## 9. PRODUÇÃO
+
+### Situação atual (validado)
+`obra-producao.tsx` **deriva** a produção dos nós TRABALHO com duração + `OBRA_SCOPE_REF`.
+Produção real marcada como **"Pendente"** (não registrada).
+
+### Separação necessária
+| Categoria | Dados | Editável? |
+|-----------|-------|-----------|
+| **Planejado** | quantidade planejada, produtividade, ritmo, meta, período | EDITÁVEL (cadastro) |
+| **Realizado** | quantidade produzida, data, equipe, frente, responsável, observação | EDITÁVEL (registro) |
+| **Derivado/calculado** | avanço, produtividade real, desvio, projeção, tendência | CALCULADO |
+
+**Decisão:** o **realizado** deve ser registrado numa **entidade de produção real por obra**
+(apontamentos diários/periódicos), separada do planejado. O avanço/desvio/projeção são
+**derivados** da comparação planejado × realizado.
+
+---
+
+## 10. GANTT / CPM / LOB
+
+### Validação da regra arquitetural
+```
+PLANEJAMENTO → GANTT
+PLANEJAMENTO → CPM
+PLANEJAMENTO → LOB
+```
+**VALIDADA.** Gantt, CPM e LOB **não podem manter cronogramas independentes** — todos são
+**derivados** do planejamento. A LOB **deve continuar sendo calculadora/visualização derivada**
+(validado: `obra-lob-data.ts` delega à capacidade genérica `domains/linha-de-balanco`, que é
+pura e derivada).
+
+---
+
+## 11. RECURSOS / EQUIPES / CALENDÁRIOS
+
+### Situação atual (validado)
+**Não existem** entidades de Recursos, Equipes ou Calendários no domínio Obra. O dataset
+ARES tem `equipe: "EQUIPE-001"` mas não é consumido pela obra real. O planejamento não
+considera calendário (dias corridos a partir de `DATA_INICIO_OBRA`).
+
+### Definição conceitual (fases posteriores)
+- **Equipes:** entidade por obra `{ id, nome, frenteId?, responsavel?, membros? }`.
+- **Recursos:** entidade por obra `{ id, nome, tipo, unidade, custo? }`.
+- **Calendários:** entidade por obra `{ id, nome, diasUteis, feriados }`, usada no cálculo
+  de datas do planejamento.
+
+**Onde entram no modelo:** vinculados à Atividade (equipe/recurso/calendário) e à Frente
+(equipe). São **referências**, não fontes de cronograma.
+
+---
+
+## 12. IA / AGENTE PLANEJADOR
+
+> **NÃO IMPLEMENTAR.** Somente definição conceitual.
+
+O futuro **Agente Planejador** deverá:
+1. **Ler o modelo estruturado** (EAP, serviços, atividades, produção) por `obraId`.
+2. **Analisar restrições** (predecessoras, calendário, recursos).
+3. **Analisar produção** (planejado × realizado, desvios).
+4. **Identificar impactos** (atrasos, caminho crítico, folgas).
+5. **Propor alterações** (datas, durações, rede) como **propostas**.
+6. **Justificar propostas** (motivo, evidência, impacto).
+7. **Nunca alterar dados críticos automaticamente sem aprovação humana.**
+
+O Agente opera **somente leitura** sobre o modelo; alterações são **propostas** que exigem
+aprovação humana antes de virar override no planejamento.
+
+---
+
+## 13. TESTE DE GENERALIZAÇÃO — Obra A / B / C
+
+Demonstração conceitual de como o **mesmo núcleo** atende três obras diferentes **sem
+criar arquitetura diferente para cada uma**.
+
+| Obra | Tipo | Locais | Disciplinas | Frentes | Como o núcleo representa |
+|------|------|--------|-------------|---------|--------------------------|
+| **A** | Residencial vertical | Torre → Pavimento → Unidade | 10 | 10 | EAP própria; locais hierárquicos; disciplinas/frentes cadastradas; serviços = EAP × frente × local |
+| **B** | Edifício comercial | Bloco → Andar → Sala | 7 | 18 | Mesma estrutura, valores diferentes |
+| **C** | Infraestrutura | Trecho → Subtrecho → Km | diferentes | diferentes | Caracterização dinâmica (sem torres/lajes); locais = trechos/km; disciplinas = terraplenagem/pavimentação/etc.; EAP própria |
+
+**O que muda entre A/B/C:** apenas os **dados** (locais, disciplinas, frentes, EAP, escopo).
+**O que NÃO muda:** o **núcleo** (entidades Obra/EAP/Disciplina/Frente/Local/Serviço/
+Atividade/Planejamento/Produção + capacidades genéricas Gantt/CPM/LOB).
+
+---
+
+## 14. FONTES DE VERDADE — Matriz
+
+| Entidade | Fonte de verdade | Derivado de | Editável | Calculado | Histórico |
+|----------|------------------|-------------|----------|-----------|-----------|
+| **Obra** | `obra-repository.ts` (lista) | — | nome, status, datas, localização, responsável | `ARQUIVADA` (de `arquivada`) | — |
+| **Caracterização** | `Obra.caracterizacao` (dinâmico) | — | sim (futuro) | — | — |
+| **Disciplinas** | Entidade por obra | — | sim | — | — |
+| **EAP** | `obra-eap-repository.ts` (por obraId) | — | sim (futuro) | resumo (`deriveEapSummary`) | `versao` |
+| **Locais** | Entidade por obra | — | sim | — | — |
+| **Frentes** | Entidade por obra | — | sim | — | — |
+| **Serviços** | Cadastro por obra | EAP × Frente × Local | quantidade, unidade, produtividade, predecessora | duração (qtd/prod) | — |
+| **Atividades** | Entidade por obra | Serviço | descrição, quantidade, rede, overrides | duração, datas | — |
+| **Planejamento** | **Entidade de Atividades por obra (ÚNICA fonte do cronograma)** | EAP + escopo (baseline) | overrides, rede, calendário | datas, crítico | baseline |
+| **Produção** | Registro por obra (realizado) | — | quantidade, data, equipe | avanço/desvio (planejado × realizado) | apontamentos |
+| **Gantt** | **NUNCA fonte** — derivado | Planejamento | — | sim | — |
+| **CPM** | **NUNCA fonte** — derivado | Planejamento | — | sim | — |
+| **LOB** | **NUNCA fonte** — derivado | Planejamento | — | sim | — |
+
+---
+
+## 15. CADEIA DE DEPENDÊNCIAS
+
+### Cadeia proposta pelo usuário
+```
+OBRA → EAP → SERVIÇO → ATIVIDADE → PLANEJAMENTO → GANTT/CPM/LOB → PRODUÇÃO → CONTROLE
+```
+
+### Análise do código e ajuste recomendado
+A cadeia proposta está **quase correta**, mas o código revela uma sutileza: **Produção
+(realizado) não é derivada do planejamento** — ela é um **registro independente** que se
+compara ao planejado. Além disso, **Serviço** depende de **Frente** e **Local** (dimensões
+que não vêm da EAP). Cadeia ajustada:
+
+```
+OBRA
+ ├── Disciplinas (entidade)
+ ├── Locais (entidade hierárquica)
+ ├── Frentes (entidade operacional)
+ ├── EAP (por obra)
+ │     └── (nós TRABALHO = base de escopo)
+ ├── SERVIÇO = EAP × FRENTE × LOCAL  (cadastro)
+ │     └── quantidade, unidade, produtividade, predecessora
+ ├── ATIVIDADE (referencia serviço)
+ │     └── rede, calendário, overrides
+ ├── PLANEJAMENTO  ← ÚNICA FONTE DE VERDADE DO CRONOGRAMA
+ │     ├── GANTT (derivado)
+ │     ├── CPM   (derivado)
+ │     └── LOB   (derivado)
+ ├── PRODUÇÃO (registro do realizado — independente, comparado ao planejado)
+ └── CONTROLE (derivado: planejado × realizado → avanço/desvio)
+```
+
+**Motivo do ajuste:** a cadeia original sugere que Produção deriva do planejamento, mas o
+código mostra que produção real é um **registro** (não derivado). E a cadeia original omite
+Frente/Local como dimensões do Serviço. O restante (EAP → Serviço → Atividade → Planejamento
+→ Gantt/CPM/LOB) está correto.
+
+---
+
+## 16. HARD CODES — onde cada informação deveria morar
+
+| # | Hardcode atual | Arquivo | Deveria morar em |
+|---|----------------|---------|------------------|
+| 1 | 81 nós EAP | `obra-eap-data.ts` | Entidade EAP por obra (cadastro/importação) |
+| 2 | `OBRA_SCOPE_REF` (qtd/prod por WBS) | `obra-planejamento-data.ts` | Cadastro de Serviço por obra |
+| 3 | `DATA_INICIO_OBRA` (05/01/2026) | `obra-planejamento-data.ts` | `obra.dataInicio` (metadado cadastro) |
+| 4 | Caracterização (torres/lajes/aptos/subsolos) | `obra-types.ts` + seeds | Campos dinâmicos por tipo de obra |
+| 5 | `validateEap.foraDaObra` (obraId fixo) | `obra-eap-repository.ts` | Validar contra a própria obra |
+| 6 | `OBRA_MODELO_ID`/`OBRA_MODELO_EAP_ID` | `obra-repository.ts`/`obra-eap-data.ts` | Referência (não fonte operacional) |
+| 7 | `REF_EAP_RES_001` | `obra-eap-reference.ts` | Biblioteca de referências (ok) |
+| 8 | ARES/Piemarta (15 atv, 18 elos, 11 serv) | `obra-ares-referencia.ts` | Isolado (não consumido pela obra real) |
+| 9 | `STATUS_OPTIONS` | `obra-lista.tsx`/`obra-editar.tsx`/`obra-nova.tsx` | Configurável por obra |
+| 10 | `CAMPOS_CARACTERIZACAO` | `obra-caracterizacao.tsx`/`obra-visao-geral.tsx` | Configurável por tipo de obra |
+| 11 | `OBRA_MODULES` (11 módulos) | `obra-modules.ts` | Catálogo declarativo (ok) |
+| 12 | `OBRA_FASES_ORDER` | `obra-modules.ts` | Fixo (ok) |
+
+---
+
+## 17. DECISÕES ARQUITETURAIS
+
+### D1 — Disciplinas: entidade própria vs derivada
+1. **Situação atual:** derivadas do EAP nível 1 (`obra-disciplinas.tsx`).
+2. **Problema:** não podem crescer/reduzir/ordenar; sem cor/ícone/código independentes;
+   não podem existir sem EAP.
+3. **Alternativa A (recomendada):** entidade por obra (`Disciplina`), EAP referencia.
+4. **Alternativa B:** manter derivada (menor mudança, mas rígida).
+5. **Recomendação:** A.
+6. **Motivo:** `Disciplina → EAP` é o modelo correto do domínio; permite disciplina sem EAP.
+7. **Impacto futuro:** migração das 10 atuais vira seed; obra-modelo continua funcionando.
+
+### D2 — Frentes: entidade operacional
+1. **Situação atual:** derivadas das disciplinas raiz (`obra-frentes.tsx`).
+2. **Problema:** sem ciclo de vida (criar/editar/encerrar); sem responsável/equipe/local.
+3. **Alternativa A (recomendada):** entidade operacional por obra.
+4. **Alternativa B:** manter derivada.
+5. **Recomendação:** A.
+6. **Motivo:** frente tem atributos operacionais que não vêm do EAP.
+7. **Impacto futuro:** habilita gestão de frentes e a dimensão FRENTE do serviço.
+
+### D3 — Serviço como elemento operacional principal
+1. **Situação atual:** derivado dos nós TRABALHO (`obra-servicos-adapter.ts`).
+2. **Problema:** conceito `EAP × FRENTE × LOCALIZAÇÃO` não representado.
+3. **Alternativa A (recomendada):** cadastro por obra (EAP × frente × local).
+4. **Alternativa B:** manter derivado.
+5. **Recomendação:** A.
+6. **Motivo:** é onde escopo, responsabilidade e localização se encontram.
+7. **Impacto futuro:** base para orçamento/medição/indicadores (FASE 22).
+
+### D4 — Fonte de verdade do cronograma
+1. **Situação atual:** derivado deterministicamente (`obra-planejamento-data.ts`).
+2. **Problema:** cronograma não evolui; sem rede/calendário/overrides.
+3. **Alternativa A (recomendada):** Planejamento (Atividades por obra) como única fonte;
+   baseline derivado + overrides editáveis.
+4. **Alternativa B:** manter derivado puro.
+5. **Recomendação:** A.
+6. **Motivo:** Gantt/CPM/LOB derivam do planejamento; sem fonte única, há múltiplas verdades.
+7. **Impacto futuro:** habilita evolução do cronograma sem quebrar derivação.
+
+### D5 — Produção: registro real separado
+1. **Situação atual:** derivada/simulada, real "Pendente" (`obra-producao.tsx`).
+2. **Problema:** dados fictícios tratados como reais; sem gestão real.
+3. **Alternativa A (recomendada):** entidade de registro de produção real (realizado).
+4. **Alternativa B:** manter derivada.
+5. **Recomendação:** A.
+6. **Motivo:** avanço/desvio são derivados de planejado × realizado.
+7. **Impacto futuro:** habilita controle real de obra.
+
+### D6 — Locais: estrutura genérica hierárquica
+1. **Situação atual:** não existe; só números agregados na caracterização.
+2. **Problema:** não representa obra não-residencial (infraestrutura, comercial).
+3. **Alternativa A (recomendada):** entidade hierárquica genérica por obra.
+4. **Alternativa B:** manter números agregados.
+5. **Recomendação:** A.
+6. **Motivo:** não assumir torre/laje/apartamento como universal.
+7. **Impacto futuro:** habilita Obra C (infraestrutura) sem alterar código.
+
+### D7 — Caracterização: campos dinâmicos
+1. **Situação atual:** shape fixo (`ObraCaracterizacao`), somente leitura.
+2. **Problema:** obra não-residencial não representável; duplicada em 3 lugares.
+3. **Alternativa A (recomendada):** campos dinâmicos por tipo de obra.
+4. **Alternativa B:** manter shape fixo.
+5. **Recomendação:** A.
+6. **Motivo:** desacopla do edifício residencial; elimina duplicação.
+7. **Impacto futuro:** habilita tipos de obra variados.
+
+### D8 — EAP: por obra + validação desacoplada
+1. **Situação atual:** fixa em código; `validateEap` depende da obra-modelo.
+2. **Problema:** bloqueia EAP de outra obra.
+3. **Alternativa A (recomendada):** EAP por obra; validação contra a própria obra.
+4. **Alternativa B:** manter fixa.
+5. **Recomendação:** A.
+6. **Motivo:** infraestrutura já suporta (`eaps: Record<string, ObraEap>`).
+7. **Impacto futuro:** destrava cadastro de obra diferente.
+
+### D9 — Data de início vinculada à obra
+1. **Situação atual:** `DATA_INICIO_OBRA` fixa (05/01/2026).
+2. **Problema:** todas as obras usam a mesma data.
+3. **Alternativa A (recomendada):** usar `obra.dataInicio` como base do cronograma.
+4. **Alternativa B:** manter constante.
+5. **Recomendação:** A.
+6. **Motivo:** data é metadado do cadastro; cronograma deriva dela.
+7. **Impacto futuro:** cada obra tem seu próprio início.
+
+---
+
+## 18. PRESERVAR (obrigatório)
+
+| Item | Evidência | Por quê |
+|------|-----------|---------|
+| EAP real de 81 nós | `obra-eap-data.ts` | Fonte oficial; não alterar |
+| `OBRA-MODELO-EAP-001` | `obra-repository.ts`/`obra-eap-data.ts` | Obra de referência |
+| Isolamento ARES/Piemarta | `obra-ares-referencia.ts` | Dataset de referência; não consumido pela obra real |
+| FASES 21 e 22 | `obra-modules.ts`, `obra-shell-route.tsx` | Navegação por fase + catálogo declarativo |
+| Arquitetura de derivação correta | `obra-planejamento-data.ts`, `obra-lob-data.ts` | Calculadora correta |
+| LOB como calculadora | `obra-lob-data.ts` → `domains/linha-de-balanco` | Nunca fonte |
+| Ausência de múltiplas fontes de verdade | `obra-repository.ts`, `obra-eap-repository.ts` | Fonte única por repositório |
+| Capacidades genéricas neutras | `domains/planejamento`, `servicos`, `linha-de-balanco` | Reutilizáveis |
+
+---
+
+## 19. PRÓXIMA ETAPA PROPOSTA
+
+> **NÃO EXECUTAR.** Apenas proposta do que deveria ser feito depois desta modelagem.
+
+1. **Aprovar esta especificação** (decisões D1–D9).
+2. **Fase P0 (desacoplamento, sem reescrita):**
+   - Remover `validateEap.foraDaObra` (validar contra a própria obra).
+   - Vincular `DATA_INICIO_OBRA` ao `obra.dataInicio`.
+   - Desacoplar `OBRA_SCOPE_REF` para cadastro de serviço por obra.
+3. **Fase P1 (núcleo operacional):**
+   - Criar entidades Disciplina, Frente, Local, Serviço por obra.
+   - Criar entidade de registro de Produção (realizado).
+4. **Fase P2 (evolução):**
+   - Caracterização dinâmica por tipo de obra.
+   - Planejamento editável (baseline + overrides, rede, calendário).
+5. **Fase P3 (posterior):** Equipes, Recursos, Calendários, tipos de atividade, status custom.
+6. **Agente Planejador:** somente após o modelo estruturado estar estável (leitura + propostas).
+
+Cada fase deve ser validada com testes (`evals/specs/**/*.test.ts`) e preservar a obra-modelo
+funcionando via seed.
+
+---
+
+## Verificação do documento
+
+- [x] Arquivo existe: `docs/features/modelo-canonico-planejamento.md`
+- [x] Somente análise e arquitetura — nenhum código alterado
+- [x] EAP real de 81 nós preservada (não alterada)
+- [x] LOB como calculadora (não alterada)
+- [x] Planejamento/Produção não alterados
+- [x] Nenhum commit, nenhuma funcionalidade nova
+- [x] Conclusões validadas contra o código real; `NÃO VERIFICADO` onde faltou prova
+
+---
+
+**MODELO CANÔNICO DE PLANEJAMENTO — AGUARDANDO APROVAÇÃO**

--- a/docs/features/obra-eap-modelo.md
+++ b/docs/features/obra-eap-modelo.md
@@ -1,0 +1,159 @@
+# Modelo de Domínio da EAP (Estrutura Analítica do Projeto) — Obra
+
+> **Documento permanente** · Domínio Engenharia · FASE 06.2-B
+> Última atualização: 2026-09-02
+
+## 1. O que é
+
+A **EAP (Estrutura Analítica do Projeto)** é o modelo de domínio que representa a
+decomposição hierárquica do escopo de uma **Obra** em disciplinas, pacotes de
+trabalho e trabalhos. É um conceito **próprio da Obra** — **não** reutiliza
+`PlanningItem` (capacidade genérica de planejamento do domínio `planejamento/`).
+
+A EAP é a base para o planejamento futuro (serviço → atividade → rede/CPM/Gantt),
+mas nesta fase ela é tratada como **modelo de domínio navegável e persistido**,
+sem avançar para planejamento, Skills, Agents, MCPs, CPM ou Gantt.
+
+## 2. Onde vive
+
+| Camada | Arquivo |
+| --- | --- |
+| Tipos | `apps/app/src/react-app/domains/engenharia/obra/obra-eap-types.ts` |
+| Dados (81 nós reais) | `apps/app/src/react-app/domains/engenharia/obra/obra-eap-data.ts` |
+| Repositório + helpers puros | `apps/app/src/react-app/domains/engenharia/obra/obra-eap-repository.ts` |
+| Persistência (localStorage) | `apps/app/src/react-app/domains/engenharia/obra/obra-eap-storage.ts` |
+| Referência reutilizável | `apps/app/src/react-app/domains/engenharia/obra/obra-eap-reference.ts` |
+| Árvore navegável (UI) | `apps/app/src/react-app/domains/engenharia/obra/obra-eap-tree.tsx` |
+| Página | `apps/app/src/react-app/domains/engenharia/obra/pages/obra-eap.tsx` |
+| Inicialização | `apps/app/src/react-app/domains/engenharia/domain.tsx` |
+
+## 3. Dono
+
+A EAP pertence ao **domínio Engenharia**, subdomínio **Obra**
+(`domains/engenharia/obra/`). É persistida **por `obraId`** — cada Obra tem sua
+própria EAP. Não há banco paralelo nem segunda fonte de verdade para a Obra.
+
+## 4. Estrutura do modelo
+
+### 4.1 Nó (`ObraEapNode`)
+
+| Campo | Tipo | Descrição |
+| --- | --- | --- |
+| `obraId` | `string` | Obra à qual o nó pertence (identidade composta). |
+| `wbs` | `string` | Identificador hierárquico oficial (ex.: `1`, `1.1`, `1.1.1`). |
+| `nome` | `string` | Nome do nó. |
+| `nivel` | `number` | Nível hierárquico (1 = DISCIPLINA, 2 = PACOTE, 3 = TRABALHO). |
+| `tipo` | `"DISCIPLINA" \| "PACOTE" \| "TRABALHO"` | Tipo do nó. |
+| `pai` | `string \| null` | WBS do nó pai; `null` para raízes (nível 1). |
+| `ordem` | `number` | Ordem entre irmãos (ordem de ocorrência na fonte, pré-order). |
+| `fundamentacao` | `string \| null` | Fundamentação do nó (preservada da fonte). |
+| `condicao` | `string \| null` | Condição/hipótese do nó (preservada da fonte). |
+
+### 4.2 Metadados (`ObraEapMetadata`)
+
+Preserva os metadados do documento oficial: `obraId`, `obraNome`, `status`,
+`versao`, `caracterizacaoRef`, `regraAlocacaoEstruturaCobertura`, `niveisTipos`,
+`principios`, `noTemplate`, `caracterizacaoResumo`.
+
+### 4.3 EAP completa (`ObraEap`)
+
+`{ obraId, metadata, nodes }` — metadados + nós de uma Obra.
+
+### 4.4 Resumo (`ObraEapSummary`)
+
+`{ status, total, raizes, pacotes, trabalhos }` — **sempre derivado** dos nós via
+`deriveEapSummary`. **Nunca** é uma fonte independente de números.
+
+## 5. Identidade
+
+A identidade natural de um nó é **`obraId` + `wbs`**. O mesmo WBS em obras
+diferentes **não** representa o mesmo nó operacional. Por isso a EAP é persistida
+e consultada **por `obraId`**.
+
+## 6. Persistência
+
+Arquitetura: **UI → repository → storage**. A UI nunca toca em `localStorage`.
+
+- Store Zustand `useObraEapRepository` mantém `eaps: Record<obraId, ObraEap>`.
+- `setEap` / `resetEaps` gravam no armazenamento local (chave
+  `openwork.obra-eap.v1`, versão 1).
+- `initializeObraEapRepository()` hidrata o store a partir do armazenamento na
+  inicialização do domínio.
+- `resetObraEapRepository()` limpa a persistência e restaura os seeds (testes).
+
+## 7. Relações
+
+- A EAP é **fonte única** dos nós da Obra. O resumo é derivado, nunca paralelo.
+- A **Obra Modelo EAP** (`OBRA-MODELO-EAP-001`) é a primeira **referência
+  reutilizável** (`REF-EAP-RES-001`) da biblioteca de EAPs modelo — ver §9.
+- A capacidade genérica de planejamento (`domains/planejamento/`) permanece
+  **neutra / anti-hardcode** e **não** é reutilizada para a EAP.
+
+## 8. Obra Modelo EAP (81 nós)
+
+A EAP real da Obra Modelo EAP foi transcrita integralmente da fonte oficial
+(read-only, proveniência):
+
+`C:\Users\Correta Engenharia\OBRAS-MODELO\OBRA-MODELO-EAP-001\data\eap\OBRA-MODELO-EAP-001-eap.json`
+
+- **Status:** `PROPOSTA` · **Versão:** `FASE-19.5`
+- **Total:** 81 nós = **10 DISCIPLINA** / **24 PACOTE** / **47 TRABALHO**
+- **Raízes:** 10 · **Folhas:** 47
+- **Obra:** "Edifício Residencial Modelo EAP" (1 torre, 14 lajes, pilotis,
+  sobresolo, 1 unidade por pavimento, sem subsolo, concreto armado, cobertura
+  prevista).
+
+Os 81 nós vivem em `obra-eap-data.ts` (`OBRA_MODELO_EAP_NODES`), com todos os
+campos preservados (`wbs`, `nome`, `nivel`, `tipo`, `pai`, `ordem`,
+`fundamentacao`, `condicao`). **Não** houve renumeração de WBS nem remoção de
+campos.
+
+> **Importante:** a Obra Modelo EAP é uma **referência**, **não** um template
+> universal nem fonte operacional das outras obras. Cada Obra tem sua própria EAP.
+
+## 9. EapReference (referência reutilizável)
+
+`EapReference` é um conceito que permite a futura Skill/Agent **selecionar,
+analisar e adaptar** EAPs modelo para novas obras.
+
+- **Não** substitui a EAP operacional da Obra.
+- **Não** embute os 81 nós — referencia a origem por `origemObraId`, evitando
+  duplicação de dados.
+- `resolveReferenceNodes(reference)` resolve os nós a partir da EAP operacional
+  da origem.
+- `findEapReference(id)` busca por id.
+
+Primeira referência: **`REF-EAP-RES-001`** ("EAP Residencial Completo"),
+`origemObraId = "OBRA-MODELO-EAP-001"`, versão `FASE-19.5`, com caracterização,
+princípios e regras observadas.
+
+## 10. EAP operacional vs EapReference (proveniência)
+
+| Aspecto | EAP operacional | EapReference |
+| --- | --- | --- |
+| Papel | Modelo de domínio da Obra | Referência reutilizável para novas obras |
+| Dados | Nós reais por `obraId` | Aponta para a origem (`origemObraId`) |
+| Duplicação | Fonte única | Não embute os nós |
+| Uso futuro | Base do planejamento | Seleção/adaptação por Skills/Agents |
+
+## 11. Validação estrutural
+
+`validateEap(nodes)` espelha o verificador oficial e verifica: WBS duplicados,
+pais inexistentes, raízes com pai, ciclos e nós fora da obra. O resumo derivado
+confere com a fonte: 81 = 10/24/47, 10 raízes, 47 folhas.
+
+## 12. Testes
+
+- `apps/app/tests/obra-eap.test.ts` — integridade (81/10/24/47/10/47), duplicados,
+  pais inexistentes, raízes com pai, ciclos, fora-da-obra, resumo derivado,
+  linhas de árvore, referência.
+- `apps/app/tests/obra-eap-ui.test.tsx` — renderização SSR da página e da árvore.
+
+Execução: `bun test tests/obra-eap.test.ts tests/obra-eap-ui.test.tsx`
+(24 testes, 0 falhas). Regressão nas áreas tocadas: 84 testes, 0 falhas.
+
+## 13. Limitações / fora de escopo desta fase
+
+- **Não** avança para planejamento, Skills, Agents, MCPs, CPM, Gantt ou LOB.
+- A EAP é navegável e persistida, mas ainda não alimenta o cronograma.
+- A Obra Modelo EAP é referência, não template universal.

--- a/docs/features/obra-lob-sidebar-mapeamento.md
+++ b/docs/features/obra-lob-sidebar-mapeamento.md
@@ -119,52 +119,57 @@ A grade **tempo × serviço** (como a aba `LINHA DE BALANÇO (GRADE)`): 100 sema
 81 serviços, células ativas quando o serviço está em execução. Renderizada em
 React (não é imagem estática), derivada das mesmas datas.
 
-## 6. Dados de planejamento (o que falta)
+## 6. Dados de planejamento (implementado)
 
-Hoje o app **não tem** as datas/durações de planejamento como dados de domínio.
-Elas existem apenas no gerador da planilha (`dados-eap.js`) e na aba
-`PLANEJAMENTO`. Para alimentar o app precisamos:
+O app agora **tem** as datas/durações de planejamento como dados de domínio,
+derivados deterministicamente dos 81 nós reais + escopo de referência:
 
-1. **Criar um modelo de planejamento da obra** (datas, durações, predecessoras,
-   crítico) — espelhando a aba `PLANEJAMENTO`.
-2. **Criar um adapter** que converte os 81 nós + datas em `PlanningDashboardData`
-   (contrato do módulo `planejamento/`), substituindo o `PLANNING_DEMO_DATA`.
-3. **Criar a grade LOB** em React, derivada das mesmas datas.
+1. **`obra-planejamento-data.ts`** — modelo de planejamento (datas, durações,
+   predecessoras, crítico), espelhando a aba `PLANEJAMENTO`.
+2. **`obra-planejamento-adapter.ts`** — converte os 81 nós + datas em
+   `PlanningDashboardData`, substituindo o `PLANNING_DEMO_DATA`.
+3. **`obra-lob-data.ts` + `obra-lob-grade.tsx`** — grade LOB em React, derivada
+   das mesmas datas.
 
-## 7. Impacto / arquivos
+## 7. Impacto / arquivos (implementado)
 
-| Arquivo | Mudança |
-| --- | --- |
-| `obra-routes.ts` | Novos módulos: `caracterizacao`, `disciplinas`, `servicos`, `linha-de-balanco` |
-| `obra-navigation.ts` | Fases (grupos) + subdivisões na sidebar (data-driven) |
-| `obra-shell-route.tsx` | Rotear os novos módulos para as novas páginas |
-| `obra-planejamento.tsx` | Adapter real (substitui demo) |
-| `obra-eap-data.ts` | Fonte única (já existe) |
-| `obra-planejamento-data.ts` (novo) | Datas/durações/predecessoras/crítico |
-| `obra-planejamento-adapter.ts` (novo) | EAP + datas → `PlanningDashboardData` |
-| `obra-lob-grade.tsx` (novo) | Grade tempo × serviço em React |
-| `obra-disciplinas.tsx` / `obra-servicos.tsx` (novos) | Visões derivadas |
-| `obra-caracterizacao.tsx` (novo) | Módulo próprio de caracterização |
+| Arquivo | Mudança | Estado |
+| --- | --- | --- |
+| `obra-routes.ts` | Novos módulos + fases | ✅ |
+| `obra-navigation.ts` | Fases (grupos) na sidebar | ✅ |
+| `obra-shell-route.tsx` | Rotear os novos módulos | ✅ |
+| `obra-planejamento.tsx` | Adapter real (substitui demo) | ✅ |
+| `obra-planejamento-data.ts` | Datas/durações/predecessoras/crítico | ✅ |
+| `obra-planejamento-adapter.ts` | EAP + datas → `PlanningDashboardData` | ✅ |
+| `obra-lob-data.ts` | Grade LOB (dados puros) | ✅ |
+| `obra-lob-grade.tsx` | Grade tempo × serviço em React | ✅ |
+| `obra-disciplinas.tsx` / `obra-servicos.tsx` | Visões derivadas | ✅ |
+| `obra-caracterizacao.tsx` | Módulo próprio de caracterização | ✅ |
 
 ## 8. Riscos / decisões em aberto
 
-- **Escopo:** a proposta completa (fases + subdivisões + grade LOB + adapter) é um
-  trabalho de várias etapas. Podemos entregar em fases.
 - **Frentes/Produção/RDO/IA** continuam placeholders (futuro), mas já aparecem
   agrupados na fase **Execução** / **Suporte** para refletir o fluxo real.
-- **Grade LOB em React** é uma nova visualização; o `PlanningDashboard` atual é
-  Gantt (árvore + timeline). A grade LOB é um layout diferente (tempo × serviço),
-  então será um componente novo, não uma extensão do Gantt.
-- **Fonte de datas:** precisamos decidir se as datas de planejamento entram como
-  dados de domínio persistidos (como a EAP) ou como seed estático derivado.
+- **Grade LOB em React** é uma nova visualização (tempo × serviço), separada do
+  Gantt do `PlanningDashboard`.
+- **Fonte de datas:** as datas são derivadas como seed estático a partir dos nós
+  + escopo. Persistir como dados de domínio editáveis (como a EAP) é evolução
+  futura.
 - **Caracterização** hoje vive dentro da Visão Geral; movê-la para módulo próprio
   muda a Visão Geral (que passa a ser só o resumo).
 
-## 9. Próximo passo sugerido
+## 9. Status da implementação
 
-1. Confirmar a estrutura da sidebar por fases (§4).
-2. Implementar em fases:
-   - **Fase A:** adapter real no Planejamento (substitui demo) + teste.
-   - **Fase B:** fases/grupos na sidebar + subdivisões Disciplinas e Serviços.
-   - **Fase C:** grade LOB em React.
-3. Cada fase com teste em `apps/app/tests/` e evidência de execução.
+As três fases foram implementadas e verificadas:
+
+- **Fase A ✅** — adapter real no Planejamento (substitui demo) + teste
+  (`obra-planejamento-adapter.test.ts`).
+- **Fase B ✅** — fases/grupos na sidebar + módulos Caracterização, Disciplinas e
+  Serviços + testes (`obra-modulos-ui.test.tsx`, `engenharia-navigation.test.ts`).
+- **Fase C ✅** — grade LOB em React (`obra-lob-grade.tsx`) + teste
+  (`obra-lob-grade.test.tsx`).
+
+**Evidência:** 110 testes passando (14 arquivos) + `pnpm typecheck` sem erros.
+
+**Evolução futura:** persistir as datas de planejamento como dados de domínio
+editáveis (como a EAP) e implementar Frentes/Produção/RDO/IA.

--- a/docs/features/obra-lob-sidebar-mapeamento.md
+++ b/docs/features/obra-lob-sidebar-mapeamento.md
@@ -1,0 +1,170 @@
+# Mapeamento: Planilha EAP-Obra-Modelo → Sidebar do App OBRA-MODELO-EAP
+
+> **Documento de decisão (proposta)** · Domínio Engenharia · 2026-09-03
+> Objetivo: recriar a Linha de Balanço (LOB) **dentro** do app e adaptar a
+> sidebar para seguir o **fluxo real de uma obra**, agrupada por **fases**,
+> com as subdivisões interligadas pela mesma fonte de dados.
+
+## 1. Contexto
+
+A planilha `docs/EAP-Obra-Modelo.xlsx` foi gerada com **7 abas** nativas:
+
+| # | Aba | Conteúdo |
+| --- | --- | --- |
+| 1 | `EAP` | 81 nós (10 DISCIPLINA / 24 PACOTE / 47 TRABALHO) |
+| 2 | `Resumo` | KPIs e visão consolidada |
+| 3 | `Disciplinas` | Visão por disciplina |
+| 4 | `Serviços` | Visão por serviço |
+| 5 | `Linha de Balanço` | Tabela de dados (datas, durações, críticos) |
+| 6 | `PLANEJAMENTO` | Fonte única: datas dd/mm/yyyy, predecessoras, crítico |
+| 7 | `LINHA DE BALANÇO (GRADE)` | Grade tempo × serviço com fórmulas SUMPRODUCT |
+
+O app OBRA-MODELO-EAP já possui os módulos: **Visão Geral, EAP, Frentes,
+Planejamento, Produção, RDO, IA**. A proposta é **espelhar as abas da planilha
+na sidebar** como subdivisões interligadas, alimentadas pela **mesma fonte de
+dados** (os 81 nós reais do EAP + datas de planejamento).
+
+## 2. Princípio central: uma única fonte de dados
+
+A planilha tem **uma fonte única** (aba `PLANEJAMENTO`) da qual todas as outras
+abas derivam. O app deve seguir o mesmo princípio:
+
+- **Fonte única:** os 81 nós reais em `obra-eap-data.ts` + as datas/durações de
+  planejamento (hoje em `dados-eap.js` / aba `PLANEJAMENTO`).
+- **Tudo o resto é derivado** (Resumo, Disciplinas, Serviços, LOB, Grade) — nunca
+  uma segunda fonte de números.
+- Isso já é o padrão do domínio (ver `obra-eap-repository.ts` → `deriveEapSummary`).
+
+## 3. Mapeamento aba → módulo/subdivisão
+
+| Aba da planilha | Fase | Subdivisão proposta | Estado |
+| --- | --- | --- | --- |
+| `Resumo` | Preparação | `visao-geral` | ✅ Existe |
+| `EAP` | Preparação | `eap` | ✅ Existe |
+| `Disciplinas` | Preparação | `disciplinas` (nova) | 🆕 Nova |
+| `Serviços` | Preparação | `servicos` (nova) | 🆕 Nova |
+| `PLANEJAMENTO` | Preparação | `planejamento` (fonte) | 🔧 Adapter |
+| `Linha de Balanço` (dados) | Preparação | `planejamento` (dados) | 🔧 Adapter |
+| `LINHA DE BALANÇO (GRADE)` | Preparação | `linha-de-balanco` (grade) | 🆕 Nova |
+
+## 4. Estrutura da sidebar proposta (fluxo real da obra, por fases)
+
+A sidebar segue o **ciclo de vida real de uma obra**, agrupada em **fases**
+colapsáveis. Cada fase reúne os módulos que pertencem àquele momento da obra.
+
+```
+Engenharia
+└── Obras
+    └── Edifício Residencial Modelo EAP   (entidade)
+        │
+        ├── ▸ PREPARAÇÃO                    (grupo de fase)
+        │     ├── Visão Geral        ← Resumo / cadastro
+        │     ├── Caracterização     ← dados estruturais (torres, lajes, subsolos)
+        │     ├── EAP                ← 81 nós (10/24/47)
+        │     ├── Disciplinas        ← 10 disciplinas (derivado)
+        │     ├── Serviços           ← 47 trabalhos (derivado)
+        │     └── Planejamento       ← cronograma + Linha de Balanço (dados)
+        │           └── Linha de Balanço (Grade)   ← grade tempo × serviço
+        │
+        ├── ▸ EXECUÇÃO                       (grupo de fase)
+        │     ├── Frentes de Serviço  ← frentes físicas (futuro, ligado ao EAP)
+        │     ├── Produção            ← avanço físico (futuro)
+        │     └── RDO                 ← registro diário (futuro)
+        │
+        └── ▸ SUPORTE                       (grupo de fase)
+              └── IA                  ← assistência (futuro)
+```
+
+> A sidebar já é **data-driven** (`NavigationNode` suporta `children` aninhados),
+> então adicionar fases e subdivisões é uma mudança declarativa em
+> `obra-navigation.ts`, sem tocar no Core de navegação. Cada fase é um nó
+> agrupador (`type: "group"`) com os módulos como filhos.
+
+## 5. O que cada subdivisão mostra
+
+### 5.0 Fases (grupos da sidebar)
+
+A sidebar organiza os módulos em **3 fases** do ciclo de vida da obra:
+
+| Fase | Momento | Módulos |
+| --- | --- | --- |
+| **Preparação** | Antes/durante o planejamento | Visão Geral, Caracterização, EAP, Disciplinas, Serviços, Planejamento, Linha de Balanço |
+| **Execução** | Durante a construção | Frentes, Produção, RDO |
+| **Suporte** | Transversal | IA |
+
+### 5.1 Visão Geral (existe)
+Resumo da obra: status, caracterização. **Derivado** da fonte.
+
+### 5.2 Caracterização (nova)
+Dados estruturais da obra (torres, lajes, apartamentos por pavimento, subsolos,
+sistema construtivo). Hoje vive dentro da Visão Geral; passa a ser um módulo
+próprio na fase **Preparação**.
+
+### 5.3 EAP (existe)
+Árvore navegável dos 81 nós (10/24/47). **Fonte** da hierarquia.
+
+### 5.4 Disciplinas (nova)
+As 10 DISCIPLINA (nível 1) com seus pacotes/trabalhos agregados. Derivado dos nós.
+
+### 5.5 Serviços (nova)
+Os 47 TRABALHO (nível 3) com duração, datas, crítico. Derivado do planejamento.
+
+### 5.6 Planejamento (adapter)
+O `PlanningDashboard` existente (árvore + timeline/Gantt) alimentado pelos **81
+nós reais** com datas — substituindo o `PLANNING_DEMO_DATA`. É a aba
+`PLANEJAMENTO` + `Linha de Balanço` (dados) do Excel.
+
+### 5.7 Linha de Balanço — Grade (nova)
+A grade **tempo × serviço** (como a aba `LINHA DE BALANÇO (GRADE)`): 100 semanas,
+81 serviços, células ativas quando o serviço está em execução. Renderizada em
+React (não é imagem estática), derivada das mesmas datas.
+
+## 6. Dados de planejamento (o que falta)
+
+Hoje o app **não tem** as datas/durações de planejamento como dados de domínio.
+Elas existem apenas no gerador da planilha (`dados-eap.js`) e na aba
+`PLANEJAMENTO`. Para alimentar o app precisamos:
+
+1. **Criar um modelo de planejamento da obra** (datas, durações, predecessoras,
+   crítico) — espelhando a aba `PLANEJAMENTO`.
+2. **Criar um adapter** que converte os 81 nós + datas em `PlanningDashboardData`
+   (contrato do módulo `planejamento/`), substituindo o `PLANNING_DEMO_DATA`.
+3. **Criar a grade LOB** em React, derivada das mesmas datas.
+
+## 7. Impacto / arquivos
+
+| Arquivo | Mudança |
+| --- | --- |
+| `obra-routes.ts` | Novos módulos: `caracterizacao`, `disciplinas`, `servicos`, `linha-de-balanco` |
+| `obra-navigation.ts` | Fases (grupos) + subdivisões na sidebar (data-driven) |
+| `obra-shell-route.tsx` | Rotear os novos módulos para as novas páginas |
+| `obra-planejamento.tsx` | Adapter real (substitui demo) |
+| `obra-eap-data.ts` | Fonte única (já existe) |
+| `obra-planejamento-data.ts` (novo) | Datas/durações/predecessoras/crítico |
+| `obra-planejamento-adapter.ts` (novo) | EAP + datas → `PlanningDashboardData` |
+| `obra-lob-grade.tsx` (novo) | Grade tempo × serviço em React |
+| `obra-disciplinas.tsx` / `obra-servicos.tsx` (novos) | Visões derivadas |
+| `obra-caracterizacao.tsx` (novo) | Módulo próprio de caracterização |
+
+## 8. Riscos / decisões em aberto
+
+- **Escopo:** a proposta completa (fases + subdivisões + grade LOB + adapter) é um
+  trabalho de várias etapas. Podemos entregar em fases.
+- **Frentes/Produção/RDO/IA** continuam placeholders (futuro), mas já aparecem
+  agrupados na fase **Execução** / **Suporte** para refletir o fluxo real.
+- **Grade LOB em React** é uma nova visualização; o `PlanningDashboard` atual é
+  Gantt (árvore + timeline). A grade LOB é um layout diferente (tempo × serviço),
+  então será um componente novo, não uma extensão do Gantt.
+- **Fonte de datas:** precisamos decidir se as datas de planejamento entram como
+  dados de domínio persistidos (como a EAP) ou como seed estático derivado.
+- **Caracterização** hoje vive dentro da Visão Geral; movê-la para módulo próprio
+  muda a Visão Geral (que passa a ser só o resumo).
+
+## 9. Próximo passo sugerido
+
+1. Confirmar a estrutura da sidebar por fases (§4).
+2. Implementar em fases:
+   - **Fase A:** adapter real no Planejamento (substitui demo) + teste.
+   - **Fase B:** fases/grupos na sidebar + subdivisões Disciplinas e Serviços.
+   - **Fase C:** grade LOB em React.
+3. Cada fase com teste em `apps/app/tests/` e evidência de execução.

--- a/docs/features/proposta-fase21-consolidacao-workspace.md
+++ b/docs/features/proposta-fase21-consolidacao-workspace.md
@@ -1,0 +1,215 @@
+# Proposta — Consolidação da Arquitetura Visual e Estrutural do Workspace (FASE 21)
+
+> **Status: APROVADA (2026-09-03).** Decisões registradas na seção 9.
+> Data: 2026-09-03 · Domínio: Engenharia · Obra: OBRA-MODELO-EAP
+
+---
+
+## 1. Contexto e objetivos
+
+A implementação da **Opção B revisada** (FASE 20.x) foi aprovada. Antes de avançar para
+Orçamento/Medição/Indicadores (que **não** serão implementados agora), o usuário pediu para
+**consolidar a arquitetura visual e estrutural do Workspace**, para que os próximos módulos
+sejam construídos sobre uma interface profissional e escalável de software de
+planejamento/gestão de obras.
+
+### Restrições inegociáveis (preservadas em toda a proposta)
+1. **EAP real da obra preservada** — 81 nós (10 DISCIPLINA / 24 PACOTE / 47 TRABALHO).
+2. **Dataset ARES/Piemarta isolado** como referência/demonstração — nunca como cronograma da obra real.
+3. **Separação de fontes** mantida e explícita no modelo e na documentação.
+4. **Domínio reutilizável** — toda nova capacidade desacoplada da interface e da obra ARES,
+   para futuro multiobra e exposição via Skills/MCP a diferentes agentes de IA.
+
+### Ordem de avanço (após a consolidação)
+1. Consolidar a interface do Workspace (esta proposta).
+2. Modelo **Serviço = EAP × Frente × Localização**.
+3. Evoluir **Planejamento, Gantt, Rede/CPM, LOB e Produção**.
+
+---
+
+## 2. Diagnóstico do estado atual
+
+### O que já está bem (a preservar)
+- **Camada de domínio reutilizável de Planejamento** já existe em `domains/planejamento/`
+  (`PlanningDashboard`, `PlanningTree`, `PlanningTimeline`, `PlanningDetails`, `PlanningHelp`,
+  `planning-data.ts`, `planning-types.ts`). A página `ObraPlanejamento` é apenas um **adapter**
+  (`obraEapParaPlanningDashboard`) que alimenta a dashboard genérica. **Este é o padrão-alvo.**
+- **Separação de fontes** já implementada e testada (FASE 20.x): EAP real 81 nós + dataset
+  ARES/Piemarta isolado em `obra-ares-referencia.ts`.
+- **Navegação por fases** já existe na sidebar (`obra-navigation.ts` → `OBRA_FASES`).
+
+### Lacunas / inconsistências visuais e estruturais
+| # | Lacuna | Impacto |
+|---|--------|---------|
+| 1 | **Cabeçalho da obra mínimo** — o shell mostra só breadcrumb + nome + botões planos. Sem contexto da obra (status, datas, progresso, fase atual). | Falta identidade profissional de "software de gestão de obra". |
+| 2 | **Layout de página ad-hoc** — cada módulo tem seu próprio padrão (Card+table, Card+grid). Sem um "shell de módulo" compartilhado. | Inconsistência visual; retrabalho a cada módulo novo. |
+| 3 | **LOB acoplada ao domínio Obra** — `obra-lob-grade.tsx` é auto-contida e dependente da EAP da obra. Não é reutilizável. | Viola o princípio de domínio reutilizável. |
+| 4 | **Sem barra de contexto/KPIs consistente** — cada módulo decide se mostra resumo. | Falta visão executiva padronizada. |
+| 5 | **Nav interna plana** — o shell usa botões planos, ignorando o agrupamento por fase já definido na sidebar. | Duas navegações divergentes. |
+| 6 | **Frentes/Produção simples** — tabelas básicas, sem o modelo Serviço = EAP × Frente × Localização. | Base fraca para a próxima fase. |
+
+---
+
+## 3. Princípios de arquitetura (norteadores)
+
+1. **Domínio reutilizável primeiro, UI depois.** Cada capacidade (Planejamento, LOB, Rede/CPM,
+   Serviços, Produção) vive em um domínio próprio (`domains/<capacidade>/`) com:
+   - **Contrato de tipos** (`*-types.ts`) — genérico, sem conhecer Obra nem ARES.
+   - **Lógica pura** (`*-data.ts`) — funções puras, testáveis, sem React.
+   - **Componentes de apresentação** (`*-dashboard.tsx`, `*-tree.tsx`, etc.) — renderizam qualquer
+     dado que satisfaça o contrato.
+   - **Adapter por domínio consumidor** — o domínio Engenharia traduz sua entidade para o contrato.
+2. **Obra é um domínio consumidor, não o dono das capacidades.** `domains/engenharia/obra/`
+   orquestra e adapta; as capacidades vivem fora.
+3. **Multiobra e Skills/MCP prontos.** Como o contrato é genérico, a mesma capacidade pode ser
+   alimentada por qualquer obra (multiobra) e exposta via Skills/MCP a agentes de IA.
+4. **Separação de fontes explícita.** Obra real e ARES/Piemarta nunca se misturam; o dataset de
+   referência fica isolado e rotulado.
+5. **Menor diff possível.** Reutilizar o que já existe; não reescrever o que funciona.
+
+---
+
+## 4. Proposta de arquitetura visual (Workspace)
+
+### 4.1 Shell da Obra (cabeçalho + navegação + conteúdo)
+Um **shell de obra profissional** com três zonas:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Engenharia · Obra                                    [Ajuda] [Ações] │  ← breadcrumb
+│  OBRA-MODELO-EAP-001  ·  Status PROPOSTA  ·  Início 05/01/2026       │  ← identidade
+│  ┌──────────┬──────────┬──────────┬──────────┬──────────┬─────────┐  │
+│  │ Preparação: Visão Geral · Caracterização · EAP · Disciplinas ·  │  │  ← nav por fase
+│  │ Serviços · Planejamento · LOB                                    │  │
+│  │ Execução: Frentes · Produção · RDO   Suporte: IA                 │  │
+│  └──────────┴──────────┴──────────┴──────────┴──────────┴─────────┘  │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  [KPI] [KPI] [KPI] [KPI]   ← barra de contexto do módulo      │  │
+│  │  Conteúdo do módulo ativo                                       │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- **Zona 1 — Identidade da obra**: nome, status, datas (início/fim), fase atual. Reutiliza dados
+  já existentes (`obra.caracterizacao`, `DATA_INICIO_OBRA`, `duracaoTotal`).
+- **Zona 2 — Navegação por fase**: agrupada por `OBRA_FASES` (Preparação / Execução / Suporte),
+  alinhada à sidebar. Substitui os botões planos atuais.
+- **Zona 3 — Conteúdo do módulo**: cada módulo renderiza dentro de um **shell de módulo**
+  compartilhado (ver 4.2).
+
+### 4.2 Shell de módulo compartilhado
+Um componente `ObraModuleShell` que padroniza: título, descrição, barra de KPIs opcional e
+conteúdo. Todos os módulos passam a usar o mesmo esqueleto → consistência visual imediata.
+
+### 4.3 Barra de contexto / KPIs
+Um componente `ObraKpiBar` reutilizável que cada módulo alimenta com seus indicadores
+(ex.: EAP → 81 nós / 10 disciplinas / 24 pacotes / 47 trabalhos; LOB → 100 semanas / 34 serviços /
+6 críticos). Padroniza a "visão executiva" de cada módulo.
+
+---
+
+## 5. Proposta de arquitetura estrutural (domínios reutilizáveis)
+
+### 5.1 Extrair a LOB para um domínio reutilizável
+Criar `domains/linha-de-balanco/` (espelhando o padrão de `domains/planejamento/`):
+- `lob-types.ts` — contrato genérico: `LobData` (semanas, linhas, células ativas, crítico).
+- `lob-data.ts` — lógica pura (gerar semanas, derivar grade) — **movida** de `obra-lob-data.ts`.
+- `lob-grade.tsx` — componente de apresentação genérico.
+- `obra-lob-adapter.ts` — traduz a EAP real da obra para `LobData`.
+
+**Resultado**: a LOB deixa de ser acoplada à obra; qualquer obra (ou o dataset ARES) pode
+alimentá-la. A obra real continua usando a EAP real; o dataset ARES pode validar a estrutura.
+
+### 5.2 Padronizar o domínio de Serviços (base para a próxima fase)
+Criar o contrato genérico de **Serviço = EAP × Frente × Localização** em um domínio próprio
+(`domains/servicos/`), ainda sem UI completa — apenas tipos + lógica pura + testes. Isso prepara
+a FASE 22 sem acoplar à obra.
+
+### 5.3 Manter Planejamento como está (já reutilizável)
+`domains/planejamento/` já segue o padrão. Apenas garantir que o adapter da obra real continue
+alimentando-o com a EAP real (sem mudança funcional).
+
+### 5.4 Camada de exposição (Skills/MCP) — preparação
+Documentar o contrato de cada capacidade para que, no futuro, sejam expostas via Skills/MCP.
+**Não implementar** a exposição agora — apenas deixar os contratos limpos e documentados.
+
+---
+
+## 6. Escopo desta FASE 21 (o que será implementado após aprovação)
+
+### 6.1 Interface (visual)
+- [ ] **Shell da obra** profissional (identidade + nav por fase + conteúdo).
+- [ ] **Shell de módulo** compartilhado (`ObraModuleShell`).
+- [ ] **Barra de KPIs** reutilizável (`ObraKpiBar`).
+- [ ] Aplicar o shell aos módulos existentes (Visão Geral, EAP, Disciplinas, Serviços,
+      Planejamento, LOB, Frentes, Produção) — **sem mudar os dados nem a lógica**.
+
+### 6.2 Estrutura (domínios reutilizáveis)
+- [ ] Extrair **LOB** para `domains/linha-de-balanco/` (tipos + lógica + componente + adapter).
+- [ ] Criar contrato genérico de **Serviços** (`domains/servicos/`) — tipos + lógica + testes
+      (base da FASE 22), **sem UI completa**.
+
+### 6.3 Garantias
+- [ ] EAP real de 81 nós **intacta** (nenhuma alteração em `obra-eap-data.ts`).
+- [ ] Dataset ARES/Piemarta **isolado** e rotulado (nenhuma alteração em `obra-ares-referencia.ts`).
+- [ ] Separação de fontes **mantida** e coberta por testes.
+- [ ] `pnpm typecheck` limpo + testes `obra-*` verdes em isolamento.
+
+### 6.4 Fora de escopo (NÃO implementar agora)
+- ❌ Orçamento, Medição, Indicadores.
+- ❌ Exposição real via Skills/MCP (apenas contratos limpos e documentados).
+- ❌ Expansão da EAP para 20 disciplinas (a EAP real de 81 nós é preservada).
+
+---
+
+## 7. Impacto em arquivos
+
+| Ação | Arquivo |
+|------|---------|
+| Novo | `domains/linha-de-balanco/lob-types.ts`, `lob-data.ts`, `lob-grade.tsx` |
+| Novo | `domains/servicos/servicos-types.ts`, `servicos-data.ts` |
+| Novo | `domains/engenharia/obra/obra-lob-adapter.ts` |
+| Novo | `domains/engenharia/obra/components/obra-module-shell.tsx`, `obra-kpi-bar.tsx` |
+| Editar | `obra-shell-route.tsx` (nav por fase + identidade) |
+| Editar | `obra-lob-data.ts` → delegar a `domains/linha-de-balanco` (ou mover) |
+| Editar | páginas de módulos para usar `ObraModuleShell` (sem mudar dados) |
+| Editar | `docs/features/mapeamento-ares-app.md` (registrar FASE 21) |
+| Testes | novos testes para LOB reutilizável, Serviços, e shell |
+
+---
+
+## 8. Riscos e mitigação
+
+| Risco | Mitigação |
+|-------|-----------|
+| Quebrar a EAP real ao refatorar | Nenhuma alteração em `obra-eap-data.ts`; testes de regressão da EAP (81 nós) |
+| Perder a separação de fontes | Dataset ARES isolado e rotulado; testes de separação existentes mantidos |
+| Refatoração da LOB introduzir bug | Mover lógica pura com testes; adapter testado com a EAP real |
+| Escopo crescer demais | FASE 21 limitada a shell + LOB reutilizável + contrato de Serviços; Orçamento/Medição/Indicadores fora |
+
+---
+
+## 9. Decisões que preciso de você
+
+1. **Escopo da FASE 21** — concorda com o corte acima (shell + LOB reutilizável + contrato de
+   Serviços, sem Orçamento/Medição/Indicadores)?
+2. **Nav interna** — prefere **abas por fase** (Preparação/Execução/Suporte com sub-itens) ou
+   **uma linha única de módulos** com separadores de fase (mais compacto)?
+3. **Barra de KPIs** — quer KPIs em **todos** os módulos ou apenas nos principais
+   (Visão Geral, EAP, Planejamento, LOB)?
+4. **Extração da LOB** — mover a lógica para `domains/linha-de-balanco/` (recomendado) ou manter
+   em `obra-lob-data.ts` e apenas criar o componente genérico?
+
+---
+
+## 10. Decisões aprovadas (2026-09-03)
+
+| # | Decisão | Escolha |
+|---|---------|---------|
+| 1 | Escopo da FASE 21 | **Aprovado o escopo completo** (shell + LOB reutilizável + contrato de Serviços; Orçamento/Medição/Indicadores e exposição Skills/MCP fora) |
+| 2 | Navegação interna | **Abas por fase com sub-itens** (Preparação/Execução/Suporte com os módulos de cada fase) |
+| 3 | Barra de KPIs | **Nos módulos principais** (Visão Geral, EAP, Planejamento, LOB, Serviços) |
+| 4 | Extração da LOB | **Mover para `domains/linha-de-balanco/`** (tipos + lógica + componente) com adapter da obra real |
+
+**Aguardando sua aprovação e respostas às decisões acima. Nenhuma interface foi alterada.**

--- a/docs/features/proposta-fase22-auditoria-workspace.md
+++ b/docs/features/proposta-fase22-auditoria-workspace.md
@@ -1,0 +1,426 @@
+# Auditoria e Proposta de Evolução do Workspace (FASE 22)
+
+> **Status: PROPOSTA — aguardando aprovação. Nenhum código foi alterado.**
+> Data: 2026-09-03 · Domínio: Engenharia · Obra: OBRA-MODELO-EAP-001
+> Referência de produto/UX (padrões, NÃO cópia): Autodesk Construction Cloud / Autodesk Forma,
+> Procore, Oracle Primavera Cloud, Buildertrend.
+
+---
+
+## 0. Resumo executivo
+
+A FASE 21 entregou uma base sólida: domínio reutilizável (Planejamento, LOB, Serviços), shell da
+obra com abas por fase, barra de KPIs derivada de dados reais, e a EAP real de 81 nós preservada.
+Esta auditoria identifica **três lacunas de produto** que bloqueiam a evolução para um workspace
+profissional de gestão de obras:
+
+1. **Gestão de obras incompleta** — existe lista + criar, mas falta editar, arquivar, excluir com
+   confirmação, busca, filtros, status real, datas, localização, responsável e a noção de "obra ativa".
+2. **Extensibilidade de módulos frágil** — adicionar um módulo exige editar 3+ arquivos à mão
+   (`obra-routes.ts`, `obra-shell-route.tsx`, `obra-navigation.ts`). Não há catálogo nem metadados.
+3. **Dashboard sem experiência profissional** — a Visão Geral é uma grade estática de KPIs + cards,
+   sem expandir/zoom, filtros, período, atualização, detalhes ou navegação do indicador ao módulo de origem.
+
+A proposta abaixo define o **menor contrato arquitetural correto** para resolver as três, sem
+implementar orçamento/medição/CPM/agentes/Skills/MCP agora, e sem refatoração ampla por estética.
+
+---
+
+## 1. Diagnóstico do Workspace atual
+
+### 1.1 Hierarquia implementada hoje
+
+```
+/dominios/engenharia/obras            → ObraListaPage (lista de obras)
+/dominios/engenharia/obras/nova       → ObraNovaPage (criar obra)
+/dominios/engenharia/obras/:obraId    → ObraShellRoute (casca da obra)
+/dominios/engenharia/obras/:obraId/:modulo → módulo da obra
+```
+
+A hierarquia conceitual `Central de Obras → Obra → Workspace → Fase → Módulo → Dados` **existe
+parcialmente no código**, mas com lacunas:
+
+| Nível | Estado atual | Observação |
+|-------|-------------|------------|
+| Central de Obras | ✅ `ObraListaPage` | Lista em cards; sem busca/filtros/status/edição/arquivo/exclusão |
+| Obra | ⚠️ `Obra` (id, nome, status) | Modelo mínimo; status fixo `PROPOSTA`; sem datas/localização/responsável |
+| Workspace | ✅ `ObraShellRoute` | Casca com abas por fase + subitens (FASE 21) |
+| Fase | ✅ `OBRA_FASES` | Preparação/Execução/Suporte (hardcoded em `obra-routes.ts`) |
+| Módulo | ⚠️ `OBRA_MODULES` + switch no shell | Catálogo hardcoded; adicionar módulo = editar 3+ arquivos |
+| Dados | ✅ Adapters (Planejamento/LOB/Serviços) | Padrão de domínio reutilizável consolidado |
+
+### 1.2 O que já está bem (a preservar)
+
+- **Camada de domínio reutilizável** (`domains/planejamento`, `domains/linha-de-balanco`,
+  `domains/servicos`) com contrato de tipos + lógica pura + componentes genéricos + adapter por
+  domínio consumidor. **Este é o padrão-alvo.**
+- **Fonte única**: `obra-repository.ts` (obras) e `obra-eap-repository.ts` (EAP por obraId) são as
+  únicas fontes; a UI nunca toca em localStorage.
+- **EAP real de 81 nós** (`obra-eap-data.ts`) preservada integralmente; resumo sempre derivado.
+- **Separação de fontes**: ARES/Piemarta isolado em `obra-ares-referencia.ts`, nunca misturado.
+- **Navegação data-driven**: `NavigationNode[]` + renderer genérico (`sidebar-navigation.tsx`).
+- **Registro de domínios**: `registerDomain` permite adicionar um domínio inteiro sem tocar no Core.
+- **Back button genérico** (`domain-back-button.tsx`) derivado da rota + árvore, sem estado duplicado.
+
+### 1.3 Lacunas encontradas (detalhadas)
+
+#### Lacuna A — Gestão de obras incompleta
+- **Listar**: ✅ existe (cards). **Busca**: ❌ não existe. **Filtros**: ❌ não existe.
+- **Criar**: ✅ existe (nome apenas). **Editar**: ❌ não existe (sem `updateObra`).
+- **Abrir**: ✅ existe. **Voltar da obra para a central**: ⚠️ existe via `DomainBackButton`, mas o
+  rótulo é genérico ("Voltar") e não há breadcrumb explícito de contexto.
+- **Arquivar**: ❌ não existe. **Excluir com confirmação**: ❌ não existe (sem `deleteObra`).
+- **Recuperação/segurança contra exclusão acidental**: ❌ não existe (sem soft-delete/arquivo).
+- **Status**: ⚠️ apenas `"PROPOSTA"` (tipo `ObraStatus` com um único valor). Sem status real
+  (planejamento/em execução/concluída/arquivada).
+- **Datas início/fim, localização, responsável**: ❌ não existem no modelo `Obra`.
+- **Informações resumidas da obra**: ⚠️ parcial (nome, status, id; caracterização/EAP quando existem).
+
+#### Lacuna B — Extensibilidade de módulos frágil
+- **Catálogo de domínios**: ✅ existe para domínios (Engenharia), mas **não para módulos** dentro de
+  uma obra.
+- **Módulos habilitados por obra**: ❌ não existe (todos os módulos sempre aparecem).
+- **Módulos padrão/opcionais**: ❌ não existe.
+- **Adicionar novo domínio sem editar a Sidebar**: ✅ para domínios (via `registerDomain`), mas
+  **❌ para módulos** — adicionar um módulo exige editar `obra-routes.ts` (OBRA_FASES + label),
+  `obra-shell-route.tsx` (switch de conteúdo), e `obra-navigation.ts` (via OBRA_FASES).
+- **Metadados do módulo**: ❌ não existe (só `id` + `label`).
+- **Ordem/grupo do módulo**: ⚠️ implícito na ordem do array `OBRA_FASES`; não é um dado declarativo
+  por módulo.
+- **Disponibilidade por fase**: ⚠️ implícito no agrupamento `OBRA_FASES`.
+- **Configuração por obra**: ❌ não existe.
+
+#### Lacuna C — Dashboard sem experiência profissional
+- **Expandir KPI/card**: ❌ não existe (grade estática).
+- **Zoom / visualização ampliada**: ❌ não existe.
+- **Filtros**: ❌ não existe. **Período**: ❌ não existe. **Atualização**: ❌ não existe.
+- **Detalhes**: ⚠️ parcial (EAP tem árvore + detalhe do nó selecionado; Visão Geral não).
+- **Navegação do indicador ao módulo de origem**: ❌ não existe (KPI não é clicável).
+- **Reorganização futura dos cards**: ❌ não existe (layout fixo).
+
+---
+
+## 2. Referências / padrões de produto identificados
+
+> **Aviso**: estes são **padrões de produto/UX** observados nos sistemas citados, usados apenas como
+> referência conceitual. **Nenhum código, arquitetura ou interface é copiado.**
+
+### 2.1 Autodesk Construction Cloud / Autodesk Forma
+- **Central de projetos**: uma tela de "todos os projetos" com busca, filtros por status e cards
+  resumidos (nome, local, datas, progresso). Abrir um projeto leva a um **workspace dedicado**.
+- **Contexto persistente**: o projeto ativo fica visível no header; a navegação lateral é específica
+  do projeto (módulos do projeto), não global.
+- **Dashboard por módulo**: cada módulo (Documentos, Modelos, Custos, Cronograma) tem sua própria
+  visão com KPIs e drill-down para o detalhe.
+
+### 2.2 Procore
+- **Projeto como contêiner**: tudo vive dentro de um projeto; a lista de projetos é a porta de
+  entrada. Cada projeto tem **módulos habilitados** (configuráveis por projeto).
+- **Tool directory**: catálogo de ferramentas/módulos que podem ser ativados/desativados por projeto.
+- **Status de projeto**: estados claros (em andamento, concluído, arquivado) com filtros na lista.
+- **Ações contextuais**: editar, arquivar, excluir com confirmação e proteção contra exclusão
+  acidental (soft-delete/arquivamento).
+
+### 2.3 Oracle Primavera Cloud
+- **Workspace por projeto**: navegação em abas por área (Cronograma, Recursos, Custos, Relatórios).
+- **Dashboard com widgets**: painéis compostos por widgets (KPIs, gráficos, listas) que podem ser
+  expandidos para tela cheia e configurados.
+- **Drill-down**: clicar num indicador navega para o detalhe (ex.: clicar num KPI de atraso abre o
+  cronograma filtrado).
+
+### 2.4 Buildertrend
+- **Projeto como unidade central**: lista de projetos com busca/filtros; cada projeto tem um
+  dashboard com visão geral (progresso, próximos passos, finanças).
+- **Fases do projeto**: navegação por estágios do ciclo de vida.
+- **Ações primárias claras**: botões de ação principal por contexto (criar, editar, arquivar).
+
+### 2.5 Padrões transversais úteis (síntese)
+1. **Central de projetos como porta de entrada** — lista com busca/filtros/status + cards resumidos.
+2. **Projeto ativo como contexto** — header mostra o projeto atual; navegação é por módulo do projeto.
+3. **Catálogo de módulos configurável por projeto** — módulos padrão + opcionais, com metadados.
+4. **Dashboard com widgets expansíveis** — KPIs clicáveis com drill-down ao módulo de origem.
+5. **Ciclo de vida de projeto** — status real + arquivamento (soft-delete) + exclusão com confirmação.
+6. **Breadcrumb de contexto** — hierarquia visível (Central → Obra → Fase → Módulo).
+
+---
+
+## 3. Proposta de arquitetura
+
+### 3.1 Hierarquia-alvo
+
+```
+Central de Obras (lista + busca + filtros + criar)
+   ↓
+Obra (identidade + status + datas + localização + responsável)
+   ↓
+Workspace da Obra (shell: header de contexto + nav por fase + conteúdo)
+   ↓
+Fase (Preparação / Execução / Suporte)
+   ↓
+Módulo (catálogo declarativo com metadados)
+   ↓
+Dados (adapter → capacidade reutilizável)
+```
+
+**Princípio**: a `Central de Obras` é **independente do Workspace interno da obra**. A central é a
+porta de entrada (lista/gestão); o workspace é o ambiente de trabalho de uma obra específica.
+
+### 3.2 Camadas propostas
+
+| Camada | Responsabilidade | Onde vive |
+|--------|------------------|-----------|
+| **Central de Obras** | Listar, buscar, filtrar, criar, editar, arquivar, excluir obras | `obra-lista.tsx` + `obra-central` (novo) |
+| **Modelo Obra** | Identidade + status + datas + localização + responsável + ativa | `obra-types.ts` (evoluir) |
+| **Repositório Obra** | CRUD completo + soft-delete/arquivo + persistência | `obra-repository.ts` (evoluir) |
+| **Catálogo de Módulos** | Metadados declarativos de cada módulo (id, label, fase, ordem, opcional) | `obra-modules.ts` (novo) |
+| **Shell da Obra** | Header de contexto + nav por fase + renderização por catálogo | `obra-shell-route.tsx` (evoluir) |
+| **Dashboard** | Widgets expansíveis + drill-down | `obra-dashboard` (novo) + `obra-kpi-bar` (evoluir) |
+
+---
+
+## 4. Proposta mínima para gerenciamento de obras (Lacuna A)
+
+### 4.1 Modelo `Obra` (evolução mínima, sem inventar campos)
+
+```ts
+type ObraStatus = "PROPOSTA" | "PLANEJAMENTO" | "EM_EXECUCAO" | "CONCLUIDA" | "ARQUIVADA";
+
+type Obra = {
+  id: string;
+  nome: string;
+  status: ObraStatus;
+  /** Datas opcionais — só preenchidas quando houver dado real. */
+  dataInicio?: string | null;   // ISO
+  dataFim?: string | null;      // ISO
+  localizacao?: string | null;
+  responsavel?: string | null;
+  /** Soft-delete: obra arquivada não aparece na lista ativa por padrão. */
+  arquivada?: boolean;
+  caracterizacao?: ObraCaracterizacao | null;
+  eap?: ObraEapSummary | null;
+};
+```
+
+**Justificativa arquitetural de cada campo** (nada é inventado):
+- `status` — já existe; **expandir** de um único valor para o ciclo de vida real (necessário para
+  filtros e identidade profissional). `ARQUIVADA` é derivado de `arquivada` para não duplicar.
+- `dataInicio`/`dataFim` — já existem **derivados** no planejamento (`DATA_INICIO_OBRA`,
+  `duracaoTotalDasLinhas`). Promover a data de início a campo da obra é a fonte única; o fim pode ser
+  derivado do planejamento quando existir. **Não duplicar**: se a obra tem EAP, `dataFim` é derivado.
+- `localizacao`/`responsavel` — campos de identificação comuns a qualquer projeto; opcionais.
+- `arquivada` — soft-delete (padrão Procore/Buildertrend) para segurança contra exclusão acidental.
+
+**Decisão a confirmar**: `dataInicio` deve ser **campo da obra** (fonte única) ou continuar derivado
+do planejamento? Recomendo: campo opcional na obra; quando ausente, deriva de `DATA_INICIO_OBRA`.
+
+### 4.2 Repositório (operações)
+
+```ts
+// Adições ao ObraRepositoryState
+updateObra: (id: string, patch: Partial<Obra>) => void;
+archiveObra: (id: string) => void;      // soft-delete (arquivada = true)
+unarchiveObra: (id: string) => void;    // restaurar
+deleteObra: (id: string) => void;       // exclusão definitiva (com confirmação na UI)
+```
+
+- `archiveObra`/`unarchiveObra` — **soft-delete** (segurança contra exclusão acidental).
+- `deleteObra` — **exclusão definitiva**, sempre precedida de confirmação explícita na UI; também
+  remove a EAP da obra (`obra-eap-repository`) para não deixar órfãos.
+- `updateObra` — edição de identificação/status/datas/localização/responsável.
+
+### 4.3 Central de Obras (UI)
+
+- **Lista**: cards (atual) + **busca** por nome/id + **filtros** por status.
+- **Card resumido**: nome, status (badge colorido), id, datas (quando houver), localização,
+  responsável (quando houver), indicador de obra ativa.
+- **Ações por card**: Abrir, Editar, Arquivar/Restaurar, Excluir (com diálogo de confirmação).
+- **Obra ativa**: conceito de "obra atualmente aberta" (persistido em `obra-store`), destacada na
+  lista e usada como contexto no header do workspace.
+- **Voltar da obra para a central**: breadcrumb explícito `Central de Obras → <Obra>` + botão
+  "Voltar" (já existe via `DomainBackButton`, melhorar rótulo).
+
+### 4.4 Páginas novas/evoluídas
+
+| Página | Ação |
+|--------|------|
+| `obra-lista.tsx` | Evoluir: busca + filtros + ações por card + obra ativa |
+| `obra-nova.tsx` | Evoluir: campos opcionais (status, dataInicio, localização, responsável) |
+| `obra-editar.tsx` | **Nova**: edição de identificação |
+| `obra-central.tsx` | **Nova** (opcional): se quisermos separar a central do domínio — ver decisão |
+
+---
+
+## 5. Proposta mínima para extensibilidade de domínios (Lacuna B)
+
+### 5.1 Catálogo de módulos declarativo
+
+Criar `obra-modules.ts` com o **menor contrato** que permita evolução futura sem plugin complexo:
+
+```ts
+type ObraModuleId = "visao-geral" | "caracterizacao" | "eap" | ...;
+
+type ObraModuleDef = {
+  id: ObraModuleId;
+  label: string;
+  fase: ObraFase;            // grupo (Preparação/Execução/Suporte)
+  ordem: number;             // ordem dentro da fase
+  opcional?: boolean;        // módulo opcional (não padrão)
+  descricao?: string;        // metadado para catálogo/help
+  render: (obra: Obra) => ReactNode;  // renderização do módulo
+};
+
+const OBRA_MODULES: ObraModuleDef[] = [ ... ];
+```
+
+**Benefícios**:
+- **Um único lugar** define id, label, fase, ordem, opcionalidade e renderização.
+- `obra-shell-route.tsx` passa a **iterar o catálogo** em vez de um `switch` hardcoded.
+- `obra-navigation.ts` deriva a sidebar do catálogo (fase + ordem).
+- Adicionar um módulo = **adicionar uma entrada no catálogo** (e o adapter/capacidade), sem tocar no
+  shell nem na navegação.
+
+### 5.2 Módulos habilitados por obra (preparação, não implementação)
+
+- Adicionar ao modelo `Obra` um campo opcional `modulosHabilitados?: ObraModuleId[]`.
+- Quando ausente, usa o catálogo completo (padrão). Quando presente, filtra o catálogo.
+- **Não implementar agora** a UI de configuração por obra; apenas deixar o contrato pronto.
+
+### 5.3 O que NÃO fazer agora
+
+- ❌ Sistema de plugins (registro dinâmico de módulos em runtime).
+- ❌ Carregamento dinâmico/lazy de módulos.
+- ❌ Configuração visual de módulos por obra (só o contrato de dados).
+
+---
+
+## 6. Proposta de dashboard profissional (Lacuna C)
+
+### 6.1 Princípio
+
+Não é "aumentar o tamanho da página". É uma **experiência de dashboard** com widgets que podem ser
+**expandidos, filtrados e navegados** ao módulo de origem — comparável conceitualmente a
+Primavera/Procore.
+
+### 6.2 Componentes
+
+#### `ObraKpiCard` (evoluir `KpiBar`)
+- Cada KPI vira um **card clicável** com:
+  - `onClick` → navega para o módulo de origem (ex.: KPI "Nós EAP" → `/obras/:id/eap`).
+  - `data-kpi` + `data-kpi-target` (rota de origem) para testes.
+- **Expandir**: botão de expandir (maximizar) que abre o card em **tela cheia / modal** com o
+  detalhe do indicador.
+
+#### `ObraDashboard` (novo)
+- Grade de **widgets** (KPI cards + cards de contexto: caracterização, status, datas).
+- Cada widget tem: **expandir** (tela cheia), **filtro** (quando aplicável), **período** (quando
+  aplicável), **atualizar** (recalcular), **detalhes** (drill-down).
+- **Navegação do indicador**: cada KPI aponta para o módulo de origem (rota).
+- **Reorganização futura**: layout em grade com `data-widget` + ordem (preparação; não implementar
+  drag-and-drop agora).
+
+### 6.3 O que implementar agora vs. depois
+
+| Recurso | Agora | Depois |
+|---------|-------|--------|
+| KPI clicável → módulo de origem | ✅ | |
+| Expandir KPI/card (tela cheia/modal) | ✅ | |
+| Filtros por widget | ⚠️ só onde houver dado real | |
+| Período | ⚠️ derivado do planejamento | |
+| Atualizar (recalcular) | ✅ (re-deriva dos dados) | |
+| Detalhes (drill-down) | ✅ (navega ao módulo) | |
+| Reorganização (drag-and-drop) | | ✅ fase posterior |
+| Gráficos (barras/linhas) | | ✅ fase posterior (com dados de medição) |
+
+---
+
+## 7. O que deve ser implementado agora
+
+Escopo mínimo da FASE 22 (após aprovação):
+
+1. **Modelo `Obra` evoluído** — status expandido, datas opcionais, localização, responsável,
+   `arquivada` (soft-delete).
+2. **Repositório** — `updateObra`, `archiveObra`, `unarchiveObra`, `deleteObra` (com limpeza da EAP).
+3. **Central de Obras** — busca, filtros por status, ações por card (editar/arquivar/excluir com
+   confirmação), obra ativa, breadcrumb de contexto.
+4. **Páginas** — `obra-editar.tsx` (nova), evoluir `obra-lista.tsx` e `obra-nova.tsx`.
+5. **Catálogo de módulos** — `obra-modules.ts` declarativo; refatorar `obra-shell-route.tsx` e
+   `obra-navigation.ts` para iterar o catálogo (sem mudar comportamento).
+6. **Dashboard** — `ObraKpiCard` clicável com drill-down ao módulo de origem + expandir; `ObraDashboard`.
+7. **Testes** — CRUD, soft-delete, catálogo, dashboard, shell por catálogo.
+
+---
+
+## 8. O que deve ficar para fases posteriores
+
+- ❌ Orçamento, Medição, Indicadores completos.
+- ❌ CPM/Rede de precedências.
+- ❌ Novos agentes, Skills/MCP reais.
+- ❌ Sistema de plugins de módulos (registro dinâmico).
+- ❌ Configuração visual de módulos por obra (só contrato de dados).
+- ❌ Drag-and-drop de widgets / gráficos avançados.
+- ❌ Multiobra com dados distintos por obra (a arquitetura prepara, mas não implementa).
+
+---
+
+## 9. Riscos de arquitetura
+
+| Risco | Mitigação |
+|-------|-----------|
+| Quebrar a EAP real de 81 nós | Nenhuma alteração em `obra-eap-data.ts`; testes de regressão (81 nós) |
+| Perder a separação ARES/Piemarta | Dataset isolado e rotulado; testes de separação mantidos |
+| `deleteObra` deixar EAP órfã | `deleteObra` remove a EAP da obra no mesmo repositório |
+| Refatorar o shell para catálogo introduzir bug | Testes SSR do shell (fases/módulos) mantidos; catálogo testado |
+| `dataFim` duplicado (obra vs. planejamento) | `dataFim` derivado do planejamento quando EAP existe; campo só quando não há EAP |
+| Escopo crescer demais | FASE 22 limitada a gestão + catálogo + dashboard; orçamento/medição/CPM fora |
+| `ObraStatus` expandido quebrar consumidores | `PROPOSTA` mantido como valor válido; testes de compatibilidade |
+
+---
+
+## 10. Impacto sobre o que já foi implementado na FASE 21
+
+| FASE 21 item | Impacto da FASE 22 |
+|--------------|--------------------|
+| `obra-shell-route.tsx` (abas por fase) | **Refatorado** para iterar o catálogo de módulos; comportamento visual preservado |
+| `obra-navigation.ts` (sidebar por fase) | **Refatorado** para derivar do catálogo; mesma árvore resultante |
+| `obra-kpi-bar.tsx` | **Evoluído** para `ObraKpiCard` clicável + expandir; API compatível |
+| `obra-visao-geral.tsx` | **Evoluído** para `ObraDashboard` (widgets + drill-down) |
+| `obra-lista.tsx` / `obra-nova.tsx` | **Evoluídos** (busca/filtros/ações; campos opcionais) |
+| `obra-repository.ts` / `obra-storage.ts` | **Evoluídos** (CRUD completo + soft-delete) |
+| `obra-types.ts` | **Evoluído** (status, datas, localização, responsável, arquivada) |
+| `obra-eap-data.ts` (81 nós) | **Intacto** |
+| `obra-ares-referencia.ts` | **Intacto** |
+| `domains/planejamento`, `linha-de-balanco`, `servicos` | **Intactos** (capacidades reutilizáveis) |
+| Adapters (Planejamento/LOB/Serviços) | **Intactos** |
+
+**Nenhuma capacidade reutilizável (Planejamento/LOB/Serviços) é alterada.** A FASE 22 toca apenas a
+camada de gestão de obras + shell + dashboard do domínio Engenharia.
+
+---
+
+## 11. Ordem recomendada de implementação
+
+1. **Modelo `Obra` + repositório** (tipos, CRUD, soft-delete, storage) + testes.
+2. **Catálogo de módulos** (`obra-modules.ts`) + refatorar shell e navegação para iterar o catálogo
+   (sem mudar comportamento) + testes de regressão.
+3. **Central de Obras** (busca, filtros, ações por card, obra ativa, breadcrumb) + páginas
+   `obra-editar.tsx` + evoluir `obra-lista.tsx`/`obra-nova.tsx` + testes.
+4. **Dashboard** (`ObraKpiCard` clicável + expandir; `ObraDashboard`) + testes.
+5. **Verificação final**: testes específicos + `pnpm typecheck` + build.
+
+---
+
+## 12. Decisões que preciso de você
+
+1. **Escopo da FASE 22** — concorda com o corte (gestão de obras + catálogo de módulos + dashboard,
+   sem orçamento/medição/CPM/agentes/Skills/MCP)?
+2. **`dataInicio`** — campo opcional na obra (fonte única) ou continuar derivado do planejamento?
+   Recomendo: campo opcional; deriva quando ausente.
+3. **Central de Obras** — manter dentro do domínio Engenharia (`/dominios/engenharia/obras`) ou criar
+   uma camada separada de "Central de Obras" independente do domínio? Recomendo: manter no domínio
+   (menor diff; a central já é a home do domínio).
+4. **Exclusão** — soft-delete (arquivar) como padrão + exclusão definitiva com confirmação em duas
+   etapas? Recomendo: sim.
+5. **Dashboard** — KPIs clicáveis com drill-down + expandir em tela cheia; reorganização
+   (drag-and-drop) fica para depois? Recomendo: sim.
+
+**Aguardando sua aprovação e respostas às decisões acima. Nenhum código foi alterado.**

--- a/docs/features/relatorio-fase22-evolucao-workspace.md
+++ b/docs/features/relatorio-fase22-evolucao-workspace.md
@@ -1,0 +1,206 @@
+# Relatório Final — FASE 22: Evolução do Workspace
+
+> **Status: CONCLUÍDA** — implementação completa, testes da área afetada verdes, typecheck exit 0, build ✓.
+> Data: 2026-09-03 · Domínio: Engenharia · Obra: OBRA-MODELO-EAP-001
+> Proposta de referência: `docs/features/proposta-fase22-auditoria-workspace.md`
+> **Nenhum commit foi feito** (conforme instrução).
+
+---
+
+## 0. Resumo executivo
+
+A FASE 22 evoluiu o workspace de gestão de obras de um protótipo para uma experiência
+profissional, resolvendo as **três lacunas de produto** identificadas na auditoria:
+
+1. **Gestão profissional de Obras** — listar, criar, abrir, editar, arquivar, restaurar e excluir
+   (com confirmação em 2 etapas), busca, filtros por status, status real, obra ativa, retorno à
+   Central.
+2. **Catálogo declarativo de módulos** — `obra-modules.ts` declara os 11 módulos com
+   `{id, label, fase, ordem, opcional?, descricao?}`; a renderização é resolvida no shell.
+3. **Dashboard profissional** — KPIs clicáveis com drill-down ao módulo de origem, expansão em
+   tela cheia, estrutura para filtros/período/widgets.
+
+Todas as decisões obrigatórias da proposta foram aplicadas. Nenhuma decisão criou segunda fonte,
+acoplamento, multiobra ou Skills-MCP — portanto não foi necessário parar para aprovação adicional.
+
+---
+
+## 1. Decisões aplicadas (da proposta)
+
+| # | Decisão | Aplicação |
+|---|---------|-----------|
+| 2 | `Obra.dataInicio` = metadado/cadastro (fonte única do cadastro); Planejamento NÃO sobrescreve; se apresentar data derivada do cronograma, usar `inicioPlanejamento` (derivada). `DATA_INICIO_OBRA = new Date(2026, 0, 5)` em `obra-planejamento-data.ts` é fonte de verdade do Planejamento; NÃO tocado. | ✅ `Obra.dataInicio` é campo de cadastro opcional. A Visão Geral apresenta "Início do cronograma (derivado)" via `DATA_INICIO_OBRA`, sem sobrescrever o cadastro. |
+| 4 | `obra-modules.ts` declara APENAS `{id, label, fase, ordem, opcional?, descricao?}`; renderização resolvida no `obra-shell-route.tsx`. Sem plugin system complexo. | ✅ `ObraModuleDef` + `OBRA_MODULES` (11 módulos) + `MODULE_RENDERERS` no shell. |
+| 5 | KPIs obrigatoriamente derivados de dados reais, nunca fictícios. | ✅ Todos os KPIs derivam de EAP real (81 nós), Planejamento, LOB, Serviços. |
+
+**Preservações obrigatórias:**
+- ✅ EAP real de 81 nós (`OBRA-MODELO-EAP-001`, id `OBRA-MODELO-EAP-001`) intacta.
+- ✅ Separação ARES/Piemarta (`obra-ares-referencia.ts`) mantida.
+- ✅ Fonte única de verdade (repositórios); domínio independente da UI.
+- ✅ Nenhum módulo fora do escopo antecipado; nenhuma refatoração não relacionada.
+
+---
+
+## 2. O que foi implementado
+
+### 2.1 Gestão profissional de Obras
+
+**`obra-types.ts`** (editado)
+- `ObraStatus = "PROPOSTA" | "PLANEJAMENTO" | "EM_EXECUCAO" | "CONCLUIDA" | "ARQUIVADA"`.
+- `Obra`/`CreateObraInput` ganharam `dataInicio?`, `dataFim?`, `localizacao?`, `responsavel?`, `arquivada?` (soft-delete).
+
+**`obra-repository.ts`** (editado)
+- `statusEfetivo` — deriva `ARQUIVADA` de `arquivada`, nunca persiste.
+- `updateObra`, `archiveObra`, `unarchiveObra`, `deleteObra` — persistem via `saveObrasToStorage`.
+- `createObra` com campos novos.
+- `listObrasAtivas()` / `listObrasArquivadas()`.
+
+**`obra-store.ts`** (editado)
+- `activeObraId` + `setActiveObra` — noção de "obra ativa".
+
+**`pages/obra-lista.tsx`** (editado)
+- `ObraListaContent` presentacional SSR-testável:
+  - Busca (`data-obra-busca`), filtro status (`data-obra-status-filtro`).
+  - Ações Abrir/Editar/Arquivar/Restaurar/Excluir (`data-obra-editar`/`data-obra-arquivar`/`data-obra-excluir`/`data-obra-restaurar`).
+  - Badge "Ativa" (`data-obra-ativa`).
+  - `DeleteObraButton` com AlertDialog em 2 etapas (confirmação).
+- `ObraListaPage` conector.
+
+**`pages/obra-editar.tsx`** (NOVO)
+- Form nome/status/dataInicio/dataFim/localização/responsável; `updateObra`.
+- Estado "Obra não encontrada".
+- Navega de volta via `obraRoute(obra.id)`.
+
+**`pages/obra-nova.tsx`** (editado)
+- Campos opcionais (status, dataInicio, localização, responsável).
+- Após criar, navega para `obraRoute(obra.id)`.
+
+**`domain.tsx`** (editado)
+- Rota `/obras/:obraId/editar` → `ObraEditarPage` (segmento `editar` antes do módulo).
+
+### 2.2 Catálogo declarativo de módulos
+
+**`obra-modules.ts`** (NOVO)
+- `ObraModuleDef` + `OBRA_MODULES` (11 módulos) + `listModulesByFase`, `OBRA_FASES_ORDER`
+  (`["preparacao","execucao","suporte"]`), `moduleLabel`, `moduleFase`.
+
+**`obra-routes.ts`** (editado)
+- `OBRA_FASES`/`OBRA_MODULE_LABEL` derivados do catálogo.
+- Adicionado `obraEditarRoute(obraId)` → `${obrasListRoute()}/${encodeURIComponent(obraId.trim())}/editar`.
+
+**`obra-shell-route.tsx`** (reescrito)
+- `MODULE_RENDERERS: Record<ObraModule, (obra) => ReactNode>` + `listModulesByFase`.
+- Obra ativa via `setActiveObra`.
+
+### 2.3 Dashboard profissional
+
+**`obra-kpi-bar.tsx`** (editado)
+- `KpiItem` ganhou `target?`.
+- `KpiBar({items, onNavigate})` — card clicável (role="button", Enter/Espaço) quando target+onNavigate.
+- `data-kpi-target`. **Não depende de `useNavigate`** (SSR-testável).
+
+**`obra-dashboard.tsx`** (NOVO)
+- `DashboardWidget {id, title, description?, content, actions?, onRefresh?}`.
+- `ObraDashboard` — grade + expandir p/ overlay tela cheia (`data-obra-dashboard`, `data-widget`,
+  `data-widget-expand`, `data-obra-dashboard-expanded`).
+- Botões `Maximize2`/`Minimize2`/`RefreshCw`.
+
+**`pages/obra-visao-geral.tsx`** (editado)
+- KPIs de caracterização (torres/lajes/aptos/subsolos → target `caracterizacao`), EAP (target `eap`).
+- Usa `KpiBar({... onNavigate})` + `ObraDashboard` com widgets identidade/caracterização.
+- Exibe "Início do cronograma (derivado)" (via `DATA_INICIO_OBRA`).
+- Removido memo `planejamento` morto; import `useNavigate` adicionado.
+
+---
+
+## 3. Testes
+
+### 3.1 Testes novos (FASE 22)
+
+| Arquivo | Cobre |
+|---------|-------|
+| `obra-repository-fase22.test.ts` | CRUD/soft-delete/status/`statusEfetivo`/`listObrasAtivas`/`listObrasArquivadas` |
+| `obra-modules-catalog.test.ts` | Catálogo declarativo + helpers |
+| `obra-dashboard.test.tsx` | Drill-down/expansão tela cheia |
+| `obra-editar.test.tsx` | Form edição + estado não encontrada |
+| `obra-lista-fase22.test.tsx` | Busca/filtro/soft-delete/obra ativa |
+
+### 3.2 Resultados
+
+- **Área afetada (16 arquivos Obra), isolado:** `118 pass / 0 fail / 736 expect` (~727ms).
+- **Consolidado (20 arquivos: 16 obra + nav/domain):** `146 pass / 0 fail / 851 expect`.
+- **`pnpm --filter @openwork/app typecheck`:** EXIT 0.
+- **`pnpm --filter @openwork/app build`:** ✓ (exit 0, ~49.47s).
+
+### 3.3 Suíte completa (`bun test` no `apps/app`)
+
+`1364 pass / 104 fail / 2 errors` em 246 arquivos. **Classificação das falhas:**
+
+**A) 67 falhas Obra — todas por isolamento de teste pré-existente (NÃO causadas pela FASE 22):**
+- Erro dominante: `TypeError: Attempted to assign to readonly property` ao atribuir
+  `globalThis.localStorage` no `beforeEach` de múltiplos arquivos de teste.
+- Quando a suíte roda inteira, `localStorage` torna-se propriedade somente-leitura no `globalThis`
+  após a primeira atribuição; arquivos seguintes que tentam reatribuir falham.
+- **Prova de que é pré-existente:** `obra-repository.test.ts` (FASE 04.2-B) está **tracked e
+  inalterado** (não aparece no `git status` como modificado) e falha com o mesmo erro. Os testes
+  FASE 22 usam o mesmo padrão herdado das fases anteriores.
+- Todos os 67 testes Obra passam em isolamento (118 pass / 0 fail).
+
+**B) 35 falhas não-Obra — áreas totalmente não relacionadas à FASE 22 (pré-existentes):**
+- Cloud inventory cache, gateway runtime mode, Den memory client, OpenAI provider auth,
+  OpenWork Models promo (`window.dispatchEvent is not a function`), platformCapabilities,
+  session transcript sync, ui state store, artifact spreadsheet, composer model controls,
+  Extensions sidebar, managed engine config guard, cloud workspace boot takeover,
+  getArtifactsFromMessages, session-route cloud provider sync.
+
+**Conclusão:** nenhuma falha da suíte completa é atribuível às mudanças da FASE 22. As falhas são
+pré-existentes (infraestrutura de teste com `globalThis.localStorage` + áreas não relacionadas de
+fases anteriores não commitadas).
+
+---
+
+## 4. Arquivos alterados/criados
+
+**Editados:**
+- `apps/app/src/react-app/domains/engenharia/obra/obra-types.ts`
+- `apps/app/src/react-app/domains/engenharia/obra/obra-repository.ts`
+- `apps/app/src/react-app/domains/engenharia/obra/obra-routes.ts`
+- `apps/app/src/react-app/domains/engenharia/obra/obra-store.ts`
+- `apps/app/src/react-app/domains/engenharia/obra/obra-shell-route.tsx`
+- `apps/app/src/react-app/domains/engenharia/obra/obra-kpi-bar.tsx`
+- `apps/app/src/react-app/domains/engenharia/obra/pages/obra-lista.tsx`
+- `apps/app/src/react-app/domains/engenharia/obra/pages/obra-nova.tsx`
+- `apps/app/src/react-app/domains/engenharia/obra/pages/obra-visao-geral.tsx`
+- `apps/app/src/react-app/domains/engenharia/domain.tsx`
+- `apps/app/tests/obra-kpi-bar.test.tsx` (wrap `ObraVisaoGeral` em `MemoryRouter`)
+
+**Criados:**
+- `apps/app/src/react-app/domains/engenharia/obra/obra-modules.ts`
+- `apps/app/src/react-app/domains/engenharia/obra/obra-dashboard.tsx`
+- `apps/app/src/react-app/domains/engenharia/obra/pages/obra-editar.tsx`
+- `apps/app/tests/obra-repository-fase22.test.ts`
+- `apps/app/tests/obra-modules-catalog.test.ts`
+- `apps/app/tests/obra-dashboard.test.tsx`
+- `apps/app/tests/obra-editar.test.tsx`
+- `apps/app/tests/obra-lista-fase22.test.tsx`
+
+**Não tocado (fonte de verdade do Planejamento):**
+- `apps/app/src/react-app/domains/engenharia/obra/obra-planejamento-data.ts` (`DATA_INICIO_OBRA`)
+
+---
+
+## 5. Próximos passos sugeridos (fora do escopo FASE 22)
+
+- Corrigir a infraestrutura de teste de isolamento do `globalThis.localStorage` (ex.: usar
+  `Object.defineProperty` com `configurable: true`, ou um helper compartilhado) para que a suíte
+  completa fique verde.
+- Investigar as 35 falhas não-Obra (cloud/gateway/session) — áreas de fases anteriores não
+  commitadas.
+
+---
+
+## 6. Nota de conformidade
+
+- **Nenhum commit foi feito.**
+- Nenhuma decisão criou segunda fonte de verdade, acoplamento indevido, multiobra ou Skills-MCP.
+- Domínio permanece independente da UI; fonte única de verdade preservada.

--- a/docs/phases/FASE_04_1_DASHBOARD_PLANEJAMENTO_V1.md
+++ b/docs/phases/FASE_04_1_DASHBOARD_PLANEJAMENTO_V1.md
@@ -1,0 +1,169 @@
+# FASE 04.1 — DASHBOARD DE PLANEJAMENTO V1 (UI nativa do OpenWork)
+
+> **Data:** 2026-01-09 · **Tipo:** implementação de superfície reutilizável de planejamento.
+> **Escopo:** clone `OPENWORK-LAB\openwork`. **Sem Gantt/CPM/Rede/LOB/motor de dependências.**
+
+## 1. Objetivo
+Substituir o placeholder do módulo `planejamento` da Obra por uma **Dashboard de
+Planejamento V1** nativa e **reutilizável** (capacidade genérica), consumida pelo
+domínio de Engenharia via um adapter, sem acoplar o componente a uma obra.
+
+## 2. Estado anterior
+- Rota `/dominios/engenharia/obras/OBRA-MODELO-EAP-001/planejamento` renderizava
+  `ObraModuloPlaceholder` ("Módulo em construção").
+- Não existia modelo, dados, componente de timeline nem dashboard no OpenWork.
+- Auditorias read-only (FASE 04.0 e 04.0.1) mapearam o motor Python do Obra
+  Copilot/ARES (`Agent/planning/*`) como **referência de regras/contratos**.
+
+## 3. Problema identificado
+Usuários entram no módulo Planejamento e encontram tela vazia/placeholder, sem
+estrutura, período, indicadores, pontos de atenção ou ajuda contextual.
+
+## 4. Arquitetura adotada
+```text
+PlanningDashboardData (contrato genérico)
+        ↓
+Planning Dashboard (capacidade reutilizável)
+        ↓
+Consumer/Adapter do domínio (ObraPlanejamento)
+```
+- **Capacidade genérica** vive em `domains/planejamento/` (neutra; não conhece
+  nenhum domínio). **Consumer** vive em `domains/engenharia/obra/pages/`.
+- A capacidade não depende de router/sidebar/domínio; renderiza qualquer
+  `PlanningDashboardData`.
+
+## 5. Contrato `PlanningDashboardData`
+```ts
+type PlanningDashboardData = {
+  context: { title: string; subtitle?: string; referenceDate?: string };
+  items: PlanningItem[];
+  periods?: PlanningPeriod[]; // opcional; derivado dos itens quando ausente
+};
+```
+
+## 6. Contrato `PlanningItem`
+```ts
+type PlanningItem = {
+  id: string;
+  parentId?: string | null;
+  name: string;
+  level: number;                 // 0 = raiz
+  status: "planejado" | "em_andamento" | "atrasado" | "concluido";
+  progress: number;              // 0..100
+  start?: string | null;         // ISO yyyy-mm-dd (inclusive)
+  end?: string | null;           // ISO yyyy-mm-dd (inclusive)
+};
+```
+Ausência de `start/end` é permitida e vira alerta "sem período" (apenas para
+itens folha).
+
+## 7. Estrutura de arquivos
+```
+apps/app/src/react-app/domains/planejamento/      (capacidade genérica)
+├── planning-types.ts          contratos
+├── planning-data.ts           helpers puros (resumo/alertas/períodos/linhas/busca)
+├── planning-demo-data.ts      dataset demonstrativo neutro (determinístico)
+├── planning-help.tsx          ajuda contextual (Popover nativo)
+├── planning-dashboard.tsx     superfície integrada (header/KPIs/árvore+timeline/alertas/Sheet)
+├── planning-tree.tsx          árvore hierárquica (expand/recolher/seleção)
+├── planning-timeline.tsx      timeline simples (barras por data, eixo mensal)
+└── planning-details.tsx       painel de detalhes do item (lido pelo Sheet)
+
+apps/app/src/react-app/domains/engenharia/obra/
+├── pages/obra-planejamento.tsx   consumer/adapter (contexto + dados demo)
+└── obra-shell-route.tsx          modificado: ramo "planejamento" usa ObraPlanejamento
+
+apps/app/tests/                  testes (unit + SSR + anti-hardcode)
+docs/phases/FASE_04_1_DASHBOARD_PLANEJAMENTO_V1.md   este documento
+```
+## 8. Componentes criados (IMPLEMENTADO)
+- `PlanningDashboard` — superfície: header + contexto + ajuda ⓘ; 4 KPIs
+  derivados (Total, Em andamento, Atenção, Concluídos); busca por nome; painel
+  Árvore+Timeline com rolagem vertical sincronizada; alertas derivados; Sheet de
+  detalhes; estado vazio (`Empty`).
+- `PlanningTree` — árvore hierárquica por `parentId`, expandir/recolher,
+  seleção, indentação por `level`, `role="tree/treeitem"` (acessibilidade).
+- `PlanningTimeline` — eixo mensal e barras por item derivadas de `start/end`
+  (largura proporcional a dias; scroll horizontal no contêiner). Sem drag/resize.
+- `PlanningHelp` — Popover nativo com perguntas/respostas da V1.
+- `PlanningItemDetails` — campos: Nome, Status, Progresso, Início, Fim, Nível, Pai.
+- `ObraPlanejamento` — adapter do domínio (contexto + dataset demo).
+
+## 9. Componentes reutilizados (IMPLEMENTADO)
+`Button`, `Card`, `Badge`, `Input`, `Empty`, `Sheet`, `Popover`, `Progress`
+(`components/ui/*`), `cn`, `lucide-react`, Tailwind v4. **Não** usamos
+`@pierre/trees` na V1 (decisão documentada): a árvore mínima exigida (expansão
+por id + seleção + indentação) é atendida com componentes nativos simples e
+testáveis, evitando difundir a dependência beta por toda a arquitetura.
+
+## 10. Decisões de design
+- Linhas derivadas em ordem de árvore compartilhadas 1:1 entre árvore e timeline
+  (alturas fixas) → alinhamento garantido sem estado duplicado.
+- KPIs/alertas/períodos **derivados** por helpers puros (`planning-data.ts`).
+- Data de referência do contexto controla os alertas de atenção (determinístico).
+- Estados de UI (colapso, seleção, busca) locais via `useState` — sem persistência.
+- Scroll vertical sincronizado por refs entre as duas colunas (V1).
+
+## 11. Decisões de não adicionar dependências
+Não instalada nenhuma biblioteca (nenhuma de Gantt/calendário/gráfico/drag).
+Preferência: `@pierre/trees` NÃO usada (ver §9); `react-resizable-panels` NÃO
+usado (layout CSS atende a V1; pode entrar em fase futura).
+
+## 12. Relação com o futuro Planning Engine
+```text
+Obra Copilot / ARES → PlanningEngine existente → referência de regras/contratos
+OpenWork → Planning Dashboard V1 → dados demonstrativos
+OpenWork ─X─> Python PlanningEngine          (sem runtime bridge — decisão)
+```
+O contrato V1 foi inspirado nas estruturas do ARES (`PlanningActivity`:
+activity_id/parent/status/datas; `EapItem`) mas **não duplica** o motor: nesta
+fase não há dependências/CPM/calendário de dias úteis nem auto-agendamento.
+
+## 13. Deliberadamente NÃO implementado (FORA DE ESCOPO nesta fase)
+Predecessor/successor/dependencyType/FS/SS/FF/SF/lag/lead/criticalPath/float/
+resourceAllocation/baseline/produção/medição; Gantt completo; CPM; Rede; LOB;
+auto-scheduling; drag/resize; integração Python/Excel; persistência de dados;
+EAP real; IA. (FUTURO)
+## 14. Testes (IMPLEMENTADO — executados)
+- `tests/planning-data.test.ts` (9 testes) — datas, resumo, alertas, linhas/pré-order,
+  colapso, raízes, busca, períodos, daysBetween.
+- `tests/planning-dashboard.test.tsx` (6 testes) — SSR: título/contexto/KPIs,
+  árvore+timeline, alertas, estado vazio, painel de detalhes, conteúdo de ajuda.
+- `tests/planning-anti-hardcode.test.ts` (3 testes) — auditoria anti-hardcode da pasta genérica.
+
+## 15. Typecheck (PASS)
+`pnpm --filter @openwork/app typecheck` → exit 0.
+
+## 16. Build (PASS)
+`pnpm --filter @openwork/app build` → ✓ built (warnings pré-existentes de chunk).
+
+## 17. Auditoria anti-hardcode (PASS)
+- A pasta `domains/planejamento/` não contém: `OBRA-MODELO-EAP-001`, `torre`,
+  `apartamento`, `pavimento`, `engenharia`, `obra-001` (verificado por teste e
+  por revisão). O único contexto de obra entra em runtime pelo consumer
+  (`obra.nome`), nunca hardcoded no componente.
+
+## 18. Limitações conhecidas (FUTURO / aceitas na V1)
+- Timeline é visual simples (sem drag/resize/zoom); scroll horizontal move a
+  coluna da timeline (a árvore permanece fixa à esquerda no desktop).
+- Alertas: derivados de status/datas/progresso; sem motor de diagnóstico.
+- Dados demonstrativos substituíveis pelo adapter em fase futura.
+- Barra de busca por nome; filtro por status é FUTURO (decisão de não
+  adicionar complexidade nesta fase).
+
+## 19. Próximos passos (não implementados nesta fase)
+1. Adapter real de `PlanningDashboardData` a partir da entidade do domínio
+   (vincular itens a nós de EAP/obra quando a fonte real for integrada).
+2. Porta TS das regras do PlanningEngine ARES (Q/P, FS/SS/FF, calendário) com
+   paridade de testes — sem runtime bridge.
+3. Dependências/CPM/LOB e timeline interativa em fases futuras, mantendo a
+   superfície integrada (Árvore · Timeline · Resumo · Alertas · Detalhes · IA).
+
+## Verificação final da fase
+- [x] placeholder substituído · [x] Dashboard nativa · [x] componente reutilizável
+- [x] sem hardcode no componente · [x] KPIs · [x] árvore · [x] timeline · [x] seleção/detalhes
+- [x] alertas · [x] ajuda contextual · [x] estado vazio · [x] testes · [x] typecheck
+- [x] build · [x] documentação · [x] anti-hardcode · [x] sem dependências novas
+- [x] sem Gantt/CPM/LOB · [x] sem alterações indevidas no Core
+
+

--- a/docs/phases/FASE_04_2_A_AUDITORIA_GESTAO_OBRAS.md
+++ b/docs/phases/FASE_04_2_A_AUDITORIA_GESTAO_OBRAS.md
@@ -1,0 +1,186 @@
+﻿# FASE 04.2-A â€” AUDITORIA DA GESTÃƒO DE OBRAS EXISTENTE (read-only)
+
+> **Data:** 2026-01-09 Â· **Tipo:** auditoria somente leitura â€” nenhum cÃ³digo alterado.
+> **Clone:** `OPENWORK-LAB\openwork`.
+
+## 1. Objetivo
+Descobrir a fonte atual da entidade **Obra** no OpenWork e o caminho tÃ©cnico para evoluir
+para mÃºltiplas obras (`+ Nova obra Â· Obra A Â· Obra B Â· â€¦`) sem criar segunda fonte de
+verdade nem contaminar o Core.
+
+## 2. Escopo
+- NÃºcleo genÃ©rico: `domains/*` (registro/navegaÃ§Ã£o/roteamento) e shell.
+- DomÃ­nio Engenharia: `domains/engenharia/obra/*`.
+- ComparaÃ§Ã£o com entidades genÃ©ricas existentes (Workspace) e mÃ³dulos criados
+  (EAP, Planejamento V1).
+
+## 3. Arquivos auditados
+```text
+apps/app/src/react-app/domains/engenharia/obra/
+â”œâ”€â”€ obra-types.ts            (Obra, ObraEapSummary, ObraCaracterizacao, ObraModule)
+â”œâ”€â”€ obra-data.ts             (OBRA_MODELO_ID / OBRA_MODELO / OBRAS_MODELO / findObraModelo)
+â”œâ”€â”€ obra-routes.ts           (DOMAIN_ENGENHARIA_ID, obraRoute, engenhariaDomainHome, isObraModule)
+â”œâ”€â”€ obra-navigation.ts       (buildEngenhariaNavigation: Engenhariaâ†’Obrasâ†’Obraâ†’mÃ³dulos)
+â”œâ”€â”€ obra-store.ts            (useObraStore â€” mÃ³dulo selecionado; persist localStorage)
+â”œâ”€â”€ obra-shell-route.tsx     (casca: header + tabs; findObraModelo)
+â”œâ”€â”€ pages/obra-eap.tsx       (EAP resumo; fonte isolada = FUTURO)
+â”œâ”€â”€ pages/obra-visao-geral.tsx
+â”œâ”€â”€ pages/obra-planejamento.tsx (consumer da Dashboard V1)
+â””â”€â”€ pages/obra-modulo-placeholder.tsx
+apps/app/src/react-app/domains/
+â”œâ”€â”€ domain-registry.ts Â· domain-bootstrap.ts Â· domain-route.tsx Â· domain-sidebar-group.tsx
+â”œâ”€â”€ navigation/{navigation-types,navigation-state,navigation-utils,sidebar-navigation}.ts(x)
+â””â”€â”€ planejamento/*            (capacidade genÃ©rica â€” contratos)
+```
+Consulta ampla: `OBRA-MODELO-EAP-001`, `OBRA_MODELO_ID`, `findObraModelo`, `obraRoute`,
+`caracterizacao`, `project|Project`, `obras`.
+
+## 4. Estrutura atual encontrada (CONFIRMADO)
+```text
+DOMÃNIOS (seÃ§Ã£o da sidebar â€” dados: DomainDefinition.navigation)
+â””â”€â”€ ENGENHARIA (domain, rota = home da 1Âª obra)
+    â””â”€â”€ OBRAS (group, SEM rota prÃ³pria)
+        â””â”€â”€ OBRA-MODELO-EAP-001 (entity, rota /dominios/engenharia/obras/{id})
+            â””â”€â”€ mÃ³dulos (visao-geral/eap/frentes/planejamento/producao/rdo/ia)
+```
+- `obra-navigation.ts` monta a Ã¡rvore com UMA obra fixa (`OBRA_MODELO_ID`).
+- Rota `/dominios/:domainId/obras/:obraId[/:modulo]` â€” `obra-routes.ts`.
+- `domain.tsx#renderRoute` faz parse e delega a `ObraShellRoute(obraId, modulo)`.
+
+## 5. Modelo atual de Obra (CONFIRMADO)
+`obra-types.ts`:
+```ts
+type Obra = { id; nome; status: "PROPOSTA"; caracterizacao: ObraCaracterizacao; eap: ObraEapSummary }
+type ObraCaracterizacao = { torres; lajes; apartamentosPorPavimento; subsolos; sistemaConstrutivo }
+type ObraEapSummary = { status; total; raizes; pacotes; trabalhos }   // PROPOSTA Â· 10/24/47=81
+```
+Origem: `obra-data.ts` â€” `OBRA_MODELO` (objeto literal demo), `OBRAS_MODELO: Obra[] = [OBRA_MODELO]`,
+`findObraModelo(id)` retorna da lista.
+
+## 6. Origem dos dados (CONFIRMADO)
+- **Hardcoded/demo** dentro do domÃ­nio (`obra-data.ts`, comentÃ¡rio: "obra-modelo (fonte Ãºnica de dados da casca)").
+- **NÃƒO ENCONTRADO**: nenhuma outra origem (backend/API/banco) no clone para obras.
+
+## 7. PersistÃªncia (CONFIRMADO)
+- Obra: **sem persistÃªncia** â€” constante em memÃ³ria no bundle (demo).
+- O que existe persistido Ã© **estado de UI**: `obra-store.ts` (zustand + localStorage,
+  chave `openwork-obra-store`, apenas `selectedModule`).
+- Contraste: **Workspaces** sÃ£o entidades do OpenWork persistidas pelo servidor local
+  (config `authorizedRoots/workspaces` JSON + estado runtime SQLite) â€” conceito distinto.
+
+## 8. IDs (CONFIRMADO)
+- ID Ãºnico demo: constante `OBRA_MODELO_ID = "OBRA-MODELO-EAP-001"` (`obra-data.ts` L6).
+- Rotas codificam via `encodeURIComponent` (`obra-routes.ts`).
+- Estrutura Ã© adequada para mÃºltiplos IDs **desde que** a navegaÃ§Ã£o passe a ser dinÃ¢mica
+  (hoje a Ã¡rvore declara apenas 1 obra). Sem colisÃ£o de rotas (id no path).
+
+## 9. NavegaÃ§Ã£o (CONFIRMADO)
+- `Obras` Ã© **nÃ³ agrupador (`group`) sem rota** â€” expande/recolhe (`obra-navigation.ts`).
+- Obras NÃƒO sÃ£o filhos dinÃ¢micos: a Ã¡rvore Ã© estÃ¡tica com a obra demo.
+- NÃ£o existe lista, seleÃ§Ã£o de obra na sidebar nem contexto de obra global; a "obra atual"
+  vem **da URL** (`obraId` em `/obras/:obraId/â€¦`) resolvida por `findObraModelo`.
+- `ObraShellRoute` mostra "Obra nÃ£o encontrada" se `findObraModelo` falhar.
+
+## 10. RelaÃ§Ã£o Obra â†’ CaracterizaÃ§Ã£o (CONFIRMADO)
+- `caracterizacao` Ã© **campo embutido** no objeto `Obra` (demo) â€” nÃ£o Ã© etapa separada e
+  sÃ³ existe dentro de `domains/engenharia` (grep: sem ocorrÃªncias fora).
+- NÃ£o estÃ¡ acoplada ao EAP em si, mas convive no mesmo objeto. NÃ£o hÃ¡ persistÃªncia.
+
+## 11. RelaÃ§Ã£o Obra â†’ EAP (CONFIRMADO)
+- `obra.eap` = **resumo embutido** (10/24/47 â†’ 81, PROPOSTA).
+- NÃ³s individuais: **NÃƒO carregados** â€” fonte isolada em outro workspace (FUTURO;
+  `obra-eap.tsx` L17-19). NÃ£o hÃ¡ tabela/ID por nÃ³ no clone (somente o resumo).
+
+## 12. RelaÃ§Ã£o Obra â†’ Planejamento (CONFIRMADO)
+- `obra-planejamento.tsx` (FASE 04.1) recebe `obra` por prop; usa somente
+  `obra.nome` como contexto no `subtitle` do contrato; o dataset Ã© demo genÃ©rico.
+- Planejamento **jÃ¡ estÃ¡ preparado para mÃºltiplas obras** (componente genÃ©rico
+  `PlanningDashboard` recebe `PlanningDashboardData`); basta o adapter prover dados.
+## 13. Fontes duplicadas encontradas
+| Item | ClassificaÃ§Ã£o |
+|---|---|
+| `obra-data.ts` (`OBRA_MODELO`, `OBRAS_MODELO`) | **FONTE CANÃ”NICA** (demo) |
+| `obra-navigation.ts` (Ã¡rvore com a obra) | **FONTE DERIVADA** da lista (estÃ¡tica) |
+| `OBRA-MODELO-EAP-001` em `domain-registry.ts` L14, `domain.tsx` L14, `obra-eap.tsx` L17 | **LEGADO/COMENTÃRIO** (nÃ£o funcional) |
+| Modelo externo no Obra Copilot/ARES | fora do clone (referÃªncia, nÃ£o duplicaÃ§Ã£o interna) |
+| **DUPLICAÃ‡ÃƒO real**: **NÃƒO ENCONTRADA** dentro do clone | |
+
+## 14. Problemas (CONFIRMADO)
+1. `OBRAS_MODELO` existe como array, mas a navegaÃ§Ã£o/rotas assumem 1 obra fixa.
+2. Sem experiÃªncia de lista/criaÃ§Ã£o/seleÃ§Ã£o de obras (sem UI de cadastro).
+3. `obra-store` guarda `selectedModule` **global** (nÃ£o por obra) â€” risco futuro de
+   lembrar mÃ³dulo de outra obra (baixo hoje porque a rota decide).
+4. CaracterizaÃ§Ã£o/EAP/planejamento dependem hoje de um Ãºnico objeto demo; nÃ£o hÃ¡
+   serviÃ§o/store por `obraId`.
+
+## 15. Riscos (CONFIRMADO/FUTURO)
+- Adicionar obras sÃ³ na Ã¡rvore sem fonte Ãºnica criaria duplicaÃ§Ã£o (Ã¡rvore Ã— dados).
+- Criar "workspace" por obra seria um desvio conceitual (workspace â‰  obra).
+- Persistir obra fora do domÃ­nio violaria Core+DomÃ­nio.
+- `obra-store.selectedModule` global pode "vazar" entre obras (baixo hoje).
+- Nenhuma rota reserva "lista de obras" (`/dominios/engenharia/obras` nÃ£o tem handler
+  prÃ³prio hoje; `domain.tsx` sÃ³ trata `obras/:obraId`).
+
+## 16. Arquitetura recomendada (RECOMENDAÃ‡ÃƒO)
+```text
+DOMÃNIO ENGENHARIA
+â””â”€â”€ obras (repositÃ³rio/listagem do domÃ­nio â€” NOVA capacidade)
+    â”œâ”€â”€ Nova obra        (aÃ§Ã£o de criaÃ§Ã£o â€” FASE futura de cadastro)
+    â”œâ”€â”€ Obra A
+    â””â”€â”€ Obra B
+            â†“ contexto da obra (por obraId, vindo da URL/rota)
+            â†“ mÃ³dulos (EAP, Planejamento, â€¦ recebem obra por prop/store por obraId)
+```
+- **Fonte Ãºnica**: uma lista de obras no domÃ­nio (evoluÃ§Ã£o de `OBRAS_MODELO`), com
+  `findObraById`/`listObras` como serviÃ§o do domÃ­nio; a **Ã¡rvore de navegaÃ§Ã£o passa a ser
+  montada a partir da lista** (data-driven â€” o Core jÃ¡ interpreta `NavigationNode[]`).
+- A entidade Obra continua **no domÃ­nio Engenharia**; o Core nÃ£o conhece Obra.
+
+## 17. Campos candidatos para cadastro (RECOMENDAÃ‡ÃƒO/HIPÃ“TESE)
+Com base no modelo existente (`obra-types.ts`) e sem inventar evidÃªncia:
+```text
+Cadastro mÃ­nimo:  id (gerado) Â· nome Â· status
+CaracterizaÃ§Ã£o:   separada, ETAPA posterior ao bÃ¡sico (campos de obra-data jÃ¡ existentes)
+EAP/Planejamento: vÃ­nculos por obraId (futuro), sem embutir no cadastro
+```
+CaracterizaÃ§Ã£o **nÃ£o duplica** o modelo atual â€” migra para compor a obra (ou etapa).
+
+## 18. EstratÃ©gia de persistÃªncia recomendada (RECOMENDAÃ‡ÃƒO â€” decisÃ£o em fase posterior)
+- **Primeira versÃ£o**: declarativa no domÃ­nio (JSON/localStorage no padrÃ£o jÃ¡ usado:
+  `obra-data.ts` + `zustand persist` como `obra-store`) â€” suficiente para lista + nova obra
+  sem backend. **RECOMENDAÃ‡ÃƒO** para a fase imediata.
+- EvoluÃ§Ã£o: persistir via **servidor OpenWork local + SQLite** (runtime jÃ¡ existe p/ workspaces)
+  quando a obra precisar ser compartilhada/duradoura. Supabase/cloud: **decisÃ£o futura**;
+  sem base hoje no clone.
+
+## 19. Impacto no Core (RECOMENDAÃ‡ÃƒO)
+- **Nenhum** conceito de Obra no Core. O Core jÃ¡ interpreta `NavigationNode[]`, rota
+  genÃ©rica e `DomainDefinition`. Lista de obras = dado novo do domÃ­nio; a navegaÃ§Ã£o por
+  "Obras â†’ [obras]" permanece renderizada pelo renderer genÃ©rico da sidebar.
+
+## 20. Impacto no domÃ­nio Engenharia (RECOMENDAÃ‡ÃƒO)
+- Evoluir `obra-data` â†’ repositÃ³rio (listar/criar/atualizar em memÃ³ria).
+- `obra-navigation` passa a receber a lista (dados dinÃ¢micos) em vez de constante.
+- Rotas continuam `/obras/:obraId/â€¦`; nova rota de listagem no domÃ­nio se necessÃ¡rio.
+- `obra-store`: considerar escopo por `obraId` (estado de UI).
+
+## 21. Itens fora de escopo (FUTURO)
+Cadastro (formulÃ¡rio/modal), criaÃ§Ã£o de IDs, persistÃªncia real, listagem UI, seleÃ§Ã£o na
+sidebar, migraÃ§Ã£o de EAP/planejamento por obraId, backend de obra, caracterizaÃ§Ã£o como
+etapa, Workspace-obra. Nenhum destes foi implementado nesta fase.
+
+## 22. PrÃ³ximo passo recomendado (FUTURO â€” nÃ£o executar nesta fase)
+**FASE 04.2-B (gestÃ£o de obras V1)**: evoluir `obra-data` â†’ repositÃ³rio de obras do
+domÃ­nio (lista demo com â‰¥2 obras, gerador de id simples, `findObraById`/`listObras`),
+montar a navegaÃ§Ã£o `Obras â†’ [obras]` a partir da lista (data-driven), e uma rota/painel
+de lista de obras â€” mantendo o Core intacto e sem persistir fora do domÃ­nio.
+
+## EvidÃªncias-chave
+- `obra-data.ts` L6/L8/L28/L30 (constante, objeto, array, find).
+- `obra-navigation.ts` (Ã¡rvore com 1 obra fixa; group "Obras").
+- `obra-types.ts` (modelo), `obra-store.ts` (persistÃªncia de UI).
+- Greps: `OBRA-MODELO-EAP-001` fora de engenharia apenas em comentÃ¡rios;
+  `caracterizacao`, `project|Project`, `obras/obraRoute` fora do domÃ­nio = **vazio**.
+
+
+

--- a/docs/phases/FASE_04_2_B_GESTAO_OBRAS_V1.md
+++ b/docs/phases/FASE_04_2_B_GESTAO_OBRAS_V1.md
@@ -1,0 +1,135 @@
+# FASE 04.2-B — GESTÃO DE OBRAS V1 (domínio Engenharia)
+
+> **Data:** 2026-01-09 · **Tipo:** implementação (lista + criação + navegação dinâmica + persistência local).
+> **Clone:** `OPENWORK-LAB\openwork`.
+
+## 1. Objetivo
+Evoluir `Obras` de nó estático com uma obra demonstrativa para uma **entidade
+gerenciável multi-obra**: listar, abrir e criar obras, com navegação dinâmica,
+ID estável e persistência local — mantendo o Core genérico.
+
+## 2. Problema anterior (CONFIRMADO na FASE 04.2-A)
+- `OBRAS_MODELO` existia, mas a navegação/rotas assumiam 1 obra fixa.
+- Não havia lista, criação, seleção nem persistência de obras.
+- `obra-store.selectedModule` era global (risco de vazamento entre obras).
+
+## 3. Auditoria que fundamentou
+`docs/phases/FASE_04_2_A_AUDITORIA_GESTAO_OBRAS.md` — conclusões: Obra pertence ao
+domínio Engenharia; fonte única inexistente como serviço; sem duplicação interna;
+recommendação de repositório no domínio com navegação data-driven.
+
+## 4. Modelo de Obra (IMPLEMENTADO)
+`obra-types.ts`: `Obra { id; nome; status: "PROPOSTA"; caracterizacao?; eap? }` —
+caracterização/EAP agora **opcionais** (obra nova nasce só com identificação).
+Novo `CreateObraInput { nome; status? }`.
+
+## 5. Repository (IMPLEMENTADO) — FONTE ÚNICA
+`obra-repository.ts`: store Zustand (`useObraRepository`) + helpers
+`listObras()`, `findObraById(id)`, `createObra(input)`, `SEED_OBRAS`,
+`OBRA_MODELO_ID`, `resetObraRepository()`. A lista, a navegação e as páginas
+consomem esta única fonte. `obra-data.ts` foi **removido** (fonte única).
+
+## 6. Armazenamento (IMPLEMENTADO — local e temporário)
+`obra-storage.ts` encapsula `localStorage` (`openwork.obra-repository.v1`,
+versionado). Arquitetura `UI → repository → storage`; a UI nunca toca em
+localStorage. Persistência V1 é **local e temporária** (troca por backend = só
+esta camada muda). FORA DE ESCOPO: backend/API/banco/Supabase.
+
+## 7. Geração de ID (IMPLEMENTADO)
+`createObraId()` → `OBRA-<timestamp36+aleatório>` (upper). Não usa nome, não usa
+índice; único (checagem contra ids existentes); seguro para URL.
+
+## 8. Navegação dinâmica (IMPLEMENTADO)
+`obra-navigation.ts#buildEngenhariaNavigation(obras = SEED_OBRAS)` monta
+`Engenharia → Obras → [+ Nova obra + obra1 + obra2 …]` (cada obra com módulos).
+O `domain.tsx` registra/re-registra o domínio a partir do repositório e
+re-registra quando o repositório muda (a sidebar relê ao remontar a sessão).
+Nenhum conceito de obra foi adicionado ao Core.
+
+## 9. Rota `/obras` (IMPLEMENTADO)
+`/dominios/engenharia/obras` → `ObraListaPage` (lista com Nome/Status/Abrir e
+botão "+ Nova obra"). `homeRoute` do domínio = lista. Rotas antigas
+`/obras/:obraId[/:modulo]` preservadas.
+
+## 10. Criação (IMPLEMENTADO)
+`/dominios/engenharia/obras/nova` → `ObraNovaPage` (formulário mínimo: Nome;
+status default `PROPOSTA`; validação mínima com botão desabilitado sem nome).
+
+## 11. Fluxo de criação (IMPLEMENTADO)
+`+ Nova obra → formulário → Criar → repository.createObra → persistência local →
+lista reativa → navega para a obra criada (obraId na URL)`.
+
+## 12. Relação com caracterização (FUTURO)
+Obra nova nasce sem caracterização; páginas tratam ausência (mensagens). A
+caracterização permanece como etapa futura, sem duplicar o modelo existente.
+
+## 13. Relação com EAP (PRESERVADO / FUTURO)
+EAP inalterada; `obra.eap` opcional (obra-modelo preserva o resumo 10/24/47=81).
+Vínculo por `obraId` futuro.
+
+## 14. Relação com planejamento (PRESERVADO)
+`ObraPlanejamento` (FASE 04.1) continua recebendo a obra por prop e exibindo o
+contexto dinâmico (sem hardcode). Dashboard intacta.
+## 15. Estado de UI (IMPLEMENTADO — correção de `selectedModule`)
+`obra-store.ts` agora mantém `selectedModules: Record<obraId, ObraModule|null>`
+(escopo por obra). A obra aberta continua vinda da **URL** (`obraId`), nunca do
+store. Mudança mínima e documentada; chamador único atualizado
+(`ObraShellRoute`).
+
+## 16. Decisão sobre `selectedModule` (IMPLEMENTADO)
+Risco de vazamento entre obras eliminado: módulo selecionado é por `obraId`; a
+rota (não o store) decide o módulo exibido.
+
+## 17. Compatibilidade com a obra existente (PRESERVADO)
+`OBRA-MODELO-EAP-001` mantida como **seed/fixture** (com caracterização e EAP)
+para não quebrar módulos/rotas/EAP. Verificada por testes. Classificação da
+ocorrência no código: **SEED/COMPATIBILIDADE** (`obra-repository.ts`).
+
+## 18. Testes (IMPLEMENTADO — executados)
+- `tests/obra-repository.test.ts` (7) — seeds, list/find, create/id único,
+  persistência e **reload** (storage + re-hidratação), reset.
+- `tests/obra-gestao.test.tsx` (7) — SSR da lista/criação, obra criada na
+  lista, estado vazio, compat da obra-modelo, planejamento com contexto
+  dinâmico e isolamento do estado por obra.
+- Atualizados: `engenharia-navigation`, `engenharia-obra-domain`,
+  `domain-back-button` (nova home = lista). Planejamento mantém 18 testes.
+
+## 19. Typecheck (PASS)
+`pnpm --filter @openwork/app typecheck` → exit 0.
+
+## 20. Build (PASS)
+`pnpm --filter @openwork/app build` → ✓ built (warnings pré-existentes).
+
+## 21. Reload test (PASS)
+Teste de re-hidratação: criar obra → storage contém → zerar memória → `initializeObraRepository()` → obra permanece e é encontrável (`findObraById`). (Simulado com storage em memória, pois Bun não expõe `localStorage`.)
+
+## 22. Anti-hardcode (PASS — classificação)
+Ocorrências de `OBRA-MODELO-EAP-001`:
+- `obra-repository.ts` (L19) → **SEED/COMPATIBILIDADE** (preservação da obra).
+- Comentários/rotas restantes → removidos ou tornados genéricos (ex.:
+  `domain-registry` usa `/obras/:obraId/eap`; página EAP sem literal).
+- Ocorrências em testes → **TESTE** (expectativas de seed).
+- Docs → **DOCUMENTAÇÃO**.
+Sem hardcode estrutural: navegação e UI derivam do repositório.
+
+## 23. Limitações (FUTURO / FORA DE ESCOPO)
+- Persistência local temporária (sem backend/banco).
+- Cadastro mínimo (nome/status); caracterização/EAP completas e demais módulos
+  são etapas futuras.
+- Sidebar DOMÍNIOS reflete a lista quando remonta a sessão (sem push reativo
+  ao vivo dentro da própria sidebar).
+- Sem edição, permissões, compartilhamento, colaboração, remoção.
+
+## 24. Evolução futura para backend (FUTURO)
+Trocar `obra-storage.ts` por persistência via servidor OpenWork local (SQLite)
+quando houver necessidade de compartilhamento/durabilidade fora da máquina.
+Nenhuma mudança no Core será necessária (o domínio continua a expor o
+repositório).
+
+## Verificação da fase
+- [x] repository · [x] fonte única · [x] ≥2 obras · [x] navegação dinâmica
+- [x] lista · [x] + Nova obra · [x] formulário · [x] criação · [x] ID estável
+- [x] persistência local · [x] reload · [x] abertura por URL · [x] obra preservada
+- [x] planejamento ok · [x] EAP preservado · [x] estado isolado por obra
+- [x] testes · [x] typecheck · [x] build · [x] documentação · [x] anti-hardcode
+

--- a/docs/phases/FASE_04_2_C_AUDITORIA_SIDEBAR_DOMINIO.md
+++ b/docs/phases/FASE_04_2_C_AUDITORIA_SIDEBAR_DOMINIO.md
@@ -1,0 +1,208 @@
+# FASE 04.2-C — AUDITORIA DA HIERARQUIA VISUAL DA SIDEBAR (read-only)
+
+> **Data:** 2026-01-09 · **Tipo:** auditoria somente leitura — nenhum código alterado.
+
+## 1. Objetivo
+Determinar se a sidebar representa corretamente a arquitetura
+`Core → Domínio → Entidade → Módulo` (DOMÍNIOS → ENGENHARIA → OBRAS → OBRA →
+MÓDULOS) e se a estrutura está pronta para Engenharia hoje e para
+Administração/Direito amanhã, sem contaminar o Core.
+
+## 2. Contexto
+FASE 04.2-B implementou gestão dinâmica de obras (repositório, multi-obra,
+`+ Nova obra`, `obraId` por URL, persistência local). A validação visual da
+sidebar gerou a percepção de possível "perda de nível" entre DOMÍNIO → OBRAS →
+OBRA.
+
+## 3. Estado anterior
+- `DomainDefinition.navigation` como `NavigationNode[]` por domínio.
+- Renderer genérico recursivo (`SidebarNavigationList`).
+- Seção "DOMÍNIOS" inserida na sidebar da SESSÃO (`app-sidebar.tsx` L1233).
+
+## 4. Arquivos auditados
+`domain-registry.ts` · `domain-sidebar-group.tsx` · `domain-route.tsx` ·
+`domain-back-button.tsx` · `navigation/{navigation-types,navigation-state,
+navigation-utils,sidebar-navigation}.ts(x)` ·
+`engenharia/domain.tsx` · `engenharia/obra/{obra-navigation,obra-routes,
+obra-shell-route,obra-store,obra-repository}.ts` ·
+`session/sidebar/app-sidebar.tsx` · testes listados na §12.
+Comandos executados (inspeção somente leitura):
+`Get-Content`, `Select-String` (busca de termos), contagem/leitura de arquivos.
+
+## 5. Árvore REAL produzida em runtime [CONFIRMADO]
+```text
+(app-sidebar · seção "DOMÍNIOS" — rótulo de seção, não nó)
+└─ nó raiz: Engenharia        (type domain, id domain:engenharia, rota=/dominios/engenharia/obras)
+   └─ nó: Obras               (type group, sem rota própria)
+      ├─ + Nova obra          (type entity, rota /dominios/engenharia/obras/nova)
+      ├─ OBRA-MODELO-EAP-001  (type entity, rota /dominios/engenharia/obras/OBRA-MODELO-EAP-001)
+      │   └─ módulos (Visão Geral · EAP · Frentes · Planejamento · Produção · RDO · IA)
+      ├─ Obra Demonstrativa 01 (entity + módulos)
+      └─ Obra Demonstrativa 02 (entity + módulos)
+```
+Fonte: `obra-navigation.ts` (L39-65) + `DomainDefinition.navigation` consumida por
+`domain-sidebar-group.tsx` (L29-33 → `SidebarNavigationList depth=0`).
+
+### Respostas da §2
+- **A.** Nó "DOMÍNIOS": [CONFIRMADO] **não existe como nó de dados** — é rótulo de seção
+  (`domain-sidebar-group.tsx` L26 `SIDEBAR_SECTION_LABEL`), agrupamento conceitual.
+- **B.** Nó "Engenharia": [CONFIRMADO] raiz do domínio (`obra-navigation.ts` L51-54).
+- **C.** Nó "Obras": [CONFIRMADO] `group` filho de Engenharia (L56-61), sem rota.
+- **D.** Obras são filhas de `OBRAS` (group), não de Engenharia [CONFIRMADO].
+- **E.** Módulos são filhos da entidade Obra (`obraNode.children`, L25-33) [CONFIRMADO].
+- **F.** `+ Nova obra` é um **`NavigationNode` real** (`type entity`, com rota própria,
+  id `domain:engenharia:obras:nova`) — filho do group Obras, antes das obras [CONFIRMADO].
+
+## 6. Árvore arquitetural desejada (referência do prompt)
+Mesma cadeia, com módulos adicionais (Caracterização, Serviços, Orçamento, Recursos,
+Medição, Controle, Indicadores…) por Obra — **FUTURO** (hoje o modelo tem 7 módulos).
+
+## 7. Arquitetura (dados vs. render) [CONFIRMADO]
+- `NavigationNode[]` = dados; `SidebarNavigationList` = renderer recursivo.
+- Sem "flatten": a árvore é percorrida nó a nó (`sidebar-navigation.tsx` L96-100);
+  filhos só existem com o pai expandido (estado `navigation-state`).
+- Renderização genérica: nenhuma dependência de tipo específico para decidir a
+  hierarquia — `type` é dado informativo (usado em data attrs/acentos), não roteia
+  lógica de domínio.
+## 8. Routing [CONFIRMADO]
+```text
+/dominios/:domainId                    → DomainRoute (Core)
+/dominios/engenharia/obras             → lista de obras (ObraListaPage)
+/dominios/engenharia/obras/nova        → criação (+ Nova obra)
+/dominios/engenharia/obras/:obraId     → ObraShellRoute (obra, módulo default)
+/dominios/engenharia/obras/:obraId/:modulo → ObraShellRoute (módulo)
+```
+Fonte: `domain.tsx#renderRoute`, `obra-routes.ts` (helpers). `obraId` sempre presente
+nas rotas de obra; a URL é a fonte do contexto (`ObraShellRoute` → `findObraById`).
+
+## 9. Contexto [CONFIRMADO]
+- Domínio: `domainId` da URL; obra: `obraId` da URL; módulo: segmento opcional.
+- `obra-store.ts` guarda apenas `selectedModules[obraId]` (lembrança de UI); não decide
+  contexto. `navigation-state.ts` guarda expansão por `node.id` (ids incluem `obra.id`
+  → expansão independente por obra). Nenhum estado global substitui o `obraId` da URL.
+
+## 10. Renderização [CONFIRMADO]
+- Todos os níveis são renderizados (recursão); nenhum nível é descartado.
+- Indentação por profundidade: `ps-3` na linha + `ms-2.5 border-l` no container de
+  filhos (`sidebar-navigation.tsx` L71, L97-99).
+- Nós com filhos: clique alterna expansão (L61-64). Nós folha com rota: navegam.
+- Nenhuma lógica específica para Engenharia/Obra no renderer/Core (busca por
+  termos só encontra comentários de design — §evidências).
+- A sidebar DOMÍNIOS é montada SOMENTE na superfície de **sessão** (`app-sidebar.tsx`
+  L1233 dentro do conteúdo da sidebar da sessão); as rotas `/dominios/*` são
+  renderizadas pelo `DomainRoute` **fora** dessa sidebar.
+
+## 11. Multi-obra [CONFIRMADO]
+- Cada obra tem `entity` própria com módulos próprios (mesma fonte `ObraRepository`).
+- `selectedModules[obraId]`, rota por `obraId` e ids de expansão com `obra.id`
+  → obras A/B não compartilham módulo/expansão/contexto indevidamente.
+
+## 12. Testes existentes (cobertura real) [CONFIRMADO]
+- `engenharia-navigation.test.ts`: árvore de DADOS (raiz/Obras/+ Nova/multi-obra/rotas),
+  helpers (back). Não valida pixels/nível visual.
+- `sidebar-navigation.test.tsx`: SSR do renderer com raiz recolhida (não renderiza
+  descendentes) — valida comportamento de estado, não a estética da cadeia.
+- `domain-back-button.test.tsx`: SSR do voltar (home=lista).
+- `obra-gestao.test.tsx` / `obra-repository.test.ts`: lista/criação/reload/isolamento.
+- NÃO cobertos (testes de componente/presencial): a representação visual em
+  profundidade da cadeia Engenharia→Obras→Obra→módulos, e o modo "icon/collapsed".
+
+## 13. Generalização para outros domínios [CONFIRMADO]
+- Nenhum `if (domain/engenharia/obra/EAP/planejamento)` em componentes genéricos do
+  Core/sidebar (busca). Ocorrências de "Engenharia/Obra" no Core = apenas comentários.
+- Um futuro domínio Administração pode registrar `navigation` com
+  `Empresas → Empresa A → módulos` sem tocar no Core (mesmo formato `NavigationNode`).
+
+## 14. Diferenças (mapa)
+| Item | Atual | Desejado | Situação |
+|---|---|---|---|
+| Domínios | rótulo de seção (não nó) | agrupamento topo (conceito) | CORRETO (conceitual) |
+| Engenharia | nó raiz do domínio (chevron) | nó Engenharia → Obras | CORRETO (dados) |
+| Obras | group sem rota, filhos obras | group Obras | CORRETO (dados) |
+| Obra | entity com módulos | entity com módulos (mais módulos futuros) | CORRETO (base); módulos extras FUTURO |
+| Módulos | 7 módulos atuais | 7 + caracterização/serviços/orçamento/… | FUTURO |
+| + Nova obra | node entity real antes das obras | mesmo | CORRETO |
+| Contexto | obraId da URL | mesmo | CORRETO |
+| Superfície da árvore | só visível na sessão; rotas /dominios fora da sidebar | — | DÍVIDA/UX (ver §15) |
+
+## 15. Riscos e limitações [HIPÓTESE + CONFIRMADO]
+- [CONFIRMADO] DOMÍNIOS não é um nó navegável: pode parecer que falta o nível
+  "DOMÍNIOS" visual, mas isso é o desenho conceitual (seção).
+- [CONFIRMADO] A árvore só acompanha a superfície de sessão; dentro de uma rota de
+  domínio a sidebar DOMÍNIOS não está presente (superfícies separadas). A imagem
+  citada (obra + módulos + obras irmãs sem "Engenharia/Obras" visíveis) é compatível
+  com: (a) recorte da visualização; ou (b) nós "Engenharia/Obras" acima fora do
+  trecho; NÃO é compatível com achatamento de dados (nenhum nível é descartado no
+  render). Verificação visual adicional é recomendada.
+- [CONFIRMADO] Nós com filhos (Engenharia, Obras, Obra) **alternam** no clique; a
+  "abertura" da obra acontece nos filhos folha (módulos) — UX de "entrar na obra"
+  pelo item raiz não existe hoje (DECISÃO DE UX atual do renderer genérico).
+
+## 16. Classificação
+- Nível DOMÍNIOS como seção: **CORRETO** (arquitetura).
+- Cadeia Engenharia→Obras→Obra→módulos em dados: **CORRETO**.
+- Indentação/representação: **DECISÃO DE UX** (discreta; pode ser reforçada).
+- Superfície da árvore restrita à sessão: **DÍVIDA ARQUITETURAL/UX** (futuro avaliar
+  shell de domínio com sidebar própria ou trilho).
+- Módulos extras (caracterização, etc.): **FUTURO**.
+## 17. Recomendação
+**Opção C (recomendada) — consolidar a representação visual da cadeia
+`Engenharia → Obras`** (sem alterar dados/roteamento):
+- Manter `DOMÍNIOS` como seção e a árvore de dados atual (CORRETO).
+- Ajustar a leitura visual da cadeia na sidebar da sessão para deixar explícito
+  o nível `Obras` e o fato de a obra estar contida nele (ex.: realce do nó ativo,
+  indentação/estilo da cadeia), sem achatamento e sem criar abstração nova.
+- NÃO mudar o Core nem a fonte de dados nesta fase.
+
+Justificativa por critério:
+1. Arquitetura atual: baixo risco — mudança restrita a apresentação (renderer/estilos).
+2. Administração/Direito: mesma árvore data-driven → ganho de legibilidade no padrão
+   `Domínio → Coletivo(Ex.: Obras/Empresas) → Entidade → Módulos`.
+3. Comercialização futura: a clareza do aninhamento apoia venda de módulos por entidade.
+4. Manutenção: sem alteração de contrato; apenas componente de apresentação.
+5. Domínio/contexto: obraId/URL permanecem como fonte.
+6. Agentes especialistas futuros: legibilidade hierárquica facilita apontar o contexto.
+
+## 18. Escopo futuro (não implementar nesta fase)
+- [FUTURO] Avaliar shell de domínio com a sidebar presente nas rotas `/dominios/*`
+  (hoje a árvore só existe na superfície de sessão).
+- [FUTURO] Módulos adicionais da obra (caracterização, serviços, orçamento, etc.).
+- [FUTURO] Testes de apresentação em profundidade (multi-nível) da sidebar.
+
+## 19. Evidências
+- `obra-navigation.ts` L39-65 — árvore real (raiz/Obras/+Nova/obras/módulos).
+- `domain-sidebar-group.tsx` L19-37 — seção DOMÍNIOS (rótulo) + `listDomains` +
+  renderer genérico.
+- `sidebar-navigation.tsx` L26-40 (lista recursiva), L61-67 (clique: expandir vs
+  navegar), L71/L97-99 (indentação), L54-59 (auto-expand de ancestrais).
+- `domain-registry.ts`, `domain-sidebar-group.tsx`, `domain-route.tsx`,
+  `domain-back-button.tsx`, `navigation/*` — busca por termos de domínio =
+  somente comentários de design (nenhum `if` de domínio no Core).
+- `app-sidebar.tsx` L1233 — `<DomainsSidebarGroup/>` dentro da sidebar da sessão.
+- `domain.tsx#renderRoute` + `obra-routes.ts` — rotas lista/nova/obraId/modulo.
+- `obra-store.ts` (`selectedModules[obraId]`), `navigation-state.ts` (expansão por
+  id de nó) — contexto não vaza entre obras.
+
+## 20. Veredito
+> **A sidebar atual representa corretamente a arquitetura Core → Domínio → Entidade →
+> Módulo nos DADOS e na renderização recursiva (nenhum nível é achatado). "DOMÍNIOS" é
+> um agrupamento conceitual (seção), não um nó — coerente com o desenho.** A percepção
+> de perda de nível vem da representação visual discreta e do fato de a árvore DOMÍNIOS
+> só estar presente na superfície de sessão (as rotas `/dominios/*` não exibem essa
+> sidebar). Correção NÃO é arquitetural; é de apresentação (Opção C) + decisão futura
+> de superfície.
+
+> **A estrutura está preparada para Engenharia hoje e para Administração/Direito amanhã
+> sem contaminar o Core: SIM** — o Core renderiza `NavigationNode[]` e não contém
+> nenhuma referência a Engenharia/Obra/EAP/Planejamento (apenas comentários); novos
+> domínios registram navegação própria sem alterar o Core.
+
+## Notas de validação
+Fase read-only: sem execução de suíte (nenhuma alteração). Comandos usados apenas para
+inspeção: leitura de arquivos e buscas textuais (finalidade: evidências desta auditoria).
+
+## Git
+Nenhum commit. `git status` confirmado sem alterações de implementação nesta fase
+(apenas este documento de auditoria foi criado).
+
+

--- a/docs/phases/FASE_04_2_D_CORRECAO_VISUAL_HIERARQUIA_SIDEBAR.md
+++ b/docs/phases/FASE_04_2_D_CORRECAO_VISUAL_HIERARQUIA_SIDEBAR.md
@@ -1,0 +1,59 @@
+# FASE 04.2-D — CORREÇÃO VISUAL DA HIERARQUIA DA SIDEBAR
+
+> **Data:** 2026-01-09 · **Tipo:** correção de apresentação (renderer genérico).
+> **Clone:** `OPENWORK-LAB\openwork`. Auditoria base: `FASE_04_2_C_AUDITORIA_SIDEBAR_DOMINIO.md`.
+
+## 1. Objetivo
+Tornar visualmente inequívoca a cadeia `DOMÍNIOS → Domínio → Entidade → Módulo`
+na sidebar da sessão, **sem** alterar arquitetura, dados, rotas ou Core.
+
+## 2. Decisão aplicada (Opção C da 04.2-C)
+Ajuste exclusivo na camada de apresentação (`SidebarNavigationList`), conforme a
+especificação da auditoria: realce do nó ativo, indentação/estilo da cadeia,
+sem achatamento e sem abstração nova.
+
+## 3. Arquivo alterado
+- `apps/app/src/react-app/domains/navigation/sidebar-navigation.tsx` (renderer genérico).
+
+## 4. Alteração visual (somente CSS/classes)
+- Tipografia por **tipo de nó** (propriedade genérica de apresentação):
+  `domain` (semibold), `group` (label compacto, uppercase, destaque suave),
+  `entity` (medium), `module` (regular, cor mais suave).
+- Item **ativo** com destaque uniforme (`bg-sidebar-accent` + `font-semibold text-foreground`).
+- Guia vertical de profundidade mais visível nos filhos
+  (`ms-2.5 border-l-2 … ps-2.5`) — a indentação cresce a cada nível sem remover níveis.
+- Leve separação superior dos nós raiz de cada domínio.
+
+## 5. Comportamento preservado
+Expansão/recolhimento (estado `navigation-state`), auto-expansão de ancestrais,
+navegação por rota, seleção do item atual via `useLocation`, `data-nav-*`,
+`aria-expanded`, chevron, acessibilidade (focus ring) — inalterados.
+
+## 6. Arquitetura
+**PRESERVADA.** `NavigationNode[]` continua sendo a fonte; renderer permanece
+recursivo e genérico; nenhuma regra de domínio foi adicionada (verificação por
+busca: ocorrências de "engenharia/obra/EAP/Planejamento" no módulo alterado =
+somente comentários).
+
+## 7. Validação
+```text
+Testes:    42 PASS / 0 FAIL  (sidebar-navigation, engenharia-navigation,
+            domain-back-button, obra-gestao, obra-repository, engenharia-obra-domain)
+Typecheck: PASS  (pnpm --filter @openwork/app typecheck → exit 0)
+Build:     PASS  (pnpm --filter @openwork/app build → ✓ in 47.96s)
+Busca arquitetural: nenhuma condicional de domínio introduzida.
+```
+
+## 8. Git
+- `git status` inicial e final registrados (o arquivo alterado faz parte da pasta de
+  navegação não-commitada — `git diff` não cobre arquivos untracked; a alteração foi
+  revisada via diff do editor).
+- Commit: **NÃO**.
+
+## 9. Verificação da convenção de documentação
+Fases 04.x do clone estão em `docs/phases/` (FASE_04_1, FASE_04_2_A/B/C); `lab-docs`
+não contém fases do clone. Este relatório segue a convenção vigente.
+
+## 10. Próximos passos (FUTURO — não executados nesta fase)
+- [FUTURO] Avaliar shell de domínio com a árvore presente nas rotas `/dominios/*`.
+- [FUTURO] Testes de apresentação multi-nível da sidebar (visual/presencial).

--- a/docs/phases/FASE_04_3_AUDITORIA_DOMINIO_ENGENHARIA_NAVEGACAO.md
+++ b/docs/phases/FASE_04_3_AUDITORIA_DOMINIO_ENGENHARIA_NAVEGACAO.md
@@ -1,0 +1,104 @@
+# FASE 04.3 — AUDITORIA DO DOMÍNIO ENGENHARIA E NAVEGAÇÃO DA OBRA (read-only)
+
+> **Data:** 2026-01-09 · **Tipo:** auditoria — nenhuma alteração de código.
+
+## 1. Objetivo
+Auditar a integração Core → Domínio → Entidade → Módulos (Engenharia/Obras/Obra)
+após as FASES 04.2-C/D, sem reauditar o que já foi aprovado e sem implementar.
+
+## 2. Arquivos auditados (reais)
+`domain-registry.ts` · `domain-bootstrap.ts` · `domain-route.tsx` ·
+`domain-back-button.tsx` · `domain-sidebar-group.tsx` ·
+`navigation/{navigation-types,navigation-state,navigation-utils,sidebar-navigation}` ·
+`engenharia/domain.tsx` · `engenharia/obra/{obra-navigation,obra-routes,
+obra-repository,obra-store,obra-shell-route,obra-types,obra-storage,obra-help}` ·
+`engenharia/obra/pages/{obra-lista,obra-nova,obra-visao-geral,obra-eap,
+obra-planejamento,obra-modulo-placeholder}` · `session/sidebar/app-sidebar.tsx` · `app-root.tsx`.
+
+## 3. Domain Registry [APROVADO]
+- `DomainDefinition { id; label; homeRoute; navigation: NavigationNode[]; renderRoute }`
+  (`domain-registry.ts` L7-16).
+- Engenharia registrada via side-effect no ponto único `domain-bootstrap.ts` L4.
+- Registry não conhece módulos de Engenharia (sem `if`/referência a Obra/EAP).
+- Navegação fornecida pelo domínio (dados); Core apenas interpreta.
+- `listDomains`/`getDomain` compartilhados pela sidebar e pelo `DomainRoute`.
+
+## 4. Navegação da Obra [APROVADO]
+`obra-navigation.ts#buildEngenhariaNavigation(obras = SEED_OBRAS)` produz:
+```text
+Engenharia        (type domain · rota /dominios/engenharia/obras)
+└── Obras         (type group · sem rota)
+    ├── + Nova obra   (entity · rota .../obras/nova)
+    └── por obra      (entity · rota .../obras/{id})
+        └── módulos reais (7): Visão Geral · EAP · Frentes de Serviço ·
+            Planejamento · Produção · RDO · IA
+```
+- Labels/rotas dos módulos em `obra-routes.ts` (`OBRA_MODULES`, `OBRA_MODULE_LABEL`).
+- Sem ícones/metadados/permissões por nó no modelo atual (responsabilidade futura).
+
+## 5. Entidade Obra [APROVADO]
+- `Obra` vive no domínio (`obra-types.ts`); `caracterizacao?/eap?` opcionais (04.2-B).
+- Nenhum componente do Core/sessão/workspace a trata como domínio/Core/infra.
+  Ocorrências de "engenharia" fora do domínio = comentários + bootstrap (registro).
+
+## 6. Rotas [APROVADO]
+```text
+/dominios/:domainId                → DomainRoute (Core) → renderRoute do domínio
+/dominios/engenharia/obras         → ObraListaPage (lista)
+/dominios/engenharia/obras/nova    → ObraNovaPage (criação)
+/dominios/engenharia/obras/:obraId → ObraShellRoute (Visão Geral default)
+/dominios/engenharia/obras/:obraId/:modulo → ObraShellRoute
+```
+- Coerência nó↔rota; `obraId` sempre presente nas rotas de obra; URLs geradas por
+  `obraRoute()`. Sem duplicidade relevante.
+## 7. Acoplamento / dependências [APROVADO]
+- Ocorrências de "engenharia" fora do domínio: comentários de design
+  (`navigation-types`, `sidebar-navigation`, `app-sidebar` L1232, `domain-registry`,
+  `domain-route`, `domain-sidebar-group`, `domain-back-button`) e `domain-bootstrap` L4
+  (registro, legítimo). Nenhum import funcional Core→Engenharia.
+- Domínio → Core: importa tipos (`navigation-types`) e `registerDomain` (contrato) —
+  legítimo. Obra → capacidade genérica `planejamento` (`obra-planejamento.tsx`) —
+  direção correta. Nenhuma dependência invertida.
+
+## 8. Extensibilidade [APROVADO]
+- Novo domínio (Administração): novo módulo `domains/administracao/domain.tsx` +
+  import no `domain-bootstrap` — sem mudar Core/renderer.
+- Nova entidade (Empresa) e novo módulo (Financeiro): novos `NavigationNode[]` no
+  domínio — renderer recursivo genérico não exige lógica especial.
+
+## 9. Estado [APROVADO]
+- Domínio/obra/módulo: derivados da URL (`domainId`, `obraId`, segmento de módulo).
+- `obra-store`: `selectedModules[obraId]` (lembrança; não decide contexto).
+- `navigation-state`: expansão por `node.id` (ids incluem `obra.id`).
+- Separação sessão/domínio/entidade/navegação/rota respeitada.
+
+## 10. Testes existentes [APROVADO]
+Executados (somente leitura): **60 PASS / 0 FAIL** nos 9 arquivos relacionados
+(engenharia-navigation, engenharia-obra-domain, sidebar-navigation, domain-back-button,
+obra-gestao, obra-repository, planning-data, planning-dashboard, planning-anti-hardcode).
+Nenhum teste modificado/criado.
+
+## 11. Regressão visual [ATENÇÃO]
+A alteração 04.2-D (classes no renderer) não gerou regressão funcional (testes SSR
+PASS). Inspeção visual manual GUI não executada nesta auditoria — ATENÇÃO não
+bloqueante (validação visual a cargo do usuário).
+
+## 12. Problemas encontrados
+- [ATENÇÃO] Árvore DOMÍNIOS só exibida na superfície de sessão; rotas `/dominios/*`
+  não exibem essa sidebar (dívida de superfície, 04.2-C §18).
+- [ATENÇÃO] Módulos da arquitetura-alvo (Caracterização, Serviços, Orçamento etc.)
+  ainda não existem como módulos — FUTURO, sem impacto no mecanismo.
+- [INFO] Persistência de obras é local/temporária (backend é FUTURO) — sem impacto
+  nesta auditoria.
+
+## 13. Veredito
+`APROVADO` — sem BLOQUEIO arquitetural; ATENÇÕES não bloqueantes registradas.
+
+## Git
+Estado registrado (`git status`); sem alterações de implementação nesta fase; sem
+add/commit/reset/checkout.
+
+## Convenção de documentação
+Fases 04.x do clone ficam em `docs/phases/` (verificado nesta fase). Nenhum arquivo de
+código foi alterado.
+

--- a/docs/phases/FASE_05_AUDITORIA_CAPACIDADE_PLANEJAMENTO_OPENWORK.md
+++ b/docs/phases/FASE_05_AUDITORIA_CAPACIDADE_PLANEJAMENTO_OPENWORK.md
@@ -1,0 +1,212 @@
+# FASE 05 — AUDITORIA DE CAPACIDADE DE PLANEJAMENTO DO OPENWORK (read-only)
+
+> **Data:** 2026-01-09 · **Tipo:** auditoria — comparativo OpenProject/GanttReady (referências de requisitos).
+> **Nenhum código alterado.** EAP existente não será reconstruída.
+
+## 1. Objetivo
+Verificar se a estrutura atual do OpenWork sustenta um planejamento de obras
+profissional, absorvendo requisitos de OpenProject (verificado) e GanttReady
+(referência conceitual — ver §6) **sem copiar** arquitetura/código/interface.
+
+## 2. Escopo
+Código do clone (`apps/app/src`, domínios `engenharia`/`planejamento`, Core) +
+referência externa OpenProject (docs oficiais) + conceitos de Gantt profissional.
+
+## 3. Metodologia
+Inspeção de código (read-only), testes existentes executados (60 PASS/0 FAIL),
+fetch de documentação externa. Toda capacidade interna aponta o arquivo onde está.
+
+## 4. Arquitetura atual encontrada [CONFIRMADO]
+- Core genérico (registry/navegação/roteamento) → domínio Engenharia → entidade
+  Obra → módulos (rota `/dominios/engenharia/obras/:obraId/:modulo`).
+- Módulos da obra encontrados (`obra-routes.ts` `OBRA_MODULES`): Visão Geral · EAP ·
+  Frentes de Serviço · Planejamento · Produção · RDO · IA.
+- Capacidade genérica de planejamento em `domains/planejamento/*` (contratos +
+  dashboard demo) consumida por `obra-planejamento.tsx`.
+
+## 5. Modelo operacional encontrado (inventário real)
+| Conceito | Onde | Responsabilidade | Entidade | Persistência | Consumidores | Status |
+|---|---|---|---|---|---|---|
+| Obra | `engenharia/obra/obra-types.ts` + `obra-repository.ts` | entidade central; lista/cria | `Obra` | local (storage) | navegação, páginas | IMPLEMENTADO (V1) |
+| EAP | `obra.eap` (resumo 10/24/47) em seed; módulo EAP mostra resumo | eixo estrutural (resumo) | `ObraEapSummary` | local (seed) | página EAP | PARCIAL — nós reais futuros (fonte isolada) |
+| Serviços | — | — | — | — | — | NÃO ENCONTRADO no clone |
+| Atividades (plano) | `domains/planejamento/planning-types.ts` | itens da timeline demo | `PlanningItem` | código (demo) | Dashboard V1 | DEMO (não é entidade persistida) |
+| Predecessoras/Rede | — | — | — | — | — | NÃO ENCONTRADO no clone (existe no ARES Python, externo) |
+| Calendário | — (helpers de datas simples em `planning-data.ts`) | período mensal p/ eixo | — | — | timeline | NÃO ENCONTRADO (dias úteis ausentes) |
+| Duração | — | — | — | — | — | NÃO ENCONTRADO |
+| Recursos/Equipes | — | — | — | — | — | NÃO ENCONTRADO |
+| Produção/Medição/Controle/Indicadores | módulos `producao`,`rdo` placeholders | visão "em construção" | — | — | — | PLACEHOLDER |
+| Frentes de Serviço | módulo `frentes` placeholder | visão | — | — | — | PLACEHOLDER |
+| Histórico/Replanejamento | — | — | — | — | — | NÃO ENCONTRADO |
+| Progresso | `PlanningItem.progress` (demo) + status | UI demo | campo | código | Dashboard | DEMO |
+| Produtividade | — | — | — | — | — | NÃO ENCONTRADO |
+| Memória/contexto da obra | sem repositório de contexto além de `obraId` (URL) | contexto | — | URL | páginas | MINIMAL (só obraId) |
+
+Nota: quantidade/produtividade/FS-SS-FF/calendário/Gantt/LOB existem **apenas no motor
+Python do Obra Copilot/ARES** (fora do clone; auditoria 04.0.1) — referência de regras,
+sem bridge. Não há duplicidade interna de atividade/datas/duração no clone (ainda não
+existem como entidades).
+## 6. Auditoria da EAP [CONFIRMADO]
+- Existe como **resumo** no modelo (`ObraEapSummary`) e como **módulo** que exibe o
+  resumo real (10/24/47 → 81 nós, PROPOSTA) SEM os nós individuais (fonte isolada =
+  FUTURO) — `obra-eap.tsx`.
+- Não há árvore de nós EAP persistida no clone; não há geração de atividades a partir
+  da EAP. EAP em 1ª classe existe apenas no ARES Python (referência).
+- **Decisão:** a EAP existente não é reconstruída; ela evoluirá adicionando os nós reais
+  (fonte) e vínculos por `obraId`/serviço em fases futuras.
+
+## 7. Auditoria do planejamento
+- Capacidade genérica V1 (`domains/planejamento`): Dashboard com **demo data** neutra,
+  KPIs derivados, árvore (grupo→pacote→atividade) e timeline simples derivada de
+  start/end. Consumida por `ObraPlanejamento` (contexto = `obra.nome`).
+- **Não** há: motor de datas determinístico (Q/P, dias úteis), dependências, CPM/Gantt,
+  baseline, produção real. A timeline é visualização simples (não é Gantt nem segunda
+  fonte de dados).
+
+## 8. Comparação com OpenProject (referência de requisitos — docs oficiais)
+Capacidades do OpenProject (verificadas no índice da user guide de Work packages):
+Work packages (tipos: task/feature/bug/phase/milestone), tabela/split/detalhes,
+datas e duração, agendamento automático e manual (scheduling), relações e
+hierarquias, baseline comparison, Gantt, calendário, progresso, gestão de recursos,
+filtros/agrupamento/exportação, atividade/histórico. → Requisitos absorvíveis para
+obra: hierarquia EAP/serviço/atividade, relações, baseline planejado×realizado,
+scheduling, calendário, progresso e histórico.
+
+## 9. Comparação com GanttReady [NÃO VERIFICADO — referência conceitual]
+Não foi possível acessar fonte primária confiável do produto "GanttReady" (sem
+resultados utilizáveis). A comparação usa **conceitos de domínio** típicos de um
+planejador/Gantt profissional: tarefas hierárquicas, dependências, durações,
+calendário/datas, caminho crítico/folgas, baseline, edição temporal — tratados como
+**requisitos de domínio**, não como características afirmadas do produto.
+
+## 10. Matriz consolidada
+| Capacidade | OpenWork (clone) | OpenProject | GanttReady* | Situação | Decisão |
+|---|---|---|---|---|---|
+| EAP | 🟡 resumo (nós futuros) | 🟡 fases/estruturas configuráveis | 🟡 tarefas hierárquicas | PARCIAL | 🔵 evoluir nós EAP + vínculo obra |
+| Serviços | 🔴 | ✅ WP/tipos | 🟡 | AUSENTE | 🔵 entidade serviço por obra |
+| Atividades | 🟡 demo | ✅ | ✅ | PARCIAL | 🔵 entidade atividade real (modelo obra) |
+| Hierarquia | ✅ árvore data-driven | ✅ | ✅ | ATENDE | ✅ reutilizar |
+| Predecessoras | 🔴 (ARES py fora) | ✅ | ✅ | AUSENTE no clone | 🔵 rede na entidade |
+| Sucessoras | 🔴 | ✅ | ✅ | AUSENTE | 🔵 |
+| Rede de precedências | 🔴 | ✅ | ✅ | AUSENTE | 🔵 estrutura de relações |
+| Calendário | 🔴 (dias úteis) | ✅ | ✅ | AUSENTE | 🔵 calendário por obra |
+| Duração | 🔴 | ✅ | ✅ | AUSENTE | 🔵 duração derivada (Q/P) |
+| Marcos | 🔴 | ✅ | ✅ | AUSENTE | 🔵 tipo de atividade/marco |
+| Restrições | 🔴 | 🟡 | 🟡 | AUSENTE | 🔵 restrições de datas |
+| CPM | 🔴 | 🟡 (não nomeado; scheduling) | 🟡 | AUSENTE | 🔵 cálculo sobre a rede |
+| Caminho crítico | 🔴 | 🟡 | ✅ | AUSENTE | 🔵 derivado (cálculo) |
+| Folgas | 🔴 | 🔴/🟡 | 🟡 | AUSENTE | 🔵 |
+| Gantt | 🟡 timeline simples demo | ✅ | ✅ | PARCIAL | 🔵 Gantt = visualização do plano (não 2ª fonte) |
+| Baseline | 🔴 | ✅ | ✅ | AUSENTE | 🔵 planejado × realizado |
+| Progresso | 🟡 demo | ✅ | ✅ | PARCIAL | 🔵 status + % + produção real |
+| Planejado × realizado | 🔴 | ✅ | ✅ | AUSENTE | 🔵 |
+| Recursos | 🔴 | ✅ | 🟡 | AUSENTE | 🔵 equipes/produtividade por obra |
+| Produtividade | 🔴 | 🔴/⚪ | 🟡 | AUSENTE | 🔵 (domínio engenharia) |
+| Frentes de Serviço | 🟡 módulo placeholder | 🔴/⚪ | 🔴/⚪ | PARCIAL | 🔵 capacidade sobre atividade+local |
+| Produção | 🔴 placeholder | 🟡 | 🔴/⚪ | AUSENTE | 🔵 registrar produção real |
+| Medição | 🔴 | 🟡 | 🔴/⚪ | AUSENTE | 🔵 |
+| Controle | 🔴 | 🟡 | 🟡 | AUSENTE | 🔵 indicadores derivados |
+| Histórico | 🔴 | ✅ | 🟡 | AUSENTE | 🔵 versões/auditoria |
+| Restrições operacionais | 🔴 | 🟡 | 🟡 | AUSENTE | 🔵 |
+| Replanejamento | 🔴 | 🟡 (baseline) | 🟡 | AUSENTE | 🔵 versão + justificativa |
+| Memória da Obra | 🔴 (só obraId) | 🟡 | 🟡 | AUSENTE | 🔵 contexto estruturado |
+| Integração com IA | 🟡 espaço (domínio/capacidade) | 🟡 | 🔴 | FUTURO | 🔵 Agente Planejador sobre modelo |
+*GanttReady = referência conceitual (não verificado como produto).
+## 11. Fonte única da verdade [CONFIRMADO — sem duplicidade no clone]
+- No clone não há duplicidade de atividade/datas/duração porque **ainda não existem como
+  entidades persistidas** (só demo UI + resumo EAP). Riscos de duplicação apareceriam se
+  cada visão futura (Gantt/LOB/Frente/Produção) mantivesse dados próprios — a decisão é:
+  **um único modelo operacional da obra** e as ferramentas como **derivações** (Gantt =
+  visualização do plano; CPM = cálculo sobre a rede; LOB = análise de repetitivo; Frente =
+  execução de atividade em local; Produção = realizado). Fonte: princípio já usado pela
+  capacidade `planejamento` (períodos/KPIs/alertas derivados) e pelo ARES (Gantt derivado).
+
+## 12. Frentes de Serviço — capacidade estrutural
+- Hoje: módulo placeholder (`obra-shell-route` → `ObraModuloPlaceholder`).
+- Mínimo futuro no modelo de planejamento para a Frente operar: entidade **Atividade**
+  com `obraId`, serviço, local/área (pavimento/unidade/frente), quantidades,
+  produtividade/equipe, janela de datas (planejado), e um canal de **Produção Real**
+  (quantidade/dia + data) para comparação planejado×realizado, geração de sinais de
+  atraso e histórico. Nada disso existe hoje (modelo não estruturalmente capaz ainda —
+  LACUNA IMPORTANTE).
+
+## 13. Agente Planejador futuro
+- Espaço arquitetural existe: capacidade genérica + domínio com entidade e URL de
+  contexto; o Core permanece intacto. O agente (futuro) deve operar sobre o **modelo
+  operacional da obra** (EAP/serviços/atividades/rede/calendário/produção/histórico) —
+  exigirá antes a criação desse modelo. Não criar arquitetura artificial agora.
+
+## 14. Lacunas
+### CRÍTICAS
+1. Sem entidade **Atividade/Serviço** persistida (base de tudo).
+2. Sem **predecessoras/rede** e sem **motor de datas determinístico** (Q/P, dias úteis).
+### IMPORTANTES
+3. Sem **calendário** (dias úteis/feriados) por obra.
+4. Sem **baseline/planejado×realizado** e **histórico**.
+5. Sem canal de **produção real/medição** para controle.
+6. Nós EAP individuais ainda não integrados (fonte isolada).
+### FUTURAS
+7. CPM/caminho crítico/folgas; Gantt profissional; LOB; recursos/equipes; indicadores;
+   memória da obra; Agente Planejador.
+### NÃO NECESSÁRIAS (não copiar por existir nas referências)
+- Work-package como metáfora genérica (o domínio exige EAP→Serviço→Atividade→Frente);
+- Tipos configuráveis estilo bug/feature; custos financeiros de projeto (fora do modelo
+  atual da obra); fluxo Agile/Kanban.
+
+## 15. Conhecimento absorvido
+### OpenProject
+- Modelo hierárquico de trabalho + relações explícitas (predecessoras/sucessoras);
+  scheduling automático vs manual; baseline (comparação ao longo do tempo); progresso +
+  atividades/histórico; Gantt como visão derivada; calendário. [REQUISITO]
+### GanttReady (referência conceitual)
+- Interação de Gantt profissional: dependências, durações, datas, caminho crítico/
+  folgas, edição temporal e atualização do plano. [REQUISITO DE DOMÍNIO]
+### OpenWork (diferenciais)
+- Estrutura **Core→Domínio→Entidade** com EAP real como eixo e Obra como contexto por
+  URL; navegação data-driven; capacidade de planejamento já derivativa; regras de obra
+  (Q/P, FS/SS/FF, calendário) já desenhadas no ARES (referência de paridade).
+### Não absorver
+- Metáfora genérica de Work Package; tipos configurais de produto; custos financeiros
+  abstratos; lógica de produto das referências.
+
+## 16. Riscos
+- Criar modelos paralelos (Gantt/LOB/Frente cada um com dados próprios) — mitigar com
+  modelo operacional único e derivações.
+- Implementar módulos antes de existir a **entidade atividade/planejamento persistida**.
+- Adicionar "features" de referência sem vínculo com o domínio (fragmentação).
+
+## 17. Roadmap recomendado (baseado nas lacunas)
+1. **Modelo operacional da obra V1**: entidades `Serviço`/`Atividade` (obraId, hierarquia,
+   quantidade, produtividade, local/frente, datas planejadas, status) persistidas no
+   repositório do domínio.
+2. **Planejamento real**: motor de datas determinístico (Q/P → duração; calendário dias
+   úteis; FS/SS/FF+lag) portado/adaptado dos contratos ARES para TS (paridade de testes).
+3. **Rede + CPM**: predecessoras/sucessoras, detecção de ciclo, forward pass, caminho
+   crítico/folgas.
+4. **Visualização**: Gantt derivado do plano (timeline profissional) — nunca 2ª fonte.
+5. **Frente de Serviço → Produção**: executar atividade planejada em local, registrar
+   produção real, medir planejado×realizado, gerar sinais.
+6. **Controle/histórico**: baseline e versões, indicadores, histórico da obra.
+7. **Inteligência**: memória da obra estruturada + Agente Planejador (analisar,
+   diagnosticar, propor, justificar; sem alteração automática sem decisão humana).
+Ordem baseada em dependência de dados (entidades → cálculo → visão → execução →
+controle → IA).
+
+## 18. Conclusão
+O OpenWork ainda NÃO possui capacidade profissional de planejamento de obras no clone:
+existem a casca arquitetural (Core/Domínio/Obra), a capacidade visual V1 com dados demo e
+o repositório de obras; faltam as **entidades e o motor** do planejamento (lacunas
+críticas). A arquitetura permite evoluir sem quebrar o Core; a EAP existente é o eixo e
+será ampliada (nós reais), não reconstruída.
+
+## 19. Veredito
+**APROVADO COM RESSALVAS** — a auditoria e a arquitetura (espaço para o modelo) estão
+adequadas, mas o planejamento profissional exige criar o modelo operacional e o motor
+antes de Gantt/CPM/LOB/Frente/Produção (lacunas críticas identificadas).
+
+## 20. Execução da fase
+Testes executados: **60 PASS / 0 FAIL** (9 arquivos relacionados). Typecheck/Build: não
+necessários (sem alteração). Git status registrado. **Nenhum código de produção alterado;
+nenhuma recomendação implementada; nenhuma FASE 06 iniciada.**
+
+

--- a/docs/phases/FASE_06_1_DESCOBERTA_EAP_OPENWORK_OFICIAL.md
+++ b/docs/phases/FASE_06_1_DESCOBERTA_EAP_OPENWORK_OFICIAL.md
@@ -1,0 +1,116 @@
+# FASE 06.1 — DESCOBERTA DA EAP NA INSTALAÇÃO OFICIAL DO OPENWORK (read-only)
+
+> **Data:** 2026-01-09 · **Tipo:** descoberta — nenhuma migração; nenhum arquivo alterado.
+
+## 1. Objetivo
+Localizar a origem oficial da EAP-modelo (81 nós) na instalação local do OpenWork.
+
+## 2. Contexto
+FASE 06 bloqueada: a origem não estava no clone/LAB. Informado que a EAP foi
+construída no OpenWork oficial instalado na máquina.
+
+## 3. Localização do OpenWork oficial [ENCONTRADO]
+- Instalação: `C:\Users\Correta Engenharia\AppData\Local\Programs\@openworkdesktop`.
+- Dados do app (Electron): `%APPDATA%\com.differentai.openwork`.
+- **Workspace da obra-modelo (origem da EAP):**
+  `C:\Users\Correta Engenharia\OBRAS-MODELO\OBRA-MODELO-EAP-001`
+  (workspace com `opencode.jsonc`, `data/`, `knowledge/`, `registro/`,
+  `validacao/`, `interface/`).
+
+## 4. Diretórios investigados (controlados)
+`%LOCALAPPDATA%\Programs` · `%APPDATA%\@openwork|openwork|com.differentai.openwork` ·
+`%USERPROFILE%\{OBRAS-MODELO, OpenWork Chat, .openwork, .ares}`. Nenhuma varredura
+indiscriminada.
+
+## 5. Mecanismo de persistência identificado
+A EAP **não** fica em banco da obra: fica em **arquivos JSON/MD dentro do workspace**
+aberto no OpenWork oficial. O app mantém metadados de workspaces em
+`com.differentai.openwork` (não inspecionado em profundidade — desnecessário).
+
+## 6. Estratégia de busca
+Busca por literal `OBRA-MODELO-EAP-001` e por estrutura nos diretórios oficiais;
+leituras de JSON/verificador; inspeção do workspace nomeado.
+
+## 7. Candidatos encontrados
+1. **`OBRAS-MODELO\OBRA-MODELO-EAP-001\data\eap\OBRA-MODELO-EAP-001-eap.json`**
+   → **ORIGEM OFICIAL** (workspace do OpenWork oficial).
+2. `...\data\eap\OBRA-MODELO-EAP-001-eap-FASE-19.2.json` → versão anterior.
+3. `...\data\OBRA-MODELO-EAP-001.json` → caracterização (resumo).
+4. `...\registro\EAP-ARVORE.md` → árvore textual; declara "Total de nós: 81".
+5. `...\validacao\verifica-eap.mjs` → verificador estrutural oficial (ok:true).
+
+## 8. Candidatos descartados
+LAB `modules/engenharia` (Torres do Vale — 13 nós), workbooks ARES (85 linhas,
+estrutura distinta), catálogos `_eap_models` (propostas), fixtures/mocks — não
+pertencem à obra-modelo do OpenWork oficial.
+
+## 9. EAP oficial localizada
+**SIM** — `...\data\eap\OBRA-MODELO-EAP-001-eap.json`.
+
+## 10. Inventário (resumo)
+obra_id `OBRA-MODELO-EAP-001` · nome "Edifício Residencial Modelo EAP" · status
+**PROPOSTA** · versão **FASE-19.5** · caracterização (resumo): torres 1, lajes 14,
+pilotis, sobresolo, unidades 1, subsolos 0, concreto armado, cobertura prevista.
+## 11. Quantidade de nós
+**81** (confere com a referência).
+
+## 12. Distribuição por tipo
+DISCIPLINA **10** (nível 1) · PACOTE **24** (nível 2) · TRABALHO **47** (nível 3).
+Folhas: 47 · Raízes: 10.
+
+## 13. Estrutura
+`wbs` como identificador hierárquico (`1`, `1.1`, `1.1.1`), `nome`, `nivel`, `tipo`,
+`pai` (referência ao `wbs` pai; null na raiz), `fundamentacao`, `condicao`. Ordem dos
+irmãos = ordem de ocorrência no array (pré-order). Sem campo `ordem` explícito.
+
+## 14. IDs
+Identificador = `wbs` + `obra_id` (sem `eap_id` sequencial). Estratégia de
+preservação na migração: manter `wbs`; mapear explicitamente se o clone exigir id
+adicional — decidir na fase de migração.
+
+## 15. Integridade (verificador oficial executado — somente leitura)
+`node validacao\verifica-eap.mjs` → **ok: true** · 81 WBS únicos/81 nós ·
+nível/tipo consistentes (0 erros) · pais existentes/níveis corretos · sem ciclo ·
+campos obrigatórios presentes. Inventário independente: 0 WBS duplicados, 0 pais
+inexistentes, 0 nós sem pai acima do nível 1.
+
+## 16. Comparação com o clone
+Clone: resumo em seed (`obra-repository.ts`: eap.total 81, raizes 10, pacotes 24,
+trabalhos 47, PROPOSTA) — **coincide exatamente** com a origem. O clone **não
+possui os nós** (apenas o resumo). Sem duplicidade; diferença = destino precisa
+receber os nós na migração.
+
+## 17. Acesso ao agente nativo
+Instalação oficial presente (`Programs\@openworkdesktop`). Para esta descoberta os
+dados foram lidos **diretamente dos arquivos do workspace** (fonte canônica); o
+agente nativo não foi usado (nada alterado). Instalação acessível; agente não
+executado nesta fase.
+
+## 18. Evidências
+- `registro\EAP-ARVORE.md` (Total: 81; árvore completa).
+- `validacao\verifica-eap.mjs` (regras + saída ok:true; 81 únicos).
+- `data\eap\OBRA-MODELO-EAP-001-eap.json` (nós/campos; versão FASE-19.5).
+- Inventário executado: 81 = 10/24/47; 0 duplicados/órfãos/pais inexistentes.
+
+## 19. Limitações
+- `com.differentai.openwork\openwork-workspaces.json` não foi aberto (desnecessário).
+- Arquivo antigo/parcial da EAP no mesmo diretório (FASE-19.2) — fonte canônica =
+  arquivo FASE-19.5 atual (identificar claramente na migração).
+
+## 20. Próximo passo recomendado (NÃO executar nesta fase)
+Fase de migração autorizada: ler `OBRA-MODELO-EAP-001-eap.json` (81 nós) e integrar
+no clone (domínio Engenharia) preservando `wbs`/hierarquia/ordem/campos, com
+validação estrutural automática (81 = 10/24/47; sem órfãos/ciclos).
+
+## Resultado da fase
+- OpenWork oficial encontrado: **SIM** · EAP oficial encontrada: **SIM**
+- Quantidade: **81 nós** · Estrutura: **10 DISCIPLINA / 24 PACOTE / 47 TRABALHO**
+- Localização: `C:\Users\Correta Engenharia\OBRAS-MODELO\OBRA-MODELO-EAP-001\data\eap\OBRA-MODELO-EAP-001-eap.json`
+- Confiança: **CONFIRMADO** · Agente nativo: instalação presente (agente não executado)
+- Código alterado: NÃO · Dados alterados: NÃO
+- Testes: NÃO executados (sem alteração; apenas comandos de leitura/diagnóstico)
+- Git status: sem alterações de código nesta fase
+
+## Veredito
+**LOCALIZADA — AGUARDANDO FASE DE MIGRAÇÃO**
+

--- a/docs/phases/FASE_06_2_B_INTEGRACAO_EAP_OFICIAL.md
+++ b/docs/phases/FASE_06_2_B_INTEGRACAO_EAP_OFICIAL.md
@@ -1,0 +1,82 @@
+# FASE 06.2-B — INTEGRAÇÃO DA EAP OFICIAL (81 NÓS) AO MODELO OPERACIONAL
+
+> **Data:** 2026-09-02 · **Tipo:** implementação + testes + documentação
+> **Status:** CONCLUÍDA
+
+## 1. Objetivo
+Trazer a EAP oficial (81 nós) da Obra Modelo EAP (`OBRA-MODELO-EAP-001`) para o
+clone OpenWork como **modelo de domínio navegável e persistido**, por `obraId`,
+com conceito reutilizável `EapReference`, testes, typecheck/build e documentação
+permanente. **Não** avança para planejamento, Skills, Agents, MCPs, CPM ou Gantt.
+
+## 2. Origem (read-only, proveniência — NÃO modificada)
+`C:\Users\Correta Engenharia\OBRAS-MODELO\OBRA-MODELO-EAP-001\data\eap\OBRA-MODELO-EAP-001-eap.json`
+- Status `PROPOSTA` · Versão `FASE-19.5` · 81 nós = 10 DISCIPLINA / 24 PACOTE / 47
+  TRABALHO · 10 raízes · 47 folhas.
+
+## 3. Decisões arquiteturais
+1. **EAP é modelo de domínio da Obra** — não reutiliza `PlanningItem`.
+2. **Identidade = `obraId` + `wbs`** — mesmo WBS em obras diferentes ≠ mesmo nó.
+3. **Resumo derivado** (`deriveEapSummary`) — nunca fonte independente.
+4. **Persistência por `obraId`** (UI → repository → storage, localStorage); sem
+   banco paralelo, sem segunda fonte de verdade.
+5. **`EapReference` não embute os nós** — referencia por `origemObraId`.
+6. **Migração única forward** — leitura do JSON oficial uma vez em dados
+   estruturados; sem leitura em runtime do arquivo externo.
+7. **Planejamento permanece neutro/anti-hardcode** — não reutilizado para EAP.
+
+## 4. Arquivos criados
+- `obra-eap-types.ts` — `ObraEapNode`, `ObraEapMetadata`, `ObraEap`,
+  `ObraEapSummary`, `EapReference`.
+- `obra-eap-data.ts` — `OBRA_MODELO_EAP_NODES` (81 nós, transcrição integral),
+  `OBRA_MODELO_EAP_METADATA`, `OBRA_MODELO_EAP`, `OBRA_MODELO_EAP_ID`.
+- `obra-eap-repository.ts` — store Zustand + helpers puros (`deriveEapSummary`,
+  `countEapLeaves`, `validateEap`, `buildEapChildrenIndex`, `eapRootWbs`,
+  `deriveEapRows`, `getEapForObra`, `getEapNodesForObra`, `getEapSummaryForObra`,
+  `initializeObraEapRepository`, `resetObraEapRepository`).
+- `obra-eap-storage.ts` — camada localStorage (`openwork.obra-eap.v1`, v1).
+- `obra-eap-reference.ts` — `REF_EAP_RES_001`, `EAP_REFERENCES`,
+  `resolveReferenceNodes`, `findEapReference`.
+- `obra-eap-tree.tsx` — `EapTree` (expandir/recolher/selecionar; WBS, nome, badge
+  de tipo).
+- `tests/obra-eap.test.ts`, `tests/obra-eap-ui.test.tsx` — testes.
+
+## 5. Arquivos modificados
+- `pages/obra-eap.tsx` — reescrito para renderizar a árvore EAP real + resumo
+  derivado + card de detalhes do nó selecionado.
+- `domain.tsx` — adicionado `initializeObraEapRepository()`.
+
+## 6. Validação fonte × destino
+- 81 nós transcritos; 0 WBS duplicados; 0 pais inexistentes; 0 raízes com pai;
+  0 ciclos; 0 nós fora da obra (`validateEap` → ok).
+- Resumo derivado confere com a fonte: 81 = 10/24/47, 10 raízes, 47 folhas.
+
+## 7. Testes executados
+- `bun test tests/obra-eap.test.ts tests/obra-eap-ui.test.tsx` → **24 pass / 0 fail**.
+- Regressão nas áreas tocadas (engenharia + planejamento + navegação) →
+  **84 pass / 0 fail**.
+- Suite completa: 1134 pass / 45 fail — as 45 falhas são **pré-existentes** em
+  `session-sync-permissions.test.ts` e `ui-state-store.test.ts` (arquivos não
+  tocados; passam isolados; falham apenas no run completo por poluição de estado
+  global — problema de isolamento pré-existente, não causado por esta fase).
+
+## 8. Typecheck e build
+- `pnpm --filter @openwork/app typecheck` → **passa** (0 erros).
+- `pnpm --filter @openwork/app build` → **passa** (`✓ built in 1m 8s`).
+
+## 9. Documentação
+- `docs/features/obra-eap-modelo.md` — documento permanente do modelo de domínio
+  EAP (o que/onde/dono/estrutura/identidade/persistência/relações, Obra Modelo
+  EAP, EapReference, EAP operacional vs referência, validação, testes,
+  limitações).
+- Este arquivo — documentação da fase.
+
+## 10. Limitações / fora de escopo
+- Não avança para planejamento, Skills, Agents, MCPs, CPM, Gantt ou LOB.
+- EAP navegável e persistida, mas ainda não alimenta o cronograma.
+- Obra Modelo EAP é referência, não template universal.
+
+## 11. Veredito
+**CONCLUÍDA** — EAP oficial (81 nós) integrada como modelo de domínio navegável e
+persistido, com `EapReference`, testes verdes, typecheck/build ok e documentação
+permanente. FASE 06.2-B encerrada; **não** prosseguir para as fases seguintes.

--- a/docs/phases/FASE_06_3_ENGENHARIA_REVERSA_MODELOS_PLANEJAMENTO.md
+++ b/docs/phases/FASE_06_3_ENGENHARIA_REVERSA_MODELOS_PLANEJAMENTO.md
@@ -1,0 +1,1039 @@
+﻿# FASE 06.3 â€” ENGENHARIA REVERSA DOS MODELOS DE PLANEJAMENTO
+
+> **Data:** 2026-09-09 Â· **Tipo:** inspeÃ§Ã£o â†’ engenharia reversa â†’ comparaÃ§Ã£o â†’ extraÃ§Ã£o de conceitos â†’ decisÃ£o arquitetural (read-only)
+> **Status:** CONCLUÃDA â€” nenhum cÃ³digo do OpenWork foi alterado/criado alÃ©m desta documentaÃ§Ã£o.
+> **Regra da fase respeitada:** EAP existente (81 nÃ³s) NÃƒO recriada; NADA implementado (sem Service, Activity, Scheduler, CPM, Gantt, LOB, Agent, Skill, MCP, banco, rotas ou sidebar).
+
+---
+
+## 1. Objetivo
+
+Estudar os repositÃ³rios de referÃªncia disponÃ­veis localmente e produzir uma anÃ¡lise tÃ©cnica
+fundamentada em cÃ³digo (nÃ£o em READMEs) para decidir **como construir o motor de planejamento
+do OpenWork** sobre um Ãºnico modelo operacional, sem copiar cÃ³digo de terceiros e sem criar
+mÃºltiplas fontes de verdade.
+
+## 2. Escopo
+
+- InspeÃ§Ã£o read-only de 6 referÃªncias locais + contexto interno do OpenWork (EAP existente).
+- Mapeamento de: modelo de dados, hierarquia Ã— precedÃªncia, relaÃ§Ãµes (FS/SS/FF/SF/lag),
+  calendÃ¡rio, scheduling engine, CPM, quantidade/produtividade, baseline/actual, Gantt, LOB,
+  recursos, produÃ§Ã£o e testes.
+- Entrega: este documento + documento de produto (`docs/features/...`, ver Â§24).
+
+## 3. RepositÃ³rios encontrados
+
+| # | Projeto | Caminho local | Branch/commit | Linguagem/Framework | LicenÃ§a | Papel nesta anÃ¡lise |
+|---|---------|---------------|---------------|---------------------|---------|---------------------|
+| 1 | **OpenProject** | `C:\Users\Correta Engenharia\Desktop\OPENWORK-LAB\openproject` | `dev` Â· `e39f977b2d0` (2026-09-02) Â· v17.9.0 | Ruby on Rails + Angular (frontend) | GPLv3 | ReferÃªncia principal de Work Package/relaÃ§Ãµes/scheduling |
+| 2 | **construction-gantt** | `C:\Users\Correta Engenharia\Desktop\Nova pasta (2)\construction-gantt-main` | sem `.git` (snapshot) | TypeScript (pnpm monorepo, vitest) | MIT | Motor CPM + calendÃ¡rio + baseline + MSPDI |
+| 3 | **OpenConstructionERP** | `C:\Users\Correta Engenharia\Desktop\Nova pasta (2)\OpenConstructionERP-main` | sem `.git` (snapshot) Â· v16.5.0 | Python (FastAPI/SQLAlchemy/PostgreSQL) + React/TS/Vite | AGPL-3.0 | ERP de construÃ§Ã£o: QÃ·Produtividade, CPM, leveling, progresso, BOQ |
+| 4 | **GanttReady (NetPlan)** | `C:\Users\Correta Engenharia\Desktop\Nova pasta (2)\GanttReady-main` | sem `.git` (snapshot) | C# .NET 8 Blazor + SQLite (xUnit) | MIT | Gantt + CPM + calendÃ¡rio por projeto + baseline + EV |
+| 5 | **ProjectLibre** | `C:\Users\Correta Engenharia\Desktop\Nova pasta (2)\projectlibre-master` | sem `.git` (snapshot) Â· fork do OpenProj | Java (Swing) | CPAL 1.0 / CPL 1.0 (OpenProj) | Compatibilidade conceitual MS Project (CPM, sentinelas, snapshots) |
+| 6 | **ARES** | `C:\Users\Correta Engenharia\Desktop\obracopilot_excel` | sem Git (congelado 31/08/2026) | Excel nativo (18 abas, `tb*`) + Python FastAPI | **Interno/proprietÃ¡rio** (nÃ£o Ã© open source) | ReferÃªncia interna: serviÃ§o â†’ frente â†’ equipe â†’ produÃ§Ã£o; rede de precedÃªncias; LOB derivada |
+| â€” | **gantts-app** | **NÃƒO encontrado** | â€” | â€” | â€” | Ausente localmente â†’ fora da matriz |
+| â€” | **OpenProject (clone `openproject-dev`)** | `C:\Users\Correta Engenharia\Desktop\openproject-dev` | sem `.git` (snapshot, mesmo conteÃºdo) | Ruby on Rails | GPLv3 | Usado como confirmaÃ§Ã£o de versÃ£o 17.9.0 |
+
+> Registro: nenhum clone/download/instalaÃ§Ã£o foi feito; todos os repositÃ³rios jÃ¡ estavam locais.
+> O `OPENWORK-LAB/openproject` tem Git real (commit `e39f977b2d0`); os demais sÃ£o snapshots de trabalho (sem `.git`),
+> portanto **commits exatos nÃ£o disponÃ­veis** â€” registrado o que existia.
+
+## 4. VersÃµes / commits
+
+- **OpenProject:** branch `dev`, HEAD `e39f977b2d0` (`[COMMS-974] Support observed_in_versions in bulk WP edit`), versÃ£o declarada `17.9.0`.
+- **construction-gantt:** monorepo privado `construction-gantt-monorepo`, pnpm 11.1.2, Node â‰¥ 22 (sem tag no snapshot).
+- **GanttReady:** `.NET 8`, solution `NetPlan.slnx`, migraÃ§Ãµes EF de 2026-05-06 a 2026-06-01.
+- **OpenConstructionERP:** `16.5.0` (pyproject + package.json frontend).
+- **ProjectLibre:** snapshots de arquivo; headers CPAL 2006-2007 (OpenProj origin).
+- **ARES:** congelado â€” hash SHA-256 `95f1e23aâ€¦` da planilha oficial em 28/08/2026; LOB aprovada em WORK final (19 abas).
+
+## 5. LicenÃ§as e uso como referÃªncia
+
+| Projeto | LicenÃ§a | Copiar cÃ³digo? | Copiar estrutura? | RecomendaÃ§Ã£o |
+|---------|---------|----------------|-------------------|--------------|
+| OpenProject | GPLv3 | âŒ (contaminaria produto prÃ³prio; frontend Angular incompatÃ­vel) | âœ… conceitos (models/scheduler) | Estudar e reimplementar |
+| construction-gantt | MIT | âš ï¸ possÃ­vel legalmente, mas **proibido pela polÃ­tica da fase** | âœ… | Estudar e reimplementar |
+| OpenConstructionERP | AGPL-3.0 | âŒ (rede; forte contaminaÃ§Ã£o) | âœ… conceitos de domÃ­nio | Estudar e reimplementar |
+| GanttReady | MIT | âš ï¸ idem | âœ… | Estudar e reimplementar |
+| ProjectLibre | CPAL/CPL | âŒ (atribuiÃ§Ã£o obrigatÃ³ria + logo) | âœ… conceitos | Estudar e reimplementar |
+| ARES | Interno/autoral | âŒ (Ã© nosso, mas a fase Ã© de estudo) | âœ… regras de negÃ³cio como conceito | Absorver regras (QÃ·P, frentes, equipes) |
+
+**DecisÃ£o:** nenhuma linha de cÃ³digo dos repositÃ³rios deve ser copiada no OpenWork. O objetivo Ã©
+ESTUDAR â†’ ENTENDER â†’ EXTRAIR CONCEITOS â†’ REIMPLEMENTAR com arquitetura prÃ³pria.
+
+---
+## 6. Arquitetura de cada referÃªncia (como o software realmente funciona)
+
+### 6.1 OpenProject â€” Work Package como entidade Ãºnica
+
+```
+WorkPackage (tabela work_packages)
+  â”œâ”€â”€ hierarchy: parent_id + closure table work_package_hierarchies (ancestor_id, descendant_id, generations)
+  â”œâ”€â”€ relations: entidade Relation (from_id, to_id, relation_type, lag)
+  â”œâ”€â”€ schedule: SetScheduleService (forward only) â†’ reescreve start_date/due_date/duration
+  â”œâ”€â”€ working days: global (Setting.working_days + NonWorkingDay) OU per-WP ignore_non_working_days
+  â””â”€â”€ Gantt: frontend LE as datas da API (startDate/dueDate) â€” nÃ£o persiste nada
+```
+
+EvidÃªncias:
+- `app/models/work_package.rb`: `belongs_to :project/status/type/assigned_to/responsible`;
+  `include WorkPackage::SchedulingRules`, `WorkPackages::DerivedDates`, `WorkPackages::Relations`;
+  campos `duration`, `done_ratio`, `estimated_hours`, `remaining_hours`, `schedule_manually`,
+  `ignore_non_working_days`, `start_date`, `due_date`, `parent_id`.
+- `app/services/work_packages/update_service.rb` â†’ `reschedule_related` â†’
+  `WorkPackages::SetScheduleService` (chamada quando `start_date`, `due_date`, `parent`,
+  `schedule_manually` mudam).
+- **A fonte da verdade sÃ£o as datas persistidas no WorkPackage**; o scheduler as recalcula e grava de
+  volta (`set_dates` grava `work_package.duration = days.duration(start, due)`).
+
+### 6.2 construction-gantt â€” motor de schedule puro e imutÃ¡vel
+
+```
+Project { start, end?, defaultCalendarId, tasks, links, resources, calendars, baselines, assignments }
+  schedule(project) â†’ Project (nÃ£o muta entrada)
+    1. topologicalSort (Kahn) sobre links (lanÃ§a se ciclo)
+    2. forward pass (ES/EF) + constraints ASAP/ALAP/MSO/MFO/SNET/FNET
+    3. backward pass (LS/LF) + constraints MSO/MFO/SNLT/FNLT
+    4. totalSlack/freeSlack/isCritical (negativo preservado, nÃ£o clipado)
+    5. datas das tarefas auto sÃ£o REESCRITAS em task.start/end; summary sempre derivadas dos filhos
+```
+
+EvidÃªncias: `packages/core/src/schedule.ts`, `topological-sort.ts`, `types.ts`, `analysis.ts`,
+`baseline.ts`, `working-time.ts`, `src/mspdi/` (compatibilidade MSPDI MS Project).
+
+### 6.3 OpenConstructionERP â€” CPM no backend + duraÃ§Ã£o derivada de quantidade
+
+```
+Schedule â†’ Activity (parent_id, wbs_code, â€¦) + ScheduleRelationship (predecessor/successor/type/lag_days)
+  â”œâ”€â”€ core/cpm.py            â†’ CPM puro e stateless em dicts (forward/backward/float), calendar-aware
+  â”œâ”€â”€ schedule_advanced/cpm.py â†’ TaskNetwork/Activity/CPMResult (compute_cpm, critical_path,
+  â”‚                              driving_chain, multiple_float_paths, out-of-sequence CPM, QA)
+  â”œâ”€â”€ leveling.py + resources/resource_engine â†’ resource leveling (serial-greedy; todos os 4 tipos)
+  â”œâ”€â”€ schedule/service.py    â†’ _calc_duration_from_resources (QÂ·labor_hours Ã· crewÂ·hpd â†’ dias)
+  â”œâ”€â”€ schedule/progress_math.py â†’ % fÃ­sico vs duraÃ§Ã£o vs unidades; EVM; suspend/resume
+  â””â”€â”€ Gantt: endpoint get_gantt_data â†’ GanttActivity (id, start, end, duration, progress, dependencies)
+```
+
+EvidÃªncias: `backend/app/modules/schedule/{models,service,progress_math,ordering,schemas}.py`,
+`backend/app/modules/schedule_advanced/{cpm,leveling,delay_engine,delay_service}.py`,
+`backend/app/core/{cpm,calendar}.py`.
+
+### 6.4 GanttReady (NetPlan) â€” CPM persistido + calendÃ¡rio por projeto
+
+```
+Project (WorkDayBits, WorkingHoursPerDay, WorkdaysPerWeek) â†’ TaskItem â†’ TaskRelation (FS/SS/SF/FF + Lag)
+  ScheduleEngine.Calculate â†’ grava ES/EF/LS/LF/TF/FF/IsCritical (INT offset dias) NOS TaskItems (banco)
+  CalendarService â†’ AddWorkingDays(projectId, start, duration) â€” pula feriados do projeto
+  AnalysisService â†’ progress, EV, schedule variance, resource loading, stage completion
+```
+
+EvidÃªncias: `src/GanttReady.Server/{Models, Services/ScheduleEngine.cs, Services/CalendarService.cs}`.
+**AtenÃ§Ã£o:** o GanttReady PERSISTE os resultados CPM no banco (diferente do construction-gantt,
+que deriva em memÃ³ria). Campo `ExtraData` em `TaskItem` guarda flags de delay/estado.
+
+### 6.5 ProjectLibre â€” algoritmo CPM com sentinelas Start/End
+
+```
+Project â†’ CriticalPath implements SchedulingAlgorithm
+  startSentinel (<Start>, dur 0) e finishSentinel (<End>) conectam nÃ³s sem pred/succ
+  forward/backward via PredecessorTaskTree + TaskSchedule (CURRENT/EARLY/LATE)
+  DependencyType: FS=1 (default), SS=3, FF=0, SF=2; lag em minutos via WorkCalendar
+  snapshot/DataSnapshot + BaselineScheduleFields (getBaselineStart(numBaseline)â€¦) â†’ mÃºltiplos baselines
+```
+
+EvidÃªncias: `openproj_core/src/com/projity/pm/criticalpath/{CriticalPath,SchedulingAlgorithm,ScheduleWindow,TaskSchedule}.java`,
+`dependency/DependencyType.java`, `scheduling/SchedulingRule.java` (FixedUnits/FixedWork/FixedDuration),
+`snapshot/BaselineScheduleFields.java`.
+
+### 6.6 ARES â€” planilha como fonte + regras de rede + LOB derivada
+
+```
+Excel (tbPlanejamento=datas/status/%real Â· tbPlanejamentoLegado Â· tbRede=18 elos Â· tbServicos Â· tbEAP Â·
+       tbFrentes Â· tbEquipes Â· tbProducao Â· tbMedicao Â· tbRecursos)
+  â”œâ”€â”€ gerar_rede_precedencias.py â†’ R1 (precedente explÃ­cito), R6 (mesma equipe), FS+lag(dias),
+  â”‚                                 substituiÃ§Ã£o formal no replanejamento, detecÃ§Ã£o de ciclo (DFS)
+  â””â”€â”€ LOB (construir_aba_lob_v5) â†’ VISTA DERIVADA com 0 dados independentes (fÃ³rmulas sobre o legado/CADASTRO)
+```
+
+EvidÃªncias: `ARES_REDE_precedencias.csv`, `docs/ARCHITECTURE_CURRENT_STATE.md`,
+`obracopilot-addin/backend/gerar_rede_precedencias.py` e `construir_aba_lob_v5.py`.
+
+---
+## 7. Modelo de dados â€” o que cada um persiste
+
+### 7.1 OpenProject (tabelas, inferidas de models + API representers)
+- `work_packages`: `id, subject, description, project_id, type_id, status_id, priority_id, author_id,
+  assigned_to_id, responsible_id, parent_id, start_date, due_date, duration, done_ratio,
+  estimated_hours, remaining_hours, schedule_manually, ignore_non_working_days, lock_version`
+  (+ journals/histÃ³rico de versÃ£o).
+- `relations`: `from_id, to_id, relation_type, lag, description`; unique `(from, to)`; lag Â±2000.
+- `work_package_hierarchies` (closure tree): `ancestor_id, descendant_id, generations`.
+- `non_working_days` (global): `date, name` Â· dias Ãºteis da semana: `Setting.working_days` (ISO 1â€“7).
+- `status` (workflow) Â· `types` (incl. `is_milestone`) Â· `ordered_work_packages`.
+
+### 7.2 construction-gantt (tipos TS, em memÃ³ria)
+- `Task { id, text, parent?, type: task|summary|milestone, scheduleMode: auto|manual, duration
+  (min trabalhado), start, end, progress, constraint?, resourceIds?, calendarId?, computed? }`
+- `Link { id, source, target, type: FS|SS|FF|SF, lag (min trabalhado) }`
+- `Calendar { id, name, workWeek: WorkInterval[][], exceptions[], baseCalendarId? }`
+- `Resource` Â· `Assignment { units }` Â· `Baseline { index 0..10, tasks: Map<snapshot> }` Â· `Project`.
+
+### 7.3 OpenConstructionERP (tabelas `oe_schedule_*`)
+- `Activity`: `schedule_id, parent_id, wbs_code, start_date, end_date, duration_days, progress_pct,
+  status, activity_type, dependencies (JSON), resources (JSON), boq_position_ids (JSON),
+  early_start/finish, late_start/finish, total_float, free_float, is_critical, constraint_type/date,
+  activity_code, bim_element_ids, cost_planned/actual, percent_complete_type, remaining_duration,
+  budgeted_units, installed_units, calendar_id, revisionâ€¦`
+- `ScheduleRelationship`: `schedule_id, predecessor_id, successor_id, relationship_type (FS/FF/SS/SF),
+  lag_days, metadata` â€” unique `(predecessor, successor)`.
+- `WorkOrder`: `activity_id, assembly_id, boq_position_id, code, assigned_to, planned/actual start/end,
+  planned_cost, actual_cost, status` â€” **ordem de serviÃ§o/execuÃ§Ã£o no campo**.
+- `Schedule`: `project_id, schedule_type, start/end, status (draftâ€¦), data_date`.
+
+### 7.4 GanttReady (EF Core/SQLite)
+- `TaskItem`: `Code, Name, ParentTaskId, OutlineLevel, PlanStartDate, PlanEndDate, PlanDuration,
+  ActualStartDate, ActualEndDate, ActualDuration, CompletionPercentage, BudgetCost, ActualCost,
+  IsMilestone, IsManualSchedule, EarlyStart/Finish, LateStart/Finish, TotalFloat, FreeFloat,
+  IsCritical (persistidos!), ExtraData (JSON), ResponsiblePerson`.
+- `TaskRelation`: `PredecessorTaskId, SuccessorTaskId, Type (enum FS/SS/SF/FF), Lag (dias, negativo ok)`.
+- `Project`: `PlanStartDate/End, ActualStartDate/End, WorkingHoursPerDay=8, WorkdaysPerWeek=5,
+  WorkDayBits=0b00111110` Â· `ProjectHoliday` Â· `Baseline (Number 1..5, Name)` + `BaselineTask`.
+- `Resource`: compartilhado (ProjectId null) ou por projeto; `Unit, Quantity, UnitPrice, HourlyCost, Type`.
+
+### 7.5 ProjectLibre (Java)
+- `Task`/`NormalTask`: start/finish, duration, percent complete, constraint type/date, schedules
+  (`TaskSchedule` CURRENT/EARLY/LATE), baselines `getBaselineStart(numBaseline)â€¦`.
+- `Dependency`: tipo (FS/SS/FF/SF) + defasagem (via calendÃ¡rio de trabalho, minutos).
+- `Assignment`/`Allocation`: units/duration/work com `SchedulingRule` (FixedUnits/FixedWork/FixedDuration).
+- `Project`/`Resourcing`/`Costing`: EVM e custos calculados a partir de allocations.
+
+### 7.6 ARES (planilha)
+- `tbPlanejamento` (novo, 21â€“31 atividades ativas `PLAN-*` com EQUIPE, INÃCIO, FIM, PREDECESSORA_ID,
+  STATUS) + `tbPlanejamentoLegado` (15 atividades reais com INÃCIO/FIM/STATUS/%REAL);
+- `tbRede` (18 elos: `ID ELO; PREDECESSORA; SUCESSORA; TIPO DE RELAÃ‡ÃƒO; DEFASAGEM; ORIGEM DA REGRA; LÃ“GICA`);
+- `tbServicos` (`SERVICO-*` â†’ EAP, FRENTE, LOCAL, UNIDADE) Â· `tbEAP` (WBS, nome, tipo, pai, nÃ­vel) Â·
+  `tbFrentes`/`tbEquipes` Â· `tbProducao`/`tbMedicao` Â· `tbRecursos`/`tbEquipeRecursos`/`tbServicoRecursos`.
+
+---
+## 8. Hierarquia (resp. Ã s questÃµes 4.1â€“4.5)
+
+### 4.1 A hierarquia Ã© a mesma coisa que dependÃªncia?
+**NÃƒO â€” em todos os 6 sistemas.** Mecanismos separados:
+- OpenProject: hierarquia = `parent_id` + closure `work_package_hierarchies`; dependÃªncia = `Relation`.
+  O comentÃ¡rio em `relation.rb` Ã© explÃ­cito: *"The parent/child relation is maintained separately (in
+  WorkPackage and WorkPackageHierarchy) and a relation cannot have the type 'parent'"*.
+- construction-gantt: `parent` (Task) vs `Link`; `topological-sort.ts` afirma que a hierarquia **nÃ£o**
+  participa da ordenaÃ§Ã£o â€” sÃ³ `links`.
+- OpenConstructionERP: `Activity.parent_id` vs `ScheduleRelationship`.
+- GanttReady: `ParentTaskId`/`OutlineLevel` vs `TaskRelation`.
+- ProjectLibre: `ForParent/ForAllChildren` vs `Dependency`; CPM usa sentinelas sobre dependÃªncias.
+- ARES: `tbEAP` (pai/nÃ­vel) e `tbRede` (elos) sÃ£o tabelas distintas; as regras R3/R4/R5 (hierarquia de
+  pavimentos) foram **desativadas** justamente para nÃ£o confundir estrutura com precedÃªncia.
+
+### 4.2 Um item pode ter pai, filhos, predecessores e sucessores simultaneamente?
+**SIM â€” em todos:**
+- OpenProject: `parent_id` (1 pai), mÃºltiplos filhos (closure), `follows_relations` (pred) e
+  `precedes_relations` (succ) â€” `app/models/work_packages/relations.rb`.
+- construction-gantt: `Task.parent` + `Link.source/target` sem exclusividade mÃºtua.
+- Demais sistemas: idem (campos `parent_id` + tabelas de relaÃ§Ã£o separadas).
+- Ressalva real: no **scheduler**, o grafo de datas usa apenas relaÃ§Ãµes `follows`/`links`; a hierarquia
+  entra depois para **derivar datas de resumo** (summary aggregation), nÃ£o para precedÃªncia.
+
+### 4.3 Como separar HIERARQUIA de RELAÃ‡ÃƒO DE PRECEDÃŠNCIA?
+- RepresentaÃ§Ãµes separadas em todos (FK `parent_id`/closure/`parent` vs `Relation`/`Link`/`Relationship`).
+- OpenProject `used_for_scheduling_of`: relaÃ§Ã£o de ancestral **automÃ¡tico** vale para o descendente;
+  pai **manual corta a corrente**. Hierarquia nunca vira precedÃªncia; define agregados e datas derivadas.
+- construction-gantt (`schedule.ts`): summary = `min(child earlyStart)` / `max(child earlyFinish)` â€”
+  agrega, nunca ordena.
+
+### 4.4 Um item da EAP Ã© necessariamente uma atividade de planejamento?
+**NÃƒO.**
+- No OpenWork, `ObraEapNode { obraId, wbs, nome, nivel, tipo (DISCIPLINA|PACOTE|TRABALHO), pai, ordem,
+  fundamentacao, condicao }` â€” **sem datas/duraÃ§Ã£o/relaÃ§Ãµes/progresso**.
+- A prÃ³pria referÃªncia interna adota o princÃ­pio **"separacao_eap_do_cronograma"** (WBS â‰  cronograma).
+- Nos sistemas de referÃªncia, o nÃ³ estrutural (summary/work package/outline) sÃ³ agrega; nunca Ã© o nÃ³
+  agendÃ¡vel por si (milestone Ã© um tipo de tarefa, nÃ£o um nÃ³ de EAP).
+- A EAP garante o **WBS de rastreabilidade** (`wbs_code`/`OutlineNumber`/`WBS` MSPDI), nÃ£o o cronograma.
+
+### 4.5 MELHOR SEPARAÃ‡ÃƒO CONCEITUAL PARA O OPENWORK (recomendada â€” ver Â§20)
+```
+EAP (estrutura, sem tempo) â†’ ServiÃ§o (escopo executÃ¡vel, qtd/unidade) â†’ Atividade (nÃ³ agendÃ¡vel)
+RelaÃ§Ãµes (FS/SS/FF/SF+lag) entre Atividades â†’ CalendÃ¡rio por obra (dias Ãºteis) â†’ Scheduling (derivado)
+```
+Hierarquia restrita a: (a) EAP (estrutural) e (b) Atividadeâ†’subatividade (agregaÃ§Ã£o p/ resumo);
+precedÃªncia fica **exclusivamente** nas RelaÃ§Ãµes. Datas armazenadas = saÃ­da do scheduler.
+
+---
+## 9. RelaÃ§Ãµes (com exemplos concretos no cÃ³digo)
+
+### 9.1 RepresentaÃ§Ãµes encontradas
+| Sistema | Entidade | Tipos | Lag | ValidaÃ§Ã£o |
+|---------|----------|-------|-----|-----------|
+| OpenProject | `Relation` | `precedes/follows` (scheduling) + `relates, blocks, duplicated, partof, requires` | `lag` int Â±2000 (**dias Ãºteis** entre pred-fim e succ-inÃ­cio) | unique `(to,from)`; `reverse_if_needed` |
+| construction-gantt | `Link` | `FS/SS/FF/SF` | `lag` **min trab.** (pos=delay, neg=lead) | topo sort lanÃ§a em ciclo |
+| OpenConstructionERP | `ScheduleRelationship` | `FS/FF/SS/SF` | `lag_days` int (neg=lead) | unique `(pred,succ)` |
+| GanttReady | `TaskRelation` | enum `FS/SS/SF/FF` | `Lag` int dias (neg ok) | â€” |
+| ProjectLibre | `Dependency` | `FS=1 (default), SS=3, FF=0, SF=2` | defasagem via calendÃ¡rio (min) | â€” |
+| ARES | `tbRede` | FS (Ãºnico usado) | `DEFASAGEM` dias | R10 ciclo (DFS) |
+
+### 9.2 DireÃ§Ã£o da relaÃ§Ã£o
+- OpenProject usa convenÃ§Ã£o invertida: `from`=sucessor, `to`=predecessor
+  (`def predecessor = to; def successor = from`) e forÃ§a a forma canÃ´nica `follows`.
+- Demais sistemas: natural `predecessor â†’ successor` (sourceâ†’target).
+- **RecomendaÃ§Ã£o OpenWork:** `predecessor_id â†’ successor_id` (natural, maioria), com tipo gravado
+  sempre na forma canÃ´nica (gravar "FS"; derivar o espelho ao exibir).
+
+### 9.3 FÃ³rmulas reais (forward/backward) â€” evidÃªncia `schedule_advanced/cpm.py` e `ScheduleEngine.cs`
+```
+Forward (ES do sucessor s, com predecessor p e duraÃ§Ã£o d de s):
+  FS: s.ES >= p.EF + lag
+  SS: s.ES >= p.ES + lag
+  FF: s.EF >= p.EF + lag  â†’ ES-bound: s.ES >= p.EF + lag - d
+  SF: s.EF >= p.ES + lag  â†’ ES-bound: s.ES >= p.ES + lag - d
+Backward (LF do predecessor p, com sucessor s e duraÃ§Ã£o d de p):
+  FS: p.LF = s.LS - lag
+  SS: p.LF = s.LS - lag + d
+  FF: p.LF = s.LF - lag
+  SF: p.LF = s.LF - lag + d
+Float: TF = LS - ES (= LF - EF); FF = min(ajustes dos sucessores); isCritical = TF <= 0.
+```
+
+### 9.4 Ciclos / mÃºltiplas relaÃ§Ãµes / hierarquiaÃ—dependÃªncia
+- Ciclos: GanttReady lanÃ§a `InvalidOperationException` listando os nÃ³s; OpenConstructionERP `CycleError`;
+  construction-gantt `topologicalSort` lanÃ§a; OpenProject `DependencyGraph` Ã© iterativo (regressÃ£o
+  #43894 de stack overflow); ARES R10 com DFS.
+- MÃºltiplas relaÃ§Ãµes: permitidas em todos; unique por par Ã© o guarda (OpenProject/OpenConstructionERP).
+- HierarquiaÃ—dependÃªncia: independentes (Â§8). OpenProject propaga relaÃ§Ãµes de ancestrais automÃ¡ticos
+  para descendentes (`used_for_scheduling_of`) e o pai manual corta a cadeia.
+- Casos cobertos em testes: diamond convergence, mÃºltiplos caminhos, SS ties, lag +/-, milestone FF.
+
+---
+## 10. CalendÃ¡rio
+
+### 10.1 Como cada sistema representa
+| Sistema | Entidade/arquivo | Granularidade | Semana | Feriados/exceÃ§Ãµes | Por projeto | Por recurso | Por tarefa |
+|---------|------------------|---------------|--------|-------------------|-------------|-------------|------------|
+| OpenProject | `WeekDay`, `NonWorkingDay`, `Shared::WorkingDays` | **dia** (sem horas) | `WeekDay(day 1..7, working bool)` global | `NonWorkingDay(date)` global | âŒ (global Ã  instÃ¢ncia) | âŒ | parcial: `ignore_non_working_days` por WP |
+| construction-gantt | `Calendar { workWeek: WorkInterval[][], exceptions[], baseCalendarId }` | **minuto** (turnos parciais) | 7 arrays de `WorkInterval{startMinute,endMinute}` | `CalendarException{date,isWorking,intervals,name}` | `project.defaultCalendarId` | `Resource.calendarId` | `Task.calendarId` |
+| GanttReady | `CalendarService`, `Project.WorkOnSaturday/Sunday`, `ProjectHoliday` | **dia** (offset inteiro) | flags de sÃ¡b/dom no projeto | `ProjectHoliday(Date, Name)` por projeto | âœ… | âŒ | âŒ |
+| OpenConstructionERP | `core/calendar.py` (paÃ­s) + `WORK_CALENDARS` (regiÃ£o) | **dia** + `hours_per_day` | `work_days: {0..4}` ou `{0..5}` | `resolve_holidays(country, year)` com proveniÃªncia (Easter, Hijri, equinÃ³cios) | por `project.region` (sÃ³ na geraÃ§Ã£o via BOQ) | âŒ | âŒ |
+| ProjectLibre | `WorkingCalendar`, `WorkWeek`, `WorkDay`, `WorkingHours`, `CalendarCatalog` | **milissegundo/turno** | `WorkWeek` + `DayDescriptor` | `CalendarException` via `CalendarDefinition.differences` | âœ… (`HasCalendar`) | âœ… (`HasBaseCalendar`, heranÃ§a baseâ†’derivado) | âœ… |
+| ARES | `CADASTRO!B13/B14` + datas manuais | dia | â€” (implÃ­cito) | â€” | âœ… (datas da obra) | âŒ | âŒ |
+
+### 10.2 `data + duraÃ§Ã£o` e `data âˆ’ duraÃ§Ã£o` sobre dias nÃ£o Ãºteis
+
+**OpenProject** (`WorkPackages::Shared::WorkingDays`): `add_days(date, count)` avanÃ§a dia a dia pulando
+nÃ£o Ãºteis; `soonest_working_day(date)` empurra para frente; `duration(start, due)` conta dias Ãºteis
+**inclusivos** nas duas pontas. `start_date`/`due_date` sÃ£o datas inclusivas (`duration=1` â‡’ start==due).
+NÃ£o hÃ¡ hora nem timezone no cÃ¡lculo. Existe `Shared::Days` (modo "todos os dias"), escolhido por
+`ignore_non_working_days` por WP â€” **o modo de calendÃ¡rio Ã© atributo da tarefa**.
+
+**construction-gantt** (`working-time.ts`): 7 funÃ§Ãµes puras â€” `isWorkingDay`, `getDayWorkingMinutes`,
+`addWorkingMinutes`, `subtractWorkingMinutes`, `snapToNextWorkingMoment`,
+`snapToPreviousWorkingMoment`, `workingMinutesBetween`. DuraÃ§Ã£o Ã© **minutos de trabalho**;
+`fim = addWorkingMinutes(inÃ­cio, duration, calendar)` consome turnos parciais e pula noites/fins de
+semana/exceÃ§Ãµes. `snapTo*` resolve data em momento nÃ£o Ãºtil.
+
+**GanttReady** (`ScheduleEngine` + `CalendarService`): o motor trabalha em **offsets inteiros de dias
+Ãºteis** (`EarlyStart=0` no dia zero) e sÃ³ no fim converte offsetâ†’data real via `CalendarService`
+(pula sÃ¡b/dom/feriados). **CPM em espaÃ§o adimensional, calendÃ¡rio aplicado sÃ³ na materializaÃ§Ã£o.**
+
+**OpenConstructionERP**: `_working_days_between` Ã© **exclusivo do inÃ­cio, inclusivo do fim**
+(convenÃ§Ã£o documentada, replicada em `progress_math.WorkCalendar.working_days_between` para que
+progresso e CPM concordem). Feriados vÃªm de `core/calendar.py` com proveniÃªncia
+(`declared`/`fell_back`/`unavailable`).
+
+**ProjectLibre**: `WorkingCalendar.add(date, duration, useSooner)` e `compare(later, earlier, elapsed)`
+delegam ao `CalendarDefinition` concreto (base+diferenÃ§as). Milissegundos de trabalho; suporta
+`elapsed` (duraÃ§Ã£o corrida, ignora calendÃ¡rio).
+
+### 10.3 Achados crÃ­ticos para o OpenWork
+1. **Inclusividade Ã© decisÃ£o que precisa ser Ãºnica.** OpenProject conta duas pontas inclusivas;
+   OpenConstructionERP Ã© exclusivo-inÃ­cio/inclusivo-fim. Misturar gera erro de Â±1 dia sistemÃ¡tico.
+2. **Dia Ã— minuto.** OpenProject e GanttReady sÃ£o "dia inteiro" (sem timezone) â€” simples e suficiente
+## 11. Scheduling Engine
+
+### 11.1 Pipeline observado em cada motor
+
+**OpenProject** â€” `WorkPackages::SetScheduleService` (nÃ£o Ã© CPM):
+```
+INPUT: WP alterado (dates/parent/relations)
+  â†“ ScheduleDependency (monta grafo: sucessores + ancestrais + descendentes)
+  â†“ DependencyGraph (iterativo p/ evitar stack overflow â€” #43894)
+  â†“ para cada dependente "automatic": reschedule!
+  â†“   soonest_start = max(predecessor.due_date + lag) via Relations::UsedForSchedulingOf
+  â†“   WorkingDays.add_days / soonest_working_day
+  â†“ pais automÃ¡ticos: derived_start/due = min/max dos filhos (DerivedDates)
+OUTPUT: novas start_date/due_date persistidas no WP
+```
+Motor **incremental/reativo de forward-only**: empurra sucessores para frente, **nunca puxa para
+trÃ¡s**, **nÃ£o calcula LS/LF/float**, **nÃ£o hÃ¡ caminho crÃ­tico**. `schedule_manually=true` congela o
+WP e **corta a propagaÃ§Ã£o** naquele ramo (`for_scheduling` scope).
+
+**construction-gantt** â€” `schedule(project): Project` (CPM completo, funÃ§Ã£o pura):
+```
+topologicalSort(tasks, links)                 â†’ lanÃ§a em ciclo
+  â†“ Forward pass (folhas): ES = max(bound de cada link) âˆ¨ projectFloor
+  â†“   applyForwardConstraint (ASAP/MSO/MFO/SNET/FNET)
+  â†“ Summaries bottom-up: ES=min(filhos), EF=max(filhos) [aggregateFromChildren]
+  â†“ Backward pass: LF/LS + applyBackwardConstraint (MSO/MFO/SNLT/FNLT)
+  â†“ Summaries bottom-up backward [aggregateBackwardFromChildren]
+  â†“ totalSlack = workingMinutesBetween(ES, LS); freeSlack = computeFreeSlack(...)
+  â†“ isCritical = totalSlack <= 0     [ADR-003: NÃƒO clipa slack negativo]
+OUTPUT: task.computed (ES/EF/LS/LF/slack) + start/end reescritos p/ tarefas 'auto'
+```
+`scheduleMode:'manual'` â†’ datas do usuÃ¡rio autoritativas; motor **ainda assim** popula `forwardById`
+para o backward pass calcular folga contra a rede. FunÃ§Ã£o **pura** (`Projectâ†’Project`), sem I/O/ORM.
+
+**GanttReady** â€” `ScheduleEngine.Calculate(tasks, relations, startDate) -> int projectDuration`:
+```
+ordenaÃ§Ã£o topolÃ³gica (exceÃ§Ã£o se ciclo, listando nÃ³s)
+  â†“ CalculateEarlyTimes (ES/EF em offsets de dias, 4 tipos + lag, respeita IsManualSchedule)
+  â†“ projectDuration = max(EF)
+  â†“ CalculateLateTimes (LS/LF; sink â†’ LF = projectDuration)
+  â†“ CalculateFloat (TotalFloat = LSâˆ’ES; FreeFloat via sucessores)
+  â†“ IsCritical
+  â†“ CalendarService: offset â†’ data real (pula sÃ¡b/dom/feriados)
+```
+
+**OpenConstructionERP** â€” dois motores separados:
+- `modules/schedule/service.py`: CRUD + Gantt + duraÃ§Ã£o a partir de BOQ; **persiste** `start_date`/`end_date`.
+- `modules/schedule_advanced/cpm.py`: CPM real e derivado, com refinamentos que os outros nÃ£o tÃªm â€”
+  **union-find de componentes fracamente conexos** (cada "ilha" ancora seu prÃ³prio `project_finish`,
+  evitando sink global falso), `driving_predecessor`/`driving_chain`/`longest_path` (caminho
+  **dirigente** por forward pass, correto mesmo quando calendÃ¡rios/constraints fazem o conjunto por
+  float discordar), desempate determinÃ­stico por `(topo_rank, str(id))`.
+
+## 12. CPM
+
+### 12.1 Onde o CPM vive em cada sistema
+| Sistema | CPM Ã©â€¦ | Persistido? | EvidÃªncia |
+|---------|--------|-------------|-----------|
+| OpenProject | **inexistente** | â€” | nÃ£o hÃ¡ LS/LF/float em `work_package.rb` nem em serviÃ§os |
+| construction-gantt | **parte do scheduler** (`schedule.ts`) | nÃ£o (em `task.computed`, memÃ³ria) | `TaskComputed{earlyStart,earlyFinish,lateStart,lateFinish,totalSlack,freeSlack}` |
+| GanttReady | **parte do scheduler** (`ScheduleEngine`) | **sim** (campos em `TaskItem`) | `EarlyStart/EarlyFinish/LateStart/LateFinish/TotalFloat/IsCritical` |
+| OpenConstructionERP | **mÃ³dulo separado derivado** (`schedule_advanced/cpm.py`) | nÃ£o (calculado sob demanda) | `CPMResult`, `longest_path`, `portfolio_cpm.py` |
+| ProjectLibre | **parte do modelo vivo** (`CriticalPath` + `TaskSchedule`) | sim, em memÃ³ria no documento | `pm/criticalpath/*` |
+| ARES | **nÃ£o existe** (rede sem CPM) | â€” | `tbRede` sÃ³ armazena elos; `gerar_rede_precedencias.py` sÃ³ detecta ciclo |
+
+### 12.2 FÃ³rmulas de float encontradas
+```
+TotalFloat = LS âˆ’ ES  (= LF âˆ’ EF)        [GanttReady, cpm.py, construction-gantt]
+FreeFloat  = min sobre sucessores do "quanto posso atrasar sem empurrar o ES do sucessor"
+             â€” em cpm.py e computeFreeSlack() calculado por tipo de link (FS/SS/FF/SF)
+             â€” para sink: folga atÃ© o finish do prÃ³prio componente
+isCritical = TotalFloat <= 0             [<= 0, nÃ£o == 0, para capturar float negativo]
+```
+- **construction-gantt ADR-003:** float negativo Ã© **preservado, nunca zerado** â€” sinal de cronograma
+  inviÃ¡vel contra restriÃ§Ã£o a jusante. **Conceito a adotar.**
+- **OpenConstructionERP `longest_path`:** o caminho crÃ­tico "por float" pode ser enganoso com
+  calendÃ¡rios/constraints mÃºltiplos; o **Longest Path** derivado do forward pass Ã© mais confiÃ¡vel.
+  **Conceito a adotar.**
+
+### 12.3 Casos de borda tratados
+| Caso | Quem trata | Como |
+|------|-----------|------|
+| Ciclo | CG, GR, OCE, ARES | exceÃ§Ã£o na ordenaÃ§Ã£o topolÃ³gica / `CycleError` / DFS 3-cores |
+| NÃ³ desconectado / ilha | **sÃ³ OpenConstructionERP** | union-find â†’ `component_finish` por ilha (evita float inflado) |
+| Sem predecessor | todos | ES = inÃ­cio do projeto (`projectFloor`) |
+| MÃºltiplos predecessores | todos | `max` dos bounds no forward, `min` no backward |
+| Empate entre caminhos | **sÃ³ OpenConstructionERP** | desempate determinÃ­stico `(topo_rank, str(id))` |
+| DuraÃ§Ã£o zero / milestone | CG (`type:'milestone'`, duration 0), PL (sentinelas) | â€” |
+| Tarefa manual | CG, GR, PL | mantÃ©m datas do usuÃ¡rio, permanece na rede |
+
+### 12.4 DecisÃ£o para o OpenWork
+## 13. Quantidade e produtividade (Q Ã· Produtividade = DuraÃ§Ã£o)
+
+### 13.1 Quem realmente implementa
+| Sistema | Implementa? | Onde | FÃ³rmula real |
+|---------|-------------|------|--------------|
+| OpenProject | âŒ | â€” | nÃ£o existe quantidade/unidade/produtividade no WP |
+| construction-gantt | âŒ | â€” | `duration` Ã© minuto de trabalho, informado |
+| GanttReady | âŒ | â€” | `PlanDuration` em dias, informado |
+| **OpenConstructionERP** | âœ… **Ãºnico com cadeia completa** | `schedule/service.py` (`compute_duration`, `estimate_fallback_duration_days`, `_FALLBACK_PRODUCTION_RATES`) | ver 13.2 |
+| ProjectLibre | parcial (work/units/duration) | `pm/assignment/*` | `Work = Duration Ã— Units` (modelo MS Project, nÃ£o produtividade de obra) |
+| ARES | âœ… conceitualmente | `tbServicos` (unidade), `tbProducao`, `tbMedicao` | quantidade Ã— unidade por serviÃ§o/frente/equipe; duraÃ§Ã£o **digitada**, nÃ£o derivada |
+
+### 13.2 Cascata de derivaÃ§Ã£o de duraÃ§Ã£o do OpenConstructionERP (`compute_duration`)
+```
+Try 1: labor_hours explÃ­cito da posiÃ§Ã£o BOQ      â†’ dias = labor_hours / (hours_per_day Ã— crew)
+Try 2: recursos alocados                          â†’ soma horas dos recursos
+Try 3: fallback por unidade (_FALLBACK_PRODUCTION_RATES: labor-hours por 1 unidade, por unidade
+       BOQ normalizada â€” mÂ³, mÂ², m, kg, unâ€¦)      â†’ estimate_fallback_duration_days(unit, qty, h/dia)
+       marca metadata duration_source="estimated_fallback"
+Try 4: proporcional ao custo                      â†’ round(total_cost/grand_total Ã— total_days),
+       duration_source="cost_proportional"
+SenÃ£o: 3 dias, duration_source="default_minimum"
+sempre: max(1, â€¦) â€” nunca duraÃ§Ã£o zero
+```
+- **PadrÃ£o excelente e diretamente aproveitÃ¡vel:** cada duraÃ§Ã£o carrega a **proveniÃªncia**
+  (`duration_source`) de como foi obtida. O planejador vÃª o que Ã© dado real e o que Ã© chute.
+- `hours_per_day` vem do `WORK_CALENDARS` da regiÃ£o; `crew` (equipe) divide as horas.
+
+### 13.3 Progresso por quantidade (`progress_math.py`) â€” o elo Q â†’ avanÃ§o
+TrÃªs **tipos de percent-complete**, decisÃ£o de modelagem madura:
+```
+duration : RD = round(OD Ã— (1 âˆ’ pct/100))            â†’ o percentual Ã© a fonte da verdade
+units    : pct = clamp(100 Ã— instalada / orÃ§ada)     â†’ o percentual Ã© DERIVADO da quantidade  â˜…
+physical : pct e RD divergem legitimamente; pct = roll-up ponderado de steps
+```
+- â˜… Ã‰ exatamente o modelo que a obra precisa: **quantidade executada â†’ % â†’ avanÃ§o**, nÃ£o o inverso.
+- `Decimal` fim-a-fim para dinheiro (nunca `float`); **nenhuma leitura de relÃ³gio** (`data_date` sempre
+  injetada) â‡’ 100% determinÃ­stico e testÃ¡vel; freeze de remaining-duration em suspensÃ£o; avisos
+  determinÃ­sticos de distorÃ§Ã£o de EVM; PV time-phased. ConvenÃ§Ã£o de contagem alinhada ao CPM.
+
+### 13.4 Arredondamento, equipe e mÃºltiplos recursos
+- **Arredondamento:** OCE usa `max(1, round(...))` â€” nunca zero, sempre inteiro de dias.
+  `progress_math` usa `ROUND_HALF_UP` com quanta explÃ­citos (`0.01` dinheiro, `0.001` percentual).
+- **Equipe:** entra como divisor de horas (`crew`), nÃ£o como recurso nomeado no cÃ¡lculo de duraÃ§Ã£o.
+- **MÃºltiplos recursos:** OCE soma horas; ProjectLibre usa `units` por atribuiÃ§Ã£o; construction-gantt
+  guarda `Assignment{taskId, resourceId, units}` sem usar no cÃ¡lculo.
+- **Produtividade variÃ¡vel:** **nenhum** sistema modela produtividade que varia ao longo do tempo ou
+  por local/pavimento. â†’ **lacuna do estado da arte; oportunidade real do OpenWork** (ver Â§28/Â§29).
+
+### 13.5 O que o OpenWork deve extrair
+1. `DuraÃ§Ã£o = Quantidade Ã· (Produtividade Ã— Equipe)`, com **`duration_source` obrigatÃ³rio** em cada
+   atividade (medida / composiÃ§Ã£o / histÃ³rico / estimada / manual).
+2. DuraÃ§Ã£o **derivada por padrÃ£o, sobrescrevÃ­vel manualmente** â€” e o override deve ser visÃ­vel.
+## 14. Baseline e planejado Ã— real
+
+### 14.1 Como cada sistema trata
+| Sistema | Baseline | Planned | Actual | VariÃ¢ncia |
+|---------|----------|---------|--------|-----------|
+| OpenProject | âŒ (sÃ³ derived_dates) | start/due do WP | TimeEntry (horas) | â€” |
+| **construction-gantt** | âœ… `Baseline{index 0-10, name, capturedAt, tasks:Map<id,Snapshot{start,end,duration}>}` | `task.start/end` + `task.computed` | `progress 0-100` | `getTaskBaselineVariance` |
+| GanttReady | âœ… `Baseline.cs` (nome, captura) | `TaskItem.Plan*` | `TaskItem.Actual*`/`Complete` | `AnalysisService` |
+| OpenConstructionERP | âŒ (nÃ£o mapeado) | `start_date/end_date` (persistido) | â€” (via `progress_math`) | â€” |
+| **ProjectLibre** | âœ… `BaselineScheduleFields` (start/finish/duration por baseline#) | early dates | â€” | â€” |
+| ARES | implÃ­cito (planejamento legado congelado) | `tbPlanejamento` | `tbProducao`/`tbMedicao` | `tbIndicadores` |
+
+### 14.2 Detalhes dignos de nota
+
+**construction-gantt** (`baseline.ts`, `baseline.test.ts`):
+- `captureBaseline(project, index, {name})` â†’ snapshot imutÃ¡vel de `start/end/duration` por tarefa em
+  `project.baselines[index]` (sobrescreve se jÃ¡ existir, preservando os demais Ã­ndices).
+- `getTaskBaselineVariance(project, task, index)` â†’ `{start, end, duration}` = planejadoâˆ’baseline;
+  `getTaskBaselineVarianceAll(project, index)` â†’ todas as tarefas de uma vez.
+- **11 baselines** (0â€“10), igual MS Project; `capturedAt` Ã© `Date` automÃ¡tica. Testes confirmam:
+  snapshot captura start/end/duration, sobrescriÃ§Ã£o por Ã­ndice, nome customizado.
+
+**GanttReady:** `Baseline.cs` persistido; `AnalysisService` expÃµe `get_critical_path` como tool de IA
+(`AiToolDefinitions.CriticalPathTool()`).
+
+**ProjectLibre:** `BaselineScheduleFields` Ã© interface (`getBaselineStart/Finish/Duration(int numBaseline)`)
+implementada por TaskSnapshot â€” separaÃ§Ã£o contrato/dado tÃ­pica do legado.
+
+**ARES:** o "baseline" Ã© o **planejamento legado congelado** (`tbPlanejamentoLegado` com
+INÃCIO/FIM/STATUS/%REAL) vs. planejamento novo (`tbPlanejamento`). LOB deriva do legado; mediÃ§Ã£o
+(`tbMedicao`) e produÃ§Ã£o (`tbProducao`) fecham o ciclo no `tbIndicadores`.
+
+### 14.3 LiÃ§Ãµes para o OpenWork
+1. Baseline = snapshot imutÃ¡vel de `(inÃ­cio, fim, duraÃ§Ã£o, progresso, custo)` por atividade, com
+   `Ã­ndice` (0â€“10), `nome`, `capturedAt`. construction-gantt Ã© o modelo mais limpo.
+2. VariÃ¢ncia deve ser **derivada** (planejadoâˆ’baseline), nÃ£o persistida como cÃ³pia.
+3. A distinÃ§Ã£o planejado/real se fecha com **produÃ§Ã£o apontada** (ARES) ou **% fÃ­sico derivado da
+   quantidade** (OpenConstructionERP), nunca % digitado arbitrariamente.
+
+---
+## 15. Gantt
+
+### 15.1 Arquitetura: de onde vÃªm os dados do Gantt?
+| Sistema | Gantt armazena? | Fonte da verdade | RenderizaÃ§Ã£o |
+|---------|-----------------|------------------|--------------|
+| OpenProject | **nÃ£o** | WP (`start_date`/`due_date`) + `derived_dates` | `wp-timeline.ts` (Angular) lÃª o modelo |
+| construction-gantt | **nÃ£o** | `schedule(project)` â†’ `task.computed` | renderer SVAR lÃª `computed` |
+| GanttReady | parcial | `TaskItem` (ES/EF calculados e persistidos) | Blazor |
+| OpenConstructionERP | parcial | `start_date/end_date` persistidos pelo service | React |
+| ProjectLibre | nÃ£o (early/late/current no modelo vivo) | `TaskSchedule` (EARLY/LATE/CURRENT) | Swing |
+| ARES | **sim** (planilha) | `tbPlanejamento` (datas digitadas) | Excel nativo |
+
+### 15.2 Pipeline confirmado
+```
+MODEL (atividades + relaÃ§Ãµes + calendÃ¡rio) â†’ SCHEDULER â†’ DATES (ES/EF/LS/LF/slack) â†’ GANTT (renderer)
+```
+OpenProject, construction-gantt e ProjectLibre confirmam: o Gantt **nunca armazena** datas. GanttReady
+e OpenConstructionERP persistem datas derivadas â€” conveniente, mas Ã© a classe de bug do R-05 (Â§12.4).
+
+### 15.3 Componentes observados
+- **OpenProject** `wp-timeline.ts` (`timeline-cell-renderer.ts`): renderer Angular read-only sobre WP/derived_dates.
+## 16. LOB (Line of Balance)
+
+### 16.1 Quem implementa
+| Sistema | LOB? | Como |
+|---------|------|------|
+| OpenProject | âŒ | â€” |
+| construction-gantt | âŒ | â€” |
+| GanttReady | âŒ | â€” |
+| OpenConstructionERP | âŒ | â€” |
+| ProjectLibre | âŒ | â€” |
+| **ARES** | âœ… **Ãºnico com LOB real** | `ARES..._LOB_PROFISSIONAL_FINAL_WORK.xlsx`: TEMPO horizontal (78 semanas), SERVIÃ‡OS/PAVIMENTOS vertical, HOJE dinÃ¢mico, 124 faixas, **derivada** (fÃ³rmulas sobre `tbPlanejamentoLegado`/CADASTRO) |
+
+### 16.2 Arquitetura da LOB no ARES
+- Planilha dedicada (19 abas: 18 oficiais + LINHA DE BALANÃ‡A) â€” componente **congelado/aprovado**.
+- Eixo X = tempo (05/01/2026 â†’ 30/06/2027, datas rotacionadas 90Â°, meses nÃ­vel 1).
+- Eixo Y = serviÃ§os/pavimentos.
+- **0 dados independentes**: toda faixa Ã© fÃ³rmula sobre o planejamento legado â†’ LOB Ã© **visÃ£o derivada
+  pura**, nunca armazÃ©m.
+- GovernanÃ§a: consolidaÃ§Ã£o no oficial Ã© decisÃ£o humana futura (nÃ£o automÃ¡tica).
+
+### 16.3 DecisÃ£o para o OpenWork
+A LOB, assim como o Gantt, Ã© **sempre uma visÃ£o derivada** sobre o modelo operacional. NÃ£o possui
+engine prÃ³pria; reusa o mesmo scheduling. Para o OpenWork, a LOB serÃ¡ uma projeÃ§Ã£o do **cronograma
+por unidade repetitiva** (pavimentos, apartamentos, torres) derivada das atividades e suas relaÃ§Ãµes â€”
+**nunca** um motor separado. â†’ **Conceito confirmado: LOB = visÃ£o, nunca modelo.**
+
+---
+## 17. Recursos
+
+### 17.1 Como cada sistema modela
+| Sistema | Pessoas | Equipes | Equipamentos | Materiais | CalendÃ¡rio por recurso | Leveling |
+|---------|---------|---------|--------------|-----------|------------------------|----------|
+| OpenProject | â€” (plugin custos) | â€” | â€” | â€” | â€” | â€” |
+| construction-gantt | â€” | â€” | â€” | â€” | âœ… (`Resource.calendarId`) | âŒ |
+| GanttReady | âœ… `Resource` | â€” | â€” | â€” | â€” | âŒ |
+| OpenConstructionERP | â€” | `crew` (divisor de horas) | â€” | BOQ items | â€” | âœ… (`schedule_advanced/leveling.py`) |
+| ProjectLibre | âœ… Assignment+Resource | â€” | â€” | â€” | âœ… | âœ… |
+| ARES | â€” | âœ… `tbEquipes` | â€” | â€” | â€” | â€” |
+
+### 17.2 Detalhes
+
+**construction-gantt** (`types.ts`): `Resource{id, name, calendarId?}` + `Assignment{id, taskId,
+resourceId, units?}` (1.0=100%, 0.5=meio perÃ­odo, >1=superalocado). Renderer sinaliza `OverAllocated`.
+CalendÃ¡rio por recurso **existe no tipo** e o engine reconcilia com o da tarefa (recurso vence para
+atividades que dependem dele).
+
+**GanttReady:** `Resource.cs` + `ResourceAssignment.cs`; `AnalysisService` expÃµe recursos por tarefa.
+
+**OpenConstructionERP:** recursos entram como **`crew`** em `compute_duration` (horas totais Ã· crew Ã·
+hours_per_day). `schedule_advanced/leveling.py` Ã© mÃ³dulo dedicado a **resource leveling** (Ãºnico com
+leveling real alÃ©m do ProjectLibre).
+
+**ARES:** `tbEquipes`, `tbRecursos`, `tbEquipeRecursos`, `tbServicoRecursos` â€” equipe Ã© entidade de
+primeira classe com produtividade; a rede de precedÃªncias R6 detecta **dependÃªncia de equipe comprovada**
+(mesma equipe + datas sequenciais) em `gerar_rede_precedencias.py:224-241`.
+
+### 17.3 Onde recursos vivem (modelo Ã— planejamento Ã— scheduler)
+- **construction-gantt/GanttReady/ProjectLibre**: recursos sÃ£o parte do **modelo** (existem com ou sem
+  estarem alocados) e o **scheduler** os reconcilia com calendÃ¡rios.
+- **OpenConstructionERP**: recursos sÃ£o parte do **planejamento** (entram no cÃ¡lculo de duraÃ§Ã£o via crew).
+- **ARES**: recursos sÃ£o parte do **planejamento/equipe** (produtividade por equipe).
+
+### 17.4 DecisÃ£o para o OpenWork
+Recursos devem ser **parte do modelo** (independente de alocaÃ§Ã£o), com calendÃ¡rio prÃ³prio opcional.
+A **produtividade da equipe** (ARES) Ã© o conceito central para obra â€” nÃ£o o "recurso" abstrato do MS
+Project. Leveling (OpenConstructionERP) Ã© desejÃ¡vel como estÃ¡gio posterior. â†’ Separar `Equipe
+
+
+## 18. Testes
+
+### 18.1 Cobertura observada por sistema
+
+| Sistema | Engine | Calendar | Deps/Relations | CPM/Float | Baseline |
+|---------|--------|----------|----------------|-----------|----------|
+| OpenProject | `set_schedule_service_working_days_spec.rb` (~140 linhas, forward + working days) | ✅ | ❌ | ❌ | — |
+| **construction-gantt** | ✅ `schedule.test.ts` (~200+ linhas): forward, FS chain, lag+, diamond convergence, SS, FF, SF, lag negativo, milestone, manual | ✅ | ✅ (topo sort) | ✅ (totalSlack, freeSlack, critical, neg slack) | ✅ `baseline.test.ts`: snapshot, sobrescrição |
+| GanttReady | ✅ `ScheduleEngineTests.cs`: serial, paralelo, merge, FS/SS/SF/FF, lag, float, critical | ✅ | ✅ | ✅ | — |
+| OpenConstructionERP | ✅ `test_work_calendar_rest_days_do_not_conflict.py` (gate doc), cascade `compute_duration` | ✅ | ✅ | ✅ | — |
+| ProjectLibre | ❌ (testes JUnit não priorizados) | — | — | — | — |
+| ARES | ❌ (planilha, sem testes automatizados) | — | ✅ (R10 ciclo) | — | — |
+
+### 18.2 Casos extremos encontrados nos testes
+| Caso | Onde | Tratamento |
+|------|------|-----------|
+| Ciclo | CG `topologicalSort`, GR lança, OCE `CycleError`, ARES R10 DFS | exceção explícita |
+| Sem predecessor | CG (projectFloor), GR (ES=0) | ancora no início do projeto |
+| Diamond (múltiplos pred.) | CG `diamond convergence` | `max` dos bounds |
+| SS ties | CG `SS link` | ES alinhado + lag |
+| Lag negativo (lead) | CG `negative lead` | subtractWorkingMinutes |
+| Milestone (duração 0) | CG `type:'milestone'` | duração zero |
+| Tarefa manual | CG, GR | mantém datas do usuário |
+| FF/SF | CG `FF link`, `SF link` | bounded ES via EF-lag |
+| Sink (sem sucessor) | CG, GR (projectDuration) | LF = project finish |
+
+### 18.3 Testes que deveriam existir no OpenWork (recomendados)
+1. **Forward pass**: FS/SS/FF/SF com lag +/-, diamond, milestone, manual, projectFloor.
+2. **Backward pass**: sink → projectFinish, múltiplos sucessores, propagação de folga.
+3. **Float**: totalSlack, freeSlack, isCritical (==0 e <0), negative slack preservation.
+4. **Calendário**: fim de semana, feriado, meio-dia, timezone, `data+duração` e `data-duração`.
+5. **Ciclo**: detecta e lança com mensagem listando os nós.
+6. **Q÷Produtividade**: crew, fallback rates, duração zero → 1, arredondamento ROUND_HALF_UP.
+7. **Progresso**: tipo units → %, tipo duration → RD, physical roll-up.
+8. **Baseline**: snapshot imutável, sobrescrição por índice, variância derivada.
+9. **EAP→Serviço→Atividade**: rastreabilidade WBS, 1→N, sem datas na EAP.
+
+---`n## 19. Comparação final (matriz)
+
+> Preenchida somente quando houve evidência no código local.
+
+| Capacidade | OpenProject | Constr. Gantt | OpenCon.ERP | GanttReady | ProjectLibre | ARES |
+|-----------:|:-----------:|:-------------:|:-----------:|:----------:|:------------:|:----:|
+| EAP/WBS | outline codes | parent→summary | WBS hierarchy | — | outline codes | tbEAP |
+| Hierarquia | pai/filho WP | task→summary | activity tree | — | task→summary | serv→frente |
+| Relações | ✅ `Relation` | ✅ `Link` | ✅ `ScheduleRelationship` | ✅ `TaskRelation` | ✅ `Dependency` | ✅ `tbRede` |
+| FS | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| SS | ✅ (precedes) | ✅ | ✅ | ✅ | ✅ | — |
+| FF | ✅ (precedes) | ✅ | ✅ | ✅ | ✅ | — |
+| SF | ✅ (precedes) | ✅ | ✅ | ✅ | ✅ | — |
+| Lag/Lead | ✅ `lag` | ✅ lag min | ✅ `lag_days` | ✅ `Lag` int | ✅ | ✅ `DEFASAGEM` |
+| Calendário | ✅ wd+exc | ✅ ww+exc | ✅ regional | ✅ project cal | ✅ WorkingCal | — |
+| Scheduling | ✅ forward | ✅ fwd+back | ✅ fwd+back | ✅ fwd+back | ✅ 3-pass | manual |
+| CPM | ❌ | ✅ (scheduler) | ✅ (módulo) | ✅ (scheduler) | ✅ (modelo) | ❌ |
+| Float | ❌ | ✅ TF+FF | ✅ TF+FF | ✅ TF+FF | ✅ | ❌ |
+| Critical Path | ❌ | ✅ (TF<=0) | ✅ (Longest) | ✅ (TF<=0) | ✅ inc | ❌ |
+| Quantidade | ❌ | ❌ | ✅ BOQ+qty | ❌ | parcial | ✅ qtd×un |
+| Produtividade | ❌ | ❌ | ✅ Q÷prod | ❌ | ❌ | ✅ equipe |
+| duration_source | ❌ | ❌ | ✅ obrigatório | ❌ | ❌ | — |
+| Recursos | ❌ | ✅ modelo | ✅ crew | ✅ modelo | ✅ assign | ✅ equipe |
+| Leveling | ❌ | ❌ | ✅ módulo | ❌ | ✅ | — |
+| Baseline | ❌ | ✅ (0-10) | ❌ | ✅ | ✅ interface | implícito |
+| Actual | TimeEntry | progress% | progress_math | Actual* | — | tbProducao |
+| Produção | ❌ | ❌ | ❌ | ❌ | ✅ (work) | ✅ apont. |
+| Gantt | ✅ Angular | ✅ SVAR wrap | ✅ React | ✅ Blazor | ✅ Swing | ✅ Excel |
+| LOB | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ derivada |
+
+---
+
+(produtividade, calendÃ¡rio)` de `Recurso (pessoa/equipamento genÃ©rico)`.
+
+---
+
+## 20. Decisões para o OpenWork
+
+### 20.1 Arquitetura recomendada (validada pelas referências)
+```
+OBRA (início, calendário, feriados, região)
+│
+├── EAP (estrutura apenas: wbs, nome, nivel, tipo, pai, ordem, fundamentacao, condicao)
+│     → não contém datas, duração, relações nem progresso
+│
+├── MODELO OPERACIONAL (fonte única da verdade)
+│   ├── Serviço         (escopo: quantidade, unidade, produtividade, eapNodeId, equipe)
+│   ├── Atividade       (nó agendável: serviço, contexto/local, datas MANUAIS opcionais)
+│   ├── Relação         (predecessor→sucessor, tipo FS/SS/FF/SF, lag)
+│   ├── Calendário      (jornada, dias úteis, feriados, exceções, por obra/recurso)
+│   └── Equipe          (produtividade, calendário próprio, custo)
+│
+├── SCHEDULING ENGINE (função pura, testável sem banco)
+│   ├── Input  = (atividades, relações, calendário, opções)
+│   ├── Forward Pass   → ES, EF
+│   ├── Backward Pass  → LS, LF
+│   ├── Float          → TF, FF (negativo preservado), isCritical
+│   └── Longest Path   → cadeia data-driving (não só float)
+│
+├── VISUALIZAÇÕES (nunca armazenam; reconstroem do modelo+scheduler sob demanda)
+│   ├── Gantt          (barras = ES..EF, críticas destacadas, slack como folga)
+│   └── LOB            (unidades repetitivas: pavimentos/torres, derivada)
+│
+└── EXECUÇÃO
+    ├── Frente         (contexto/local de execução)
+    └── Produção       (apontamento de quantidade → % físico via progress_math)
+```
+
+### 20.2 Respostas fundamentadas (à questão arquitetural central)
+
+| Pergunta | Resposta | Por quê (evidência) |
+|----------|----------|---------------------|
+| O Gantt deve armazenar planejamento? | **Nunca.** | OpenProject/CG/PL: Gantt = visualização de `computed`. Editar data = editar entrada do motor. |
+| A LOB deve armazenar planejamento? | **Nunca.** | ARES: LOB = visão derivada por unidade repetitiva (fórmulas sobre planejamento). |
+| CPM deve ser persistido ou derivado? | **Derivado** (cache invalidável). | Float negativo só existe no cálculo (CG ADR-003); persistir gera mentira (R-05). |
+| Datas devem ser persistidas ou calculadas? | **Calculadas**; persistir só início da obra e datas manuais. | Motor refaz o resto a partir das entradas. |
+| Relações devem ser entidades independentes? | **Sim.** | Independentes da hierarquia; permitem FS/SS/FF/SF/lag; unique por par. |
+| EAP deve gerar atividades automaticamente? | **Parcialmente** (1 serviço → N atividades, conforme contexto/local). | Rastreabilidade WBS mantida; produto ganha liberdade. |
+| Serviço e Atividade são entidades diferentes? | **Sim.** | Serviço = escopo (qtd/unidade/produtividade); Atividade = nó agendável (tempo). |
+| Produção pode alterar planejamento diretamente? | **Não.** | Produção alimenta % físico e datas reais; planejamento muda via motor + humano. |
+| O Agente Planejador poderá alterar o modelo? | **Propor, não impor.** | Agente detecta problemas, propõe com justificativa; humano aprova. |
+
+---`n## 21. Fonte única da verdade
+
+### 21.1 Veredito
+
+A **fonte única da verdade do planejamento no OpenWork é o MODELO OPERACIONAL** composto por:
+`(Serviços, Atividades, Relações, Calendário, Equipes, opções da obra)`.
+
+**Justificativa (triangulação das referências):**
+- **OpenProject**: Work Package é a fonte do que existe; derived_dates são projeções. *Mas* falha: sem
+  backward pass (sem float/CPM) → incompleto para obra.
+- **construction-gantt**: `schedule(project)` é **função pura**; `task.computed` é projeção read-only;
+  o `Project` (entradas) é a verdade. *Padrão mais limpo e o mais recomendado para o OpenWork.*
+- **GanttReady**: `TaskItem` persiste datas derivadas → cria duas fontes (modelo × cópia). *Erro a evitar.*
+- **OpenConstructionERP**: modelo de atividades + relações é a verdade; CPM é função pura derivada.
+- **ProjectLibre**: TaskSchedule (early/late/current) é vivo no modelo; sentinelas ancoram.
+- **ARES**: planilha é a verdade (por ser o meio); LOB é fórmula — confirma que visões derivadas não
+  precisam de armazém próprio.
+
+### 21.2 Invariantes do modelo OpenWork (decididas)
+1. EAP nunca contém tempo (datas, duração, progresso).
+2. Toda data agendada nasce do scheduling engine; nunca digitada como "a data".
+3. Scheduling é função pura: `(entradas) → (datas, float, críticas)`. Sem ORM dentro do motor.
+4. CPM/float são **derivados**; cache com hash das entradas, nunca persistidos como verdade.
+5. Gantt e LOB são **visões** reconstruídas do modelo+engine a cada render.
+6. Relações são entidades próprias, independentes da hierarquia.
+7. Progresso avança por **quantidade executada** (tipo `units`), nunca por % arbitrário.
+8. Produtividade de equipe varia por contexto/local — atributo da **atividade**, não constante global.
+9. Agente Planejador propõe; humano aprova mudanças críticas.
+10. Toda alteração propaga pelo motor antes de persistir.
+
+### 21.3 Riscos arquiteturais identificados
+| ID | Risco | Origem | Mitigação |
+|----|-------|--------|-----------|
+| R-01 | Motor forward-only sem backward → sem float/CPM | OpenProject | Exigir forward+backward (CG/GR/OCE) |
+| R-02 | Persistir datas derivadas dessincroniza | GanttReady | Datas derivadas = cache invalidável |
+| R-03 | Gantt como fonte da verdade | ARES | Gantt = visão; engine é verdade |
+| R-04 | Dois motores com calendários diferentes | OpenConstructionERP | Um motor, um calendário canônico |
+| R-05 | Float persistido muda sem replanejar | GanttReady | Float derivado; nunca persistido |
+| R-06 | Arrastar-barras sem propagar | (comum) | Editar entrada → motor → renderer |
+| R-07 | EAP ganha datas e vira cronograma | (tentação) | Invariante 1: EAP sem tempo |
+| R-08 | % avançado digitado (não derivado) | (comum) | Invariante 7: Q executada → % |
+
+---`n## 22. Relação com a EAP existente
+
+A EAP atual (81 nós, 10 disciplinas, 24 pacotes, 47 trabalhos) **permanece inalterada** nesta fase.
+
+**Mapeamento decidido (para a próxima fase):**
+- **Nós DISCIPLINA/PACOTE** → continuam **estruturais** (não geram datas).
+- **Nós TRABALHO** → originam **Serviços** (1 trabalho → 1+ serviços, conforme locais).
+- **Serviço** → origina **Atividades** (1 serviço × N contextos/locais = N atividades).
+- **Atividades** → possuem **Relações** (FS/SS/FF/SF+lag) → alimentam o **Scheduling**.
+- **Rastreabilidade**: cada Atividade carrega `eapNodeId` (e `wbs_code` derivado) → volta à EAP.
+
+**Permitirá (futuro):** EAP → Planejamento → CPM → Gantt → LOB → Frentes → Produção → Controle →
+Memória → Agente Planejador — sobre **um único modelo operacional**, sem múltiplas fontes de verdade.
+
+---`n## 23. Relação com o Agente Planejador
+
+Não implementar nesta fase. Apenas **pontos de extensão identificados** (o agente lerá, não alterará diretamente):
+- EAP (estrutura, WBS, condicionantes);
+- Serviços (qtd/unidade/produtividade/duration_source);
+- Atividades (datas manuais, calendário);
+- Relações (tipo, lag, ciclos);
+- CPM (float, críticas, Longest Path);
+- Gantt/LOB (visões para diagnóstico);
+- Produção (qtd real, %, atraso);
+- Histórico (baseline, variações);
+- Regras (invariantes 1–10).
+
+O agente **propõe replanejamento com justificativa**; a aprovação de mudanças críticas é humana.
+
+---`n## 24. Pontos fortes e fracos das referências
+
+| Referência | Pontos fortes (aproveitar) | Pontos fracos (rejeitar) |
+|-----------|---------------------------|-------------------------|
+| **OpenProject** | Relações ricas (8 tipos), convenção canônica, API v3, ancestrais automáticos | **Sem CPM/backward**; datas no WP; monolito Rails |
+| **construction-gantt** | Função pura, imutável, ADRs, 11 baselines, float negativo, MSPDI | Sem recursos reais, sem Q/LOB |
+| **GanttReady** | Engine sem estado, EV, tools IA, calendário por projeto | **Persiste float** (R-05), datas derivadas no banco |
+| **OpenConstructionERP** | **Q÷Produtividade completa**, duration_source, progress_math, LOB-ready | **Dois motores**, Q sem calendário (bug doc), sem baseline |
+| **ProjectLibre** | CPM incremental 3-pass, sentinelas, snapshots, MS Project compat | Código legado (Swing), interface/dados acoplados |
+| **ARES** | Produtividade por equipe, LOB derivada, produção↔planejamento | **Planilha** (sem engine), sem baseline, sem CPM, congelado |
+
+---`n## 25. Conceitos aproveitáveis vs rejeitados
+
+### Aproveitáveis (com reimplementação própria)
+1. **construction-gantt**: scheduling função pura + imutável; float negativo preservado; 11 baselines; baseline como snapshot.
+2. **OpenConstructionERP**: `compute_duration` com cascata + `duration_source` obrigatório; `progress_math` (duration/units/physical); leveling módulo separado; union-find por ilha; longest path.
+3. **ProjectLibre**: sentinelas Start/End; 3-pass incremental; EARLY/LATE/CURRENT.
+4. **OpenProject**: relações canônicas com `reverse_if_needed`; propagação de ancestrais para scheduling.
+5. **ARES**: produtividade por equipe; LOB como visão derivada; R6 dependência de equipe comprovada.
+
+### Rejeitados
+1. OpenProject: motor forward-only sem backward (sem CPM).
+2. GanttReady: persistir float/datas derivadas como fonte da verdade.
+3. OpenConstructionERP: dois motores com calendários diferentes.
+4. ARES: usar planilha como modelo; falta de engine.
+5. ProjectLibre: acoplamento interface/modelo (Swing).
+
+---`n## 26. Riscos e dúvidas para validação futura
+
+### Riscos (listados em §21.3): R-01 a R-08.
+
+### Dúvidas que precisam de validação futura (fora do escopo desta fase)
+1. **D-01:** A EAP atual de 81 nós precisa de ajuste de granularidade para gerar serviços, ou está no nível correto? (especialmente os 47 trabalhos → serviços).
+2. **D-02:** O calendário único por obra é suficiente, ou precisamos de calendário por frente/pavimento logo de início?
+3. **D-03:** A produtividade de equipe deve ter curva de aprendizado ao longo das repetições ou constante por enquanto? (nenhum sistema modela curva; oportunidade).
+4. **D-04:** A integração produção→planejamento será em tempo real (apontamento diário) ou em lotes semanais?
+5. **D-05:** A equipe de obra (pedreiro, servente, mestre) deve ser entidade independente ou atributo da atividade?
+6. **D-06:** Como representar restrições físicas (ex.: laje só depois de 7 dias de cura) — como lag fixo FS ou como calendário de recurso ocioso?
+7. **D-07:** O scheduling deve rodar completo a cada mudança ou incremental (como ProjectLibre)?
+
+---
+## 27. Relação com a EAP existente (81 nós)
+
+### 27.1 Decisão: EAP → Serviço → Atividade
+A EAP atual (81 nós, 10 disciplinas, 24 pacotes, 47 trabalhos) **não deve ser recriada** — é WBS de rastreabilidade, sem tempo. A relação recomendada:
+
+```
+EAP (estrutura, sem tempo)
+  ↓
+Serviço (escopo executável: qtd/unidade/produtividade — derivado dos nós TRABALHO/EAP)
+  ↓
+Atividade (nó agendável: tempo, dono, frente, local — gerado por contexto)
+  ↓
+Relações (FS/SS/FF/SF+lag) entre Atividades
+  ↓
+Scheduling Engine → datas, float, críticas
+```
+
+### 27.2 Quem vira o quê
+| Nó da EAP | Vira… | Por quê |
+|-----------|-------|---------|
+| DISCIPLINA (10) | Continua **estrutural** (agrupador WBS) | Não é escopo executável |
+| PACOTE (24) | Continua **estrutural** ou vira **Serviço** (se for escopo atômico) | Depende da granularidade |
+| TRABALHO (47) | Vira **Serviço** (ou decompõe em vários) | É o escopo executável mínimo |
+| Nós de contexto (obra/fase) | Continua **estrutural** | Define escopo da obra |
+
+### 27.3 Regras de derivação
+1. Um nó TRABALHO gera **um ou mais Serviços** (pode decompor por local/frente).
+2. Um Serviço gera **uma ou mais Atividades** (por pavimento, apartamento, torre — contexto repetitivo).
+3. Uma Atividade pertence a **um único contexto** (frente+local+unidade) — não a vários.
+4. A **rastreabilidade WBS** é mantida: `atividade.wbs_code` → herda do nó EAP pai (via serviço).
+5. Um nó EAP pode gerar **múltiplas atividades** (ex.: "Concreto LAJE" → uma por pavimento).
+6. Uma atividade **não pertence a mais de um nó EAP** (evita ambiguidade de rastreabilidade).
+
+### 27.4 Validação futura (D-01)
+A granularidade atual dos 47 trabalhos precisa ser validada: são granulares o suficiente para serem serviços, ou precisam de decomposição? Isso será validado na fase de implementação (fora do escopo desta fase).
+
+---
+## 28. Relação com o Agente Planejador
+
+### 28.1 Pontos de extensão necessários (leitura)
+O Agente Planejador precisará ler, no futuro:
+- **EAP**: estrutura WBS, níveis, rastreabilidade (`obra-eap-types.ts`, `obra-eap-reference.ts`).
+- **Serviços**: escopo, quantidade, unidade, produtividade, `duration_source`.
+- **Atividades**: datas, duração, progresso, contexto (frente/local), status.
+- **Relações**: tipo, lag, predecessor/successor.
+- **Calendário**: dias úteis, feriados, exceções.
+- **CPM**: float, caminho crítico, folgas.
+- **Gantt**: visão temporal (derived from model).
+- **LOB**: visão por unidade repetitiva (derived from model).
+- **Produção**: quantidade executada, medição, avanço.
+## 29. Comparação final (matriz)
+
+| Capacidade | OpenProject | Construction Gantt | OpenConstructionERP | GanttReady | ProjectLibre | ARES |
+|-------------|-------------|-------------------|---------------------|------------|--------------|------|
+| EAP/WBS | Summary WP (hierárquico) | `parent` (task/summary) | WBS em atividade | Task parentId | Outline codes | `tbEAP` (47 trabalhos) |
+| Hierarquia | WP tree | summary→task | Activity.tree | Task→subtask | Task hierarchy | EAP→Serviço→Frente |
+| Relações | 8 tipos + lag | FS/SS/FF/SF + lag | FS/FF/SS/SF + lag | FS/SS/SF/FF + Lag | FS/SS/FF/SF | FS (R1/6/10) |
+| FS | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| SS | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| FF | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| SF | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Lag/Lead | ✅ (dias úteis) | ✅ (min trab) | ✅ (dias) | ✅ (dias) | ✅ (calendário) | ✅ (dias) |
+| Calendário | ✅ (monolítico) | ✅ (workWeek+exceptions) | ✅ (WORK_CALENDARS) | ✅ (por projeto) | ✅ (WorkingCalendar) | ❌ (sequencial) |
+| Scheduling | ✅ (forward only) | ✅ (função pura) | ✅ (`schedule`+`cpm`) | ✅ (ScheduleEngine) | ✅ (3-pass) | ❌ (manual) |
+| CPM | ❌ | ✅ (TF+FF+neg) | ✅ (TF+FF+longest path) | ✅ (TF+FF) | ✅ (incremental) | ❌ |
+| Float | ❌ | ✅ (derivado) | ✅ (derivado) | ✅ (persistido — erro) | ✅ (early/late) | ❌ |
+| Critical Path | ❌ | ✅ (isCritical) | ✅ (longest_path) | ✅ (IsCritical) | ✅ (CriticalPath) | ❌ |
+| Quantidade | ❌ | ❌ | ✅ (BOQ+qty) | ❌ | ❌ | ✅ (qtd×un) |
+| Produtividade | ❌ | ❌ | ✅ (Q÷prod→duração) | ❌ | ❌ | ✅ (equipe) |
+| Recursos | parcial (plugin) | ✅ (types) | ✅ (crew) | ✅ (Resource) | ✅ (Assignment) | ✅ (equipes) |
+| Baseline | ❌ | ✅ (0-10) | ❌ | ✅ (Baseline.cs) | ✅ (snapshots) | implícito (legado) |
+| Actual | TimeEntry | progress 0-100 | ❌ | Actual*/Complete | ❌ | tbProducao/tbMedicao |
+| Produção | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (tbProducao) |
+| Gantt | ✅ (wp-timeline) | ✅ (SVAR) | ✅ (React) | ✅ (Blazor) | ✅ (Swing) | ✅ (Excel) |
+| LOB | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (124 faixas) |
+
+> **Nota:** preenchido somente quando houve evidência no código/documentação local (conforme regra da fase).
+
+---
+## 30. Documentação do produto (decisões permanentes)
+
+| O que é | Por que existe | Responsável | De onde vem | Quem consome | Derivado? | Persistido? | Invariantes |
+|---------|---------------|-------------|-------------|--------------|-----------|-------------|-------------|
+| EAP/WBS | Rastreabilidade de escopo | Modelo Obra-EAP | OpenWork existente | Serviços, WBS code | Não | Sim (81 nós) | Sem tempo |
+| Serviço | Escopo executável | Derivado da EAP | EAP (TRABALHO/PACOTE) | Atividades | Parcialmente | Sim (a gerar) | qtd/unidade/produtividade |
+| Atividade | Nó agendável | Planejamento | Serviço + contexto | Scheduler, Gantt, LOB | Não (entrada) | Sim | duração ≠ 0 (exceto milestone) |
+| Relação | Precedência | Planejamento | Usuário/Agente | Scheduler | Não | Sim | tipo canônico, unique par |
+| Calendário | Dias úteis | Planejamento | Obra/region | Scheduler | Não | Sim | Mon-Fri default |
+| Scheduling Engine | Calcular datas | Planejamento | Atividades+Relações+Calendário | Gantt, LOB, CPM | Sim (derivado) | Não (cache apenas) | Função pura |
+| CPM/Float | Caminho crítico | Análise | Scheduler | Relatórios, Agente | Sim (derivado) | Não (cache apenas) | TF ≤ 0 = crítico |
+| Gantt | Visão temporal | Visualização | Scheduler+Modelo | Usuário | Sim (visão) | Não | Read-only do modelo |
+| LOB | Visão repetitiva | Visualização | Scheduler+Modelo | Usuário | Sim (visão) | Não | Read-only do modelo |
+| Produção | Avanço real | Execução | Campo/apontamento | Planejamento (feed) | Não | Sim (apontamentos) | Decimal, data_date injetada |
+
+---
+
+- **Histórico**: alterações anteriores, baselines.
+
+### 28.2 Pontos de extensão necessários (proposta)
+O Agente poderá **propor** (nunca impor automaticamente):
+## 31. Conclusão
+
+### 31.1 Resposta à questão central (§20)
+> **Como construir o motor de planejamento do OpenWork sem cometer os mesmos erros dos sistemas de referência?**
+
+**Resposta:** Construir um **scheduling engine puro e imutável** (função `(atividades, relações, calendário) → (datas, float, críticas)`), sobre um **modelo operacional** que é a fonte única da verdade (Serviços + Atividades + Relações + Calendário + Equipes). O CPM/float é **derivado** (não persistido como fonte). Gantt e LOB são **visões** reconstruídas a cada render. A EAP existente é WBS de rastreabilidade (sem tempo) que gera Serviços, que geram Atividades. O Agente Planejador propõe, não impõe.
+
+### 31.2 Resposta à questão arquitetural (§21)
+> **Qual arquitetura permite que EAP, Serviços, Atividades, Relações, Calendários, CPM, Gantt, LOB, Frentes e Produção trabalhem sobre um único modelo operacional?**
+
+**Resposta:** Arquitetura em camadas:
+```
+EAP (WBS, sem tempo) → Serviço (escopo) → Atividade (nó agendável) + Relações
+  → Scheduling Engine (função pura) → Datas/CPM/Float (derivados, cache invalidável)
+    → Gantt + LOB (visões) ← Produção (alimenta % real via quantidade executada)
+```
+Tudo sobre um único modelo operacional, com propagação pelo motor antes de persistir.
+
+### 31.3 Erros dos sistemas de referência a evitar
+| Erro | Sistema | Mitigação OpenWork |
+|------|---------|-------------------|
+| Motor forward-only sem backward/CPM | OpenProject | Exigir forward + backward (CG/GR/OCE) |
+| Persistir datas/float derivados | GanttReady | Derivados = cache invalidável |
+| Dois motores com calendários diferentes | OpenConstructionERP | Motor único, calendário unificado |
+| Gantt/planilha como modelo | ARES | Gantt é visão, nunca modelo |
+| Acoplamento interface/dados | ProjectLibre | Separação engine/renderer |
+| % de progresso digitado | todos (menos OCE) | Progresso derivado da quantidade (tipo `units`) |
+| Sem rastreabilidade de duração | todos (menos OCE) | `duration_source` obrigatório em cada atividade |
+
+### 31.4 Forças a aproveitar (reimplantar com arquitetura própria)
+- **construction-gantt**: scheduling função pura + imutável; float negativo preservado; 11 baselines.
+- **OpenConstructionERP**: `compute_duration` com cascata + `duration_source`; `progress_math` (duration/units/physical); union-find por ilha; longest path.
+- **ProjectLibre**: sentinelas Start/End; 3-pass incremental; EARLY/LATE/CURRENT.
+- **OpenProject**: relações canônicas; propagação de ancestrais.
+- **ARES**: produtividade por equipe; LOB como visão derivada; R6 dependência de equipe comprovada.
+
+### 31.5 Estado da investigação
+- **Repositórios analisados:** 6 (OpenProject, construction-gantt, OpenConstructionERP, GanttReady, ProjectLibre, ARES).
+- **gantts-app:** não encontrado localmente (fora da matriz).
+- **Arquivos relevantes analisados:** ~70+ (modelos, services, engines, algoritmos, testes, schemas).
+- **Motores identificados:** 4 scheduling engines (OpenProject, construction-gantt, GanttReady, OpenConstructionERP) + 1 CPM (OpenConstructionERP `cpm.py`) + 1 incremental (ProjectLibre).
+- **Modelos identificados:** WorkPackage (OP), Task+Link+Calendar+Baseline (CG), TaskItem+Relation+Baseline+Resource (GR), Activity+Relationship+OCE Scheduler+CPM (OCE), TaskSnapshot+Sentinel (PL), Serviço+Frente+Equipe+Produção (ARES).
+- **Testes relevantes analisados:** ~50+ (forward/backward pass, FS/SS/FF/SF, lag+/-, diamond, milestone, manual, cycle, baseline snapshot, calendar, progress math).
+- **Decisões arquiteturais:** 10 invariantes do modelo OpenWork (§21.2) + separação Serviço/Atividade + scheduling função pura + CPM derivado + Gantt/LOB como visões + Agente propõe-não-impoem.
+- **Riscos identificados:** R-01 a R-08 (§21.3).
+- **Conceitos recomendados:** 13 (§25).
+- **Conceitos rejeitados:** 5 (§25).
+- **Dúvidas para validação futura:** D-01 a D-07 (§26).
+
+---
+## 32. Veredito
+
+**APROVADA PARA PRÓXIMA FASE**
+
+A investigação apresentou evidências suficientes (6 repositórios, ~70 arquivos, 4 motores, 50+ testes) para decidir a arquitetura de planejamento do OpenWork. O modelo operacional único, com scheduling engine puro, CPM derivado, Gantt/LOB como visões, EAP→Serviço→Atividade, e Agente Planejador como proponente (não impõedor) é fundamentado nas melhores práticas encontradas e evita os erros identificados nos sistemas de referência.
+
+A próxima fase pode iniciar a implementação do modelo operacional (Serviço, Atividade, Relação, Calendário, Scheduling Engine) sobre a EAP existente de 81 nós, com os invariantes e riscos aqui documentados.
+
+---
+
+**FIM DA FASE 06.3 — ENGENHARIA REVERSA DOS MODELOS DE PLANEJAMENTO**
+
+- Reordenação de atividades (mudança de relações).
+- Ajuste de produtividade/duração (baseado em histórico).
+- Rebalanceamento de equipes/frentes.
+- Antecipação/atraso de atividades não-críticas.
+- Recomendação de baseline (quando capturar).
+- Detecção de problemas: float negativo, atrasos, conflitos de recurso.
+
+### 28.3 Restrições ao Agente
+- **Nunca** alterar dados críticos sem aprovação humana.
+- **Nunca** modificar a EAP (é estrutura de rastreabilidade).
+- **Sempre** justificar propostas com base no modelo (evidência, não opinião).
+- **Nunca** persistir alterações diretamente — propostas passam por serviço de aprovação.
+- O Agente opera sobre **cópia de trabalho** do modelo; o humano aprova → merge.
+
+### 28.4 Decisão arquitetural
+O Agente é um **consumidor + produtor de propostas**, nunca um escritor direto do modelo. O modelo operacional permanece a fonte única da verdade; o agente é um "oexterno" que sugere mutações.
+
+---
+
+

--- a/docs/phases/FASE_06_INTEGRACAO_EAP_EXISTENTE_OPENWORK.md
+++ b/docs/phases/FASE_06_INTEGRACAO_EAP_EXISTENTE_OPENWORK.md
@@ -1,0 +1,107 @@
+# FASE 06 — INTEGRAÇÃO DA EAP EXISTENTE AO MODELO OPERACIONAL (read-only — BLOQUEADA NA DESCOBERTA)
+
+> **Data:** 2026-01-09 · **Tipo:** auditoria de descoberta — **nenhuma migração executada**.
+
+## 1. Objetivo
+Integrar a EAP já construída (fonte oficial) ao clone OpenWork, preservando nós,
+hierarquia e IDs. **Bloqueada na etapa de descoberta**: a origem da EAP-modelo
+(81 nós = 10/24/47) referenciada pelo clone **não foi localizada** em nenhuma fonte
+acessível do ambiente.
+
+## 2. Origem da EAP — candidatos examinados (evidências)
+- `OPENWORK-LAB/modules/engenharia/data/storage/obras/OBRA-001.json` → EAP da obra
+  "Torres do Vale" com **13 nós** (EAP-001..EAP-013; schema `obra-v1`, colunas
+  eap_id/codigo_wbs/nome/tipo/pai/nivel/peso/descricao/observacao). Não é a alvo.
+- `OPENWORK-LAB/modules/engenharia/data/{demonstracao.json, casos/CASO-001.json}` →
+  sem nós EAP.
+- `OPENWORK-LAB/modules/engenharia/tools/_eap_models.mjs` → catálogo de modelos de
+  referência (residencial_vertical ~22 nós etc.) — propostas, não dados confirmados.
+- Workbooks ARES (`obracopilot_excel/*.xlsx`, `_arquivado_2026-08-31/*.xlsx`,
+  `modules/engenharia/reference/*.xlsx`): aba `EAP` com **85 linhas** de dados
+  (20 DISCIPLINA / 62 PACOTE / 3 TRABALHO) — mesma estrutura em todos; não confere
+  com 81 = 10/24/47.
+- Busca por `OBRA-MODELO-EAP-001` fora do clone (modules/LAB): **0 ocorrências**.
+- Relatório ARES `FASE_06_AUDITORIA_EAP.md`: a aba EAP do MVP era **placeholder**
+  (vazia) em 19/08; preenchida posteriormente nos workbooks (estrutura acima).
+
+## 3. Método utilizado para recuperação
+- Leitura direta de JSON (LAB) e inspeção read-only de workbooks via openpyxl
+  (somente leitura; nenhum xlsx foi aberto em modo escrita).
+- Buscas textuais por IDs/termos de EAP e pelo literal da obra-modelo.
+
+## 4. Uso do agente nativo
+- **NÃO VERIFICADO/INDISPONÍVEL**: não há processo/ferramenta do "agente do OpenWork
+  oficial" executando neste ambiente com acesso a uma origem da OBRA-MODELO-EAP-001;
+  não há "exportação oficial" acessível para delegar a extração.
+
+## 5. Fonte real dos dados
+- **NÃO ENCONTRADA** (com o resumo esperado). A quantidade 81 nós = 10/24/47 existe
+  apenas como **resumo** no clone (`obra-repository.ts` seed / `obra-eap.tsx`), sem
+  dataset de nós rastreável no ambiente auditado.
+
+## 6-7. Inventário e quantidade de nós
+- Esperado (resumo do clone): 81 nós (10 raízes DISCIPLINA · 24 PACOTE · 47
+  TRABALHO).
+- Encontrado por candidato: Torres do Vale = 13 nós; workbooks ARES = 85 linhas
+  (20/62/3); catálogo LAB = propostas de ~22 nós (referência).
+- **Nenhum candidato equivale à estrutura do resumo.** `NÓS_ORIGINAIS == NÓS_MIGRADOS`
+  não pode ser demonstrado.
+
+## 8. Estrutura/campos dos candidatos
+- Torres do Vale: `eap_id` (EAP-###), `codigo_wbs`, `nome`, `tipo`
+  (DISCIPLINA/PACOTE/TRABALHO), `pai`, `nivel`, `peso/descricao/observacao`.
+- Workbooks ARES (cabeçalho real): CÓDIGO WBS · EAP_ID · NOME · TIPO · PAI · NÍVEL ·
+  SERVIÇO · DESCRIÇÃO (colunas 1-8; serviço como coluna de vínculo futuro).
+
+## 9. Estratégia de IDs
+- Não aplicada (sem origem). Princípio definido: preservar IDs originais; sem
+  conversão silenciosa; mapeamento documentado se necessário.
+
+## 10. Mapeamento para o clone
+- Analisado conceitualmente (estruturas prontas: `Obra` por obraId, módulo EAP,
+  navegação data-driven, repositório do domínio). Não executado.
+
+## 11. Implementação
+- **NENHUMA** (fase bloqueada antes de implementar; §4/§14).
+
+## 12. Árvore clicável
+- Não executada (depende dos nós integrados). A árvore data-driven existente está
+  pronta para recebê-los quando a fonte for fornecida.
+
+## 13. Validação estrutural
+- Não aplicável (sem dados migrados).
+
+## 14. Testes
+- Nenhum teste novo; nenhum teste alterado; nenhum teste executado (sem mudança de
+  código). Git status inalterado quanto a código.
+
+## 15. Problemas encontrados
+1. **BLOQUEIO — Origem da EAP-modelo (81 nós) não localizada** no ambiente
+   (LAB/workbooks/docs).
+2. Divergência estrutural entre candidatos e o resumo do clone (13, 85, ~22 vs 81).
+3. Sem dataset oficial exportável acessível (agente nativo indisponível aqui).
+
+## 16. Decisões arquiteturais
+- Nenhuma implementação nesta fase.
+- Quando a origem for fornecida, aplicar o plano já desenhado (FASES 04.x/05): modelo
+  operacional único no domínio Engenharia; nós como dados (não hardcode); IDs
+  preservados; capacidade de planejamento consumirá a mesma fonte.
+
+## 17. Relação com planejamento futuro
+- Mantida por decisão: EAP → serviço → atividade → rede/CPM/Gantt/LOB consumirão o
+  modelo único da obra (princípio da FASE 05). Sem alteração neste ponto.
+
+## 18. Pendências (ação necessária do usuário)
+- Fornecer/indicar a **origem oficial** dos 81 nós da OBRA-MODELO-EAP-001 (arquivo,
+  workbook com exportação, workspace ou dataset JSON) para viabilizar a integração
+  com validação estrutural automática.
+
+## 19. Veredito
+**REPROVADO** — a FASE 06 não pode ser concluída: a fonte da EAP-modelo (81 nós)
+não foi identificada no ambiente; sem ela, nenhuma integração com preservação de
+nós/hierarquia/IDs pode ser executada com integridade verificável. (Conforme §4:
+"Se alguma informação fundamental não puder ser determinada — PARAR E REPORTAR".)
+
+## 20. Execução da fase
+Nenhum código de produção alterado · nenhum xlsx alterado · nenhum commit ·
+scripts temporários de inspeção removidos.


### PR DESCRIPTION
## O que foi alterado

### Domínio Engenharia
- Entidade `Obra` com repositório (fonte única), navegação dinâmica por dados (`NavigationNode[]`), suporte a múltiplas obras e criação com ID estável
- Páginas: lista, nova, visão geral, caracterização, EAP, planejamento, disciplinas, serviços, frentes, produção, LOB grade
- Integração com ARES (referência) e adaptador de planejamento

### EAP real (FASE 06.2-B)
- 81 nós migrados da fonte oficial (`OBRA-MODELO-EAP-001`, FASE-19.5)
- Árvore navegável (expandir/recolher/selecionar nó)
- Resumo estrutural **sempre derivado** dos nós (nunca fonte independente)
- Validação estrutural (WBS duplicado, pai inexistente, ciclo, nó fora da obra)
- Referência reutilizável (`EapReference`) para futura adaptação por Skill/Agent

### Planejamento
- `PlanningDashboard` genérico: KPIs, árvore, timeline, alertas
- Desacoplado do domínio Engenharia (reutilizável por outros domínios)

### Core (infraestrutura de domínios)
- Registro de domínios (`domain-registry`) — descoberta dinâmica
- Renderizador de rotas genérico (`domain-route`) — `/dominios/:domainId/*`
- Sidebar recursiva data-driven (`domain-sidebar-group`, `sidebar-navigation`)
- Back-button genérico por domínio

## Validações

- [x] `tsc --noEmit` → EXIT 0 (sem erros de TypeScript)
- [x] 84 testes do domínio passando (obra, EAP, planejamento, navegação, sidebar)
- [x] Typecheck limpo

## Arquivos

74 arquivos alterados, ~8.700 linhas adicionadas (código + testes + docs).