### PR TITLE
ci: run the OpenWork Tests lanes in parallel on bigger runners

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,7 +43,7 @@ jobs:
             core.setOutput("lane", lane)
             core.info(`Selected lane: ${lane}`)
 
-  openwork-tests:
+  openwork-tests-specs:
     needs: classify-changes
     if: needs.classify-changes.outputs.lane == 'full'
     runs-on: ${{ matrix.os }}
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2204, macos-14]
+        os: [blacksmith-16vcpu-ubuntu-2204, blacksmith-12vcpu-macos-15]
 
     steps:
       - name: Checkout
@@ -171,6 +171,132 @@ jobs:
 
       - name: Run eval spec lane
         run: pnpm --dir evals run test:pr
+
+  openwork-tests-unit:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.lane == 'full'
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [blacksmith-16vcpu-ubuntu-2204, blacksmith-12vcpu-macos-15]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Install OpenCode CLI
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+        run: |
+          set -euo pipefail
+
+          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
+          version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
+          version="$(echo "$version" | tr -d '\r\n' | sed 's/^v//')"
+
+          if [ -z "$version" ]; then
+            echo "Unable to resolve OpenCode version from constants.json." >&2
+            exit 1
+          fi
+
+          arch="$(uname -m)"
+          case "${RUNNER_OS}" in
+            Linux)
+              if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+                opencode_asset="opencode-linux-arm64.tar.gz"
+              else
+                opencode_asset="opencode-linux-x64-baseline.tar.gz"
+              fi
+              ;;
+            macOS)
+              if [ "$arch" = "arm64" ]; then
+                opencode_asset="opencode-darwin-arm64.zip"
+              else
+                opencode_asset="opencode-darwin-x64-baseline.zip"
+              fi
+              ;;
+            *)
+              echo "Unsupported OS: ${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
+
+          url="https://github.com/${repo}/releases/download/v${version}/${opencode_asset}"
+          tmp_dir="$RUNNER_TEMP/opencode"
+          extract_dir="$tmp_dir/extracted"
+          rm -rf "$tmp_dir"
+          mkdir -p "$extract_dir"
+
+          curl_headers=()
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            curl_headers+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" )
+          fi
+
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "${curl_headers[@]}" -o "$tmp_dir/$opencode_asset" "$url"
+
+          if [[ "$opencode_asset" == *.tar.gz ]]; then
+            tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"
+          else
+            unzip -q "$tmp_dir/$opencode_asset" -d "$extract_dir"
+          fi
+
+          if [ -f "$extract_dir/opencode" ]; then
+            bin_path="$extract_dir/opencode"
+          elif [ -f "$extract_dir/opencode.exe" ]; then
+            bin_path="$extract_dir/opencode.exe"
+          else
+            echo "OpenCode binary not found in archive" >&2
+            ls -la "$extract_dir"
+            exit 1
+          fi
+
+          install_dir="$HOME/.opencode/bin"
+          mkdir -p "$install_dir"
+          cp "$bin_path" "$install_dir/opencode"
+          chmod 755 "$install_dir/opencode"
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Verify OpenCode
+        run: opencode --version
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', 'evals/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Install eval workspace
+        run: pnpm --dir evals install --frozen-lockfile --prefer-offline
 
       - name: Run app unit tests
         run: pnpm --filter @openwork/app test
@@ -297,7 +423,7 @@ jobs:
   # Single stable context for branch rulesets to require. Green only when
   # the lane selected by classification succeeds; always reports.
   openwork-tests-required:
-    needs: [classify-changes, openwork-tests, validate-models-snapshot, validate-docs]
+    needs: [classify-changes, openwork-tests-specs, openwork-tests-unit, validate-models-snapshot, validate-docs]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -305,12 +431,14 @@ jobs:
         env:
           CLASSIFY_RESULT: ${{ needs.classify-changes.result }}
           LANE: ${{ needs.classify-changes.outputs.lane }}
-          TEST_RESULT: ${{ needs.openwork-tests.result }}
+          SPECS_RESULT: ${{ needs.openwork-tests-specs.result }}
+          UNIT_RESULT: ${{ needs.openwork-tests-unit.result }}
           SNAPSHOT_RESULT: ${{ needs.validate-models-snapshot.result }}
           DOCS_RESULT: ${{ needs.validate-docs.result }}
         run: |
           echo "classification: $CLASSIFY_RESULT ($LANE)"
