### PR TITLE
fix(app): hide engine retry internals from task-create toast unless developer mode is on

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1265,6 +1265,8 @@ export default {
   "session.export_local_only": "Export is only supported for local workers.",
   "session.engine_catching_up_title": "OpenCode is catching up",
   "session.engine_catching_up_detail": "The engine did not answer in time. Retrying ({attempt}/{total})…",
+  "session.still_loading_title": "Still loading…",
+  "session.still_loading_detail": "Getting your workspace ready. This can take a moment.",
   "session.engine_not_responding_title": "OpenCode is not responding",
   "session.engine_not_responding_detail": "The engine did not answer after {attempts} attempts. It may be restarting or overloaded.",
   "session.engine_unavailable_title": "OpenCode unavailable",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -497,6 +497,8 @@ export default {
   "session.export_local_only": "Экспорт поддерживается только для локальных воркеров.",
   "session.engine_catching_up_title": "OpenCode догоняет",
   "session.engine_catching_up_detail": "Движок не ответил вовремя. Повтор ({attempt}/{total})…",
+  "session.still_loading_title": "Всё ещё загружается…",
+  "session.still_loading_detail": "Подготавливаем рабочее пространство. Это может занять немного времени.",
   "session.engine_not_responding_title": "OpenCode не отвечает",
   "session.engine_not_responding_detail": "Движок не ответил после {attempts} попыток. Возможно, он перезапускается или перегружен.",
   "session.engine_unavailable_title": "OpenCode недоступен",

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -212,6 +212,26 @@ export function describeTaskCreateFailure(error: unknown, attempts: number): Tas
   return { kind: "unavailable", title: t("session.engine_unavailable_title"), description: message };
 }
 
+export type TaskCreateRetryNotice = { title: string; description: string };
+
+/** Retry countdown wording; engine internals stay behind developer mode. */
+export function describeTaskCreateRetry(input: {
+  developerMode: boolean;
+  attempt: number;
+  attempts: number;
+}): TaskCreateRetryNotice {
+  if (input.developerMode) {
+    return {
+      title: t("session.engine_catching_up_title"),
+      description: t("session.engine_catching_up_detail", { attempt: input.attempt, total: input.attempts }),
+    };
+  }
+  return {
+    title: t("session.still_loading_title"),
+    description: t("session.still_loading_detail"),
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -75,6 +75,7 @@ import {
   type RouteSession,
   describeRouteError,
   describeTaskCreateFailure,
+  describeTaskCreateRetry,
   describeWorkspaceCreateError,
   downloadWorkspaceJson,
   folderNameFromPath,
@@ -2087,9 +2088,10 @@ export function SessionRoute() {
         ),
         retryDelaysMs: TASK_CREATE_RETRY_DELAYS_MS,
         onRetry: (attempt) => {
-          toast.info(t("session.engine_catching_up_title"), {
+          const notice = describeTaskCreateRetry({ developerMode, attempt, attempts });
+          toast.info(notice.title, {
             id: toastId,
-            description: t("session.engine_catching_up_detail", { attempt: String(attempt), total: String(attempts) }),
+            description: notice.description,
             duration: Infinity,
           });
         },
@@ -2159,7 +2161,7 @@ export function SessionRoute() {
       }
       return null;
     }
-  }, [applyLastUsedModelToSession, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
+  }, [applyLastUsedModelToSession, developerMode, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we

--- a/apps/app/tests/task-create-engine-retry.test.ts
+++ b/apps/app/tests/task-create-engine-retry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   describeTaskCreateFailure,
+  describeTaskCreateRetry,
   TASK_CREATE_RETRY_DELAYS_MS,
   withTransientEngineRetry,
 } from "../src/react-app/shell/route-workspaces";
@@ -99,5 +100,22 @@ describe("describeTaskCreateFailure", () => {
     expect(failure.kind).toBe("unavailable");
     expect(failure.title).toBe("OpenCode unavailable");
     expect(failure.description).toBe("Workspace path is not authorized");
+  });
+});
+
+describe("describeTaskCreateRetry", () => {
+  test("hides engine internals when developer mode is off", () => {
+    const notice = describeTaskCreateRetry({ developerMode: false, attempt: 2, attempts: 4 });
+    expect(notice.title).toBe("Still loading…");
+    expect(notice.description).not.toContain("OpenCode");
+    expect(notice.description).not.toContain("engine");
+    expect(notice.description).not.toContain("Retrying");
+    expect(notice.description).not.toContain("2/4");
+  });
+
+  test("keeps the retry countdown when developer mode is on", () => {
+    const notice = describeTaskCreateRetry({ developerMode: true, attempt: 2, attempts: 4 });
+    expect(notice.title).toBe("OpenCode is catching up");
+    expect(notice.description).toContain("Retrying (2/4)…");
   });
 });

--- a/evals/specs/task-create-engine-stall-recovery.test.ts
+++ b/evals/specs/task-create-engine-stall-recovery.test.ts
@@ -31,7 +31,7 @@ test("task creation retry policy is bounded and classifies an exhausted engine s
   expect(result.error, output).toBeUndefined();
   expect(result.status, output).toBe(0);
   expect(output).toContain("0 fail");
-  expect(output).toMatch(/\b(8|9) pass\b/);
+  expect(output).toMatch(/\b10 pass\b/);
   expect(output).not.toContain("(fail)");
 
   evidence.recordAssertionEvidence(
@@ -47,6 +47,11 @@ test("task creation retry policy is bounded and classifies an exhausted engine s
   evidence.recordAssertionEvidence(
     "The final toast distinguishes a stalled engine from an unavailable one",
     "Timeouts and opencode_engine_unreachable/503 yield 'OpenCode is not responding' with the attempt count (and a Reload engine action in the route); terminal errors keep 'OpenCode unavailable' with the raw message.",
+    true,
+  );
+  evidence.recordAssertionEvidence(
+    "Retry countdown hides engine internals unless developer mode is on",
+    "With developer mode off the retry toast says 'Still loading…' with no engine, retry, or attempt-count wording; with developer mode on it keeps 'OpenCode is catching up — Retrying (n/4)…'.",
     true,
   );
 });


### PR DESCRIPTION
## Summary
While a new task is being created and the engine stalls, the retry toast said **"OpenCode is catching up — The engine did not answer in time. Retrying (2/4)…"** to everyone. That level of internal detail should only surface with developer mode on.

- Developer mode **off**: toast now reads **"Still loading…"** / "Getting your workspace ready. This can take a moment." — no engine, retry, or attempt-count wording.
- Developer mode **on**: unchanged technical countdown.
- Extracted the wording into a pure `describeTaskCreateRetry()` helper in `route-workspaces.ts` so it is unit-testable; `session-route.tsx` calls it (and `developerMode` is now in the callback deps). Retry policy and the final failure toast are untouched.
- Added `session.still_loading_*` strings (en, ru).

## Verification
Lane: **local fallback** (no Daytona credentials in this environment). App-less PR lane; the spec is a bun-test wrapper, no app surface needed.

- `pnpm --filter @openwork/app exec tsc -p tsconfig.json --noEmit` → exit 0
- `pnpm --filter @openwork/app exec bun test --isolate tests/task-create-engine-retry.test.ts tests/route-session-list.test.ts` → 10 pass, 0 fail
- `pnpm evals:pr specs/task-create-engine-stall-recovery.test.ts` → 1 passed, 0 failed, 0 skipped (on PR head)

Verdict: **Passed**. Test evidence published in the sticky comment below.