### PR TITLE
fix(dashboards): surface missing required launch input instead of "Unexpected server error"

### DIFF
--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -24,6 +24,7 @@ import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } 
 import {
   callMcpAppTool,
   listMcpAppCatalog,
+  McpAppHostError,
   projectedMcpToolName,
   resolveConnectMcpAppResource,
   resolveMcpAppResource,
@@ -165,9 +166,11 @@ async function startFixtureMcp(
   });
   mcp.setRequestHandler(CallToolRequestSchema, async ({ params }) => {
     if (params.name === "render_report" && typeof params.arguments?.id !== "string") {
+      // A control character and an oversized tail model a hostile provider;
+      // the host must relay neither verbatim.
       throw new McpError(
         ErrorCode.InvalidParams,
-        'Invalid arguments for tool render_report: [{"path":["id"],"message":"Required"}]',
+        `Invalid arguments for tool render_report: [{"path":["id"],"message":"Required"}]\u0007 ${"x".repeat(2_000)}`,
       );
     }
     return {
@@ -667,19 +670,28 @@ describe("MCP Apps host transport", () => {
     // A dashboard tile launched with input that omits a required argument must
     // show the provider's rejection, which names the missing key, instead of
     // the generic 500 "Unexpected server error" an untyped throw produces.
-    await expect(callMcpAppTool({
-      serverConfig: config,
-      workspaceId: WORKSPACE_ID,
-      workspaceRoot: root,
-      serverName: "fixture",
-      name: "render_report",
-      resourceUri: RESOURCE_URI,
-      arguments: {},
-    })).rejects.toMatchObject({
-      name: "McpAppHostError",
-      code: "tool_call_failed",
-      message: expect.stringContaining('"path":["id"],"message":"Required"'),
-    });
+    let failure: unknown = null;
+    try {
+      await callMcpAppTool({
+        serverConfig: config,
+        workspaceId: WORKSPACE_ID,
+        workspaceRoot: root,
+        serverName: "fixture",
+        name: "render_report",
+        resourceUri: RESOURCE_URI,
+        arguments: {},
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(McpAppHostError);
+    if (!(failure instanceof McpAppHostError)) throw new Error("unreachable");
+    expect(failure.code).toBe("tool_call_failed");
+    // Provider text is relayed, but bounded: no control characters, capped length.
+    expect(failure.message).toContain('"path":["id"],"message":"Required"');
+    expect(failure.message).not.toContain("\u0007");
+    expect(failure.message.length).toBeLessThanOrEqual(512 + 1);
+    expect(failure.message.endsWith("…")).toBe(true);
   });
 
   test("mediates a resource-bound same-server tool for its exact MCP App", async () => {

--- a/apps/server/src/mcp-app-host.test.ts
+++ b/apps/server/src/mcp-app-host.test.ts
@@ -7,7 +7,9 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
   CallToolRequestSchema,
+  ErrorCode,
   ListToolsRequestSchema,
+  McpError,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { addMcp } from "./mcp.js";
@@ -161,10 +163,18 @@ async function startFixtureMcp(
       }],
     };
   });
-  mcp.setRequestHandler(CallToolRequestSchema, async ({ params }) => ({
-    content: [{ type: "text", text: `detail:${String(params.arguments?.id ?? "")}` }],
-    structuredContent: { id: params.arguments?.id ?? null },
-  }));
+  mcp.setRequestHandler(CallToolRequestSchema, async ({ params }) => {
+    if (params.name === "render_report" && typeof params.arguments?.id !== "string") {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Invalid arguments for tool render_report: [{"path":["id"],"message":"Required"}]',
+      );
+    }
+    return {
+      content: [{ type: "text", text: `detail:${String(params.arguments?.id ?? "")}` }],
+      structuredContent: { id: params.arguments?.id ?? null },
+    };
+  });
 
   let transport: WebStandardStreamableHTTPServerTransport;
   let serverOrigin = "";
@@ -648,6 +658,27 @@ describe("MCP Apps host transport", () => {
     expect(result).toMatchObject({
       content: [{ type: "text", text: "detail:42" }],
       structuredContent: { id: "42" },
+    });
+  });
+
+  test("surfaces a provider argument rejection as a typed host error, not an unhandled failure", async () => {
+    const { config, root } = await configuredFixture("openwork-mcp-app-call-rejected-");
+
+    // A dashboard tile launched with input that omits a required argument must
+    // show the provider's rejection, which names the missing key, instead of
+    // the generic 500 "Unexpected server error" an untyped throw produces.
+    await expect(callMcpAppTool({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      serverName: "fixture",
+      name: "render_report",
+      resourceUri: RESOURCE_URI,
+      arguments: {},
+    })).rejects.toMatchObject({
+      name: "McpAppHostError",
+      code: "tool_call_failed",
+      message: expect.stringContaining('"path":["id"],"message":"Required"'),
     });
   });
 

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -760,7 +760,15 @@ export async function callMcpAppTool(input: {
         "This MCP App tool requires user approval before OpenWork can call it.",
       );
     }
-    const result = await client.callTool({ name: input.name, arguments: input.arguments ?? {} });
+    // A provider that rejects the call (for example JSON-RPC -32602 for a
+    // missing required argument) must reach the member as that rejection,
+    // not as an unhandled 500 "Unexpected server error".
+    const result = await client.callTool({ name: input.name, arguments: input.arguments ?? {} }).catch((error: unknown) => {
+      throw new McpAppHostError(
+        "tool_call_failed",
+        error instanceof Error && error.message ? error.message : "The MCP App tool call failed.",
+      );
+    });
     if (new TextEncoder().encode(JSON.stringify(result)).byteLength > MAX_RESULT_BYTES) {
       throw new McpAppHostError("result_too_large", "The MCP App tool result exceeds the 1 MiB host limit.");
     }

--- a/apps/server/src/mcp-app-host.ts
+++ b/apps/server/src/mcp-app-host.ts
@@ -26,6 +26,8 @@ const MAX_TOOL_PAGES = 32;
 const MAX_TOOLS = 2_048;
 const MAX_RESOURCE_BYTES = 768 * 1024;
 const MAX_RESULT_BYTES = 1024 * 1024;
+/** Same cap Den applies to provider-declared error excerpts before relaying them. */
+const MAX_PROVIDER_ERROR_CHARS = 512;
 
 type McpAppCsp = {
   connectDomains: string[];
@@ -66,6 +68,22 @@ export class McpAppHostError extends Error {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A bounded, single-line excerpt of a provider's error text. Providers already
+ * return arbitrary tool *results* to the same callers, so relaying their
+ * rejection is not a new disclosure, but the text is untrusted: strip control
+ * characters and cap its length before it becomes an API error message.
+ */
+function providerErrorExcerpt(error: unknown): string | null {
+  if (!(error instanceof Error) || !error.message) return null;
+  const sanitized = error.message
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!sanitized) return null;
+  return sanitized.length > MAX_PROVIDER_ERROR_CHARS ? `${sanitized.slice(0, MAX_PROVIDER_ERROR_CHARS)}…` : sanitized;
 }
 
 function stringHeaders(value: unknown): Record<string, string> {
@@ -762,12 +780,10 @@ export async function callMcpAppTool(input: {
     }
     // A provider that rejects the call (for example JSON-RPC -32602 for a
     // missing required argument) must reach the member as that rejection,
-    // not as an unhandled 500 "Unexpected server error".
+    // not as an unhandled 500 "Unexpected server error". The text is
+    // provider-controlled: bound it the same way Den bounds provider excerpts.
     const result = await client.callTool({ name: input.name, arguments: input.arguments ?? {} }).catch((error: unknown) => {
-      throw new McpAppHostError(
-        "tool_call_failed",
-        error instanceof Error && error.message ? error.message : "The MCP App tool call failed.",
-      );
+      throw new McpAppHostError("tool_call_failed", providerErrorExcerpt(error) ?? "The MCP App tool call failed.");
     });
     if (new TextEncoder().encode(JSON.stringify(result)).byteLength > MAX_RESULT_BYTES) {
       throw new McpAppHostError("result_too_large", "The MCP App tool result exceeds the 1 MiB host limit.");

--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -777,6 +777,14 @@ function safeBaseMessageFor(input: {
       ? `${message} Provider-declared message (untrusted): "${input.providerErrorMessage}".`
       : message
   }
+  if (input.code === "MCP_INVALID_PARAMS" || input.code === "MCP_PROVIDER_INVALID_PARAMS") {
+    // The provider's own rejection names the offending argument; without it a
+    // member cannot correct a launch input that omits a required field.
+    const message = "The provider rejected the tool arguments."
+    return input.providerErrorMessage
+      ? `${message} Provider-declared message (untrusted): "${input.providerErrorMessage}".`
+      : message
+  }
   if (input.code === "MCP_PROVIDER_DECLARED_ERROR") {
     const message = input.jsonRpcCode === undefined
       ? "The provider answered with a JSON-RPC error OpenWork does not recognize."

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -166,9 +166,14 @@ export function mcpToolVisibleToApp(tool: { _meta?: unknown }): boolean {
 
 /** True when the launch tool declares required input, so a tile cannot start it with empty arguments. */
 export function mcpToolRequiresInput(tool: { inputSchema?: unknown }): boolean {
+  return mcpToolRequiredInputKeys(tool).length > 0
+}
+
+/** The launch-input keys the tool's schema marks required, so an author can supply them and Den can validate. */
+export function mcpToolRequiredInputKeys(tool: { inputSchema?: unknown }): string[] {
   const schema: unknown = tool.inputSchema
-  if (!isRecord(schema)) return false
-  return Array.isArray(schema.required) && schema.required.length > 0
+  if (!isRecord(schema) || !Array.isArray(schema.required)) return []
+  return schema.required.filter((key): key is string => typeof key === "string" && key.length > 0)
 }
 const MANUAL_MCP_TOOL_REQUEST_MAX_BYTES = 1024 * 1024
 const externalMcpDiscoveryFetch = env.allowPrivateMcpUrls ? createRealmSafeFetch() : createGuardedFetch()
@@ -505,6 +510,8 @@ const connectionMcpAppSchema = z.object({
   title: z.string().nullable(),
   description: z.string().nullable(),
   requiresInput: z.boolean(),
+  /** Launch-input keys the tool's input schema marks required. Empty when the app launches with no input. */
+  requiredInputKeys: z.array(z.string()),
   requiresApproval: z.boolean(),
 }).meta({ ref: "ExternalMcpConnectionMcpApp" })
 
@@ -2006,6 +2013,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             title: typeof tool.title === "string" && tool.title.trim() ? tool.title : tool.annotations?.title ?? null,
             description: typeof tool.description === "string" ? tool.description : null,
             requiresInput: mcpToolRequiresInput(tool),
+            requiredInputKeys: mcpToolRequiredInputKeys(tool),
             requiresApproval: tool.annotations?.readOnlyHint !== true || tool.annotations?.destructiveHint === true,
           }]
         })

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -502,6 +502,11 @@ describe("external MCP diagnostics", () => {
       providerErrorMessage: "Provider rejected private argument detail",
     })
     expect(error.diagnostic.operatorAction).toContain("do not retry the same arguments")
+    // The member-facing message must carry the provider's rejection so a
+    // dashboard launch that omits a required argument names that argument.
+    expect(error.message).toBe(
+      'The provider rejected the tool arguments. Provider-declared message (untrusted): "Provider rejected private argument detail".',
+    )
   })
 
   test("classifies downstream provider authorization links without treating -32001 as a timeout", () => {

--- a/ee/apps/den-api/test/mcp-connection-apps.test.ts
+++ b/ee/apps/den-api/test/mcp-connection-apps.test.ts
@@ -45,3 +45,13 @@ test("required launch input is detected from the input schema", () => {
   expect(connections.mcpToolRequiresInput({ inputSchema: { type: "object", required: [] } })).toBe(false)
   expect(connections.mcpToolRequiresInput({ inputSchema: { type: "object", required: ["query"] } })).toBe(true)
 })
+
+test("required launch-input keys are listed so authors can supply and Den can validate them", () => {
+  expect(connections.mcpToolRequiredInputKeys({})).toEqual([])
+  expect(connections.mcpToolRequiredInputKeys({ inputSchema: { type: "object", required: [] } })).toEqual([])
+  expect(connections.mcpToolRequiredInputKeys({ inputSchema: { type: "object", required: ["cloudId", "pageId"] } }))
+    .toEqual(["cloudId", "pageId"])
+  // Non-string entries are provider schema noise, never keys an author can type.
+  expect(connections.mcpToolRequiredInputKeys({ inputSchema: { type: "object", required: ["cloudId", 7, ""] } }))
+    .toEqual(["cloudId"])
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-detail-screen.tsx
@@ -33,6 +33,14 @@ function elementKey(element: DashboardElement) {
   return `${element.serverName}:${element.toolName}`;
 }
 
+/** Required launch-input keys the author left out (or set to undefined). */
+export function missingRequiredInputKeys(
+  requiredInputKeys: string[],
+  launchArguments: Record<string, unknown>,
+): string[] {
+  return requiredInputKeys.filter((key) => !Object.hasOwn(launchArguments, key) || launchArguments[key] === undefined);
+}
+
 export function OrgDashboardDetailScreen({ dashboardId }: { dashboardId: string }) {
   const { orgSlug } = useOrgDashboard();
   const router = useRouter();
@@ -364,6 +372,13 @@ function ConnectionAppRow({
         setArgumentsError("Launch input must be valid JSON.");
         return;
       }
+      // A tile whose input omits a key the tool requires fails on every
+      // launch, so refuse it here and name the missing keys.
+      const missingKeys = missingRequiredInputKeys(app.requiredInputKeys, launchArguments);
+      if (missingKeys.length > 0) {
+        setArgumentsError(`Launch input is missing required ${missingKeys.length === 1 ? "key" : "keys"}: ${missingKeys.join(", ")}.`);
+        return;
+      }
     }
     setArgumentsError(null);
     onAdd({
@@ -417,10 +432,19 @@ function ConnectionAppRow({
       {!added && app.requiresInput ? (
         <label className="mt-2 block">
           <span className="mb-1 block text-[11.5px] font-medium text-gray-600">Launch input (JSON, required by this app)</span>
+          {app.requiredInputKeys.length > 0 ? (
+            <span className="mb-1 block text-[11.5px] text-gray-500" data-testid="required-input-keys">
+              Required {app.requiredInputKeys.length === 1 ? "key" : "keys"}: {app.requiredInputKeys.map((key) => (
+                <code key={key} className="mr-1 rounded bg-gray-100 px-1 font-mono text-[11px] text-gray-800">{key}</code>
+              ))}
+            </span>
+          ) : null}
           <textarea
             value={argumentsText}
             onChange={(event) => setArgumentsText(event.target.value)}
-            placeholder='{ "example": "value" }'
+            placeholder={app.requiredInputKeys.length > 0
+              ? `{ ${app.requiredInputKeys.map((key) => `"${key}": "…"`).join(", ")} }`
+              : '{ "example": "value" }'}
             rows={2}
             className="w-full resize-none rounded-xl border border-gray-200 px-3 py-2 font-mono text-[12px] text-gray-900 outline-none transition placeholder:text-gray-300 focus:border-gray-400"
           />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboards-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboards-data.tsx
@@ -45,6 +45,8 @@ export type ConnectionMcpApp = DashboardElement & {
   connectionId: string;
   description: string | null;
   requiresInput: boolean;
+  /** Launch-input keys the tool's input schema marks required. */
+  requiredInputKeys: string[];
   requiresApproval: boolean;
 };
 
@@ -167,6 +169,9 @@ function parseConnectionApp(value: unknown): ConnectionMcpApp | null {
     connectionId: element.connectionId,
     description: readString(value.description),
     requiresInput: value.requiresInput === true,
+    requiredInputKeys: Array.isArray(value.requiredInputKeys)
+      ? value.requiredInputKeys.filter((key): key is string => typeof key === "string" && key.length > 0)
+      : [],
     requiresApproval: value.requiresApproval === true,
   };
 }

--- a/ee/apps/den-web/tests/dashboard-mcp-app-catalog.test.ts
+++ b/ee/apps/den-web/tests/dashboard-mcp-app-catalog.test.ts
@@ -8,6 +8,7 @@ import {
   connectionCanListMcpApps,
   mcpAppCatalogIsLoading,
 } from "../app/(den)/dashboard/_components/dashboard-mcp-app-catalog";
+import { missingRequiredInputKeys } from "../app/(den)/dashboard/_components/org-dashboard-detail-screen";
 
 const app: ConnectionMcpApp = {
   serverName: "reports",
@@ -18,6 +19,7 @@ const app: ConnectionMcpApp = {
   title: "Weekly report",
   description: "Shows the weekly report",
   requiresInput: false,
+  requiredInputKeys: [],
   requiresApproval: false,
 };
 
@@ -51,5 +53,15 @@ describe("dashboard MCP App catalog", () => {
   test("shows discovered Apps while another MCP is still loading", () => {
     expect(mcpAppCatalogIsLoading(0, true)).toBe(true);
     expect(mcpAppCatalogIsLoading(1, true)).toBe(false);
+  });
+
+  test("names the required launch-input keys a pasted payload omits", () => {
+    // A launch input missing a key the tool requires fails on every launch,
+    // so the add-app dialog must refuse it and say which key is missing.
+    expect(missingRequiredInputKeys(["cloudId", "pageId"], { pageId: "1122334455" })).toEqual(["cloudId"]);
+    expect(missingRequiredInputKeys(["cloudId", "jql"], { jql: "project = HELPDESK" })).toEqual(["cloudId"]);
+    expect(missingRequiredInputKeys(["cloudId", "jql"], { cloudId: "example-cloud-id", jql: "project = HELPDESK" })).toEqual([]);
+    expect(missingRequiredInputKeys(["cloudId"], { cloudId: undefined })).toEqual(["cloudId"]);
+    expect(missingRequiredInputKeys([], {})).toEqual([]);
   });
 });

--- a/evals/specs/dashboard-atlassian-launch-input.test.ts
+++ b/evals/specs/dashboard-atlassian-launch-input.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Customer report (2026-09): Dashboard tiles for the Atlassian remote MCP
+ * fail identically for an org-account connection and an individual-accounts
+ * connection when launched with the exact pasted JSON payloads
+ * (`{"pageId": "1122334455"}` and a JQL query with escaped quotes).
+ *
+ * Root cause: both payloads omit `cloudId`, which both tools require. Before
+ * the fix the author could not see that (the catalog exposed only a
+ * `requiresInput` boolean), Den's proxy replaced the provider's rejection with
+ * a generic phase message, and the Desktop host let the untyped throw become
+ * HTTP 500 "Unexpected server error" on the tile.
+ *
+ * This spec proves the fixed pipeline against a deterministic Atlassian-shaped
+ * witness MCP through the real Den connection proxy and the real Desktop
+ * App-host launch code (`resolveConnectMcpAppResource` / `callMcpAppTool`):
+ *
+ * 1. The add-app catalog (`/v1/mcp-connections/:id/mcp-apps`) lists each
+ *    tool's `requiredInputKeys`, so authoring can show and validate them.
+ * 2. The pasted launch JSON survives Den storage and the whole launch pipeline
+ *    byte-identically — escaped quotes are NOT double-escaped.
+ * 3. A launch that omits `cloudId` fails as a typed
+ *    `McpAppHostError("tool_call_failed")` whose message relays the provider's
+ *    own rejection naming `cloudId` (mapped to 422, never a 500).
+ * 4. An individual-accounts (per-member OAuth) connection without a connected
+ *    account is excluded from the Desktop app-host server index entirely and
+ *    its app catalog answers 409 "Connect your account…" — the needs_signin
+ *    surface.
+ * 5. Control: the identical launch succeeds once `cloudId` is supplied.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, onTestFinished } from "vitest";
+import { createOrgConnection, denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { localMysqlIsRunning, localRedisIsRunning, server, test } from "@openwork/testkit";
+import {
+  callMcpAppTool,
+  McpAppHostError,
+  resolveConnectMcpAppResource,
+} from "../../apps/server/src/mcp-app-host.js";
+import {
+  writeOpenWorkConnectMcpAppHostAuthorization,
+  writeOpenWorkConnectMcpAppHostCatalog,
+} from "../../apps/server/src/connect-mcp-server-catalog.js";
+import type { ServerConfig } from "../../apps/server/src/types.js";
+
+// The Atlassian witness is an inline loopback MCP server, so Den must run in
+// the same place — the same local-placement constraint remote-mcp-apps uses.
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1"
+  && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = localPlacement && await localMysqlIsRunning();
+const redisOpen = localPlacement && await localRedisIsRunning();
+const title = !localPlacement
+  ? "dashboard Atlassian launch input skipped — needs local placement without OPENWORK_EVAL_DAYTONA/OPENWORK_EVAL_DEN_API_URL"
+  : !mysqlOpen
+    ? "dashboard Atlassian launch input skipped — needs MySQL on 127.0.0.1:3306"
+    : !redisOpen
+      ? "dashboard Atlassian launch input skipped — needs Redis on 127.0.0.1:6379"
+      : "dashboard tiles forward pasted Atlassian launch JSON intact and surface the provider's rejection when a required argument is missing";
+
+const CONFLUENCE_RESOURCE = "ui://atlassian/confluence-page/view.html";
+const JIRA_RESOURCE = "ui://atlassian/jql-search/view.html";
+const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
+
+/** JSON shaped exactly like the launch input pasted into the dashboard add-app dialog. */
+const PASTED_CONFLUENCE_JSON = `{"pageId": "1122334455"}`;
+const PASTED_JQL_JSON = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
+const EXPECTED_JQL = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+  return value;
+}
+
+function parsedLaunchInput(pasted: string): Record<string, unknown> {
+  // Mirrors ee/apps/den-web org-dashboard-detail-screen.tsx ConnectionAppRow:
+  // the dialog only checks JSON.parse succeeds and the value is an object.
+  const parsed: unknown = JSON.parse(pasted);
+  return requireRecord(parsed, "pasted launch input");
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "cache-control": "no-store", "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+type WitnessCall = { name: string; args: Record<string, unknown> };
+
+/** Deterministic Atlassian-remote-MCP-shaped witness: getConfluencePage and
+ * searchJiraIssuesUsingJql both require cloudId and reject a call without it
+ * using a JSON-RPC invalid-params error, the shape an SDK zod server emits. */
+function atlassianWitnessRpc(
+  message: Record<string, unknown>,
+  receivedCalls: WitnessCall[],
+): Record<string, unknown> | null {
+  if (message.method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: {
+          tools: { listChanged: false },
+          resources: { listChanged: false, subscribe: false },
+          extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+        },
+        serverInfo: { name: "atlassian-remote-mcp-witness", version: "1.0.0" },
+      },
+    };
+  }
+  if (message.id === undefined) return null;
+  if (message.method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        tools: [
+          {
+            name: "getConfluencePage",
+            title: "Get Confluence page",
+            description: "Get a Confluence page by id.",
+            inputSchema: {
+              type: "object",
+              properties: { cloudId: { type: "string" }, pageId: { type: "string" } },
+              required: ["cloudId", "pageId"],
+            },
+            annotations: { readOnlyHint: true, destructiveHint: false },
+            _meta: { ui: { resourceUri: CONFLUENCE_RESOURCE, visibility: ["model", "app"] } },
+          },
+          {
+            name: "searchJiraIssuesUsingJql",
+            title: "Search Jira issues using JQL",
+            description: "Search Jira issues with a JQL query.",
+            inputSchema: {
+              type: "object",
+              properties: { cloudId: { type: "string" }, jql: { type: "string" } },
+              required: ["cloudId", "jql"],
+            },
+            annotations: { readOnlyHint: true, destructiveHint: false },
+            _meta: { ui: { resourceUri: JIRA_RESOURCE, visibility: ["model", "app"] } },
+          },
+        ],
+      },
+    };
+  }
+  if (message.method === "resources/read") {
+    const params = isRecord(message.params) ? message.params : {};
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        contents: [{
+          uri: params.uri,
+          mimeType: "text/html;profile=mcp-app",
+          text: APP_HTML,
+          _meta: {
+            ui: {
+              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+              prefersBorder: true,
+            },
+          },
+        }],
+      },
+    };
+  }
+  if (message.method === "tools/call") {
+    const params = isRecord(message.params) ? message.params : {};
+    const name = typeof params.name === "string" ? params.name : "";
+    const args = isRecord(params.arguments) ? params.arguments : {};
+    receivedCalls.push({ name, args });
+    if (typeof args.cloudId !== "string" || !args.cloudId) {
+      return {
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32602,
+          message: `Invalid arguments for tool ${name}: [{"code":"invalid_type","expected":"string","received":"undefined","path":["cloudId"],"message":"Required"}]`,
+        },
+      };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { content: [{ type: "text", text: `ok:${name}` }], structuredContent: { ok: true } },
+    };
+  }
+  return { jsonrpc: "2.0", id: message.id, result: {} };
+}
+
+const WORKSPACE_ID = "ws_dashboard_atlassian_repro";
+
+function desktopServerConfig(root: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: WORKSPACE_ID, name: "Repro", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+function orgHeaders(session: DenSession, orgId: string): Record<string, string> {
+  return { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId };
+}
+
+async function organizationId(admin: DenSession): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${admin.token}` } });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = organizations[0] && typeof organizations[0].id === "string" ? organizations[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+let agentRequestId = 0;
+
+async function agentRpc(
+  apiUrl: string,
+  token: string,
+  method: string,
+  params: Record<string, unknown>,
+  endpoint: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<Record<string, unknown>> {
+  const id = ++agentRequestId;
+  const response = await fetch(`${apiUrl}${endpoint}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      ...extraHeaders,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    signal: AbortSignal.timeout(90_000),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new Error(`MCP ${method} failed: HTTP ${response.status} ${raw.slice(0, 500)}`);
+  const payload: unknown = raw.trimStart().startsWith("{")
+    ? JSON.parse(raw)
+    : raw.split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => JSON.parse(line.slice(5)) as unknown)
+      .find((candidate) => isRecord(candidate) && candidate.id === id);
+  const message = requireRecord(payload, `${method} response`);
+  if (message.error) throw new Error(`MCP ${method} returned ${JSON.stringify(message.error)}`);
+  return requireRecord(message.result, `${method} result`);
+}
+
+test.skipIf(!localPlacement || !mysqlOpen || !redisOpen)(title, { timeout: 300_000 }, async ({ evidence, place }) => {
+  const receivedCalls: WitnessCall[] = [];
+  const witness = createServer((request, response) => {
+    void (async () => {
+      if (request.method !== "POST") {
+        sendJson(response, 405, { error: "method_not_allowed" });
+        return;
+      }
+      const raw = await readBody(request);
+      const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
+      const messages = Array.isArray(parsed) ? parsed : [parsed];
+      const replies = messages.flatMap((entry) => {
+        if (!isRecord(entry)) return [];
+        const reply = atlassianWitnessRpc(entry, receivedCalls);
+        return reply ? [reply] : [];
+      });
+      if (replies.length === 0) {
+        response.writeHead(202);
+        response.end();
+        return;
+      }
+      sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    witness.once("error", reject);
+    witness.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => witness.close((error) => (error ? reject(error) : resolve())));
+  });
+  const witnessAddress = witness.address();
+  if (!witnessAddress || typeof witnessAddress === "string") throw new Error("The Atlassian witness did not bind a port.");
+  const witnessUrl = `http://127.0.0.1:${witnessAddress.port}/mcp`;
+
+  await using den = await server({
+    place,
+    env: { DEN_DASHBOARDS_ENABLED: "true" },
+    org: { name: `Dashboard Atlassian repro ${Date.now()}`, admin: { name: "Avery" } },
+  });
+  const orgId = await organizationId(den.admin);
+  const headers = orgHeaders(den.admin, orgId);
+
+  // The two reported connection configurations.
+  const orgAccountConnection = await createOrgConnection(den.admin, {
+    name: "Atlassian (One org account)",
+    url: witnessUrl,
+    authType: "none",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+  const individualConnection = await createOrgConnection(den.admin, {
+    name: "Atlassian (Individual accounts connected)",
+    url: witnessUrl,
+    authType: "oauth",
+    credentialMode: "per_member",
+    access: { orgWide: true },
+  });
+
+  // 1. The dashboard add-app catalog names both tools AND lists the keys
+  //    their input schemas require, so the author can see cloudId is needed
+  //    and the add-app dialog can refuse a payload that omits it.
+  const appsResult = await denFetch(den.admin, `/v1/mcp-connections/${orgAccountConnection.id}/mcp-apps`, { headers });
+  expect(appsResult.response.status, appsResult.text).toBe(200);
+  const apps = isRecord(appsResult.body) && Array.isArray(appsResult.body.apps)
+    ? appsResult.body.apps.filter(isRecord)
+    : [];
+  const confluenceApp = requireRecord(apps.find((app) => app.toolName === "getConfluencePage"), "Confluence app entry");
+  const jqlApp = requireRecord(apps.find((app) => app.toolName === "searchJiraIssuesUsingJql"), "JQL app entry");
+  expect(confluenceApp.requiresInput).toBe(true);
+  expect(jqlApp.requiresInput).toBe(true);
+  expect(confluenceApp.requiredInputKeys).toEqual(["cloudId", "pageId"]);
+  expect(jqlApp.requiredInputKeys).toEqual(["cloudId", "jql"]);
+  evidence.recordAssertionEvidence(
+    "The dashboard add-app catalog names the required launch-input keys",
+    `GET /v1/mcp-connections/:id/mcp-apps lists getConfluencePage with requiredInputKeys=${JSON.stringify(confluenceApp.requiredInputKeys)} and searchJiraIssuesUsingJql with requiredInputKeys=${JSON.stringify(jqlApp.requiredInputKeys)}, so the add-app dialog can show them and refuse a pasted payload that omits cloudId.`,
+    JSON.stringify(confluenceApp.requiredInputKeys) === JSON.stringify(["cloudId", "pageId"])
+      && JSON.stringify(jqlApp.requiredInputKeys) === JSON.stringify(["cloudId", "jql"]),
+  );
+
+  // 2. Store the dashboard with the exact pasted payloads and prove the
+  //    launch arguments round-trip byte-identically (no double escaping).
+  const confluenceArguments = parsedLaunchInput(PASTED_CONFLUENCE_JSON);
+  const jqlArguments = parsedLaunchInput(PASTED_JQL_JSON);
+  expect(jqlArguments.jql).toBe(EXPECTED_JQL);
+  const serverName = typeof confluenceApp.serverName === "string" ? confluenceApp.serverName : "";
+  const elements = [
+    {
+      serverName,
+      connectionId: orgAccountConnection.id,
+      toolName: "getConfluencePage",
+      projectedToolName: String(confluenceApp.projectedToolName ?? ""),
+      resourceUri: CONFLUENCE_RESOURCE,
+      title: "Confluence page",
+      launchArguments: confluenceArguments,
+    },
+    {
+      serverName,
+      connectionId: orgAccountConnection.id,
+      toolName: "searchJiraIssuesUsingJql",
+      projectedToolName: String(jqlApp.projectedToolName ?? ""),
+      resourceUri: JIRA_RESOURCE,
+      title: "Jira queue",
+      launchArguments: jqlArguments,
+    },
+  ];
+  const createResult = await denFetch(den.admin, "/v1/dashboards", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ name: "Atlassian board", elements }),
+  });
+  expect(createResult.response.status, createResult.text).toBe(201);
+  const dashboard = requireRecord(requireRecord(createResult.body, "dashboard response").item, "dashboard item");
+  const grantResult = await denFetch(den.admin, `/v1/dashboards/${String(dashboard.id)}/access`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ orgWide: true, role: "viewer" }),
+  });
+  expect(grantResult.response.status, grantResult.text).toBe(201);
+  const grantedResult = await denFetch(den.admin, "/v1/me/dashboards", { headers });
+  expect(grantedResult.response.status, grantedResult.text).toBe(200);
+  const grantedItems = isRecord(grantedResult.body) && Array.isArray(grantedResult.body.items)
+    ? grantedResult.body.items.filter(isRecord)
+    : [];
+  const granted = requireRecord(grantedItems.find((item) => item.id === dashboard.id), "granted dashboard");
+  const grantedElements = Array.isArray(granted.elements) ? granted.elements.filter(isRecord) : [];
+  const grantedJql = requireRecord(
+    grantedElements.find((element) => element.toolName === "searchJiraIssuesUsingJql"),
+    "granted JQL element",
+  );
+  const grantedJqlArguments = requireRecord(grantedJql.launchArguments, "granted JQL launch arguments");
+  expect(grantedJqlArguments.jql).toBe(EXPECTED_JQL);
+  const grantedConfluence = requireRecord(
+    grantedElements.find((element) => element.toolName === "getConfluencePage"),
+    "granted Confluence element",
+  );
+  expect(grantedConfluence.launchArguments).toEqual({ pageId: "1122334455" });
+  evidence.recordAssertionEvidence(
+    "Pasted launch JSON round-trips through Den storage byte-identically",
+    `The JQL string with escaped quotes stored on the dashboard element and returned by /v1/me/dashboards strictly equals the pasted value (${JSON.stringify(EXPECTED_JQL).slice(0, 120)}…) — escaping is not the failure.`,
+    grantedJqlArguments.jql === EXPECTED_JQL,
+  );
+
+  // 3. The individual-accounts connection with no connected member account is
+  //    the needs_signin surface: its app catalog answers 409 and it is absent
+  //    from the Desktop app-host server index.
+  const individualApps = await denFetch(den.admin, `/v1/mcp-connections/${individualConnection.id}/mcp-apps`, { headers });
+  expect(individualApps.response.status, individualApps.text).toBe(409);
+  expect(individualApps.text).toContain("Connect your account");
+
+  const tokenResult = await denFetch(den.admin, "/v1/mcp/token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": orgId },
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  expect(tokenResult.response.ok, tokenResult.text).toBe(true);
+  const appHostToken = String(requireRecord(tokenResult.body, "MCP token response").appHostToken ?? "");
+  expect(appHostToken).not.toBe("");
+  const appHostHeaders = { "x-openwork-mcp-client-capabilities": "mcp-app-host-v1" };
+  const indexRead = await agentRpc(
+    den.ref.apiUrl,
+    appHostToken,
+    "resources/read",
+    { uri: "openwork://connect/mcp-servers/index.json" },
+    "/mcp/agent",
+    appHostHeaders,
+  );
+  const indexContents = Array.isArray(indexRead.contents) ? indexRead.contents.filter(isRecord) : [];
+  const index = requireRecord(JSON.parse(String(indexContents[0]?.text ?? "{}")), "Connect MCP server index");
+  const indexedServers = Array.isArray(index.servers) ? index.servers.filter(isRecord) : [];
+  const indexedIds = indexedServers.map((entry) => String(entry.connectionId ?? ""));
+  expect(indexedIds).toContain(orgAccountConnection.id);
+  expect(indexedIds).not.toContain(individualConnection.id);
+  evidence.recordAssertionEvidence(
+    "An unconnected individual-accounts connection is the needs_signin surface",
+    `GET /v1/mcp-connections/:id/mcp-apps answered 409 "Connect your account before using this MCP's tools." and the Desktop app-host server index omits connection ${individualConnection.id} while listing ${orgAccountConnection.id}; a tile granted over it can only fail with "The originating Connect MCP server is not available to this workspace."`,
+    individualApps.response.status === 409 && !indexedIds.includes(individualConnection.id),
+  );
+
+  // 4. Launch exactly as the Desktop tile does, through the real Den
+  //    connection proxy, using the real Desktop App-host code.
+  const root = await mkdtemp(join(tmpdir(), "dashboard-atlassian-repro-"));
+  const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  const previousDevMode = process.env.OPENWORK_DEV_MODE;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_DEV_MODE = "1";
+  onTestFinished(async () => {
+    if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+    else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+    if (previousDevMode === undefined) delete process.env.OPENWORK_DEV_MODE;
+    else process.env.OPENWORK_DEV_MODE = previousDevMode;
+    await rm(root, { recursive: true, force: true });
+  });
+  await mkdir(join(root, ".git"), { recursive: true });
+  const desktopConfig = desktopServerConfig(root);
+  const proxyUrl = `${den.ref.apiUrl}/mcp/agent/connections/${encodeURIComponent(orgAccountConnection.id)}`;
+  await writeOpenWorkConnectMcpAppHostCatalog(desktopConfig, WORKSPACE_ID, {
+    schemaVersion: "openwork.connect/mcp-servers/1",
+    servers: [{
+      connectionId: orgAccountConnection.id,
+      name: orgAccountConnection.name,
+      description: null,
+      url: proxyUrl,
+    }],
+  });
+  await writeOpenWorkConnectMcpAppHostAuthorization(desktopConfig, WORKSPACE_ID, `Bearer ${appHostToken}`, proxyUrl);
+
+  const resolved = await resolveConnectMcpAppResource({
+    serverConfig: desktopConfig,
+    workspaceId: WORKSPACE_ID,
+    workspaceRoot: root,
+    launch: {
+      connectionId: orgAccountConnection.id,
+      toolName: "getConfluencePage",
+      resourceUri: CONFLUENCE_RESOURCE,
+    },
+  });
+  expect(resolved.toolName).toBe("getConfluencePage");
+  expect(resolved.html).toBe(APP_HTML);
+
+  receivedCalls.length = 0;
+  const launchFailures: Array<{ tool: string; error: unknown }> = [];
+  for (const launch of [
+    { tool: "getConfluencePage", resourceUri: CONFLUENCE_RESOURCE, args: confluenceArguments },
+    { tool: "searchJiraIssuesUsingJql", resourceUri: JIRA_RESOURCE, args: jqlArguments },
+  ]) {
+    try {
+      const result = await callMcpAppTool({
+        serverConfig: desktopConfig,
+        workspaceId: WORKSPACE_ID,
+        workspaceRoot: root,
+        serverName: resolved.serverName,
+        name: launch.tool,
+        resourceUri: launch.resourceUri,
+        arguments: launch.args,
+        approved: true,
+      });
+      throw new Error(`Expected the ${launch.tool} launch to fail, got: ${JSON.stringify(result).slice(0, 500)}`);
+    } catch (error) {
+      launchFailures.push({ tool: launch.tool, error });
+    }
+  }
+  // Both launches fail because cloudId is missing, and the failure is a typed
+  // McpAppHostError("tool_call_failed") carrying the provider's own rejection
+  // (relayed by Den as an untrusted provider-declared message) — so
+  // /mcp-apps/call answers 422 with a message that names cloudId instead of
+  // the generic 500 "Unexpected server error".
+  for (const failure of launchFailures) {
+    expect(failure.error, `launch ${failure.tool} should fail as a typed host error`).toBeInstanceOf(McpAppHostError);
+    expect(failure.error).toMatchObject({ code: "tool_call_failed" });
+    const message = failure.error instanceof Error ? failure.error.message : "";
+    expect(message, `launch ${failure.tool} names the missing argument`).toContain("cloudId");
+    expect(message).toContain("Required");
+    expect(message).toContain("rejected the tool arguments");
+    expect(message).not.toContain("Unexpected server error");
+  }
+  const failureMessages = launchFailures.map((failure) => (
+    failure.error instanceof Error ? failure.error.message : String(failure.error)
+  ));
+  // Both connections' payloads produce the same failure because the missing
+  // cloudId is independent of the connection's credential mode.
+  expect(failureMessages).toHaveLength(2);
+  // The witness received the pasted arguments exactly once each and intact.
+  expect(receivedCalls).toEqual([
+    { name: "getConfluencePage", args: { pageId: "1122334455" } },
+    { name: "searchJiraIssuesUsingJql", args: { jql: EXPECTED_JQL } },
+  ]);
+  evidence.recordAssertionEvidence(
+    "A launch missing a required argument surfaces the provider's rejection naming that argument",
+    `callMcpAppTool threw McpAppHostError(tool_call_failed) for both tools with messages ${JSON.stringify(failureMessages).slice(0, 700)}; /workspace/:id/mcp-apps/call maps this to 422 tool_call_failed so the dashboard tile shows the provider's own text naming cloudId, never the generic "Unexpected server error". The witness received the pasted arguments byte-identically (jql intact, no cloudId), so the only failure is the missing required argument.`,
+    launchFailures.length === 2 && failureMessages.every((message) => message.includes("cloudId") && !message.includes("Unexpected server error")),
+  );
+
+  // 5. Control: the identical pipeline succeeds when cloudId is supplied, so
+  //    the pasted-JSON path itself is sound.
+  receivedCalls.length = 0;
+  const controlResult = await callMcpAppTool({
+    serverConfig: desktopConfig,
+    workspaceId: WORKSPACE_ID,
+    workspaceRoot: root,
+    serverName: resolved.serverName,
+    name: "searchJiraIssuesUsingJql",
+    resourceUri: JIRA_RESOURCE,
+    arguments: { cloudId: "example-cloud-id", ...jqlArguments },
+    approved: true,
+  });
+  expect(controlResult.isError).not.toBe(true);
+  expect(receivedCalls).toEqual([
+    { name: "searchJiraIssuesUsingJql", args: { cloudId: "example-cloud-id", jql: EXPECTED_JQL } },
+  ]);
+  evidence.recordAssertionEvidence(
+    "The same launch succeeds once cloudId is supplied",
+    `callMcpAppTool with { cloudId, jql } returned a non-error result through the same Den proxy and Desktop App-host pipeline, isolating the root cause to the missing required argument that the add-app dialog neither surfaced nor validated.`,
+    controlResult.isError !== true,
+  );
+});

--- a/evals/specs/dashboard-atlassian-launch-input.test.ts
+++ b/evals/specs/dashboard-atlassian-launch-input.test.ts
@@ -27,7 +27,6 @@
  *    surface.
  * 5. Control: the identical launch succeeds once `cloudId` is supplied.
  */
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -45,6 +44,16 @@ import {
   writeOpenWorkConnectMcpAppHostCatalog,
 } from "../../apps/server/src/connect-mcp-server-catalog.js";
 import type { ServerConfig } from "../../apps/server/src/types.js";
+import {
+  confluenceResourceUri as CONFLUENCE_RESOURCE,
+  createAtlassianWitness,
+  expectedJql as EXPECTED_JQL,
+  isRecord,
+  jiraResourceUri as JIRA_RESOURCE,
+  pastedConfluenceJson as PASTED_CONFLUENCE_JSON,
+  pastedJqlJson as PASTED_JQL_JSON,
+} from "../worlds/dashboard-launch-input.ts";
+import type { WitnessCall } from "../worlds/dashboard-launch-input.ts";
 
 // The Atlassian witness is an inline loopback MCP server, so Den must run in
 // the same place — the same local-placement constraint remote-mcp-apps uses.
@@ -60,18 +69,7 @@ const title = !localPlacement
       ? "dashboard Atlassian launch input skipped — needs Redis on 127.0.0.1:6379"
       : "dashboard tiles forward pasted Atlassian launch JSON intact and surface the provider's rejection when a required argument is missing";
 
-const CONFLUENCE_RESOURCE = "ui://atlassian/confluence-page/view.html";
-const JIRA_RESOURCE = "ui://atlassian/jql-search/view.html";
 const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
-
-/** JSON shaped exactly like the launch input pasted into the dashboard add-app dialog. */
-const PASTED_CONFLUENCE_JSON = `{"pageId": "1122334455"}`;
-const PASTED_JQL_JSON = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
-const EXPECTED_JQL = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
@@ -83,126 +81,6 @@ function parsedLaunchInput(pasted: string): Record<string, unknown> {
   // the dialog only checks JSON.parse succeeds and the value is an object.
   const parsed: unknown = JSON.parse(pasted);
   return requireRecord(parsed, "pasted launch input");
-}
-
-function readBody(request: IncomingMessage): Promise<string> {
-  request.setEncoding("utf8");
-  return new Promise((resolve, reject) => {
-    let body = "";
-    request.on("data", (chunk: string) => {
-      body += chunk;
-    });
-    request.on("end", () => resolve(body));
-    request.on("error", reject);
-  });
-}
-
-function sendJson(response: ServerResponse, status: number, body: unknown): void {
-  response.writeHead(status, { "cache-control": "no-store", "content-type": "application/json" });
-  response.end(JSON.stringify(body));
-}
-
-type WitnessCall = { name: string; args: Record<string, unknown> };
-
-/** Deterministic Atlassian-remote-MCP-shaped witness: getConfluencePage and
- * searchJiraIssuesUsingJql both require cloudId and reject a call without it
- * using a JSON-RPC invalid-params error, the shape an SDK zod server emits. */
-function atlassianWitnessRpc(
-  message: Record<string, unknown>,
-  receivedCalls: WitnessCall[],
-): Record<string, unknown> | null {
-  if (message.method === "initialize") {
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: "2025-06-18",
-        capabilities: {
-          tools: { listChanged: false },
-          resources: { listChanged: false, subscribe: false },
-          extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
-        },
-        serverInfo: { name: "atlassian-remote-mcp-witness", version: "1.0.0" },
-      },
-    };
-  }
-  if (message.id === undefined) return null;
-  if (message.method === "tools/list") {
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        tools: [
-          {
-            name: "getConfluencePage",
-            title: "Get Confluence page",
-            description: "Get a Confluence page by id.",
-            inputSchema: {
-              type: "object",
-              properties: { cloudId: { type: "string" }, pageId: { type: "string" } },
-              required: ["cloudId", "pageId"],
-            },
-            annotations: { readOnlyHint: true, destructiveHint: false },
-            _meta: { ui: { resourceUri: CONFLUENCE_RESOURCE, visibility: ["model", "app"] } },
-          },
-          {
-            name: "searchJiraIssuesUsingJql",
-            title: "Search Jira issues using JQL",
-            description: "Search Jira issues with a JQL query.",
-            inputSchema: {
-              type: "object",
-              properties: { cloudId: { type: "string" }, jql: { type: "string" } },
-              required: ["cloudId", "jql"],
-            },
-            annotations: { readOnlyHint: true, destructiveHint: false },
-            _meta: { ui: { resourceUri: JIRA_RESOURCE, visibility: ["model", "app"] } },
-          },
-        ],
-      },
-    };
-  }
-  if (message.method === "resources/read") {
-    const params = isRecord(message.params) ? message.params : {};
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        contents: [{
-          uri: params.uri,
-          mimeType: "text/html;profile=mcp-app",
-          text: APP_HTML,
-          _meta: {
-            ui: {
-              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
-              prefersBorder: true,
-            },
-          },
-        }],
-      },
-    };
-  }
-  if (message.method === "tools/call") {
-    const params = isRecord(message.params) ? message.params : {};
-    const name = typeof params.name === "string" ? params.name : "";
-    const args = isRecord(params.arguments) ? params.arguments : {};
-    receivedCalls.push({ name, args });
-    if (typeof args.cloudId !== "string" || !args.cloudId) {
-      return {
-        jsonrpc: "2.0",
-        id: message.id,
-        error: {
-          code: -32602,
-          message: `Invalid arguments for tool ${name}: [{"code":"invalid_type","expected":"string","received":"undefined","path":["cloudId"],"message":"Required"}]`,
-        },
-      };
-    }
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { content: [{ type: "text", text: `ok:${name}` }], structuredContent: { ok: true } },
-    };
-  }
-  return { jsonrpc: "2.0", id: message.id, result: {} };
 }
 
 const WORKSPACE_ID = "ws_dashboard_atlassian_repro";