-          echo "openwork-tests: $TEST_RESULT"
+          echo "openwork test specs: $SPECS_RESULT"
+          echo "openwork test unit/build/e2e: $UNIT_RESULT"
           echo "snapshot validation: $SNAPSHOT_RESULT"
           echo "docs validation: $DOCS_RESULT"
 
@@ -321,13 +449,13 @@ jobs:
 
           case "$LANE" in
             full)
-              [ "$TEST_RESULT" = "success" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
+              [ "$SPECS_RESULT" = "success" ] && [ "$UNIT_RESULT" = "success" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
               ;;
             snapshot)
-              [ "$SNAPSHOT_RESULT" = "success" ] && [ "$TEST_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
+              [ "$SNAPSHOT_RESULT" = "success" ] && [ "$SPECS_RESULT" = "skipped" ] && [ "$UNIT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
               ;;
             docs)
-              [ "$DOCS_RESULT" = "success" ] && [ "$TEST_RESULT" = "skipped" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] || exit 1
+              [ "$DOCS_RESULT" = "success" ] && [ "$SPECS_RESULT" = "skipped" ] && [ "$UNIT_RESULT" = "skipped" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] || exit 1
               ;;
             *)
               echo "Changed-file classification returned an unexpected value; blocking merge." >&2

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -20,8 +20,6 @@ const namedLiveSpec = process.argv.some((argument) => argument.endsWith(".live.t
 export default defineConfig({
   test: {
     ...common,
-    fileParallelism: managedStack,
-    maxWorkers: e2eWorkers,
     projects: [
       {
         resolve: appResolve,
@@ -38,6 +36,8 @@ export default defineConfig({
         test: {
           ...common,
           name: "e2e",
+          fileParallelism: managedStack,
+          maxWorkers: e2eWorkers,
           testTimeout: 600_000,
           hookTimeout: 600_000,
           globalSetup: ["./runner/prepare-stack.ts"],


### PR DESCRIPTION
## Why

"OpenWork Tests" takes ~5m40s per OS. Where it goes (run `33819581353`, Linux):

| step | time |
| --- | ---: |
| Run eval spec lane | 174s |
| Run app unit tests | 35s |
| Run server unit tests | 26s |
| Run eval runner unit tests | 20s |
| Run e2e tests | 37s |
| everything else | ~40s |

Two causes:

1. **`evals/vitest.config.ts` capped the pr lane at 3 workers by accident.** `fileParallelism`/`maxWorkers` were set on the top-level `test` object for the e2e lane's benefit, but that applies to every project — so 118 pr spec files ran on 3 workers no matter how big the runner was.
2. **Everything is one serial job** on the smallest runners (`blacksmith-4vcpu-ubuntu-2204`, GitHub `macos-14`).

## What

- `evals/vitest.config.ts`: move `fileParallelism`/`maxWorkers` into the `e2e` project only. The `pr` project uses vitest's per-core default.
- `.github/workflows/ci-tests.yml`:
  - Split `openwork-tests` into `openwork-tests-specs` (eval spec lane) and `openwork-tests-unit` (unit ×5, outbound manifest, server bundle, Electron typecheck, app e2e). Identical setup steps; both run per OS in parallel.
  - Runners → `blacksmith-16vcpu-ubuntu-2204` and `blacksmith-12vcpu-macos-15` (both already used by the release workflows).
  - `openwork-tests-required` keeps its name (ruleset context) and now requires both jobs to succeed in the `full` lane / both skipped otherwise.

## Verification

Workflow/config only. Lane: local (Node 24).

```
$ time pnpm --dir evals run test:pr        # on this branch
1:21.97 total                              # was ~5:40 with the 3-worker cap

$ pnpm --dir evals exec vitest run --project pr specs/daytona-e2e-regression-concurrency.test.ts specs/daytona-e2e-regression-schedule.test.ts
5 passed
$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/ci-tests.yml'))"   # ok
```

Two pr specs time out locally on both this branch and unmodified `dev` (`thread-approvals-engine-memory`, `app-sdk-smoke-isolation` — the latter shells `pnpm --filter @openwork/app test:e2e` with a 60s cap that only fits on CI). Both pass in CI; unrelated to this change.

The real proof is this PR's own checks: compare `openwork-tests-specs` / `openwork-tests-unit` durations against the ~5m40s baseline.
