### PR TITLE
test(evals): poll live stage probes in world-stage-isolation

### DIFF
--- a/evals/specs/world-stage-isolation.test.ts
+++ b/evals/specs/world-stage-isolation.test.ts
@@ -27,6 +27,18 @@ async function probe(url: string): Promise<number | "rejected"> {
   }
 }
 
+// A live stage must answer; a single 2s attempt on a loaded CI runner is not
+// proof that it does not. Rejection is asserted single-shot only after
+// `eventually` has already observed the process gone.
+async function probeUntilOk(url: string, label: string): Promise<number | "rejected"> {
+  return eventually(() => probe(url), {
+    within: 10_000,
+    intervalMs: 250,
+    label,
+    until: (status) => status === 200,
+  });
+}
+
 test("staged worlds run side by side without touching each other", async ({ evidence }) => {
   const root = await mkdtemp(join(tmpdir(), "openwork-world-stage-isolation-"));
   const worldsDirectory = join(root, "worlds");
@@ -108,8 +120,8 @@ if (import.meta.main) await runRecipe(world);
     assert.equal(isProcessAlive(stageA.pid), true);
     assert.equal(isProcessAlive(stageB.pid), true);
     assert.notEqual(stageA.outputs.url, stageB.outputs.url);
-    assert.equal(await probe(stageA.outputs.url), 200);
-    assert.equal(await probe(stageB.outputs.url), 200);
+    assert.equal(await probeUntilOk(stageA.outputs.url, "stage a answers"), 200);
+    assert.equal(await probeUntilOk(stageB.outputs.url, "stage b answers"), 200);
     const stageAAfterBoth = await readScriptWorldSnapshot(stageAPath);
     const stageBAfterBoth = await readScriptWorldSnapshot(stageBPath);
     assert.ok(stageAAfterBoth);
@@ -131,7 +143,7 @@ if (import.meta.main) await runRecipe(world);
       label: "stage a stops while stage b remains available",
     });
     assert.equal(await probe(stageA.outputs.url), "rejected");
-    assert.equal(await probe(stageB.outputs.url), 200);
+    assert.equal(await probeUntilOk(stageB.outputs.url, "stage b still answers after stage a is down"), 200);
     assert.equal(await exists(stageAPath), false);
     const stageBAfterDownA = await readScriptWorldSnapshot(stageBPath);
     assert.ok(stageBAfterDownA);


### PR DESCRIPTION
## Why

`dev` run [33823027028](https://github.com/different-ai/openwork/actions/runs/33823027028/job/100869634543) (macOS) failed with:

```
FAIL specs/world-stage-isolation.test.ts > staged worlds run side by side without touching each other
AssertionError: Expected values to be strictly equal:  'rejected' !== 200
  ❯ specs/world-stage-isolation.test.ts:112:12
```

Both staged world processes were alive and had published their URLs; the spec then probed stage A with **one** `fetch` under a hard `AbortSignal.timeout(2_000)`. On the loaded 3-core runner that single request didn't complete in 2s, so a healthy stage was reported as rejected. The same spec already uses `eventually(..., within: 10_000)` for the *negative* probe after teardown (line 140) — only the positive probes were single-shot.

With #4379 running the pr lane at full per-core parallelism, single-shot 2s probes get more fragile, not less.

## What

Add `probeUntilOk()` = `eventually(probe, { within: 10_000, intervalMs: 250, until: status === 200 })` and use it for the three "stage is live" assertions. The "stage A is rejected after `down`" assertion stays single-shot, since `eventually` has already observed the process gone at that point.

## Verification

Spec-only change. Lane: local (Node 24).

```
$ pnpm --dir evals exec vitest run --project pr specs/world-stage-isolation.test.ts   # ×3
✓ specs/world-stage-isolation.test.ts (1 test) 4093ms
✓ specs/world-stage-isolation.test.ts (1 test) 4077ms
✓ specs/world-stage-isolation.test.ts (1 test) 4100ms
```

Verdict: **Passed**.