@@ -278,31 +156,7 @@ async function agentRpc(
 
 test.skipIf(!localPlacement || !mysqlOpen || !redisOpen)(title, { timeout: 300_000 }, async ({ evidence, place }) => {
   const receivedCalls: WitnessCall[] = [];
-  const witness = createServer((request, response) => {
-    void (async () => {
-      if (request.method !== "POST") {
-        sendJson(response, 405, { error: "method_not_allowed" });
-        return;
-      }
-      const raw = await readBody(request);
-      const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
-      const messages = Array.isArray(parsed) ? parsed : [parsed];
-      const replies = messages.flatMap((entry) => {
-        if (!isRecord(entry)) return [];
-        const reply = atlassianWitnessRpc(entry, receivedCalls);
-        return reply ? [reply] : [];
-      });
-      if (replies.length === 0) {
-        response.writeHead(202);
-        response.end();
-        return;
-      }
-      sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
-    })().catch((error: unknown) => {
-      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
-      else response.destroy(error instanceof Error ? error : undefined);
-    });
-  });
+  const witness = createAtlassianWitness(receivedCalls);
   await new Promise<void>((resolve, reject) => {
     witness.once("error", reject);
     witness.listen(0, "127.0.0.1", resolve);

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Customer report (2026-09): Dashboard tiles for the Atlassian remote MCP
+ * "don't work" with the exact pasted JSON payloads, identically across an
+ * org-account and an individual-accounts connection.
+ *
+ * Root cause: both payloads omit the required `cloudId` argument. Before the
+ * fix every hop hid the provider's rejection and the tile read "Unexpected
+ * server error".
+ *
+ * This spec drives the real Desktop dashboard tile against a deterministic
+ * Atlassian-shaped witness MCP through a real Den connection proxy — no
+ * fetch stubs — and asserts the member now sees the provider's own rejection
+ * naming `cloudId` on the tile, never the generic 500 text. The witness proves
+ * the pasted launch arguments arrived byte-identically.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { expect, onTestFinished } from "vitest";
+import { createOrgConnection, denFetch, evalIn, waitFor } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { app, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const requirements: TestNeeds = {
+  optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+// The Atlassian witness is an inline loopback MCP server, so Den must run in
+// the same place — the same local-placement constraint remote-mcp-apps uses.
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1"
+  && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const title = missingRequirements.length > 0
+  ? `dashboard Atlassian tile error skipped — needs: ${missingRequirements.join(", ")}`
+  : !localPlacement
+    ? "dashboard Atlassian tile error skipped — needs local placement without OPENWORK_EVAL_DAYTONA/OPENWORK_EVAL_DEN_API_URL"
+    : "a dashboard tile launched with the reported Atlassian JSON names the missing required argument";
+
+const CONFLUENCE_RESOURCE = "ui://atlassian/confluence-page/view.html";
+const JIRA_RESOURCE = "ui://atlassian/jql-search/view.html";
+const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
+const PASTED_CONFLUENCE_JSON = `{"pageId": "1122334455"}`;
+const PASTED_JQL_JSON = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
+const EXPECTED_JQL = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+  return value;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "cache-control": "no-store", "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+type WitnessCall = { name: string; args: Record<string, unknown> };
+
+function atlassianWitnessRpc(
+  message: Record<string, unknown>,
+  receivedCalls: WitnessCall[],
+): Record<string, unknown> | null {
+  if (message.method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: {
+          tools: { listChanged: false },
+          resources: { listChanged: false, subscribe: false },
+          extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+        },
+        serverInfo: { name: "atlassian-remote-mcp-witness", version: "1.0.0" },
+      },
+    };
+  }
+  if (message.id === undefined) return null;
+  if (message.method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        tools: [
+          {
+            name: "getConfluencePage",
+            title: "Get Confluence page",
+            description: "Get a Confluence page by id.",
+            inputSchema: {
+              type: "object",
+              properties: { cloudId: { type: "string" }, pageId: { type: "string" } },
+              required: ["cloudId", "pageId"],
+            },
+            annotations: { readOnlyHint: true, destructiveHint: false },
+            _meta: { ui: { resourceUri: CONFLUENCE_RESOURCE, visibility: ["model", "app"] } },
+          },
+          {
+            name: "searchJiraIssuesUsingJql",
+            title: "Search Jira issues using JQL",
+            description: "Search Jira issues with a JQL query.",
+            inputSchema: {
+              type: "object",
+              properties: { cloudId: { type: "string" }, jql: { type: "string" } },
+              required: ["cloudId", "jql"],
+            },
+            annotations: { readOnlyHint: true, destructiveHint: false },
+            _meta: { ui: { resourceUri: JIRA_RESOURCE, visibility: ["model", "app"] } },
+          },
+        ],
+      },
+    };
+  }
+  if (message.method === "resources/read") {
+    const params = isRecord(message.params) ? message.params : {};
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        contents: [{
+          uri: params.uri,
+          mimeType: "text/html;profile=mcp-app",
+          text: APP_HTML,
+          _meta: {
+            ui: {
+              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+              prefersBorder: true,
+            },
+          },
+        }],
+      },
+    };
+  }
+  if (message.method === "tools/call") {
+    const params = isRecord(message.params) ? message.params : {};
+    const name = typeof params.name === "string" ? params.name : "";
+    const args = isRecord(params.arguments) ? params.arguments : {};
+    receivedCalls.push({ name, args });
+    if (typeof args.cloudId !== "string" || !args.cloudId) {
+      return {
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32602,
+          message: `Invalid arguments for tool ${name}: [{"code":"invalid_type","expected":"string","received":"undefined","path":["cloudId"],"message":"Required"}]`,
+        },
+      };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { content: [{ type: "text", text: `ok:${name}` }], structuredContent: { ok: true } },
+    };
+  }
+  return { jsonrpc: "2.0", id: message.id, result: {} };
+}
+
+function orgHeaders(session: DenSession, orgId: string): Record<string, string> {
+  return { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId };
+}
+
+async function organizationId(admin: DenSession): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${admin.token}` } });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = organizations[0] && typeof organizations[0].id === "string" ? organizations[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+test.skipIf(!localPlacement)(title, { timeout: 480_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+
+  const receivedCalls: WitnessCall[] = [];
+  const witness = createServer((request, response) => {
+    void (async () => {
+      if (request.method !== "POST") {
+        sendJson(response, 405, { error: "method_not_allowed" });
+        return;
+      }
+      const raw = await readBody(request);
+      const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
+      const messages = Array.isArray(parsed) ? parsed : [parsed];
+      const replies = messages.flatMap((entry) => {
+        if (!isRecord(entry)) return [];
+        const reply = atlassianWitnessRpc(entry, receivedCalls);
+        return reply ? [reply] : [];
+      });
+      if (replies.length === 0) {
+        response.writeHead(202);
+        response.end();
+        return;
+      }
+      sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    witness.once("error", reject);
+    witness.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => witness.close((error) => (error ? reject(error) : resolve())));
+  });
+  const witnessAddress = witness.address();
+  if (!witnessAddress || typeof witnessAddress === "string") throw new Error("The Atlassian witness did not bind a port.");
+  const witnessUrl = `http://127.0.0.1:${witnessAddress.port}/mcp`;
+
+  await using den = await server({
+    place,
+    env: { DEN_DASHBOARDS_ENABLED: "true" },
+    org: { name: `Dashboard Atlassian tile ${Date.now()}`, admin: { name: "Avery" } },
+  });
+  const orgId = await organizationId(den.admin);
+  const headers = orgHeaders(den.admin, orgId);
+
+  const connection = await createOrgConnection(den.admin, {
+    name: "Atlassian (One org account)",
+    url: witnessUrl,
+    authType: "none",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
+
+  const appsResult = await denFetch(den.admin, `/v1/mcp-connections/${connection.id}/mcp-apps`, { headers });
+  expect(appsResult.response.status, appsResult.text).toBe(200);
+  const apps = isRecord(appsResult.body) && Array.isArray(appsResult.body.apps)
+    ? appsResult.body.apps.filter(isRecord)
+    : [];
+  const confluenceApp = requireRecord(apps.find((entry) => entry.toolName === "getConfluencePage"), "Confluence app entry");
+  const jqlApp = requireRecord(apps.find((entry) => entry.toolName === "searchJiraIssuesUsingJql"), "JQL app entry");
+
+  const confluenceArguments = requireRecord(JSON.parse(PASTED_CONFLUENCE_JSON), "Confluence launch input");
+  const jqlArguments = requireRecord(JSON.parse(PASTED_JQL_JSON), "JQL launch input");
+  expect(jqlArguments.jql).toBe(EXPECTED_JQL);
+  const createResult = await denFetch(den.admin, "/v1/dashboards", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      name: "Atlassian board",
+      elements: [
+        {
+          serverName: String(confluenceApp.serverName ?? ""),
+          connectionId: connection.id,
+          toolName: "getConfluencePage",
+          projectedToolName: String(confluenceApp.projectedToolName ?? ""),
+          resourceUri: CONFLUENCE_RESOURCE,
+          title: "Confluence page",
+          launchArguments: confluenceArguments,
+        },
+        {
+          serverName: String(jqlApp.serverName ?? ""),
+          connectionId: connection.id,
+          toolName: "searchJiraIssuesUsingJql",
+          projectedToolName: String(jqlApp.projectedToolName ?? ""),
+          resourceUri: JIRA_RESOURCE,
+          title: "Jira queue",
+          launchArguments: jqlArguments,
+        },
+      ],
+    }),
+  });
+  expect(createResult.response.status, createResult.text).toBe(201);
+  const dashboard = requireRecord(requireRecord(createResult.body, "dashboard response").item, "dashboard item");
+  const dashboardId = String(dashboard.id ?? "");
+  const grantResult = await denFetch(den.admin, `/v1/dashboards/${dashboardId}/access`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ orgWide: true, role: "viewer" }),
+  });
+  expect(grantResult.response.status, grantResult.text).toBe(201);
+
+  const tokenResult = await denFetch(den.admin, "/v1/mcp/token", {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": orgId },
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  expect(tokenResult.response.ok, tokenResult.text).toBe(true);
+  const tokenBody = requireRecord(tokenResult.body, "MCP token response");
+  const mcpToken = String(tokenBody.token ?? "");
+  const appHostMcpToken = String(tokenBody.appHostToken ?? "");
+  expect(mcpToken).not.toBe("");
+  expect(appHostMcpToken).not.toBe("");
+
+  await using desktop = await app({ den, as: "admin", place });
+
+  // The signed-in harness Desktop does not run the production Cloud
+  // provisioning loop, so hand it the same Connect MCP configuration the
+  // product writes: the central Cloud MCP entry plus the private App-host
+  // authorization. This is the documented reconcile surface, not a stub.
+  const reconciled = await evalIn(desktop, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(desktop.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
+      method: "POST",
+      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        config: {
+          type: "remote",
+          url: ${JSON.stringify(`${den.ref.apiUrl}/mcp/agent`)},
+          enabled: true,
+          headers: { Authorization: ${JSON.stringify(`Bearer ${mcpToken}`)} },
+          oauth: false,
+        },
+        appHostAuthorization: ${JSON.stringify(`Bearer ${appHostMcpToken}`)},
+        trigger: "dashboard-atlassian-tile-error",
+      }),
+    });
+    const text = await response.text();
+    return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
+  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  expect(reconciled).toBe("ok");
+
+  // The Dashboard navigation lives in the sidebar and renders only after
+  // Desktop reads dashboardEnabled from /v1/me/desktop-config. Open the
+  // sidebar if it is collapsed, then wait for the button.
+  const findDashboardButton = `[...document.querySelectorAll("button")]
+      .find((entry) => entry.textContent?.trim() === "Dashboard")`;
+  await waitFor(desktop, `(() => {
+    const button = ${findDashboardButton};
+    if (button instanceof HTMLButtonElement && !button.disabled) return true;
+    const sidebarOpen = [...document.querySelectorAll("button")]
+      .some((entry) => entry.textContent?.includes("Search sessions"));
+    if (!sidebarOpen) {
+      const toggle = [...document.querySelectorAll("button")]
+        .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
+      if (toggle instanceof HTMLButtonElement) toggle.click();
+    }
+    return false;
+  })()`, {
+    timeoutMs: 90_000,
+    label: "Dashboard navigation available",
+  });
+  const dashboardOpened = await evalIn(desktop, `(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((entry) => entry.textContent?.trim() === "Dashboard");
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  expect(dashboardOpened).toBe(true);
+  await waitFor(desktop, `(() => {
+    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${dashboardId}"]`)});
+    return section instanceof HTMLElement
+      && section.innerText.includes("Confluence page")
+      && section.innerText.includes("Jira queue")
+      && Boolean(section.querySelector('button[aria-label="Run Confluence page"]'))
+      && Boolean(section.querySelector('button[aria-label="Run Jira queue"]'));
+  })()`, {
+    timeoutMs: 90_000,
+    label: "granted Atlassian dashboard tiles rendered with Run buttons",
+  });
+
+  // Launch both tiles exactly as the member does: press Run.
+  receivedCalls.length = 0;
+  for (const tile of ["Confluence page", "Jira queue"]) {
+    const ran = await evalIn(desktop, `(() => {
+      const button = document.querySelector(${JSON.stringify(`button[aria-label="Run ${tile}"]`)});
+      if (!(button instanceof HTMLButtonElement)) return false;
+      button.click();
+      return true;
+    })()`);
+    expect(ran, `Run button for ${tile}`).toBe(true);
+  }
+
+  await waitFor(desktop, `(() => {
+    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${dashboardId}"]`)});
+    if (!(section instanceof HTMLElement)) return false;
+    const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
+    const confluence = tiles.find((tile) => tile.textContent?.includes("Confluence page"));
+    const jql = tiles.find((tile) => tile.textContent?.includes("Jira queue"));
+    return confluence instanceof HTMLElement
+      && jql instanceof HTMLElement
+      && confluence.innerText.includes("cloudId")
+      && jql.innerText.includes("cloudId");
+  })()`, {
+    timeoutMs: 120_000,
+    label: "both Atlassian tiles name the missing required argument",
+  });
+
+  const tileState = await evalIn(desktop, `(() => {
+    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${dashboardId}"]`)});
+    if (!(section instanceof HTMLElement)) return null;
+    const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
+    const read = (title) => {
+      const tile = tiles.find((entry) => entry.textContent?.includes(title));
+      if (!(tile instanceof HTMLElement)) return null;
+      return {
+        text: tile.innerText.replace(/\\s+/g, " ").trim(),
+        badgeFailed: tile.innerText.includes("Refresh failed"),
+        opaque: tile.innerText.includes("Unexpected server error"),
+        namesCloudId: tile.innerText.includes("cloudId"),
+      };
+    };
+    return { confluence: read("Confluence page"), jql: read("Jira queue") };
+  })()`);
+  const state = requireRecord(tileState, "tile state");
+  const confluenceTile = requireRecord(state.confluence, "Confluence tile state");
+  const jqlTile = requireRecord(state.jql, "JQL tile state");
+  // The launch still fails (cloudId is genuinely missing), but the member now
+  // reads the provider's rejection naming the argument, not a generic 500.
+  expect(confluenceTile.badgeFailed).toBe(true);
+  expect(jqlTile.badgeFailed).toBe(true);
+  expect(confluenceTile.namesCloudId).toBe(true);
+  expect(jqlTile.namesCloudId).toBe(true);
+  expect(confluenceTile.opaque).toBe(false);
+  expect(jqlTile.opaque).toBe(false);
+  expect(String(confluenceTile.text)).toContain("rejected the tool arguments");
+  expect(String(jqlTile.text)).toContain("rejected the tool arguments");
+
+  // The witness saw both launches with the pasted arguments byte-identical
+  // and no cloudId — the provider rejection is the only failure in the chain.
+  const witnessedByTool = new Map(receivedCalls.map((call) => [call.name, call.args]));
+  expect(witnessedByTool.get("getConfluencePage")).toEqual({ pageId: "1122334455" });
+  expect(witnessedByTool.get("searchJiraIssuesUsingJql")).toEqual({ jql: EXPECTED_JQL });
+
+  evidence.recordAssertionEvidence(
+    "The dashboard tile names the missing required argument instead of a generic server error",
+    `After Run, both tiles show the "Refresh failed" badge with the provider's rejection naming cloudId and never "Unexpected server error" (confluence=${JSON.stringify(confluenceTile)}, jql=${JSON.stringify(jqlTile)}).`,
+    confluenceTile.namesCloudId === true && jqlTile.namesCloudId === true
+      && confluenceTile.opaque === false && jqlTile.opaque === false,
+  );
+  evidence.recordAssertionEvidence(
+    "The pasted launch JSON reached the provider intact",
+    `The witness received getConfluencePage ${JSON.stringify(witnessedByTool.get("getConfluencePage"))} and searchJiraIssuesUsingJql with the exact single-escaped JQL string; the provider rejected both for the missing required cloudId with JSON-RPC -32602.`,
+    JSON.stringify(witnessedByTool.get("searchJiraIssuesUsingJql")) === JSON.stringify({ jql: EXPECTED_JQL }),
+  );
+});

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -1,3 +1,13 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import {
+  atlassianDashboardTiles,
+  confluenceTileTitle,
+  expectedJql,
+  jiraTileTitle,
+} from "../worlds/dashboard-launch-input.ts";
+import type { DashboardTileFacts } from "../worlds/dashboard-launch-input.ts";
+
 /**
  * Customer report (2026-09): Dashboard tiles for the Atlassian remote MCP
  * "don't work" with the exact pasted JSON payloads, identically across an
@@ -12,433 +22,72 @@
  * fetch stubs — and asserts the member now sees the provider's own rejection
  * naming `cloudId` on the tile, never the generic 500 text. The witness proves
  * the pasted launch arguments arrived byte-identically.
+ *
+ * The witness is an inline loopback MCP server, so Den must run in the same
+ * place — the same local-placement constraint remote-mcp-apps declares.
  */
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { expect, onTestFinished } from "vitest";
-import { createOrgConnection, denFetch, evalIn, waitFor } from "@openwork/behaviors";
-import type { DenSession } from "@openwork/behaviors";
-import { app, needs, server, test, unmetNeeds } from "@openwork/testkit";
-import type { TestNeeds } from "@openwork/testkit";
 
