### PR TITLE
feat(den-web): Manage → Advanced tabs (Collections, Desktop policies, Brand appearance) + Sources tab in Plugin Directory

### DIFF
--- a/docs/cloud-organization-role-access.md
+++ b/docs/cloud-organization-role-access.md
@@ -29,29 +29,34 @@ Only the current `owner` can transfer ownership. The target must be an active `s
 
 For cloud organization admins (`owner`, `super-admin`, and `admin`), the Den Web sidebar order is:
 
-- Dashboard
-- Your Connections, when enabled
-- Extensions
-  - Marketplace
-  - Sources
-  - Plugins
+- Work
+  - Dashboard
+  - My Library
+  - My Automations, when enabled
+  - OpenWork Web, when enabled
+- Manage
+  - Plugin Directory, with Plugins, Agents, Commands, Hooks, MCPs, and Sources tabs
   - Connectors
-- Models
-  - OpenWork Models
-  - LLM Providers
-- Members
-- Analytics
-- Settings
-  - General
-  - Diagnostics
-  - Brand appearance
-  - Desktop Policies
-  - Stripe
-  - API Keys
-  - SSO
-  - SCIM
+  - Dashboards, when enabled
+  - Models
+    - OpenWork Models, on hosted deployments only
+    - Bring your Own Keys
+  - Advanced, with Collections, Desktop policies, and Brand appearance tabs
+- Observability
+  - Workflow Runs, when enabled
+  - Analytics
+- Team
+  - Members
+  - Settings
+    - General
+    - Diagnostics
+    - Billing
+    - API Keys
+    - SSO
+    - SCIM
+    - Tool Tester, when connectors are enabled
 
-Plain members have member access only: Dashboard, plus Your Connections when that capability is enabled.
+Plain members have member access only: Dashboard, My Library, and My Automations / OpenWork Web when enabled.
 
 ## Role matrix
 

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -651,6 +651,10 @@ export function getIntegrationsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/integrations`;
 }
 
