### PR TITLE
chore(evals): neutral wording in config-provider-disconnect spec comments

### DIFF
--- a/evals/specs/config-provider-disconnect.test.ts
+++ b/evals/specs/config-provider-disconnect.test.ts
@@ -4,7 +4,7 @@ import { briefTest, claim, testBrief } from "@openwork/testkit";
 import type { Client, ProviderListItem, WorkspaceDisplay } from "../../apps/app/src/app/types";
 import { createProviderAuthStore } from "../../apps/app/src/react-app/domains/connections/provider-auth/store";
 
-// Airwallex report (Desktop 0.18.41/0.18.42): a provider named `LiteLLM`
+// Field report (Desktop 0.18.41/0.18.42): a custom OpenAI-compatible provider
 // defined in the user-level ~/.config/opencode/opencode.json cannot be
 // disconnected from Settings > AI Providers — clicking Disconnect removes no
 // state (auth removal is a no-op because the definition lives in a config
@@ -147,7 +147,7 @@ briefTest(testBrief({
 }), async ({ prove }) => {
   const { engine, ui, store } = createHarness();
 
-  // --- Config-file provider (the Airwallex LiteLLM case) ---
+  // --- Config-file provider (the reported case) ---
   const message = await store.disconnectProvider("litellm");
 
   // Auth removal was attempted for exactly this provider (it is a no-op on


### PR DESCRIPTION
Comment-only change: replace the origin attribution in two spec comments with neutral wording. No behaviour or test-logic change; the spec still passes (1 passed, 0 skipped).