-const requirements: TestNeeds = {
-  optIn: ["OPENWORK_EVAL_E2E_TESTS"],
-};
-const missingRequirements = unmetNeeds(requirements, process.env);
-// The Atlassian witness is an inline loopback MCP server, so Den must run in
-// the same place — the same local-placement constraint remote-mcp-apps uses.
 const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1"
   && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
-const title = missingRequirements.length > 0
-  ? `dashboard Atlassian tile error skipped — needs: ${missingRequirements.join(", ")}`
-  : !localPlacement
-    ? "dashboard Atlassian tile error skipped — needs local placement without OPENWORK_EVAL_DAYTONA/OPENWORK_EVAL_DEN_API_URL"
-    : "a dashboard tile launched with the reported Atlassian JSON names the missing required argument";
 
-const CONFLUENCE_RESOURCE = "ui://atlassian/confluence-page/view.html";
-const JIRA_RESOURCE = "ui://atlassian/jql-search/view.html";
-const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
-const PASTED_CONFLUENCE_JSON = `{"pageId": "1122334455"}`;
-const PASTED_JQL_JSON = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
-const EXPECTED_JQL = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
+const test = spec.world(atlassianDashboardTiles, { timeout: 480_000 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+function requireTile(value: DashboardTileFacts | null, label: string): DashboardTileFacts {
+  if (!value) throw new Error(`${label} tile was not rendered.`);
   return value;
 }
 
-function readBody(request: IncomingMessage): Promise<string> {
-  request.setEncoding("utf8");
-  return new Promise((resolve, reject) => {
-    let body = "";
-    request.on("data", (chunk: string) => {
-      body += chunk;
+test.skipIf(!localPlacement)(
+  "a dashboard tile launched with the reported Atlassian JSON names the missing required argument",
+  async ({ world, user, probe, evidence }) => {
+    await probe.eventually(() => world.openDashboard(), {
+      within: 90_000,
+      label: "Dashboard navigation opened",
     });
-    request.on("end", () => resolve(body));
-    request.on("error", reject);
-  });
-}
-
-function sendJson(response: ServerResponse, status: number, body: unknown): void {
-  response.writeHead(status, { "cache-control": "no-store", "content-type": "application/json" });
-  response.end(JSON.stringify(body));
-}
-
-type WitnessCall = { name: string; args: Record<string, unknown> };
-
-function atlassianWitnessRpc(
-  message: Record<string, unknown>,
-  receivedCalls: WitnessCall[],
-): Record<string, unknown> | null {
-  if (message.method === "initialize") {
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: "2025-06-18",
-        capabilities: {
-          tools: { listChanged: false },
-          resources: { listChanged: false, subscribe: false },
-          extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
-        },
-        serverInfo: { name: "atlassian-remote-mcp-witness", version: "1.0.0" },
-      },
-    };
-  }
-  if (message.id === undefined) return null;
-  if (message.method === "tools/list") {
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        tools: [
-          {
-            name: "getConfluencePage",
-            title: "Get Confluence page",
-            description: "Get a Confluence page by id.",
-            inputSchema: {
-              type: "object",
-              properties: { cloudId: { type: "string" }, pageId: { type: "string" } },
-              required: ["cloudId", "pageId"],
-            },
-            annotations: { readOnlyHint: true, destructiveHint: false },
-            _meta: { ui: { resourceUri: CONFLUENCE_RESOURCE, visibility: ["model", "app"] } },
-          },
-          {
-            name: "searchJiraIssuesUsingJql",
-            title: "Search Jira issues using JQL",
-            description: "Search Jira issues with a JQL query.",
-            inputSchema: {
-              type: "object",
-              properties: { cloudId: { type: "string" }, jql: { type: "string" } },
-              required: ["cloudId", "jql"],
-            },
-            annotations: { readOnlyHint: true, destructiveHint: false },
-            _meta: { ui: { resourceUri: JIRA_RESOURCE, visibility: ["model", "app"] } },
-          },
-        ],
-      },
-    };
-  }
-  if (message.method === "resources/read") {
-    const params = isRecord(message.params) ? message.params : {};
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        contents: [{
-          uri: params.uri,
-          mimeType: "text/html;profile=mcp-app",
-          text: APP_HTML,
-          _meta: {
-            ui: {
-              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
-              prefersBorder: true,
-            },
-          },
-        }],
-      },
-    };
-  }
-  if (message.method === "tools/call") {
-    const params = isRecord(message.params) ? message.params : {};
-    const name = typeof params.name === "string" ? params.name : "";
-    const args = isRecord(params.arguments) ? params.arguments : {};
-    receivedCalls.push({ name, args });
-    if (typeof args.cloudId !== "string" || !args.cloudId) {
-      return {
-        jsonrpc: "2.0",
-        id: message.id,
-        error: {
-          code: -32602,
-          message: `Invalid arguments for tool ${name}: [{"code":"invalid_type","expected":"string","received":"undefined","path":["cloudId"],"message":"Required"}]`,
-        },
-      };
-    }
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { content: [{ type: "text", text: `ok:${name}` }], structuredContent: { ok: true } },
-    };
-  }
-  return { jsonrpc: "2.0", id: message.id, result: {} };
-}
-
-function orgHeaders(session: DenSession, orgId: string): Record<string, string> {
-  return { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId };
-}
-
-async function organizationId(admin: DenSession): Promise<string> {
-  const result = await denFetch(admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${admin.token}` } });
-  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
-  const id = organizations[0] && typeof organizations[0].id === "string" ? organizations[0].id : "";
-  if (!result.response.ok || !id) {
-    throw new Error(`Finding the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
-  }
-  return id;
-}
-
-test.skipIf(!localPlacement)(title, { timeout: 480_000 }, async ({ evidence, place }) => {
-  needs(requirements);
-
-  const receivedCalls: WitnessCall[] = [];
-  const witness = createServer((request, response) => {
-    void (async () => {
-      if (request.method !== "POST") {
-        sendJson(response, 405, { error: "method_not_allowed" });
-        return;
-      }
-      const raw = await readBody(request);
-      const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
-      const messages = Array.isArray(parsed) ? parsed : [parsed];
-      const replies = messages.flatMap((entry) => {
-        if (!isRecord(entry)) return [];
-        const reply = atlassianWitnessRpc(entry, receivedCalls);
-        return reply ? [reply] : [];
-      });
-      if (replies.length === 0) {
-        response.writeHead(202);
-        response.end();
-        return;
-      }
-      sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
-    })().catch((error: unknown) => {
-      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
-      else response.destroy(error instanceof Error ? error : undefined);
+    await probe.eventually(() => world.tilesReady(), {
+      within: 90_000,
+      label: "granted Atlassian dashboard tiles rendered with Run buttons",
     });
-  });
-  await new Promise<void>((resolve, reject) => {
-    witness.once("error", reject);
-    witness.listen(0, "127.0.0.1", resolve);
-  });
-  onTestFinished(async () => {
-    await new Promise<void>((resolve, reject) => witness.close((error) => (error ? reject(error) : resolve())));
-  });
-  const witnessAddress = witness.address();
-  if (!witnessAddress || typeof witnessAddress === "string") throw new Error("The Atlassian witness did not bind a port.");
-  const witnessUrl = `http://127.0.0.1:${witnessAddress.port}/mcp`;
 
-  await using den = await server({
-    place,
-    env: { DEN_DASHBOARDS_ENABLED: "true" },
-    org: { name: `Dashboard Atlassian tile ${Date.now()}`, admin: { name: "Avery" } },
-  });
-  const orgId = await organizationId(den.admin);
-  const headers = orgHeaders(den.admin, orgId);
+    // Launch both tiles exactly as the member does: press Run.
+    world.receivedCalls.length = 0;
+    await user.click({ role: "button", label: `Run ${confluenceTileTitle}` });
+    await user.click({ role: "button", label: `Run ${jiraTileTitle}` });
 
-  const connection = await createOrgConnection(den.admin, {
-    name: "Atlassian (One org account)",
-    url: witnessUrl,
-    authType: "none",
-    credentialMode: "shared",
-    access: { orgWide: true },
-  });
-
-  const appsResult = await denFetch(den.admin, `/v1/mcp-connections/${connection.id}/mcp-apps`, { headers });
-  expect(appsResult.response.status, appsResult.text).toBe(200);
-  const apps = isRecord(appsResult.body) && Array.isArray(appsResult.body.apps)
-    ? appsResult.body.apps.filter(isRecord)
-    : [];
-  const confluenceApp = requireRecord(apps.find((entry) => entry.toolName === "getConfluencePage"), "Confluence app entry");
-  const jqlApp = requireRecord(apps.find((entry) => entry.toolName === "searchJiraIssuesUsingJql"), "JQL app entry");
-
-  const confluenceArguments = requireRecord(JSON.parse(PASTED_CONFLUENCE_JSON), "Confluence launch input");
-  const jqlArguments = requireRecord(JSON.parse(PASTED_JQL_JSON), "JQL launch input");
-  expect(jqlArguments.jql).toBe(EXPECTED_JQL);
-  const createResult = await denFetch(den.admin, "/v1/dashboards", {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      name: "Atlassian board",
-      elements: [
-        {
-          serverName: String(confluenceApp.serverName ?? ""),
-          connectionId: connection.id,
-          toolName: "getConfluencePage",
-          projectedToolName: String(confluenceApp.projectedToolName ?? ""),
-          resourceUri: CONFLUENCE_RESOURCE,
-          title: "Confluence page",
-          launchArguments: confluenceArguments,
-        },
-        {
-          serverName: String(jqlApp.serverName ?? ""),
-          connectionId: connection.id,
-          toolName: "searchJiraIssuesUsingJql",
-          projectedToolName: String(jqlApp.projectedToolName ?? ""),
-          resourceUri: JIRA_RESOURCE,
-          title: "Jira queue",
-          launchArguments: jqlArguments,
-        },
-      ],
-    }),
-  });
-  expect(createResult.response.status, createResult.text).toBe(201);
-  const dashboard = requireRecord(requireRecord(createResult.body, "dashboard response").item, "dashboard item");
-  const dashboardId = String(dashboard.id ?? "");
-  const grantResult = await denFetch(den.admin, `/v1/dashboards/${dashboardId}/access`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ orgWide: true, role: "viewer" }),
-  });
-  expect(grantResult.response.status, grantResult.text).toBe(201);
-
-  const tokenResult = await denFetch(den.admin, "/v1/mcp/token", {
-    method: "POST",
-    headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": orgId },
-    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
-  });
-  expect(tokenResult.response.ok, tokenResult.text).toBe(true);
-  const tokenBody = requireRecord(tokenResult.body, "MCP token response");
-  const mcpToken = String(tokenBody.token ?? "");
-  const appHostMcpToken = String(tokenBody.appHostToken ?? "");
-  expect(mcpToken).not.toBe("");
-  expect(appHostMcpToken).not.toBe("");
-
-  await using desktop = await app({ den, as: "admin", place });
-
-  // The signed-in harness Desktop does not run the production Cloud
-  // provisioning loop, so hand it the same Connect MCP configuration the
-  // product writes: the central Cloud MCP entry plus the private App-host
-  // authorization. This is the documented reconcile surface, not a stub.
-  const reconciled = await evalIn(desktop, `(async () => {
-    const port = localStorage.getItem("openwork.server.port");
-    const token = localStorage.getItem("openwork.server.token");
-    if (!port || !token) return "missing local server credentials";
-    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(desktop.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
-      method: "POST",
-      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        config: {
-          type: "remote",
-          url: ${JSON.stringify(`${den.ref.apiUrl}/mcp/agent`)},
-          enabled: true,
-          headers: { Authorization: ${JSON.stringify(`Bearer ${mcpToken}`)} },
-          oauth: false,
-        },
-        appHostAuthorization: ${JSON.stringify(`Bearer ${appHostMcpToken}`)},
-        trigger: "dashboard-atlassian-tile-error",
-      }),
+    const tiles = await probe.eventually(() => world.tiles(), {
+      within: 120_000,
+      label: "both Atlassian tiles name the missing required argument",
+      until: (value) => value.confluence?.namesCloudId === true && value.jql?.namesCloudId === true,
     });
-    const text = await response.text();
-    return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
-  })()`, { awaitPromise: true, timeoutMs: 120_000 });
-  expect(reconciled).toBe("ok");
+    const confluenceTile = requireTile(tiles.confluence, confluenceTileTitle);
+    const jqlTile = requireTile(tiles.jql, jiraTileTitle);
 
