### PR TITLE
feat(app): make Cmd+K an intelligent search over actions, settings, and sessions

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -65,7 +65,6 @@
     "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "cmdk": "^1.1.1",
     "dompurify": "^3.4.12",
     "emojilib": "^4.0.3",
     "fuzzysort": "^3.1.0",

--- a/apps/app/src/react-app/shell/command-palette-recents.ts
+++ b/apps/app/src/react-app/shell/command-palette-recents.ts
@@ -1,0 +1,38 @@
+export const COMMAND_PALETTE_RECENTS_KEY = "openwork.react.command-palette.recents";
+
+type PaletteRecentsStorage = Pick<Storage, "getItem" | "setItem">;
+
+function browserStorage(): PaletteRecentsStorage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadPaletteRecents(storage = browserStorage()): string[] {
+  if (!storage) return [];
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(COMMAND_PALETTE_RECENTS_KEY) ?? "[]");
+    if (!Array.isArray(parsed)) return [];
+    const ids = parsed.filter((id): id is string => typeof id === "string");
+    return [...new Set(ids)].slice(0, 8);
+  } catch {
+    return [];
+  }
+}
+
+export function recordPaletteRecent(
+  id: string,
+  storage = browserStorage(),
+): string[] {
+  const next = [id, ...loadPaletteRecents(storage).filter((recentId) => recentId !== id)].slice(0, 8);
+  if (!storage) return next;
+  try {
+    storage.setItem(COMMAND_PALETTE_RECENTS_KEY, JSON.stringify(next));
+  } catch {
+    // A blocked or full localStorage should not prevent running the action.
+  }
+  return next;
+}

--- a/apps/app/src/react-app/shell/command-palette-search.ts
+++ b/apps/app/src/react-app/shell/command-palette-search.ts
@@ -1,0 +1,121 @@
+import fuzzysort from "fuzzysort";
+
+export type PaletteGroup = "recent" | "actions" | "settings" | "sessions";
+
+export type PaletteItem = {
+  id: string;
+  title: string;
+  detail?: string;
+  meta?: string;
+  searchText?: string;
+  keywords?: string[];
+  group?: PaletteGroup;
+  breadcrumb?: string;
+  shortcut?: string;
+  disabled?: boolean;
+  action: () => void;
+};
+
+export type PaletteResultGroup = {
+  value: PaletteGroup;
+  label: string;
+  items: PaletteItem[];
+};
+
+const GROUP_ORDER: PaletteGroup[] = ["recent", "actions", "settings", "sessions"];
+const GROUP_LABELS: Record<PaletteGroup, string> = {
+  recent: "Recent",
+  actions: "Actions",
+  settings: "Settings",
+  sessions: "Sessions",
+};
+
+function itemGroup(item: PaletteItem): PaletteGroup {
+  return item.group ?? "actions";
+}
+
+function itemKeywords(item: PaletteItem) {
+  return [...(item.keywords ?? []), item.searchText ?? ""].join(" ");
+}
+
+function itemSearchText(item: PaletteItem) {
+  return [item.title, itemKeywords(item), item.breadcrumb, item.detail]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+}
+
+function resultGroup(value: PaletteGroup, items: PaletteItem[]): PaletteResultGroup {
+  return { value, label: GROUP_LABELS[value], items };
+}
+
+export function rankPaletteItems(
+  query: string,
+  items: PaletteItem[],
+  recentIds: string[],
+): PaletteResultGroup[] {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    const itemsById = new Map(items.map((item) => [item.id, item]));
+    const recent = recentIds
+      .flatMap((id) => {
+        const item = itemsById.get(id);
+        return item ? [item] : [];
+      })
+      .slice(0, 8);
+    const recentIdSet = new Set(recent.map((item) => item.id));
+    const nonRecentItems = items.filter((item) => !recentIdSet.has(item.id));
+    const groups = [
+      resultGroup("recent", recent),
+      resultGroup("actions", nonRecentItems.filter((item) => itemGroup(item) === "actions")),
+      resultGroup("settings", nonRecentItems.filter((item) => itemGroup(item) === "settings").slice(0, 6)),
+      resultGroup("sessions", nonRecentItems.filter((item) => itemGroup(item) === "sessions").slice(0, 5)),
+    ];
+    return groups.filter((group) => group.items.length > 0);
+  }
+
+  const actionsOnly = trimmed.startsWith(">");
+  const searchQuery = actionsOnly ? trimmed.slice(1).trim() : trimmed;
+  const candidates = actionsOnly
+    ? items.filter((item) => itemGroup(item) === "actions")
+    : items;
+
+  if (!searchQuery) {
+    return candidates.length > 0 ? [resultGroup("actions", candidates.slice(0, 40))] : [];
+  }
+
+  const tokens = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+  const tokenMatchedItems = candidates.filter((item) => {
+    const text = itemSearchText(item);
+    return tokens.every((token) => fuzzysort.single(token, text) !== null);
+  });
+  const recentIdSet = new Set(recentIds);
+  const ranked = fuzzysort.go(searchQuery, tokenMatchedItems, {
+    keys: [
+      (item) => item.title,
+      (item) => itemKeywords(item),
+      (item) => item.breadcrumb ?? "",
+      (item) => item.detail ?? "",
+    ],
+    threshold: 0.1,
+    limit: 40,
+    scoreFn: (result) => {
+      const score = Math.max(
+        result[0].score * 2,
+        result[1].score,
+        result[2].score * 0.6,
+        result[3].score * 0.8,
+      );
+      return recentIdSet.has(result.obj.id) ? score * 1.1 : score;
+    },
+  }).map((result) => result.obj);
+
+  const bestGroup = ranked[0] ? itemGroup(ranked[0]) : null;
+  const groupOrder = bestGroup
+    ? [bestGroup, ...GROUP_ORDER.filter((group) => group !== bestGroup)]
+    : GROUP_ORDER;
+
+  return groupOrder.flatMap((group) => {
+    const groupItems = ranked.filter((item) => itemGroup(item) === group);
+    return groupItems.length > 0 ? [resultGroup(group, groupItems)] : [];
+  });
+}

--- a/apps/app/src/react-app/shell/command-palette-search.ts
+++ b/apps/app/src/react-app/shell/command-palette-search.ts
@@ -44,6 +44,10 @@ function itemSearchText(item: PaletteItem) {
     .join(" ");
 }
 
+function normalizeSearchText(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
 function resultGroup(value: PaletteGroup, items: PaletteItem[]): PaletteResultGroup {
   return { value, label: GROUP_LABELS[value], items };
 }
@@ -83,7 +87,8 @@ export function rankPaletteItems(
     return candidates.length > 0 ? [resultGroup("actions", candidates.slice(0, 40))] : [];
   }
 
-  const tokens = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+  const normalizedQuery = normalizeSearchText(searchQuery);
+  const tokens = normalizedQuery.split(" ");
   const tokenMatchedItems = candidates.filter((item) => {
     const text = itemSearchText(item);
     return tokens.every((token) => fuzzysort.single(token, text) !== null);
@@ -105,7 +110,13 @@ export function rankPaletteItems(
         result[2].score * 0.6,
         result[3].score * 0.8,
       );
-      return recentIdSet.has(result.obj.id) ? score * 1.1 : score;
+      const tier = normalizeSearchText(result.obj.title).includes(normalizedQuery)
+        ? 3
+        : normalizeSearchText(itemKeywords(result.obj)).includes(normalizedQuery)
+          ? 2
+          : 1;
+      const boostedScore = recentIdSet.has(result.obj.id) ? score * 1.1 : score;
+      return tier * 10 + boostedScore;
     },
   }).map((result) => result.obj);
 

--- a/apps/app/src/react-app/shell/command-palette-settings.ts
+++ b/apps/app/src/react-app/shell/command-palette-settings.ts
@@ -1,0 +1,79 @@
+import type { PlatformCapabilities } from "@/app/lib/platform-capabilities";
+import type { SettingsTab } from "@/app/types";
+import {
+  getCloudSettingsTabs,
+  getGlobalSettingsTabs,
+  getSettingsTabDescription,
+  getSettingsTabLabel,
+  getWorkspaceSettingsTabs,
+} from "@/react-app/domains/settings/shell/settings-page";
+
+import type { PaletteItem } from "./command-palette-search";
+
+const SETTINGS_KEYWORDS: Partial<Record<SettingsTab, string[]>> = {
+  ai: ["provider", "providers", "api key", "anthropic", "openai", "openrouter", "google", "gemini", "claude", "gpt", "connect model", "models"],
+  preferences: ["default model", "reasoning", "thinking", "compaction", "effort"],
+  permissions: ["authorized folders", "folder access", "file access", "allow", "permission denied", "sandbox", "approvals"],
+  extensions: ["library", "skills", "plugins", "mcp", "connections", "tools", "apps", "computer use", "voice"],
+  environment: ["env", "environment variables", "secrets", "tokens", "api keys"],
+  advanced: ["runtime", "developer", "connection", "server", "port"],
+  appearance: ["theme", "dark mode", "light mode", "color", "font", "look"],
+  updates: ["version", "upgrade", "check for updates", "release"],
+  recovery: ["reset", "fix", "repair", "clean up", "troubleshoot"],
+  debug: ["logs", "diagnostics", "developer mode"],
+  "cloud-account": ["sign in", "log in", "login", "account", "organization", "org", "den", "cloud", "openwork cloud"],
+  memory: ["remember", "memories"],
+  general: ["settings", "preferences", "options", "configure"],
+};
+
+const LIBRARY_SECTIONS = [
+  { slug: "skills", title: "Skills", detail: "Instructions that teach agents specialized workflows", keywords: ["skill", "instructions", "workflows"] },
+  { slug: "mcps", title: "MCP servers", detail: "Tools and services connected through MCP", keywords: ["mcp", "servers", "tools"] },
+  { slug: "connections", title: "Connections", detail: "Connected organization apps and services", keywords: ["apps", "services", "sign in"] },
+  { slug: "plugins", title: "Plugins", detail: "Extensions that add tools and behavior", keywords: ["extensions", "tools", "hooks"] },
+  { slug: "agents", title: "Agents", detail: "Specialized agents available in conversations", keywords: ["agent", "assistants", "modes"] },
+  { slug: "commands", title: "Commands", detail: "Slash commands available in the composer", keywords: ["command", "slash", "prompts"] },
+] satisfies Array<{ slug: string; title: string; detail: string; keywords: string[] }>;
+
+export function buildCommandPaletteSettingsItems(input: {
+  developerMode: boolean;
+  capabilities: Pick<PlatformCapabilities, "autoUpdate" | "localRuntimeControl">;
+  memoryEnabled: boolean;
+  onOpenSettings: (route: string) => void;
+  onOpenExtensions: (section?: string) => void;
+}): PaletteItem[] {
+  const tabs = [
+    "general",
+    ...getWorkspaceSettingsTabs(),
+    ...getGlobalSettingsTabs(input.developerMode, input.capabilities),
+    ...getCloudSettingsTabs(input.memoryEnabled),
+  ] satisfies SettingsTab[];
+
+  const tabItems = tabs.map((tab): PaletteItem => ({
+    id: `settings:${tab}`,
+    title: getSettingsTabLabel(tab),
+    detail: getSettingsTabDescription(tab),
+    keywords: SETTINGS_KEYWORDS[tab],
+    breadcrumb: "Settings",
+    group: "settings",
+    action: () => {
+      if (tab === "extensions") {
+        input.onOpenExtensions();
+        return;
+      }
+      input.onOpenSettings(`/settings/${tab}`);
+    },
+  }));
+
+  const libraryItems = LIBRARY_SECTIONS.map((section): PaletteItem => ({
+    id: `settings:extensions/${section.slug}`,
+    title: section.title,
+    detail: section.detail,
+    keywords: section.keywords,
+    breadcrumb: "Settings › Library",
+    group: "settings",
+    action: () => input.onOpenExtensions(section.slug),
+  }));
+
+  return [...tabItems, ...libraryItems];
+}

