### PR TITLE
fix(app): keep workspace state across a Settings round trip

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -35,6 +35,7 @@ import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
 import { OpenWorkDenHelpLink } from "../../workspace/openwork-den-help-link";
 import { NotificationBell } from "../../../shell/notification-center";
+import { useUiStateStore } from "../../../shell/ui-state-store";
 import type {
   WorkspaceConnectionState,
   WorkspaceSessionGroup,
@@ -933,8 +934,15 @@ function isSessionActivityStatus(status: string | undefined): status is SessionA
 }
 
 export function AppSidebar(props: AppSidebarProps) {
-  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = React.useState<Set<string>>(
-    () => new Set(),
+  // Lives in the UI store (not component state) so the open/closed state of
+  // each workspace group survives this sidebar unmounting, e.g. while the
+  // user is in Settings.
+  const expandedWorkspaceIdList = useUiStateStore((state) => state.expandedWorkspaceIds);
+  const expandWorkspace = useUiStateStore((state) => state.expandWorkspace);
+  const toggleWorkspaceExpanded = useUiStateStore((state) => state.toggleWorkspaceExpanded);
+  const expandedWorkspaceIds = React.useMemo(
+    () => new Set(expandedWorkspaceIdList),
+    [expandedWorkspaceIdList],
   );
   const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = React.useState<Record<string, number>>({});
   const previousSessionStatusRef = React.useRef<Record<string, string>>({});
@@ -967,31 +975,6 @@ export function AppSidebar(props: AppSidebarProps) {
     if (selectedId) store.clearUnread(selectedId);
     previousSessionStatusRef.current = statuses;
   }, [props.selectedSessionId, props.sessionStatusById]);
-
-  const expandWorkspace = React.useCallback((workspaceId: string) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-    setExpandedWorkspaceIds((previous) => {
-      if (previous.has(id)) return previous;
-      const next = new Set(previous);
-      next.add(id);
-      return next;
-    });
-  }, []);
-
-  const toggleWorkspaceExpanded = React.useCallback((workspaceId: string) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-    setExpandedWorkspaceIds((previous) => {
-      const next = new Set(previous);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  }, []);
 
   React.useEffect(() => {
     const id = props.selectedWorkspaceId.trim();

--- a/apps/app/src/react-app/shell/app-menu.tsx
+++ b/apps/app/src/react-app/shell/app-menu.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource react */
 import { useEffect, type ReactNode } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { useUpdateCheckRequestStore } from "../domains/settings/state/update-check-request";
 import { useUiStateStore } from "./ui-state-store";
+import { settingsNavigationFromPathname } from "./workspace-routes";
 
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
@@ -11,13 +12,18 @@ const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 
 export function AppMenuProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const toggleSidebar = useUiStateStore((state) => state.toggleSidebar);
 
   useEffect(() => {
-    const openSettings = () => navigate("/settings/general");
+    const openSettingsTab = (tab: string) => {
+      const target = settingsNavigationFromPathname(pathname, tab);
+      navigate(target.to, { state: target.state });
+    };
+    const openSettings = () => openSettingsTab("general");
     const checkUpdates = () => {
       useUpdateCheckRequestStore.getState().requestUpdateCheck();
-      navigate("/settings/updates");
+      openSettingsTab("updates");
     };
 
     window.addEventListener(NATIVE_MENU_OPEN_SETTINGS_EVENT, openSettings);
@@ -28,7 +34,7 @@ export function AppMenuProvider({ children }: { children: ReactNode }) {
       window.removeEventListener(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, toggleSidebar);
       window.removeEventListener(NATIVE_MENU_CHECK_UPDATES_EVENT, checkUpdates);
     };
-  }, [navigate, toggleSidebar]);
+  }, [navigate, pathname, toggleSidebar]);
 
   return <>{children}</>;
 }

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -703,6 +703,7 @@ export function useControlActions(actions: readonly OpenworkControlAction[]) {
 }
 
 import { SETTINGS_TAB_VALUES } from "../../../app/types";