-  // The Dashboard navigation lives in the sidebar and renders only after
-  // Desktop reads dashboardEnabled from /v1/me/desktop-config. Open the
-  // sidebar if it is collapsed, then wait for the button.
-  const findDashboardButton = `[...document.querySelectorAll("button")]
-      .find((entry) => entry.textContent?.trim() === "Dashboard")`;
-  await waitFor(desktop, `(() => {
-    const button = ${findDashboardButton};
-    if (button instanceof HTMLButtonElement && !button.disabled) return true;
-    const sidebarOpen = [...document.querySelectorAll("button")]
-      .some((entry) => entry.textContent?.includes("Search sessions"));
-    if (!sidebarOpen) {
-      const toggle = [...document.querySelectorAll("button")]
-        .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
-      if (toggle instanceof HTMLButtonElement) toggle.click();
-    }
-    return false;
-  })()`, {
-    timeoutMs: 90_000,
-    label: "Dashboard navigation available",
-  });
-  const dashboardOpened = await evalIn(desktop, `(() => {
-    const button = [...document.querySelectorAll("button")]
-      .find((entry) => entry.textContent?.trim() === "Dashboard");
-    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
-    button.click();
-    return true;
-  })()`);
-  expect(dashboardOpened).toBe(true);
-  await waitFor(desktop, `(() => {
-    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${dashboardId}"]`)});
-    return section instanceof HTMLElement
-      && section.innerText.includes("Confluence page")
-      && section.innerText.includes("Jira queue")
-      && Boolean(section.querySelector('button[aria-label="Run Confluence page"]'))
-      && Boolean(section.querySelector('button[aria-label="Run Jira queue"]'));
-  })()`, {
-    timeoutMs: 90_000,
-    label: "granted Atlassian dashboard tiles rendered with Run buttons",
-  });
+    // The launch still fails (cloudId is genuinely missing), but the member now
+    // reads the provider's rejection naming the argument, not a generic 500.
+    expect(confluenceTile.badgeFailed).toBe(true);
+    expect(jqlTile.badgeFailed).toBe(true);
+    expect(confluenceTile.namesCloudId).toBe(true);
+    expect(jqlTile.namesCloudId).toBe(true);
+    expect(confluenceTile.opaque).toBe(false);
+    expect(jqlTile.opaque).toBe(false);
+    expect(confluenceTile.text).toContain("rejected the tool arguments");
+    expect(jqlTile.text).toContain("rejected the tool arguments");
 
-  // Launch both tiles exactly as the member does: press Run.
-  receivedCalls.length = 0;
-  for (const tile of ["Confluence page", "Jira queue"]) {
-    const ran = await evalIn(desktop, `(() => {
-      const button = document.querySelector(${JSON.stringify(`button[aria-label="Run ${tile}"]`)});
-      if (!(button instanceof HTMLButtonElement)) return false;
-      button.click();
-      return true;
-    })()`);
-    expect(ran, `Run button for ${tile}`).toBe(true);
-  }
+    // The witness saw both launches with the pasted arguments byte-identical
+    // and no cloudId — the provider rejection is the only failure in the chain.
+    const witnessedByTool = new Map(world.receivedCalls.map((call) => [call.name, call.args]));
+    expect(witnessedByTool.get("getConfluencePage")).toEqual({ pageId: "1122334455" });
+    expect(witnessedByTool.get("searchJiraIssuesUsingJql")).toEqual({ jql: expectedJql });
 
-  await waitFor(desktop, `(() => {
-    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${dashboardId}"]`)});
-    if (!(section instanceof HTMLElement)) return false;
-    const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
-    const confluence = tiles.find((tile) => tile.textContent?.includes("Confluence page"));
-    const jql = tiles.find((tile) => tile.textContent?.includes("Jira queue"));
-    return confluence instanceof HTMLElement
-      && jql instanceof HTMLElement
-      && confluence.innerText.includes("cloudId")
-      && jql.innerText.includes("cloudId");
-  })()`, {
-    timeoutMs: 120_000,
-    label: "both Atlassian tiles name the missing required argument",
-  });
-
-  const tileState = await evalIn(desktop, `(() => {
-    const section = document.querySelector(${JSON.stringify(`[data-granted-dashboard="${dashboardId}"]`)});
-    if (!(section instanceof HTMLElement)) return null;
-    const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
-    const read = (title) => {
-      const tile = tiles.find((entry) => entry.textContent?.includes(title));
-      if (!(tile instanceof HTMLElement)) return null;
-      return {
-        text: tile.innerText.replace(/\\s+/g, " ").trim(),
-        badgeFailed: tile.innerText.includes("Refresh failed"),
-        opaque: tile.innerText.includes("Unexpected server error"),
-        namesCloudId: tile.innerText.includes("cloudId"),
-      };
-    };
-    return { confluence: read("Confluence page"), jql: read("Jira queue") };
-  })()`);
-  const state = requireRecord(tileState, "tile state");
-  const confluenceTile = requireRecord(state.confluence, "Confluence tile state");
-  const jqlTile = requireRecord(state.jql, "JQL tile state");
-  // The launch still fails (cloudId is genuinely missing), but the member now
-  // reads the provider's rejection naming the argument, not a generic 500.
-  expect(confluenceTile.badgeFailed).toBe(true);
-  expect(jqlTile.badgeFailed).toBe(true);
-  expect(confluenceTile.namesCloudId).toBe(true);
-  expect(jqlTile.namesCloudId).toBe(true);
-  expect(confluenceTile.opaque).toBe(false);
-  expect(jqlTile.opaque).toBe(false);
-  expect(String(confluenceTile.text)).toContain("rejected the tool arguments");
-  expect(String(jqlTile.text)).toContain("rejected the tool arguments");
-
-  // The witness saw both launches with the pasted arguments byte-identical
-  // and no cloudId — the provider rejection is the only failure in the chain.
-  const witnessedByTool = new Map(receivedCalls.map((call) => [call.name, call.args]));
-  expect(witnessedByTool.get("getConfluencePage")).toEqual({ pageId: "1122334455" });
-  expect(witnessedByTool.get("searchJiraIssuesUsingJql")).toEqual({ jql: EXPECTED_JQL });
-
-  evidence.recordAssertionEvidence(
-    "The dashboard tile names the missing required argument instead of a generic server error",
-    `After Run, both tiles show the "Refresh failed" badge with the provider's rejection naming cloudId and never "Unexpected server error" (confluence=${JSON.stringify(confluenceTile)}, jql=${JSON.stringify(jqlTile)}).`,
-    confluenceTile.namesCloudId === true && jqlTile.namesCloudId === true
-      && confluenceTile.opaque === false && jqlTile.opaque === false,
-  );
-  evidence.recordAssertionEvidence(
-    "The pasted launch JSON reached the provider intact",
-    `The witness received getConfluencePage ${JSON.stringify(witnessedByTool.get("getConfluencePage"))} and searchJiraIssuesUsingJql with the exact single-escaped JQL string; the provider rejected both for the missing required cloudId with JSON-RPC -32602.`,
-    JSON.stringify(witnessedByTool.get("searchJiraIssuesUsingJql")) === JSON.stringify({ jql: EXPECTED_JQL }),
-  );
-});
+    evidence.recordAssertionEvidence(
+      "The dashboard tile names the missing required argument instead of a generic server error",
+      `After Run, both tiles show the "Refresh failed" badge with the provider's rejection naming cloudId and never "Unexpected server error" (confluence=${JSON.stringify(confluenceTile)}, jql=${JSON.stringify(jqlTile)}).`,
+      confluenceTile.namesCloudId && jqlTile.namesCloudId && !confluenceTile.opaque && !jqlTile.opaque,
+    );
+    evidence.recordAssertionEvidence(
+      "The pasted launch JSON reached the provider intact",
+      `The witness received getConfluencePage ${JSON.stringify(witnessedByTool.get("getConfluencePage"))} and searchJiraIssuesUsingJql with the exact single-escaped JQL string; the provider rejected both for the missing required cloudId with JSON-RPC -32602.`,
+      JSON.stringify(witnessedByTool.get("searchJiraIssuesUsingJql")) === JSON.stringify({ jql: expectedJql }),
+    );
+  },
+);

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -54,8 +54,16 @@ test.skipIf(!localPlacement)(
     await user.click({ role: "button", label: `Run ${confluenceTileTitle}` });
     await user.click({ role: "button", label: `Run ${jiraTileTitle}` });
 
+    // What the member sees: the provider's rejection naming cloudId with the
+    // failed-refresh badge, and never the pre-fix generic 500 text.
+    await user.see({ text: /rejected the tool arguments/ }, { timeoutMs: 120_000 });
+    await user.see({ text: /cloudId/ });
+    await user.see({ text: /Refresh failed/ });
+    await user.notSee({ text: /Unexpected server error/ });
+
+    // Per-tile facts prove both tiles (not just one) carry that message.
     const tiles = await probe.eventually(() => world.tiles(), {
-      within: 120_000,
+      within: 30_000,
       label: "both Atlassian tiles name the missing required argument",
       until: (value) => value.confluence?.namesCloudId === true && value.jql?.namesCloudId === true,
     });

--- a/evals/worlds/dashboard-launch-input.ts
+++ b/evals/worlds/dashboard-launch-input.ts
@@ -1,0 +1,431 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Den, Seed } from "@openwork/env";
+import { evalIn as rawEvalIn } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+
+/**
+ * A managed Dashboard whose two tiles launch an Atlassian-shaped MCP with
+ * launch input that omits the required `cloudId` argument — the reported
+ * failure shape. The witness MCP mirrors the Atlassian remote MCP: same tool
+ * names, `cloudId` required, read-only annotations, MCP-App `ui://` bindings,
+ * and a JSON-RPC -32602 rejection when `cloudId` is missing.
+ *
+ * Payloads are anonymized, structure-identical stand-ins for the reported
+ * ones (a Confluence page id and a JQL string with escaped quotes).
+ */
+
+export const confluenceResourceUri = "ui://atlassian/confluence-page/view.html";
+export const jiraResourceUri = "ui://atlassian/jql-search/view.html";
+export const confluenceTileTitle = "Confluence page";
+export const jiraTileTitle = "Jira queue";
+export const pastedConfluenceJson = `{"pageId": "1122334455"}`;
+export const pastedJqlJson = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
+export const expectedJql = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
+
+const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
+
+export type WitnessCall = { name: string; args: Record<string, unknown> };
+
+/** What one dashboard tile shows the member after a launch attempt. */
+export interface DashboardTileFacts {
+  text: string;
+  badgeFailed: boolean;
+  /** The pre-fix generic 500 text. */
+  opaque: boolean;
+  namesCloudId: boolean;
+}
+
+export interface DashboardTilesFacts {
+  confluence: DashboardTileFacts | null;
+  jql: DashboardTileFacts | null;
+}
+
+function parseTileFacts(value: unknown): DashboardTileFacts | null {
+  if (!isRecord(value) || typeof value.text !== "string") return null;
+  return {
+    text: value.text,
+    badgeFailed: value.badgeFailed === true,
+    opaque: value.opaque === true,
+    namesCloudId: value.namesCloudId === true,
+  };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object: ${JSON.stringify(value)}`);
+  return value;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "cache-control": "no-store", "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("The Atlassian witness did not bind a TCP port.");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
+  });
+}
+
+function withDispose<T extends object>(value: T, dispose: () => Promise<void>): T & AsyncDisposable {
+  return Object.assign(value, { [Symbol.asyncDispose]: dispose });
+}
+
+export function atlassianWitnessRpc(
+  message: Record<string, unknown>,
+  receivedCalls: WitnessCall[],
+): Record<string, unknown> | null {
+  if (message.method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: "2025-06-18",
+        capabilities: {
+          tools: { listChanged: false },
+          resources: { listChanged: false, subscribe: false },
+          extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+        },
+        serverInfo: { name: "atlassian-remote-mcp-witness", version: "1.0.0" },
+      },
+    };
+  }
+  if (message.id === undefined) return null;
+  if (message.method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        tools: [
+          {
+            name: "getConfluencePage",
+            title: "Get Confluence page",
+            description: "Get a Confluence page by id.",
+            inputSchema: {
+              type: "object",
+              properties: { cloudId: { type: "string" }, pageId: { type: "string" } },
+              required: ["cloudId", "pageId"],
+            },
+            annotations: { readOnlyHint: true, destructiveHint: false },
+            _meta: { ui: { resourceUri: confluenceResourceUri, visibility: ["model", "app"] } },
+          },
+          {
+            name: "searchJiraIssuesUsingJql",
+            title: "Search Jira issues using JQL",
+            description: "Search Jira issues with a JQL query.",
+            inputSchema: {
+              type: "object",
+              properties: { cloudId: { type: "string" }, jql: { type: "string" } },
+              required: ["cloudId", "jql"],
+            },
+            annotations: { readOnlyHint: true, destructiveHint: false },
+            _meta: { ui: { resourceUri: jiraResourceUri, visibility: ["model", "app"] } },
+          },
+        ],
+      },
+    };
+  }
+  if (message.method === "resources/read") {
+    const params = isRecord(message.params) ? message.params : {};
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        contents: [{
+          uri: params.uri,
+          mimeType: "text/html;profile=mcp-app",
+          text: APP_HTML,
+          _meta: {
+            ui: {
+              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
+              prefersBorder: true,
+            },
+          },
+        }],
+      },
+    };
+  }
+  if (message.method === "tools/call") {
+    const params = isRecord(message.params) ? message.params : {};
+    const name = typeof params.name === "string" ? params.name : "";
+    const args = isRecord(params.arguments) ? params.arguments : {};
+    receivedCalls.push({ name, args });
+    if (typeof args.cloudId !== "string" || !args.cloudId) {
+      return {
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32602,
+          message: `Invalid arguments for tool ${name}: [{"code":"invalid_type","expected":"string","received":"undefined","path":["cloudId"],"message":"Required"}]`,
+        },
+      };
+    }
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { content: [{ type: "text", text: `ok:${name}` }], structuredContent: { ok: true } },
+    };
+  }
+  return { jsonrpc: "2.0", id: message.id, result: {} };
+}
+
+/** A loopback MCP server shaped like the Atlassian remote MCP. */
+export function createAtlassianWitness(receivedCalls: WitnessCall[]): Server {
+  return createServer((request, response) => {
+    void (async () => {
+      if (request.method !== "POST") {
+        sendJson(response, 405, { error: "method_not_allowed" });
+        return;
+      }
+      const raw = await readBody(request);
+      const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
+      const messages = Array.isArray(parsed) ? parsed : [parsed];
+      const replies = messages.flatMap((entry) => {
+        if (!isRecord(entry)) return [];
+        const reply = atlassianWitnessRpc(entry, receivedCalls);
+        return reply ? [reply] : [];
+      });
+      if (replies.length === 0) {
+        response.writeHead(202);
+        response.end();
+        return;
+      }
+      sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+}
+
+async function activeOrganizationId(seed: Seed, session: DenSession): Promise<string> {
+  const result = await seed.api(session, "/v1/me/orgs");
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
+  const id = orgs[0] && typeof orgs[0].id === "string" ? orgs[0].id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Resolving the active organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function mintMcpTokens(seed: Seed, den: Den, organizationId: string): Promise<{ mcpToken: string; appHostToken: string }> {
+  const result = await seed.api(den.admin, "/v1/mcp/token", {
+    method: "POST",
+    headers: { "x-openwork-org-id": organizationId },
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  const body = requireRecord(result.body, "MCP token response");
+  const mcpToken = typeof body.token === "string" ? body.token : "";
+  const appHostToken = typeof body.appHostToken === "string" ? body.appHostToken : "";
+  if (!result.response.ok || !mcpToken || !appHostToken) {
+    throw new Error(`Minting the MCP tokens failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return { mcpToken, appHostToken };
+}
+
+export async function atlassianDashboardTiles(seed: Seed) {
+  const receivedCalls: WitnessCall[] = [];
+  const witness = createAtlassianWitness(receivedCalls);
+  const witnessUrl = `${await listen(witness)}/mcp`;
+  try {
+    const den = await seed.den({
+      env: { DEN_DASHBOARDS_ENABLED: "true" },
+      org: { name: `Dashboard launch input ${Date.now()}`, admin: { name: "Avery" } },
+    });
+    const organizationId = await activeOrganizationId(seed, den.admin);
+    const orgHeaders = { "x-openwork-org-id": organizationId };
+    const connection = await seed.orgConnection(den.admin, {
+      name: "Atlassian (One org account)",
+      url: witnessUrl,
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true },
+    });
+
+    const appsResult = await seed.api(den.admin, `/v1/mcp-connections/${connection.id}/mcp-apps`, { headers: orgHeaders });
+    if (appsResult.response.status !== 200) {
+      throw new Error(`Listing connection MCP Apps failed: HTTP ${appsResult.response.status} ${appsResult.text.slice(0, 500)}`);
+    }
+    const apps = isRecord(appsResult.body) && Array.isArray(appsResult.body.apps) ? appsResult.body.apps.filter(isRecord) : [];
+    const confluenceApp = requireRecord(apps.find((entry) => entry.toolName === "getConfluencePage"), "Confluence app entry");
+    const jqlApp = requireRecord(apps.find((entry) => entry.toolName === "searchJiraIssuesUsingJql"), "JQL app entry");
+
+    // Mirror the add-app dialog: bare JSON.parse of the pasted text.
+    const confluenceArguments = requireRecord(JSON.parse(pastedConfluenceJson), "Confluence launch input");
+    const jqlArguments = requireRecord(JSON.parse(pastedJqlJson), "JQL launch input");
+    const createResult = await seed.api(den.admin, "/v1/dashboards", {
+      method: "POST",
+      headers: orgHeaders,
+      body: JSON.stringify({
+        name: "Atlassian board",
+        elements: [
+          {
+            serverName: String(confluenceApp.serverName ?? ""),
+            connectionId: connection.id,
+            toolName: "getConfluencePage",
+            projectedToolName: String(confluenceApp.projectedToolName ?? ""),
+            resourceUri: confluenceResourceUri,
+            title: confluenceTileTitle,
+            launchArguments: confluenceArguments,
+          },
+          {
+            serverName: String(jqlApp.serverName ?? ""),
+            connectionId: connection.id,
+            toolName: "searchJiraIssuesUsingJql",
+            projectedToolName: String(jqlApp.projectedToolName ?? ""),
+            resourceUri: jiraResourceUri,
+            title: jiraTileTitle,
+            launchArguments: jqlArguments,
+          },
+        ],
+      }),
+    });
+    if (createResult.response.status !== 201) {
+      throw new Error(`Creating the dashboard failed: HTTP ${createResult.response.status} ${createResult.text.slice(0, 500)}`);
+    }
+    const dashboardId = String(requireRecord(requireRecord(createResult.body, "dashboard response").item, "dashboard item").id ?? "");
+    const grantResult = await seed.api(den.admin, `/v1/dashboards/${dashboardId}/access`, {
+      method: "POST",
+      headers: orgHeaders,
+      body: JSON.stringify({ orgWide: true, role: "viewer" }),
+    });
+    if (grantResult.response.status !== 201) {
+      throw new Error(`Granting the dashboard failed: HTTP ${grantResult.response.status} ${grantResult.text.slice(0, 500)}`);
+    }
+
+    const { mcpToken, appHostToken } = await mintMcpTokens(seed, den, organizationId);
+    const app = await seed.desktop({ den, as: "admin" });
+    const workspace = await seed.workspace(app, seed.tmpPath("dashboard-launch-input"));
+    // The signed-in harness Desktop does not run the production Cloud
+    // provisioning loop, so hand it the same Connect MCP configuration the
+    // product writes: the central Cloud MCP entry plus the private App-host
+    // authorization. This is the documented reconcile surface, not a stub.
+    // TODO(primitive): seed.connectMcp
+    const reconciled = await rawEvalIn(app, `(async () => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      if (!port || !token) return "missing local server credentials";
+      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
+        method: "POST",
+        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          config: {
+            type: "remote",
+            url: ${JSON.stringify(`${den.ref.apiUrl}/mcp/agent`)},
+            enabled: true,
+            headers: { Authorization: ${JSON.stringify(`Bearer ${mcpToken}`)} },
+            oauth: false,
+          },
+          appHostAuthorization: ${JSON.stringify(`Bearer ${appHostToken}`)},
+          trigger: "dashboard-launch-input-world",
+        }),
+      });
+      const text = await response.text();
+      return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
+    })()`, { awaitPromise: true, timeoutMs: 120_000 });
+    if (reconciled !== "ok") throw new Error(`Reconciling Connect MCP for the desktop failed: ${String(reconciled)}`);
+
+    const section = `[data-granted-dashboard="${dashboardId}"]`;
+    return withDispose({
+      app,
+      dashboardId,
+      connectionId: connection.id,
+      receivedCalls,
+      /**
+       * Opens the Dashboard from the sidebar navigation, which renders only
+       * after Desktop reads dashboardEnabled from /v1/me/desktop-config.
+       * Returns whether the navigation was clicked yet; opens a collapsed
+       * sidebar on the way.
+       */
+      // TODO(primitive): user.click({ role: "button", text: "Dashboard" }) should locate the sidebar rail entry and open a collapsed sidebar.
+      async openDashboard(): Promise<boolean> {
+        const opened = await rawEvalIn(app, `(() => {
+          const button = [...document.querySelectorAll("button")]
+            .find((entry) => entry.textContent?.trim() === "Dashboard");
+          if (button instanceof HTMLButtonElement && !button.disabled) {
+            button.click();
+            // In a narrow harness window the sidebar is an overlay that covers
+            // the tile grid; collapse it so tiles are hit-testable.
+            const toggle = [...document.querySelectorAll("button")]
+              .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
+            if (toggle instanceof HTMLButtonElement) toggle.click();
+            return true;
+          }
+          const sidebarOpen = [...document.querySelectorAll("button")]
+            .some((entry) => entry.textContent?.includes("Search sessions"));
+          if (!sidebarOpen) {
+            const toggle = [...document.querySelectorAll("button")]
+              .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
+            if (toggle instanceof HTMLButtonElement) toggle.click();
+          }
+          return false;
+        })()`);
+        return opened === true;
+      },
+      /** True once both granted tiles render with their Run buttons. */
+      // TODO(primitive): probe.dashboardTiles should expose granted tiles and their launch controls.
+      async tilesReady(): Promise<boolean> {
+        const ready = await rawEvalIn(app, `(() => {
+          const section = document.querySelector(${JSON.stringify(section)});
+          return section instanceof HTMLElement
+            && section.innerText.includes(${JSON.stringify(confluenceTileTitle)})
+            && section.innerText.includes(${JSON.stringify(jiraTileTitle)})
+            && Boolean(section.querySelector('button[aria-label="Run ${confluenceTileTitle}"]'))
+            && Boolean(section.querySelector('button[aria-label="Run ${jiraTileTitle}"]'));
+        })()`);
+        return ready === true;
+      },
+      /** The member-visible state of both tiles. */
+      // TODO(primitive): probe.dashboardTiles
+      async tiles(): Promise<DashboardTilesFacts> {
+        const value = await rawEvalIn(app, `(() => {
+          const section = document.querySelector(${JSON.stringify(section)});
+          if (!(section instanceof HTMLElement)) return null;
+          const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
+          const read = (title) => {
+            const tile = tiles.find((entry) => entry.textContent?.includes(title));
+            if (!(tile instanceof HTMLElement)) return null;
+            return {
+              text: tile.innerText.replace(/\\s+/g, " ").trim(),
+              badgeFailed: tile.innerText.includes("Refresh failed"),
+              opaque: tile.innerText.includes("Unexpected server error"),
+              namesCloudId: tile.innerText.includes("cloudId"),
+            };
+          };
+          return { confluence: read(${JSON.stringify(confluenceTileTitle)}), jql: read(${JSON.stringify(jiraTileTitle)}) };
+        })()`);
+        const facts = isRecord(value) ? value : {};
+        return { confluence: parseTileFacts(facts.confluence), jql: parseTileFacts(facts.jql) };
+      },
+    }, () => closeServer(witness));
+  } catch (error) {
+    await closeServer(witness);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Problem

A Dashboard tile whose saved launch input omits an argument the MCP tool requires (e.g. the Atlassian remote MCP's `cloudId` for `getConfluencePage` / `searchJiraIssuesUsingJql`) fails on every launch with the generic **"Unexpected server error"** and a **"Refresh failed"** badge — identically for org-account and individual-account connections, because the rejection happens before credential mode matters.

Three hops hid the real cause:

1. **Desktop host** (`apps/server/src/mcp-app-host.ts`): `callMcpAppTool` let the SDK `McpError` escape untyped, so `rethrowMcpAppHostError` didn't map it and the route answered HTTP 500 `internal_error`.
2. **Den diagnostics** (`ee/apps/den-api/.../external-mcp-diagnostics.ts`): `MCP_INVALID_PARAMS` / `MCP_PROVIDER_INVALID_PARAMS` produced the phase-generic *"requested provider operation failed"* text even though the provider's rejection naming the argument was already captured as `providerErrorMessage`.
3. **Authoring** (`ee/apps/den-api/.../mcp-connections.ts`, `ee/apps/den-web/.../org-dashboard-detail-screen.tsx`): `GET /v1/mcp-connections/:id/mcp-apps` exposed only a `requiresInput` boolean, so the add-app dialog could neither show which keys a tool needs nor validate the pasted JSON.

Ruled out (and now asserted): JSON double-escaping. A JQL string with escaped quotes round-trips Den storage and reaches the provider byte-identically.

## Fix (smallest diff per layer)

- **Desktop host**: rethrow `client.callTool` rejections as `McpAppHostError("tool_call_failed", message)` → 422 with the provider's message on the tile. The message is bounded (`providerErrorExcerpt`: control chars stripped, 512-char cap — the same bound Den applies to provider excerpts) because it is provider-controlled text reaching viewer-scoped callers.
- **Den diagnostics**: invalid-params codes now render `The provider rejected the tool arguments. Provider-declared message (untrusted): "…"` — reusing the existing sanitized `providerErrorMessage` (control chars stripped, 512-char cap) and the existing "(untrusted)" convention already used for `MCP_PROVIDER_DECLARED_ERROR`. No new provider data is captured.
- **Authoring**: new `mcpToolRequiredInputKeys()`; `/mcp-apps` returns `requiredInputKeys: string[]` (OpenAPI schema updated). The add-app dialog shows the required keys, pre-fills the placeholder, and refuses **Add** with `Launch input is missing required key: cloudId.` Older Den → `[]`, so behavior degrades to today's.

Not done deliberately: server-side `launchArguments` validation in `POST/PATCH /v1/dashboards` (would require Den to fetch the provider schema on every save; the dialog is where the JSON is pasted).

**After the fix, the tile reads** (asserted on the real Electron tile):
`MCP error -32603: The provider rejected the tool arguments. Provider-declared message (untrusted): "Invalid arguments for tool getConfluencePage: [{…"path":["cloudId"],"message":"Required"}]".`

## Verification

**Lane: local** (cold-boot `server()`, MySQL 3306 + Redis 6379). Daytona credentials are available, but both specs embed an inline loopback witness MCP (shaped like the Atlassian remote MCP: same tool names, `cloudId` required, MCP-App `ui://` bindings) that a remote Den cannot reach — the same local-placement constraint `remote-mcp-apps.e2e.test.ts` declares. Both specs skip loudly under `OPENWORK_EVAL_DAYTONA=1` / `OPENWORK_EVAL_DEN_API_URL`.

| Check | Command | Result |
| --- | --- | --- |
| `evals/specs/dashboard-atlassian-launch-input.test.ts` — real Den connection proxy + real Desktop App-host code; asserts `requiredInputKeys`, byte-identical `launchArguments` round-trip, typed `tool_call_failed` naming `cloudId`, per-member needs_signin surface (409 + absent from app-host index), and the control launch succeeding once `cloudId` is supplied | `pnpm --dir evals run test:pr specs/dashboard-atlassian-launch-input.test.ts` | exit 0 — 1 passed, 0 failed, 0 skipped |
| `evals/specs/dashboard-atlassian-tile-error.e2e.test.ts` — `spec.world(atlassianDashboardTiles)` (`evals/worlds/dashboard-launch-input.ts`); real Electron; `user.click` Run on both tiles; `user.see` the provider's rejection naming `cloudId` + "Refresh failed", `user.notSee` "Unexpected server error"; `world.tiles()` proves both tiles carry it; witness received the pasted args intact | `pnpm evals:e2e dashboard-atlassian-tile-error` | exit 0 — 1 passed, 0 failed, 0 skipped, verdict `passed` |
| `apps/server/src/mcp-app-host.test.ts` (+1: hostile-provider rejection → typed, bounded host error) | `bun --conditions=development test src/mcp-app-host.test.ts` | 24 pass, 0 fail |
| Eval-runner unit gate (layering lint `specs-use-testkit-only`, channel ratchet, runner tests) | `pnpm --dir evals run test` | exit 0 |
| `ee/apps/den-api/test/external-mcp-diagnostics.test.ts` (extended: message carries provider text) | `bun test test/external-mcp-diagnostics.test.ts` | 83 pass, 0 fail |
| `ee/apps/den-api/test/mcp-connection-apps.test.ts` (+1: `mcpToolRequiredInputKeys`) | `bun test test/mcp-connection-apps.test.ts` | 5 pass, 0 fail |
| `ee/apps/den-web/tests/dashboard-mcp-app-catalog.test.ts` (+1: `missingRequiredInputKeys`) | `bun test --conditions development tests/dashboard-mcp-app-catalog.test.ts` | 4 pass, 0 fail |

`tsc --noEmit` reports no errors in any touched file in `apps/server`, `ee/apps/den-api`, or `ee/apps/den-web`. Pre-existing, unrelated: `external-mcp-diagnostics.test.ts › uses one absolute deadline…` fails only when co-scheduled in one bun process with `mcp-connection-action-app.test.ts`; reproduces on pristine `origin/dev` files and passes in isolation.

Test evidence for both specs is published below (runs bound to the head SHA `174208abc`). Warden findings on `1a40e49a8` (bounded provider text; `user.see` witnesses) were addressed in `174208abc` with inline replies.

**Follow-up worth a separate ticket:** the test-evidence publisher keeps one sticky comment per PR, so the PR-lane run is posted as a second labelled comment.

**Verdict: Passed.**