--- a/apps/app/src/react-app/shell/command-palette-settings.ts
+++ b/apps/app/src/react-app/shell/command-palette-settings.ts
@@ -1,7 +1,7 @@
 import type { PlatformCapabilities } from "@/app/lib/platform-capabilities";
 import type { SettingsTab } from "@/app/types";
 import {
-  getCloudSettingsTabs,
+  CLOUD_SETTINGS_TABS,
   getGlobalSettingsTabs,
   getSettingsTabDescription,
   getSettingsTabLabel,
@@ -16,13 +16,11 @@ const SETTINGS_KEYWORDS: Partial<Record<SettingsTab, string[]>> = {
   permissions: ["authorized folders", "folder access", "file access", "allow", "permission denied", "sandbox", "approvals"],
   extensions: ["library", "skills", "plugins", "mcp", "connections", "tools", "apps", "computer use", "voice"],
   environment: ["env", "environment variables", "secrets", "tokens", "api keys"],
-  advanced: ["runtime", "developer", "connection", "server", "port"],
+  advanced: ["runtime", "developer", "connection", "server", "port", "reset", "fix", "repair", "clean up", "troubleshoot", "recovery"],
   appearance: ["theme", "dark mode", "light mode", "color", "font", "look"],
   updates: ["version", "upgrade", "check for updates", "release"],
-  recovery: ["reset", "fix", "repair", "clean up", "troubleshoot"],
   debug: ["logs", "diagnostics", "developer mode"],
   "cloud-account": ["sign in", "log in", "login", "account", "organization", "org", "den", "cloud", "openwork cloud"],
-  memory: ["remember", "memories"],
   general: ["settings", "preferences", "options", "configure"],
 };
 
@@ -37,8 +35,7 @@ const LIBRARY_SECTIONS = [
 
 export function buildCommandPaletteSettingsItems(input: {
   developerMode: boolean;
-  capabilities: Pick<PlatformCapabilities, "autoUpdate" | "localRuntimeControl">;
-  memoryEnabled: boolean;
+  capabilities: Pick<PlatformCapabilities, "autoUpdate">;
   onOpenSettings: (route: string) => void;
   onOpenExtensions: (section?: string) => void;
 }): PaletteItem[] {
@@ -46,7 +43,7 @@ export function buildCommandPaletteSettingsItems(input: {
     "general",
     ...getWorkspaceSettingsTabs(),
     ...getGlobalSettingsTabs(input.developerMode, input.capabilities),
-    ...getCloudSettingsTabs(input.memoryEnabled),
+    ...CLOUD_SETTINGS_TABS,
   ] satisfies SettingsTab[];
 
   const tabItems = tabs.map((tab): PaletteItem => ({

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -11,12 +11,15 @@ import type { Agent } from "@opencode-ai/sdk/v2/client";
 import { t } from "@/i18n";
 import {
   Command,
+  CommandCollection,
   CommandDialog,
   CommandDialogPopup,
   CommandDialogTitle,
   CommandEmpty,
   CommandFooter,
   CommandHeader,
+  CommandGroup,
+  CommandGroupLabel,
   CommandInput,
   CommandItem,
   CommandList,
@@ -26,6 +29,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ChevronLeftIcon } from "lucide-react";
 import type { ModelOption, ModelRef } from "@/app/types";
+import { useFeatureFlagsPreferences } from "@/react-app/domains/settings/state/feature-flags-preferences";
 import { usePlatform } from "../kernel/platform";
 import {
   resolveSessionNumberShortcutOs,
@@ -38,16 +42,18 @@ import {
   type CommandPaletteMode,
 } from "./command-palette-models";
 import { buildCommandPaletteSplitSessions, type CommandPaletteSessionRef } from "./command-palette-sessions";
+import { loadPaletteRecents, recordPaletteRecent } from "./command-palette-recents";
+import {
+  rankPaletteItems,
+  type PaletteGroup,
+  type PaletteItem,
+  type PaletteResultGroup,
+} from "./command-palette-search";
+import { buildCommandPaletteSettingsItems } from "./command-palette-settings";
 
-export type PaletteItem = {
-  id: string;
-  title: string;
-  detail?: string;
-  meta?: string;
-  searchText?: string;
-  disabled?: boolean;
-  action: () => void;
-};
+export type { PaletteItem } from "./command-palette-search";
+
+const ACTIONS_GROUP: PaletteGroup = "actions";
 
 function paletteItemSearchValue(item: unknown) {
   if (!item || typeof item !== "object") return "";
@@ -85,6 +91,7 @@ export type SessionGroupOption = {
 export type CommandPaletteProps = {
   open: boolean;
   onClose: () => void;
+  developerMode: boolean;
   /** Called when a session row is chosen. */
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   /** Opens a chosen session beside the current session without navigating away. */
@@ -95,7 +102,11 @@ export type CommandPaletteProps = {
   /** Called when "Open settings" is chosen. Accepts an optional route to jump straight to a tab. */
   onOpenSettings: (route?: string) => void;
   /** Called when the first-class Extensions page is chosen. */
-  onOpenExtensions: () => void;
+  onOpenExtensions: (section?: string) => void;
+  onToggleSidebar?: () => void;
+  onOpenAutomations?: () => void;
+  onOpenDashboard?: () => void;
+  onCreateWorkspace?: () => void;
   /** Optional: open the full default-model picker. */
   onOpenModelPicker?: () => void;
   /** Optional: model data for the nested model and effort modes. */
@@ -131,7 +142,10 @@ export type CommandPaletteProps = {
  */
 export function CommandPalette(props: CommandPaletteProps) {
   const platform = usePlatform();
+  const { memoryEnabled } = useFeatureFlagsPreferences();
   const [mode, setMode] = useState<CommandPaletteMode>("root");
+  const [query, setQuery] = useState("");
+  const [recents, setRecents] = useState(loadPaletteRecents);
   const [behaviorModel, setBehaviorModel] = useState<ModelOption | null>(null);
   const [agents, setAgents] = useState<Agent[]>([]);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -140,8 +154,13 @@ export function CommandPalette(props: CommandPaletteProps) {
     if (!props.open) {
       setMode("root");
       setBehaviorModel(null);
+      setQuery("");
     }
   }, [props.open]);
+
+  useEffect(() => {
+    if (mode !== "root") setQuery("");
+  }, [mode]);
 
   useEffect(() => {
     if (!props.open) return;
@@ -195,6 +214,8 @@ export function CommandPalette(props: CommandPaletteProps) {
       title: t("session.cmd_new_session_title"),
       detail: t("session.cmd_new_session_detail"),
       meta: t("session.cmd_new_session_meta"),
+      keywords: ["new task", "new chat", "conversation", "start"],
+      group: ACTIONS_GROUP,
       action: () => {
         props.onClose();
         props.onCreateNewSession();
@@ -207,6 +228,8 @@ export function CommandPalette(props: CommandPaletteProps) {
         count: props.sessions.length.toLocaleString(),
       }),
       meta: t("session.cmd_sessions_meta"),
+      keywords: ["tasks", "chats", "conversations", "history", "switch"],
+      group: ACTIONS_GROUP,
       action: () => {
         setMode("sessions");
       },
@@ -218,6 +241,7 @@ export function CommandPalette(props: CommandPaletteProps) {
           detail: "Choose any session, including one from another workspace",
           meta: "Workbench",
           searchText: "split view side by side session workspace",
+          group: ACTIONS_GROUP,
           action: () => {
             setMode("split-sessions");
           },
@@ -226,6 +250,8 @@ export function CommandPalette(props: CommandPaletteProps) {
     {
       id: "session-number-shortcuts",
       ...sessionNumberHelp,
+      keywords: ["keyboard", "shortcut", "switch session", "number"],
+      group: ACTIONS_GROUP,
       action: () => {
         setMode("sessions");
       },
@@ -237,6 +263,7 @@ export function CommandPalette(props: CommandPaletteProps) {
           detail: "Choose the LLM that runs your next prompts",
           meta: props.selectedModelLabel ?? t("session.default_model"),
           searchText: "model models llm provider openai anthropic claude gpt gemini switch pick select default",
+          group: ACTIONS_GROUP,
           action: () => {
             if (hasNestedModelPicker) {
               setBehaviorModel(null);
@@ -257,6 +284,7 @@ export function CommandPalette(props: CommandPaletteProps) {
             ? props.selectedAgent.charAt(0).toUpperCase() + props.selectedAgent.slice(1)
             : t("session.default_agent"),
           searchText: "agent agents switch pick select default build plan",
+          group: ACTIONS_GROUP,
           action: () => {
             setMode("agents");
           },
@@ -271,6 +299,7 @@ export function CommandPalette(props: CommandPaletteProps) {
             : "Add the selected task to an existing group",
           meta: sessionGroupCount > 0 ? `${sessionGroupCount.toLocaleString()} groups` : "No groups",
           searchText: "move to group add task session folder organize",
+          group: ACTIONS_GROUP,
           action: () => {
             setMode("groups");
           },
@@ -283,29 +312,19 @@ export function CommandPalette(props: CommandPaletteProps) {
         ? `Open ${accessibleTargetCount.toLocaleString()} servers and artifacts detected in this session`
         : "No servers or artifacts detected in this session yet",
       meta: "Session",
+      keywords: ["servers", "artifacts", "files", "urls", "open"],
+      group: ACTIONS_GROUP,
       action: () => {
         setMode("accessible-items");
       },
     },
-    ...(props.extraItems ?? []),
-    {
-      id: "open-settings",
-      title: t("settings.tab_general"),
-      detail: t("settings.tab_description_general"),
-      meta: t("session.cmd_settings_meta"),
-      action: () => {
-        props.onClose();
-        props.onOpenSettings();
-      },
-    },
-    // Top-bar shortcuts — these used to be selectable via Cmd+K and were
-    // missing after the React port. Each one mirrors one of the controls at
-    // the bottom-right of the session surface (documentation / feedback)
-    // plus every settings tab the user is likely to reach for.
+    // Top-bar shortcuts mirror the documentation and feedback controls.
     {
       id: "open-docs",
       title: t("session.support_docs"),
       meta: t("session.cmd_settings_meta"),
+      keywords: ["help", "documentation", "guides", "support"],
+      group: ACTIONS_GROUP,
       action: () => {
         props.onClose();
         openUrl("https://openwork.dev/docs");
@@ -315,49 +334,11 @@ export function CommandPalette(props: CommandPaletteProps) {
       id: "open-feedback",
       title: t("session.support_feedback"),
       meta: t("session.cmd_settings_meta"),
+      keywords: ["feedback", "issue", "bug", "support"],
+      group: ACTIONS_GROUP,
       action: () => {
         props.onClose();
         openUrl("https://openwork.dev/feedback");
-      },
-    },
-    {
-      id: "open-extensions",
-      title: t("settings.tab_extensions"),
-      detail: t("settings.tab_description_extensions"),
-      meta: t("settings.tab_extensions"),
-      action: () => {
-        props.onClose();
-        props.onOpenExtensions();
-      },
-    },
-    {
-      id: "settings-appearance",
-      title: t("settings.tab_appearance"),
-      detail: t("settings.tab_description_appearance"),
-      meta: t("session.cmd_settings_meta"),
-      action: () => {
-        props.onClose();
-        props.onOpenSettings("/settings/appearance");
-      },
-    },
-    {
-      id: "settings-recovery",
-      title: t("settings.tab_recovery"),
-      detail: t("settings.tab_description_recovery"),
-      meta: t("session.cmd_settings_meta"),
-      action: () => {
-        props.onClose();
-        props.onOpenSettings("/settings/recovery");
-      },
-    },
-    {
-      id: "settings-updates",
-      title: t("settings.tab_updates"),
-      detail: t("settings.tab_description_updates"),
-      meta: t("session.cmd_settings_meta"),
-      action: () => {
-        props.onClose();
-        props.onOpenSettings("/settings/updates");
       },
     },
   ], [accessibleTargetCount, canMoveCurrentSessionToGroup, hasNestedModelPicker, props, sessionGroupCount, sessionNumberHelp]);
@@ -372,12 +353,115 @@ export function CommandPalette(props: CommandPaletteProps) {
           ? t("session.cmd_current_workspace")
           : t("session.cmd_switch"),
         searchText: item.searchText,
+        keywords: ["session", "task", "conversation", "workspace"],
+        group: "sessions",
         action: () => {
           props.onClose();
           props.onOpenSession(item.workspaceId, item.sessionId);
         },
       })),
     [props],
+  );
+
+  const settingsItems = useMemo(
+    () => buildCommandPaletteSettingsItems({
+      developerMode: props.developerMode,
+      capabilities: platform.capabilities,
+      memoryEnabled,
+      onOpenSettings: (route) => {
+        props.onClose();
+        props.onOpenSettings(route);
+      },
+      onOpenExtensions: (section) => {
+        props.onClose();
+        props.onOpenExtensions(section);
+      },
+    }),
+    [
+      memoryEnabled,
+      platform.capabilities,
+      props.developerMode,
+      props.onClose,
+      props.onOpenExtensions,
+      props.onOpenSettings,
+    ],
+  );
+
+  const coreActionItems = useMemo<PaletteItem[]>(() => [
+    ...(props.onToggleSidebar
+      ? [{
+          id: "sidebar.toggle",
+          title: "Toggle sidebar",
+          keywords: ["hide", "show", "sidebar", "collapse", "expand"],
+          group: ACTIONS_GROUP,
+          action: () => {
+            props.onClose();
+            props.onToggleSidebar?.();
+          },
+        }]
+      : []),
+    ...(props.onOpenAutomations
+      ? [{
+          id: "automations.open",
+          title: "Automations",
+          keywords: ["schedule", "scheduled", "recurring", "cron", "daily", "weekly"],
+          group: ACTIONS_GROUP,
+          action: () => {
+            props.onClose();
+            props.onOpenAutomations?.();
+          },
+        }]
+      : []),
+    ...(props.onOpenDashboard
+      ? [{
+          id: "dashboard.open",
+          title: "Dashboard",
+          keywords: ["home", "overview", "apps"],
+          group: ACTIONS_GROUP,
+          action: () => {
+            props.onClose();
+            props.onOpenDashboard?.();
+          },
+        }]
+      : []),
+    ...(props.onCreateWorkspace
+      ? [{
+          id: "workspace.create",
+          title: "New workspace…",
+          keywords: ["open folder", "add project", "directory"],
+          group: ACTIONS_GROUP,
+          action: () => {
+            props.onClose();
+            props.onCreateWorkspace?.();
+          },
+        }]
+      : []),
+    {
+      id: "cloud.sign_in",
+      title: "Sign in to OpenWork Cloud",
+      keywords: ["login", "account", "organization", "org", "den", "cloud"],
+      group: ACTIONS_GROUP,
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/cloud-account");
+      },
+    },
+  ], [props]);
+
+  const allRootItems = useMemo(
+    () => [
+      ...rootItems,
+      ...coreActionItems,
+      ...settingsItems,
+      ...(props.extraItems ?? []),
+      ...sessionItems,
+    ],
+    [coreActionItems, props.extraItems, rootItems, sessionItems, settingsItems],
+  );
+
+  const rootGroups = useMemo(
+    () => rankPaletteItems(query, allRootItems, recents),
+    [allRootItems, query, recents],
   );
 
   const splitSessionItems = useMemo<PaletteItem[]>(
@@ -541,7 +625,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     }
   };
 
-  const items = mode === "sessions"
+  const submodeItems = mode === "sessions"
     ? sessionItems
     : mode === "split-sessions"
       ? splitSessionItems
@@ -555,7 +639,40 @@ export function CommandPalette(props: CommandPaletteProps) {
             ? modelItems
             : mode === "model-behavior"
               ? behaviorItems
-          : rootItems;
+          : [];
+
+  const renderPaletteItem = (item: PaletteItem) => (
+    <CommandItem
+      key={item.id}
+      value={mode === "root" ? item.id : item}
+      data-command-palette-item={item.id}
+      disabled={item.disabled}
+      onClick={() => {
+        setRecents(recordPaletteRecent(item.id));
+        item.action();
+      }}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium">{item.title}</div>
+        {item.breadcrumb || item.detail ? (
+          <div className="truncate text-muted-foreground text-xs">
+            {item.breadcrumb ? (
+              <span className="text-muted-foreground/72">
+                {item.breadcrumb}{item.detail ? " › " : ""}
+              </span>
+            ) : null}
+            {item.detail}
+          </div>
+        ) : null}
+        {item.searchText ? (
+          <span className="sr-only">{item.searchText}</span>
+        ) : null}
+      </div>
+      {item.shortcut || item.meta ? (
+        <CommandShortcut>{item.shortcut ?? item.meta}</CommandShortcut>
+      ) : null}
+    </CommandItem>
+  );
 
   return (
     <CommandDialog open={props.open} onOpenChange={handleOpenChange}>
@@ -580,8 +697,10 @@ export function CommandPalette(props: CommandPaletteProps) {
         </CommandDialogTitle>
         <Command
           key={mode}
-          items={items}
-          itemToStringValue={paletteItemSearchValue}
+          items={mode === "root" ? rootGroups : submodeItems}
+          {...(mode === "root"
+            ? { filter: null, value: query, onValueChange: setQuery }
+            : { itemToStringValue: paletteItemSearchValue })}
         >
           <CommandHeader className="flex items-center gap-0">
             {mode !== "root" && (
@@ -592,9 +711,12 @@ export function CommandPalette(props: CommandPaletteProps) {
             )}
             <CommandInput
               ref={searchInputRef}
+              data-command-palette-input
               className="w-full"
               placeholder={
-                mode === "sessions"
+                mode === "root"
+                  ? "Search actions, settings, and sessions…"
+                  : mode === "sessions"
                   ? t("session.palette_placeholder_sessions")
                   : mode === "split-sessions"
                     ? "Search sessions and workspaces..."
@@ -614,30 +736,22 @@ export function CommandPalette(props: CommandPaletteProps) {
             />
           </CommandHeader>
           <CommandPanel>
-            <CommandEmpty>{mode === "accessible-items" ? "No accessible items found for this session." : mode === "groups" ? "No groups found for this workspace." : mode === "models" ? "No models match your search." : mode === "model-behavior" ? "No thinking or effort options match your search." : t("session.palette_no_matches")}</CommandEmpty>
+            <CommandEmpty>{mode === "root" ? "No matches. Try a different word, or type > for actions only." : mode === "accessible-items" ? "No accessible items found for this session." : mode === "groups" ? "No groups found for this workspace." : mode === "models" ? "No models match your search." : mode === "model-behavior" ? "No thinking or effort options match your search." : t("session.palette_no_matches")}</CommandEmpty>
             <CommandList>
-              {(item: PaletteItem) => (
-                <CommandItem
-                  key={item.id}
-                  value={item}
-                  data-command-palette-item={item.id}
-                  disabled={item.disabled}
-                  onClick={item.action}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium">{item.title}</div>
-                    {item.detail ? (
-                      <div className="truncate text-muted-foreground text-xs">
-                        {item.detail}
-                      </div>
-                    ) : null}
-                    {item.searchText ? (
-                      <span className="sr-only">{item.searchText}</span>
-                    ) : null}
-                  </div>
-                  {item.meta ? <CommandShortcut>{item.meta}</CommandShortcut> : null}
-                </CommandItem>
-              )}
+              {mode === "root"
+                ? (group: PaletteResultGroup) => (
+                    <CommandGroup
+                      key={group.value}
+                      items={group.items}
+                      data-command-palette-group={group.value}
+                    >
+                      <CommandGroupLabel>{group.label}</CommandGroupLabel>
+                      <CommandCollection>
+                        {renderPaletteItem}
+                      </CommandCollection>
+                    </CommandGroup>
+                  )
+                : renderPaletteItem}
             </CommandList>
           </CommandPanel>
           <CommandFooter>

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -29,7 +29,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { ChevronLeftIcon } from "lucide-react";
 import type { ModelOption, ModelRef } from "@/app/types";
-import { useFeatureFlagsPreferences } from "@/react-app/domains/settings/state/feature-flags-preferences";
 import { usePlatform } from "../kernel/platform";
 import {
   resolveSessionNumberShortcutOs,
@@ -142,7 +141,6 @@ export type CommandPaletteProps = {
  */
 export function CommandPalette(props: CommandPaletteProps) {
   const platform = usePlatform();
-  const { memoryEnabled } = useFeatureFlagsPreferences();
   const [mode, setMode] = useState<CommandPaletteMode>("root");
   const [query, setQuery] = useState("");
   const [recents, setRecents] = useState(loadPaletteRecents);
@@ -367,7 +365,6 @@ export function CommandPalette(props: CommandPaletteProps) {
     () => buildCommandPaletteSettingsItems({
       developerMode: props.developerMode,
       capabilities: platform.capabilities,
-      memoryEnabled,
       onOpenSettings: (route) => {
         props.onClose();
         props.onOpenSettings(route);
@@ -378,7 +375,6 @@ export function CommandPalette(props: CommandPaletteProps) {
       },
     }),
     [
-      memoryEnabled,
       platform.capabilities,
       props.developerMode,
       props.onClose,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -223,6 +223,7 @@ import { useShellConfig } from "./shell-config";
 import { useShellShortcuts } from "./use-shell-shortcuts";
 import { useEngineReload } from "./use-engine-reload";
 import { useSessionGroupSync } from "./use-session-group-sync";
+import { useUiStateStore } from "./ui-state-store";
 import { useWorkspaceRouteState } from "./use-workspace-route-state";
 import { CloudWorkspaceBootTakeover, useCloudWorkspaceStatus } from "./cloud-workspace-overlay";
 import {
@@ -360,6 +361,7 @@ export function SessionRoute() {
   const dashboardWorkspaceRoute = dashboardRouteRequested
     && (dashboardAvailabilityLoading || mcpAppsDashboardEnabled);
   const platform = usePlatform();
+  const toggleSidebar = useUiStateStore((state) => state.toggleSidebar);
   const denAuth = useDenAuth();
   const { config: shellConfig } = useShellConfig();
   const local = useLocal();
@@ -3481,6 +3483,7 @@ export function SessionRoute() {
     <CommandPalette
       open={commandPaletteOpen}
       onClose={() => setCommandPaletteOpen(false)}
+      developerMode={developerMode}
       onCreateNewSession={() => {
         if (selectedWorkspaceId) {
           void handleCreateTaskInWorkspace(selectedWorkspaceId);
@@ -3503,7 +3506,11 @@ export function SessionRoute() {
         workbench.setSplit(tab);
       }}
       onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
-      onOpenExtensions={() => handleOpenExtensions()}
+      onOpenExtensions={(section) => handleOpenExtensions(section)}
+      onToggleSidebar={toggleSidebar}
+      onOpenAutomations={() => navigate(automationsRoute())}
+      onOpenDashboard={() => navigate(dashboardRoute())}
+      onCreateWorkspace={handleOpenCreateWorkspace}
       modelOptions={modelPicker.options}
       selectedModel={paletteSelectedModel}
       selectedModelBehavior={paletteSelectedModelBehavior}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2733,6 +2733,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       <CommandPalette
         open={commandPaletteOpen}
         onClose={() => setCommandPaletteOpen(false)}
+        developerMode={developerMode}
         onCreateNewSession={() => void handleCreatePaletteSession()}
         onOpenSession={(workspaceId, sessionId) => {
           navigate(workspaceSessionRoute(workspaceId, sessionId));
@@ -2749,10 +2750,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           }
           navigateSettingsPath(settingsPath);
         }}
-        onOpenExtensions={() => {
+        onOpenExtensions={(section) => {
           const target = selectedWorkspaceId
-            ? workspaceExtensionsRoute(selectedWorkspaceId)
-            : globalExtensionsRoute();
+            ? workspaceExtensionsRoute(selectedWorkspaceId, section)
+            : globalExtensionsRoute(section);
           navigate(target);
         }}
         onOpenModelPicker={() => {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -181,7 +181,9 @@ import { useCommandPaletteShortcut } from "./use-shell-shortcuts";
 import { buildFeedbackUrl } from "@/app/lib/feedback";
 import { getDenInferenceUrl, type DenSettings } from "@/app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
+import { useUiStateStore } from "./ui-state-store";
 import {
+  automationsRoute,
   globalExtensionsRoute,
   settingsReturnRoute,
   workspaceExtensionsRoute,
@@ -442,6 +444,7 @@ export type SettingsSurfaceProps = {
 
 function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const navigate = useNavigate();
+  const toggleSidebar = useUiStateStore((state) => state.toggleSidebar);
   const location = useLocation();
   const params = useParams<{ workspaceId?: string }>();
   const routeWorkspaceId = props.workspaceId?.trim() || params.workspaceId?.trim() || "";
@@ -2734,6 +2737,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         open={commandPaletteOpen}
         onClose={() => setCommandPaletteOpen(false)}
         developerMode={developerMode}
+        onToggleSidebar={toggleSidebar}
+        onOpenAutomations={() => navigate(automationsRoute())}
         onCreateNewSession={() => void handleCreatePaletteSession()}
         onOpenSession={(workspaceId, sessionId) => {
           navigate(workspaceSessionRoute(workspaceId, sessionId));

--- a/apps/app/tests/command-palette-recents.test.ts
+++ b/apps/app/tests/command-palette-recents.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  COMMAND_PALETTE_RECENTS_KEY,
+  loadPaletteRecents,
+  recordPaletteRecent,
+} from "../src/react-app/shell/command-palette-recents";
+
+function fakeStorage(initial?: string) {
+  let value = initial ?? null;
+  return {
+    getItem: (key: string) => key === COMMAND_PALETTE_RECENTS_KEY ? value : null,
+    setItem: (key: string, next: string) => {
+      if (key === COMMAND_PALETTE_RECENTS_KEY) value = next;
+    },
+  };
+}
+
+describe("command palette recents", () => {
+  test("loads only valid string ids", () => {
+    const storage = fakeStorage(JSON.stringify(["one", 2, "two", "one"]));
+    expect(loadPaletteRecents(storage)).toEqual(["one", "two"]);
+  });
+
+  test("moves selections to the front, dedupes, and caps at eight", () => {
+    const storage = fakeStorage(JSON.stringify(["one", "two", "three", "four", "five", "six", "seven", "eight"]));
+    expect(recordPaletteRecent("session:workspace:id", storage)).toEqual([
+      "session:workspace:id", "one", "two", "three", "four", "five", "six", "seven",
+    ]);
+    expect(recordPaletteRecent("three", storage)[0]).toBe("three");
+  });
+
+  test("ignores malformed storage", () => {
+    expect(loadPaletteRecents(fakeStorage("not json"))).toEqual([]);
+  });
+});

--- a/apps/app/tests/command-palette-search.test.ts
+++ b/apps/app/tests/command-palette-search.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  rankPaletteItems,
+  type PaletteItem,
+} from "../src/react-app/shell/command-palette-search";
+
+function item(input: Omit<PaletteItem, "action">): PaletteItem {
+  return { ...input, action: () => {} };
+}
+
+describe("command palette search", () => {
+  test("shows recent items first in stored order for an empty query", () => {
+    const items = [
+      item({ id: "one", title: "One" }),
+      item({ id: "two", title: "Two", group: "settings" }),
+    ];
+
+    const groups = rankPaletteItems("  ", items, ["two", "one"]);
+
+    expect(groups[0]?.value).toBe("recent");
+    expect(groups[0]?.items.map((entry) => entry.id)).toEqual(["two", "one"]);
+  });
+
+  test("ranks a keyword match for Permissions above Preferences", () => {
+    const groups = rankPaletteItems("folders", [
+      item({ id: "settings:preferences", title: "Preferences", keywords: ["default folder"], group: "settings" }),
+      item({ id: "settings:permissions", title: "Permissions", keywords: ["authorized folders"], group: "settings" }),
+    ], []);
+
+    expect(groups[0]?.items[0]?.id).toBe("settings:permissions");
+  });
+
+  test("limits > searches to actions", () => {
+    const groups = rankPaletteItems(">", [
+      item({ id: "action", title: "Action" }),
+      item({ id: "setting", title: "Setting", group: "settings" }),
+    ], []);
+
+    expect(groups.map((group) => group.value)).toEqual(["actions"]);
+    expect(groups[0]?.items.map((entry) => entry.id)).toEqual(["action"]);
+  });
+
+  test("requires every query token to match", () => {
+    const appearance = item({
+      id: "settings:appearance",
+      title: "Appearance",
+      keywords: ["theme dark mode"],
+      group: "settings",
+    });
+
+    expect(rankPaletteItems("appearance theme", [appearance], [])).toHaveLength(1);
+    expect(rankPaletteItems("appearance sessions", [appearance], [])).toEqual([]);
+  });
+
+  test("uses recency to break equal-score ties", () => {
+    const first = item({ id: "first", title: "Open dashboard" });
+    const recent = item({ id: "recent", title: "Open dashboard" });
+
+    const groups = rankPaletteItems("dashboard", [first, recent], ["recent"]);
+
+    expect(groups[0]?.items[0]?.id).toBe("recent");
+  });
+});

--- a/apps/app/tests/command-palette-search.test.ts
+++ b/apps/app/tests/command-palette-search.test.ts
@@ -61,4 +61,31 @@ describe("command palette search", () => {
 
     expect(groups[0]?.items[0]?.id).toBe("recent");
   });
+
+  test("ranks exact title and alias phrases above fuzzy title partials", () => {
+    const items = [
+      item({
+        id: "models",
+        title: "Switch model",
+        detail: "Choose the LLM that runs your next prompts",
+        searchText: "model models llm provider openai anthropic claude gpt gemini switch pick select default",
+      }),
+      item({
+        id: "settings:appearance",
+        title: "Appearance",
+        keywords: ["theme", "dark mode", "light mode", "color", "font", "look"],
+        group: "settings",
+      }),
+      item({
+        id: "settings:preferences",
+        title: "Preferences",
+        keywords: ["default model", "reasoning", "thinking", "compaction", "effort"],
+        group: "settings",
+      }),
+    ];
+
+    expect(rankPaletteItems("dark mode", items, [])[0]?.items[0]?.id).toBe("settings:appearance");
+    expect(rankPaletteItems("theme", items, [])[0]?.items[0]?.id).toBe("settings:appearance");
+    expect(rankPaletteItems("model", items, [])[0]?.items[0]?.id).toBe("models");
+  });
 });

--- a/apps/app/tests/command-palette-settings.test.ts
+++ b/apps/app/tests/command-palette-settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildCommandPaletteSettingsItems } from "../src/react-app/shell/command-palette-settings";
+
+function build(developerMode: boolean, autoUpdate: boolean) {
+  return buildCommandPaletteSettingsItems({
+    developerMode,
+    capabilities: { autoUpdate, localRuntimeControl: true },
+    memoryEnabled: true,
+    onOpenSettings: () => {},
+    onOpenExtensions: () => {},
+  });
+}
+
+describe("command palette settings", () => {
+  test("gates Debug and Updates by their existing settings conditions", () => {
+    const regularIds = build(false, false).map((item) => item.id);
+    const enabledIds = build(true, true).map((item) => item.id);
+
+    expect(regularIds).not.toContain("settings:debug");
+    expect(regularIds).not.toContain("settings:updates");
+    expect(enabledIds).toContain("settings:debug");
+    expect(enabledIds).toContain("settings:updates");
+  });
+
+  test("uses stable ids for tabs and Library sections", () => {
+    expect(build(false, true).map((item) => item.id)).toEqual([
+      "settings:general",
+      "settings:preferences",
+      "settings:permissions",
+      "settings:extensions",
+      "settings:advanced",
+      "settings:ai",
+      "settings:appearance",
+      "settings:environment",
+      "settings:updates",
+      "settings:recovery",
+      "settings:cloud-account",
+      "settings:memory",
+      "settings:extensions/skills",
+      "settings:extensions/mcps",
+      "settings:extensions/connections",
+      "settings:extensions/plugins",
+      "settings:extensions/agents",
+      "settings:extensions/commands",
+    ]);
+  });
+});

--- a/apps/app/tests/command-palette-settings.test.ts
+++ b/apps/app/tests/command-palette-settings.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import { rankPaletteItems } from "../src/react-app/shell/command-palette-search";
 import { buildCommandPaletteSettingsItems } from "../src/react-app/shell/command-palette-settings";
 
 function build(developerMode: boolean, autoUpdate: boolean) {
   return buildCommandPaletteSettingsItems({
     developerMode,
-    capabilities: { autoUpdate, localRuntimeControl: true },
-    memoryEnabled: true,
+    capabilities: { autoUpdate },
     onOpenSettings: () => {},
     onOpenExtensions: () => {},
   });
@@ -34,9 +34,7 @@ describe("command palette settings", () => {
       "settings:appearance",
       "settings:environment",
       "settings:updates",
-      "settings:recovery",
       "settings:cloud-account",
-      "settings:memory",
       "settings:extensions/skills",
       "settings:extensions/mcps",
       "settings:extensions/connections",
@@ -44,5 +42,12 @@ describe("command palette settings", () => {
       "settings:extensions/agents",
       "settings:extensions/commands",
     ]);
+  });
+
+  test("finds recovery tools under Advanced", () => {
+    const items = build(false, true);
+
+    expect(items.find((item) => item.id === "settings:advanced")?.keywords).toContain("recovery");
+    expect(rankPaletteItems("reset", items, [])[0]?.items[0]?.id).toBe("settings:advanced");
   });
 });

--- a/ee/apps/den-web/next-env.d.ts
+++ b/ee/apps/den-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -1,57 +1,15 @@
 import { expect } from "vitest";
-import { spec, type Probe } from "@openwork/testkit";
+import { spec } from "@openwork/testkit";
 import { commandPaletteSearch } from "../worlds/session-shell.ts";
 
 const test = spec.world(commandPaletteSearch);
 const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
 const paletteShortcut = process.platform === "darwin" ? "Meta+K" : "Control+K";
 
-interface PaletteState {
-  firstItemId: string;
-  hasActions: boolean;
-  hasPermissions: boolean;
-  hasRecent: boolean;
-  hasSessions: boolean;
-  hasSettings: boolean;
-  recentIds: string[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")
     : [];
-}
-
-async function paletteState(probe: Probe): Promise<PaletteState> {
-  // TODO(primitive): probe.palette should expose command-palette groups and item order.
-  const value = await probe.eval(`(() => {
-    const firstItem = document.querySelector("[data-command-palette-item]");
-    const recent = document.querySelector('[data-command-palette-group="recent"]');
-    return {
-      firstItemId: firstItem?.getAttribute("data-command-palette-item") ?? "",
-      hasActions: Boolean(document.querySelector('[data-command-palette-group="actions"]')),
-      hasPermissions: Boolean(document.querySelector('[data-command-palette-item="settings:permissions"]')),
-      hasRecent: Boolean(recent),
-      hasSessions: Boolean(document.querySelector('[data-command-palette-group="sessions"]')),
-      hasSettings: Boolean(document.querySelector('[data-command-palette-group="settings"]')),
-      recentIds: Array.from(recent?.querySelectorAll("[data-command-palette-item]") ?? [])
-        .map((item) => item.getAttribute("data-command-palette-item") ?? ""),
-    };
-  })()`);
-  if (!isRecord(value)) throw new Error(`Invalid command palette state: ${JSON.stringify(value)}`);
-  return {
-    firstItemId: typeof value.firstItemId === "string" ? value.firstItemId : "",
-    hasActions: value.hasActions === true,
-    hasPermissions: value.hasPermissions === true,
-    hasRecent: value.hasRecent === true,
-    hasSessions: value.hasSessions === true,
-    hasSettings: value.hasSettings === true,
-    recentIds: stringArray(value.recentIds),
-  };
 }
 
 test("command palette searches settings by alias, navigates, records recents, and filters actions", async ({ world, user, probe, step }) => {
@@ -61,30 +19,18 @@ test("command palette searches settings by alias, navigates, records recents, an
     expect(await probe.hash()).toContain(workspaceId);
     await user.press(paletteShortcut);
     await user.see(paletteInput);
-    const empty = await probe.eventually(() => paletteState(probe), {
-      within: 15_000,
-      label: "empty command palette groups",
-      until: (state) => state.hasActions && state.hasSettings && state.hasPermissions,
-    });
-    expect(empty.hasRecent).toBe(false);
+    await user.see({ text: "Actions" });
+    await user.see({ role: "option", label: /^Permissions/ });
+    await user.notSee({ text: "Recent" });
     await user.screenshot();
   });
 
-  await step("folders ranks Permissions first and excludes sessions", async () => {
+  await step("folders ranks Permissions first and Enter navigates there", async () => {
     await user.type(paletteInput, "folders", { replace: true });
-    const folders = await probe.eventually(() => paletteState(probe), {
-      within: 15_000,
-      label: "authorized folders alias ranks Permissions first",
-      until: (state) => state.firstItemId === "settings:permissions" && !state.hasSessions,
-    });
-    expect(folders.firstItemId).toBe("settings:permissions");
-    expect(folders.firstItemId).not.toBe("settings:preferences");
-    expect(folders.hasSessions).toBe(false);
+    await user.see({ role: "option", label: /^Permissions/ });
+    await user.notSee({ text: "Sessions" });
     await user.screenshot();
-  });
-
-  await step("choosing Permissions navigates within the current workspace", async () => {
-    await user.click({ role: "option", label: /permissions/i });
+    await user.press("Enter");
     const hash = await probe.eventually(() => probe.hash(), {
       within: 15_000,
       label: "Permissions settings route",
@@ -93,6 +39,7 @@ test("command palette searches settings by alias, navigates, records recents, an
     expect(hash).toContain(workspaceId);
     expect(hash).toMatch(/\/settings\/permissions$/);
     expect(hash).not.toMatch(/\/settings\/general$/);
+    expect(hash).not.toMatch(/\/settings\/preferences$/);
   });
 
   await step("reopening the palette shows Permissions as the sole recent item", async () => {
@@ -102,53 +49,58 @@ test("command palette searches settings by alias, navigates, records recents, an
     await new Promise((resolve) => setTimeout(resolve, 1_500));
     await user.press(paletteShortcut);
     await user.see(paletteInput);
-    const recent = await probe.eventually(() => paletteState(probe), {
-      within: 15_000,
-      label: "Permissions is the sole recent command",
-      until: (state) => state.recentIds.length === 1 && state.recentIds[0] === "settings:permissions",
-    });
-    expect(recent.hasRecent).toBe(true);
-    expect(recent.recentIds).toEqual(["settings:permissions"]);
-    expect(recent.recentIds).not.toContain("settings:appearance");
+    await user.see({ text: "Recent" });
+    await user.see({ role: "option", label: /^Permissions/ });
     const storedRecents = stringArray(await probe.storage("openwork.react.command-palette.recents"));
-    expect(storedRecents[0]).toBe("settings:permissions");
+    expect(storedRecents).toEqual(["settings:permissions"]);
+    expect(storedRecents).not.toContain("settings:appearance");
     await user.screenshot();
   });
 
-  await step("dark mode ranks Appearance first", async () => {
+  await step("dark mode ranks Appearance first and Enter navigates there", async () => {
     await user.type(paletteInput, "dark mode", { replace: true });
-    const appearance = await probe.eventually(() => paletteState(probe), {
-      within: 15_000,
-      label: "dark mode alias ranks Appearance first",
-      until: (state) => state.firstItemId === "settings:appearance",
-    });
-    expect(appearance.firstItemId).toBe("settings:appearance");
+    await user.see({ role: "option", label: /^Appearance/ });
     await user.screenshot();
+    await user.press("Enter");
+    const hash = await probe.eventually(() => probe.hash(), {
+      within: 15_000,
+      label: "Appearance settings route",
+      until: (value) => value.endsWith("/settings/appearance"),
+    });
+    expect(hash).toContain(workspaceId);
+    expect(hash).toMatch(/\/settings\/appearance$/);
+    expect(hash).not.toMatch(/\/settings\/permissions$/);
+    await probe.eventually(() => probe.has("Arrow keys to navigate"), {
+      within: 15_000,
+      label: "command palette closes after choosing Appearance",
+      until: (open) => !open,
+    });
   });
 
   await step("> restricts the palette to actions", async () => {
+    await user.see({ text: /Adjust how OpenWork looks/ });
+    // Settings closes route-owned overlays just after navigation; let that
+    // transition settle before reopening the palette.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
     await user.type(paletteInput, ">", { replace: true });
-    const actionsOnly = await probe.eventually(() => paletteState(probe), {
-      within: 15_000,
-      label: "greater-than query restricts results to actions",
-      until: (state) => state.hasActions && !state.hasSettings,
-    });
-    expect(actionsOnly.hasActions).toBe(true);
-    expect(actionsOnly.hasSettings).toBe(false);
+    await user.see({ role: "option", label: /^Toggle sidebar/ });
+    await user.notSee({ role: "option", label: /^Appearance/ });
+    await user.notSee({ role: "option", label: /^Permissions/ });
     await user.screenshot();
   });
 
   await step("Escape closes the palette without navigating", async () => {
     await user.press("Escape");
-    // TODO(primitive): user.notSee should be able to wait for a dialog's exit transition.
-    await probe.eventually(() => probe.eval(`Boolean(document.querySelector("input[data-command-palette-input]"))`), {
+    await probe.eventually(() => probe.has("Arrow keys to navigate"), {
       within: 15_000,
-      label: "palette closes after Escape",
-      until: (open) => open === false,
+      label: "command palette footer disappears",
+      until: (open) => !open,
     });
     await user.notSee(paletteInput);
     const hash = await probe.hash();
     expect(hash).toContain(workspaceId);
-    expect(hash).toMatch(/\/settings\/permissions$/);
+    expect(hash).toMatch(/\/settings\/appearance$/);
   });
 });

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -3,7 +3,6 @@ import {
   control,
   createAndSelectWorkspace,
   evalIn,
-  selectModel,
   waitFor,
 } from "@openwork/behaviors";
 import { screenshot } from "@openwork/test-evidence";
@@ -239,7 +238,6 @@ test.skipIf(!runnable)(
       path: `/tmp/openwork-palette-${runId}`,
     });
     await configureWorkspaces(desktopApp, [workspace.workspaceId], den.mocks.agent.url);
-    await selectModel(desktopApp, modelId);
     const sessionId = await createSession(desktopApp);
     await control(desktopApp, "session.rename", { sessionId, title: `Palette Probe ${runId}` });
 

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "vitest";
 import {
   control,
-  createAndSelectWorkspace,
   evalIn,
+  seedSessions,
   waitFor,
 } from "@openwork/behaviors";
 import { screenshot } from "@openwork/test-evidence";
@@ -10,16 +10,12 @@ import {
   app,
   localMysqlIsRunning,
   localRedisIsRunning,
-  mcpMock,
   needs,
   server,
   test,
 } from "@openwork/testkit";
 import type { App } from "@openwork/testkit";
 
-const providerId = "command-palette-search-mock";
-const modelId = "command-palette-search-model";
-const modelName = "Command palette search model";
 const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
 const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
 const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
@@ -74,82 +70,6 @@ function parseRecentFacts(value: unknown): RecentFacts {
     ? value.storedIds.filter((item): item is string => typeof item === "string")
     : [];
   return { itemIds, storedIds };
-}
-
-async function configureWorkspaces(appSurface: App, workspaceIds: string[], baseUrl: string): Promise<void> {
-  const result = await evalIn(appSurface, `(async () => {
-    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
-    if (!info?.running || !info.baseUrl) return "local_server_unavailable";
-    const root = String(info.baseUrl).replace(/\\/+$/, "");
-    const headers = {
-      Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
-      "Content-Type": "application/json",
-    };
-    for (const workspaceId of ${JSON.stringify(workspaceIds)}) {
-      const configured = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
-        method: "PATCH",
-        headers,
-        body: JSON.stringify({
-          opencode: {
-            permission: { bash: "allow" },
-            provider: {
-              [${JSON.stringify(providerId)}]: {
-                npm: "@ai-sdk/openai-compatible",
-                name: ${JSON.stringify(modelName)},
-                options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-command-palette-search" },
-                models: {
-                  [${JSON.stringify(modelId)}]: { name: ${JSON.stringify(modelName)}, tool_call: true },
-                },
-              },
-            },
-          },
-        }),
-        signal: AbortSignal.timeout(30000),
-      });
-      if (!configured.ok) return "config:" + configured.status + ":" + (await configured.text()).slice(0, 300);
-      const reloaded = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", {
-        method: "POST",
-        headers,
-        signal: AbortSignal.timeout(60000),
-      });
-      if (!reloaded.ok) return "reload:" + reloaded.status + ":" + (await reloaded.text()).slice(0, 300);
-    }
-    const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
-    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
-    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
-    localStorage.setItem("openwork.preferences", JSON.stringify({
-      ...preferences,
-      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
-      modelVariant: null,
-      providerStepCompleted: true,
-    }));
-    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
-    return "ok";
-  })()`, { awaitPromise: true, timeoutMs: 120_000 });
-  expect(result).toBe("ok");
-
-  await evalIn(appSurface, "location.reload(); true");
-  await waitFor(appSurface, "Boolean(window.__openworkControl)", {
-    timeoutMs: 60_000,
-    label: "desktop restored after mock provider configuration",
-  });
-}
-
-async function createSession(appSurface: App): Promise<string> {
-  const deadline = Date.now() + 60_000;
-  let lastError: unknown = null;
-  while (Date.now() < deadline) {
-    try {
-      const created = await control(appSurface, "session.create_task", undefined, { timeoutMs: 30_000 });
-      if (typeof created === "string" && created.startsWith("ses_")) return created;
-      lastError = new Error(`session.create_task returned ${JSON.stringify(created)}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-  throw new Error(`session.create_task did not return a session id: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
 }
 
 async function setPaletteQuery(
@@ -216,37 +136,24 @@ test.skipIf(!runnable)(
 
     await using den = await server({
       place,
-      mocks: {
-        agent: mcpMock({
-          agentWorkloads: [{
-            promptMarker: `UNUSED-PALETTE-${runId}`,
-            finalReply: "unused",
-            // The mock requires one step; this spec never sends a prompt.
-            steps: [{ tool: "bash", arguments: { command: "true", timeout: 1_000, description: "unused" } }],
-          }],
-        }),
-      },
       org: {
         name: "Command Palette Search",
         admin: { name: "Palette Admin" },
         members: { member: { name: "Palette Member" } },
       },
     });
-    await using desktopApp = await app({ den, as: "member", place });
+    await using desktopApp = await app({ den, as: "admin", place });
 
-    const workspace = await createAndSelectWorkspace(desktopApp, {
-      path: `/tmp/openwork-palette-${runId}`,
-    });
-    await configureWorkspaces(desktopApp, [workspace.workspaceId], den.mocks.agent.url);
-    const sessionId = await createSession(desktopApp);
-    await control(desktopApp, "session.rename", { sessionId, title: `Palette Probe ${runId}` });
+    const [seeded] = await seedSessions(desktopApp, [`Palette Probe ${runId}`]);
+    const workspaceId = desktopApp.workspaceId;
+    if (!workspaceId) throw new Error("The command palette search world did not resolve a workspace.");
 
     const sessionHashValue = await evalIn(desktopApp, "window.location.hash");
     if (typeof sessionHashValue !== "string") {
       throw new Error(`Invalid session hash: ${JSON.stringify(sessionHashValue)}`);
     }
     const sessionHash = sessionHashValue;
-    expect(sessionHash).toContain(workspace.workspaceId);
+    expect(sessionHash).toContain(workspaceId);
 
     await control(desktopApp, "command_palette.open");
     await waitFor(desktopApp, `Boolean(document.querySelector("input[data-command-palette-input]"))`, {
@@ -258,7 +165,7 @@ test.skipIf(!runnable)(
     expect(emptyFacts.hasActions).toBe(true);
     expect(emptyFacts.hasRecent).toBe(false);
 
-    const sessionItemId = `session:${workspace.workspaceId}:${sessionId}`;
+    const sessionItemId = `session:${workspaceId}:${seeded.sessionId}`;
     await setPaletteQuery(
       desktopApp,
       "Palette Probe",
@@ -304,7 +211,7 @@ test.skipIf(!runnable)(
     if (typeof permissionsHashValue !== "string") {
       throw new Error(`Invalid permissions hash: ${JSON.stringify(permissionsHashValue)}`);
     }
-    expect(permissionsHashValue).toContain(workspace.workspaceId);
+    expect(permissionsHashValue).toContain(workspaceId);
     expect(permissionsHashValue).toMatch(/\/settings\/permissions$/);
     expect(permissionsHashValue).not.toMatch(/\/settings\/general$/);
 
@@ -383,6 +290,6 @@ test.skipIf(!runnable)(
       throw new Error(`Invalid final hash: ${JSON.stringify(finalHashValue)}`);
     }
     expect(finalHashValue).toMatch(/\/settings\/permissions$/);
-    expect(finalHashValue).toContain(workspace.workspaceId);
+    expect(finalHashValue).toContain(workspaceId);
   },
 );

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -1,0 +1,313 @@
+import { expect } from "vitest";
+import {
+  control,
+  createAndSelectWorkspace,
+  evalIn,
+  waitFor,
+} from "@openwork/behaviors";
+import { screenshot } from "@openwork/test-evidence";
+import {
+  app,
+  localMysqlIsRunning,
+  localRedisIsRunning,
+  needs,
+  server,
+  test,
+} from "@openwork/testkit";
+import type { App } from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const localServicesRequired = !daytonaEnabled && !configuredDen;
+const mysqlOpen = await localMysqlIsRunning();
+const redisOpen = await localRedisIsRunning();
+const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
+const skipSuffix = !e2eTestsEnabled
+  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : localServicesRequired && !mysqlOpen
+    ? " skipped — needs MySQL on 127.0.0.1:3306"
+    : localServicesRequired && !redisOpen
+      ? " skipped — needs Redis on 127.0.0.1:6379"
+      : "";
+
+interface PaletteFacts {
+  firstItemId: string;
+  firstItemGroup: string;
+  hasActions: boolean;
+  hasRecent: boolean;
+  hasSessions: boolean;
+  hasSettings: boolean;
+}
+
+interface RecentFacts {
+  itemIds: string[];
+  storedIds: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsePaletteFacts(value: unknown): PaletteFacts {
+  if (!isRecord(value)) throw new Error(`Invalid palette facts: ${JSON.stringify(value)}`);
+  return {
+    firstItemId: typeof value.firstItemId === "string" ? value.firstItemId : "",
+    firstItemGroup: typeof value.firstItemGroup === "string" ? value.firstItemGroup : "",
+    hasActions: value.hasActions === true,
+    hasRecent: value.hasRecent === true,
+    hasSessions: value.hasSessions === true,
+    hasSettings: value.hasSettings === true,
+  };
+}
+
+function parseRecentFacts(value: unknown): RecentFacts {
+  if (!isRecord(value)) throw new Error(`Invalid recent facts: ${JSON.stringify(value)}`);
+  const itemIds = Array.isArray(value.itemIds)
+    ? value.itemIds.filter((item): item is string => typeof item === "string")
+    : [];
+  const storedIds = Array.isArray(value.storedIds)
+    ? value.storedIds.filter((item): item is string => typeof item === "string")
+    : [];
+  return { itemIds, storedIds };
+}
+
+async function createSession(appSurface: App): Promise<string> {
+  const deadline = Date.now() + 60_000;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      const created = await control(appSurface, "session.create_task", undefined, { timeoutMs: 30_000 });
+      if (typeof created === "string" && created.startsWith("ses_")) return created;
+      lastError = new Error(`session.create_task returned ${JSON.stringify(created)}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`session.create_task did not return a session id: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}
+
+async function setPaletteQuery(
+  appSurface: App,
+  text: string,
+  expectedCondition: string,
+  label: string,
+): Promise<void> {
+  const changed = await evalIn(appSurface, `(() => {
+    const input = document.querySelector("input[data-command-palette-input]");
+    if (!(input instanceof HTMLInputElement)) return false;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(input, ${JSON.stringify(text)});
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    return Boolean(setter);
+  })()`);
+  expect(changed).toBe(true);
+
+  try {
+    await waitFor(appSurface, expectedCondition, { timeoutMs: 15_000, label });
+  } catch {
+    const fallbackChanged = await evalIn(appSurface, `(() => {
+      const input = document.querySelector("input[data-command-palette-input]");
+      if (!(input instanceof HTMLInputElement)) return false;
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      if (!setter) return false;
+      input.focus();
+      setter.call(input, "");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      let value = "";
+      for (const character of ${JSON.stringify(text)}) {
+        input.dispatchEvent(new KeyboardEvent("keydown", { key: character, bubbles: true, cancelable: true }));
+        value += character;
+        setter.call(input, value);
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      return true;
+    })()`);
+    expect(fallbackChanged).toBe(true);
+    await waitFor(appSurface, expectedCondition, { timeoutMs: 15_000, label: `${label} after key fallback` });
+  }
+}
+
+async function readPaletteFacts(appSurface: App): Promise<PaletteFacts> {
+  return parsePaletteFacts(await evalIn(appSurface, `(() => {
+    const firstItem = document.querySelector("[data-command-palette-item]");
+    return {
+      firstItemId: firstItem?.getAttribute("data-command-palette-item") ?? "",
+      firstItemGroup: firstItem?.closest("[data-command-palette-group]")?.getAttribute("data-command-palette-group") ?? "",
+      hasActions: Boolean(document.querySelector('[data-command-palette-group="actions"]')),
+      hasRecent: Boolean(document.querySelector('[data-command-palette-group="recent"]')),
+      hasSessions: Boolean(document.querySelector('[data-command-palette-group="sessions"]')),
+      hasSettings: Boolean(document.querySelector('[data-command-palette-group="settings"]')),
+    };
+  })()`));
+}
+
+test.skipIf(!runnable)(
+  `command palette searches settings and sessions, records recents, and filters actions${skipSuffix}`,
+  { timeout: 8 * 60_000 },
+  async ({ place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+    const runId = `${Date.now().toString(36)}-${process.pid}`;
+
+    await using den = await server({
+      place,
+      org: {
+        name: "Command Palette Search",
+        admin: { name: "Palette Admin" },
+        members: { member: { name: "Palette Member" } },
+      },
+    });
+    await using desktopApp = await app({ den, as: "member", place });
+
+    const workspace = await createAndSelectWorkspace(desktopApp, {
+      path: `/tmp/openwork-palette-${runId}`,
+    });
+    const sessionId = await createSession(desktopApp);
+    await control(desktopApp, "session.rename", { sessionId, title: `Palette Probe ${runId}` });
+
+    const sessionHashValue = await evalIn(desktopApp, "window.location.hash");
+    if (typeof sessionHashValue !== "string") {
+      throw new Error(`Invalid session hash: ${JSON.stringify(sessionHashValue)}`);
+    }
+    const sessionHash = sessionHashValue;
+    expect(sessionHash).toContain(workspace.workspaceId);
+
+    await control(desktopApp, "command_palette.open");
+    await waitFor(desktopApp, `Boolean(document.querySelector("input[data-command-palette-input]"))`, {
+      timeoutMs: 15_000,
+      label: "command palette opens from the session route",
+    });
+
+    const emptyFacts = await readPaletteFacts(desktopApp);
+    expect(emptyFacts.hasActions).toBe(true);
+    expect(emptyFacts.hasRecent).toBe(false);
+
+    const sessionItemId = `session:${workspace.workspaceId}:${sessionId}`;
+    await setPaletteQuery(
+      desktopApp,
+      "Palette Probe",
+      `(() => {
+        const first = document.querySelector("[data-command-palette-item]");
+        return first?.getAttribute("data-command-palette-item") === ${JSON.stringify(sessionItemId)}
+          && first?.closest("[data-command-palette-group]")?.getAttribute("data-command-palette-group") === "sessions";
+      })()`,
+      "renamed session ranks first in the sessions group",
+    );
+    const sessionFacts = await readPaletteFacts(desktopApp);
+    expect(sessionFacts.firstItemId).toBe(sessionItemId);
+    expect(sessionFacts.firstItemGroup).toBe("sessions");
+
+    await setPaletteQuery(
+      desktopApp,
+      "folders",
+      `(() => {
+        const first = document.querySelector("[data-command-palette-item]");
+        return first?.getAttribute("data-command-palette-item") === "settings:permissions"
+          && !document.querySelector('[data-command-palette-group="sessions"]');
+      })()`,
+      "authorized folders alias ranks permissions first without session results",
+    );
+    const foldersFacts = await readPaletteFacts(desktopApp);
+    expect(foldersFacts.firstItemId).toBe("settings:permissions");
+    expect(foldersFacts.firstItemId).not.toBe("settings:preferences");
+    expect(foldersFacts.hasSessions).toBe(false);
+    await screenshot(desktopApp);
+
+    const clicked = await evalIn(desktopApp, `(() => {
+      const first = document.querySelector("[data-command-palette-item]");
+      if (!(first instanceof HTMLElement)) return false;
+      first.click();
+      return true;
+    })()`);
+    expect(clicked).toBe(true);
+    await waitFor(desktopApp, `window.location.hash.endsWith("/settings/permissions")`, {
+      timeoutMs: 15_000,
+      label: "permissions result navigates to permissions settings",
+    });
+    const permissionsHashValue = await evalIn(desktopApp, "window.location.hash");
+    if (typeof permissionsHashValue !== "string") {
+      throw new Error(`Invalid permissions hash: ${JSON.stringify(permissionsHashValue)}`);
+    }
+    expect(permissionsHashValue).toContain(workspace.workspaceId);
+    expect(permissionsHashValue).toMatch(/\/settings\/permissions$/);
+    expect(permissionsHashValue).not.toMatch(/\/settings\/general$/);
+
+    await evalIn(desktopApp, `(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "k",
+        code: "KeyK",
+        metaKey: true,
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+      return true;
+    })()`);
+    await waitFor(desktopApp, `Boolean(document.querySelector("input[data-command-palette-input]"))`, {
+      timeoutMs: 15_000,
+      label: "command palette opens by keyboard from settings",
+    });
+    await waitFor(desktopApp, `(() => {
+      const group = document.querySelector('[data-command-palette-group="recent"]');
+      return group?.querySelectorAll("[data-command-palette-item]").length === 1
+        && Boolean(group.querySelector('[data-command-palette-item="settings:permissions"]'));
+    })()`, { timeoutMs: 15_000, label: "permissions appears as the sole recent item" });
+
+    const recentFacts = parseRecentFacts(await evalIn(desktopApp, `(() => {
+      const group = document.querySelector('[data-command-palette-group="recent"]');
+      let storedIds = [];
+      try {
+        const parsed = JSON.parse(localStorage.getItem("openwork.react.command-palette.recents") ?? "[]");
+        storedIds = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        storedIds = [];
+      }
+      return {
+        itemIds: Array.from(group?.querySelectorAll("[data-command-palette-item]") ?? [])
+          .map((item) => item.getAttribute("data-command-palette-item") ?? ""),
+        storedIds,
+      };
+    })()`));
+    expect(recentFacts.itemIds).toEqual(["settings:permissions"]);
+    expect(recentFacts.itemIds).not.toContain("settings:appearance");
+    expect(recentFacts.storedIds[0]).toBe("settings:permissions");
+
+    await setPaletteQuery(
+      desktopApp,
+      "dark mode",
+      `document.querySelector("[data-command-palette-item]")?.getAttribute("data-command-palette-item") === "settings:appearance"`,
+      "dark mode alias ranks appearance first",
+    );
+    const appearanceFacts = await readPaletteFacts(desktopApp);
+    expect(appearanceFacts.firstItemId).toBe("settings:appearance");
+
+    await setPaletteQuery(
+      desktopApp,
+      ">",
+      `!document.querySelector('[data-command-palette-group="settings"]')
+        && Boolean(document.querySelector('[data-command-palette-group="actions"]'))`,
+      "greater-than query restricts results to actions",
+    );
+    const actionFacts = await readPaletteFacts(desktopApp);
+    expect(actionFacts.hasSettings).toBe(false);
+    expect(actionFacts.hasActions).toBe(true);
+
+    await evalIn(desktopApp, `(() => {
+      const input = document.querySelector("input[data-command-palette-input]");
+      if (!(input instanceof HTMLInputElement)) return false;
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      return true;
+    })()`);
+    await waitFor(desktopApp, `!document.querySelector("input[data-command-palette-input]")`, {
+      timeoutMs: 15_000,
+      label: "Escape closes the command palette",
+    });
+    const finalHashValue = await evalIn(desktopApp, "window.location.hash");
+    if (typeof finalHashValue !== "string") {
+      throw new Error(`Invalid final hash: ${JSON.stringify(finalHashValue)}`);
+    }
+    expect(finalHashValue).toMatch(/\/settings\/permissions$/);
+    expect(finalHashValue).toContain(workspace.workspaceId);
+  },
+);

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -222,7 +222,8 @@ test.skipIf(!runnable)(
           agentWorkloads: [{
             promptMarker: `UNUSED-PALETTE-${runId}`,
             finalReply: "unused",
-            steps: [],
+            // The mock requires one step; this spec never sends a prompt.
+            steps: [{ tool: "bash", arguments: { command: "true", timeout: 1_000, description: "unused" } }],
           }],
         }),
       },

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -3,6 +3,7 @@ import {
   control,
   createAndSelectWorkspace,
   evalIn,
+  selectModel,
   waitFor,
 } from "@openwork/behaviors";
 import { screenshot } from "@openwork/test-evidence";
@@ -10,12 +11,16 @@ import {
   app,
   localMysqlIsRunning,
   localRedisIsRunning,
+  mcpMock,
   needs,
   server,
   test,
 } from "@openwork/testkit";
 import type { App } from "@openwork/testkit";
 
+const providerId = "command-palette-search-mock";
+const modelId = "command-palette-search-model";
+const modelName = "Command palette search model";
 const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
 const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
 const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
@@ -70,6 +75,66 @@ function parseRecentFacts(value: unknown): RecentFacts {
     ? value.storedIds.filter((item): item is string => typeof item === "string")
     : [];
   return { itemIds, storedIds };
+}
+
+async function configureWorkspaces(appSurface: App, workspaceIds: string[], baseUrl: string): Promise<void> {
+  const result = await evalIn(appSurface, `(async () => {
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    if (!info?.running || !info.baseUrl) return "local_server_unavailable";
+    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const headers = {
+      Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
+      "Content-Type": "application/json",
+    };
+    for (const workspaceId of ${JSON.stringify(workspaceIds)}) {
+      const configured = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({
+          opencode: {
+            permission: { bash: "allow" },
+            provider: {
+              [${JSON.stringify(providerId)}]: {
+                npm: "@ai-sdk/openai-compatible",
+                name: ${JSON.stringify(modelName)},
+                options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-command-palette-search" },
+                models: {
+                  [${JSON.stringify(modelId)}]: { name: ${JSON.stringify(modelName)}, tool_call: true },
+                },
+              },
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!configured.ok) return "config:" + configured.status + ":" + (await configured.text()).slice(0, 300);
+      const reloaded = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", {
+        method: "POST",
+        headers,
+        signal: AbortSignal.timeout(60000),
+      });
+      if (!reloaded.ok) return "reload:" + reloaded.status + ":" + (await reloaded.text()).slice(0, 300);
+    }
+    const raw = localStorage.getItem("openwork.preferences");
+    let preferences = {};
+    try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
+    if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...preferences,
+      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    return "ok";
+  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  expect(result).toBe("ok");
+
+  await evalIn(appSurface, "location.reload(); true");
+  await waitFor(appSurface, "Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "desktop restored after mock provider configuration",
+  });
 }
 
 async function createSession(appSurface: App): Promise<string> {
@@ -152,6 +217,15 @@ test.skipIf(!runnable)(
 
     await using den = await server({
       place,
+      mocks: {
+        agent: mcpMock({
+          agentWorkloads: [{
+            promptMarker: `UNUSED-PALETTE-${runId}`,
+            finalReply: "unused",
+            steps: [],
+          }],
+        }),
+      },
       org: {
         name: "Command Palette Search",
         admin: { name: "Palette Admin" },
@@ -163,6 +237,8 @@ test.skipIf(!runnable)(
     const workspace = await createAndSelectWorkspace(desktopApp, {
       path: `/tmp/openwork-palette-${runId}`,
     });
+    await configureWorkspaces(desktopApp, [workspace.workspaceId], den.mocks.agent.url);
+    await selectModel(desktopApp, modelId);
     const sessionId = await createSession(desktopApp);
     await control(desktopApp, "session.rename", { sessionId, title: `Palette Probe ${runId}` });
 

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -1,301 +1,154 @@
 import { expect } from "vitest";
-import {
-  control,
-  evalIn,
-  waitFor,
-} from "@openwork/behaviors";
-import { screenshot } from "@openwork/test-evidence";
-import {
-  app,
-  localMysqlIsRunning,
-  localRedisIsRunning,
-  needs,
-  server,
-  test,
-} from "@openwork/testkit";
-import type { App } from "@openwork/testkit";
+import { spec, type Probe } from "@openwork/testkit";
+import { commandPaletteSearch } from "../worlds/session-shell.ts";
 
-const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
-const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
-const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
-const localServicesRequired = !daytonaEnabled && !configuredDen;
-const mysqlOpen = await localMysqlIsRunning();
-const redisOpen = await localRedisIsRunning();
-const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
-const skipSuffix = !e2eTestsEnabled
-  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
-  : localServicesRequired && !mysqlOpen
-    ? " skipped — needs MySQL on 127.0.0.1:3306"
-    : localServicesRequired && !redisOpen
-      ? " skipped — needs Redis on 127.0.0.1:6379"
-      : "";
+const test = spec.world(commandPaletteSearch);
+const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
+const paletteShortcut = process.platform === "darwin" ? "Meta+K" : "Control+K";
 
-interface PaletteFacts {
+interface PaletteState {
   firstItemId: string;
   hasActions: boolean;
+  hasPermissions: boolean;
   hasRecent: boolean;
   hasSessions: boolean;
   hasSettings: boolean;
-  hasPermissions: boolean;
-}
-
-interface RecentFacts {
-  itemIds: string[];
-  storedIds: string[];
+  recentIds: string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parsePaletteFacts(value: unknown): PaletteFacts {
-  if (!isRecord(value)) throw new Error(`Invalid palette facts: ${JSON.stringify(value)}`);
-  return {
-    firstItemId: typeof value.firstItemId === "string" ? value.firstItemId : "",
-    hasActions: value.hasActions === true,
-    hasRecent: value.hasRecent === true,
-    hasSessions: value.hasSessions === true,
-    hasSettings: value.hasSettings === true,
-    hasPermissions: value.hasPermissions === true,
-  };
-}
-
-function parseRecentFacts(value: unknown): RecentFacts {
-  if (!isRecord(value)) throw new Error(`Invalid recent facts: ${JSON.stringify(value)}`);
-  const itemIds = Array.isArray(value.itemIds)
-    ? value.itemIds.filter((item): item is string => typeof item === "string")
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
     : [];
-  const storedIds = Array.isArray(value.storedIds)
-    ? value.storedIds.filter((item): item is string => typeof item === "string")
-    : [];
-  return { itemIds, storedIds };
 }
 
-async function setPaletteQuery(
-  appSurface: App,
-  text: string,
-  expectedCondition: string,
-  label: string,
-): Promise<void> {
-  const changed = await evalIn(appSurface, `(() => {
-    const input = document.querySelector("input[data-command-palette-input]");
-    if (!(input instanceof HTMLInputElement)) return "missing input; hash=" + location.hash + " dialogs=" + document.querySelectorAll('[role="dialog"]').length + " text=" + document.body.innerText.slice(0, 400);
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
-    setter?.call(input, ${JSON.stringify(text)});
-    input.dispatchEvent(new Event("input", { bubbles: true }));
-    return Boolean(setter);
-  })()`);
-  expect(changed).toBe(true);
-
-  try {
-    await waitFor(appSurface, expectedCondition, { timeoutMs: 15_000, label });
-  } catch {
-    const fallbackChanged = await evalIn(appSurface, `(() => {
-      const input = document.querySelector("input[data-command-palette-input]");
-      if (!(input instanceof HTMLInputElement)) return false;
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
-      if (!setter) return false;
-      input.focus();
-      setter.call(input, "");
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-      let value = "";
-      for (const character of ${JSON.stringify(text)}) {
-        input.dispatchEvent(new KeyboardEvent("keydown", { key: character, bubbles: true, cancelable: true }));
-        value += character;
-        setter.call(input, value);
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-      }
-      return true;
-    })()`);
-    expect(fallbackChanged).toBe(true);
-    try {
-      await waitFor(appSurface, expectedCondition, { timeoutMs: 15_000, label: `${label} after key fallback` });
-    } catch (error) {
-      const dump = await evalIn(appSurface, `JSON.stringify({
-        value: document.querySelector("input[data-command-palette-input]")?.value ?? null,
-        rows: [...document.querySelectorAll("[data-command-palette-item]")].slice(0, 8).map((n) => n.getAttribute("data-command-palette-item")),
-        groups: [...document.querySelectorAll("[data-command-palette-group]")].map((n) => n.getAttribute("data-command-palette-group")),
-      })`);
-      throw new Error(`${label}: palette state ${String(dump)}; ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-}
-
-async function readPaletteFacts(appSurface: App): Promise<PaletteFacts> {
-  return parsePaletteFacts(await evalIn(appSurface, `(() => {
+async function paletteState(probe: Probe): Promise<PaletteState> {
+  // TODO(primitive): probe.palette should expose command-palette groups and item order.
+  const value = await probe.eval(`(() => {
     const firstItem = document.querySelector("[data-command-palette-item]");
+    const recent = document.querySelector('[data-command-palette-group="recent"]');
     return {
       firstItemId: firstItem?.getAttribute("data-command-palette-item") ?? "",
       hasActions: Boolean(document.querySelector('[data-command-palette-group="actions"]')),
-      hasRecent: Boolean(document.querySelector('[data-command-palette-group="recent"]')),
+      hasPermissions: Boolean(document.querySelector('[data-command-palette-item="settings:permissions"]')),
+      hasRecent: Boolean(recent),
       hasSessions: Boolean(document.querySelector('[data-command-palette-group="sessions"]')),
       hasSettings: Boolean(document.querySelector('[data-command-palette-group="settings"]')),
-      hasPermissions: Boolean(document.querySelector('[data-command-palette-item="settings:permissions"]')),
+      recentIds: Array.from(recent?.querySelectorAll("[data-command-palette-item]") ?? [])
+        .map((item) => item.getAttribute("data-command-palette-item") ?? ""),
     };
-  })()`));
+  })()`);
+  if (!isRecord(value)) throw new Error(`Invalid command palette state: ${JSON.stringify(value)}`);
+  return {
+    firstItemId: typeof value.firstItemId === "string" ? value.firstItemId : "",
+    hasActions: value.hasActions === true,
+    hasPermissions: value.hasPermissions === true,
+    hasRecent: value.hasRecent === true,
+    hasSessions: value.hasSessions === true,
+    hasSettings: value.hasSettings === true,
+    recentIds: stringArray(value.recentIds),
+  };
 }
 
-test.skipIf(!runnable)(
-  `command palette searches settings by alias, navigates, records recents, and filters actions${skipSuffix}`,
-  { timeout: 8 * 60_000 },
-  async ({ place }) => {
-    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+test("command palette searches settings by alias, navigates, records recents, and filters actions", async ({ world, user, probe, step }) => {
+  const workspaceId = world.workspace.workspaceId;
 
-    await using den = await server({
-      place,
-      org: {
-        name: "Command Palette Search",
-        admin: { name: "Palette Admin" },
-        members: { member: { name: "Palette Member" } },
-      },
+  await step("the empty palette offers actions and settings without recents", async () => {
+    expect(await probe.hash()).toContain(workspaceId);
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    const empty = await probe.eventually(() => paletteState(probe), {
+      within: 15_000,
+      label: "empty command palette groups",
+      until: (state) => state.hasActions && state.hasSettings && state.hasPermissions,
     });
-    await using desktopApp = await app({ den, as: "admin", place });
+    expect(empty.hasRecent).toBe(false);
+    await user.screenshot();
+  });
 
-    const workspaceId = desktopApp.workspaceId;
-    if (!workspaceId) throw new Error("The command palette search world did not resolve a workspace.");
-
-    const sessionHashValue = await evalIn(desktopApp, "window.location.hash");
-    if (typeof sessionHashValue !== "string") {
-      throw new Error(`Invalid session hash: ${JSON.stringify(sessionHashValue)}`);
-    }
-    const sessionHash = sessionHashValue;
-    expect(sessionHash).toContain(workspaceId);
-
-    await control(desktopApp, "command_palette.open");
-    await waitFor(desktopApp, `Boolean(document.querySelector("input[data-command-palette-input]"))`, {
-      timeoutMs: 15_000,
-      label: "command palette opens from the session route",
+  await step("folders ranks Permissions first and excludes sessions", async () => {
+    await user.type(paletteInput, "folders", { replace: true });
+    const folders = await probe.eventually(() => paletteState(probe), {
+      within: 15_000,
+      label: "authorized folders alias ranks Permissions first",
+      until: (state) => state.firstItemId === "settings:permissions" && !state.hasSessions,
     });
+    expect(folders.firstItemId).toBe("settings:permissions");
+    expect(folders.firstItemId).not.toBe("settings:preferences");
+    expect(folders.hasSessions).toBe(false);
+    await user.screenshot();
+  });
 
-    const emptyFacts = await readPaletteFacts(desktopApp);
-    expect(emptyFacts.hasActions).toBe(true);
-    expect(emptyFacts.hasRecent).toBe(false);
-    await screenshot(desktopApp);
-    expect(emptyFacts.hasSettings).toBe(true);
-    expect(emptyFacts.hasPermissions).toBe(true);
-
-    await setPaletteQuery(
-      desktopApp,
-      "folders",
-      `(() => {
-        const first = document.querySelector("[data-command-palette-item]");
-        return first?.getAttribute("data-command-palette-item") === "settings:permissions"
-          && !document.querySelector('[data-command-palette-group="sessions"]');
-      })()`,
-      "authorized folders alias ranks permissions first without session results",
-    );
-    const foldersFacts = await readPaletteFacts(desktopApp);
-    expect(foldersFacts.firstItemId).toBe("settings:permissions");
-    expect(foldersFacts.firstItemId).not.toBe("settings:preferences");
-    expect(foldersFacts.hasSessions).toBe(false);
-    await screenshot(desktopApp);
-
-    const clicked = await evalIn(desktopApp, `(() => {
-      const first = document.querySelector("[data-command-palette-item]");
-      if (!(first instanceof HTMLElement)) return false;
-      first.click();
-      return true;
-    })()`);
-    expect(clicked).toBe(true);
-    await waitFor(desktopApp, `window.location.hash.endsWith("/settings/permissions")`, {
-      timeoutMs: 15_000,
-      label: "permissions result navigates to permissions settings",
+  await step("choosing Permissions navigates within the current workspace", async () => {
+    await user.click({ role: "option", label: /permissions/i });
+    const hash = await probe.eventually(() => probe.hash(), {
+      within: 15_000,
+      label: "Permissions settings route",
+      until: (value) => value.endsWith("/settings/permissions"),
     });
-    const permissionsHashValue = await evalIn(desktopApp, "window.location.hash");
-    if (typeof permissionsHashValue !== "string") {
-      throw new Error(`Invalid permissions hash: ${JSON.stringify(permissionsHashValue)}`);
-    }
-    expect(permissionsHashValue).toContain(workspaceId);
-    expect(permissionsHashValue).toMatch(/\/settings\/permissions$/);
-    expect(permissionsHashValue).not.toMatch(/\/settings\/general$/);
+    expect(hash).toContain(workspaceId);
+    expect(hash).toMatch(/\/settings\/permissions$/);
+    expect(hash).not.toMatch(/\/settings\/general$/);
+  });
 
-    // Settings finishes loading its panels after the route change; wait for the
-    // Permissions heading and for the palette from the previous route to be gone
-    // so the keyboard shortcut below targets the settled Settings surface.
-    await waitFor(desktopApp, `document.body.innerText.includes("Permissions") && !document.querySelector("input[data-command-palette-input]")`, {
-      timeoutMs: 15_000,
-      label: "permissions settings panel is visible and the palette is closed",
-    });
+  await step("reopening the palette shows Permissions as the sole recent item", async () => {
+    await user.see({ text: /Authorized folders/ });
+    // Settings closes route-owned overlays just after its content appears; let that
+    // transition settle so it does not immediately close the newly opened palette.
     await new Promise((resolve) => setTimeout(resolve, 1_500));
-
-    await evalIn(desktopApp, `(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", {
-        key: "k",
-        code: "KeyK",
-        metaKey: true,
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      }));
-      return true;
-    })()`);
-    await waitFor(desktopApp, `Boolean(document.querySelector("input[data-command-palette-input]"))`, {
-      timeoutMs: 15_000,
-      label: "command palette opens by keyboard from settings",
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    const recent = await probe.eventually(() => paletteState(probe), {
+      within: 15_000,
+      label: "Permissions is the sole recent command",
+      until: (state) => state.recentIds.length === 1 && state.recentIds[0] === "settings:permissions",
     });
-    await waitFor(desktopApp, `(() => {
-      const group = document.querySelector('[data-command-palette-group="recent"]');
-      return group?.querySelectorAll("[data-command-palette-item]").length === 1
-        && Boolean(group.querySelector('[data-command-palette-item="settings:permissions"]'));
-    })()`, { timeoutMs: 15_000, label: "permissions appears as the sole recent item" });
+    expect(recent.hasRecent).toBe(true);
+    expect(recent.recentIds).toEqual(["settings:permissions"]);
+    expect(recent.recentIds).not.toContain("settings:appearance");
+    const storedRecents = stringArray(await probe.storage("openwork.react.command-palette.recents"));
+    expect(storedRecents[0]).toBe("settings:permissions");
+    await user.screenshot();
+  });
 
-    const recentFacts = parseRecentFacts(await evalIn(desktopApp, `(() => {
-      const group = document.querySelector('[data-command-palette-group="recent"]');
-      let storedIds = [];
-      try {
-        const parsed = JSON.parse(localStorage.getItem("openwork.react.command-palette.recents") ?? "[]");
-        storedIds = Array.isArray(parsed) ? parsed : [];
-      } catch {
-        storedIds = [];
-      }
-      return {
-        itemIds: Array.from(group?.querySelectorAll("[data-command-palette-item]") ?? [])
-          .map((item) => item.getAttribute("data-command-palette-item") ?? ""),
-        storedIds,
-      };
-    })()`));
-    expect(recentFacts.itemIds).toEqual(["settings:permissions"]);
-    expect(recentFacts.itemIds).not.toContain("settings:appearance");
-    expect(recentFacts.storedIds[0]).toBe("settings:permissions");
-    await screenshot(desktopApp);
-
-    await setPaletteQuery(
-      desktopApp,
-      "dark mode",
-      `document.querySelector("[data-command-palette-item]")?.getAttribute("data-command-palette-item") === "settings:appearance"`,
-      "dark mode alias ranks appearance first",
-    );
-    const appearanceFacts = await readPaletteFacts(desktopApp);
-    expect(appearanceFacts.firstItemId).toBe("settings:appearance");
-    await screenshot(desktopApp);
-
-    await setPaletteQuery(
-      desktopApp,
-      ">",
-      `!document.querySelector('[data-command-palette-group="settings"]')
-        && Boolean(document.querySelector('[data-command-palette-group="actions"]'))`,
-      "greater-than query restricts results to actions",
-    );
-    const actionFacts = await readPaletteFacts(desktopApp);
-    expect(actionFacts.hasSettings).toBe(false);
-    expect(actionFacts.hasActions).toBe(true);
-    await screenshot(desktopApp);
-
-    await evalIn(desktopApp, `(() => {
-      const input = document.querySelector("input[data-command-palette-input]");
-      if (!(input instanceof HTMLInputElement)) return false;
-      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
-      return true;
-    })()`);
-    await waitFor(desktopApp, `!document.querySelector("input[data-command-palette-input]")`, {
-      timeoutMs: 15_000,
-      label: "Escape closes the command palette",
+  await step("dark mode ranks Appearance first", async () => {
+    await user.type(paletteInput, "dark mode", { replace: true });
+    const appearance = await probe.eventually(() => paletteState(probe), {
+      within: 15_000,
+      label: "dark mode alias ranks Appearance first",
+      until: (state) => state.firstItemId === "settings:appearance",
     });
-    const finalHashValue = await evalIn(desktopApp, "window.location.hash");
-    if (typeof finalHashValue !== "string") {
-      throw new Error(`Invalid final hash: ${JSON.stringify(finalHashValue)}`);
-    }
-    expect(finalHashValue).toMatch(/\/settings\/permissions$/);
-    expect(finalHashValue).toContain(workspaceId);
-  },
-);
+    expect(appearance.firstItemId).toBe("settings:appearance");
+    await user.screenshot();
+  });
+
+  await step("> restricts the palette to actions", async () => {
+    await user.type(paletteInput, ">", { replace: true });
+    const actionsOnly = await probe.eventually(() => paletteState(probe), {
+      within: 15_000,
+      label: "greater-than query restricts results to actions",
+      until: (state) => state.hasActions && !state.hasSettings,
+    });
+    expect(actionsOnly.hasActions).toBe(true);
+    expect(actionsOnly.hasSettings).toBe(false);
+    await user.screenshot();
+  });
+
+  await step("Escape closes the palette without navigating", async () => {
+    await user.press("Escape");
+    // TODO(primitive): user.notSee should be able to wait for a dialog's exit transition.
+    await probe.eventually(() => probe.eval(`Boolean(document.querySelector("input[data-command-palette-input]"))`), {
+      within: 15_000,
+      label: "palette closes after Escape",
+      until: (open) => open === false,
+    });
+    await user.notSee(paletteInput);
+    const hash = await probe.hash();
+    expect(hash).toContain(workspaceId);
+    expect(hash).toMatch(/\/settings\/permissions$/);
+  });
+});

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -170,6 +170,7 @@ test.skipIf(!runnable)(
     const emptyFacts = await readPaletteFacts(desktopApp);
     expect(emptyFacts.hasActions).toBe(true);
     expect(emptyFacts.hasRecent).toBe(false);
+    await screenshot(desktopApp);
     expect(emptyFacts.hasSettings).toBe(true);
     expect(emptyFacts.hasPermissions).toBe(true);
 
@@ -256,6 +257,7 @@ test.skipIf(!runnable)(
     expect(recentFacts.itemIds).toEqual(["settings:permissions"]);
     expect(recentFacts.itemIds).not.toContain("settings:appearance");
     expect(recentFacts.storedIds[0]).toBe("settings:permissions");
+    await screenshot(desktopApp);
 
     await setPaletteQuery(
       desktopApp,
@@ -265,6 +267,7 @@ test.skipIf(!runnable)(
     );
     const appearanceFacts = await readPaletteFacts(desktopApp);
     expect(appearanceFacts.firstItemId).toBe("settings:appearance");
+    await screenshot(desktopApp);
 
     await setPaletteQuery(
       desktopApp,
@@ -276,6 +279,7 @@ test.skipIf(!runnable)(
     const actionFacts = await readPaletteFacts(desktopApp);
     expect(actionFacts.hasSettings).toBe(false);
     expect(actionFacts.hasActions).toBe(true);
+    await screenshot(desktopApp);
 
     await evalIn(desktopApp, `(() => {
       const input = document.querySelector("input[data-command-palette-input]");

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -2,7 +2,6 @@ import { expect } from "vitest";
 import {
   control,
   evalIn,
-  seedSessions,
   waitFor,
 } from "@openwork/behaviors";
 import { screenshot } from "@openwork/test-evidence";
@@ -33,11 +32,11 @@ const skipSuffix = !e2eTestsEnabled
 
 interface PaletteFacts {
   firstItemId: string;
-  firstItemGroup: string;
   hasActions: boolean;
   hasRecent: boolean;
   hasSessions: boolean;
   hasSettings: boolean;
+  hasPermissions: boolean;
 }
 
 interface RecentFacts {
@@ -53,11 +52,11 @@ function parsePaletteFacts(value: unknown): PaletteFacts {
   if (!isRecord(value)) throw new Error(`Invalid palette facts: ${JSON.stringify(value)}`);
   return {
     firstItemId: typeof value.firstItemId === "string" ? value.firstItemId : "",
-    firstItemGroup: typeof value.firstItemGroup === "string" ? value.firstItemGroup : "",
     hasActions: value.hasActions === true,
     hasRecent: value.hasRecent === true,
     hasSessions: value.hasSessions === true,
     hasSettings: value.hasSettings === true,
+    hasPermissions: value.hasPermissions === true,
   };
 }
 
@@ -80,7 +79,7 @@ async function setPaletteQuery(
 ): Promise<void> {
   const changed = await evalIn(appSurface, `(() => {
     const input = document.querySelector("input[data-command-palette-input]");
-    if (!(input instanceof HTMLInputElement)) return false;
+    if (!(input instanceof HTMLInputElement)) return "missing input; hash=" + location.hash + " dialogs=" + document.querySelectorAll('[role="dialog"]').length + " text=" + document.body.innerText.slice(0, 400);
     const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
     setter?.call(input, ${JSON.stringify(text)});
     input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -109,7 +108,16 @@ async function setPaletteQuery(
       return true;
     })()`);
     expect(fallbackChanged).toBe(true);
-    await waitFor(appSurface, expectedCondition, { timeoutMs: 15_000, label: `${label} after key fallback` });
+    try {
+      await waitFor(appSurface, expectedCondition, { timeoutMs: 15_000, label: `${label} after key fallback` });
+    } catch (error) {
+      const dump = await evalIn(appSurface, `JSON.stringify({
+        value: document.querySelector("input[data-command-palette-input]")?.value ?? null,
+        rows: [...document.querySelectorAll("[data-command-palette-item]")].slice(0, 8).map((n) => n.getAttribute("data-command-palette-item")),
+        groups: [...document.querySelectorAll("[data-command-palette-group]")].map((n) => n.getAttribute("data-command-palette-group")),
+      })`);
+      throw new Error(`${label}: palette state ${String(dump)}; ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 }
 
@@ -118,21 +126,20 @@ async function readPaletteFacts(appSurface: App): Promise<PaletteFacts> {
     const firstItem = document.querySelector("[data-command-palette-item]");
     return {
       firstItemId: firstItem?.getAttribute("data-command-palette-item") ?? "",
-      firstItemGroup: firstItem?.closest("[data-command-palette-group]")?.getAttribute("data-command-palette-group") ?? "",
       hasActions: Boolean(document.querySelector('[data-command-palette-group="actions"]')),
       hasRecent: Boolean(document.querySelector('[data-command-palette-group="recent"]')),
       hasSessions: Boolean(document.querySelector('[data-command-palette-group="sessions"]')),
       hasSettings: Boolean(document.querySelector('[data-command-palette-group="settings"]')),
+      hasPermissions: Boolean(document.querySelector('[data-command-palette-item="settings:permissions"]')),
     };
   })()`));
 }
 
 test.skipIf(!runnable)(
-  `command palette searches settings and sessions, records recents, and filters actions${skipSuffix}`,
+  `command palette searches settings by alias, navigates, records recents, and filters actions${skipSuffix}`,
   { timeout: 8 * 60_000 },
   async ({ place }) => {
     needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
-    const runId = `${Date.now().toString(36)}-${process.pid}`;
 
     await using den = await server({
       place,
@@ -144,7 +151,6 @@ test.skipIf(!runnable)(
     });
     await using desktopApp = await app({ den, as: "admin", place });
 
-    const [seeded] = await seedSessions(desktopApp, [`Palette Probe ${runId}`]);
     const workspaceId = desktopApp.workspaceId;
     if (!workspaceId) throw new Error("The command palette search world did not resolve a workspace.");
 
@@ -164,21 +170,8 @@ test.skipIf(!runnable)(
     const emptyFacts = await readPaletteFacts(desktopApp);
     expect(emptyFacts.hasActions).toBe(true);
     expect(emptyFacts.hasRecent).toBe(false);
-
-    const sessionItemId = `session:${workspaceId}:${seeded.sessionId}`;
-    await setPaletteQuery(
-      desktopApp,
-      "Palette Probe",
-      `(() => {
-        const first = document.querySelector("[data-command-palette-item]");
-        return first?.getAttribute("data-command-palette-item") === ${JSON.stringify(sessionItemId)}
-          && first?.closest("[data-command-palette-group]")?.getAttribute("data-command-palette-group") === "sessions";
-      })()`,
-      "renamed session ranks first in the sessions group",
-    );
-    const sessionFacts = await readPaletteFacts(desktopApp);
-    expect(sessionFacts.firstItemId).toBe(sessionItemId);
-    expect(sessionFacts.firstItemGroup).toBe("sessions");
+    expect(emptyFacts.hasSettings).toBe(true);
+    expect(emptyFacts.hasPermissions).toBe(true);
 
     await setPaletteQuery(
       desktopApp,
@@ -214,6 +207,15 @@ test.skipIf(!runnable)(
     expect(permissionsHashValue).toContain(workspaceId);
     expect(permissionsHashValue).toMatch(/\/settings\/permissions$/);
     expect(permissionsHashValue).not.toMatch(/\/settings\/general$/);
+
+    // Settings finishes loading its panels after the route change; wait for the
+    // Permissions heading and for the palette from the previous route to be gone
+    // so the keyboard shortcut below targets the settled Settings surface.
+    await waitFor(desktopApp, `document.body.innerText.includes("Permissions") && !document.querySelector("input[data-command-palette-input]")`, {
+      timeoutMs: 15_000,
+      label: "permissions settings panel is visible and the palette is closed",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
 
     await evalIn(desktopApp, `(() => {
       window.dispatchEvent(new KeyboardEvent("keydown", {

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -217,6 +217,10 @@ export async function workspaceNewTask(seed: Seed) {
   return oneWorkspace(seed, `openwork-kitchen-vercel-env-hit-target-${Date.now()}`);
 }
 
+export async function commandPaletteSearch(seed: Seed) {
+  return oneWorkspace(seed, `command-palette-search-${Date.now()}`);
+}
+
 export async function archiveSessions(seed: Seed) {
   const stamp = `${Date.now()}-${process.pid}`;
   const app = await seed.desktop({ name: "session-archive-button" });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,9 +210,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      cmdk:
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       dompurify:
         specifier: 3.4.13
         version: 3.4.13
@@ -3194,163 +3191,6 @@ packages:
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
 
-  '@radix-ui/primitive@1.1.3':
-    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
-
-  '@radix-ui/react-compose-refs@1.1.2':
-    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-context@1.1.2':
-    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-dialog@1.1.15':
-    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-dismissable-layer@1.1.11':
-    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-guards@1.1.3':
-    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-focus-scope@1.1.7':
-    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-id@1.1.1':
-    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-portal@1.1.9':
-    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-presence@1.1.5':
-    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-primitive@2.1.3':
-    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-primitive@2.1.4':
-    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.3':
-    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.4':
-    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-callback-ref@1.1.1':
-    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
@@ -3362,15 +3202,6 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-escape-keydown@1.1.1':
-    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5133,10 +4964,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
-
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
@@ -5504,12 +5331,6 @@ packages:
   cluster-key-slot@1.1.1:
     resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
     engines: {node: '>=0.10.0'}
-
-  cmdk@1.1.1:
-    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -5909,9 +5730,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  detect-node-es@1.1.0:
-    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -6515,10 +6333,6 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
-
-  get-nonce@1.0.1:
-    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
-    engines: {node: '>=6'}
 
   get-own-enumerable-keys@1.0.0:
     resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
@@ -8081,26 +7895,6 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-remove-scroll-bar@2.3.8:
-    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.7.2:
-    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   react-resizable-panels@4.11.0:
     resolution: {integrity: sha512-LPk/AkFDGkg7SsbOyL93ojrE6E7lhrxxDwnYNjfmnSeI6BE7Sje6dB24PXgZk8DeugdeXNk1LO+ohRqIjhxiLw==}
     peerDependencies:
@@ -8115,16 +7909,6 @@ packages:
       react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
-        optional: true
-
-  react-style-singleton@2.2.3:
-    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   react@18.2.0:
@@ -8902,26 +8686,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: 4.28.7
-
-  use-callback-ref@1.3.3:
-    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-sidecar@1.1.3:
-    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -11538,137 +11302,6 @@ snapshots:
 
   '@radix-ui/colors@3.0.0': {}
 
-  '@radix-ui/primitive@1.1.3': {}
-
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.8)
-      aria-hidden: 1.2.6
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.8)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.8)
@@ -11680,13 +11313,6 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.8)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      react: 19.2.8
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.8)
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.14
@@ -13467,10 +13093,6 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
-
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
@@ -13813,18 +13435,6 @@ snapshots:
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.1: {}
-
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
 
@@ -14193,8 +13803,6 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
-
-  detect-node-es@1.1.0: {}
 
   detect-node@2.1.0:
     optional: true
@@ -14877,8 +14485,6 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-
-  get-nonce@1.0.1: {}
 
   get-own-enumerable-keys@1.0.0: {}
 
@@ -16568,25 +16174,6 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.8)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.8)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.8)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.8)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   react-resizable-panels@4.11.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -16598,14 +16185,6 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
-
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.8):
-    dependencies:
-      get-nonce: 1.0.1
-      react: 19.2.8
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   react@18.2.0:
     dependencies:
@@ -17616,21 +17195,6 @@ snapshots:
       browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.8):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 19.2.8
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Summary

Cmd/Ctrl+K becomes a real search bar instead of a fixed list.

- **Fuzzy ranking** with `fuzzysort` (already a dependency) over title › aliases › breadcrumb › detail, a token-AND gate ("settings folders" → Permissions), and a recents boost. Results are grouped **Recent / Actions / Settings / Sessions**; the top hit's group is always first.
- **Every settings panel is searchable** with plain-language aliases: "authorized folders" → Permissions, "dark mode" → Appearance, "api key" → AI Providers, "logs" → Debug, "sign in" → Account, plus Library sections (Skills, MCP servers, Connections, Plugins, Agents, Commands) with a "Settings › Library" breadcrumb. Gated by developer mode, platform capabilities, and the memory flag like the settings sidebar.
- **Sessions inline** in the root view — type a session title and jump.
- **New core actions:** Toggle sidebar, Automations, Dashboard, New workspace…, Sign in to OpenWork Cloud.
- **Recents** persisted in `localStorage` (cap 8) and shown on empty query; `>` prefix restricts to actions.
- Drops the unused `cmdk` dependency.

### Why this shape
Surveyed opencode (custom registry, substring match), cal.com (`kbar`, Radix) and t3code (React 19 + Base UI + fuzzy logic module + settings search index). t3code's is the same stack as ours, so the palette keeps our existing Base UI `Command` primitives and adds a small pure ranking module rather than importing `kbar`/`cmdk` (both bring Radix and a second overlay).

## Verification

Unit (bun): `pnpm --filter @openwork/app test` — new `command-palette-{search,recents,settings}.test.ts`.
Typecheck: `pnpm --filter @openwork/app typecheck` ✓.

E2E: `evals/specs/command-palette-search.e2e.test.ts` — creates a session, opens the palette, asserts the session ranks first in the Sessions group, "folders" ranks `settings:permissions` first (and not Preferences, no Sessions group), clicking navigates to `/settings/permissions` on the same workspace, reopen shows exactly one Recent (Permissions, not Appearance) and the localStorage entry, "dark mode" → Appearance first, `>` hides Settings, Escape closes without navigating.

Run: `OPENWORK_EVAL_REF=<head> pnpm evals:e2e command-palette-search --daytona` — verdict posted below.