### PR TITLE
fix(den-web): add clickjacking and baseline OWASP security headers

### DIFF
--- a/ee/apps/den-web/next.config.js
+++ b/ee/apps/den-web/next.config.js
@@ -2,12 +2,39 @@ const path = require("path");
 const { denApiRedirects } = require("./next-config-den-api-redirects.cjs");
 const { withObservabilityNextConfig } = require("./observability/next-config-observability.cjs");
 
+// Baseline OWASP security headers (OWASP WSTG-CLNT-09 clickjacking, secure headers).
+// Den Web is never embedded in a frame, so framing is denied outright.
+//
+// Deliberately NOT set here (read before adding):
+// - A full Content-Security-Policy (script-src, style-src, connect-src, ...).
+//   The CSP below is frame-ancestors only. A real script CSP needs per-request
+//   nonces generated in proxy.ts and threaded through the root layout, plus an
+//   audit of every inline script (PostHog via /ow, Sentry, next/script). Do not
+//   add 'unsafe-inline' as a shortcut; it defeats the purpose.
+// - Cross-Origin-Opener-Policy: same-origin. It severs window.opener, which
+//   app/(den)/reauth/complete/page.tsx and
+//   app/(den)/dashboard/_components/mcp-authorization-url.ts rely on to
+//   postMessage back to the opener after an OAuth popup round-trips through an
+//   external IdP. Use same-origin-allow-popups at most, and test both flows.
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   skipTrailingSlashRedirect: true,
+  poweredByHeader: false,
   transpilePackages: ["@openwork/ui", "@openwork-ee/utils", "@openwork-ee/telemetry-contracts"],
   outputFileTracingRoot: path.join(__dirname, "../../.."),
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
+  },
   async redirects() {
     return denApiRedirects(process.env);
   },


### PR DESCRIPTION
## Summary

Den Web served no security headers, leaving it framable by any origin (clickjacking, OWASP WSTG-CLNT-09). This adds Next.js-native `headers()` in `ee/apps/den-web/next.config.js` for every route, plus `poweredByHeader: false`.

| Header | Value |
|---|---|
| `X-Frame-Options` | `DENY` |
| `Content-Security-Policy` | `frame-ancestors 'none'` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | camera/mic/geolocation/payment/usb disabled |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
| `X-Powered-By` | removed |

Nothing in the repo embeds den-web in an iframe/webview, so `DENY` is safe.

**Deliberately omitted** (documented in-file for future agents): a full script CSP (needs nonces via `proxy.ts` and an inline-script audit) and `Cross-Origin-Opener-Policy: same-origin` (breaks the `window.opener.postMessage` reauth and MCP OAuth popup flows).

## Verification

Config-only change; verified at runtime by starting `pnpm dev:local` and curling `/` and `/api/health`:

```
X-Frame-Options: DENY
Content-Security-Policy: frame-ancestors 'none'
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
```

`X-Powered-By` no longer present. No testkit spec added — this is inert Next config with no app-observable behavior beyond response headers.