### PR TITLE
feat(web): header search bar that opens the command palette

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -70,6 +70,7 @@ import { useShellConfig } from "../../../shell/shell-config";
 import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-store";
 import type { SessionNumberShortcutsState } from "../../../shell/session-number-shortcuts";
 import { useBootOverlayVisible } from "../../../shell/boot-state";
+import { CommandPaletteSearchBar } from "../../../shell/command-palette-search-bar";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
@@ -1481,7 +1482,13 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
             </div>
 
-            <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
+            {!props.primarySlot ? (
+              <div className="flex shrink-0 justify-end px-1 md:min-w-0 md:flex-1 md:justify-center md:px-4">
+                <CommandPaletteSearchBar />
+              </div>
+            ) : null}
+
+            <div className="flex min-w-0 items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {!props.primarySlot && findButtonSessionId && !hasMainContentTakeover ? (
                 <Tooltip>
                   <TooltipTrigger

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/sidebar";
 import { t } from "../../../../i18n";
 import { NotificationBell } from "../../../shell/notification-center";
+import { CommandPaletteSearchBar } from "../../../shell/command-palette-search-bar";
 import { usePlatform } from "../../../kernel/platform";
 import type { SettingsTab } from "../../../../app/types";
 import {
@@ -70,6 +71,9 @@ export function SettingsShell(props: SettingsShellProps) {
               workspaces={props.workspaces}
               onSelectWorkspace={props.onSelectWorkspace}
             />
+          </div>
+          <div className="flex shrink-0 justify-end px-1 md:min-w-0 md:flex-1 md:justify-center md:px-4">
+            <CommandPaletteSearchBar />
           </div>
           <div className="flex shrink-0 items-center gap-1 mac:titlebar-no-drag">
             <Button
@@ -133,7 +137,10 @@ export function SettingsShell(props: SettingsShellProps) {
                   </span>
                 ) : null}
               </div>
-              <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
+              <div className="flex shrink-0 justify-end px-1 md:min-w-0 md:flex-1 md:justify-center md:px-4">
+                <CommandPaletteSearchBar />
+              </div>
+              <div className="flex min-w-0 items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
                 <NotificationBell />
                 <Button
                   variant="ghost"

--- a/apps/app/src/react-app/shell/command-palette-bus.ts
+++ b/apps/app/src/react-app/shell/command-palette-bus.ts
@@ -1,0 +1,5 @@
+export const OPEN_COMMAND_PALETTE_EVENT = "openwork:command-palette:open";
+
+export function openCommandPalette(): void {
+  window.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
+}

--- a/apps/app/src/react-app/shell/command-palette-search-bar.tsx
+++ b/apps/app/src/react-app/shell/command-palette-search-bar.tsx
@@ -1,0 +1,39 @@
+/** @jsxImportSource react */
+import { SearchIcon } from "lucide-react";
+
+import { isWebDeployment } from "../../app/lib/openwork-deployment";
+import { CommandShortcut } from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { usePlatform } from "../kernel/platform";
+import { openCommandPalette } from "./command-palette-bus";
+import { resolveSessionNumberShortcutOs } from "./session-number-shortcuts";
+
+export function CommandPaletteSearchBar({ className }: { className?: string }) {
+  const platform = usePlatform();
+  const os = resolveSessionNumberShortcutOs(
+    platform.os,
+    typeof navigator === "undefined" ? "" : navigator.platform,
+  );
+
+  if (!isWebDeployment()) return null;
+
+  const isMac = os === "macos";
+
+  return (
+    <button
+      type="button"
+      data-testid="command-palette-search-bar"
+      aria-label="Search or jump to"
+      aria-keyshortcuts={isMac ? "Meta+K" : "Control+K"}
+      className={cn(
+        "inline-flex h-7 items-center gap-2 rounded-lg border border-border bg-muted/40 px-2.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring mac:titlebar-no-drag md:w-full md:max-w-md",
+        className,
+      )}
+      onClick={openCommandPalette}
+    >
+      <SearchIcon size={14} />
+      <span className="hidden truncate md:inline">Search or jump to…</span>
+      <CommandShortcut className="hidden md:inline">{isMac ? "⌘K" : "Ctrl K"}</CommandShortcut>
+    </button>
+  );
+}

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -22,6 +22,7 @@ import {
   type ThinkingModeShortcutDirection,
 } from "./thinking-mode-shortcut";
 import { isFavoriteModelShortcut } from "./favorite-model-shortcut";
+import { OPEN_COMMAND_PALETTE_EVENT } from "./command-palette-bus";
 
 export type UseShellShortcutsInput = {
   canCreateTask: boolean;
@@ -43,11 +44,19 @@ export function useCommandPaletteShortcut(enabled = true) {
     event.preventDefault();
     setCommandPaletteOpen((value) => !value);
   });
+  const handleOpenCommandPalette = useEffectEvent(() => {
+    if (enabled) setCommandPaletteOpen(true);
+  });
 
   useEffect(() => {
-    const handler = (event: KeyboardEvent) => handleCommandPaletteShortcut(event);
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    const shortcutHandler = (event: KeyboardEvent) => handleCommandPaletteShortcut(event);
+    const openHandler = () => handleOpenCommandPalette();
+    window.addEventListener("keydown", shortcutHandler);
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, openHandler);
+    return () => {
+      window.removeEventListener("keydown", shortcutHandler);
+      window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, openHandler);
+    };
   }, []);
 
   return { commandPaletteOpen, setCommandPaletteOpen };

