### PR TITLE
test(app): count Shiki <br> line breaks in the tool detail height stub

### DIFF
--- a/apps/app/tests/tool-aggregate-group.test.tsx
+++ b/apps/app/tests/tool-aggregate-group.test.tsx
@@ -272,9 +272,11 @@ describe("tool aggregate long details", () => {
     Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
       configurable: true,
       value(this: HTMLElement) {
+        // Shiki's inline highlighting replaces "\n" with <br>, and it lands
+        // asynchronously, so count both forms to stay independent of timing.
         const visibleLines = this.classList.contains("line-clamp-1")
           ? 1
-          : Math.max(1, (this.textContent ?? "").split("\n").length);
+          : Math.max(1, (this.textContent ?? "").split("\n").length, this.querySelectorAll("br").length + 1);
         return new DOMRect(0, 0, 320, visibleLines * 20);
       },
     });


### PR DESCRIPTION
## Summary

\`OpenWork Tests\` has been red on \`dev\` since #4353 (e.g. run 33792415925 at \`ac4b36112\`) with:

```
tests/tool-aggregate-group.test.tsx:325
(fail) tool aggregate long details > clicking a clipped command reveals every line and copies the full command
Expected: 4
Received: 1
```

**Root cause:** the test stubs \`getBoundingClientRect\` and derives visible lines from \`textContent.split("\n")\`. But \`ShellCommandText\` upgrades to Shiki inline HTML asynchronously, and Shiki emits \`<br>\` with zero \`\n\` characters. Whenever highlighting resolves before the expanded measurement — reliably on the Linux CI runner, rarely on a fast Mac — the stub reports 1 line. The product renders correctly; only the stub was wrong.

**Fix (test-only):** also count \`<br>\` elements, so the stub is independent of Shiki timing.

## Verification

Local, Bun 1.3.14 (matches CI):

- Faithful repro: render \`DetailBox\` expanded, wait for \`data-shell-command-highlighted\`, measure. Old stub → \`Expected: 4 / Received: 1\`; new stub → pass.
- \`bun test --isolate tests/\` in \`apps/app\`: 1166 pass, 0 fail.

Unit-suite-only change; no testkit spec involved.