+export function getPluginSourcesRoute(orgSlug?: string | null): string {
+  return `${getPluginsRoute(orgSlug)}?view=sources`;
+}
+
 export function getGithubIntegrationRoute(orgSlug?: string | null): string {
   return `${getIntegrationsRoute(orgSlug)}/github`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/advanced/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/advanced/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdvancedPage() {
+  redirect("/dashboard/marketplaces");
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/integrations/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/integrations/page.tsx
@@ -1,5 +1,5 @@
-import { IntegrationsScreen } from "../../_components/integrations-screen";
+import { redirect } from "next/navigation";
 
 export default function IntegrationsPage() {
-  return <IntegrationsScreen />;
+  redirect("/dashboard/plugins?view=sources");
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/plugins/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/plugins/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import { PluginsScreen } from "../../_components/plugins-screen";
 
 export default function PluginsPage() {
-  return <PluginsScreen />;
+  return (
+    <Suspense fallback={null}>
+      <PluginsScreen />
+    </Suspense>
+  );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/advanced-page-template.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/advanced-page-template.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Laptop, Palette, Store } from "lucide-react";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { type TabItem, UnderlineTabs } from "../../_components/ui/tabs";
+import {
+  getBrandAppearanceRoute,
+  getDesktopPoliciesRoute,
+  getMarketplacesRoute,
+} from "../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+
+export type AdvancedTab = "collections" | "desktop-policies" | "brand-appearance";
+
+const ADVANCED_TABS: readonly TabItem<AdvancedTab>[] = [
+  { value: "collections", label: "Collections", icon: Store },
+  { value: "desktop-policies", label: "Desktop policies", icon: Laptop },
+  { value: "brand-appearance", label: "Brand appearance", icon: Palette },
+];
+
+const ADVANCED_DESCRIPTIONS: Record<AdvancedTab, string> = {
+  collections: "Collections contain plugins. The built-in OpenWork collection and assigned collections show up inside the desktop app after sign-in.",
+  "desktop-policies": "Control which desktop capabilities are available to the whole org, specific members, or teams.",
+  "brand-appearance": "Customize how your workspace appears across OpenWork.",
+};
+
+export function AdvancedPageTemplate({ tab, children }: { tab: AdvancedTab; children: ReactNode }) {
+  const router = useRouter();
+  const { orgSlug } = useOrgDashboard();
+
+  function routeFor(next: AdvancedTab) {
+    const routes: Record<AdvancedTab, string> = {
+      collections: getMarketplacesRoute(orgSlug),
+      "desktop-policies": getDesktopPoliciesRoute(orgSlug),
+      "brand-appearance": getBrandAppearanceRoute(orgSlug),
+    };
+    return routes[next];
+  }
+
+  return (
+    <DashboardPageTemplate
+      title="Advanced"
+      description={ADVANCED_DESCRIPTIONS[tab]}
+      colors={["#F1F5F9", "#0F172A", "#475569", "#CBD5E1"]}
+    >
+      <div data-testid="advanced-tabs" className="mb-6">
+        <UnderlineTabs
+          tabs={ADVANCED_TABS}
+          activeTab={tab}
+          onChange={(next) => router.push(routeFor(next))}
+        />
+      </div>
+      {children}
+    </DashboardPageTemplate>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/brand-appearance-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/brand-appearance-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ImageUp, Palette, Trash2 } from "lucide-react";
+import { ImageUp, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
 import {
@@ -9,12 +9,12 @@ import {
   parseOrganizationMetadata,
   type DenManagedBrandAsset,
 } from "../../_lib/den-org";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { AdvancedPageTemplate } from "./advanced-page-template";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
 
 const BRAND_ASSET_MAX_BYTES = 2 * 1024 * 1024;
@@ -267,23 +267,18 @@ export function BrandAppearanceScreen() {
 
   return (
     <div data-testid="brand-appearance-screen">
-      <DashboardPageTemplate
-        icon={Palette}
-        title="Brand appearance"
-        description="Customize how your workspace appears across OpenWork."
-        colors={["#F5F3FF", "#4C1D95", "#8B5CF6", "#DDD6FE"]}
-      >
+      <AdvancedPageTemplate tab="brand-appearance">
         {!orgContext.entitlements.desktopPolicies ? (
           <EnterprisePlanNotice feature="White-label brand appearance" />
         ) : (
           <form className="grid gap-6" onSubmit={handleSave}>
             {pageError ? <DenNotice message={pageError} /> : null}
-            {pageSuccess ? <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">{pageSuccess}</div> : null}
+            {pageSuccess ? <DenNotice tone="neutral" message={pageSuccess} /> : null}
 
             <DenCard size="spacious" className="grid gap-6">
               <div className="grid gap-2">
                 <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-violet-500">Workspace brand</p>
-                <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">Desktop identity</h2>
+                <h2 className="text-[16px] font-semibold tracking-[-0.01em] text-gray-900">Desktop identity</h2>
                 <p className="text-[14px] text-gray-500">Set the desktop application name, wordmark, app icon, and accent color.</p>
               </div>
 
@@ -317,7 +312,7 @@ export function BrandAppearanceScreen() {
             </div>
           </form>
         )}
-      </DashboardPageTemplate>
+      </AdvancedPageTemplate>
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policies-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policies-screen.tsx
@@ -2,9 +2,10 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Laptop, Plus } from "lucide-react";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { Plus } from "lucide-react";
 import { DenButton, buttonVariants } from "../../_components/ui/button";
+import { DenCatalogList, DenCatalogRow } from "../../_components/ui/catalog-row";
+import { DenNotice } from "../../_components/ui/notice";
 import { getDesktopPolicyRoute, getNewDesktopPolicyRoute, getOrgAccessFlags } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
@@ -12,6 +13,7 @@ import {
   useOrgDesktopPolicies,
   type DenDesktopPolicy,
 } from "./desktop-policy-data";
+import { AdvancedPageTemplate } from "./advanced-page-template";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
 
 function formatPolicyTimestamp(value: string | null) {
@@ -74,13 +76,8 @@ export function DesktopPoliciesScreen() {
   };
 
   return (
-    <DashboardPageTemplate
-      icon={Laptop}
-      title="Desktop policies"
-      description="Control which desktop capabilities are available to the whole org, specific members, or teams."
-      colors={["#F8FAFC", "#0F172A", "#38BDF8", "#A78BFA"]}
-    >
-      <div className="mb-6 flex flex-wrap items-center justify-end gap-3">
+    <AdvancedPageTemplate tab="desktop-policies">
+      <div className="mb-6 flex items-center justify-end">
         {canManage ? (
           <Link href={getNewDesktopPolicyRoute(orgSlug)} className={buttonVariants({ variant: "primary" })}>
             <Plus className="h-4 w-4" aria-hidden="true" />
@@ -94,78 +91,50 @@ export function DesktopPoliciesScreen() {
       </div>
 
       {orgContext && !orgContext.entitlements.desktopPolicies ? <EnterprisePlanNotice feature="Desktop policy management" /> : null}
-      {pageError ? <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">{pageError}</div> : null}
-      {pageSuccess ? <div className="mb-6 rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">{pageSuccess}</div> : null}
-      {error ? <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">{error}</div> : null}
+      {pageError ? <DenNotice message={pageError} className="mb-6" /> : null}
+      {pageSuccess ? <DenNotice tone="neutral" message={pageSuccess} className="mb-6" /> : null}
+      {error ? <DenNotice message={error} className="mb-6" /> : null}
 
       {busy ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">Loading desktop policies...</div>
       ) : visiblePolicies.length === 0 ? (
-        <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center text-[15px] text-gray-500">No desktop policies.</div>
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
+          <p className="text-[15px] font-semibold tracking-[-0.02em] text-gray-900">No desktop policies yet</p>
+          <p className="mx-auto mt-2 max-w-[520px] text-[13px] leading-6 text-gray-500">
+            Create a policy to control which desktop capabilities members can use.
+          </p>
+        </div>
       ) : (
-        <section className="overflow-hidden rounded-[28px] border border-gray-200 bg-white">
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-left text-[14px]">
-              <colgroup>
-                <col />
-                <col className="w-[1%]" />
-                <col className="w-[1%]" />
-                <col className="w-[1%]" />
-                <col className="w-[1%]" />
-              </colgroup>
-              <thead className="bg-gray-50 text-[12px] uppercase tracking-[0.08em] text-gray-500">
-                <tr>
-                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Name</th>
-                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Enabled</th>
-                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Priority</th>
-                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium">Created</th>
-                  <th scope="col" className="whitespace-nowrap px-4 py-3 font-medium text-right">
-                    <span className="sr-only">Actions</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {visiblePolicies.map((policy) => {
-                  const editHref = getDesktopPolicyRoute(orgSlug, policy.id);
-                  return (
-                    <tr key={policy.id} className="align-middle">
-                      <td className="whitespace-nowrap px-4 py-4">
-                        <div className="flex items-center gap-2">
-                          <span className="text-[14px] font-medium text-gray-950">{policy.policyName}</span>
-                          {policy.isDefault ? (
-                            <span className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-sky-700">Default</span>
-                          ) : null}
-                        </div>
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-4">
-                        <span className={`inline-flex items-center rounded-full px-3 py-1 text-[12px] font-medium ${policy.isEnabled ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
-                          {policy.isEnabled ? "Yes" : "No"}
-                        </span>
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-4 text-[13px] text-gray-600">
-                        {policy.isDefault ? "Fallback" : policy.priority}
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-4 text-[13px] text-gray-600">
-                        {formatPolicyTimestamp(policy.createdAt)}
-                      </td>
-                      <td className="whitespace-nowrap px-4 py-4">
-                        <div className="flex justify-end gap-2">
-                          <Link href={editHref} className={buttonVariants({ variant: "secondary", size: "sm" })}>
-                            {canManage ? "Edit" : "View"}
-                          </Link>
-                          {!policy.isDefault ? (
-                            <DenButton type="button" variant="destructive" size="sm" onClick={() => void softDeletePolicy(policy)} disabled={!canManage || deleting}>Delete</DenButton>
-                          ) : null}
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </section>
+        <DenCatalogList
+          label={`${visiblePolicies.length} polic${visiblePolicies.length === 1 ? "y" : "ies"}`}
+          valueLabel="Priority"
+          valueWidth="150px"
+        >
+          {visiblePolicies.map((policy) => (
+            <DenCatalogRow
+              key={policy.id}
+              title={policy.policyName}
+              badge={policy.isDefault ? (
+                <span className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.1em] leading-none text-sky-700">Default</span>
+              ) : undefined}
+              description={policy.isEnabled ? "Enabled" : "Disabled"}
+              value={policy.isDefault ? "Fallback" : String(policy.priority)}
+              valueCaption={`Created ${formatPolicyTimestamp(policy.createdAt)}`}
+              valueWidth="150px"
+              action={
+                <div className="flex shrink-0 items-center gap-2">
+                  <Link href={getDesktopPolicyRoute(orgSlug, policy.id)} className={buttonVariants({ variant: "secondary", size: "sm" })}>
+                    {canManage ? "Edit" : "View"}
+                  </Link>
+                  {!policy.isDefault ? (
+                    <DenButton type="button" variant="destructive" size="sm" onClick={() => void softDeletePolicy(policy)} disabled={!canManage || deleting}>Delete</DenButton>
+                  ) : null}
+                </div>
+              }
+            />
+          ))}
+        </DenCatalogList>
       )}
-    </DashboardPageTemplate>
+    </AdvancedPageTemplate>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/github-integration-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/github-integration-screen.tsx
@@ -23,7 +23,7 @@ import {
   getGithubIntegrationAccountRoute,
   getGithubIntegrationRoute,
   getGithubIntegrationSetupRoute,
-  getIntegrationsRoute,
+  getPluginSourcesRoute,
 } from "../../_lib/den-org";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
@@ -64,7 +64,7 @@ export function GithubIntegrationScreen() {
       <GithubConnectorInstanceRouter
         connectorInstanceId={connectorInstanceId}
         mode={mode}
-        onBack={() => router.push(getIntegrationsRoute(orgSlug))}
+        onBack={() => router.push(getPluginSourcesRoute(orgSlug))}
       />
     );
   }
@@ -686,7 +686,7 @@ function GithubConnectedAccountSelectionPhase({ connectorAccountId }: { connecto
     >
       <div className="mb-6 flex items-center justify-between gap-3">
         <Link
-          href={getIntegrationsRoute(orgSlug)}
+          href={getPluginSourcesRoute(orgSlug)}
           className="inline-flex items-center gap-1.5 text-[13px] text-gray-400 transition hover:text-gray-700"
         >
           <ArrowLeft className="h-4 w-4" />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integrations-screen.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { Cable, Check, GitBranch, Loader2, Plus, Settings, Trash2 } from "lucide-react";
 import { getGithubIntegrationAccountRoute, getGithubIntegrationRoute, getGithubIntegrationSetupRoute } from "../../_lib/den-org";
 import { DenButton } from "../../_components/ui/button";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { DenNotice } from "../../_components/ui/notice";
 import { IntegrationConnectDialog } from "./integration-connect-dialog";
 import { IntegrationIcon } from "./integration-icon";
 import {
@@ -19,7 +19,7 @@ import {
 } from "./integration-data";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
-export function IntegrationsScreen() {
+export function IntegrationsPanel() {
   const { orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error } = useIntegrations();
   const disconnect = useDisconnectIntegration();
@@ -54,25 +54,21 @@ export function IntegrationsScreen() {
   const providers = Object.values(INTEGRATION_PROVIDERS);
 
   return (
-    <DashboardPageTemplate
-      icon={Cable}
-      title="Sources"
-      description="Connect to GitHub or Bitbucket. Once an account is linked, plugins and skills from those repositories show up on the Plugins page."
-      colors={["#E0F2FE", "#0C4A6E", "#0284C7", "#7DD3FC"]}
-    >
+    <>
       {error || startGithubInstall.error ? (
-        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
-          {error instanceof Error
+        <DenNotice
+          className="mb-6"
+          message={error instanceof Error
             ? error.message
             : startGithubInstall.error instanceof Error
               ? startGithubInstall.error.message
               : "Failed to load integrations."}
-        </div>
+        />
       ) : null}
 
       {isLoading ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
-          Loading integrations…
+          Loading sources…
         </div>
       ) : (
         <div className="grid gap-4 lg:grid-cols-2">
@@ -156,7 +152,7 @@ export function IntegrationsScreen() {
         provider={dialogProvider}
         onClose={() => setDialogProvider(null)}
       />
-    </DashboardPageTemplate>
+    </>
   );
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplaces-screen.tsx
@@ -3,11 +3,11 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
-import { Cable, Loader2, Plus, Search, Store } from "lucide-react";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { Cable, Loader2, Plus, Search } from "lucide-react";
 import { DenInput } from "../../_components/ui/input";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
-import { getIntegrationsRoute, getMarketplaceRoute, getOrgAccessFlags } from "../../_lib/den-org";
+import { DenNotice } from "../../_components/ui/notice";
+import { getMarketplaceRoute, getOrgAccessFlags, getPluginSourcesRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { useHasAnyIntegration } from "./integration-data";
 import {
@@ -18,6 +18,7 @@ import {
 } from "./marketplace-data";
 import { DenCatalogList, DenCatalogRow } from "../../_components/ui/catalog-row";
 import { CatalogIdentityTile } from "./catalog-identity-tile";
+import { AdvancedPageTemplate } from "./advanced-page-template";
 
 export function MarketplacesScreen() {
   const { orgContext, orgSlug } = useOrgDashboard();
@@ -49,12 +50,7 @@ export function MarketplacesScreen() {
   }, [marketplaces, normalizedQuery]);
 
   return (
-    <DashboardPageTemplate
-      icon={Store}
-      title="Collections"
-      description="Collections contain plugins. The built-in OpenWork collection and assigned collections show up inside the desktop app after sign-in."
-      colors={["#FEF3C7", "#92400E", "#F59E0B", "#FDE68A"]}
-    >
+    <AdvancedPageTemplate tab="collections">
       <div className="mb-6 flex flex-col gap-3 sm:flex-row">
         <div className="min-w-0 flex-1">
           <DenInput
@@ -73,9 +69,10 @@ export function MarketplacesScreen() {
       </div>
 
       {error ? (
-        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
-          {error instanceof Error ? error.message : "Failed to load collections."}
-        </div>
+        <DenNotice
+          message={error instanceof Error ? error.message : "Failed to load collections."}
+          className="mb-6"
+        />
       ) : null}
 
       {isLoading || integrationsLoading ? (
@@ -83,7 +80,7 @@ export function MarketplacesScreen() {
           Loading collections…
         </div>
       ) : !hasAnyIntegration && marketplaces.length === 0 ? (
-        <ConnectIntegrationEmptyState integrationsHref={getIntegrationsRoute(orgSlug)} />
+        <ConnectIntegrationEmptyState integrationsHref={getPluginSourcesRoute(orgSlug)} />
       ) : filtered.length === 0 ? (
         <EmptyState
           title={marketplaces.length === 0 ? "No collections yet" : "No collections match that search"}
@@ -94,7 +91,7 @@ export function MarketplacesScreen() {
           }
           action={
             marketplaces.length === 0
-              ? { href: getIntegrationsRoute(orgSlug), label: "Open Integrations", icon: Cable }
+              ? { href: getPluginSourcesRoute(orgSlug), label: "Open Sources", icon: Cable }
               : undefined
           }
         />
@@ -131,7 +128,7 @@ export function MarketplacesScreen() {
           }}
         />
       ) : null}
-    </DashboardPageTemplate>
+    </AdvancedPageTemplate>
   );
 }
 
@@ -251,9 +248,9 @@ function EmptyState({
 function ConnectIntegrationEmptyState({ integrationsHref }: { integrationsHref: string }) {
   return (
     <EmptyState
-      title="Connect an integration to discover collections"
+      title="Connect a source to discover collections"
       description="Collections are created when OpenWork finds plugins in a connected repository. Assign them to everyone in your org or specific users and teams."
-      action={{ href: integrationsHref, label: "Open Integrations", icon: Cable }}
+      action={{ href: integrationsHref, label: "Open Sources", icon: Cable }}
     />
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -10,7 +10,6 @@ import {
   ChevronDown,
   ChevronRight,
   FileText,
-  GitFork,
   Globe,
   Home,
   LayoutDashboard,
@@ -20,7 +19,7 @@ import {
   MessageSquare,
   ScrollText,
   Plug,
-  Puzzle,
+  Settings2,
   SlidersHorizontal,
   Sparkles,
   type LucideIcon,
@@ -79,6 +78,8 @@ type DashboardNavItem = {
   icon: LucideIcon;
   badge?: string;
   testId?: string;
+  /** Extra pathname prefixes that select this entry. */
+  matchHrefs?: string[];
   /**
    * Grouped entries (Models, Settings) link to the first child and expand
    * their children while the current page is inside the group.
@@ -274,8 +275,12 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   if (pathname.startsWith(getCustomLlmProvidersRoute(orgSlug))) {
     return "Bring your Own Keys";
   }
-  if (pathname.startsWith(getDesktopPoliciesRoute(orgSlug))) {
-    return "Desktop Policies";
+  if (
+    pathname.startsWith(getDesktopPoliciesRoute(orgSlug))
+    || pathname.startsWith(getMarketplacesRoute(orgSlug))
+    || pathname.startsWith(getBrandAppearanceRoute(orgSlug))
+  ) {
+    return "Advanced";
   }
   if (pathname.startsWith(getDiagnosticsRoute(orgSlug))) {
     return "Diagnostics";
@@ -292,11 +297,8 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   if (pathname.startsWith(getPluginsRoute(orgSlug))) {
     return "Plugin Directory";
   }
-  if (pathname.startsWith(getMarketplacesRoute(orgSlug))) {
-    return "Collections";
-  }
   if (pathname.startsWith(getIntegrationsRoute(orgSlug))) {
-    return "Sources";
+    return "Plugin Directory";
   }
   if (pathname.startsWith(getMcpConnectionsRoute(orgSlug))) {
     return "Connectors";
@@ -315,9 +317,6 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   }
   if (pathname.startsWith(getBillingRoute(orgSlug))) {
     return "Billing";
-  }
-  if (pathname.startsWith(getBrandAppearanceRoute(orgSlug))) {
-    return "Brand appearance";
   }
   if (pathname.startsWith(getOrgSettingsRoute(orgSlug))) {
     return "Org Settings";
@@ -420,8 +419,8 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     && orgContext?.capabilities.openworkWeb === true;
 
   // One nav, two audiences. Members see Work only. Admins add Manage
-  // (catalog + connectors + models), Observability, and Team. Connections
-  // live inside My Library; Tool Tester lives under Settings.
+  // (catalog + connectors + models + Advanced), Observability, and Team.
+  // Advanced groups collections, desktop policies, and brand appearance as tabs.
   const workItems: DashboardNavItem[] = [
     {
       href: activeOrg ? getOrgDashboardRoute(activeOrg.slug) : "#",
@@ -471,11 +470,6 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const manageItems: DashboardNavItem[] = access.isAdmin && activeOrg
     ? [
         {
-          href: getMarketplacesRoute(activeOrg.slug),
-          label: "Collections",
-          icon: Puzzle,
-        },
-        {
           href: getPluginsRoute(activeOrg.slug),
           label: "Plugin Directory",
           icon: Box,
@@ -486,12 +480,6 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           icon: Plug,
           badge: "MCPs",
         },
-        {
-          href: getIntegrationsRoute(activeOrg.slug),
-          label: "Sources",
-          icon: GitFork,
-          badge: "Alpha",
-        },
         ...(orgManagedDashboardsEnabled
           ? [{
               href: getManagedDashboardsRoute(activeOrg.slug),
@@ -500,6 +488,15 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
             }]
           : []),
         ...(modelsGroup ? [modelsGroup] : []),
+        {
+          href: getMarketplacesRoute(activeOrg.slug),
+          label: "Advanced",
+          icon: Settings2,
+          matchHrefs: [
+            getDesktopPoliciesRoute(activeOrg.slug),
+            getBrandAppearanceRoute(activeOrg.slug),
+          ],
+        },
       ]
     : [];
   const observabilityItems: DashboardNavItem[] = access.isAdmin && activeOrg
@@ -521,8 +518,6 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           ? [
               { href: getOrgSettingsRoute(activeOrg.slug), label: "General" },
               { href: getDiagnosticsRoute(activeOrg.slug), label: "Diagnostics" },
-              { href: getBrandAppearanceRoute(activeOrg.slug), label: "Brand appearance" },
-              { href: getDesktopPoliciesRoute(activeOrg.slug), label: "Desktop Policies" },
               { href: getBillingRoute(activeOrg.slug), label: "Billing" },
               { href: getApiKeysRoute(activeOrg.slug), label: "API Keys" },
               { href: getSsoRoute(activeOrg.slug), label: "SSO" },
@@ -763,7 +758,11 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
                               pathname === getYourConnectionsRoute(activeOrg.slug)
                               || pathname.startsWith(`${getYourConnectionsRoute(activeOrg.slug)}/`)
                             ))
-                          : pathname === item.href || pathname.startsWith(`${item.href}/`));
+                          : pathname === item.href
+                            || pathname.startsWith(`${item.href}/`)
+                            || (item.matchHrefs ?? []).some(
+                              (href) => pathname === href || pathname.startsWith(`${href}/`),
+                            ));
 
                   return (
                     <div key={item.label}>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugins-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugins-screen.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import {
   Cable,
+  GitFork,
   Plus,
   Puzzle,
   Search,
   Server,
-  Store,
   Terminal,
   Users,
   Webhook,
@@ -16,10 +17,11 @@ import {
 import { UnderlineTabs } from "../../_components/ui/tabs";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenInput } from "../../_components/ui/input";
-import { buttonVariants } from "../../_components/ui/button";
-import { getIntegrationsRoute, getNewPluginRoute, getPluginRoute } from "../../_lib/den-org";
+import { buttonVariants, DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
+import { getNewPluginRoute, getPluginRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
-import { useHasAnyIntegration } from "./integration-data";
+import { useIntegrations } from "./integration-data";
 import {
   type DenPlugin,
   getPluginCategoryLabel,
@@ -29,8 +31,9 @@ import {
 } from "./plugin-data";
 import { DenCatalogList, DenCatalogRow } from "../../_components/ui/catalog-row";
 import { CatalogIdentityTile } from "./catalog-identity-tile";
+import { IntegrationsPanel } from "./integrations-screen";
 
-type PluginView = "plugins" | "agents" | "commands" | "hooks" | "mcps";
+type PluginView = "plugins" | "agents" | "commands" | "hooks" | "mcps" | "sources";
 
 const PLUGIN_TABS = [
   { value: "plugins" as const, label: "Plugins", icon: Puzzle },
@@ -38,13 +41,25 @@ const PLUGIN_TABS = [
   { value: "commands" as const, label: "Commands", icon: Terminal },
   { value: "hooks" as const, label: "Hooks", icon: Webhook },
   { value: "mcps" as const, label: "MCPs", icon: Server },
+  { value: "sources" as const, label: "Sources", icon: GitFork },
 ];
 
+const SEARCH_PLACEHOLDERS: Record<PluginView, string> = {
+  plugins: "Search plugins...",
+  agents: "Search agents...",
+  commands: "Search commands...",
+  hooks: "Search hooks...",
+  mcps: "Search MCPs...",
+  sources: "Search sources...",
+};
+
 export function PluginsScreen() {
+  const searchParams = useSearchParams();
   const { orgSlug } = useOrgDashboard();
   const { data: plugins = [], isLoading, error } = usePlugins();
-  const { hasAny: hasAnyIntegration, isLoading: integrationsLoading } = useHasAnyIntegration();
-  const [activeView, setActiveView] = useState<PluginView>("plugins");
+  const { data: connections = [], isLoading: integrationsLoading } = useIntegrations();
+  const hasAnyIntegration = connections.length > 0;
+  const [activeView, setActiveView] = useState<PluginView>(searchParams.get("view") === "sources" ? "sources" : "plugins");
   const [query, setQuery] = useState("");
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -142,24 +157,16 @@ export function PluginsScreen() {
     commands: allCommands.length,
     hooks: allHooks.length,
     mcps: allMcps.length,
+    sources: connections.length,
   };
 
-  const searchPlaceholder =
-    activeView === "plugins"
-      ? "Search plugins..."
-      : activeView === "agents"
-          ? "Search agents..."
-          : activeView === "commands"
-            ? "Search commands..."
-            : activeView === "hooks"
-              ? "Search hooks..."
-              : "Search MCPs...";
+  const searchPlaceholder = SEARCH_PLACEHOLDERS[activeView];
 
   return (
     <DashboardPageTemplate
       icon={Puzzle}
       title="Plugin Directory"
-      description="Discover and manage plugins — bundles of skills, hooks, MCP servers, agents, and commands that extend your workers."
+      description="Discover and manage plugins — bundles of skills, hooks, MCP servers, agents, and commands — and the sources they are imported from."
       colors={["#EDE9FE", "#4C1D95", "#7C3AED", "#C4B5FD"]}
     >
       <div className="mb-8 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
@@ -170,34 +177,41 @@ export function PluginsScreen() {
             onChange={setActiveView}
             showZeroCounts
           />
-          <div>
-            <DenInput
-              type="search"
-              icon={Search}
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder={searchPlaceholder}
-            />
-          </div>
+          {activeView !== "sources" ? (
+            <div>
+              <DenInput
+                type="search"
+                icon={Search}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+              />
+            </div>
+          ) : null}
         </div>
-        <Link href={getNewPluginRoute(orgSlug)} className={buttonVariants({ variant: "primary" })}>
-          <Plus size={15} />
-          Create plugin
-        </Link>
+        {activeView !== "sources" ? (
+          <Link href={getNewPluginRoute(orgSlug)} className={buttonVariants({ variant: "primary" })}>
+            <Plus size={15} />
+            Create plugin
+          </Link>
+        ) : null}
       </div>
 
       {error ? (
-        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
-          {error instanceof Error ? error.message : "Failed to load plugins."}
-        </div>
+        <DenNotice
+          message={error instanceof Error ? error.message : "Failed to load plugins."}
+          className="mb-6"
+        />
       ) : null}
 
-      {isLoading || integrationsLoading ? (
+      {activeView === "sources" ? (
+        <IntegrationsPanel />
+      ) : isLoading || integrationsLoading ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
           Loading plugin catalog...
         </div>
       ) : !hasAnyIntegration && plugins.length === 0 ? (
-        <ConnectIntegrationEmptyState integrationsHref={getIntegrationsRoute(orgSlug)} />
+        <ConnectIntegrationEmptyState onOpenSources={() => setActiveView("sources")} />
       ) : activeView === "plugins" ? (
         filteredPlugins.length === 0 ? (
           <EmptyState
@@ -320,27 +334,23 @@ function EmptyState({ title, description }: { title: string; description: string
   );
 }
 
-function ConnectIntegrationEmptyState({ integrationsHref }: { integrationsHref: string }) {
+function ConnectIntegrationEmptyState({ onOpenSources }: { onOpenSources: () => void }) {
   return (
     <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
       <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-[14px] bg-gray-100 text-gray-500">
         <Cable className="h-6 w-6" />
       </div>
       <p className="text-[16px] font-medium tracking-[-0.03em] text-gray-900">
-        Connect an integration to discover plugins
+        Connect a source to discover plugins
       </p>
       <p className="mx-auto mt-3 max-w-[520px] text-[15px] leading-8 text-gray-500">
-        Plugins, skills, hooks, and MCP servers are sourced from the repositories you connect on the
-        Integrations page. Connect GitHub or Bitbucket to see your catalog populate.
+        Plugins, skills, hooks, and MCP servers are sourced from the repositories you connect in the
+        Sources tab. Connect GitHub to see your catalog populate.
       </p>
       <div className="mt-6 flex justify-center">
-        <Link
-          href={integrationsHref}
-          className={buttonVariants({ variant: "primary" })}
-        >
-          <Cable className="h-4 w-4" aria-hidden="true" />
-          Open Integrations
-        </Link>
+        <DenButton icon={Cable} onClick={onOpenSources}>
+          Open Sources
+        </DenButton>
       </div>
     </div>
   );

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -10,26 +10,26 @@ function readDashboardComponent(name: string) {
 }
 
 describe("connector and marketplace polish", () => {
-  test("labels Sources alpha and keeps Collections first with Connectors as MCPs", () => {
+  test("keeps Plugin Directory before Connectors and removes the Sources sidebar item", () => {
     const shell = readDashboardComponent("org-dashboard-shell.tsx");
-    const marketplaceIndex = shell.indexOf('getMarketplacesRoute(activeOrg.slug),\n          label: "Collections"');
     const pluginsIndex = shell.indexOf('getPluginsRoute(activeOrg.slug),\n          label: "Plugin Directory"');
     const connectorsIndex = shell.indexOf('getMcpConnectionsRoute(activeOrg.slug),\n          label: "Connectors"');
-    const sourcesIndex = shell.indexOf('getIntegrationsRoute(activeOrg.slug),\n          label: "Sources"');
 
-    expect(marketplaceIndex).toBeGreaterThan(-1);
-    expect(marketplaceIndex).toBeLessThan(pluginsIndex);
+    expect(pluginsIndex).toBeGreaterThan(-1);
     expect(pluginsIndex).toBeLessThan(connectorsIndex);
-    expect(connectorsIndex).toBeLessThan(sourcesIndex);
     expect(shell).toContain('badge: "MCPs"');
-    expect(shell).toContain('badge: "Alpha"');
+    expect(shell).not.toContain('label: "Sources"');
+    expect(shell).not.toContain('badge: "Alpha"');
   });
 
-  test("keeps the Sources page title free of maturity badges", () => {
-    const screen = readDashboardComponent("integrations-screen.tsx");
+  test("renders Sources as the last Plugin Directory tab", () => {
+    const integrationsScreen = readDashboardComponent("integrations-screen.tsx");
+    const pluginsScreen = readDashboardComponent("plugins-screen.tsx");
 
-    expect(screen).toContain('title="Sources"');
-    expect(screen).not.toContain("badgeLabel");
+    expect(integrationsScreen).toContain("export function IntegrationsPanel()");
+    expect(integrationsScreen).not.toContain("DashboardPageTemplate");
+    expect(pluginsScreen).toContain('label: "Sources"');
+    expect(pluginsScreen).toContain('searchParams.get("view")');
   });
 
   test("uses the smart connector bar and the approved connector copy", () => {

--- a/ee/apps/den-web/tests/org-dashboard-sidebar-ia.test.ts
+++ b/ee/apps/den-web/tests/org-dashboard-sidebar-ia.test.ts
@@ -36,12 +36,11 @@ describe("Den org sidebar information architecture", () => {
     expect(shell).not.toMatch(/label: "OpenWork Web"[\s\S]{0,120}badge:/);
   });
 
-  test("admins see Manage then Observability then Team, with Models as a Providers category", () => {
-    const marketplace = indexOfNeedle('label: "Collections"');
+  test("admins see the streamlined Manage section before Observability and Team", () => {
     const pluginDirectory = indexOfNeedle('label: "Plugin Directory"');
     const connectors = indexOfNeedle('label: "Connectors"');
-    const sources = indexOfNeedle('label: "Sources"');
     const managedDashboards = indexOfNeedle('label: "Dashboards"');
+    const advanced = indexOfNeedle('label: "Advanced"');
     const workflowRuns = indexOfNeedle('label: "Workflow Runs"');
     const analytics = indexOfNeedle('label: "Analytics"');
     const workSection = indexOfNeedle('{ label: "Work", items: workItems }');
@@ -49,10 +48,9 @@ describe("Den org sidebar information architecture", () => {
     const observabilitySection = indexOfNeedle('{ label: "Observability", items: observabilityItems }');
     const teamSection = indexOfNeedle('{ label: "Team", items: teamItems }');
 
-    expect(marketplace).toBeLessThan(pluginDirectory);
     expect(pluginDirectory).toBeLessThan(connectors);
-    expect(connectors).toBeLessThan(sources);
-    expect(sources).toBeLessThan(managedDashboards);
+    expect(connectors).toBeLessThan(managedDashboards);
+    expect(managedDashboards).toBeLessThan(advanced);
     expect(workflowRuns).toBeLessThan(analytics);
     expect(workSection).toBeLessThan(manageSection);
     expect(manageSection).toBeLessThan(observabilitySection);
@@ -61,6 +59,13 @@ describe("Den org sidebar information architecture", () => {
     expect(shell).toContain('badge: "MCPs"');
     expect(shell).toContain('label: "Tool Tester"');
     expect(shell).toContain("mcpConnectionsEnabled && access.isAdmin");
+    expect(shell).toMatch(
+      /matchHrefs:\s*\[\s*getDesktopPoliciesRoute\(activeOrg\.slug\),\s*getBrandAppearanceRoute\(activeOrg\.slug\),\s*\]/,
+    );
+    expect(shell).not.toContain('label: "Collections"');
+    expect(shell).not.toContain('label: "Sources"');
+    expect(shell).not.toContain('label: "Brand appearance"');
+    expect(shell).not.toContain('label: "Desktop Policies"');
   });
 
   test("redirects the old Script runs path to Workflow runs", () => {

--- a/evals/specs/den-manage-advanced-ia.e2e.test.ts
+++ b/evals/specs/den-manage-advanced-ia.e2e.test.ts
@@ -1,0 +1,118 @@
+import { spec } from "@openwork/testkit";
+import { expect } from "vitest";
+import { adminDashboardWeb } from "../worlds/den-admin-navigation.ts";
+
+// The Den admin IA consolidates Collections, Desktop policies, and Brand
+// appearance under one Manage > Advanced entry. Plugin Directory now owns
+// Sources, while the legacy integrations URL redirects to that selected tab.
+const test = spec.world(adminDashboardWeb, { timeout: 420_000 });
+
+test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Directory", async ({ world, user, probe, evidence }) => {
+  async function sidebarLabels(): Promise<string[]> {
+    const value = await probe.eval("Array.from(document.querySelectorAll('[data-testid=\"den-org-sidebar\"] a')).map((a) => (a.textContent ?? '').trim())");
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  }
+
+  async function selectedTabs(): Promise<string[]> {
+    const value = await probe.eval("Array.from(document.querySelectorAll('[role=\"tab\"][aria-selected=\"true\"]')).map((tab) => Array.from(tab.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE).map((node) => node.textContent ?? '').join('').trim())");
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  }
+
+  async function pathnameAndSearch(): Promise<string> {
+    const value = await probe.eval("window.location.pathname + window.location.search");
+    return typeof value === "string" ? value : "";
+  }
+
+  await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 90_000 });
+  const initialLabels = await probe.eventually(sidebarLabels, {
+    within: 30_000,
+    label: "new top-level admin navigation",
+    until: (labels) => labels.includes("Advanced") && labels.includes("Plugin Directory"),
+  });
+  const initialOk = initialLabels.includes("Advanced") && initialLabels.includes("Plugin Directory")
+    && !initialLabels.includes("Collections") && !initialLabels.includes("Sources")
+    && !initialLabels.includes("Brand appearance") && !initialLabels.includes("Desktop Policies");
+  expect(initialOk).toBe(true);
+  evidence.recordAssertionEvidence("The sidebar has Advanced and Plugin Directory without legacy top-level or Settings children", `Sidebar links: ${JSON.stringify(initialLabels)}`, initialOk);
+
+  await user.click({ role: "link", label: "Advanced" });
+  const advancedPath = await probe.eventually(pathnameAndSearch, {
+    within: 30_000, label: "Advanced route", until: (path) => path === "/dashboard/marketplaces",
+  });
+  await user.see({ text: "Advanced" }, { timeoutMs: 30_000 });
+  const collectionsTabs = await probe.eventually(selectedTabs, {
+    within: 30_000, label: "Collections tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Collections",
+  });
+  const advancedOk = advancedPath === "/dashboard/marketplaces" && collectionsTabs.length === 1 && collectionsTabs[0] === "Collections";
+  expect(advancedOk).toBe(true);
+  evidence.recordAssertionEvidence("Advanced opens Collections at /dashboard/marketplaces with no other tab selected", `path=${advancedPath}; selected=${JSON.stringify(collectionsTabs)}`, advancedOk);
+  await user.screenshot();
+
+  await user.click({ role: "tab", label: "Desktop policies" });
+  const desktopPath = await probe.eventually(pathnameAndSearch, {
+    within: 30_000, label: "Desktop policies route", until: (path) => path === "/dashboard/desktop-policies",
+  });
+  const desktopTabs = await probe.eventually(selectedTabs, {
+    within: 30_000, label: "Desktop policies tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Desktop policies",
+  });
+  const desktopLabels = await probe.eventually(sidebarLabels, {
+    within: 30_000, label: "single Advanced sidebar entry", until: (labels) => labels.includes("Advanced") && !labels.includes("Desktop Policies"),
+  });
+  const desktopOk = desktopPath === "/dashboard/desktop-policies" && desktopTabs[0] === "Desktop policies"
+    && desktopLabels.includes("Advanced") && !desktopLabels.includes("Desktop Policies");
+  expect(desktopOk).toBe(true);
+  evidence.recordAssertionEvidence("Desktop policies is an Advanced tab, not a separate sidebar child", `path=${desktopPath}; selected=${JSON.stringify(desktopTabs)}; sidebar=${JSON.stringify(desktopLabels)}`, desktopOk);
+
+  await user.click({ role: "tab", label: "Brand appearance" });
+  const brandPath = await probe.eventually(pathnameAndSearch, {
+    within: 30_000, label: "Brand appearance route", until: (path) => path === "/dashboard/brand-appearance",
+  });
+  await user.see({ testId: "brand-appearance-screen" }, { timeoutMs: 30_000 });
+  const brandTabs = await probe.eventually(selectedTabs, {
+    within: 30_000, label: "Brand appearance tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Brand appearance",
+  });
+  const brandOk = brandPath === "/dashboard/brand-appearance" && brandTabs.length === 1 && brandTabs[0] === "Brand appearance";
+  expect(brandOk).toBe(true);
+  evidence.recordAssertionEvidence("Brand appearance is the only selected Advanced tab on its screen", `path=${brandPath}; selected=${JSON.stringify(brandTabs)}`, brandOk);
+
+  await user.navigate(new URL("/dashboard/org-settings", world.den.ref.webUrl).toString());
+  await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
+  const settingsLabels = await probe.eventually(sidebarLabels, {
+    within: 30_000,
+    label: "expanded Settings children",
+    until: (labels) => labels.includes("General") && labels.includes("Billing"),
+  });
+  const settingsOk = settingsLabels.includes("General") && settingsLabels.includes("Billing")
+    && !settingsLabels.includes("Brand appearance") && !settingsLabels.includes("Desktop Policies");
+  expect(settingsOk).toBe(true);
+  evidence.recordAssertionEvidence("Expanded Settings keeps General and Billing but removes Brand appearance and Desktop Policies", `Sidebar links: ${JSON.stringify(settingsLabels)}`, settingsOk);
+
+  await user.click({ role: "link", label: "Plugin Directory" });
+  const pluginsPath = await probe.eventually(pathnameAndSearch, {
+    within: 30_000, label: "Plugin Directory route", until: (path) => path === "/dashboard/plugins",
+  });
+  await user.see({ role: "tab", label: /^Sources/ }, { timeoutMs: 30_000 });
+  await user.see({ text: "Create plugin" }, { timeoutMs: 30_000 });
+  await user.click({ role: "tab", label: /^Sources/ });
+  const sourceTabs = await probe.eventually(selectedTabs, {
+    within: 30_000, label: "Sources tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Sources",
+  });
+  await user.see({ text: "GitHub" }, { timeoutMs: 30_000 });
+  await user.see({ role: "button", label: "Connect" }, { timeoutMs: 30_000 });
+  await user.notSee({ text: "Create plugin" }, { timeoutMs: 3_000 });
+  const sourcesOk = pluginsPath === "/dashboard/plugins" && sourceTabs.length === 1 && sourceTabs[0] === "Sources";
+  expect(sourcesOk).toBe(true);
+  evidence.recordAssertionEvidence("Plugin Directory Sources shows GitHub Connect and hides Create plugin", `path=${pluginsPath}; selected=${JSON.stringify(sourceTabs)}; GitHub and Connect visible; Create plugin absent`, sourcesOk);
+  await user.screenshot();
+
+  await user.navigate(new URL("/dashboard/integrations", world.den.ref.webUrl).toString());
+  const redirectPath = await probe.eventually(pathnameAndSearch, {
+    within: 30_000, label: "legacy integrations redirect", until: (path) => path === "/dashboard/plugins?view=sources",
+  });
+  const redirectedTabs = await probe.eventually(selectedTabs, {
+    within: 30_000, label: "redirected Sources tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Sources",
+  });
+  const redirectOk = redirectPath === "/dashboard/plugins?view=sources" && redirectedTabs.length === 1 && redirectedTabs[0] === "Sources";
+  expect(redirectOk).toBe(true);
+  evidence.recordAssertionEvidence("The legacy integrations URL redirects only to Plugin Directory Sources", `path=${redirectPath}; selected=${JSON.stringify(redirectedTabs)}`, redirectOk);
+});

--- a/evals/specs/den-manage-advanced-ia.e2e.test.ts
+++ b/evals/specs/den-manage-advanced-ia.e2e.test.ts
@@ -8,23 +8,8 @@ import { adminDashboardWeb } from "../worlds/den-admin-navigation.ts";
 const test = spec.world(adminDashboardWeb, { timeout: 420_000 });
 
 test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Directory", async ({ world, user, probe, evidence }) => {
-  async function sidebarLabels(): Promise<string[]> {
-    const value = await probe.eval("Array.from(document.querySelectorAll('[data-testid=\"den-org-sidebar\"] a')).map((a) => (a.textContent ?? '').trim())");
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-  }
-
-  async function selectedTabs(): Promise<string[]> {
-    const value = await probe.eval("Array.from(document.querySelectorAll('[role=\"tab\"][aria-selected=\"true\"]')).map((tab) => Array.from(tab.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE).map((node) => node.textContent ?? '').join('').trim())");
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-  }
-
-  async function pathnameAndSearch(): Promise<string> {
-    const value = await probe.eval("window.location.pathname + window.location.search");
-    return typeof value === "string" ? value : "";
-  }
-
   await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 90_000 });
-  const initialLabels = await probe.eventually(sidebarLabels, {
+  const initialLabels = await probe.eventually(() => world.sidebarLinks(), {
     within: 30_000,
     label: "new top-level admin navigation",
     until: (labels) => labels.includes("Advanced") && labels.includes("Plugin Directory"),
@@ -36,11 +21,11 @@ test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Direc
   evidence.recordAssertionEvidence("The sidebar has Advanced and Plugin Directory without legacy top-level or Settings children", `Sidebar links: ${JSON.stringify(initialLabels)}`, initialOk);
 
   await user.click({ role: "link", label: "Advanced" });
-  const advancedPath = await probe.eventually(pathnameAndSearch, {
+  const advancedPath = await probe.eventually(() => world.location(), {
     within: 30_000, label: "Advanced route", until: (path) => path === "/dashboard/marketplaces",
   });
   await user.see({ text: "Advanced" }, { timeoutMs: 30_000 });
-  const collectionsTabs = await probe.eventually(selectedTabs, {
+  const collectionsTabs = await probe.eventually(() => world.selectedTabs(), {
     within: 30_000, label: "Collections tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Collections",
   });
   const advancedOk = advancedPath === "/dashboard/marketplaces" && collectionsTabs.length === 1 && collectionsTabs[0] === "Collections";
@@ -49,13 +34,13 @@ test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Direc
   await user.screenshot();
 
   await user.click({ role: "tab", label: "Desktop policies" });
-  const desktopPath = await probe.eventually(pathnameAndSearch, {
+  const desktopPath = await probe.eventually(() => world.location(), {
     within: 30_000, label: "Desktop policies route", until: (path) => path === "/dashboard/desktop-policies",
   });
-  const desktopTabs = await probe.eventually(selectedTabs, {
+  const desktopTabs = await probe.eventually(() => world.selectedTabs(), {
     within: 30_000, label: "Desktop policies tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Desktop policies",
   });
-  const desktopLabels = await probe.eventually(sidebarLabels, {
+  const desktopLabels = await probe.eventually(() => world.sidebarLinks(), {
     within: 30_000, label: "single Advanced sidebar entry", until: (labels) => labels.includes("Advanced") && !labels.includes("Desktop Policies"),
   });
   const desktopOk = desktopPath === "/dashboard/desktop-policies" && desktopTabs[0] === "Desktop policies"
@@ -64,11 +49,11 @@ test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Direc
   evidence.recordAssertionEvidence("Desktop policies is an Advanced tab, not a separate sidebar child", `path=${desktopPath}; selected=${JSON.stringify(desktopTabs)}; sidebar=${JSON.stringify(desktopLabels)}`, desktopOk);
 
   await user.click({ role: "tab", label: "Brand appearance" });
-  const brandPath = await probe.eventually(pathnameAndSearch, {
+  const brandPath = await probe.eventually(() => world.location(), {
     within: 30_000, label: "Brand appearance route", until: (path) => path === "/dashboard/brand-appearance",
   });
   await user.see({ testId: "brand-appearance-screen" }, { timeoutMs: 30_000 });
-  const brandTabs = await probe.eventually(selectedTabs, {
+  const brandTabs = await probe.eventually(() => world.selectedTabs(), {
     within: 30_000, label: "Brand appearance tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Brand appearance",
   });
   const brandOk = brandPath === "/dashboard/brand-appearance" && brandTabs.length === 1 && brandTabs[0] === "Brand appearance";
@@ -77,7 +62,7 @@ test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Direc
 
   await user.navigate(new URL("/dashboard/org-settings", world.den.ref.webUrl).toString());
   await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
-  const settingsLabels = await probe.eventually(sidebarLabels, {
+  const settingsLabels = await probe.eventually(() => world.sidebarLinks(), {
     within: 30_000,
     label: "expanded Settings children",
     until: (labels) => labels.includes("General") && labels.includes("Billing"),
@@ -88,13 +73,13 @@ test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Direc
   evidence.recordAssertionEvidence("Expanded Settings keeps General and Billing but removes Brand appearance and Desktop Policies", `Sidebar links: ${JSON.stringify(settingsLabels)}`, settingsOk);
 
   await user.click({ role: "link", label: "Plugin Directory" });
-  const pluginsPath = await probe.eventually(pathnameAndSearch, {
+  const pluginsPath = await probe.eventually(() => world.location(), {
     within: 30_000, label: "Plugin Directory route", until: (path) => path === "/dashboard/plugins",
   });
   await user.see({ role: "tab", label: /^Sources/ }, { timeoutMs: 30_000 });
   await user.see({ text: "Create plugin" }, { timeoutMs: 30_000 });
   await user.click({ role: "tab", label: /^Sources/ });
-  const sourceTabs = await probe.eventually(selectedTabs, {
+  const sourceTabs = await probe.eventually(() => world.selectedTabs(), {
     within: 30_000, label: "Sources tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Sources",
   });
   await user.see({ text: "GitHub" }, { timeoutMs: 30_000 });
@@ -106,10 +91,10 @@ test("the Den admin sidebar exposes Advanced and moves Sources into Plugin Direc
   await user.screenshot();
 
   await user.navigate(new URL("/dashboard/integrations", world.den.ref.webUrl).toString());
-  const redirectPath = await probe.eventually(pathnameAndSearch, {
+  const redirectPath = await probe.eventually(() => world.location(), {
     within: 30_000, label: "legacy integrations redirect", until: (path) => path === "/dashboard/plugins?view=sources",
   });
-  const redirectedTabs = await probe.eventually(selectedTabs, {
+  const redirectedTabs = await probe.eventually(() => world.selectedTabs(), {
     within: 30_000, label: "redirected Sources tab selected", until: (tabs) => tabs.length === 1 && tabs[0] === "Sources",
   });
   const redirectOk = redirectPath === "/dashboard/plugins?view=sources" && redirectedTabs.length === 1 && redirectedTabs[0] === "Sources";

--- a/evals/worlds/den-admin-navigation.ts
+++ b/evals/worlds/den-admin-navigation.ts
@@ -1,0 +1,15 @@
+import type { Seed } from "@openwork/env";
+
+export async function adminDashboardWeb(seed: Seed) {
+  const den = await seed.den({
+    org: { name: `Admin navigation ${Date.now()}`, admin: { name: "Navigation Admin" } },
+  });
+  const web = await seed.web({
+    den,
+    signedInAs: den.admin,
+    startPath: "/dashboard",
+    headless: true,
+    viewport: { width: 1440, height: 1100 },
+  });
+  return { den, web };
+}

--- a/evals/worlds/den-admin-navigation.ts
+++ b/evals/worlds/den-admin-navigation.ts
@@ -1,5 +1,9 @@
 import type { Seed } from "@openwork/env";
 
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
 export async function adminDashboardWeb(seed: Seed) {
   const den = await seed.den({
     org: { name: `Admin navigation ${Date.now()}`, admin: { name: "Navigation Admin" } },
@@ -11,5 +15,25 @@ export async function adminDashboardWeb(seed: Seed) {
     headless: true,
     viewport: { width: 1440, height: 1100 },
   });
-  return { den, web };
+  return {
+    den,
+    web,
+    /** The current web location's pathname and search. */
+    // TODO(primitive): probe.location should expose pathname+search on web surfaces; probe.hash only covers the hash.
+    async location(): Promise<string> {
+      const value = await seed.evalIn(web, "window.location.pathname + window.location.search");
+      if (typeof value !== "string") throw new Error("Expected the web location to be a string.");
+      return value;
+    },
+    /** The accessible link names in the organization sidebar. */
+    // TODO(primitive): probe should list accessible link names inside a container by testId.
+    async sidebarLinks(): Promise<string[]> {
+      return strings(await seed.evalIn(web, "Array.from(document.querySelectorAll('[data-testid=\"den-org-sidebar\"] a')).map((a) => (a.textContent ?? '').trim())"));
+    },
+    /** The direct text labels of selected tabs. */
+    // TODO(primitive): user.see({ role: "tab" }) cannot assert aria-selected today.
+    async selectedTabs(): Promise<string[]> {
+      return strings(await seed.evalIn(web, "Array.from(document.querySelectorAll('[role=\"tab\"][aria-selected=\"true\"]')).map((tab) => Array.from(tab.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE).map((node) => node.textContent ?? '').join('').trim())"));
+    },
+  };
 }


### PR DESCRIPTION
## What

Den admin dashboard information-architecture change, with a light design pass on the screens touched.

**Manage → Advanced.** Collections, Desktop policies, and Brand appearance now live under one `Advanced` sidebar item in the Manage section, rendered as `UnderlineTabs` on a shared `AdvancedPageTemplate` (same tab primitive Plugin Directory, Members, and collection detail already use). Routes are unchanged (`/dashboard/marketplaces`, `/dashboard/desktop-policies`, `/dashboard/brand-appearance`) — tabs navigate between them, so deep links and existing Back links from the collection detail and policy editor keep working. The sidebar item stays selected on all three (and their sub-routes) via a new `matchHrefs` on `DashboardNavItem`. The top-level Collections/Sources items and the Settings → Brand appearance / Desktop Policies children are removed. `/dashboard/advanced` redirects to the first tab.

**Sources → Plugin Directory.** Sources is now the sixth Plugin Directory tab (plugins remain the default). Deep-linkable via `/dashboard/plugins?view=sources`; `/dashboard/integrations` redirects there. GitHub setup Back links and the "connect a source" empty states point at the tab.

**Design pass (touched screens only).** Desktop policies raw `<table>` → `DenCatalogList`/`DenCatalogRow` like Collections and Plugins in the same page family; ad-hoc red/green banners → `DenNotice`; brand card heading flattened under the Advanced hero; consistent header/empty-state treatment.

## Screens

| Advanced → Collections | Plugin Directory → Sources |
| --- | --- |
| see test evidence comment | see test evidence comment |

## Verification

- `pnpm --filter @openwork-ee/den-web typecheck` — pass
- `bun test tests/org-dashboard-sidebar-ia.test.ts tests/connector-marketplace-polish.test.ts` — 8 pass / 0 fail (assertions updated to the new IA)
- `pnpm evals:e2e den-manage-advanced-ia --local` — new journey spec `evals/specs/den-manage-advanced-ia.e2e.test.ts`; evidence published on this PR head in the sticky comment below.
- `node scripts/spec-boundary-ratchet.mjs` — pass
- `pnpm --filter @openwork-ee/den-web lint` fails with `next lint` being removed in Next 16 — pre-existing on `dev`, unrelated.

Docs: `docs/cloud-organization-role-access.md` sidebar section rewritten to the actual IA (it was already stale).