### PR TITLE
fix(composer): keep the prompt box editable when the session snapshot fails

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1295,7 +1295,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                 kind: isImageAttachment(attachment) ? "image" : "file",
                 previewUrl: attachment.previewUrl,
               }))}
-              disabled={props.disabled}
+              submitDisabled={props.disabled}
               placeholder={t("composer.placeholder")}
               onChange={props.onDraftChange}
               onSubmit={handleEditorSubmit}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -53,7 +53,7 @@ type EditorProps = {
   mentions: Record<string, ComposerMentionKind>;
   pastedText?: PastedTextToken[];
   attachments?: ComposerAttachmentToken[];
-  disabled: boolean;
+  submitDisabled: boolean;
   placeholder: string;
   onChange: (value: string) => void;
   onSubmit: (options: { queue: boolean }) => void | Promise<void>;
@@ -818,14 +818,9 @@ function SyncPlugin(props: {
   mentions: Record<string, ComposerMentionKind>;
   pastedText?: PastedTextToken[];
   attachments?: ComposerAttachmentToken[];
-  disabled: boolean;
 }) {
   const [editor] = useLexicalComposerContext();
   const valueRef = useRef(props.value);
-
-  useEffect(() => {
-    editor.setEditable(!props.disabled);
-  }, [editor, props.disabled]);
 
   useEffect(() => {
     // When the external value is cleared (e.g. after sending a message),
@@ -1235,12 +1230,12 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
       onError(error: Error) {
         throw error;
       },
-        editable: !props.disabled,
-        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode, ComposerAttachmentNode],
-        editorState: () => {
-          setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
-        },
-      }),
+      editable: true,
+      nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode, ComposerAttachmentNode],
+      editorState: () => {
+        setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
+      },
+    }),
     [],
   );
 
@@ -1291,9 +1286,8 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
           mentions={props.mentions}
           pastedText={props.pastedText}
           attachments={props.attachments}
-          disabled={props.disabled}
         />
-        <SubmitPlugin onSubmit={props.onSubmit} disabled={props.disabled} />
+        <SubmitPlugin onSubmit={props.onSubmit} disabled={props.submitDisabled} />
         <PasteChipPlugin onPasteText={props.onPasteText} />
         <PastedTextExpandPlugin pastedText={props.pastedText} onExpandPastedText={props.onExpandPastedText} />
         <AttachmentRemovePlugin onRemoveAttachment={props.onRemoveAttachment} />

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1108,6 +1108,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [cloudQueueRetryVersion, setCloudQueueRetryVersion] = useState(0);
   const sending = props.cloudMcpSubmissionState.status === "sending";
   const cloudQueueBlockedRef = useRef(false);
+  const evalSnapshotFailureRef = useRef(false);
   // Shared with promote-to-send so a manual send-now cannot race the idle drain.
   const drainingQueueRef = useRef(false);
   // Admission-aware drain state. It lives in a module-level per-session store
@@ -1144,6 +1145,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
     queryFn: async ({ signal }) => {
+      if (evalSnapshotFailureRef.current) {
+        throw new Error("eval: forced session snapshot failure");
+      }
       const startedAt = Date.now();
       const item = await composeNativeSessionSnapshot(
         { opencodeBaseUrl: props.opencodeBaseUrl, token: props.openworkToken },
@@ -1154,6 +1158,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return item;
     },
     staleTime: 500,
+    retry: (failureCount) => !evalSnapshotFailureRef.current && failureCount < 3,
   });
 
   const currentSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
@@ -1177,6 +1182,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, currentSnapshot]);
 
   useEffect(() => {
+    evalSnapshotFailureRef.current = false;
     hydratedKeyRef.current = null;
     setSteering(false);
     setError(null);
@@ -1670,6 +1676,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
     isFetching: snapshotQuery.isFetching,
     isError: snapshotQuery.isError || Boolean(error),
   });
