### PR TITLE
fix(app): stop offering org models whose member credential is gone

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -336,6 +336,12 @@ export type DenOrgLlmProvider = {
   name: string;
   providerConfig: Record<string, unknown>;
   hasApiKey: boolean;
+  /**
+   * For `credentialMode: "per_member"` providers: whether the CALLING member
+   * currently has an active credential binding. Den returns it on the usable
+   * provider list; `hasApiKey` is always false for per-member providers.
+   */
+  hasMyCredential?: boolean;
   models: DenOrgLlmProviderModel[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -2056,6 +2062,7 @@ function parseDenOrgLlmProvider(value: unknown): DenOrgLlmProvider | null {
     name: value.name,
     providerConfig: parseJsonRecord(value.providerConfig),
     hasApiKey: value.hasApiKey === true,
+    ...(typeof value.hasMyCredential === "boolean" ? { hasMyCredential: value.hasMyCredential } : {}),
     models: Array.isArray(value.models)
       ? value.models.flatMap((model) => {
           const parsed = parseDenOrgLlmProviderModel(model);

--- a/apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options.ts
@@ -1,6 +1,10 @@
 import type { DenOrgLlmProvider } from "@/app/lib/den";
 import type { ModelOption } from "@/app/types";
-import { getCloudManagedProviderId, isCloudManagedProviderKey } from "./cloud-provider-config";
+import {
+  getCloudManagedProviderId,
+  getCloudProviderEnv,
+  isCloudManagedProviderKey,
+} from "./cloud-provider-config";
 
 export function filterCloudManagedModelOptions<T extends Pick<ModelOption, "providerID">>(
   options: readonly T[],
@@ -11,10 +15,28 @@ export function filterCloudManagedModelOptions<T extends Pick<ModelOption, "prov
     : options.filter((option) => !isCloudManagedProviderKey(option.providerID));
 }
 
+/**
+ * A granted provider can only serve requests when a credential exists for
+ * the calling member: the organization's shared key, the member's own
+ * per-member binding, or no credential declared at all. A grant without a
+ * credential (for example a per-member LiteLLM key the member removed) must
+ * not be offered as a selectable model — the engine will never connect it.
+ */
+export function hasUsableCloudProviderCredential(
+  provider: Pick<DenOrgLlmProvider, "providerConfig" | "hasApiKey" | "hasMyCredential">,
+): boolean {
+  return (
+    provider.hasApiKey ||
+    provider.hasMyCredential === true ||
+    getCloudProviderEnv(provider.providerConfig).length === 0
+  );
+}
+
 export function assignedModelOptions(
   providers: readonly DenOrgLlmProvider[],
 ): ModelOption[] {
   return providers.flatMap((provider) => {
+    if (!hasUsableCloudProviderCredential(provider)) return [];
     const providerID = getCloudManagedProviderId(provider);
     if (!providerID) return [];
 

--- a/apps/app/tests/assigned-model-options.test.ts
+++ b/apps/app/tests/assigned-model-options.test.ts
@@ -8,14 +8,30 @@ import {
 } from "../src/react-app/domains/connections/provider-auth/assigned-model-options";
 
 function provider(
-  input: Pick<DenOrgLlmProvider, "id" | "source" | "providerId" | "name" | "hasApiKey" | "models">,
+  input: Pick<DenOrgLlmProvider, "id" | "source" | "providerId" | "name" | "hasApiKey" | "models"> &
+    Partial<Pick<DenOrgLlmProvider, "providerConfig" | "hasMyCredential">>,
 ): DenOrgLlmProvider {
   return {
-    ...input,
     providerConfig: {},
     createdAt: null,
     updatedAt: null,
+    ...input,
   };
+}
+
+const perMemberModels = [{ id: "litellm-model-01", name: "LiteLLM Model 1", config: {}, createdAt: null }];
+
+function perMemberProvider(hasMyCredential: boolean | undefined): DenOrgLlmProvider {
+  return provider({
+    id: "lpr_acme_litellm",
+    source: "custom",
+    providerId: "acme-litellm",
+    name: "Acme LiteLLM",
+    providerConfig: { env: ["LITELLM_API_KEY"] },
+    hasApiKey: false,
+    ...(hasMyCredential === undefined ? {} : { hasMyCredential }),
+    models: perMemberModels,
+  });
 }
 
 function option(providerID: string, modelID: string, title: string): ModelOption {
@@ -68,6 +84,43 @@ describe("assigned model options", () => {
         source: "cloud",
       },
     ]);
+  });
+
+  test("drops a granted provider whose credential the member no longer has", () => {
+    // A per-member provider (hasApiKey is always false) is offered only while
+    // the calling member holds an active binding. After the member's key is
+    // removed the grant remains but the engine can never connect it, so the
+    // picker must not list its models (field-reported stale "Enabled" defect).
+    expect(assignedModelOptions([perMemberProvider(false)])).toEqual([]);
+    expect(assignedModelOptions([perMemberProvider(undefined)])).toEqual([]);
+
+    expect(assignedModelOptions([perMemberProvider(true)])).toMatchObject([
+      { providerID: "lpr_acme_litellm", modelID: "litellm-model-01", source: "cloud" },
+    ]);
+  });
+
+  test("keeps shared-key providers and providers that declare no credential", () => {
+    expect(
+      assignedModelOptions([
+        provider({
+          id: "lpr_shared",
+          source: "custom",
+          providerId: "shared-gateway",
+          name: "Shared Gateway",
+          providerConfig: { env: ["SHARED_GATEWAY_API_KEY"] },
+          hasApiKey: true,
+          models: perMemberModels,
+        }),
+        provider({
+          id: "lpr_keyless",
+          source: "custom",
+          providerId: "keyless-gateway",
+          name: "Keyless Gateway",
+          hasApiKey: false,
+          models: perMemberModels,
+        }),
+      ]).map((option) => option.providerID),
+    ).toEqual(["lpr_shared", "lpr_keyless"]);
   });
 
   test("keeps local API-key models and lets the live workspace catalog replace fallbacks", () => {

--- a/evals/specs/cloud-provider-stale-enabled-model-picker.test.ts
+++ b/evals/specs/cloud-provider-stale-enabled-model-picker.test.ts
@@ -1,0 +1,233 @@
+// Regression spec for a field-reported "stale Enabled state" defect
+// (desktop 0.18.41/0.18.42):
+// after an org-managed cloud provider (per-member LiteLLM key) was
+// disconnected, the composer model picker was forced open with "The model you
+// were using is no longer available…" yet the very same provider was still
+// listed with all of its models and a green "Enabled" pill.
+//
+// Cause: the picker merged grant-based Den options (`assignedModelOptions`)
+// into the engine catalog regardless of credential state, and the desktop
+// parser dropped Den's per-member `hasMyCredential` flag entirely.
+//
+// The spec drives the REAL renderer pipeline (the exact exported functions
+// `useModelPicker` composes) with a deterministic witness of the
+// post-disconnect state and asserts both halves of the contract:
+//   - the availability gate (which forces the picker open) declares the
+//     provider's models unavailable, AND
+//   - the picker option list offers none of that provider's models,
+//   - while a granted provider whose credential is still active keeps its
+//     models before the engine has connected it (the pre-workspace window).
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+import type { DenOrgLlmProvider } from "../../apps/app/src/app/lib/den";
+import type { ModelOption } from "../../apps/app/src/app/types";
+import {
+  assignedModelOptions,
+  filterCloudManagedModelOptions,
+  mergeModelOptions,
+} from "../../apps/app/src/react-app/domains/connections/provider-auth/assigned-model-options";
+import { filterEntitledModelOptions } from "../../apps/app/src/react-app/domains/connections/provider-auth/provider-policy";
+import { computeModelAvailability } from "../../apps/app/src/react-app/domains/session/surface/model-availability";
+import { getConnectedProviderItems } from "../../apps/app/src/react-app/infra/provider-list-query";
+
+const PROVIDER_KEY = "lpr_acme_litellm_eval";
+const MODEL_COUNT = 12;
+
+function grantedProvider(hasMyCredential: boolean): DenOrgLlmProvider {
+  return {
+    id: PROVIDER_KEY,
+    source: "custom",
+    providerId: "acme-litellm",
+    name: "Acme LiteLLM",
+    providerConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      api: "https://litellm.acme.example/v1",
+      env: ["LITELLM_API_KEY"],
+    },
+    // Per-member providers never carry a shared org key.
+    hasApiKey: false,
+    hasMyCredential,
+    models: Array.from({ length: MODEL_COUNT }, (_, index) => ({
+      id: `litellm-model-${String(index + 1).padStart(2, "0")}`,
+      name: `LiteLLM Model ${index + 1}`,
+      config: {},
+      createdAt: null,
+    })),
+    createdAt: null,
+    updatedAt: null,
+  };
+}
+
+/**
+ * The Den grant catalog entry for "Acme LiteLLM" as the session route
+ * holds it in `cloudOrgProviders` AFTER the member deleted their per-member
+ * credential (DELETE /v1/llm-providers/:id/my-credential): the grant remains,
+ * the credential is gone, all 12 models still listed.
+ */
+const grantedDisconnectedProvider = grantedProvider(false);
+
+/**
+ * The workspace engine's provider list AFTER the disconnect settled: the
+ * server-side cloud provider sync skipped the provider (needs_key), removed
+ * the runtime `lpr_*` block, and the engine reloaded. Nothing is connected —
+ * this is the catalog the availability gate trusts.
+ */
+const engineListAfterDisconnect: ProviderListResponse = {
+  all: [],
+  connected: [],
+  default: {},
+};
+
+const noRestrictions = () => false;
+
+const currentModel = {
+  providerID: PROVIDER_KEY,
+  modelID: "litellm-model-01",
+};
+
+/** Replicates the option pipeline of `useModelPicker` (use-model-picker.ts). */
+function buildPickerOptions(input: {
+  engineList: ProviderListResponse;
+  grantCatalog: readonly DenOrgLlmProvider[];
+  cloudProvidersEnabled: boolean;
+  restrictToCloud: boolean;
+}): ModelOption[] {
+  const engineOptions: ModelOption[] = getConnectedProviderItems(input.engineList).flatMap(
+    (provider) =>
+      Object.entries(provider.models).map(([modelID, model]) => ({
+        providerID: provider.id,
+        modelID,
+        title: model.name || modelID,
+        description: provider.name,
+        behaviorTitle: "",
+        behaviorLabel: "",
+        behaviorDescription: "",
+        behaviorValue: null,
+        isFree: false,
+      })),
+  );
+  const merged = filterCloudManagedModelOptions(
+    mergeModelOptions(engineOptions, assignedModelOptions(input.grantCatalog)),
+    input.cloudProvidersEnabled,
+  );
+  return filterEntitledModelOptions(merged, {
+    restrictToCloud: input.restrictToCloud,
+    checkRestriction: noRestrictions,
+  });
+}
+
+test("the availability gate that forces the picker open declares the disconnected org model unavailable", async ({ evidence }) => {
+  const availability = computeModelAvailability(currentModel, {
+    workspaceReady: true,
+    loading: false,
+    signedIn: true,
+    cloudProviderSyncReady: true,
+    openWorkModelsSyncing: false,
+    restrictToCloud: true,
+    checkRestriction: noRestrictions,
+    cloudProviderList: engineListAfterDisconnect,
+    providerList: engineListAfterDisconnect,
+  });
+
+  expect(availability).toEqual({
+    status: "unavailable",
+    reason: "provider_not_connected",
+  });
+
+  // Negative half: the same gate never fires while catalogs are unsettled —
+  // the "no longer available" subtitle is a settled verdict, not a race.
+  const pendingAvailability = computeModelAvailability(currentModel, {
+    workspaceReady: true,
+    loading: false,
+    signedIn: true,
+    cloudProviderSyncReady: false,
+    openWorkModelsSyncing: false,
+    restrictToCloud: true,
+    checkRestriction: noRestrictions,
+    cloudProviderList: null,
+    providerList: null,
+  });
+  expect(pendingAvailability).toEqual({ status: "pending" });
+
+  evidence.recordAssertionEvidence(
+    "The disconnected org provider's model is a settled 'unavailable' verdict",
+    `computeModelAvailability returned ${JSON.stringify(availability)} against the post-disconnect engine catalog, and 'pending' while the catalog was unsettled.`,
+    true,
+  );
+});
+
+test("the picker offers no model of a granted provider whose member credential is gone", async ({ evidence }) => {
+  const options = buildPickerOptions({
+    engineList: engineListAfterDisconnect,
+    grantCatalog: [grantedDisconnectedProvider],
+    cloudProvidersEnabled: true, // member is signed in to Den
+    restrictToCloud: true,
+  });
+
+  const staleOptions = options.filter((option) => option.providerID === PROVIDER_KEY);
+  expect(staleOptions).toEqual([]);
+  expect(options).toEqual([]);
+
+  // The picker and the availability gate now agree: the model the session was
+  // using is unavailable AND is not re-offered.
+  const availability = computeModelAvailability(currentModel, {
+    workspaceReady: true,
+    loading: false,
+    signedIn: true,
+    cloudProviderSyncReady: true,
+    openWorkModelsSyncing: false,
+    restrictToCloud: true,
+    checkRestriction: noRestrictions,
+    cloudProviderList: engineListAfterDisconnect,
+    providerList: engineListAfterDisconnect,
+  });
+  expect(availability.status).toBe("unavailable");
+
+  evidence.recordAssertionEvidence(
+    "Disconnected grant no longer leaks into the model picker",
+    `With an empty post-disconnect engine catalog and a credential-less grant for ${PROVIDER_KEY}, the picker pipeline produced ${staleOptions.length} options for that provider while the availability verdict was '${availability.status}'.`,
+    staleOptions.length === 0 && availability.status === "unavailable",
+  );
+});
+
+test("a granted provider with an active member credential keeps its models before the engine connects it", async ({ evidence }) => {
+  // Positive half (the #3714 pre-workspace window must keep working): the
+  // engine has not materialized anything yet, but the member holds an active
+  // per-member binding, so the grant catalog legitimately supplies the models.
+  const options = buildPickerOptions({
+    engineList: engineListAfterDisconnect,
+    grantCatalog: [grantedProvider(true)],
+    cloudProvidersEnabled: true,
+    restrictToCloud: true,
+  });
+  const offered = options.filter((option) => option.providerID === PROVIDER_KEY);
+  expect(offered).toHaveLength(MODEL_COUNT);
+  expect(offered.every((option) => option.source === "cloud")).toBe(true);
+  expect(offered.some((option) => option.modelID === currentModel.modelID)).toBe(true);
+
+  // Negative halves: the merge is not simply echoing everything.
+  // 1. Signed out (cloudProvidersEnabled=false) removes the cloud options.
+  const signedOutOptions = buildPickerOptions({
+    engineList: engineListAfterDisconnect,
+    grantCatalog: [grantedProvider(true)],
+    cloudProvidersEnabled: false,
+    restrictToCloud: false,
+  });
+  expect(signedOutOptions).toHaveLength(0);
+  // 2. A provider that is neither granted nor connected never appears.
+  const revokedOptions = buildPickerOptions({
+    engineList: engineListAfterDisconnect,
+    grantCatalog: [],
+    cloudProvidersEnabled: true,
+    restrictToCloud: true,
+  });
+  expect(revokedOptions).toHaveLength(0);
+
+  evidence.recordAssertionEvidence(
+    "Credentialed grants still supply models before the engine connects",
+    `Active per-member binding: ${offered.length}/${MODEL_COUNT} models offered; signed-out: ${signedOutOptions.length}; revoked grant: ${revokedOptions.length}.`,
+    offered.length === MODEL_COUNT && signedOutOptions.length === 0 && revokedOptions.length === 0,
+  );
+});


### PR DESCRIPTION
## Bug (field report, Desktop 0.18.41/0.18.42)

> After an org-managed LiteLLM provider is disconnected (initiated from chat), it still shows **Enabled** but no longer works — "Enabled" reads as "connected".

Reported symptom: the composer **Models** picker is forced open with *"The model you were using is no longer available, please select a different model for this session."* — yet the same org-managed provider is still listed with "12 models", the blue org badge, **Current**, and a green **Enabled** pill. Expanding it re-offers the exact models that just stopped working.

The provider is an org-managed (`lpr_*`) provider with **per-member** LiteLLM keys. When a member's key is removed, the grant remains but the engine can no longer connect the provider.

## Root cause

Two independent facts combined:

1. `apps/app/src/react-app/domains/session/modals/use-model-picker.ts:152-155` merges grant-based Den options (`assignedModelOptions(cloudOrgProviders)`, wired in `session-route.tsx:787-790,901`) into the engine catalog **unconditionally**. `assigned-model-options.ts` built options from ids/names/models only — never credential state — so fallback-only entries for a disconnected provider survived even after the engine catalog (which the "no longer available" verdict trusts) had settled to *nothing connected*. Introduced by #3714 (pre-workspace model listing); #3723 later scoped it to signed-in members only, so sign-**out** cleared it but credential loss did not.
2. `apps/app/src/app/lib/den.ts` dropped Den's `hasMyCredential` flag (returned by `GET /v1/llm-providers` for per-member providers, `ee/apps/den-api/src/routes/org/llm-providers.ts:728-731`). The desktop only read `hasApiKey`, which is always `false` for per-member providers — so a per-member disconnect was invisible to the grant catalog.

(The green "Enabled" pill itself is the `disabled_providers` toggle in `model-picker-modal.tsx:430-444`; it never received a connection signal. With this fix a credential-less provider is no longer listed, so the pill can no longer contradict the subtitle.)

Not the same defect as #4357: that fixed Disconnect for providers declared in a user-level `opencode.json` (no org badge). This one is the org-managed per-member path shown in the screenshot; it still reproduced on `dev` after #4357 merged.

## Fix

- `den.ts`: parse `hasMyCredential?: boolean` on `DenOrgLlmProvider`.
- `assigned-model-options.ts`: new `hasUsableCloudProviderCredential()` — a granted provider contributes fallback models only when it has the org's shared key (`hasApiKey`), the member's own binding (`hasMyCredential`), or declares no credential env at all. `assignedModelOptions` skips the rest.

`session-route.tsx` consumes `assignedModelOptions` for both the picker fallback and `entitledModelOptions`, so the "organization models empty" state stays truthful too. Credentialed grants keep supplying models before the engine connects them (the #3714 pre-workspace window — covered by the new positive-half tests). No UI copy changes.

## Proof

- **New pr-lane spec** `evals/specs/cloud-provider-stale-enabled-model-picker.test.ts` drives the real renderer pipeline (`getConnectedProviderItems` → `mergeModelOptions`/`assignedModelOptions`/`filterCloudManagedModelOptions` → `filterEntitledModelOptions`, plus `computeModelAvailability`) with the post-disconnect state (empty engine catalog, grant still listing 12 models, `hasMyCredential: false`):
  - the availability gate returns a settled `unavailable` (the forced-open subtitle) and `pending` while catalogs are unsettled;
  - the picker offers **zero** models of the credential-less grant (was 12 before the fix — the unfixed version of this spec passed as a DEFECT REPRO on `dev` @ `ac4b36112`);
  - positive half: an active per-member binding still yields all 12 models before the engine connects; negative halves: signed-out → 0, revoked grant → 0.
- **Unit** `apps/app/tests/assigned-model-options.test.ts`: `hasMyCredential: false`/absent → dropped; `true` → kept; shared-key and no-env providers kept.

Runs (lane: **local** — Daytona CLI unauthorized in this environment):

- `pnpm evals:pr specs/cloud-provider-stale-enabled-model-picker.test.ts` → exit 0, **3 passed, 0 skipped**.
- `pnpm --filter @openwork/app typecheck` → clean.
- `bun test --isolate tests/assigned-model-options.test.ts tests/automation-model-options.test.ts tests/cloud-providers-view.test.ts tests/session-provider-auth-server-sync.test.ts` → 29 pass.
- `pnpm --filter @openwork/app test` → same 6 pre-existing failures as a clean `origin/dev` control (identical failure set, diff-verified; same set #4357 reported).
- `pnpm --dir evals run test:pr` → 165 passed / 3 skipped / 2 failed, both failures local Den-boot contention when Den-driving specs run in parallel against one MySQL (`Another next dev server is already running`; den-api build race) — pre-existing local-env class, those specs skip on GitHub CI.
- `node evals/scripts/spec-impact.mjs` → advisory warning only (`desktop.connect-library` contract touched); the changed behavior is proven by the new pr-lane spec above.

## Follow-ups (not in this PR)

- Picker badge copy for org providers: `Connected` / `Not connected` + "Connect your key…" instead of the `Enabled` toggle label.
- `automation-model-options.ts` builds Automation model choices from the same grant catalog without a credential check (server revalidates on save).
- `removeCloudProviderInternal` does not force-refresh the `opencode-provider-list` query (5-min staleTime) the way the Settings disconnect path does.