+import { settingsNavigationFromPathname } from "../workspace-routes";
 
 const SETTINGS_TABS: ReadonlySet<string> = new Set<string>(
   SETTINGS_TAB_VALUES.filter((tab) => tab !== "extensions"),
@@ -710,6 +711,14 @@ const SETTINGS_TABS: ReadonlySet<string> = new Set<string>(
 
 export function OpenworkRouteControlActions() {
   const navigate = useNavigate();
+  const location = useLocation();
+  // Read through a ref so the action list stays stable across route changes.
+  const pathnameRef = useRef(location.pathname);
+  pathnameRef.current = location.pathname;
+  const openSettingsTab = useCallback((tab: string) => {
+    const target = settingsNavigationFromPathname(pathnameRef.current, tab);
+    navigate(target.to, { state: target.state });
+  }, [navigate]);
 
   const actions = useMemo<OpenworkControlAction[]>(() => [
     {
@@ -724,7 +733,7 @@ export function OpenworkRouteControlActions() {
       label: "Open general settings",
       description: "Navigate to general settings.",
       sideEffect: "navigation",
-      execute: () => navigate("/settings/general"),
+      execute: () => openSettingsTab("general"),
     },
     {
       id: "route.extensions.skills",
@@ -738,21 +747,21 @@ export function OpenworkRouteControlActions() {
       label: "Open provider settings",
       description: "Navigate to AI provider settings.",
       sideEffect: "navigation",
-      execute: () => navigate("/settings/ai"),
+      execute: () => openSettingsTab("ai"),
     },
     {
       id: "route.settings.authorized_folders",
       label: "Open authorized folder settings",
       description: "Navigate to authorized folders and file access settings.",
       sideEffect: "navigation",
-      execute: () => navigate("/settings/permissions"),
+      execute: () => openSettingsTab("permissions"),
     },
     {
       id: "route.settings.appearance",
       label: "Open appearance settings",
       description: "Navigate to appearance settings.",
       sideEffect: "navigation",
-      execute: () => navigate("/settings/appearance"),
+      execute: () => openSettingsTab("appearance"),
     },
     {
       id: "settings.panel.open",
@@ -779,7 +788,7 @@ export function OpenworkRouteControlActions() {
             error: `Unknown settings panel: ${panel || "(empty)"}. Expected one of ${Array.from(SETTINGS_TABS).join(", ")}.`,
           };
         }
-        navigate(`/settings/${panel}`);
+        openSettingsTab(panel);
         return { ok: true, panel };
       },
     },
@@ -822,7 +831,7 @@ export function OpenworkRouteControlActions() {
         hint: "Use settings.panel.open for settings such as AI providers, and route.extensions.skills to browse Library.",
       }),
     },
-  ], [navigate]);
+  ], [navigate, openSettingsTab]);
 
   useControlActions(actions);
   return null;

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -185,6 +185,7 @@ import { getDenInferenceUrl, type DenSettings } from "@/app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
 import {
   globalExtensionsRoute,
+  settingsReturnRoute,
   workspaceExtensionsRoute,
   workspaceSessionRoute,
   workspaceSettingsRoute,
@@ -388,18 +389,6 @@ function readNavigationSessionId(state: unknown): string | null {
   if (!state || typeof state !== "object") return null;
   const value = (state as { sessionId?: unknown }).sessionId;
   return typeof value === "string" ? value.trim() || null : null;
-}
-
-export function settingsReturnRoute(
-  selectedWorkspaceId: string,
-  navigationWorkspaceId: string | null,
-  navigationSessionId: string | null,
-) {
-  if (!selectedWorkspaceId) return "/session";
-  const returnSessionId = navigationWorkspaceId === selectedWorkspaceId
-    ? navigationSessionId
-    : null;
-  return workspaceSessionRoute(selectedWorkspaceId, returnSessionId);
 }
 
 export function settingsDeveloperModePaletteItem(

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -29,6 +29,10 @@ export type UiState = {
   sidebarOpen: boolean;
   // Deliberately not persisted so each app load starts with only chat visible.
   sidePanelState: SidePanelState;
+  // Which workspace groups are open in the session sidebar. Kept in memory
+  // (not persisted) so leaving for Settings and coming back does not collapse
+  // them: the session route unmounts while Settings is open.
+  expandedWorkspaceIds: string[];
   applicationMenuVisible: boolean;
   workspaceLeftSidebarWidth: number;
   workspaceLeftSidebarResizing: boolean;
@@ -39,6 +43,7 @@ export type UiState = {
 const initialState: UiState = {
   sidebarOpen: true,
   sidePanelState: {},
+  expandedWorkspaceIds: [],
   applicationMenuVisible: false,
   workspaceLeftSidebarWidth: DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
   workspaceLeftSidebarResizing: false,
@@ -228,6 +233,33 @@ export function toggleSidePanelState(
   return setSidePanelState(state, sessionId, getSidePanelState(state, sessionId) === panel ? null : panel);
 }
 
+export function expandWorkspace(state: UiState, workspaceId: string): UiState {
+  const id = workspaceId.trim();
+  if (!id || state.expandedWorkspaceIds.includes(id)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    expandedWorkspaceIds: [...state.expandedWorkspaceIds, id],
+  };
+}
+
+export function toggleWorkspaceExpanded(state: UiState, workspaceId: string): UiState {
+  const id = workspaceId.trim();
+  if (!id) {
+    return state;
+  }
+  if (!state.expandedWorkspaceIds.includes(id)) {
+    return expandWorkspace(state, id);
+  }
+
+  return {
+    ...state,
+    expandedWorkspaceIds: state.expandedWorkspaceIds.filter((entry) => entry !== id),
+  };
+}
+
 export function setApplicationMenuVisible(state: UiState, visible: boolean): UiState {
   if (state.applicationMenuVisible === visible) {
     return state;
@@ -298,6 +330,8 @@ type UiStateStore = UiState & {
   toggleSidebar: () => void;
   setSidePanelState: (sessionId: string | null | undefined, panel: SidePanelItem | null) => void;
   toggleSidePanelState: (sessionId: string | null | undefined, panel: SidePanelItem) => void;
+  expandWorkspace: (workspaceId: string) => void;
+  toggleWorkspaceExpanded: (workspaceId: string) => void;
   setApplicationMenuVisible: (visible: boolean) => void;
   setWorkspaceLeftSidebarWidth: (width: number) => void;
   setWorkspaceLeftSidebarResizing: (resizing: boolean) => void;
@@ -312,6 +346,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   toggleSidebar: () => set((state) => toggleSidebar(state)),
   setSidePanelState: (sessionId, panel) => set((state) => setSidePanelState(state, sessionId, panel)),
   toggleSidePanelState: (sessionId, panel) => set((state) => toggleSidePanelState(state, sessionId, panel)),
+  expandWorkspace: (workspaceId) => set((state) => expandWorkspace(state, workspaceId)),
+  toggleWorkspaceExpanded: (workspaceId) => set((state) => toggleWorkspaceExpanded(state, workspaceId)),
   setApplicationMenuVisible: (visible) => {
     set((state) => setApplicationMenuVisible(state, visible));
     syncApplicationMenuVisible(visible);

--- a/apps/app/src/react-app/shell/workspace-routes.ts
+++ b/apps/app/src/react-app/shell/workspace-routes.ts
@@ -15,6 +15,38 @@ export function workspaceSettingsRoute(
   return `/workspace/${encodeURIComponent(workspaceId.trim())}/settings/${tab}`;
 }
 
+/**
+ * Where closing Settings lands. The originating session is restored only when
+ * Settings is still on the workspace it was opened from.
+ */
+export function settingsReturnRoute(
+  selectedWorkspaceId: string,
+  navigationWorkspaceId: string | null,
+  navigationSessionId: string | null,
+) {
+  if (!selectedWorkspaceId) return "/session";
+  const returnSessionId = navigationWorkspaceId === selectedWorkspaceId
+    ? navigationSessionId
+    : null;
+  return workspaceSessionRoute(selectedWorkspaceId, returnSessionId);
+}
+
+/**
+ * Settings entry from anywhere that only knows the current URL (native menu,
+ * agent control actions). Keeps the workspace in the route and remembers the
+ * open session in navigation state so closing Settings returns to exactly
+ * where the user was, matching the in-app settings button.
+ */
+export function settingsNavigationFromPathname(pathname: string, tab: SettingsTab | string) {
+  const match = /^\/workspace\/([^/]+)(?:\/session\/([^/]+))?/.exec(pathname);
+  const workspaceId = match?.[1] ? decodeURIComponent(match[1]) : "";
+  const sessionId = match?.[2] ? decodeURIComponent(match[2]) : null;
+  return {
+    to: workspaceId ? workspaceSettingsRoute(workspaceId, tab) : `/settings/${tab}`,
+    state: { workspaceId, sessionId },
+  };
+}
+
 export function automationsRoute() {
   return "/automations";
 }

--- a/apps/app/tests/settings-route.test.ts
+++ b/apps/app/tests/settings-route.test.ts
@@ -5,7 +5,6 @@ import {
   parseExtensionsPath,
   parseSettingsPath,
   settingsDeveloperModePaletteItem,
-  settingsReturnRoute,
   settingsPathForRoute,
 } from "../src/react-app/shell/settings-route";
 import {
@@ -13,6 +12,7 @@ import {
   getWorkspaceSettingsTabs,
   isSettingsTabActive,
 } from "../src/react-app/domains/settings/shell/settings-page";
+import { settingsNavigationFromPathname, settingsReturnRoute } from "../src/react-app/shell/workspace-routes";
 
 describe("settings route parsing", () => {
   test("parses the first-class Extensions route for direct workspace navigation and reloads", () => {
@@ -115,6 +115,17 @@ describe("settings navigation", () => {
   test("does not carry a session into a different selected workspace", () => {
     expect(settingsReturnRoute("workspace_2", "workspace_1", "session_1")).toBe(
       "/workspace/workspace_2/session",
+    );
+  });
+
+  test("native menu / agent settings entry round-trips back to the open session", () => {
+    // Regression: Cmd+, and settings.panel.open used to enter Settings via
+    // the global /settings route with no navigation state, so closing
+    // Settings dropped the user onto the workspace's empty "new task" state.
+    const entry = settingsNavigationFromPathname("/workspace/workspace_1/session/session_1", "general");
+    expect(entry.to).toBe("/workspace/workspace_1/settings/general");
+    expect(settingsReturnRoute("workspace_1", entry.state.workspaceId, entry.state.sessionId)).toBe(
+      "/workspace/workspace_1/session/session_1",
     );
   });
 

--- a/apps/app/tests/ui-state-store.test.ts
+++ b/apps/app/tests/ui-state-store.test.ts
@@ -68,7 +68,7 @@ Object.defineProperty(globalThis, "localStorage", {
   value: storage,
 });
 
-const { persistUiState, toggleSidePanelState, useUiStateStore } = await import(
+const { expandWorkspace, persistUiState, toggleSidePanelState, toggleWorkspaceExpanded, useUiStateStore } = await import(
   "../src/react-app/shell/ui-state-store"
 );
 const { usePanelTabStore } = await import("../src/react-app/domains/session/panel/panel-tab-store");
@@ -92,6 +92,7 @@ describe("ui state store", () => {
     const state: UiState = {
       sidebarOpen: true,
       sidePanelState: { ses_1: "extensions" },
+      expandedWorkspaceIds: ["ws_1"],
       applicationMenuVisible: false,
       workspaceLeftSidebarWidth: 260,
       workspaceLeftSidebarResizing: false,
@@ -103,6 +104,7 @@ describe("ui state store", () => {
 
     const parsed = requireJsonObject(storage.getItem(PERSISTED_UI_STATE_KEY));
     expect("sidePanelState" in parsed).toBe(false);
+    expect("expandedWorkspaceIds" in parsed).toBe(false);
     expect(objectValue(parsed, "workspaceRightSidebarExpanded")).toBe(true);
     expect(objectValue(parsed, "workspaceRightSidebarExpandedWidth")).toBe(520);
   });
@@ -116,6 +118,7 @@ describe("ui state store", () => {
     const state: UiState = {
       sidebarOpen: true,
       sidePanelState: {},
+      expandedWorkspaceIds: [],
       applicationMenuVisible: false,
       workspaceLeftSidebarWidth: 260,
       workspaceLeftSidebarResizing: false,
@@ -128,6 +131,37 @@ describe("ui state store", () => {
 
     const closed = toggleSidePanelState(opened, "ses_1", "extensions");
     expect(closed.sidePanelState).toEqual({ ses_1: null });
+  });
+
+  test("keeps sidebar workspace expansion in the store so it survives the sidebar unmounting", () => {
+    // Opening Settings unmounts the session sidebar. Expansion state must
+    // outlive that, so it lives in the store rather than component state.
+    const base: UiState = {
+      sidebarOpen: true,
+      sidePanelState: {},
+      expandedWorkspaceIds: [],
+      applicationMenuVisible: false,
+      workspaceLeftSidebarWidth: 260,
+      workspaceLeftSidebarResizing: false,
+      workspaceRightSidebarExpanded: false,
+      workspaceRightSidebarExpandedWidth: 520,
+    };
+
+    const one = expandWorkspace(base, " ws_1 ");
+    expect(one.expandedWorkspaceIds).toEqual(["ws_1"]);
+    expect(expandWorkspace(one, "ws_1")).toBe(one);
+    expect(expandWorkspace(one, "  ")).toBe(one);
+
+    const two = toggleWorkspaceExpanded(one, "ws_2");
+    expect(two.expandedWorkspaceIds).toEqual(["ws_1", "ws_2"]);
+    const collapsed = toggleWorkspaceExpanded(two, "ws_1");
+    expect(collapsed.expandedWorkspaceIds).toEqual(["ws_2"]);
+
+    useUiStateStore.getState().expandWorkspace("ws_store");
+    useUiStateStore.getState().toggleWorkspaceExpanded("ws_toggle");
+    expect(useUiStateStore.getState().expandedWorkspaceIds).toEqual(["ws_store", "ws_toggle"]);
+    useUiStateStore.getState().toggleWorkspaceExpanded("ws_toggle");
+    expect(useUiStateStore.getState().expandedWorkspaceIds).toEqual(["ws_store"]);
   });
 
   test("preserves active panel content while the panel closes and reopens", () => {

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -16,6 +16,7 @@ import {
   preserveWorkspaceRouteSession,
   removeWorkspaceRouteSession,
   sessionIdForLegacyWorkspaceInference,
+  settingsNavigationFromPathname,
   globalExtensionsRoute,
   workspaceExtensionsRoute,
   workspaceSettingsRoute,
@@ -33,6 +34,33 @@ describe("workspace surface routes", () => {
       "/workspace/workspace%2Fa/extensions/skills",
     );
     expect(globalExtensionsRoute("mcps")).toBe("/extensions/mcps");
+  });
+
+  test("menu/agent settings entry keeps the workspace and remembers the open session", () => {
+    // Native menu "Settings…" and agent settings.panel.open only know the URL.
+    // They must enter Settings the same way the in-app button does, so
+    // settingsReturnRoute can bring the user back to the same session.
+    const fromSession = settingsNavigationFromPathname(
+      "/workspace/workspace%2Fa/session/session_1",
+      "general",
+    );
+    expect(fromSession).toEqual({
+      to: "/workspace/workspace%2Fa/settings/general",
+      state: { workspaceId: "workspace/a", sessionId: "session_1" },
+    });
+
+    expect(settingsNavigationFromPathname("/workspace/workspace_1/session", "updates")).toEqual({
+      to: "/workspace/workspace_1/settings/updates",
+      state: { workspaceId: "workspace_1", sessionId: null },
+    });
+    expect(settingsNavigationFromPathname("/workspace/workspace_1/extensions/skills", "ai")).toEqual({
+      to: "/workspace/workspace_1/settings/ai",
+      state: { workspaceId: "workspace_1", sessionId: null },
+    });
+    expect(settingsNavigationFromPathname("/automations", "general")).toEqual({
+      to: "/settings/general",
+      state: { workspaceId: "", sessionId: null },
+    });
   });
 });
 

--- a/evals/specs/settings-round-trip-keeps-workspace-state.test.ts
+++ b/evals/specs/settings-round-trip-keeps-workspace-state.test.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+
+import {
+  DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
+  expandWorkspace,
+  persistUiState,
+  toggleWorkspaceExpanded,
+  type UiState,
+} from "../../apps/app/src/react-app/shell/ui-state-store";
+import {
+  settingsNavigationFromPathname,
+  settingsReturnRoute,
+} from "../../apps/app/src/react-app/shell/workspace-routes";
+
+// Reported bug: open Settings in OpenWork desktop, come back, and the state of
+// which workspaces were "opened" is gone. Two independent causes:
+//   1. The sidebar kept expanded workspace groups in component state, and
+//      Settings is a separate route that unmounts the sidebar.
+//   2. Cmd+, (native menu) and agent settings actions entered Settings on the
+//      bare /settings route with no navigation state, so closing Settings could
+//      not return to the open session.
+
+function uiState(overrides: Partial<UiState> = {}): UiState {
+  return {
+    sidebarOpen: true,
+    sidePanelState: {},
+    expandedWorkspaceIds: [],
+    applicationMenuVisible: false,
+    workspaceLeftSidebarWidth: DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
+    workspaceLeftSidebarResizing: false,
+    workspaceRightSidebarExpanded: false,
+    workspaceRightSidebarExpandedWidth: 520,
+    ...overrides,
+  };
+}
+
+function appSource(relativePath: string) {
+  return readFileSync(fileURLToPath(new URL(`../../apps/app/src/${relativePath}`, import.meta.url)), "utf8");
+}
+
+test("expanded workspace groups live in the UI store, not in the sidebar component", async ({ evidence }) => {
+  // The sidebar must read expansion from the store so unmounting it (Settings
+  // is its own route) cannot reset which groups are open.
+  const sidebar = appSource("react-app/domains/session/sidebar/app-sidebar.tsx");
+  expect(sidebar).toContain("useUiStateStore((state) => state.expandedWorkspaceIds)");
+  expect(sidebar).toContain("useUiStateStore((state) => state.toggleWorkspaceExpanded)");
+  expect(sidebar).not.toMatch(/useState<Set<string>>/);
+
+  // Store semantics: expanding is idempotent, toggling collapses only the
+  // requested group, and other groups are untouched.
+  const one = expandWorkspace(uiState(), " ws_a ");
+  expect(one.expandedWorkspaceIds).toEqual(["ws_a"]);
+  expect(expandWorkspace(one, "ws_a")).toBe(one);
+  const two = toggleWorkspaceExpanded(one, "ws_b");
+  expect(two.expandedWorkspaceIds).toEqual(["ws_a", "ws_b"]);
+  const collapsedA = toggleWorkspaceExpanded(two, "ws_a");
+  expect(collapsedA.expandedWorkspaceIds).toEqual(["ws_b"]);
+
+  evidence.recordAssertionEvidence(
+    "Sidebar workspace expansion survives the sidebar unmounting",
+    "AppSidebar reads expandedWorkspaceIds and its toggles from useUiStateStore instead of a local useState Set; the store reducers add, keep, and remove exactly the requested workspace id.",
+    true,
+  );
+});
+
+test("workspace expansion is session-scoped memory and is never written to disk", async ({ evidence }) => {
+  // Negative half: a fresh app load must still start with only the selected
+  // workspace open, so the store keeps this in memory only.
+  const written: Record<string, string> = {};
+  const storage = {
+    setItem(key: string, value: string) {
+      written[key] = value;
+    },
+  };
+  const previousWindow = Reflect.get(globalThis, "window");
+  Reflect.set(globalThis, "window", { localStorage: storage });
+  try {
+    persistUiState(uiState({ expandedWorkspaceIds: ["ws_a", "ws_b"] }));
+  } finally {
+    Reflect.set(globalThis, "window", previousWindow);
+  }
+  const persisted = Object.values(written);
+  expect(persisted).toHaveLength(1);
+  expect(persisted[0]).not.toContain("expandedWorkspaceIds");
+  expect(persisted[0]).not.toContain("ws_a");
+
+  evidence.recordAssertionEvidence(
+    "Expanded workspaces are not persisted across app launches",
+    "persistUiState writes the UI state blob without expandedWorkspaceIds, so a relaunch still opens only the selected workspace group.",
+    true,
+  );
+});
+
+test("Cmd+, and agent settings actions return to the session they were opened from", async ({ evidence }) => {
+  const pathname = "/workspace/ws_a/session/ses_1";
+
+  // Entering Settings from a URL-only caller keeps the workspace in the route
+  // and carries the open session in navigation state...
+  const entry = settingsNavigationFromPathname(pathname, "general");
+  expect(entry.to).toBe("/workspace/ws_a/settings/general");
+  expect(entry.state).toEqual({ workspaceId: "ws_a", sessionId: "ses_1" });
+
+  // ...so closing Settings lands on the exact same session.
+  expect(settingsReturnRoute("ws_a", entry.state.workspaceId, entry.state.sessionId)).toBe(pathname);
+
+  // Regression guard: the old bare-route entries dropped the session.
+  expect(settingsReturnRoute("ws_a", null, null)).toBe("/workspace/ws_a/session");
+
+  // Both URL-only callers must go through the shared helper.
+  const appMenu = appSource("react-app/shell/app-menu.tsx");
+  const controlProvider = appSource("react-app/shell/control/control-provider.tsx");
+  expect(appMenu).toContain("settingsNavigationFromPathname(");
+  expect(appMenu).not.toContain('navigate("/settings/general")');
+  expect(controlProvider).toContain("settingsNavigationFromPathname(");
+  expect(controlProvider).not.toContain('navigate("/settings/general")');
+  expect(controlProvider).not.toContain("navigate(`/settings/${panel}`)");
+
+  evidence.recordAssertionEvidence(
+    "Native menu and settings.panel.open round-trip back to the open session",
+    "settingsNavigationFromPathname produces a workspace-scoped settings route plus {workspaceId, sessionId} state, settingsReturnRoute maps that state back to the originating session route, and app-menu.tsx and control-provider.tsx no longer navigate to the bare /settings route.",
+    true,
+  );
+});
+
+test("the session is not carried into a different workspace's settings", async ({ evidence }) => {
+  // Negative half: switching workspace inside Settings must not reopen a
+  // session that belongs to the workspace Settings was opened from.
+  const entry = settingsNavigationFromPathname("/workspace/ws_a/session/ses_1", "ai");
+  expect(settingsReturnRoute("ws_b", entry.state.workspaceId, entry.state.sessionId)).toBe(
+    "/workspace/ws_b/session",
+  );
+
+  // Routes without a workspace still produce a valid global settings entry.
+  expect(settingsNavigationFromPathname("/automations", "general")).toEqual({
+    to: "/settings/general",
+    state: { workspaceId: "", sessionId: null },
+  });
+  expect(settingsReturnRoute("", null, null)).toBe("/session");
+
+  evidence.recordAssertionEvidence(
+    "Remembered session stays bound to its own workspace",
+    "settingsReturnRoute only restores the session when the selected workspace matches the one Settings was opened from; other workspaces and workspace-less routes fall back to their session root.",
+    true,
+  );
+});

--- a/evals/specs/sidebar-left-width-expansion.test.ts
+++ b/evals/specs/sidebar-left-width-expansion.test.ts
@@ -13,6 +13,7 @@ function uiState(overrides: Partial<UiState> = {}): UiState {
   return {
     sidebarOpen: true,
     sidePanelState: {},
+    expandedWorkspaceIds: [],
     applicationMenuVisible: false,
     workspaceLeftSidebarWidth: DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
     workspaceLeftSidebarResizing: false,


### PR DESCRIPTION
## Problem

Open Settings in OpenWork desktop, come back, and the state of which workspaces were "opened" is gone. Reproduced on the live app: 5 expanded sidebar workspaces → 2 after one round trip, and `Cmd+,` → Back to app dropped the open session.

Two independent root causes:

1. **Sidebar expansion was component state.** `AppSidebar` held `expandedWorkspaceIds` in `useState(new Set())`. Settings is a separate top-level route (`/workspace/:id/settings/*`), so it unmounts `SessionRoute` and the sidebar; on return only the selected workspace re-expands.
2. **URL-only Settings entries carried no context.** The in-app settings button passes `{ workspaceId, sessionId }` as navigation state so `settingsReturnRoute` can return to the same session. The native menu (`Cmd+,`) and the agent control actions (`settings.panel.open`, `route.settings.*`) did `navigate("/settings/general")` — bare route, no state — so closing Settings landed on the workspace's empty "new task" screen.

## Fix

- `ui-state-store.ts`: `expandedWorkspaceIds` (in memory, deliberately **not** persisted) with `expandWorkspace` / `toggleWorkspaceExpanded`; `app-sidebar.tsx` reads/writes the store.
- `workspace-routes.ts`: `settingsNavigationFromPathname(pathname, tab)` → workspace-scoped settings route + `{ workspaceId, sessionId }` state parsed from the current URL. Used by `app-menu.tsx` and `control-provider.tsx`.
- `settingsReturnRoute` moved from `settings-route.tsx` to `workspace-routes.ts` (pure, importable by specs).

## Verification

Lane: **local** (no Daytona credentials in this environment). All on PR head `cdc285715`.

| Command | Result |
|---|---|
| `pnpm --dir evals exec vitest run --config vitest.config.ts --project pr specs/settings-round-trip-keeps-workspace-state.test.ts specs/sidebar-left-width-expansion.test.ts` | **6 passed / 0 failed / 0 skipped** |
| `pnpm evals:pr` (full PR lane) | 165 passed / 4 failed / 3 skipped — see below |
| `bun test --isolate tests/` in `apps/app` | 1177 pass / 7 fail — same 6 named failures on clean `origin/dev`, see below |
| `tsc -p tsconfig.json --noEmit` in `apps/app` | exit 0 |
| `pnpm --dir evals run lint:layers` | no dependency violations |

**Pre-existing failures (control on clean `origin/dev` via `git stash -u`, same commands):**
- evals PR lane: `app-sdk-smoke-isolation`, `effective-permissions-attribution`, `thread-approvals-engine-memory` fail identically on clean `origin/dev` (need a local OpenCode/Den stack). `sso-saml-acs-delivery` failed once in the full run on a `den-web dev:local` boot race and **passes** when re-run alone on this head (1 passed).
- `apps/app` bun tests: `assigned OpenWork Connect capability inventory` ×2, `app inspector OpenCode client`, `cloud workspace boot takeover`, `session-route cloud provider sync wiring`, `Extensions sidebar destination` — identical set on clean `origin/dev`.

**New spec** `evals/specs/settings-round-trip-keeps-workspace-state.test.ts` (4 claims, each with its negative half):
- expanded groups live in the UI store, not sidebar component state (source assertion + reducer semantics)
- expansion is never written to disk (`persistUiState` output excludes it)
- `Cmd+,` / `settings.panel.open` entry round-trips to the exact originating session; `app-menu.tsx` and `control-provider.tsx` no longer hit the bare `/settings` route
- the remembered session is not carried into a different workspace's Settings

Also fixed the `UiState` literal in the existing `sidebar-left-width-expansion.test.ts` for the new field.

**Manual live check** (supplementary, not proof): `dev-headless` world with 3 workspaces + open session; expanded two others → `openwork:native-menu:open-settings` → Back to app ⇒ URL back on the exact session, all three still expanded; `check-updates` path carried `{workspaceId, sessionId}` in `history.state`.

Verdict: **Passed** for the claims above (local lane).
