### PR TITLE
fix(server,den-api): remove the credential an earlier release left under the bare catalog name

### DIFF
--- a/apps/server/src/cloud-provider-sync.e2e.test.ts
+++ b/apps/server/src/cloud-provider-sync.e2e.test.ts
@@ -629,6 +629,73 @@ describe("cloud provider sync gateway", () => {
     expect((await env.list()).find((entry) => entry.key === "UNRELATED_API_KEY")?.value).toBe("sk-unrelated");
   });
 
+  test("moves the org credential an earlier release stored under the bare catalog name and never touches a member's different value", async () => {
+    const root = await createRoot();
+    // A models.dev provider: Den stores the declared name but the connect
+    // payload delivers the provider-scoped runtime name (LPR_<row tail>_<name>).
+    const catalogProviderId = "lpr_01kx4t3amgendr682dmp6120jv";
+    const declaredEnv = "OPENAI_API_KEY";
+    const scopedEnv = `LPR_120JV_${declaredEnv}`;
+    const orgCredential = "test-only-organization-credential";
+    const userCredential = "test-only-users-own-credential";
+    const stored: FakeProvider = {
+      id: catalogProviderId,
+      providerId: "openai",
+      name: "Organization OpenAI",
+      source: "models_dev",
+      updatedAt: "2026-09-01T00:00:00.000Z",
+      providerConfig: { id: "openai", name: "OpenAI", npm: "@ai-sdk/openai", env: [declaredEnv] },
+      apiKey: orgCredential,
+      apiKeys: null,
+      models: [{ id: "assigned-model", name: "Assigned model", config: {} }],
+    };
+    const runtime: FakeProvider = { ...stored, providerConfig: { ...stored.providerConfig, env: [scopedEnv] } };
+    const fetchImpl = Object.assign(async (input: Parameters<typeof globalThis.fetch>[0]) => {
+      const url = new URL(String(input));
+      if (url.hostname === "den.example.test") {
+        if (url.pathname === "/v1/llm-providers") return Response.json({ llmProviders: [stored] });
+        if (url.pathname === `/v1/llm-providers/${catalogProviderId}/connect`) {
+          return Response.json({ llmProvider: runtime });
+        }
+      }
+      if (url.hostname === "engine.example.test" && url.pathname.startsWith("/auth/")) return Response.json(true);
+      return Response.json({ error: "not_found" }, { status: 404 });
+    }, { preconnect: globalThis.fetch.preconnect });
+    const config = serverConfig(root, "https://engine.example.test");
+    const env = new EnvService({ path: process.env.OPENWORK_ENV_STORE });
+    const envValues = async () => new Map((await env.list()).map((entry) => [entry.key, entry.value]));
+    const session = { baseUrl: "https://den.example.test", token: "den-token", orgId: "org-env-upgrade" };
+    const newSync = () => {
+      const sync = new CloudProviderSync({ config, env, fetchImpl, reloadEngine: async () => undefined, intervalMs: 3_600_000 });
+      stops.push(() => sync.stop());
+      return sync;
+    };
+
+    // The previous release wrote the org credential under the bare catalog
+    // name; the app was then upgraded, so nothing in memory owns that key.
+    await env.upsertMany([{ key: declaredEnv, value: orgCredential }]);
+    let sync = newSync();
+    await sync.setSession(session);
+    expect((await sync.run("first-sync-after-upgrade")).status).toBe("applied");
+    const afterUpgrade = await envValues();
+    expect(afterUpgrade.get(scopedEnv)).toBe(orgCredential);
+    expect(afterUpgrade.has(declaredEnv)).toBe(false);
+    expect((await sync.run("steady")).status).toBe("noop");
+
+    // A member's own key under the bare name has a different value: a
+    // restart-then-sync must leave it alone.
+    sync.stop();
+    await env.upsertMany([{ key: declaredEnv, value: userCredential }]);
+    sync = newSync();
+    await sync.setSession(session);
+    expect((await sync.run("restart")).status).toBe("applied");
+    const afterRestart = await envValues();
+    expect(afterRestart.get(declaredEnv)).toBe(userCredential);
+    expect(afterRestart.get(scopedEnv)).toBe(orgCredential);
+    expect((await sync.run("steady-with-own-key")).status).toBe("noop");
+    expect(afterRestart.get(declaredEnv)).toBe(userCredential);
+  });
+
   test("materializes Den providers globally, reconciles changes, and sweeps the session", async () => {
     const root = await createRoot();
     const engineRequests: string[] = [];

--- a/apps/server/src/cloud-provider-sync.ts
+++ b/apps/server/src/cloud-provider-sync.ts
@@ -112,6 +112,13 @@ type DenProviderConnection = DenProvider & {
   apiKey: string | null;
   apiKeys: Record<string, string> | null;
   memberCredentialState: "missing" | "active" | "blocked" | "stale" | "error" | null;
+  /**
+   * The env names as stored in Den (from the list payload). The connect
+   * payload carries the runtime names, which Den scopes per provider for
+   * catalog providers; where the two differ, the stored name is where an
+   * earlier release put this credential.
+   */
+  declaredEnvNames: string[];
 };
 
 type EnvEntry = {
@@ -130,6 +137,12 @@ type PreparedMaterialization = {
   fingerprint: string;
   providers: MaterializedProvider[];
   envEntries: EnvEntry[];
+  /**
+   * Entries an earlier release wrote under a catalog provider's declared name.
+   * Deleted only while the store still holds exactly the value now written
+   * under the runtime name; a different value there is the user's own key.
+   */
+  supersededEntries: EnvEntry[];
   skipped: CloudProviderSyncSkippedProvider[];
 };
 
@@ -283,7 +296,8 @@ function parseProviderList(payload: unknown): DenProvider[] {
   return providers;
 }
 
-function parseProviderConnection(payload: unknown, expectedId: string): DenProviderConnection {
+function parseProviderConnection(payload: unknown, listed: DenProvider): DenProviderConnection {
+  const expectedId = listed.id;
   if (!isRecord(payload) || !isRecord(payload.llmProvider)) {
     throw new Error(`den_llm_provider_connect_invalid_response_${expectedId}`);
   }
@@ -308,6 +322,7 @@ function parseProviderConnection(payload: unknown, expectedId: string): DenProvi
     apiKey: typeof payload.llmProvider.apiKey === "string" ? payload.llmProvider.apiKey : null,
     apiKeys: parseApiKeys(payload.llmProvider.apiKeys),
     memberCredentialState,
+    declaredEnvNames: readProviderEnvNames(listed.providerConfig),
   };
 }
 
@@ -362,7 +377,7 @@ async function fetchProviders(
     providers.map(async (provider) =>
       parseProviderConnection(
         await requestJson(fetchImpl, session, `/v1/llm-providers/${encodeURIComponent(provider.id)}/connect`),
-        provider.id,
+        provider,
       )),
   );
 }
@@ -524,6 +539,17 @@ function prepareMaterialization(
   for (const provider of materialized) {
     for (const entry of provider.envEntries) upsertEnvEntry(envEntries, entry.key, entry.value);
   }
+  const desiredKeys = new Set(envEntries.map((entry) => entry.key));
+  const supersededEntries: EnvEntry[] = [];
+  for (const { provider, envEntries: written } of materialized) {
+    readProviderEnvNames(provider.providerConfig).forEach((runtimeName, index) => {
+      const declaredName = provider.declaredEnvNames[index];
+      const value = written.find((entry) => entry.key === runtimeName)?.value;
+      if (declaredName && declaredName !== runtimeName && value !== undefined && !desiredKeys.has(declaredName)) {
+        upsertEnvEntry(supersededEntries, declaredName, value);
+      }
+    });
+  }
 
   // Preserve den-api's stable, secret-safe owp:v1 fingerprint format.
   const fingerprintPayload = materialized.map((entry) => ({
@@ -540,6 +566,7 @@ function prepareMaterialization(
     fingerprint: `owp:v1:${hashString(stableJson(fingerprintPayload))}`,
     providers: materialized,
     envEntries,
+    supersededEntries,
     skipped,
   };
 }
@@ -954,6 +981,13 @@ export class CloudProviderSync {
     // cloud credential behind permanently.
     for (const key of desiredEnvKeys) this.ownedEnvKeys.add(key);
     const envDeletes = [...this.ownedEnvKeys].filter((key) => !desiredEnvKeys.has(key));
+    // Ownership is in-memory, so after the app restarts nothing remembers the
+    // credential an earlier release wrote under the bare catalog name — and
+    // left there it keeps enabling OpenCode's built-in vendor catalog. Remove
+    // it only on an exact value match: a different value is the user's own.
+    for (const entry of prepared.supersededEntries) {
+      if (storedEnv.get(entry.key) === entry.value && !envDeletes.includes(entry.key)) envDeletes.push(entry.key);
+    }
     for (const key of envDeletes) {
       await this.env.delete(key);
       this.ownedEnvKeys.delete(key);

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -68,6 +68,12 @@ type PreparedMaterialization = {
   fingerprint: string
   providers: MaterializedProvider[]
   envEntries: EnvEntry[]
+  /**
+   * Entries an earlier release wrote under a catalog provider's declared name
+   * before runtime names were provider-scoped. Deleted only while the worker
+   * still holds exactly the value now written under the scoped name.
+   */
+  supersededEntries: EnvEntry[]
 }
 
 type FetchImpl = (input: string, init?: RequestInit) => Promise<Response>
@@ -413,6 +419,18 @@ function prepareMaterialization(providers: CloudProviderMaterializationProvider[
       upsertEnvEntry(envEntries, entry.key, entry.value)
     }
   }
+  const desiredKeys = new Set(envEntries.map((entry) => entry.key))
+  const supersededEntries: EnvEntry[] = []
+  for (const { provider, envEntries: written } of materialized) {
+    const declared = readProviderEnvNames(provider.providerConfig)
+    runtimeProviderEnvNames(provider).forEach((runtimeName, index) => {
+      const declaredName = declared[index]
+      const value = written.find((entry) => entry.key === runtimeName)?.value
+      if (declaredName && declaredName !== runtimeName && value !== undefined && !desiredKeys.has(declaredName)) {
+        upsertEnvEntry(supersededEntries, declaredName, value)
+      }
+    })
+  }
 
   const fingerprintPayload = materialized.map((entry) => ({
     id: entry.provider.id,
@@ -429,7 +447,12 @@ function prepareMaterialization(providers: CloudProviderMaterializationProvider[
     fingerprint: `owp:v1:${hashString(stableJson(fingerprintPayload))}`,
     providers: materialized,
     envEntries,
+    supersededEntries,
   }
+}
+
+function staleSupersededKeys(supersededEntries: EnvEntry[], snapshot: EnvSnapshot) {
+  return supersededEntries.filter((entry) => snapshot.get(entry.key) === entry.value).map((entry) => entry.key)
 }
 
 export function computeCloudProviderMaterializationFingerprint(providers: CloudProviderMaterializationProvider[]) {
@@ -654,20 +677,20 @@ async function readEnvSnapshot(input: {
   fetchImpl: FetchImpl
   instanceUrl: string
   hostToken: string
-  entries: EnvEntry[]
+  keys: string[]
 }): Promise<EnvSnapshot> {
   const snapshot: EnvSnapshot = new Map()
-  for (const entry of input.entries) {
-    if (snapshot.has(entry.key)) {
+  for (const key of input.keys) {
+    if (snapshot.has(key)) {
       continue
     }
     const existing = await readEnvEntry({
       fetchImpl: input.fetchImpl,
       instanceUrl: input.instanceUrl,
       hostToken: input.hostToken,
-      key: entry.key,
+      key,
     })
-    snapshot.set(entry.key, existing?.value ?? null)
+    snapshot.set(key, existing?.value ?? null)
   }
 
   return snapshot
@@ -1012,11 +1035,17 @@ export async function materializeCloudWorkerProviders(input: {
       fetchImpl,
       instanceUrl,
       hostToken: tokens.hostToken,
-      entries: prepared.envEntries,
+      keys: [...prepared.envEntries, ...prepared.supersededEntries].map((entry) => entry.key),
     })
+    const staleKeys = staleSupersededKeys(prepared.supersededEntries, envSnapshot)
+    // Roll back only what this pass writes or deletes; a bare-name entry that
+    // is left alone is never touched on the way out either.
+    const touchedKeys = new Set([...prepared.envEntries.map((entry) => entry.key), ...staleKeys])
+    const envRollbackSnapshot: EnvSnapshot = new Map([...envSnapshot].filter(([key]) => touchedKeys.has(key)))
     if (
       materializedProviderStateMatches(prepared, currentManagedProviders)
       && materializedEnvStateMatches(prepared.envEntries, envSnapshot)
+      && staleKeys.length === 0
     ) {
       materializedFingerprintByWorkerInstance.set(cacheKey, fingerprint)
       materializationFailureByWorkerInstance.delete(cacheKey)
@@ -1091,7 +1120,7 @@ export async function materializeCloudWorkerProviders(input: {
           fetchImpl,
           instanceUrl,
           hostToken: tokens.hostToken,
-          snapshot: envSnapshot,
+          snapshot: envRollbackSnapshot,
         }).catch((rollbackError) => {
           materializationLogger.warn("cloud provider env rollback failed", {
             worker_id: input.workerId,
@@ -1101,6 +1130,24 @@ export async function materializeCloudWorkerProviders(input: {
         })
       }
       throw error
+    }
+
+    // The org credential an earlier release left under the bare catalog name
+    // would keep enabling OpenCode's built-in vendor catalog. Remove it only on
+    // an exact value match (a different value is the member's own), and only
+    // after the scoped names are in place; a failed delete is retried by the
+    // next pass because it keeps the state out of noop.
+    for (const key of staleKeys) {
+      await deleteEnvEntry({ fetchImpl, instanceUrl, hostToken: tokens.hostToken, key, ignoreNotFound: true }).catch(
+        (deleteError) => {
+          materializationLogger.warn("cloud provider stale env cleanup failed", {
+            worker_id: input.workerId,
+            organization_id: input.organizationId,
+            env_key: key,
+            reason: deleteError instanceof Error ? deleteError.message : "env_delete_failed",
+          })
+        },
+      )
     }
 
     materializedFingerprintByWorkerInstance.set(cacheKey, fingerprint)

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -419,18 +419,19 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
     ])
-    expect(instance.calls[2]?.headers["x-openwork-host-token"]).toBe("host-token")
-    expect(instance.calls[2]?.body).toEqual({
+    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[3]?.body).toEqual({
       entries: [{ key: ANTHROPIC_API_KEY_ENV, value: "sk-anthropic" }],
     })
-    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
-    expect(instance.calls[3]?.headers.authorization).toBeUndefined()
+    expect(instance.calls[4]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[4]?.headers.authorization).toBeUndefined()
     expect(instance.calls.every((call) => call.redirect === "error")).toBe(true)
-    expect(instance.calls[3]?.body).toEqual({
+    expect(instance.calls[4]?.body).toEqual({
       provider: {
         [provider.id]: {
           id: "anthropic",
@@ -475,6 +476,33 @@ describe("Cloud provider materialization", () => {
       id: "azure",
       env: [AZURE_RESOURCE_NAME_ENV, AZURE_API_KEY_ENV],
     })
+  })
+
+  test("removes the org credential an earlier release left under the bare catalog name, never a different value", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+
+    // Worker materialized before runtime names were provider-scoped: the org
+    // credential sits under ANTHROPIC_API_KEY, which also switches on
+    // OpenCode's built-in Anthropic catalog.
+    const upgraded = makeInstance({
+      envValues: { ANTHROPIC_API_KEY: "sk-anthropic" },
+      runtimeProviders: { [provider.id]: { ...makeAnthropicRuntimeProvider(), env: ["ANTHROPIC_API_KEY"] } },
+    })
+    const first = await materialize({ providers: () => [provider], fetchImpl: upgraded.fetchImpl, force: true })
+    expect(first.status).toBe("applied")
+    expect(upgraded.envValue(ANTHROPIC_API_KEY_ENV)).toBe("sk-anthropic")
+    expect(upgraded.envValue("ANTHROPIC_API_KEY")).toBeNull()
+    expect(callMethods(upgraded.calls)).toContain("DELETE /env/ANTHROPIC_API_KEY")
+
+    const second = await materialize({ providers: () => [provider], fetchImpl: upgraded.fetchImpl, force: true })
+    expect(second.status).toBe("noop")
+
+    // A different value under the bare name is the member's own key.
+    const withOwnKey = makeInstance({ envValues: { ANTHROPIC_API_KEY: "sk-members-own" } })
+    await materialize({ providers: () => [provider], fetchImpl: withOwnKey.fetchImpl, force: true })
+    expect(withOwnKey.envValue(ANTHROPIC_API_KEY_ENV)).toBe("sk-anthropic")
+    expect(withOwnKey.envValue("ANTHROPIC_API_KEY")).toBe("sk-members-own")
+    expect(callMethods(withOwnKey.calls)).not.toContain("DELETE /env/ANTHROPIC_API_KEY")
   })
 
   test("a custom provider keeps the exact env name its author declared", async () => {
@@ -564,6 +592,7 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
     ])
     expect(writeCalls(instance.calls)).toHaveLength(0)
   })
@@ -586,6 +615,7 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
@@ -609,6 +639,7 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /opencode/config",
@@ -783,6 +814,7 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
     ])
     expect(instance.calls.some((call) => call.method === "PATCH")).toBe(false)
@@ -814,6 +846,7 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "PATCH /runtime-config/providers",
@@ -878,6 +911,7 @@ describe("Cloud provider materialization", () => {
     expect(callMethods(instance.calls)).toEqual([
       "GET /opencode/config",
       `GET /env/${ANTHROPIC_API_KEY_ENV}`,
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /runtime-config/providers",
       "GET /runtime/versions",


### PR DESCRIPTION
## Problem

#4281 scopes catalog providers' runtime env names (`OPENAI_API_KEY` → `LPR_120JV_OPENAI_API_KEY`). Every desktop and worker that synced before it still holds the org credential under the **bare** name, and nothing removes it:

- On the desktop, cloud-sync ownership of env keys (`ownedEnvKeys`) is in-memory. The app upgrade that ships #4281 restarts the server, so the first sync afterwards desires only the scoped key, owns only the scoped key, and never reclaims the bare one. The stale `OPENAI_API_KEY=<org secret>` would stay in the env store indefinitely, still enabling OpenCode's built-in OpenAI catalog and shadowing the member's own key — the very bug #4281 fixes.
- Cloud workers never deleted env keys at all, so the bare entry stays until the sandbox is recycled.

## The change

Both planes already see the declared names (the stored row / the list payload) and the runtime names (the connect payload / the materializer). Where they differ for a materialized provider, the declared-name entry is deleted **only while it holds exactly the value now written under the runtime name**. A different value under that name is the member's own key and is never touched.

- **Desktop server** (`apps/server/src/cloud-provider-sync.ts`): `parseProviderConnection` keeps the list payload's declared names; `prepareMaterialization` derives `supersededEntries`; `apply` adds exact-value matches to the existing `envDeletes` path, so the deletion counts as a change and triggers the reload like any other env change.
- **Worker materializer** (`ee/apps/den-api/src/llm/cloud-provider-materialization.ts`): the env snapshot also reads the superseded keys; a stale entry keeps the pass out of `noop`; the delete runs best-effort after the scoped names and provider blocks are verified (a failed delete is logged and retried on the next pass); the rollback snapshot covers only keys the pass writes or deletes.
- Older Den + new desktop: connect returns the declared names, nothing differs, nothing is deleted.

## Proof

- `pnpm test -- src/cloud-provider-sync.e2e.test.ts` in `apps/server` — new colocated scenario (the former `evals/specs/cloud-provider-env-namespacing.test.ts` was retired by #4402): a desktop with `OPENAI_API_KEY=<org secret>` from the previous release and a **fresh** `CloudProviderSync` (no in-memory ownership) moves the credential to the scoped name and removes the bare entry, then goes `noop`; a member's different value under the bare name survives another fresh instance and sync. 8 pass; the new test fails against `dev` without this change.
- `bun test --conditions development test/cloud-provider-materialization.test.ts test/cloud-provider-materialization-read-retry.test.ts` in `ee/apps/den-api` — new case: worker with the org secret under the bare name → deleted, second pass `noop`; worker with a different value under the bare name → left alone, no DELETE issued. 28 pass.
- `pnpm test -- src/cloud-provider-sync` in `apps/server` — 15 pass across both sync suites. `tsc --noEmit` for `apps/server` and `ee/apps/den-api` — green. `evals/scripts/spec-boundary-ratchet.mjs` — 74 specs checked, clean.

## Note for reviewers

A member who had manually pasted the *same* org secret under the bare name loses that entry; the identical value is served under the scoped name, so nothing stops working. Voice Mode and image generation read `OPENAI_API_KEY` from the env store directly and were previously lit implicitly by an org OpenAI catalog provider; after #4281 they are not, which is the intended scoping.

