### PR TITLE
ci(changelog): fire the release-notes dispatch and let re-runs repair documented releases

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           if grep -Fq "[$TAG](https://github.com/different-ai/openwork/compare/" packages/docs/changelog.mdx; then
             echo "documented=true" >> "$GITHUB_OUTPUT"
-            echo "$TAG is already documented; skipping changelog automation."
+            echo "$TAG is already documented; skipping docs generation and only refreshing the release notes."
           else
             echo "documented=false" >> "$GITHUB_OUTPUT"
           fi
@@ -131,7 +131,7 @@ jobs:
           echo "PREV=$PREV" >> "$GITHUB_ENV"
 
       - name: Setup Node
-        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        if: steps.guard.outputs.stable == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -197,8 +197,10 @@ jobs:
             --body-file /tmp/pr_body.txt)"
           gh pr merge "$pr_url" --auto --squash --delete-branch
 
+      # Runs for already-documented tags too, so a manual dispatch can repair a
+      # release whose notes were hand-written or whose original dispatch failed.
       - name: Update GitHub Release notes
-        if: steps.guard.outputs.stable == 'true' && steps.dedupe.outputs.documented == 'false'
+        if: steps.guard.outputs.stable == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1050,7 +1050,12 @@ jobs:
   dispatch-changelog:
     name: Dispatch changelog
     needs: [resolve-release, publish-release]
-    if: needs.publish-release.outputs.published_stable == 'true'
+    # always() is required: resolve-benchmark is a skipped ancestor on every
+    # production release, and the implicit success() would skip this job.
+    if: |
+      always() &&
+      needs.publish-release.result == 'success' &&
+      needs.publish-release.outputs.published_stable == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # This job deliberately checks out nothing and runs no repository code, so
     # actions: write is never available to code executed from the release tag.


### PR DESCRIPTION
## Problem

#4310 shipped in v0.18.42, yet the [v0.18.42 release](https://github.com/different-ai/openwork/releases/tag/v0.18.42) still shows the static boilerplate body. Two independent gaps:

1. **`dispatch-changelog` never ran.** In release run [33684965670](https://github.com/different-ai/openwork/actions/runs/33684922457) `publish-release` succeeded and logged `Set output 'published_stable'`, but `Dispatch changelog` was **skipped**. Its `if:` had no status function, so GitHub ANDed the implicit `success()`, which requires every *transitive* ancestor to succeed — and `resolve-benchmark` (an ancestor of `resolve-release`) is skipped on every production release. Every other downstream job in this workflow already uses `always() && needs.X.result == 'success'` for exactly this reason; this was the one job that did not.
2. **Manual re-runs could not repair a release.** `changelog.yml`'s final `Update GitHub Release notes` step was gated on `documented == 'false'`, so the "after merge" recovery from #4310 (`gh workflow run changelog.yml -f tag=v0.18.40`, run [33821890117](https://github.com/different-ai/openwork/actions/runs/33821890117)) hit "already documented" and skipped the release-body rewrite along with everything else. v0.18.40/v0.18.41 (hand-written in #4314) could never get real release notes.

## What changed

- **`release-macos-aarch64.yml`** — `dispatch-changelog.if` becomes `always() && needs.publish-release.result == 'success' && needs.publish-release.outputs.published_stable == 'true'`, matching the sibling jobs. Permissions and steps unchanged.
- **`changelog.yml`** — `Setup Node` and `Update GitHub Release notes` now run for every stable tag, documented or not. The extractor is idempotent and exits 1 with empty stdout for an undocumented tag, so a blank body still cannot be written. Docs generation / PR opening remain gated on `documented == 'false'`.

## Verification

Workflow-only change; no runtime surface in the app. Lane: **local**.

- Both workflow files parsed with `yaml`; asserted `jobs.dispatch-changelog.if` and the release-notes step `if` have the intended values.
- Repair path exercised locally against the hand-written v0.18.41 entry on `dev`:
  `node scripts/release/release-notes-from-changelog.mjs v0.18.41 --existing-body <boilerplate>` → emits the v0.18.41 title, five bullets, docs + compare links, and preserves the Windows signing line.
- Not provable locally: the live `gh workflow run` dispatch. First real proof is the next stable release; the `Dispatch changelog` job must show `success` instead of `skipped`.

## After merge

```
gh workflow run changelog.yml -f tag=v0.18.40
gh workflow run changelog.yml -f tag=v0.18.41
```
Both are already documented, so these now only rewrite the release bodies. v0.18.42 was dispatched by hand ([33843043520](https://github.com/different-ai/openwork/actions/runs/33843043520)) and takes the full generation path.
