### PR TITLE
fix(world): give isolated headless worlds their own OpenCode sessions database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ even before a dedicated UI exists.
  `pnpm dev:headless-web` remains a compatibility alias with its prior foreground
  default (`--detach` still works). Read
  `tmp/dev-headless-web.json` for the owner-only runtime manifest.
- It does not use `~/.config/openwork/server.json`. Stop a running script with
+ It does not use `~/.config/openwork/server.json`, and its engine keeps its own
+ sessions database at `tmp/dev-headless-opencode.db` instead of the desktop
+ app's `~/.local/share/opencode/opencode.db`. Stop a running script with
  `pnpm world down dev-headless`; pass script options after `--`, for example
  `pnpm world up dev-headless --detach -- --replace --keep-tokens`. Cloud sign-in
  is copy/paste handoff (Den cannot redirect grants to localhost): Account → Sign

--- a/evals/specs/headless-world-engine-isolation.test.ts
+++ b/evals/specs/headless-world-engine-isolation.test.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+// An `isolated` headless world used to inherit the person's HOME and open the
+// installed desktop app's ~/.local/share/opencode/opencode.db, so two
+// long-lived engines contended for one SQLite writer and world sessions leaked
+// into the person's history.
+
+test("an isolated headless world gives its engine a private sessions database", ({ evidence }) => {
+  const result = spawnSync("pnpm", [
+    "--filter",
+    "@openwork/world",
+    "exec",
+    "node",
+    "--test",
+    "test/headless-isolation.test.ts",
+    "test/headless-production.test.ts",
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 120_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const output = `${result.stdout}${result.stderr}`;
+
+  expect(result.error, output).toBeUndefined();
+  expect(result.status, output).toBe(0);
+  expect(output).toMatch(/ℹ pass 9\b/);
+  expect(output).toMatch(/ℹ fail 0\b/);
+  expect(output).toContain("dev-headless keeps its engine sessions database under tmp/");
+  expect(output).toContain("isolated engine env points OPENCODE_DB at the world database and nothing else");
+  expect(output).toContain("an explicit OPENCODE_DB wins over the world default");
+
+  evidence.recordAssertionEvidence(
+    "The isolated world's engine opens tmp/dev-headless-opencode.db",
+    "resolveHeadlessWorldRuntimePaths yields a world-owned database path and isolatedHeadlessEngineEnv sets exactly OPENCODE_DB to it, leaving HOME and XDG_DATA_HOME untouched so provider credentials still resolve.",
+    true,
+  );
+  evidence.recordAssertionEvidence(
+    "Explicit overrides and the installed-production world are unchanged",
+    "An explicit OPENCODE_DB still wins, and the installed-production env test keeps pointing at the installed database.",
+    true,
+  );
+});

--- a/packages/world/src/headless-web.ts
+++ b/packages/world/src/headless-web.ts
@@ -59,6 +59,8 @@ export interface HeadlessWorldRuntimePaths {
   serverConfigPath: string;
   webLogPath: string;
   headlessLogPath: string;
+  /** Sessions database for the world's managed OpenCode engine. */
+  opencodeDbPath: string;
 }
 
 export interface InstalledProductionHeadlessState {
@@ -291,6 +293,7 @@ export function resolveHeadlessWorldRuntimePaths(
       serverConfigPath: resolveHeadlessServerConfigPath(repoRoot),
       webLogPath: join(directory, "dev-web.log"),
       headlessLogPath: join(directory, "dev-headless.log"),
+      opencodeDbPath: join(directory, "dev-headless-opencode.db"),
     };
   }
   const directory = join(repoRoot, "tmp", "worlds", "runtime", name);
@@ -300,7 +303,24 @@ export function resolveHeadlessWorldRuntimePaths(
     serverConfigPath: join(directory, "server.json"),
     webLogPath: join(directory, "web.log"),
     headlessLogPath: join(directory, "server.log"),
+    opencodeDbPath: join(directory, "opencode.db"),
   };
+}
+
+/**
+ * Engine data for an `isolated` world. Only the sessions database moves: the
+ * default engine otherwise opens the same ~/.local/share/opencode/opencode.db
+ * as the installed desktop app, so both processes contend for one SQLite
+ * writer and the world's sessions land in the person's history. Provider
+ * credentials and the engine log stay where they are so the world keeps
+ * working with the person's configured providers. An explicit OPENCODE_DB wins.
+ */
+export function isolatedHeadlessEngineEnv(
+  runtimePaths: Pick<HeadlessWorldRuntimePaths, "opencodeDbPath">,
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const explicit = env.OPENCODE_DB?.trim();
+  return { OPENCODE_DB: explicit || runtimePaths.opencodeDbPath };
 }
 
 export async function readHeadlessRuntimeManifest(path: string): Promise<HeadlessRuntimeManifest | null> {
@@ -783,7 +803,7 @@ export async function launchHeadlessWeb(options: HeadlessWebLaunchOptions): Prom
   const headlessEnv: NodeJS.ProcessEnv = {
     ...env,
     OPENWORK_DEV_MODE: "1",
-    ...(productionState ? installedProductionHeadlessEnv(productionState) : {}),
+    ...(productionState ? installedProductionHeadlessEnv(productionState) : isolatedHeadlessEngineEnv(runtimePaths, env)),
     ...(productionState ? {} : { OPENWORK_WORKSPACE: workspace }),
     OPENWORK_HOST: host,
     OPENWORK_REMOTE_ACCESS: remoteAccessEnabled ? "1" : "0",

--- a/packages/world/test/headless-isolation.test.ts
+++ b/packages/world/test/headless-isolation.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import test from "node:test";
+import { isolatedHeadlessEngineEnv, resolveHeadlessWorldRuntimePaths } from "../src/headless-web.ts";
+
+// An `isolated` headless world must not open the installed desktop app's
+// ~/.local/share/opencode/opencode.db: two long-lived writers on one SQLite
+// file contend for the single writer lock and mix world sessions into the
+// person's history.
+
+test("dev-headless keeps its engine sessions database under tmp/", () => {
+  const paths = resolveHeadlessWorldRuntimePaths("/repo", "dev-headless");
+  assert.equal(paths.opencodeDbPath, join("/repo", "tmp", "dev-headless-opencode.db"));
+});
+
+test("named worlds keep their engine sessions database inside their runtime directory", () => {
+  const paths = resolveHeadlessWorldRuntimePaths("/repo", "acme-demo");
+  assert.equal(paths.opencodeDbPath, join(paths.directory, "opencode.db"));
+  assert.equal(paths.directory, join("/repo", "tmp", "worlds", "runtime", "acme-demo"));
+});
+
+test("isolated engine env points OPENCODE_DB at the world database and nothing else", () => {
+  const paths = resolveHeadlessWorldRuntimePaths("/repo", "dev-headless");
+  const env = isolatedHeadlessEngineEnv(paths, { HOME: "/Users/person", XDG_DATA_HOME: "/Users/person/.local/share" });
+  assert.deepEqual(env, { OPENCODE_DB: join("/repo", "tmp", "dev-headless-opencode.db") });
+  // Provider credentials and the engine log stay with the person: no XDG/HOME rewrite.
+  assert.equal("XDG_DATA_HOME" in env, false);
+  assert.equal("HOME" in env, false);
+});
+
+test("an explicit OPENCODE_DB wins over the world default", () => {
+  const paths = resolveHeadlessWorldRuntimePaths("/repo", "dev-headless");
+  assert.deepEqual(
+    isolatedHeadlessEngineEnv(paths, { OPENCODE_DB: " /elsewhere/opencode.db " }),
+    { OPENCODE_DB: "/elsewhere/opencode.db" },
+  );
+  assert.deepEqual(
+    isolatedHeadlessEngineEnv(paths, { OPENCODE_DB: "   " }),
+    { OPENCODE_DB: join("/repo", "tmp", "dev-headless-opencode.db") },
+  );
+});


### PR DESCRIPTION
## Why

`pnpm world up dev-headless` (state `isolated`) spawned its managed `opencode serve` with the person's `HOME` and no `OPENCODE_DB`, so it opened the **same** `~/.local/share/opencode/opencode.db` as the installed desktop app. Two long-lived engines on one SQLite file means every journal write in one is a `busy_timeout` wait in the other, and world sessions land in the person's history. On the reporting machine a headless engine from Sep 1 was still holding the desktop's 1.5 GB database open while the desktop engine was timing out. Only `installed-production` worlds isolated engine data (`installedProductionHeadlessEnv`).

## What

- `resolveHeadlessWorldRuntimePaths` exposes `opencodeDbPath`: `tmp/dev-headless-opencode.db` for the compatibility world, `tmp/worlds/runtime/<name>/opencode.db` for named worlds.
- New `isolatedHeadlessEngineEnv(runtimePaths, env)` sets **exactly** `OPENCODE_DB` for the isolated branch. `HOME`/`XDG_*` are deliberately untouched so the world keeps the person's provider `auth.json` and engine log; an explicit `OPENCODE_DB` still wins.
- The managed engine inherits the server's `process.env` (`managed-opencode.ts`), so the variable reaches `opencode serve` without further plumbing.
- AGENTS.md documents the location.

Behavior change: the isolated world no longer sees desktop sessions — which is what "isolated" means. `installed-production` is unchanged.

## Verification

Lane: **local** (pure path/env resolution; no Daytona prerequisite applies).

```
pnpm evals:pr specs/headless-world-engine-isolation.test.ts
  ✓ an isolated headless world gives its engine a private sessions database  (1 passed, 0 failed, 0 skipped) exit 0
pnpm --filter @openwork/world exec node --test test/headless-isolation.test.ts test/headless-production.test.ts   9 pass / 0 fail
pnpm --filter @openwork/world typecheck                                                                            exit 0
```

Verdict: **Passed**.

Related: #4371 (server log file). Follow-ups: engine-rollover fingerprint, engine-stall UX.