+  const failSessionSnapshotControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.session_snapshot.fail",
+      label: "Force the session snapshot query to fail",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: async () => {
+        evalSnapshotFailureRef.current = true;
+        const result = await snapshotQuery.refetch();
+        return { ok: true, isError: result.isError };
+      },
+    };
+  }, [props.sessionId, snapshotQuery.refetch]);
+  useControlAction(props.isControlTarget ? failSessionSnapshotControlAction : null);
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
     const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {

--- a/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
+++ b/apps/app/tests/composer-editable-on-snapshot-error.test.tsx
@@ -1,0 +1,219 @@
+/** @jsxImportSource react */
+import { expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createRequire } from "node:module";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+
+const workspaceId = "workspace-composer-snapshot-error";
+const sessionId = "session-composer-snapshot-error";
+
+function createSnapshot(targetSessionId: string, messageText: string): OpenworkSessionSnapshot {
+  const messageId = `${targetSessionId}-user-message`;
+  return {
+    session: {
+      id: targetSessionId,
+      slug: targetSessionId,
+      projectID: "project-composer-snapshot-error",
+      directory: "/tmp/project-composer-snapshot-error",
+      title: "Composer snapshot error",
+      version: "1",
+      time: { created: 1, updated: 1 },
+    },
+    messages: [{
+      info: {
+        id: messageId,
+        sessionID: targetSessionId,
+        role: "user",
+        time: { created: 1 },
+        agent: "build",
+        model: { providerID: "test", modelID: "test-model" },
+      },
+      parts: [{
+        id: `${messageId}-part`,
+        sessionID: targetSessionId,
+        messageID: messageId,
+        type: "text",
+        text: messageText,
+      }],
+    }],
+    todos: [],
+    status: { type: "idle" },
+  };
+}
+
+async function waitFor(predicate: () => boolean, label: string) {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+test("the composer stays editable when snapshot refresh fails or the model is unavailable", async () => {
+  const require = createRequire(import.meta.url);
+  // Bun's isolated test loader cycles Lexical's ESM entries; use their real CJS entries before the app imports the editor.
+  for (const moduleId of [
+    "lexical",
+    "@lexical/react/LexicalComposer.js",
+    "@lexical/react/LexicalPlainTextPlugin.js",
+    "@lexical/react/LexicalContentEditable.js",
+    "@lexical/react/LexicalErrorBoundary.js",
+    "@lexical/react/LexicalOnChangePlugin.js",
+    "@lexical/react/LexicalHistoryPlugin.js",
+    "@lexical/react/LexicalComposerContext.js",
+  ]) {
+    const moduleExports = require(moduleId);
+    mock.module(moduleId, () => moduleExports);
+  }
+  const [
+    { createOpenworkServerClient },
+    { IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE },
+    { useComposerStateStore },
+    { getReactQueryClient },
+    { LocalProvider },
+    { ShellConfigProvider },
+  ] = await Promise.all([
+    import("../src/app/lib/openwork-server"),
+    import("../src/react-app/domains/connections/cloud-mcp-submit-readiness"),
+    import("../src/react-app/domains/session/surface/composer-state-store"),
+    import("../src/react-app/infra/query-client"),
+    import("../src/react-app/kernel/local-provider"),
+    import("../src/react-app/shell/shell-config"),
+  ]);
+  const registeredDom = typeof globalThis.window === "undefined" || typeof globalThis.document === "undefined";
+  if (registeredDom) GlobalRegistrator.register({ url: "http://localhost/" });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    value: true,
+  });
+  document.open();
+  document.write("<!doctype html><html><body></body></html>");
+  document.close();
+  Object.defineProperty(document, "compatMode", { configurable: true, value: "CSS1Compat" });
+  const fetchStub = async () => new Response("{}", { headers: { "content-type": "application/json" } });
+  Object.defineProperty(globalThis, "fetch", { configurable: true, value: fetchStub });
+  Object.defineProperty(window, "fetch", { configurable: true, value: fetchStub });
+  window.localStorage.setItem("openwork.shell-config", JSON.stringify({ starterCards: false }));
+  let rejectSnapshot = false;
+  let fetchedSnapshot = createSnapshot(sessionId, "Cached transcript remains visible.");
+  mock.module("@/components/model-select", () => ({ ModelSelect: () => null }));
+  mock.module("@/app/lib/opencode-session-native", () => ({
+    composeNativeSessionSnapshot: async () => {
+      if (rejectSnapshot) throw new Error("snapshot refresh failed");
+      return fetchedSnapshot;
+    },
+  }));
+  const { SessionSurface } = await import("../src/react-app/domains/session/surface/session-surface");
+  const { snapshotKey } = await import("../src/react-app/domains/session/sync/session-sync");
+  const queryClient = getReactQueryClient();
+  queryClient.clear();
+  const key = snapshotKey(workspaceId, sessionId);
+  queryClient.setQueryDefaults(key, { retryDelay: 0 });
+  queryClient.setQueryData(key, fetchedSnapshot);
+  const client = createOpenworkServerClient({ baseUrl: "http://127.0.0.1:1", token: "test-token" });
+  const container = document.createElement("div");
+  const unavailableContainer = document.createElement("div");
+  document.body.append(container, unavailableContainer);
+  const root = createRoot(container);
+  const unavailableRoot = createRoot(unavailableContainer);
+  let sendCount = 0;
+
+  const surface = (targetSessionId: string, modelUnavailable: boolean) => (
+    <QueryClientProvider client={queryClient}>
+      <LocalProvider>
+        <ShellConfigProvider>
+          <SessionSurface
+            client={client}
+            workspaceId={workspaceId}
+            workspaceRoot="/tmp/project-composer-snapshot-error"
+            sessionId={targetSessionId}
+            draftScope="local"
+            isControlTarget={false}
+            opencodeBaseUrl="http://127.0.0.1:1/opencode"
+            openworkToken="test-token"
+            developerMode
+            modelLabel="Test model"
+            onModelClick={() => {}}
+            modelPickerOpen={false}
+            selectedModel={{ providerID: "test", modelID: "test-model" }}
+            resolveModelAvailability={modelUnavailable ? () => ({ status: "unavailable", reason: "model_missing" }) : undefined}
+            onModelPickerOpenChange={() => {}}
+            onModelChange={() => {}}
+            onSendDraft={async () => {
+              sendCount += 1;
+              return { outcome: "accepted" };
+            }}
+            cloudMcpSubmissionState={IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE}
+            onOpenConnect={() => {}}
+            onDraftChange={() => {}}
+            attachmentsEnabled={false}
+            attachmentsDisabledReason="Not needed in this test"
+            modelVariantLabel="Default"
+            modelVariant={null}
+            onModelVariantChange={() => {}}
+            agentLabel="OpenWork"
+            selectedAgent={null}
+            listAgents={async () => []}
+            onSelectAgent={() => {}}
+            listCommands={async () => []}
+            recentFiles={[]}
+            searchFiles={async () => []}
+            isRemoteWorkspace
+            isSandboxWorkspace={false}
+            providerConnectedCount={1}
+          />
+        </ShellConfigProvider>
+      </LocalProvider>
+    </QueryClientProvider>
+  );
+
+  try {
+    await act(async () => root.render(surface(sessionId, false)));
+    await waitFor(() => container.textContent?.includes("Cached transcript remains visible.") === true, "the cached transcript");
+
+    rejectSnapshot = true;
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: key });
+    });
+    await waitFor(() => queryClient.getQueryState(key)?.status === "error", "the failed snapshot query");
+    expect(container.querySelector('[contenteditable="true"][data-lexical-editor="true"]')).not.toBeNull();
+
+    await act(async () => useComposerStateStore.getState().setDraft(sessionId, "still typing"));
+    await waitFor(
+      () => container.querySelector('[data-lexical-editor="true"]')?.textContent === "still typing",
+      "the draft to reach Lexical",
+    );
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Run task"]')?.disabled).toBe(true);
+    expect(sendCount).toBe(0);
+    expect(container.textContent).toContain("Cached transcript remains visible.");
+
+    const unavailableSessionId = "session-composer-model-unavailable";
+    rejectSnapshot = false;
+    fetchedSnapshot = createSnapshot(unavailableSessionId, "Unavailable model transcript.");
+    queryClient.setQueryData(snapshotKey(workspaceId, unavailableSessionId), fetchedSnapshot);
+    await act(async () => unavailableRoot.render(surface(unavailableSessionId, true)));
+    await waitFor(
+      () => unavailableContainer.querySelector('[contenteditable="true"][data-lexical-editor="true"]') !== null,
+      "the unavailable-model Lexical editor",
+    );
+    expect(unavailableContainer.querySelector<HTMLButtonElement>('button[aria-label="Run task"]')?.disabled).toBe(true);
+  } finally {
+    await act(async () => {
+      root.unmount();
+      unavailableRoot.unmount();
+    });
+    useComposerStateStore.setState({ sessions: {}, queuedDrafts: {}, history: {} });
+    queryClient.clear();
+    container.remove();
+    unavailableContainer.remove();
+    mock.restore();
+    if (registeredDom) await GlobalRegistrator.unregister();
+  }
+});

