### PR TITLE
feat(app): pin and rename the open session from Cmd+K

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import type { CSSProperties } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
 import { ArrowLeft, Cloud, FileText, Globe, Mic2, MoreHorizontal, PanelRight, TextSearch, X, Zap } from "lucide-react";
 
@@ -71,6 +71,10 @@ import { type SidePanelItem, useUiStateStore } from "../../../shell/ui-state-sto
 import type { SessionNumberShortcutsState } from "../../../shell/session-number-shortcuts";
 import { useBootOverlayVisible } from "../../../shell/boot-state";
 import { CommandPaletteSearchBar } from "../../../shell/command-palette-search-bar";
+import {
+  OPEN_RENAME_SESSION_EVENT,
+  renameSessionIdFromEvent,
+} from "../../../shell/session-actions-bus";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTarget, type OpenTarget } from "../artifacts/open-target";
@@ -1281,6 +1285,19 @@ export function SessionPage(props: SessionPageProps) {
     setRenameTitle(sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId));
     setRenameOpen(true);
   };
+
+  const handleRenameSessionRequest = useEffectEvent((event: Event) => {
+    if (!props.onRenameSession) return;
+    const sessionId = renameSessionIdFromEvent(event);
+    if (sessionId) openRenameModal(sessionId);
+  });
+
+  useEffect(() => {
+    if (!props.onRenameSession) return;
+    const handler = (event: Event) => handleRenameSessionRequest(event);
+    window.addEventListener(OPEN_RENAME_SESSION_EVENT, handler);
+    return () => window.removeEventListener(OPEN_RENAME_SESSION_EVENT, handler);
+  }, [props.onRenameSession]);
 
   const submitRename = async () => {
     const sessionId = sessionActionId;

--- a/apps/app/src/react-app/shell/session-actions-bus.ts
+++ b/apps/app/src/react-app/shell/session-actions-bus.ts
@@ -1,0 +1,10 @@
+export const OPEN_RENAME_SESSION_EVENT = "openwork:session:rename";
+
+export function requestRenameSession(sessionId: string): void {
+  window.dispatchEvent(new CustomEvent(OPEN_RENAME_SESSION_EVENT, { detail: { sessionId } }));
+}
+
+export function renameSessionIdFromEvent(event: Event): string | null {
+  if (!(event instanceof CustomEvent)) return null;
+  return typeof event.detail?.sessionId === "string" ? event.detail.sessionId : null;
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -176,6 +176,7 @@ import { useShareWorkspaceState } from "@/react-app/domains/workspace/share-work
 import { ModelPickerModal, MODEL_PICKER_UNAVAILABLE_SUBTITLE } from "@/react-app/domains/session/modals/model-picker-modal";
 import { CommandPalette, type PaletteItem, type SessionGroupOption } from "./command-palette";
 import { buildCommandPaletteSessions } from "./command-palette-sessions";
+import { requestRenameSession } from "./session-actions-bus";
 import type { ThinkingModeShortcutDirection } from "./thinking-mode-shortcut";
 import { SessionSearchDialog } from "./session-search-dialog";
 import type { SessionMessageFetcher } from "@/react-app/domains/session/search/session-search";
@@ -703,6 +704,9 @@ export function SessionRoute() {
     selectedWorkspaceId ? state.groupsByWorkspace[selectedWorkspaceId] : undefined
   ));
   const assignSessionToGroup = sessionManagementStore((state) => state.assignGroup);
+  const currentSessionPinned = sessionManagementStore((state) => (
+    selectedSessionId ? state.pinnedIds.includes(selectedSessionId) : false
+  ));
   const seedWorkspaceActivitySessions = useSessionActivityStore((state) => state.seedWorkspaceSessions);
   const sessionActivityByWorkspaceId = useSessionActivityStore((state) => state.statusesByWorkspaceId);
 
@@ -2617,6 +2621,39 @@ export function SessionRoute() {
     ) ?? null;
   }, [paletteSessionOptions, selectedSessionId, selectedWorkspaceId]);
 
