### PR TITLE
test(app): keep inherited OpenCode env out of the SDK smoke engines

### DIFF
--- a/apps/app/scripts/_util.mjs
+++ b/apps/app/scripts/_util.mjs
@@ -2,11 +2,17 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import net from "node:net";
-import { mkdtempSync, realpathSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+
+function withoutInheritedOpencodeEnv(env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !/^OPENCODE_/.test(key) && key !== "XDG_CONFIG_HOME"),
+  );
+}
 
 function resolveBasicAuthHeader() {
   const password = process.env.OPENCODE_SERVER_PASSWORD?.trim() ?? "";
@@ -57,6 +63,10 @@ export async function spawnOpencodeServe({
 
   const cwd = realpathSync(directory);
   const isolatedRoot = mkdtempSync(join(tmpdir(), "openwork-opencode-smoke-"));
+  const configDir = join(isolatedRoot, "config");
+  const xdgConfigHome = join(isolatedRoot, "xdg");
+  mkdirSync(configDir);
+  mkdirSync(xdgConfigHome);
   const args = ["serve", "--hostname", hostname, "--port", String(port)];
   for (const origin of corsOrigins) {
     args.push("--cors", origin);
@@ -66,13 +76,18 @@ export async function spawnOpencodeServe({
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
     env: {
-      ...process.env,
+      ...withoutInheritedOpencodeEnv(process.env),
       // Core SDK smoke scripts must not inherit a developer or CI runner's
-      // sessions database, MCPs, plugins, or provider setup. A shared DB also
-      // serializes every script behind the same SQLite writer. Browser-entry
-      // opts out of the pure config because it deliberately creates a project
-      // command, but it still receives an isolated database.
+      // OPENCODE_* setup because OPENCODE_CONFIG_CONTENT merges rather than
+      // replaces inherited config. XDG_CONFIG_HOME is redirected to an empty
+      // temp directory so neither the inherited profile nor
+      // ~/.config/opencode is loaded. A shared DB also serializes every script
+      // behind the same SQLite writer.
+      // Browser-entry opts out of the pure config because it deliberately
+      // creates a project command.
       OPENCODE_DB: join(isolatedRoot, "opencode.db"),
+      OPENCODE_CONFIG_DIR: configDir,
+      XDG_CONFIG_HOME: xdgConfigHome,
       ...(pure
         ? {
             OPENCODE_CONFIG_CONTENT: "{}",

--- a/evals/specs/app-sdk-smoke-isolation.test.ts
+++ b/evals/specs/app-sdk-smoke-isolation.test.ts
@@ -1,35 +1,54 @@
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { expect } from "vitest";
 import { test } from "@openwork/testkit";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
-test("the app SDK smoke suite isolates each OpenCode process and completes", ({ evidence }) => {
-  const result = spawnSync("pnpm", [
-    "--filter",
-    "@openwork/app",
-    "test:e2e",
-  ], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    timeout: 60_000,
-    maxBuffer: 10 * 1024 * 1024,
-  });
-  const output = `${result.stdout}${result.stderr}`;
+test("the app SDK smoke suite keeps a poisoned parent environment out of every smoke engine", ({ evidence }) => {
+  const poisonRoot = mkdtempSync(join(tmpdir(), "openwork-app-sdk-smoke-poison-"));
+  try {
+    const poisonedConfig = join(poisonRoot, "opencode.json");
+    const xdgConfigHome = join(poisonRoot, "xdg");
+    const xdgOpencodeDir = join(xdgConfigHome, "opencode");
+    mkdirSync(xdgOpencodeDir, { recursive: true });
+    writeFileSync(poisonedConfig, '{ "poisoned":');
+    writeFileSync(join(xdgOpencodeDir, "opencode.jsonc"), '{ "poisoned":');
 
-  expect(result.error, output).toBeUndefined();
-  expect(result.status, output).toBe(0);
-  expect(output).not.toContain('"ok": false');
-  expect(output).not.toContain('"status": "error"');
-  expect(output).toContain('"name": "path.get"');
-  expect(output).toContain('"name": "session.messages switch"');
-  expect(output).toContain('"root":".openwork/test-engine"');
-  expect(output).toContain('"name": "assert.built-in-browser-quickstart"');
+    const result = spawnSync("pnpm", [
+      "--filter",
+      "@openwork/app",
+      "test:e2e",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 90_000,
+      maxBuffer: 10 * 1024 * 1024,
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG: poisonedConfig,
+        XDG_CONFIG_HOME: xdgConfigHome,
+      },
+    });
+    const output = `${result.stdout}${result.stderr}`;
 
-  evidence.recordAssertionEvidence(
-    "Every core SDK smoke script receives isolated OpenCode state",
-    "The exact app test:e2e command completes core health/path/session/prompt/todo/SSE, session switching, filesystem operations, and the browser-entry project command with no error report.",
-    true,
-  );
+    expect(result.error, output).toBeUndefined();
+    expect(result.status, output).toBe(0);
+    expect(output).not.toContain('"ok": false');
+    expect(output).not.toContain('"status": "error"');
+    expect(output).toContain('"name": "path.get"');
+    expect(output).toContain('"name": "session.messages switch"');
+    expect(output).toContain('"root":".openwork/test-engine"');
+    expect(output).toContain('"name": "assert.built-in-browser-quickstart"');
+
+    evidence.recordAssertionEvidence(
+      "A poisoned parent environment does not reach any core SDK smoke engine",
+      "With poisoned OPENCODE_CONFIG and XDG_CONFIG_HOME values, the exact app test:e2e command completes core health/path/session/prompt/todo/SSE, session switching, filesystem operations, and the browser-entry project command with no error report.",
+      true,
+    );
+  } finally {
+    rmSync(poisonRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Why

`evals/specs/app-sdk-smoke-isolation.test.ts` is green on CI but hangs locally (and then fails on its 60s budget) whenever the parent shell carries `OPENCODE_*` variables — e.g. any dev shell or agent running inside OpenWork, which exports `OPENCODE_CONFIG=~/.config/openwork/runtime-opencode-config.json`, `OPENCODE_SERVER_PASSWORD`, `OPENCODE_MODELS_URL`.

`spawnOpencodeServe` spread `process.env` into every smoke `opencode serve`. `OPENCODE_CONFIG_CONTENT="{}"` is *merged on top of* an inherited `OPENCODE_CONFIG`, not a replacement, so the "pure" isolation still loaded the live app's MCPs, 7 plugins, and providers. `browser-entry` (`pure: false`) then hung at `session.create`. The real `~/.config/opencode/opencode.jsonc` (global MCPs) leaked the same way — opencode 1.18.18 does not honor `OPENCODE_CONFIG_DIR` for that path, only `XDG_CONFIG_HOME` (probe: `config.get()` returned the global MCP and `path.get().config === ~/.config/opencode`).

## What

- `apps/app/scripts/_util.mjs`: drop every inherited `OPENCODE_*` variable and redirect `XDG_CONFIG_HOME` to an empty dir inside the per-process temp root (cleaned up on close). Existing `pure` flags unchanged.
- `evals/specs/app-sdk-smoke-isolation.test.ts`: the spec now runs the exact `pnpm --filter @openwork/app test:e2e` under a **poisoned** `OPENCODE_CONFIG` and `XDG_CONFIG_HOME` (invalid JSON) and still requires every script to report; budget 60s → 90s (pr project testTimeout is 120s; CI takes ~24s).

## Proof

Local lane (macOS, from a shell that reproduces the leak):

- Control, `_util.mjs` stashed: `pnpm --dir evals exec vitest run --project pr specs/app-sdk-smoke-isolation.test.ts` → **Failed** — `Config file at …/poison-*/xdg/opencode/opencode.jsonc is not valid JSON(C)`.
- With fix, same command → **Passed** (1/1, 23.6s).
- Original repro: `OPENCODE_CONFIG=$HOME/.config/openwork/runtime-opencode-config.json pnpm --filter @openwork/app test:e2e` → exit 0 (was: browser-entry hang > 60s).
- Probe after fix (`pure: false`): `mcp keys: []`, config path under the temp `xdg/opencode`.

Verdict: **Passed**. Test evidence for the PR head is published in the sticky comment below.