--- a/evals/specs/web-search-bar-opens-palette.e2e.test.ts
+++ b/evals/specs/web-search-bar-opens-palette.e2e.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { webSearchBar } from "../worlds/web-shell.ts";
+
+const test = spec.world(webSearchBar, { timeout: 8 * 60_000 });
+const searchBar = { testId: "command-palette-search-bar" };
+const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
+
+test("the web header search bar opens the command palette from sessions and settings", async ({ world, user, probe, step }) => {
+  const webUser = user.on(world.web);
+  const webProbe = probe.on(world.web);
+
+  await step("the web header shows a search bar and the palette is closed", async () => {
+    await webUser.see(searchBar);
+    await webUser.notSee(paletteInput);
+    expect(await webProbe.text()).toMatch(/Describe your task/);
+    await webUser.screenshot();
+  });
+
+  await step("clicking the search bar opens the palette", async () => {
+    await webUser.click(searchBar);
+    await webUser.see(paletteInput);
+    await webUser.see({ text: "Actions" });
+    await webUser.screenshot();
+  });
+
+  await step("typing folders and Enter lands on Permissions", async () => {
+    await webUser.type(paletteInput, "folders", { replace: true });
+    await webUser.see({ role: "option", label: /^Permissions/ });
+    await webUser.press("Enter");
+    await probe.eventually(() => webProbe.has("Arrow keys to navigate"), {
+      within: 15_000,
+      until: (open) => !open,
+    });
+    await webUser.see({ text: /Authorized folders/ });
+    await webUser.notSee({ text: /Adjust how OpenWork looks/ });
+    await webUser.notSee({ text: /Describe your task/ });
+  });
+
+  await step("the Settings header keeps the search bar and reopens the palette", async () => {
+    await webUser.see({ text: /Authorized folders/ });
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    await webUser.see(searchBar);
+    await webUser.click(searchBar);
+    await webUser.see(paletteInput);
+    await webUser.screenshot();
+    await webUser.press("Escape");
+    await probe.eventually(() => webProbe.has("Arrow keys to navigate"), {
+      within: 15_000,
+      until: (open) => !open,
+    });
+    await webUser.notSee(paletteInput);
+    await webUser.see({ text: /Authorized folders/ });
+  });
+});