--- a/evals/specs/composer-editable-during-snapshot-error.e2e.test.ts
+++ b/evals/specs/composer-editable-during-snapshot-error.e2e.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { snapshotFailure } from "../worlds/chat.ts";
+
+const test = spec.world(snapshotFailure);
+
+test("the composer stays editable while the session snapshot query is in error", async ({ user, agent, step }) => {
+  const text = "Draft survives the broken snapshot without being sent — composer proof 9472.";
+  const transcriptLiteral = "chat-transcript-proof";
+
+  await step("the composer remains editable after the snapshot fails", async () => {
+    await user.see("composer", { editable: true, timeoutMs: 30_000 });
+  });
+
+  await step("a distinctive draft can be typed and remains editable", async () => {
+    await user.type("composer", text);
+    await user.see("composer", { editable: true, text, timeoutMs: 30_000 });
+  });
+
+  await step("typing does not send and the cached transcript remains visible", async () => {
+    const transcript = await agent.run("session.read_transcript", { count: 30 });
+    const readableTranscript = JSON.stringify(transcript);
+    expect(readableTranscript).not.toContain(text);
+    expect(readableTranscript).toContain(transcriptLiteral);
+    await user.see({ text: /chat-transcript-proof/ }, { timeoutMs: 30_000 });
+  });
+});

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1062,6 +1062,29 @@ export async function sessionErrorCard(seed: Seed) {
   return { app, workspace, session };
 }
 