+  const currentSessionActionPaletteItems = useMemo<PaletteItem[]>(() => {
+    if (!selectedSessionId || !selectedWorkspaceId || !currentSessionForGroupMove) return [];
+    const items: PaletteItem[] = [{
+      id: "session.pin.toggle",
+      title: currentSessionPinned
+        ? t("session_management.unpin_session")
+        : t("session_management.pin_session"),
+      detail: currentSessionForGroupMove.title,
+      meta: "Session",
+      keywords: ["pin", "unpin", "favorite", "star", "keep on top", "sidebar"],
+      group: "actions",
+      action: () => {
+        setCommandPaletteOpen(false);
+        sessionManagementStore.getState().togglePin(selectedSessionId);
+      },
+    }];
+    if (opencodeClient) {
+      items.push({
+        id: "session.rename",
+        title: "Rename session…",
+        detail: currentSessionForGroupMove.title,
+        meta: "Session",
+        keywords: ["rename", "title", "name", "edit title"],
+        group: "actions",
+        action: () => {
+          setCommandPaletteOpen(false);
+          requestRenameSession(selectedSessionId);
+        },
+      });
+    }
+    return items;
+  }, [currentSessionForGroupMove, currentSessionPinned, opencodeClient, selectedSessionId, selectedWorkspaceId]);
+
   const currentSessionGroupId = selectedSessionId
     ? selectedWorkspaceGroupState?.assignments[selectedSessionId] ?? null
     : null;
@@ -3540,7 +3577,7 @@ export function SessionRoute() {
       currentSessionForGroupMove={currentSessionForGroupMove}
       currentSessionGroupId={currentSessionGroupId}
       onMoveCurrentSessionToGroup={handleMoveCurrentSessionToGroup}
-      extraItems={[...(sessionFindPaletteItem ? [sessionFindPaletteItem] : []), sessionSearchPaletteItem, ...terminalPaletteItems, developerModePaletteItem, diagnosticsCopyPaletteItem, diagnosticsExportPaletteItem, nextSessionTabPaletteItem, prevSessionTabPaletteItem, reloadConfigPaletteItem]}
+      extraItems={[...currentSessionActionPaletteItems, ...(sessionFindPaletteItem ? [sessionFindPaletteItem] : []), sessionSearchPaletteItem, ...terminalPaletteItems, developerModePaletteItem, diagnosticsCopyPaletteItem, diagnosticsExportPaletteItem, nextSessionTabPaletteItem, prevSessionTabPaletteItem, reloadConfigPaletteItem]}
       listAgents={listAgents}
       selectedAgent={selectedAgent}
       onSelectAgent={setSelectedAgent}

--- a/apps/app/tests/command-palette-search.test.ts
+++ b/apps/app/tests/command-palette-search.test.ts
@@ -88,4 +88,30 @@ describe("command palette search", () => {
     expect(rankPaletteItems("theme", items, [])[0]?.items[0]?.id).toBe("settings:appearance");
     expect(rankPaletteItems("model", items, [])[0]?.items[0]?.id).toBe("models");
   });
+
+  test("ranks current session pin and rename actions first", () => {
+    const items = [
+      item({
+        id: "settings:permissions",
+        title: "Permissions",
+        keywords: ["authorized folders", "folder access", "file access", "allow", "permission denied", "sandbox", "approvals"],
+        group: "settings",
+      }),
+      item({
+        id: "session.pin.toggle",
+        title: "Pin session",
+        keywords: ["pin", "unpin", "favorite", "star", "keep on top", "sidebar"],
+        group: "actions",
+      }),
+      item({
+        id: "session.rename",
+        title: "Rename session…",
+        keywords: ["rename", "title", "name", "edit title"],
+        group: "actions",
+      }),
+    ];
+
+    expect(rankPaletteItems("pin", items, [])[0]?.items[0]?.id).toBe("session.pin.toggle");
+    expect(rankPaletteItems("rename", items, [])[0]?.items[0]?.id).toBe("session.rename");
+  });
 });

