### PR TITLE
feat(app): New split — open an empty session as the secondary pane

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -2021,6 +2021,7 @@ export default {
   "session_management.pin_session": "Pin session",
   "session_management.unpin_session": "Unpin session",
   "session_management.open_in_split_view": "Open in split view",
+  "session_management.new_split": "New split",
   "session_management.close_split_view": "Close split view",
   "session_management.split_view": "Split view",
   "session_management.pinned": "Pinned",

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -158,6 +158,7 @@ export type SessionPageSidebarProps = {
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
+  onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
   onCreateTaskWithPrompt?: (workspaceId: string, prompt: string, attachments?: ComposerAttachment[]) => void;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
@@ -1377,6 +1378,7 @@ export function SessionPage(props: SessionPageProps) {
           onOpenSession={openSessionTab}
           onPrefetchSession={props.sidebar.onPrefetchSession}
           onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
+          onCreateSplitTaskInWorkspace={props.sidebar.onCreateSplitTaskInWorkspace}
           onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
           onOpenDeleteSession={props.onDeleteSession ? (sessionId) => {
             setSessionActionId(sessionId);

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -16,6 +16,7 @@ export type SidebarContextValue = {
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
+  onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;
   onOpenDeleteSession?: (sessionId: string) => void;
   onArchiveSession?: (sessionId: string, archived: boolean) => void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  PanelRightOpen,
   Plus,
   Search,
   Share2,
@@ -290,6 +291,7 @@ function SessionMenuContent({
   const canOpenInSplit = Boolean(primary)
     && !isSameWorkbenchSession(sessionRef, primary)
     && !isSameWorkbenchSession(sessionRef, secondary);
+  const canCreateNewSplit = Boolean(primary);
   const openInSplitView = () => {
     const tab = {
       workspaceId,
@@ -314,6 +316,12 @@ function SessionMenuContent({
           <DropdownMenuItem data-session-menu-open-split onClick={openInSplitView}>
             <Columns2 className="size-4" />
             {t("session_management.open_in_split_view")}
+          </DropdownMenuItem>
+        ) : null}
+        {canCreateNewSplit ? (
+          <DropdownMenuItem data-session-menu-new-split onClick={() => ctx.onCreateSplitTaskInWorkspace(workspaceId)}>
+            <PanelRightOpen className="size-4" />
+            {t("session_management.new_split")}
           </DropdownMenuItem>
         ) : null}
         {isInSplit ? (
@@ -399,6 +407,12 @@ function SessionMenuContent({
         <ContextMenuItem data-session-menu-open-split onClick={openInSplitView}>
           <Columns2 className="size-4" />
           {t("session_management.open_in_split_view")}
+        </ContextMenuItem>
+      ) : null}
+      {canCreateNewSplit ? (
+        <ContextMenuItem data-session-menu-new-split onClick={() => ctx.onCreateSplitTaskInWorkspace(workspaceId)}>
+          <PanelRightOpen className="size-4" />
+          {t("session_management.new_split")}
         </ContextMenuItem>
       ) : null}
       {isInSplit ? (
@@ -895,6 +909,7 @@ export type AppSidebarProps = {
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
+  onCreateSplitTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: (sessionId: string) => void;
   onOpenDeleteSession?: (sessionId: string) => void;
   onArchiveSession?: (sessionId: string, archived: boolean) => void;
@@ -1034,6 +1049,7 @@ export function AppSidebar(props: AppSidebarProps) {
     onOpenSession: props.onOpenSession,
     onPrefetchSession: props.onPrefetchSession,
     onCreateTaskInWorkspace: props.onCreateTaskInWorkspace,
+    onCreateSplitTaskInWorkspace: props.onCreateSplitTaskInWorkspace,
     onOpenRenameSession: props.onOpenRenameSession,
     onOpenDeleteSession: props.onOpenDeleteSession,
     onArchiveSession: props.onArchiveSession,

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -98,6 +98,8 @@ export type CommandPaletteProps = {
   currentSession?: CommandPaletteSessionRef | null;
   /** Called when "New session" is chosen. */
   onCreateNewSession: () => void;
+  /** Starts an empty session beside the current session. */
+  onCreateNewSplitSession?: () => void;
   /** Called when "Open settings" is chosen. Accepts an optional route to jump straight to a tab. */
   onOpenSettings: (route?: string) => void;
   /** Called when the first-class Extensions page is chosen. */
@@ -242,6 +244,19 @@ export function CommandPalette(props: CommandPaletteProps) {
           group: ACTIONS_GROUP,
           action: () => {
             setMode("split-sessions");
+          },
+        }]
+      : []),
+    ...(props.onCreateNewSplitSession && props.currentSession
+      ? [{
+          id: "new-split",
+          title: "New split",
+          detail: "Start an empty session beside this one",
+          meta: "Workbench",
+          searchText: "new split empty session side by side pane",
+          action: () => {
+            props.onClose();
+            props.onCreateNewSplitSession?.();
           },
         }]
       : []),

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2064,7 +2064,10 @@ export function SessionRoute() {
     });
   }, [local, selectedSessionId]);
 
-  const handleCreateTaskInWorkspace = useCallback(async (workspaceId: string): Promise<string | null> => {
+  const handleCreateTaskInWorkspaceWithOpenMode = useCallback(async (
+    workspaceId: string,
+    openAs: "primary" | "split",
+  ): Promise<string | null> => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
     if (
       !workspace ||
@@ -2108,14 +2111,16 @@ export function SessionRoute() {
         void refreshCloudProviderSync("new_chat");
       }
       captureAnalyticsEvent("task_created", {
-        source: "new_task",
+        source: openAs === "split" ? "new_split" : "new_task",
         workspace_type: workspace.workspaceType ?? "unknown",
       });
       toast.dismiss(taskCreateUnavailableToastId(workspaceId));
       toast.dismiss();
-      setLegacySelectedWorkspaceId(workspaceId);
-      writeActiveWorkspaceId(workspaceId || null);
-      writeLastSessionFor(workspaceId, session.id);
+      if (openAs === "primary") {
+        setLegacySelectedWorkspaceId(workspaceId);
+        writeActiveWorkspaceId(workspaceId || null);
+        writeLastSessionFor(workspaceId, session.id);
+      }
       rememberPendingCreatedSession(workspaceId, session.id);
       applyLastUsedModelToSession(session.id);
       setSessionsByWorkspaceId((current) => {
@@ -2126,8 +2131,21 @@ export function SessionRoute() {
         sessionsByWorkspaceIdRef.current = next;
         return next;
       });
-      navigateToWorkspaceSession(workspaceId, session.id);
-      focusPromptSoon();
+      if (openAs === "primary") {
+        navigateToWorkspaceSession(workspaceId, session.id);
+        focusPromptSoon();
+      } else {
+        const tab = {
+          workspaceId,
+          workspaceTitle: workspace.displayNameResolved.trim() || workspaceId,
+          sessionId: session.id,
+          title: session.title,
+        };
+        const workbench = useWorkbenchStore.getState();
+        workbench.openTab(tab);
+        workbench.setSplit(tab);
+        workbench.focusPane("secondary");
+      }
       void refreshRouteState();
       return session.id;
     } catch (error) {
@@ -2140,7 +2158,7 @@ export function SessionRoute() {
         description: failure.description,
         action: {
           label: "Retry",
-          onClick: () => void handleCreateTaskInWorkspace(workspaceId),
+          onClick: () => void handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs),
         },
         // A blue/green reload brings up a fresh engine without killing live
         // sessions; the full desktop restart stays a last resort elsewhere.
@@ -2150,7 +2168,7 @@ export function SessionRoute() {
                 label: t("session.engine_reload_action"),
                 onClick: () => {
                   void reloadEngineWithDesktopFallback(endpoint.client, endpoint.workspaceId)
-                    .then(() => handleCreateTaskInWorkspace(workspaceId))
+                    .then(() => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs))
                     .catch(() => undefined);
                 },
               },
@@ -2170,6 +2188,16 @@ export function SessionRoute() {
       return null;
     }
   }, [applyLastUsedModelToSession, developerMode, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
+
+  const handleCreateTaskInWorkspace = useCallback(
+    (workspaceId: string): Promise<string | null> => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, "primary"),
+    [handleCreateTaskInWorkspaceWithOpenMode],
+  );
+
+  const handleCreateSplitTaskInWorkspace = useCallback(
+    (workspaceId: string): Promise<string | null> => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, "split"),
+    [handleCreateTaskInWorkspaceWithOpenMode],
+  );
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we
@@ -3312,6 +3340,9 @@ export function SessionRoute() {
             }
           });
         },
+        onCreateSplitTaskInWorkspace: (workspaceId) => {
+          void handleCreateSplitTaskInWorkspace(workspaceId);
+        },
         onCreateTaskWithPrompt: (workspaceId, prompt, attachments) => {
           void (async () => {
             const workspace = workspaces.find((item) => item.id === workspaceId);
@@ -3526,6 +3557,11 @@ export function SessionRoute() {
       onCreateNewSession={() => {
         if (selectedWorkspaceId) {
           void handleCreateTaskInWorkspace(selectedWorkspaceId);
+        }
+      }}
+      onCreateNewSplitSession={() => {
+        if (selectedWorkspaceId) {
+          void handleCreateSplitTaskInWorkspace(selectedWorkspaceId);
         }
       }}
       onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}

--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -169,10 +169,10 @@ class DaytonaPlacementHost implements Host {
   readonly #preparedHost: Host | undefined;
   readonly #surfaces = new Map<SurfaceHandle, PlacedSurface>();
 
-  constructor(ref: string, preparedSandbox?: string) {
+  constructor(ref: string, preparedSandbox?: string, preparedEngineCacheDir?: string) {
     this.#ref = ref;
     this.#preparedSandbox = preparedSandbox;
-    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox) : undefined;
+    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox, preparedEngineCacheDir) : undefined;
   }
 
   async #provision(name: string): Promise<PlacedSurface> {
@@ -189,7 +189,7 @@ class DaytonaPlacementHost implements Host {
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });
     return {
-      host: daytonaSandbox(provisioned.sandbox),
+      host: daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined),
       sandbox: provisioned.sandbox,
       created: provisioned.created,
     };
@@ -244,9 +244,9 @@ class DaytonaPlace implements Place {
   readonly #ref: string;
   readonly #host: Host;
 
-  constructor(ref: string, preparedDesktopSandbox?: string) {
+  constructor(ref: string, preparedDesktopSandbox?: string, preparedEngineCacheDir?: string) {
     this.#ref = ref;
-    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox);
+    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox, preparedEngineCacheDir);
   }
 
   host(): Host {
@@ -277,7 +277,11 @@ export function resolvePlace(env: NodeJS.ProcessEnv = process.env): Place {
     || (worldPlace === undefined && env.OPENWORK_EVAL_DAYTONA?.trim() === "1");
   if (useDaytona) {
     const ref = env.OPENWORK_EVAL_REF?.trim() || env.GITHUB_SHA?.trim() || "dev";
-    return new DaytonaPlace(ref, env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim());
+    return new DaytonaPlace(
+      ref,
+      env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim(),
+      env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR?.trim(),
+    );
   }
   return new LocalPlace(env.OPENWORK_EVAL_MYSQL_URL?.trim() || DEFAULT_MYSQL_URL);
 }

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -24,6 +24,8 @@ export interface DaytonaHostOptions {
   reservedChromePorts?: number[];
   reservedElectronPorts?: number[];
   serverScript?: boolean;
+  /** Exact per-provision engine cache root to seed into fresh Electron profiles. */
+  engineCacheDir?: string;
   waitForCdp?: (url: string, timeoutMs: number, label: string) => Promise<void>;
 }
 
@@ -546,6 +548,10 @@ function appendExtraEnv(assignments: Map<string, string>, env: Record<string, st
 
 export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
   const exec = options.exec ?? defaultDaytonaExec;
+  const engineCacheDir = options.engineCacheDir?.trim();
+  if (options.engineCacheDir !== undefined && !engineCacheDir) {
+    throw new Error("Daytona engineCacheDir must not be empty.");
+  }
   const previewCache = new Map<number, string>();
   const electronPorts: PortAllocation = { primary: 9825, next: 9830, used: portSet(options.reservedElectronPorts) };
   const chromePorts: PortAllocation = { primary: 9222, next: 9230, used: portSet(options.reservedChromePorts) };
@@ -592,15 +598,17 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
     try {
       await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
-      const cachedDevData = "/workspace/.openwork-daytona/engine-cache/openwork-dev-data";
-      const profileDevData = `${userDataDir}/openwork-dev-data`;
-      const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
-      await checkedExec(
-        exec,
-        ["exec", sandbox, "--", seedCommand],
-        `seed Daytona Electron engine cache ${userDataDir}`,
-        { timeoutMs: 60_000 },
-      );
+      if (engineCacheDir) {
+        const cachedDevData = `${engineCacheDir}/openwork-dev-data`;
+        const profileDevData = `${userDataDir}/openwork-dev-data`;
+        const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
+        await checkedExec(
+          exec,
+          ["exec", sandbox, "--", seedCommand],
+          `seed Daytona Electron engine cache ${userDataDir}`,
+          { timeoutMs: 60_000 },
+        );
+      }
       if (opts.bootstrap) {
         const bootstrapJson = `${JSON.stringify(opts.bootstrap, null, 2)}\n`;
         const encoded = Buffer.from(bootstrapJson, "utf8").toString("base64");

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -592,6 +592,15 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
     try {
       await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
+      const cachedDevData = "/workspace/.openwork-daytona/engine-cache/openwork-dev-data";
+      const profileDevData = `${userDataDir}/openwork-dev-data`;
+      const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
+      await checkedExec(
+        exec,
+        ["exec", sandbox, "--", seedCommand],
+        `seed Daytona Electron engine cache ${userDataDir}`,
+        { timeoutMs: 60_000 },
+      );
       if (opts.bootstrap) {
         const bootstrapJson = `${JSON.stringify(opts.bootstrap, null, 2)}\n`;
         const encoded = Buffer.from(bootstrapJson, "utf8").toString("base64");

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -474,6 +474,10 @@ echo WARM_OK`;
     });
     if (result?.stdout.includes("WARM_TIMEOUT")) {
       log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
+    } else if (result?.stdout.includes("WARM_OK")) {
+      log(`==> engine cache warmed for ${sandbox}`);
+    } else if (result?.stdout.includes("WARM_PRESENT")) {
+      log(`==> engine cache already warm for ${sandbox}`);
     }
   });
 

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -43,6 +43,7 @@ export interface DesktopSandboxOptions {
 export interface DesktopSandbox {
   sandbox: string;
   created: boolean;
+  engineCacheDir: string | null;
 }
 
 export interface DenSandboxOptions {
@@ -94,6 +95,8 @@ export interface ConnectorE2eTestEnv {
   denWebUrl: string;
   sandboxA: string;
   sandboxB: string;
+  engineCacheDirA: string | null;
+  engineCacheDirB: string | null;
   mockUrl: string;
   ref: string;
   created: string[];
@@ -224,6 +227,7 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
   const ref = assertSafeRef(options.ref);
   const reused = options.reuse?.trim() || "";
   let sandbox = reused;
+  let engineCacheDir: string | null = null;
 
   await timedStep(log, "sandbox gate", async () => {
     if (reused) {
@@ -414,29 +418,26 @@ echo detached`;
     const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
     const pluginManifestSuffix = b64('"}}');
     const devtoolsManifest = b64('{"dependencies":{"opencode-chrome-devtools":"latest"}}');
+    const warmDir = `/tmp/openwork-engine-warm-${Date.now()}`;
     const warmScript = `set -e
-W=/workspace/.openwork-daytona/engine-cache
-if [ -d "$W/openwork-dev-data/xdg/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/node_modules" ]; then
-  echo WARM_PRESENT
-  exit 0
-fi
-D=/tmp/engine-warm/openwork-dev-data
-rm -rf /tmp/engine-warm
+W=${warmDir}
+rm -rf /workspace/.openwork-daytona/engine-cache "$W"
+D="$W/openwork-dev-data"
 mkdir -p "$D/home" "$D/xdg/config/opencode" "$D/config/opencode" "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest"
-rm -f /tmp/engine-warm.log
+LOG="$W/warm.log"
 sidecars=(/workspace/apps/desktop/resources/sidecars/opencode-*)
 SIDECAR="\${sidecars[0]:-}"
 if [ ! -x "$SIDECAR" ]; then
-  echo "No executable OpenCode sidecar found" > /tmp/engine-warm.log
+  echo "No executable OpenCode sidecar found" > "$LOG"
   echo WARM_TIMEOUT
-  tail -80 /tmp/engine-warm.log 2>&1 || true
+  tail -80 "$LOG" 2>&1 || true
   exit 0
 fi
-ENGINE_VERSION=$("$SIDECAR" --version 2>>/tmp/engine-warm.log | tail -1 || true)
+ENGINE_VERSION=$("$SIDECAR" --version 2>>"$LOG" | tail -1 || true)
 if [ -z "$ENGINE_VERSION" ]; then
-  echo "OpenCode sidecar did not report a version" >> /tmp/engine-warm.log
+  echo "OpenCode sidecar did not report a version" >> "$LOG"
   echo WARM_TIMEOUT
-  tail -80 /tmp/engine-warm.log 2>&1 || true
+  tail -80 "$LOG" 2>&1 || true
   exit 0
 fi
 printf %s ${pluginManifestPrefix} | base64 -d > "$D/xdg/config/opencode/package.json"
@@ -446,24 +447,22 @@ cp "$D/xdg/config/opencode/package.json" "$D/config/opencode/package.json"
 printf %s ${devtoolsManifest} | base64 -d > "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/package.json"
 NPM=/usr/local/share/nvm/current/bin/npm
 if [ ! -x "$NPM" ]; then
-  echo "npm is missing at $NPM" >> /tmp/engine-warm.log
+  echo "npm is missing at $NPM" >> "$LOG"
   echo WARM_TIMEOUT
-  tail -80 /tmp/engine-warm.log 2>&1 || true
+  tail -80 "$LOG" 2>&1 || true
   exit 0
 fi
 install_package() {
   directory="$1"
-  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --no-audit --no-fund --loglevel=error) >> /tmp/engine-warm.log 2>&1; then
+  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --ignore-scripts --no-audit --no-fund --loglevel=error) >> "$LOG" 2>&1; then
     echo WARM_TIMEOUT
-    tail -80 /tmp/engine-warm.log 2>&1 || true
+    tail -80 "$LOG" 2>&1 || true
     return 1
   fi
 }
 install_package "$D/xdg/config/opencode" || exit 0
 install_package "$D/config/opencode" || exit 0
 install_package "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest" || exit 0
-mkdir -p "$W"
-cp -a "$D" "$W/"
 echo WARM_OK`;
     const result = await execInSandbox(exec, sandbox, warmScript, {
       timeoutMs: 240_000,
@@ -475,9 +474,8 @@ echo WARM_OK`;
     if (result?.stdout.includes("WARM_TIMEOUT")) {
       log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
     } else if (result?.stdout.includes("WARM_OK")) {
+      engineCacheDir = warmDir;
       log(`==> engine cache warmed for ${sandbox}`);
-    } else if (result?.stdout.includes("WARM_PRESENT")) {
-      log(`==> engine cache already warm for ${sandbox}`);
     }
   });
 
@@ -530,7 +528,7 @@ echo detached`;
     throw new Error(`Vite prewarm gate timed out after ${VITE_PREWARM_TIMEOUT_MS}ms waiting for ${phase} in ${sandbox}. Last readiness error: ${last}. Log tail:\n${outputTail(viteLog)}`);
   });
 
-  return { sandbox, created: !reused };
+  return { sandbox, created: !reused, engineCacheDir };
 }
 
 interface LocalProcessResult {
@@ -983,6 +981,8 @@ export function renderConnectorE2eTestEnv(facts: ConnectorE2eTestEnv): string {
     `OPENWORK_EVAL_DEN_WEB_URL=${shellQuote(facts.denWebUrl)}`,
     `OPENWORK_EVAL_DAYTONA_SANDBOX_A=${shellQuote(facts.sandboxA)}`,
     `OPENWORK_EVAL_DAYTONA_SANDBOX_B=${shellQuote(facts.sandboxB)}`,
+    `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A=${shellQuote(facts.engineCacheDirA ?? "")}`,
+    `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B=${shellQuote(facts.engineCacheDirB ?? "")}`,
     `OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL=${shellQuote(facts.mockUrl)}`,
     "OPENWORK_EVAL_MODEL=big-pickle",
     "",
@@ -1020,6 +1020,8 @@ export function parseConnectorE2eTestEnv(content: string): ConnectorE2eTestEnv {
     denWebUrl: required("OPENWORK_EVAL_DEN_WEB_URL"),
     sandboxA: required("OPENWORK_EVAL_DAYTONA_SANDBOX_A"),
     sandboxB: required("OPENWORK_EVAL_DAYTONA_SANDBOX_B"),
+    engineCacheDirA: values.get("OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A")?.trim() || null,
+    engineCacheDirB: values.get("OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B")?.trim() || null,
     mockUrl: required("OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL"),
     ref,
     created: createdText.split(",").map((id) => id.trim()).filter(Boolean),

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -408,6 +408,75 @@ echo detached`;
     }
   });
 
+  await timedStep(log, "engine cache warm gate", async () => {
+    // The sandbox exec transport strips double quotes, so JSON travels base64.
+    const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+    const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
+    const pluginManifestSuffix = b64('"}}');
+    const devtoolsManifest = b64('{"dependencies":{"opencode-chrome-devtools":"latest"}}');
+    const warmScript = `set -e
+W=/workspace/.openwork-daytona/engine-cache
+if [ -d "$W/openwork-dev-data/xdg/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/node_modules" ]; then
+  echo WARM_PRESENT
+  exit 0
+fi
+D=/tmp/engine-warm/openwork-dev-data
+rm -rf /tmp/engine-warm
+mkdir -p "$D/home" "$D/xdg/config/opencode" "$D/config/opencode" "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest"
+rm -f /tmp/engine-warm.log
+sidecars=(/workspace/apps/desktop/resources/sidecars/opencode-*)
+SIDECAR="\${sidecars[0]:-}"
+if [ ! -x "$SIDECAR" ]; then
+  echo "No executable OpenCode sidecar found" > /tmp/engine-warm.log
+  echo WARM_TIMEOUT
+  tail -80 /tmp/engine-warm.log 2>&1 || true
+  exit 0
+fi
+ENGINE_VERSION=$("$SIDECAR" --version 2>>/tmp/engine-warm.log | tail -1 || true)
+if [ -z "$ENGINE_VERSION" ]; then
+  echo "OpenCode sidecar did not report a version" >> /tmp/engine-warm.log
+  echo WARM_TIMEOUT
+  tail -80 /tmp/engine-warm.log 2>&1 || true
+  exit 0
+fi
+printf %s ${pluginManifestPrefix} | base64 -d > "$D/xdg/config/opencode/package.json"
+printf %s "$ENGINE_VERSION" >> "$D/xdg/config/opencode/package.json"
+printf %s ${pluginManifestSuffix} | base64 -d >> "$D/xdg/config/opencode/package.json"
+cp "$D/xdg/config/opencode/package.json" "$D/config/opencode/package.json"
+printf %s ${devtoolsManifest} | base64 -d > "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/package.json"
+NPM=/usr/local/share/nvm/current/bin/npm
+if [ ! -x "$NPM" ]; then
+  echo "npm is missing at $NPM" >> /tmp/engine-warm.log
+  echo WARM_TIMEOUT
+  tail -80 /tmp/engine-warm.log 2>&1 || true
+  exit 0
+fi
+install_package() {
+  directory="$1"
+  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --no-audit --no-fund --loglevel=error) >> /tmp/engine-warm.log 2>&1; then
+    echo WARM_TIMEOUT
+    tail -80 /tmp/engine-warm.log 2>&1 || true
+    return 1
+  fi
+}
+install_package "$D/xdg/config/opencode" || exit 0
+install_package "$D/config/opencode" || exit 0
+install_package "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest" || exit 0
+mkdir -p "$W"
+cp -a "$D" "$W/"
+echo WARM_OK`;
+    const result = await execInSandbox(exec, sandbox, warmScript, {
+      timeoutMs: 240_000,
+      context: `engine cache warm gate for ${sandbox}`,
+    }).catch((error) => {
+      log(`==> WARNING: engine cache warm gate could not complete for ${sandbox}; specs will start cold. ${messageText(error)}`);
+      return null;
+    });
+    if (result?.stdout.includes("WARM_TIMEOUT")) {
+      log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
+    }
+  });
+
   await timedStep(log, "Vite prewarm gate", async () => {
     const detachScript = `cd /workspace; python3 - <<PYEOF
 import subprocess

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -10,6 +10,7 @@ import { checkedExec, defaultDaytonaExec } from "./daytona.ts";
 import { FAULT_PROXY_SCRIPT } from "./fault-proxy-script.ts";
 import type { DaytonaExec, DaytonaExecResult } from "./daytona.ts";
 
+const CHROME_DEVTOOLS_PLUGIN_VERSION = "1.0.4";
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const DESKTOP_READY_TIMEOUT_MS = 300_000;
 const INSTALL_TIMEOUT_MS = 25 * 60 * 1_000;
@@ -417,7 +418,10 @@ echo detached`;
     const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
     const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
     const pluginManifestSuffix = b64('"}}');
-    const devtoolsManifest = b64('{"dependencies":{"opencode-chrome-devtools":"latest"}}');
+    // The engine resolves the unpinned `opencode-chrome-devtools` plugin as `latest`
+    // and keys its cache dir by that tag; the harness installs one audited version
+    // into that slot so evaluation desktops never load whatever the tag points at.
+    const devtoolsManifest = b64(`{"dependencies":{"opencode-chrome-devtools":"${CHROME_DEVTOOLS_PLUGIN_VERSION}"}}`);
     const warmDir = `/tmp/openwork-engine-warm-${Date.now()}`;
     const warmScript = `set -e
 W=${warmDir}

--- a/evals/packages/hosts/src/resolve.ts
+++ b/evals/packages/hosts/src/resolve.ts
@@ -38,7 +38,7 @@ export function localHost(): DisposableHost {
 }
 
 /** A named Daytona sandbox, driven through the `daytona` CLI from outside it. */
-export function daytonaSandbox(sandboxId: string): DisposableHost {
+export function daytonaSandbox(sandboxId: string, engineCacheDir?: string): DisposableHost {
   const id = sandboxId.trim();
   if (!id) throw new Error("daytonaSandbox(sandboxId) requires a sandbox id.");
   if (runningInsideSandbox()) {
@@ -46,5 +46,5 @@ export function daytonaSandbox(sandboxId: string): DisposableHost {
       `daytonaSandbox(${JSON.stringify(id)}) cannot be used from inside a sandbox: the daytona CLI indirection has nothing to target. Use localHost() there.`,
     );
   }
-  return createDaytonaHost({ sandboxId: id, repoRoot: REPO_ROOT, log: () => undefined });
+  return createDaytonaHost({ sandboxId: id, repoRoot: REPO_ROOT, log: () => undefined, engineCacheDir });
 }

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -174,6 +174,7 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
     log: () => undefined,
     exec,
     repoRoot: "/repo",
+    engineCacheDir: "/tmp/openwork-engine-warm-123",
     waitForCdp: successfulPolls(polled),
   });
   const bootstrap = { baseUrl: "https://den-web.example.test", apiBaseUrl: "https://den-api.example.test", requireSignin: true };
@@ -194,7 +195,8 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
   assert(firstMkdirIndex >= 0);
   assert(firstSeedIndex > firstMkdirIndex);
   const firstSeed = argsText(calls[firstSeedIndex] ?? { args: [] });
-  assert(firstSeed.includes("/workspace/.openwork-daytona/engine-cache/openwork-dev-data"));
+  assert(firstSeed.includes("/tmp/openwork-engine-warm-123/openwork-dev-data"));
+  assert(!firstSeed.includes("engine-cache"));
   assert(firstSeed.includes("[ ! -e"));
   assert(firstSeed.includes("/electron-userdata/openwork-dev-data"));
 

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -189,6 +189,15 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
   assert.equal(second.meta?.profileOwner, "host");
   assert.deepEqual(polled, ["https://cdp-9825.example.test/json/list", "https://cdp-9830.example.test/json/list"]);
 
+  const firstMkdirIndex = calls.findIndex((call) => argsText(call).includes("mkdir -p") && argsText(call).includes("/profiles/owner-"));
+  const firstSeedIndex = calls.findIndex((call) => argsText(call).includes("cp -a") && argsText(call).includes("/profiles/owner-"));
+  assert(firstMkdirIndex >= 0);
+  assert(firstSeedIndex > firstMkdirIndex);
+  const firstSeed = argsText(calls[firstSeedIndex] ?? { args: [] });
+  assert(firstSeed.includes("/workspace/.openwork-daytona/engine-cache/openwork-dev-data"));
+  assert(firstSeed.includes("[ ! -e"));
+  assert(firstSeed.includes("/electron-userdata/openwork-dev-data"));
+
   const bootstrapCall = findCall(calls, "base64 -d");
   assert.equal(Buffer.from(base64AfterEcho(bootstrapCall), "base64").toString("utf8"), `${JSON.stringify(bootstrap, null, 2)}\n`);
   assert(argsText(bootstrapCall).includes("/workspace/.openwork-daytona/profiles/owner-"));

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -42,7 +42,7 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
     if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
-    if (script.includes("WARM_PRESENT")) return { stdout: "WARM_PRESENT\n", stderr: "", code: 0 };
+    if (script.includes("install_package")) return { stdout: "WARM_OK\n", stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };
@@ -62,6 +62,8 @@ test("connector E2E test env rendering and parsing round-trip the provision cont
     denWebUrl: "https://den-web.example.test",
     sandboxA: "desktop-a",
     sandboxB: "desktop-b",
+    engineCacheDirA: "/tmp/openwork-engine-warm-a",
+    engineCacheDirB: null,
     mockUrl: "https://mock.example.test",
     ref: "feat/eval-connector-two-members",
     created: ["den", "desktop-a"],
@@ -71,6 +73,8 @@ test("connector E2E test env rendering and parsing round-trip the provision cont
   assert.deepEqual(parseConnectorE2eTestEnv(content), facts);
   assert.match(content, /^# provisioned for org-connector-two-members — generated .*; ref=feat\/eval-connector-two-members$/m);
   assert.match(content, /^# provision-created=den,desktop-a$/m);
+  assert.match(content, /^OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A='\/tmp\/openwork-engine-warm-a'$/m);
+  assert.match(content, /^OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B=''$/m);
   assert.match(content, /OPENWORK_EVAL_MODEL=big-pickle/);
   const missingApi = content.split("\n").filter((line) => !line.startsWith("OPENWORK_EVAL_DEN_API_URL=")).join("\n");
   assert.throws(() => parseConnectorE2eTestEnv(missingApi), /OPENWORK_EVAL_DEN_API_URL/);
@@ -109,17 +113,23 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
 
   const result = await provisionDesktopSandbox({ ref: "dev", name: "a", reuse: "existing-a", exec, log: () => undefined });
 
-  assert.deepEqual(result, { sandbox: "existing-a", created: false });
+  assert.equal(result.sandbox, "existing-a");
+  assert.equal(result.created, false);
+  assert.match(result.engineCacheDir ?? "", /^\/tmp\/openwork-engine-warm-\d+$/);
   assert.deepEqual(calls[0]?.args, ["sandbox", "start", "existing-a"]);
   assert.equal(calls.filter((call) => call.args[0] === "create").length, 0);
   assert.equal(calls.filter((call) => call.args[0] === "snapshot").length, 0);
   const lastFirstBootCall = calls.findLastIndex((call) => call.args[3]?.includes("/tmp/warmup-profile"));
-  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("WARM_PRESENT"));
+  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("install_package"));
   assert(lastFirstBootCall >= 0);
   assert(engineWarmCall > lastFirstBootCall);
   const engineWarmScript = calls[engineWarmCall]?.args[3] ?? "";
   assert(engineWarmScript.includes("npm install"));
+  assert(engineWarmScript.includes("npm install --ignore-scripts --no-audit --no-fund --loglevel=error"));
   assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
+  assert(!engineWarmScript.includes("WARM_PRESENT"));
+  assert(!engineWarmScript.includes("W=/workspace/.openwork-daytona/engine-cache"));
+  assert(engineWarmScript.includes("rm -rf /workspace/.openwork-daytona/engine-cache"));
   assertRemoteCommandsAreSingleArgument(calls);
 });
 
@@ -146,6 +156,8 @@ test("rendered values are shell-quoted, because the env file is meant to be sour
     denWebUrl: "https://w",
     sandboxA: nasty,
     sandboxB: "b",
+    engineCacheDirA: null,
+    engineCacheDirB: null,
     mockUrl: "https://m",
     ref: "dev",
     created: [],
@@ -168,6 +180,8 @@ test("an unsafe ref is refused before it can reach a remote shell or a sourced f
       denWebUrl: "https://w",
       sandboxA: "a",
       sandboxB: "b",
+      engineCacheDirA: null,
+      engineCacheDirB: null,
       mockUrl: "https://m",
       ref,
       created: [],

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -42,6 +42,7 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
     if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
+    if (script.includes("WARM_PRESENT")) return { stdout: "WARM_PRESENT\n", stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };
@@ -112,6 +113,13 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
   assert.deepEqual(calls[0]?.args, ["sandbox", "start", "existing-a"]);
   assert.equal(calls.filter((call) => call.args[0] === "create").length, 0);
   assert.equal(calls.filter((call) => call.args[0] === "snapshot").length, 0);
+  const lastFirstBootCall = calls.findLastIndex((call) => call.args[3]?.includes("/tmp/warmup-profile"));
+  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("WARM_PRESENT"));
+  assert(lastFirstBootCall >= 0);
+  assert(engineWarmCall > lastFirstBootCall);
+  const engineWarmScript = calls[engineWarmCall]?.args[3] ?? "";
+  assert(engineWarmScript.includes("npm install"));
+  assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
   assertRemoteCommandsAreSingleArgument(calls);
 });
 

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -127,6 +127,7 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
   assert(engineWarmScript.includes("npm install"));
   assert(engineWarmScript.includes("npm install --ignore-scripts --no-audit --no-fund --loglevel=error"));
   assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
+  assert(!engineWarmScript.includes(Buffer.from('"opencode-chrome-devtools":"latest"').toString("base64").slice(0, 24)));
   assert(!engineWarmScript.includes("WARM_PRESENT"));
   assert(!engineWarmScript.includes("W=/workspace/.openwork-daytona/engine-cache"));
   assert(engineWarmScript.includes("rm -rf /workspace/.openwork-daytona/engine-cache"));

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -596,6 +596,16 @@ export class UserChannel implements User {
     return this.#click(target, 1, "click", options);
   }
 
+  rightClick(target: Target, options: ClickOptions = {}): Promise<void> {
+    const surface = requireSurface(this.#surface);
+    const hitTestDetail = options.hitTest === false ? ", hitTest=false" : "";
+    return this.#runtime.call("user", "rightClick", `rightClick(${targetDetail(target)}${hitTestDetail})`, surface, async () => {
+      if (this.#runtime.adapters.user?.click) return this.#runtime.adapters.user.click(surface, target, 1);
+      const found = await waitForLocated(surface, target, { mustHitTest: options.hitTest !== false });
+      await clickAt(surface, found.center, { button: "right" });
+    });
+  }
+
   dblclick(target: Target): Promise<void> {
     return this.#click(target, 2, "dblclick");
   }

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -35,6 +35,7 @@ export interface ProbeEvalOptions {
 
 export interface User {
   click(target: Target, options?: ClickOptions): Promise<void>;
+  rightClick(target: Target, options?: ClickOptions): Promise<void>;
   dblclick(target: Target): Promise<void>;
   type(target: Target, text: string, options?: TypeOptions): Promise<void>;
   press(key: string): Promise<void>;

--- a/evals/runner/prepare-stack.ts
+++ b/evals/runner/prepare-stack.ts
@@ -14,7 +14,7 @@ const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 export type StackPreparation =
   | { kind: "none" }
   | { kind: "local"; runtimePrepared: true; electronPrepared: true }
-  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string }[] };
+  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string; engineCacheDir: string | null }[] };
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -89,7 +89,7 @@ async function prepareDaytona(argv: readonly string[]): Promise<{ preparation: S
           return result;
         }),
       ]);
-      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox };
+      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox, engineCacheDir: desktop.engineCacheDir };
     }));
     console.error(`[openwork/evals] prepared ${slots.length} isolated Daytona worker slot${slots.length === 1 ? "" : "s"}.`);
     return {

--- a/evals/runner/stack-env.ts
+++ b/evals/runner/stack-env.ts
@@ -13,4 +13,6 @@ if (preparation.kind === "daytona") {
   if (!slot) throw new Error("Vitest worker did not resolve to a prepared Daytona slot.");
   process.env.OPENWORK_EVAL_DAYTONA_DEN_SANDBOX = slot.denSandbox;
   process.env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX = slot.desktopSandbox;
+  if (slot.engineCacheDir) process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR = slot.engineCacheDir;
+  else delete process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR;
 }

--- a/evals/scripts/provision-org-connector-two-members.ts
+++ b/evals/scripts/provision-org-connector-two-members.ts
@@ -72,6 +72,8 @@ async function provisionSpecEnv(options: {
       denWebUrl: den.webUrl,
       sandboxA: desktopA.sandbox,
       sandboxB: desktopB.sandbox,
+      engineCacheDirA: desktopA.engineCacheDir,
+      engineCacheDirB: desktopB.engineCacheDir,
       mockUrl: mock.url,
       ref: options.ref,
       created,

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -1,0 +1,219 @@
+import { expect } from "vitest";
+import { evalIn, go, listSessions, seedSessions, waitFor } from "@openwork/behaviors";
+import type { Surface } from "@openwork/cdp";
+import { screenshot } from "@openwork/test-evidence";
+import {
+  app as launchApp,
+  createAdmin,
+  createOrg,
+  localMysqlIsRunning,
+  localRedisIsRunning,
+  needs,
+  server,
+  test,
+} from "@openwork/testkit";
+
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
+const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const localServicesRequired = !daytonaEnabled && !configuredDen;
+const mysqlOpen = await localMysqlIsRunning();
+const redisOpen = await localRedisIsRunning();
+const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
+const skipSuffix = !e2eTestsEnabled
+  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : localServicesRequired && !mysqlOpen
+    ? " skipped — needs MySQL on 127.0.0.1:3306"
+    : localServicesRequired && !redisOpen
+      ? " skipped — needs Redis on 127.0.0.1:6379"
+      : "";
+
+type SplitFacts = {
+  layoutKind: string;
+  primarySessionId: string;
+  secondarySessionId: string;
+  primarySurfaceSessionId: string;
+  secondarySurfaceSessionId: string;
+  secondaryPaneWorkspaceId: string;
+  secondaryPaneCount: number;
+  locationHash: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSplitFacts(value: unknown): SplitFacts {
+  if (!isRecord(value)) throw new Error(`Invalid split facts: ${JSON.stringify(value)}`);
+  const text = (key: string) => typeof value[key] === "string" ? value[key] : "";
+  return {
+    layoutKind: text("layoutKind"),
+    primarySessionId: text("primarySessionId"),
+    secondarySessionId: text("secondarySessionId"),
+    primarySurfaceSessionId: text("primarySurfaceSessionId"),
+    secondarySurfaceSessionId: text("secondarySurfaceSessionId"),
+    secondaryPaneWorkspaceId: text("secondaryPaneWorkspaceId"),
+    secondaryPaneCount: typeof value.secondaryPaneCount === "number" ? value.secondaryPaneCount : -1,
+    locationHash: text("locationHash"),
+  };
+}
+
+async function openSessionRoute(app: Surface, workspaceId: string, sessionId: string): Promise<void> {
+  await go(app, `/workspace/${workspaceId}/session/${sessionId}`);
+  await waitFor(app, `Boolean(document.querySelector(
+    '[data-session-surface-id="${sessionId}"]'
+  ))`, { timeoutMs: 60_000, label: "primary session route" });
+}
+
+async function openNewSplitFromContextMenu(app: Surface, workspaceId: string, sessionId: string): Promise<void> {
+  const opened = await evalIn(app, `(() => {
+    const row = document.querySelector(
+      '[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]'
+    );
+    if (!(row instanceof HTMLElement)) return false;
+    row.scrollIntoView({ block: "center" });
+    const target = row.querySelector('[data-session-tab-id="${sessionId}"]') ?? row;
+    if (!(target instanceof HTMLElement)) return false;
+    const rect = target.getBoundingClientRect();
+    target.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      buttons: 2,
+      clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
+      clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
+    }));
+    return true;
+  })()`);
+  expect(opened).toBe(true);
+  await waitFor(app, `Boolean(document.querySelector('[role="menu"]'))`, {
+    timeoutMs: 15_000,
+    label: "session context menu",
+  });
+  const itemExists = await evalIn(app, `Boolean(document.querySelector('[data-session-menu-new-split]'))`);
+  expect(itemExists).toBe(true);
+  const clicked = await evalIn(app, `(() => {
+    const item = document.querySelector('[data-session-menu-new-split]');
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+}
+
+async function openNewSplitFromPalette(app: Surface): Promise<void> {
+  await evalIn(app, `(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      metaKey: true,
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    }));
+    return true;
+  })()`);
+  await waitFor(app, `Boolean(document.querySelector('[data-command-palette-item="new-split"]'))`, {
+    timeoutMs: 15_000,
+    label: "New split command",
+  });
+  const itemExists = await evalIn(app, `Boolean(document.querySelector('[data-command-palette-item="new-split"]'))`);
+  expect(itemExists).toBe(true);
+  const clicked = await evalIn(app, `(() => {
+    const item = document.querySelector('[data-command-palette-item="new-split"]');
+    if (!(item instanceof HTMLElement)) return false;
+    item.click();
+    return true;
+  })()`);
+  expect(clicked).toBe(true);
+}
+
+async function readSplitFacts(app: Surface): Promise<SplitFacts> {
+  return parseSplitFacts(await evalIn(app, `(() => {
+    const context = window.__openworkControl?.context?.();
+    const layout = context?.conversations?.layout;
+    const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
+    const secondaryPanes = [...document.querySelectorAll('[data-workbench-pane="secondary"]')];
+    const secondaryPane = secondaryPanes[0];
+    return {
+      layoutKind: layout?.kind ?? "",
+      primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
+      secondarySessionId: layout?.secondarySessionId ?? "",
+      primarySurfaceSessionId: primaryPane?.querySelector('[data-session-surface-id]')
+        ?.getAttribute('data-session-surface-id') ?? "",
+      secondarySurfaceSessionId: secondaryPane?.querySelector('[data-session-surface-id]')
+        ?.getAttribute('data-session-surface-id') ?? "",
+      secondaryPaneWorkspaceId: secondaryPane?.getAttribute('data-workbench-workspace-id') ?? "",
+      secondaryPaneCount: secondaryPanes.length,
+      locationHash: window.location.hash,
+    };
+  })()`));
+}
+
+test.skipIf(!runnable)(
+  `new split creates fresh same-workspace secondary sessions without moving the primary${skipSuffix}`,
+  { timeout: 600_000 },
+  async ({ place }) => {
+    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+    await using stack = new AsyncDisposableStack();
+    const den = stack.use(await server({ place, provision: false, web: true }));
+    await createAdmin(den, {});
+    stack.use(await createOrg(den, "acme"));
+    const app = stack.use(await launchApp({ den, place, as: "admin" }));
+    await seedSessions(app, ["New split primary"]);
+    const workspaceId = app.workspaceId;
+    if (!workspaceId) throw new Error("The new split world did not resolve a workspace.");
+
+    const seededSessions = await listSessions(app);
+    const primary = seededSessions.find((session) => session.title === "New split primary");
+    if (!primary) throw new Error(`The seeded primary session was not found: ${JSON.stringify(seededSessions)}`);
+
+    await openSessionRoute(app, workspaceId, primary.sessionId);
+    const before = (await listSessions(app)).map((session) => session.sessionId);
+
+    await openNewSplitFromContextMenu(app, workspaceId, primary.sessionId);
+    await waitFor(app, `window.__openworkControl?.context?.().conversations?.layout?.kind === "split"`, {
+      timeoutMs: 60_000,
+      label: "context-menu new split layout",
+    });
+
+    const firstFacts = await readSplitFacts(app);
+    expect(firstFacts.layoutKind).toBe("split");
+    expect(firstFacts.primarySessionId).toBe(primary.sessionId);
+    expect(firstFacts.primarySurfaceSessionId).toBe(primary.sessionId);
+    expect(firstFacts.secondarySessionId).toMatch(/^ses_/);
+    expect(before).not.toContain(firstFacts.secondarySessionId);
+    expect(firstFacts.secondarySurfaceSessionId).toBe(firstFacts.secondarySessionId);
+    expect(firstFacts.secondaryPaneWorkspaceId).toBe(workspaceId);
+    expect(firstFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${primary.sessionId}`);
+    const afterContextMenu = await listSessions(app);
+    expect(afterContextMenu).toHaveLength(before.length + 1);
+    expect(afterContextMenu.map((session) => session.sessionId)).toContain(firstFacts.secondarySessionId);
+    // session.list_sessions exposes only IDs and titles, so message freshness is not observable here.
+
+    await openNewSplitFromPalette(app);
+    await waitFor(app, `(() => {
+      const layout = window.__openworkControl?.context?.().conversations?.layout;
+      return layout?.kind === "split"
+        && layout?.secondarySessionId !== ${JSON.stringify(firstFacts.secondarySessionId)};
+    })()`, { timeoutMs: 60_000, label: "palette new split replaces secondary session" });
+
+    const secondFacts = await readSplitFacts(app);
+    expect(secondFacts.layoutKind).toBe("split");
+    expect(secondFacts.primarySessionId).toBe(primary.sessionId);
+    expect(secondFacts.primarySurfaceSessionId).toBe(primary.sessionId);
+    expect(secondFacts.secondarySessionId).toMatch(/^ses_/);
+    expect(secondFacts.secondarySessionId).not.toBe(firstFacts.secondarySessionId);
+    expect(afterContextMenu.map((session) => session.sessionId)).not.toContain(secondFacts.secondarySessionId);
+    expect(secondFacts.secondarySurfaceSessionId).toBe(secondFacts.secondarySessionId);
+    expect(secondFacts.secondaryPaneWorkspaceId).toBe(workspaceId);
+    expect(secondFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${primary.sessionId}`);
+    expect(secondFacts.secondaryPaneCount).toBe(1);
+    const afterPalette = await listSessions(app);
+    expect(afterPalette).toHaveLength(before.length + 2);
+    expect(afterPalette.map((session) => session.sessionId)).toContain(secondFacts.secondarySessionId);
+
+    await screenshot(app);
+  },
+);

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -22,6 +22,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function regexEscape(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
 function parseSplitFacts(value: unknown): SplitFacts {
   if (!isRecord(value)) throw new Error(`Invalid split facts: ${JSON.stringify(value)}`);
   const text = (key: string) => typeof value[key] === "string" ? value[key] : "";
@@ -59,10 +63,11 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   const beforeIds = before.map((session) => session.sessionId);
 
   await step("New split in the session context menu opens a fresh secondary", async () => {
-    const opened = await world.openSessionMenu(primarySessionId, workspaceId);
-    expect(opened).toBe(true);
+    await user.rightClick({ role: "button", label: new RegExp(`^${regexEscape(world.session.title)}(?:,| —|$)`) });
     await user.see({ role: "menuitem", label: "New split" });
     await user.click({ role: "menuitem", label: "New split" });
+    await user.see({ text: "Split view" });
+    await user.see({ text: "New session" });
   });
 
   const { firstFacts, afterContextMenu } = await step("the context menu creates one same-workspace split session", async () => {
@@ -116,6 +121,8 @@ test("new split creates fresh same-workspace secondary sessions without moving t
     await user.type(paletteInput, "new split", { replace: true });
     await user.see({ role: "option", label: /^New split/ });
     await user.press("Enter");
+    await user.see({ text: "Split view" });
+    await user.see({ text: "New session" });
   });
 
   await step("the palette creates one more session while preserving the primary route", async () => {

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -90,8 +90,10 @@ async function openNewSplitFromContextMenu(app: Surface, workspaceId: string, se
     timeoutMs: 15_000,
     label: "session context menu",
   });
-  const itemExists = await evalIn(app, `Boolean(document.querySelector('[data-session-menu-new-split]'))`);
-  expect(itemExists).toBe(true);
+  await waitFor(app, `Boolean(document.querySelector('[data-session-menu-new-split]'))`, {
+    timeoutMs: 15_000,
+    label: "New split menu item",
+  });
   const clicked = await evalIn(app, `(() => {
     const item = document.querySelector('[data-session-menu-new-split]');
     if (!(item instanceof HTMLElement)) return false;
@@ -170,6 +172,11 @@ test.skipIf(!runnable)(
     if (!primary) throw new Error(`The seeded primary session was not found: ${JSON.stringify(seededSessions)}`);
 
     await openSessionRoute(app, workspaceId, primary.sessionId);
+    // New split is offered once the workbench knows its primary pane.
+    await waitFor(app, `(() => {
+      const layout = window.__openworkControl?.context?.().conversations?.layout;
+      return layout?.kind === "single" && layout?.sessionId === ${JSON.stringify(primary.sessionId)};
+    })()`, { timeoutMs: 60_000, label: "single layout on the seeded primary" });
     const before = (await listSessions(app)).map((session) => session.sessionId);
 
     await openNewSplitFromContextMenu(app, workspaceId, primary.sessionId);

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -39,28 +39,6 @@ function parseSplitFacts(value: unknown): SplitFacts {
   };
 }
 
-const splitFactsExpression = `(() => {
-    const context = window.__openworkControl?.context?.();
-    const layout = context?.conversations?.layout;
-    const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
-    const secondaryPanes = [...document.querySelectorAll('[data-workbench-pane="secondary"]')];
-    const secondaryPane = secondaryPanes[0];
-    return {
-      layoutKind: layout?.kind ?? "",
-      primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
-      secondarySessionId: layout?.secondarySessionId ?? "",
-      primaryWorkspaceId: layout?.primaryWorkspaceId ?? "",
-      secondaryWorkspaceId: layout?.secondaryWorkspaceId ?? "",
-      primarySurfaceSessionId: primaryPane?.querySelector('[data-session-surface-id]')
-        ?.getAttribute('data-session-surface-id') ?? "",
-      secondarySurfaceSessionId: secondaryPane?.querySelector('[data-session-surface-id]')
-        ?.getAttribute('data-session-surface-id') ?? "",
-      secondaryPaneWorkspaceId: secondaryPane?.getAttribute('data-workbench-workspace-id') ?? "",
-      secondaryPaneCount: secondaryPanes.length,
-      locationHash: window.location.hash,
-    };
-  })()`;
-
 test("new split creates fresh same-workspace secondary sessions without moving the primary", async ({ world, user, agent, probe, step, place }) => {
   // The key chord belongs to the machine running the app, not the one running the spec.
   const paletteShortcut = place.kind !== "daytona" && process.platform === "darwin" ? "Meta+K" : "Control+K";
@@ -68,45 +46,27 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   const primarySessionId = world.session.sessionId;
 
   const { primaryHash, before } = await step("the seeded session is the single primary pane", async () => {
-    await probe.eventually(() => probe.eval(`(() => {
-      const layout = window.__openworkControl?.context?.().conversations?.layout;
-      return layout?.kind === "single" && layout?.sessionId === ${JSON.stringify(primarySessionId)};
-    })()`), {
+    await probe.eventually(() => world.splitFacts(), {
       within: 60_000,
       label: "single layout on the seeded primary",
-      until: (ready) => ready === true,
+      until: (value) => {
+        const facts = parseSplitFacts(value);
+        return facts.layoutKind === "single" && facts.primarySessionId === primarySessionId;
+      },
     });
     return { primaryHash: await probe.hash(), before: await agent.list() };
   });
   const beforeIds = before.map((session) => session.sessionId);
 
   await step("New split in the session context menu opens a fresh secondary", async () => {
-    const opened = await probe.eval(`(() => {
-      const row = document.querySelector(
-        '[data-sidebar-session-id="${primarySessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]'
-      );
-      if (!(row instanceof HTMLElement)) return false;
-      row.scrollIntoView({ block: "center" });
-      const target = row.querySelector('[data-session-tab-id="${primarySessionId}"]') ?? row;
-      if (!(target instanceof HTMLElement)) return false;
-      const rect = target.getBoundingClientRect();
-      target.dispatchEvent(new MouseEvent("contextmenu", {
-        bubbles: true,
-        cancelable: true,
-        button: 2,
-        buttons: 2,
-        clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
-        clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
-      }));
-      return true;
-    })()`);
+    const opened = await world.openSessionMenu(primarySessionId, workspaceId);
     expect(opened).toBe(true);
     await user.see({ role: "menuitem", label: "New split" });
     await user.click({ role: "menuitem", label: "New split" });
   });
 
   const { firstFacts, afterContextMenu } = await step("the context menu creates one same-workspace split session", async () => {
-    const firstValue = await probe.eventually(() => probe.eval(splitFactsExpression), {
+    const firstValue = await probe.eventually(() => world.splitFacts(), {
       within: 60_000,
       label: "context-menu new split layout",
       until: (value) => {
@@ -160,7 +120,7 @@ test("new split creates fresh same-workspace secondary sessions without moving t
 
   await step("the palette creates one more session while preserving the primary route", async () => {
     const afterContextMenuIds = afterContextMenu.map((session) => session.sessionId);
-    const secondValue = await probe.eventually(() => probe.eval(splitFactsExpression), {
+    const secondValue = await probe.eventually(() => world.splitFacts(), {
       within: 60_000,
       label: "palette new split replaces the secondary session",
       until: (value) => {

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -1,37 +1,17 @@
 import { expect } from "vitest";
-import { evalIn, go, listSessions, seedSessions, waitFor } from "@openwork/behaviors";
-import type { Surface } from "@openwork/cdp";
-import { screenshot } from "@openwork/test-evidence";
-import {
-  app as launchApp,
-  createAdmin,
-  createOrg,
-  localMysqlIsRunning,
-  localRedisIsRunning,
-  needs,
-  server,
-  test,
-} from "@openwork/testkit";
+import { spec } from "@openwork/testkit";
+import { newSplitPrimary } from "../worlds/chat.ts";
 
-const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
-const daytonaEnabled = process.env.OPENWORK_EVAL_DAYTONA === "1";
-const configuredDen = Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
-const localServicesRequired = !daytonaEnabled && !configuredDen;
-const mysqlOpen = await localMysqlIsRunning();
-const redisOpen = await localRedisIsRunning();
-const runnable = e2eTestsEnabled && (!localServicesRequired || (mysqlOpen && redisOpen));
-const skipSuffix = !e2eTestsEnabled
-  ? " skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
-  : localServicesRequired && !mysqlOpen
-    ? " skipped — needs MySQL on 127.0.0.1:3306"
-    : localServicesRequired && !redisOpen
-      ? " skipped — needs Redis on 127.0.0.1:6379"
-      : "";
+const test = spec.world(newSplitPrimary);
+const paletteShortcut = process.platform === "darwin" ? "Meta+K" : "Control+K";
+const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
 
 type SplitFacts = {
   layoutKind: string;
   primarySessionId: string;
   secondarySessionId: string;
+  primaryWorkspaceId: string;
+  secondaryWorkspaceId: string;
   primarySurfaceSessionId: string;
   secondarySurfaceSessionId: string;
   secondaryPaneWorkspaceId: string;
@@ -50,6 +30,8 @@ function parseSplitFacts(value: unknown): SplitFacts {
     layoutKind: text("layoutKind"),
     primarySessionId: text("primarySessionId"),
     secondarySessionId: text("secondarySessionId"),
+    primaryWorkspaceId: text("primaryWorkspaceId"),
+    secondaryWorkspaceId: text("secondaryWorkspaceId"),
     primarySurfaceSessionId: text("primarySurfaceSessionId"),
     secondarySurfaceSessionId: text("secondarySurfaceSessionId"),
     secondaryPaneWorkspaceId: text("secondaryPaneWorkspaceId"),
@@ -58,80 +40,7 @@ function parseSplitFacts(value: unknown): SplitFacts {
   };
 }
 
-async function openSessionRoute(app: Surface, workspaceId: string, sessionId: string): Promise<void> {
-  await go(app, `/workspace/${workspaceId}/session/${sessionId}`);
-  await waitFor(app, `Boolean(document.querySelector(
-    '[data-session-surface-id="${sessionId}"]'
-  ))`, { timeoutMs: 60_000, label: "primary session route" });
-}
-
-async function openNewSplitFromContextMenu(app: Surface, workspaceId: string, sessionId: string): Promise<void> {
-  const opened = await evalIn(app, `(() => {
-    const row = document.querySelector(
-      '[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]'
-    );
-    if (!(row instanceof HTMLElement)) return false;
-    row.scrollIntoView({ block: "center" });
-    const target = row.querySelector('[data-session-tab-id="${sessionId}"]') ?? row;
-    if (!(target instanceof HTMLElement)) return false;
-    const rect = target.getBoundingClientRect();
-    target.dispatchEvent(new MouseEvent("contextmenu", {
-      bubbles: true,
-      cancelable: true,
-      button: 2,
-      buttons: 2,
-      clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
-      clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
-    }));
-    return true;
-  })()`);
-  expect(opened).toBe(true);
-  await waitFor(app, `Boolean(document.querySelector('[role="menu"]'))`, {
-    timeoutMs: 15_000,
-    label: "session context menu",
-  });
-  await waitFor(app, `Boolean(document.querySelector('[data-session-menu-new-split]'))`, {
-    timeoutMs: 15_000,
-    label: "New split menu item",
-  });
-  const clicked = await evalIn(app, `(() => {
-    const item = document.querySelector('[data-session-menu-new-split]');
-    if (!(item instanceof HTMLElement)) return false;
-    item.click();
-    return true;
-  })()`);
-  expect(clicked).toBe(true);
-}
-
-async function openNewSplitFromPalette(app: Surface): Promise<void> {
-  await evalIn(app, `(() => {
-    window.dispatchEvent(new KeyboardEvent("keydown", {
-      key: "k",
-      code: "KeyK",
-      metaKey: true,
-      ctrlKey: true,
-      bubbles: true,
-      cancelable: true,
-    }));
-    return true;
-  })()`);
-  await waitFor(app, `Boolean(document.querySelector('[data-command-palette-item="new-split"]'))`, {
-    timeoutMs: 15_000,
-    label: "New split command",
-  });
-  const itemExists = await evalIn(app, `Boolean(document.querySelector('[data-command-palette-item="new-split"]'))`);
-  expect(itemExists).toBe(true);
-  const clicked = await evalIn(app, `(() => {
-    const item = document.querySelector('[data-command-palette-item="new-split"]');
-    if (!(item instanceof HTMLElement)) return false;
-    item.click();
-    return true;
-  })()`);
-  expect(clicked).toBe(true);
-}
-
-async function readSplitFacts(app: Surface): Promise<SplitFacts> {
-  return parseSplitFacts(await evalIn(app, `(() => {
+const splitFactsExpression = `(() => {
     const context = window.__openworkControl?.context?.();
     const layout = context?.conversations?.layout;
     const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
@@ -141,6 +50,8 @@ async function readSplitFacts(app: Surface): Promise<SplitFacts> {
       layoutKind: layout?.kind ?? "",
       primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
       secondarySessionId: layout?.secondarySessionId ?? "",
+      primaryWorkspaceId: layout?.primaryWorkspaceId ?? "",
+      secondaryWorkspaceId: layout?.secondaryWorkspaceId ?? "",
       primarySurfaceSessionId: primaryPane?.querySelector('[data-session-surface-id]')
         ?.getAttribute('data-session-surface-id') ?? "",
       secondarySurfaceSessionId: secondaryPane?.querySelector('[data-session-surface-id]')
@@ -149,78 +60,147 @@ async function readSplitFacts(app: Surface): Promise<SplitFacts> {
       secondaryPaneCount: secondaryPanes.length,
       locationHash: window.location.hash,
     };
-  })()`));
-}
+  })()`;
 
-test.skipIf(!runnable)(
-  `new split creates fresh same-workspace secondary sessions without moving the primary${skipSuffix}`,
-  { timeout: 600_000 },
-  async ({ place }) => {
-    needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+test("new split creates fresh same-workspace secondary sessions without moving the primary", async ({ world, user, agent, probe, step }) => {
+  const workspaceId = world.workspace.workspaceId;
+  const primarySessionId = world.session.sessionId;
 
-    await using stack = new AsyncDisposableStack();
-    const den = stack.use(await server({ place, provision: false, web: true }));
-    await createAdmin(den, {});
-    stack.use(await createOrg(den, "acme"));
-    const app = stack.use(await launchApp({ den, place, as: "admin" }));
-    await seedSessions(app, ["New split primary"]);
-    const workspaceId = app.workspaceId;
-    if (!workspaceId) throw new Error("The new split world did not resolve a workspace.");
-
-    const seededSessions = await listSessions(app);
-    const primary = seededSessions.find((session) => session.title === "New split primary");
-    if (!primary) throw new Error(`The seeded primary session was not found: ${JSON.stringify(seededSessions)}`);
-
-    await openSessionRoute(app, workspaceId, primary.sessionId);
-    // New split is offered once the workbench knows its primary pane.
-    await waitFor(app, `(() => {
+  const { primaryHash, before } = await step("the seeded session is the single primary pane", async () => {
+    await probe.eventually(() => probe.eval(`(() => {
       const layout = window.__openworkControl?.context?.().conversations?.layout;
-      return layout?.kind === "single" && layout?.sessionId === ${JSON.stringify(primary.sessionId)};
-    })()`, { timeoutMs: 60_000, label: "single layout on the seeded primary" });
-    const before = (await listSessions(app)).map((session) => session.sessionId);
-
-    await openNewSplitFromContextMenu(app, workspaceId, primary.sessionId);
-    await waitFor(app, `window.__openworkControl?.context?.().conversations?.layout?.kind === "split"`, {
-      timeoutMs: 60_000,
-      label: "context-menu new split layout",
+      return layout?.kind === "single" && layout?.sessionId === ${JSON.stringify(primarySessionId)};
+    })()`), {
+      within: 60_000,
+      label: "single layout on the seeded primary",
+      until: (ready) => ready === true,
     });
+    return { primaryHash: await probe.hash(), before: await agent.list() };
+  });
+  const beforeIds = before.map((session) => session.sessionId);
 
-    const firstFacts = await readSplitFacts(app);
+  await step("New split in the session context menu opens a fresh secondary", async () => {
+    const opened = await probe.eval(`(() => {
+      const row = document.querySelector(
+        '[data-sidebar-session-id="${primarySessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]'
+      );
+      if (!(row instanceof HTMLElement)) return false;
+      row.scrollIntoView({ block: "center" });
+      const target = row.querySelector('[data-session-tab-id="${primarySessionId}"]') ?? row;
+      if (!(target instanceof HTMLElement)) return false;
+      const rect = target.getBoundingClientRect();
+      target.dispatchEvent(new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        button: 2,
+        buttons: 2,
+        clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
+        clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
+      }));
+      return true;
+    })()`);
+    expect(opened).toBe(true);
+    await user.see({ role: "menuitem", label: "New split" });
+    await user.click({ role: "menuitem", label: "New split" });
+  });
+
+  const { firstFacts, afterContextMenu } = await step("the context menu creates one same-workspace split session", async () => {
+    const firstValue = await probe.eventually(() => probe.eval(splitFactsExpression), {
+      within: 60_000,
+      label: "context-menu new split layout",
+      until: (value) => {
+        const facts = parseSplitFacts(value);
+        return facts.layoutKind === "split"
+          && facts.primarySessionId === primarySessionId
+          && facts.primaryWorkspaceId === workspaceId
+          && facts.primarySurfaceSessionId === primarySessionId
+          && /^ses_/.test(facts.secondarySessionId)
+          && !beforeIds.includes(facts.secondarySessionId)
+          && facts.secondaryWorkspaceId === facts.primaryWorkspaceId
+          && facts.secondarySurfaceSessionId === facts.secondarySessionId
+          && facts.secondaryPaneWorkspaceId === workspaceId
+          && facts.secondaryPaneCount === 1
+          && facts.locationHash === primaryHash;
+      },
+    });
+    const firstFacts = parseSplitFacts(firstValue);
     expect(firstFacts.layoutKind).toBe("split");
-    expect(firstFacts.primarySessionId).toBe(primary.sessionId);
-    expect(firstFacts.primarySurfaceSessionId).toBe(primary.sessionId);
+    expect(firstFacts.primarySessionId).toBe(primarySessionId);
+    expect(firstFacts.primaryWorkspaceId).toBe(workspaceId);
+    expect(firstFacts.primarySurfaceSessionId).toBe(primarySessionId);
     expect(firstFacts.secondarySessionId).toMatch(/^ses_/);
-    expect(before).not.toContain(firstFacts.secondarySessionId);
+    expect(beforeIds).not.toContain(firstFacts.secondarySessionId);
+    expect(firstFacts.secondaryWorkspaceId).toBe(firstFacts.primaryWorkspaceId);
     expect(firstFacts.secondarySurfaceSessionId).toBe(firstFacts.secondarySessionId);
     expect(firstFacts.secondaryPaneWorkspaceId).toBe(workspaceId);
-    expect(firstFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${primary.sessionId}`);
-    const afterContextMenu = await listSessions(app);
+    expect(firstFacts.secondaryPaneCount).toBe(1);
+    expect(firstFacts.locationHash).toBe(primaryHash);
+    expect(await probe.hash()).toContain(`/session/${primarySessionId}`);
+
+    const afterContextMenu = await probe.eventually(() => agent.list(), {
+      within: 60_000,
+      label: "context-menu split session appears in the session list",
+      until: (sessions) => sessions.length === before.length + 1
+        && sessions.some((session) => session.sessionId === firstFacts.secondarySessionId),
+    });
     expect(afterContextMenu).toHaveLength(before.length + 1);
     expect(afterContextMenu.map((session) => session.sessionId)).toContain(firstFacts.secondarySessionId);
-    // session.list_sessions exposes only IDs and titles, so message freshness is not observable here.
+    await user.screenshot();
+    return { firstFacts, afterContextMenu };
+  });
 
-    await openNewSplitFromPalette(app);
-    await waitFor(app, `(() => {
-      const layout = window.__openworkControl?.context?.().conversations?.layout;
-      return layout?.kind === "split"
-        && layout?.secondarySessionId !== ${JSON.stringify(firstFacts.secondarySessionId)};
-    })()`, { timeoutMs: 60_000, label: "palette new split replaces secondary session" });
+  await step("New split in the command palette replaces the secondary with another fresh session", async () => {
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "new split", { replace: true });
+    await user.see({ role: "option", label: /^New split/ });
+    await user.press("Enter");
+  });
 
-    const secondFacts = await readSplitFacts(app);
+  await step("the palette creates one more session while preserving the primary route", async () => {
+    const afterContextMenuIds = afterContextMenu.map((session) => session.sessionId);
+    const secondValue = await probe.eventually(() => probe.eval(splitFactsExpression), {
+      within: 60_000,
+      label: "palette new split replaces the secondary session",
+      until: (value) => {
+        const facts = parseSplitFacts(value);
+        return facts.layoutKind === "split"
+          && facts.primarySessionId === primarySessionId
+          && facts.primaryWorkspaceId === workspaceId
+          && facts.primarySurfaceSessionId === primarySessionId
+          && /^ses_/.test(facts.secondarySessionId)
+          && facts.secondarySessionId !== firstFacts.secondarySessionId
+          && !afterContextMenuIds.includes(facts.secondarySessionId)
+          && facts.secondaryWorkspaceId === facts.primaryWorkspaceId
+          && facts.secondarySurfaceSessionId === facts.secondarySessionId
+          && facts.secondaryPaneWorkspaceId === workspaceId
+          && facts.secondaryPaneCount === 1
+          && facts.locationHash === primaryHash;
+      },
+    });
+    const secondFacts = parseSplitFacts(secondValue);
     expect(secondFacts.layoutKind).toBe("split");
-    expect(secondFacts.primarySessionId).toBe(primary.sessionId);
-    expect(secondFacts.primarySurfaceSessionId).toBe(primary.sessionId);
+    expect(secondFacts.primarySessionId).toBe(primarySessionId);
+    expect(secondFacts.primaryWorkspaceId).toBe(workspaceId);
+    expect(secondFacts.primarySurfaceSessionId).toBe(primarySessionId);
     expect(secondFacts.secondarySessionId).toMatch(/^ses_/);
     expect(secondFacts.secondarySessionId).not.toBe(firstFacts.secondarySessionId);
-    expect(afterContextMenu.map((session) => session.sessionId)).not.toContain(secondFacts.secondarySessionId);
+    expect(afterContextMenuIds).not.toContain(secondFacts.secondarySessionId);
+    expect(secondFacts.secondaryWorkspaceId).toBe(secondFacts.primaryWorkspaceId);
     expect(secondFacts.secondarySurfaceSessionId).toBe(secondFacts.secondarySessionId);
     expect(secondFacts.secondaryPaneWorkspaceId).toBe(workspaceId);
-    expect(secondFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${primary.sessionId}`);
     expect(secondFacts.secondaryPaneCount).toBe(1);
-    const afterPalette = await listSessions(app);
+    expect(secondFacts.locationHash).toBe(primaryHash);
+    expect(await probe.hash()).toContain(`/session/${primarySessionId}`);
+
+    const afterPalette = await probe.eventually(() => agent.list(), {
+      within: 60_000,
+      label: "palette split session appears in the session list",
+      until: (sessions) => sessions.length === before.length + 2
+        && sessions.some((session) => session.sessionId === secondFacts.secondarySessionId),
+    });
     expect(afterPalette).toHaveLength(before.length + 2);
     expect(afterPalette.map((session) => session.sessionId)).toContain(secondFacts.secondarySessionId);
-
-    await screenshot(app);
-  },
-);
+    await user.screenshot();
+  });
+});

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -22,10 +22,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function regexEscape(value: string): string {
-  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
-}
-
 function parseSplitFacts(value: unknown): SplitFacts {
   if (!isRecord(value)) throw new Error(`Invalid split facts: ${JSON.stringify(value)}`);
   const text = (key: string) => typeof value[key] === "string" ? value[key] : "";
@@ -63,7 +59,8 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   const beforeIds = before.map((session) => session.sessionId);
 
   await step("New split in the session context menu opens a fresh secondary", async () => {
-    await user.rightClick({ role: "button", label: new RegExp(`^${regexEscape(world.session.title)}(?:,| —|$)`) });
+    // The sidebar row is the first place the title renders; the pane header comes later in DOM order.
+    await user.rightClick({ text: world.session.title });
     await user.see({ role: "menuitem", label: "New split" });
     await user.click({ role: "menuitem", label: "New split" });
     await user.see({ text: "Split view" });

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -3,7 +3,6 @@ import { spec } from "@openwork/testkit";
 import { newSplitPrimary } from "../worlds/chat.ts";
 
 const test = spec.world(newSplitPrimary);
-const paletteShortcut = process.platform === "darwin" ? "Meta+K" : "Control+K";
 const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
 
 type SplitFacts = {
@@ -62,7 +61,9 @@ const splitFactsExpression = `(() => {
     };
   })()`;
 
-test("new split creates fresh same-workspace secondary sessions without moving the primary", async ({ world, user, agent, probe, step }) => {
+test("new split creates fresh same-workspace secondary sessions without moving the primary", async ({ world, user, agent, probe, step, place }) => {
+  // The key chord belongs to the machine running the app, not the one running the spec.
+  const paletteShortcut = place.kind !== "daytona" && process.platform === "darwin" ? "Meta+K" : "Control+K";
   const workspaceId = world.workspace.workspaceId;
   const primarySessionId = world.session.sessionId;
 

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -232,28 +232,7 @@ export async function newSplitPrimary(seed: Seed) {
       locationHash: window.location.hash,
     };
   })()`);
-  const openSessionMenu = async (sessionId: string, workspaceId: string): Promise<boolean> => {
-    const rowSelector = `[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`;
-    const tabSelector = `[data-session-tab-id="${sessionId}"]`;
-    return await evalIn(app, `(() => {
-      const row = document.querySelector(${JSON.stringify(rowSelector)});
-      if (!(row instanceof HTMLElement)) return false;
-      row.scrollIntoView({ block: "center" });
-      const target = row.querySelector(${JSON.stringify(tabSelector)}) ?? row;
-      if (!(target instanceof HTMLElement)) return false;
-      const rect = target.getBoundingClientRect();
-      target.dispatchEvent(new MouseEvent("contextmenu", {
-        bubbles: true,
-        cancelable: true,
-        button: 2,
-        buttons: 2,
-        clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
-        clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
-      }));
-      return true;
-    })()`) === true;
-  };
-  return { app, workspace, session, splitFacts, openSessionMenu };
+  return { app, workspace, session, splitFacts };
 }
 
 export async function shimmerChat(seed: Seed) {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { join, resolve } from "node:path";
+import { evalIn } from "@openwork/behaviors";
 import type { Seed } from "@openwork/env";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -210,7 +211,49 @@ export async function newSplitPrimary(seed: Seed) {
   const app = await seed.desktop({ name: "new-split-session" });
   const workspace = await seed.workspace(app, seed.tmpPath("new-split-session"));
   const session = await seedSessionRetry(seed, app, { title: "New split primary" });
-  return { app, workspace, session };
+  const splitFacts = () => evalIn(app, `(() => {
+    const context = window.__openworkControl?.context?.();
+    const layout = context?.conversations?.layout;
+    const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
+    const secondaryPanes = [...document.querySelectorAll('[data-workbench-pane="secondary"]')];
+    const secondaryPane = secondaryPanes[0];
+    return {
+      layoutKind: layout?.kind ?? "",
+      primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
+      secondarySessionId: layout?.secondarySessionId ?? "",
+      primaryWorkspaceId: layout?.primaryWorkspaceId ?? "",
+      secondaryWorkspaceId: layout?.secondaryWorkspaceId ?? "",
+      primarySurfaceSessionId: primaryPane?.querySelector('[data-session-surface-id]')
+        ?.getAttribute('data-session-surface-id') ?? "",
+      secondarySurfaceSessionId: secondaryPane?.querySelector('[data-session-surface-id]')
+        ?.getAttribute('data-session-surface-id') ?? "",
+      secondaryPaneWorkspaceId: secondaryPane?.getAttribute('data-workbench-workspace-id') ?? "",
+      secondaryPaneCount: secondaryPanes.length,
+      locationHash: window.location.hash,
+    };
+  })()`);
+  const openSessionMenu = async (sessionId: string, workspaceId: string): Promise<boolean> => {
+    const rowSelector = `[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`;
+    const tabSelector = `[data-session-tab-id="${sessionId}"]`;
+    return await evalIn(app, `(() => {
+      const row = document.querySelector(${JSON.stringify(rowSelector)});
+      if (!(row instanceof HTMLElement)) return false;
+      row.scrollIntoView({ block: "center" });
+      const target = row.querySelector(${JSON.stringify(tabSelector)}) ?? row;
+      if (!(target instanceof HTMLElement)) return false;
+      const rect = target.getBoundingClientRect();
+      target.dispatchEvent(new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        button: 2,
+        buttons: 2,
+        clientX: rect.left + Math.min(24, Math.max(1, rect.width / 2)),
+        clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
+      }));
+      return true;
+    })()`) === true;
+  };
+  return { app, workspace, session, splitFacts, openSessionMenu };
 }
 
 export async function shimmerChat(seed: Seed) {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -206,6 +206,13 @@ export async function paletteSessionActions(seed: Seed) {
   return { app, workspace, session };
 }
 
+export async function newSplitPrimary(seed: Seed) {
+  const app = await seed.desktop({ name: "new-split-session" });
+  const workspace = await seed.workspace(app, seed.tmpPath("new-split-session"));
+  const session = await seedSessionRetry(seed, app, { title: "New split primary" });
+  return { app, workspace, session };
+}
+
 export async function shimmerChat(seed: Seed) {
   const base = await emptyChat(seed);
   await seedControls(seed, base.app, [{ action: "eval.chat_loading.seed" }]);

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -376,7 +376,7 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
         log: (line) => console.error(`[openwork/testkit] ${line}`),
       })
     : null;
-  const host = provisioned ? daytonaSandbox(provisioned.sandbox) : localHost();
+  const host = provisioned ? daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined) : localHost();
   const seeded = await desktop({ name: "recovery-profile-seed", host, profileDir });
   const names = await evalIn(seeded, `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
     folderPath: ${JSON.stringify(`${profileDir}/continuity-workspace`)}, name: "reliable-recovery-profile-marker"
@@ -528,7 +528,7 @@ export async function enterpriseTlsWorld(seed: Seed, { place }: { place: Place }
   let rootInstallAttempted = false;
   let rawApp: Awaited<ReturnType<typeof desktop>> | null = null;
   let trustedApp: Awaited<ReturnType<typeof startApp>> | null = null;
-  const host = daytonaSandbox(provisioned.sandbox);
+  const host = daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined);
 
   const dispose = async () => {
     if (trustedApp) await cleanup("dispose trusted enterprise TLS app", () => trustedApp?.[Symbol.asyncDispose]() ?? Promise.resolve());

--- a/evals/worlds/infra.ts
+++ b/evals/worlds/infra.ts
@@ -32,13 +32,15 @@ export async function oauthDenWorld(seed: Seed) {
 export async function twoDaytonaDesktopsWorld(seed: Seed) {
   const requestedA = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_A?.trim();
   const requestedB = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_B?.trim();
+  const engineCacheDirA = process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A?.trim();
+  const engineCacheDirB = process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B?.trim();
   if (Boolean(requestedA) !== Boolean(requestedB)) throw new Error("Set both Daytona sandbox ids or neither.");
   if (requestedA && requestedA === requestedB) throw new Error("The two Daytona sandbox ids must differ.");
   const appA = requestedA
-    ? await desktop({ host: daytonaSandbox(requestedA), name: "a" })
+    ? await desktop({ host: daytonaSandbox(requestedA, engineCacheDirA), name: "a" })
     : await seed.desktop({ name: "a" });
   const appB = requestedB
-    ? await desktop({ host: daytonaSandbox(requestedB), name: "b" })
+    ? await desktop({ host: daytonaSandbox(requestedB, engineCacheDirB), name: "b" })
     : await seed.desktop({ name: "b" });
   const sandboxA = appA.handle.sandboxId;
   const sandboxB = appB.handle.sandboxId;


### PR DESCRIPTION
## What

Adds **New split**: create a fresh, empty session in a workspace and open it as the secondary split pane while the primary pane and route stay where they are.

Two entry points:
- **Sidebar**: right-click any session row (or its `⋯` menu) → **New split**. Uses that row's workspace. Shown whenever a primary session is open, including on the current session's own row.
- **Cmd+K** → **New split**. Uses the selected workspace.

## How

- `session-route.tsx`: `handleCreateTaskInWorkspace` is now a thin wrapper over one creator with `openAs: "primary" | "split"`. The split path keeps the retry/toast/analytics/model-apply behaviour but skips the navigate / active-workspace / last-session writes and instead `openTab` → `setSplit` → `focusPane("secondary")`. Retry and engine-reload toasts preserve the mode.
- `app-sidebar.tsx` / `app-sidebar-provider.tsx` / `session-page.tsx`: menu item (`data-session-menu-new-split`) plumbed through the sidebar context.
- `command-palette.tsx`: `new-split` item, gated like `open-in-split-view`.
- `en.ts`: one label. No workbench-store changes; existing reducers cover it.

## Verification — Passed

Spec `evals/specs/new-split-session.e2e.test.ts`, Daytona lane, on this head (`checkout resolved 1a8b35b6a5dc`):

```
✓ new split creates fresh same-workspace secondary sessions without moving the primary  275660ms
passed 1 / failed 0 / skipped 0
```

Claims asserted, for both entry points: layout is `split`; primary session id and route unchanged; secondary is a new `ses_…` id not present before; same workspace; session count grows by exactly one per action; exactly one secondary pane (palette replaces, doesn't stack). Evidence is in the sticky test-evidence comment; supplementary screenshots of both flows are in an earlier comment.

Typecheck (`tsc -p apps/app/tsconfig.json --noEmit`) and `bun test tests/workbench-store.test.ts tests/command-palette-sessions.test.ts` (8 pass) green.

## Depends on #4415

This branch includes the two harness commits from #4415 (engine cache pre-warm). Without them every app-driving spec on `dev` dies at `seedSessions` because the engine's cold plugin install wedges in the sandbox. Merge #4415 first; this PR then reduces to the three feature/spec commits.