+export async function snapshotFailure(seed: Seed) {
+  const app = await seed.desktop({ name: "composer-snapshot-failure" });
+  const workspace = await seed.workspace(app, seed.tmpPath("composer-snapshot-failure"));
+  const session = await seedSessionRetry(seed, app, { title: "Composer snapshot failure proof" });
+  await arrangeControl(seed, app, "eval.chat_transcript.seed");
+  const failure = await seed.evalIn(app, `async () => {
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      const available = window.__openworkControl?.listActions()
+        .find((candidate) => candidate.id === "eval.session_snapshot.fail" && !candidate.disabled);
+      if (available) break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    const result = await window.__openworkControl.execute("eval.session_snapshot.fail", null);
+    if (!result?.ok) throw new Error(String(result?.error ?? "control action failed"));
+    return result.result;
+  }`, { awaitPromise: true, timeoutMs: 120_000 });
+  if (!isRecord(failure) || failure.isError !== true) {
+    throw new Error(`Session snapshot failure was not established: ${JSON.stringify(failure)}`);
+  }
+  return { app, workspace, session };
+}
+
 export async function taskActivity(seed: Seed) {
   const app = await seed.desktop({ name: "task-activity-shimmer" });
   const workspace = await seed.workspace(app, seed.tmpPath("task-activity-shimmer"));

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1067,7 +1067,7 @@ export async function snapshotFailure(seed: Seed) {
   const workspace = await seed.workspace(app, seed.tmpPath("composer-snapshot-failure"));
   const session = await seedSessionRetry(seed, app, { title: "Composer snapshot failure proof" });
   await arrangeControl(seed, app, "eval.chat_transcript.seed");
-  const failure = await seed.evalIn(app, `async () => {
+  const failureJson = await seed.evalIn(app, `async () => {
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
       const available = window.__openworkControl?.listActions()
@@ -1077,8 +1077,9 @@ export async function snapshotFailure(seed: Seed) {
     }
     const result = await window.__openworkControl.execute("eval.session_snapshot.fail", null);
     if (!result?.ok) throw new Error(String(result?.error ?? "control action failed"));
-    return result.result;
+    return JSON.stringify(result.result);
   }`, { awaitPromise: true, timeoutMs: 120_000 });
+  const failure: unknown = typeof failureJson === "string" ? JSON.parse(failureJson) : failureJson;
   if (!isRecord(failure) || failure.isError !== true) {
     throw new Error(`Session snapshot failure was not established: ${JSON.stringify(failure)}`);
   }

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1078,7 +1078,7 @@ export async function snapshotFailure(seed: Seed) {
     const result = await window.__openworkControl.execute("eval.session_snapshot.fail", null);
     if (!result?.ok) throw new Error(String(result?.error ?? "control action failed"));
     return JSON.stringify(result.result);
-  }`, { awaitPromise: true, timeoutMs: 120_000 });
+  }`, { args: [], awaitPromise: true, timeoutMs: 120_000 });
   const failure: unknown = typeof failureJson === "string" ? JSON.parse(failureJson) : failureJson;
   if (!isRecord(failure) || failure.isError !== true) {
     throw new Error(`Session snapshot failure was not established: ${JSON.stringify(failure)}`);


### PR DESCRIPTION
## Problem

Reported in #bug: "Under certain circumstances, the OpenWork prompt box does not allow me to type into it." Screenshot showed an empty composer with placeholder, a wide selection-style caret, "Jump to latest", idle session, no error.

Root cause: `session-surface.tsx` passed `disabled={model.transitionState !== "idle" || sessionModelUnavailable}` to the Lexical editor. `transitionState` becomes `"failed"` on *any* `snapshotQuery.isError` (or local `error` state — including a failed clipboard copy). Two things made it invisible:

- Lexical 0.35 renders a non-editable editor identically to an editable empty one (placeholder still shows, no styling), and clicking a `contenteditable="false"` `<p><br></p>` draws exactly the wide highlight in the screenshot.
- The "Failed to load session" UI only renders when there is no cached transcript, so a failed *background* refetch (sleep/wake, engine restart, `refetchOnWindowFocus`) locked the composer with nothing on screen.

The gate was inherited wholesale from the Solid→React port (#1470) with no rationale; #4108 already removed it for the `isFetching` branch for exactly this reason.

## Change

- `editor.tsx` / `composer.tsx`: the editor is always editable. `disabled` is renamed `submitDisabled` on the editor and only gates Enter-submit. The send button and `handleSend` guards are unchanged.
- `session-surface.tsx`: dev-only `eval.session_snapshot.fail` control action (same pattern as the other `eval.*` hooks) that forces the snapshot query into error state and returns `{ ok, isError }`. `retry` now reads the eval flag at fetch time; default behaviour (3 retries) is preserved.
- `new-task-composer.tsx` needs no change: its `disabled` now only blocks send, as intended.

## Verification

**Unit (bun)** — `apps/app/tests/composer-editable-on-snapshot-error.test.tsx` renders the real `SessionSurface`, fails the snapshot refetch, and asserts the editor stays `contenteditable="true"`, typed text lands, the send button stays disabled, `onSendDraft` is never called, and the cached transcript is preserved; also covers the model-unavailable case.

```
pnpm --filter @openwork/app exec bun test --isolate tests/composer-editable-on-snapshot-error.test.tsx tests/composer-focus-continuity.test.tsx tests/session-transition-controller.test.ts
# 5 pass, 0 fail, 12 expect() calls
pnpm --filter @openwork/app typecheck   # exit 0
```
Confirmed red without the fix: with `editor.tsx`/`composer.tsx` stashed the new test fails (0 pass, 1 fail).

**E2E (testkit)** — `evals/specs/composer-editable-during-snapshot-error.e2e.test.ts` with world `snapshotFailure` in `evals/worlds/chat.ts` (seeds a transcript, executes `eval.session_snapshot.fail`, throws unless `isError: true`). Claims: composer editable + typed text lands; negative: text is not in the transcript (no send) and the seeded transcript literal is still visible. Channel ratchet: 0 raw escapes; `pnpm --dir evals typecheck:spec-layer` exit 0.

```
node evals/bin/evals.mjs composer-editable-during-snapshot-error --daytona
# verdict: passed (1/1, 0 skipped)
```

**Verdict: Passed** on Daytona against the PR head (see the test-evidence comment). The earlier red runs were the engine-bootstrap hang diagnosed in #4423; #4397 pre-seeds the engine cache in eval sandboxes, which is why this now runs.

Pre-existing unrelated bun failures on `origin/dev` (not touched here): `connect-capability-inventory`, `app-inspector`, `cloud-workspace-overlay`, `session-provider-auth-server-sync`.

## Follow-ups (out of scope)
- A failed clipboard copy or stop request sets `error`, which still disables *send* until dismissed; the `SessionErrorCard` renders at the top of the transcript where it can be off-screen.
- Consider visible disabled styling on the composer shell so a non-editable state can never be silent again.