### PR TITLE
ci(evals): fall back to the full E2E set when a PR only touches excluded specs

### DIFF
--- a/.github/workflows/daytona-e2e-regression-suite.yml
+++ b/.github/workflows/daytona-e2e-regression-suite.yml
@@ -172,7 +172,8 @@ jobs:
           )"
 
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            matched_tests="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" | { grep -E '^evals/specs/[^/]+\.e2e\.test\.ts$' || true; } | sed 's#^evals/specs/##' | jq -Rsc 'split("\n") | map(select(length > 0))')"
+            changed_tests="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" | { grep -E '^evals/specs/[^/]+\.e2e\.test\.ts$' || true; } | sed 's#^evals/specs/##' | jq -Rsc 'split("\n") | map(select(length > 0))')"
+            matched_tests="$(echo "$eligible_tests" | jq -c --argjson changed "$changed_tests" 'map(select(. as $test | ($changed | index($test)) != null))')"
             only_filter=""
           else
             matched_tests='[]'
@@ -214,8 +215,8 @@ jobs:
             echo "- Dedicated-workflow exclusions: $(echo "$dedicated_workflow_json" | jq 'length')"
             echo
             echo "Matrix tests: $(echo "$tests" | jq 'length') across $(echo "$batches" | jq 'length') batches"
-            if [ "$EVENT_NAME" = "workflow_run" ] && [ "$(echo "$tests" | jq 'length')" -eq 0 ]; then
-              echo "Warden suggestion: add or update an evals/specs/<feature>.e2e.test.ts test for this PR."
+            if [ "$EVENT_NAME" = "workflow_run" ] && [ "$(echo "$matched_tests" | jq 'length')" -eq 0 ]; then
+              echo "No changed eligible E2E spec in this PR; running the full eligible set."
             fi
             echo "$batches" | jq -r '.[] | "- `\(.name)`: \(.tests | length) E2E tests"'
             echo

--- a/evals/specs/daytona-e2e-regression-schedule.test.ts
+++ b/evals/specs/daytona-e2e-regression-schedule.test.ts
@@ -1,4 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "vitest";
 import { test } from "@openwork/testkit";
@@ -38,17 +42,158 @@ test("the regression suite runs the full eligible suite bi-daily without manual 
   );
 });
 