--- a/evals/specs/web-search-bar-opens-palette.e2e.test.ts
+++ b/evals/specs/web-search-bar-opens-palette.e2e.test.ts
@@ -1,4 +1,3 @@
-import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { webSearchBar } from "../worlds/web-shell.ts";
 
@@ -13,7 +12,7 @@ test("the web header search bar opens the command palette from sessions and sett
   await step("the web header shows a search bar and the palette is closed", async () => {
     await webUser.see(searchBar);
     await webUser.notSee(paletteInput);
-    expect(await webProbe.text()).toMatch(/Describe your task/);
+    await webUser.see({ text: /Describe your task/ });
     await webUser.screenshot();
   });
 

--- a/evals/worlds/web-shell.ts
+++ b/evals/worlds/web-shell.ts
@@ -1,0 +1,18 @@
+import type { Place, Seed } from "@openwork/env";
+import { chrome } from "@openwork/hosts";
+import { bootDevHeadless } from "./infra.ts";
+
+export async function webSearchBar(_seed: Seed, { place }: { place: Place }) {
+  const stack = new AsyncDisposableStack();
+  const headless = await bootDevHeadless(stack, {
+    name: `web-search-bar-${process.pid}`,
+    replace: true,
+  });
+  const web = stack.use(await chrome({
+    name: "web-search-bar",
+    host: place.host(),
+    startUrl: headless.manifest.webUrl,
+    headless: true,
+  }));
+  return { web, headless, [Symbol.asyncDispose]: () => stack.disposeAsync() };
+}


### PR DESCRIPTION
## Summary

Follow-up to #4393 for the **web interface** (`VITE_OPENWORK_DEPLOYMENT=web`, e.g. `pnpm world up dev-headless`): a **"Search or jump to… ⌘K"** bar sits at the top of both the session header and the Settings header and opens the intelligent command palette. Below `md` it collapses to a search icon so phone-width web tabs keep the entry point. Desktop renders nothing (it keeps the keyboard-only palette).

- `command-palette-bus.ts` — tiny window-event bus (`openCommandPalette()`), the same pattern t3code uses; `useCommandPaletteShortcut` listens to it.
- `command-palette-search-bar.tsx` — real `<button>` with `aria-label="Search or jump to"`, `aria-keyshortcuts`, `data-testid="command-palette-search-bar"`; OS-aware ⌘K / Ctrl K chip.
- Mounted as a centered middle slot in `session-page.tsx` (primary pane only) and both `settings-shell.tsx` headers.

## Use cases
- Web users who don't know ⌘K discover the palette from the bar → type `folders` → **Permissions**; `dark mode` → **Appearance**; `>` → actions only; recents on reopen — all from #4393.
- Works on the Settings screen too, so jumping between panels never requires the sidebar.

## Verification
- Unit: `pnpm --filter @openwork/app test` (palette tests 12/12), typecheck ✓, `lint:layers` + both spec ratchets clean.
- **E2E — Passed** ×3 locally (19s each): `evals/specs/web-search-bar-opens-palette.e2e.test.ts` on a new `webSearchBar` world (`evals/worlds/web-shell.ts`: boots the headless web deployment + local server and attaches headless Chrome — the first spec that drives the real web build).
  `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/web-search-bar-opens-palette.e2e.test.ts`
  Claims: bar visible and palette closed on load (negative: session composer present); click → palette open with Actions; `folders` + Enter → Permissions panel visible (negatives: Appearance copy and the composer are gone); Settings header still has the bar, click reopens, Escape closes and Permissions stays.
- Manual check in the OpenWork built-in browser at phone width: icon-only variant, click opens palette with focus in the input.

### Screenshots (from the E2E run)
![Web session header with the search bar](./web-1.png)
![Clicking the bar opens the palette](./web-2.png)
![Settings header keeps the bar; palette reopens with Recent](./web-3.png)