--- a/evals/specs/command-palette-pin-rename.e2e.test.ts
+++ b/evals/specs/command-palette-pin-rename.e2e.test.ts
@@ -1,0 +1,71 @@
+import { spec } from "@openwork/testkit";
+import { paletteSessionActions } from "../worlds/chat.ts";
+
+const test = spec.world(paletteSessionActions);
+const shortcut = process.platform === "darwin" ? "Meta+K" : "Control+K";
+const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
+const paletteFooter = { text: "Arrow keys to navigate" };
+
+test("the command palette pins and renames the open session", async ({ world, user, probe, step }) => {
+  await step("the palette offers Pin session for the open session", async () => {
+    await user.notSee({ text: "Pinned" });
+    await user.press(shortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "pin", { replace: true });
+    await user.see({ role: "option", label: /^Pin session/ });
+    await user.notSee({ role: "option", label: /^Unpin session/ });
+    await user.screenshot();
+  });
+
+  await step("choosing it pins the session", async () => {
+    await user.press("Enter");
+    await probe.eventually(() => probe.has("Arrow keys to navigate"), {
+      within: 15_000,
+      label: "command palette footer disappears after pinning",
+      until: (open) => !open,
+    });
+    await user.see({ text: "Pinned" });
+    await user.see({ text: world.session.title });
+    await user.press(shortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "pin", { replace: true });
+    await user.see({ role: "option", label: /^Unpin session/ });
+    await user.notSee({ role: "option", label: /^Pin session/ });
+    await user.screenshot();
+    await user.press("Escape");
+    await probe.eventually(() => probe.has("Arrow keys to navigate"), {
+      within: 15_000,
+      label: "command palette footer disappears after Escape",
+      until: (open) => !open,
+    });
+    await user.notSee(paletteFooter);
+  });
+
+  await step("Rename session… opens the rename dialog", async () => {
+    await user.press(shortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "rename", { replace: true });
+    await user.see({ role: "option", label: /^Rename session/ });
+    await user.press("Enter");
+    await user.see({ text: "Rename session" });
+    await user.see({ label: "Session name" });
+    await user.screenshot();
+  });
+
+  await step("saving a new name updates the sidebar", async () => {
+    await user.type({ label: "Session name" }, "Renamed from the palette", { replace: true });
+    await user.click({ role: "button", label: "Save" });
+    await probe.eventually(() => probe.has("Renamed from the palette"), {
+      within: 15_000,
+      label: "renamed session appears in the sidebar",
+    });
+    await user.see({ text: "Renamed from the palette" });
+    await probe.eventually(() => probe.has(world.session.title), {
+      within: 15_000,
+      label: "previous session title disappears",
+      until: (has) => !has,
+    });
+    await user.notSee({ text: world.session.title });
+    await user.screenshot();
+  });
+});

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -199,6 +199,13 @@ export async function emptyChat(seed: Seed) {
   return { app, workspace, session };
 }
 
+export async function paletteSessionActions(seed: Seed) {
+  const app = await seed.desktop({ name: "command-palette-pin-rename" });
+  const workspace = await seed.workspace(app, seed.tmpPath("command-palette-pin-rename"));
+  const session = await seedSessionRetry(seed, app, { title: "Palette pin rename probe" });
+  return { app, workspace, session };
+}
+
 export async function shimmerChat(seed: Seed) {
   const base = await emptyChat(seed);
   await seedControls(seed, base.app, [{ action: "eval.chat_loading.seed" }]);


### PR DESCRIPTION
## Summary

Follow-up to #4393: from **⌘K / Ctrl+K** you can now act on the session you're looking at.

- **Pin session / Unpin session** (`session.pin.toggle`) — label follows the pin state; aliases: pin, unpin, favorite, star, keep on top, sidebar.
- **Rename session…** (`session.rename`) — opens the existing rename dialog (title prefilled) via a tiny window-event bus (`session-actions-bus.ts`), same pattern as the palette bus. Aliases: rename, title, name, edit title.

Both rows show the current session title as detail and only appear when a session is open (rename also needs the engine client, like the sidebar menu).

## Verification
- Unit: `bun test tests/command-palette-search.test.ts` — `pin` / `rename` rank these actions first (7/7). Typecheck ✓. `lint:layers` + spec ratchets clean.
- **E2E — Passed** (local cold boot, `evals/specs/command-palette-pin-rename.e2e.test.ts`, new `paletteSessionActions` world with a seeded session):
  `OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/command-palette-pin-rename.e2e.test.ts`
  Claims: no "Pinned" group before; `pin` shows **Pin session** and not Unpin; Enter → sidebar "Pinned" group appears; reopening shows **Unpin session** and not Pin; `rename` + Enter opens the "Rename session" dialog with the "Session name" field; typing a new name + Save → sidebar shows the new title and the old title is gone.

Screenshots from the run are attached below.