-test("PR-triggered selection intersects matched tests as basenames", async ({ evidence }) => {
+test("PR-triggered selection falls back to the full eligible set when no eligible spec changed", async ({ evidence }) => {
   const workflow = await readFile(workflowPath, "utf8");
-  const matchedAssignment = String.raw`matched_tests="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" | { grep -E '^evals/specs/[^/]+\.e2e\.test\.ts$' || true; } | sed 's#^evals/specs/##' | jq -Rsc 'split("\n") | map(select(length > 0))')"`;
+  const lines = workflow.split("\n");
+  const stepIndex = lines.findIndex((line) => line.includes("- name: Build E2E test matrix"));
+  const runIndex = lines.findIndex((line, index) => index > stepIndex && line.trim() === "run: |");
+  const bodyLines: string[] = [];
 
-  expect(workflow).toContain(matchedAssignment);
-  expect(workflow).toContain("| sed 's#^evals/specs/##' \\");
+  expect(stepIndex).toBeGreaterThan(-1);
+  expect(runIndex).toBeGreaterThan(stepIndex);
+
+  for (const line of lines.slice(runIndex + 1)) {
+    if (line !== "" && !line.startsWith("          ")) break;
+    bodyLines.push(line.startsWith("          ") ? line.slice(10) : line);
+  }
+
+  const stepBody = bodyLines.join("\n");
+  expect(stepBody.length).toBeGreaterThan(0);
+  expect(stepBody).toContain("set -euo pipefail");
+
+  const tempDir = mkdtempSync(join(tmpdir(), "e2e-matrix-"));
+  const fixtureRepo = join(tempDir, "repo");
+  const fixtureSpecs = join(fixtureRepo, "evals/specs");
+  const fixtureScripts = join(fixtureRepo, "evals/scripts");
+  mkdirSync(fixtureSpecs, { recursive: true });
+  mkdirSync(fixtureScripts, { recursive: true });
+  writeFileSync(join(fixtureSpecs, "alpha.e2e.test.ts"), "export const alpha = true;\n");
+  writeFileSync(join(fixtureSpecs, "beta.e2e.test.ts"), "export const beta = true;\n");
+  writeFileSync(join(fixtureSpecs, "excluded.e2e.test.ts"), "export const excluded = true;\n");
+  writeFileSync(
+    join(fixtureSpecs, "daytona-e2e-regression-profile.json"),
+    JSON.stringify({ excluded: [{ test: "excluded.e2e.test.ts", reason: "fixture exclusion" }] }),
+  );
+  writeFileSync(
+    join(fixtureScripts, "list-daytona-raw-desktop-tests.mjs"),
+    await readFile(new URL("../scripts/list-daytona-raw-desktop-tests.mjs", import.meta.url)),
+  );
+
+  const git = (args: string[]): string => {
+    const result = spawnSync("git", args, { cwd: fixtureRepo, encoding: "utf8" });
+    if (result.error) throw result.error;
+    expect(result.status, result.stderr).toBe(0);
+    return result.stdout.trim();
+  };
+
+  git(["init", "-q"]);
+  git(["add", "-A"]);
+  git(["-c", "user.name=Fixture", "-c", "user.email=fixture@example.com", "commit", "-q", "-m", "base"]);
+  const baseSha = git(["rev-parse", "HEAD"]);
+
+  type MatrixBatch = { name: string; tests: string[] };
+  const isStringArray = (value: unknown): value is string[] =>
+    Array.isArray(value) && value.every((entry: unknown) => typeof entry === "string");
+  const isMatrixBatches = (value: unknown): value is MatrixBatch[] =>
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "name" in entry &&
+        typeof entry.name === "string" &&
+        "tests" in entry &&
+        isStringArray(entry.tests),
+    );
+
+  const runPlan = ({
+    eventName,
+    baseSha: planBaseSha,
+    headSha,
+    only,
+  }: {
+    eventName: string;
+    baseSha?: string;
+    headSha?: string;
+    only?: string;
+  }): { batches: MatrixBatch[]; hasTests: string; summary: string } => {
+    const scriptPath = join(tempDir, "matrix.sh");
+    const summaryPath = join(tempDir, "summary.md");
+    const outputPath = join(tempDir, "output.txt");
+    writeFileSync(scriptPath, stepBody);
+    writeFileSync(summaryPath, "");
+    writeFileSync(outputPath, "");
+    const result = spawnSync("bash", [scriptPath], {
+      cwd: fixtureRepo,
+      env: {
+        ...process.env,
+        EVENT_NAME: eventName,
+        BASE_SHA: planBaseSha ?? "",
+        HEAD_SHA: headSha ?? "",
+        ONLY_FILTER: only ?? "",
+        GITHUB_STEP_SUMMARY: summaryPath,
+        GITHUB_OUTPUT: outputPath,
+      },
+      encoding: "utf8",
+    });
+    if (result.error) throw result.error;
+    expect(result.status, result.stderr).toBe(0);
+
+    const output = readFileSync(outputPath, "utf8");
+    const batchLine = output.split("\n").find((line) => line.startsWith("batches="));
+    const hasTestsLine = output.split("\n").find((line) => line.startsWith("has_tests="));
+    if (!batchLine || !hasTestsLine) throw new Error(`Invalid step output: ${output}`);
+    const parsedBatches: unknown = JSON.parse(batchLine.slice("batches=".length));
+    expect(isMatrixBatches(parsedBatches)).toBe(true);
+    if (!isMatrixBatches(parsedBatches)) throw new Error("Invalid batches output");
+
+    return {
+      batches: parsedBatches,
+      hasTests: hasTestsLine.slice("has_tests=".length),
+      summary: readFileSync(summaryPath, "utf8"),
+    };
+  };
+
+  const scenario = (file: string, content: string): string => {
+    git(["checkout", "-q", "--detach", baseSha]);
+    writeFileSync(join(fixtureRepo, file), content);
+    git(["add", "-A"]);
+    git(["-c", "user.name=Fixture", "-c", "user.email=fixture@example.com", "commit", "-q", "-m", file]);
+    return git(["rev-parse", "HEAD"]);
+  };
+
+  const matrixTests = (batches: MatrixBatch[]): string[] => batches.flatMap((batch) => batch.tests).sort();
+  const fallback = "No changed eligible E2E spec in this PR; running the full eligible set.";
+
+  const excludedHead = scenario("evals/specs/excluded.e2e.test.ts", "export const excluded = false;\n");
+  const excludedPlan = runPlan({ eventName: "workflow_run", baseSha, headSha: excludedHead });
+  expect(matrixTests(excludedPlan.batches)).toEqual(["alpha.e2e.test.ts", "beta.e2e.test.ts"]);
+  expect(excludedPlan.hasTests).toBe("true");
+  expect(excludedPlan.summary).toContain(fallback);
+  expect(excludedPlan.summary).not.toContain("Warden suggestion");
+
+  const eligibleHead = scenario("evals/specs/alpha.e2e.test.ts", "export const alpha = false;\n");
+  const eligiblePlan = runPlan({ eventName: "workflow_run", baseSha, headSha: eligibleHead });
+  expect(matrixTests(eligiblePlan.batches)).toEqual(["alpha.e2e.test.ts"]);
+  expect(eligiblePlan.hasTests).toBe("true");
+  expect(eligiblePlan.summary).not.toContain(fallback);
+
+  const readmeHead = scenario("README.md", "fixture\n");
+  const readmePlan = runPlan({ eventName: "workflow_run", baseSha, headSha: readmeHead });
+  expect(matrixTests(readmePlan.batches)).toEqual(["alpha.e2e.test.ts", "beta.e2e.test.ts"]);
+  expect(readmePlan.hasTests).toBe("true");
+  expect(readmePlan.summary).toContain(fallback);
+
+  const scheduledPlan = runPlan({ eventName: "schedule", only: "beta" });
+  expect(matrixTests(scheduledPlan.batches)).toEqual(["beta.e2e.test.ts"]);
+  expect(scheduledPlan.hasTests).toBe("true");
+  expect(scheduledPlan.summary).not.toContain(fallback);
+
   expect(workflow).not.toContain(["spec", "impact.mjs"].join("-"));
 
   evidence.recordAssertionEvidence(
-    "PR-triggered Daytona E2E selection compares matched and eligible test basenames",
-    "The workflow selects changed top-level E2E files with git diff and strips the evals/specs/ prefix before intersecting them with the basename inventory.",
+    "The Daytona E2E matrix step selects eligible tests and falls back when needed",
+    "The shell step extracted from the workflow ran against a fixture repository across excluded-change, eligible-change, non-E2E-change, and scheduled-filter scenarios.",
     true,
   );
 });


### PR DESCRIPTION
## Why

Tracked in #3915. The three most recent `Daytona E2E Regression Suite` failures were `verdict` failures with an empty matrix, not product regressions:

- Runs [33841753494](https://github.com/different-ai/openwork/actions/runs/33841753494) and [33844367127](https://github.com/different-ai/openwork/actions/runs/33844367127) (PR #4390): the PR's only e2e change was `dashboard-duplicate-capability-tiles.e2e.test.ts`, which the same PR added to `daytona-e2e-regression-profile.json`'s excluded list. The plan step built `matched_tests` from `git diff` *before* removing excluded specs, so `matched` was non-empty, the "fall back to the full eligible set" branch from #4378 never ran, the filter yielded `[]`, the e2e job was skipped, and `verdict` failed.
- Run [33816055555](https://github.com/different-ai/openwork/actions/runs/33816055555) (PR #4377) ran under the pre-#4378 spec-impact workflow, which had no fallback at all; already superseded.

## What

`.github/workflows/daytona-e2e-regression-suite.yml`, `Build E2E test matrix` step only:

- Intersect the changed e2e specs with `eligible_tests` first, so the existing `($matched | length == 0)` fallback covers "changed specs are all excluded" the same way it covers "no spec changed".
- Replace the now-unreachable `Warden suggestion:` summary line with a truthful one printed when the fallback happens.

`evals/specs/daytona-e2e-regression-schedule.test.ts`:

- The second test used to assert the *exact shell text* of the `matched_tests=` line, so it went red on this refactor (and on any future one) while never catching the actual bug. It now extracts the `Build E2E test matrix` `run:` body from the workflow at test time and executes it against a throwaway git fixture repo, asserting on `GITHUB_OUTPUT` (`batches`, `has_tests`) and `GITHUB_STEP_SUMMARY` across four scenarios: only an excluded spec changed, one eligible spec changed, no e2e spec changed, and a scheduled run with `ONLY_FILTER`.

No changes to the `e2e` or `verdict` jobs, or to the profile.

## Verification

Rebased on `dev` (picks up #4404, which fixed the unrelated `spec-boundary-ratchet` failure on the previous CI run).

```
pnpm evals:pr specs/daytona-e2e-regression-schedule.test.ts
```
Placement: local, `pr` lane. Verdict: **Passed** — `Tests 2 passed (2)`. Every claim has an observable assertion (matrix contents, `has_tests`, summary line presence/absence).

Mutation check — same spec with `dev`'s workflow copied over this branch's:
`× PR-triggered selection falls back to the full eligible set when no eligible spec changed` → `expected [] to deeply equal [ 'alpha.e2e.test.ts', 'beta.e2e.test.ts' ]`. The spec reproduces the empty-matrix regression from PR #4390 and goes green only with this fix.

`node evals/scripts/spec-boundary-ratchet.mjs` → `170 specs checked` (spec is grandfathered in the baseline; baseline untouched). `tsc --noEmit -p evals` clean for the spec.

Note: because this PR touches `.github/`, the regression suite itself withholds on it ("PR changes trusted review machinery") — expected.

## Follow-up (not in this PR)

Run [33805238155](https://github.com/different-ai/openwork/actions/runs/33805238155) failed in `plan` with "Warden summary or pull request head does not match": a push landed while Warden was running. That is a benign race but exits 1 and posts an alert; it could withhold with `authorized=false` instead.

