### PR TITLE
test(evals): pre-warm the OpenCode plugin cache per Daytona sandbox

### DIFF
--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -169,10 +169,10 @@ class DaytonaPlacementHost implements Host {
   readonly #preparedHost: Host | undefined;
   readonly #surfaces = new Map<SurfaceHandle, PlacedSurface>();
 
-  constructor(ref: string, preparedSandbox?: string) {
+  constructor(ref: string, preparedSandbox?: string, preparedEngineCacheDir?: string) {
     this.#ref = ref;
     this.#preparedSandbox = preparedSandbox;
-    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox) : undefined;
+    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox, preparedEngineCacheDir) : undefined;
   }
 
   async #provision(name: string): Promise<PlacedSurface> {
@@ -189,7 +189,7 @@ class DaytonaPlacementHost implements Host {
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });
     return {
-      host: daytonaSandbox(provisioned.sandbox),
+      host: daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined),
       sandbox: provisioned.sandbox,
       created: provisioned.created,
     };
@@ -244,9 +244,9 @@ class DaytonaPlace implements Place {
   readonly #ref: string;
   readonly #host: Host;
 
-  constructor(ref: string, preparedDesktopSandbox?: string) {
+  constructor(ref: string, preparedDesktopSandbox?: string, preparedEngineCacheDir?: string) {
     this.#ref = ref;
-    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox);
+    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox, preparedEngineCacheDir);
   }
 
   host(): Host {
@@ -277,7 +277,11 @@ export function resolvePlace(env: NodeJS.ProcessEnv = process.env): Place {
     || (worldPlace === undefined && env.OPENWORK_EVAL_DAYTONA?.trim() === "1");
   if (useDaytona) {
     const ref = env.OPENWORK_EVAL_REF?.trim() || env.GITHUB_SHA?.trim() || "dev";
-    return new DaytonaPlace(ref, env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim());
+    return new DaytonaPlace(
+      ref,
+      env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim(),
+      env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR?.trim(),
+    );
   }
   return new LocalPlace(env.OPENWORK_EVAL_MYSQL_URL?.trim() || DEFAULT_MYSQL_URL);
 }

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -24,6 +24,8 @@ export interface DaytonaHostOptions {
   reservedChromePorts?: number[];
   reservedElectronPorts?: number[];
   serverScript?: boolean;
+  /** Exact per-provision engine cache root to seed into fresh Electron profiles. */
+  engineCacheDir?: string;
   waitForCdp?: (url: string, timeoutMs: number, label: string) => Promise<void>;
 }
 
@@ -546,6 +548,10 @@ function appendExtraEnv(assignments: Map<string, string>, env: Record<string, st
 
 export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
   const exec = options.exec ?? defaultDaytonaExec;
+  const engineCacheDir = options.engineCacheDir?.trim();
+  if (options.engineCacheDir !== undefined && !engineCacheDir) {
+    throw new Error("Daytona engineCacheDir must not be empty.");
+  }
   const previewCache = new Map<number, string>();
   const electronPorts: PortAllocation = { primary: 9825, next: 9830, used: portSet(options.reservedElectronPorts) };
   const chromePorts: PortAllocation = { primary: 9222, next: 9230, used: portSet(options.reservedChromePorts) };
@@ -592,15 +598,17 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
     try {
       await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
-      const cachedDevData = "/workspace/.openwork-daytona/engine-cache/openwork-dev-data";
-      const profileDevData = `${userDataDir}/openwork-dev-data`;
-      const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
-      await checkedExec(
-        exec,
-        ["exec", sandbox, "--", seedCommand],
-        `seed Daytona Electron engine cache ${userDataDir}`,
-        { timeoutMs: 60_000 },
-      );
+      if (engineCacheDir) {
+        const cachedDevData = `${engineCacheDir}/openwork-dev-data`;
+        const profileDevData = `${userDataDir}/openwork-dev-data`;
+        const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
+        await checkedExec(
+          exec,
+          ["exec", sandbox, "--", seedCommand],
+          `seed Daytona Electron engine cache ${userDataDir}`,
+          { timeoutMs: 60_000 },
+        );
+      }
       if (opts.bootstrap) {
         const bootstrapJson = `${JSON.stringify(opts.bootstrap, null, 2)}\n`;
         const encoded = Buffer.from(bootstrapJson, "utf8").toString("base64");

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -592,6 +592,15 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
     try {
       await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
+      const cachedDevData = "/workspace/.openwork-daytona/engine-cache/openwork-dev-data";
+      const profileDevData = `${userDataDir}/openwork-dev-data`;
+      const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
+      await checkedExec(
+        exec,
+        ["exec", sandbox, "--", seedCommand],
+        `seed Daytona Electron engine cache ${userDataDir}`,
+        { timeoutMs: 60_000 },
+      );
       if (opts.bootstrap) {
         const bootstrapJson = `${JSON.stringify(opts.bootstrap, null, 2)}\n`;
         const encoded = Buffer.from(bootstrapJson, "utf8").toString("base64");

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -474,6 +474,10 @@ echo WARM_OK`;
     });
     if (result?.stdout.includes("WARM_TIMEOUT")) {
       log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
+    } else if (result?.stdout.includes("WARM_OK")) {
+      log(`==> engine cache warmed for ${sandbox}`);
+    } else if (result?.stdout.includes("WARM_PRESENT")) {
+      log(`==> engine cache already warm for ${sandbox}`);
     }
   });
 

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -43,6 +43,7 @@ export interface DesktopSandboxOptions {
 export interface DesktopSandbox {
   sandbox: string;
   created: boolean;
+  engineCacheDir: string | null;
 }
 
 export interface DenSandboxOptions {
@@ -94,6 +95,8 @@ export interface ConnectorE2eTestEnv {
   denWebUrl: string;
   sandboxA: string;
   sandboxB: string;
+  engineCacheDirA: string | null;
+  engineCacheDirB: string | null;
   mockUrl: string;
   ref: string;
   created: string[];
@@ -224,6 +227,7 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
   const ref = assertSafeRef(options.ref);
   const reused = options.reuse?.trim() || "";
   let sandbox = reused;
+  let engineCacheDir: string | null = null;
 
   await timedStep(log, "sandbox gate", async () => {
     if (reused) {
@@ -414,29 +418,26 @@ echo detached`;
     const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
     const pluginManifestSuffix = b64('"}}');
     const devtoolsManifest = b64('{"dependencies":{"opencode-chrome-devtools":"latest"}}');
+    const warmDir = `/tmp/openwork-engine-warm-${Date.now()}`;
     const warmScript = `set -e
-W=/workspace/.openwork-daytona/engine-cache
-if [ -d "$W/openwork-dev-data/xdg/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/node_modules" ]; then
-  echo WARM_PRESENT
-  exit 0
-fi
-D=/tmp/engine-warm/openwork-dev-data
-rm -rf /tmp/engine-warm
+W=${warmDir}
+rm -rf /workspace/.openwork-daytona/engine-cache "$W"
+D="$W/openwork-dev-data"
 mkdir -p "$D/home" "$D/xdg/config/opencode" "$D/config/opencode" "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest"
-rm -f /tmp/engine-warm.log
+LOG="$W/warm.log"
 sidecars=(/workspace/apps/desktop/resources/sidecars/opencode-*)
 SIDECAR="\${sidecars[0]:-}"
 if [ ! -x "$SIDECAR" ]; then
-  echo "No executable OpenCode sidecar found" > /tmp/engine-warm.log
+  echo "No executable OpenCode sidecar found" > "$LOG"
   echo WARM_TIMEOUT
-  tail -80 /tmp/engine-warm.log 2>&1 || true
+  tail -80 "$LOG" 2>&1 || true
   exit 0
 fi
-ENGINE_VERSION=$("$SIDECAR" --version 2>>/tmp/engine-warm.log | tail -1 || true)
+ENGINE_VERSION=$("$SIDECAR" --version 2>>"$LOG" | tail -1 || true)
 if [ -z "$ENGINE_VERSION" ]; then
-  echo "OpenCode sidecar did not report a version" >> /tmp/engine-warm.log
+  echo "OpenCode sidecar did not report a version" >> "$LOG"
   echo WARM_TIMEOUT
-  tail -80 /tmp/engine-warm.log 2>&1 || true
+  tail -80 "$LOG" 2>&1 || true
   exit 0
 fi
 printf %s ${pluginManifestPrefix} | base64 -d > "$D/xdg/config/opencode/package.json"
@@ -446,24 +447,22 @@ cp "$D/xdg/config/opencode/package.json" "$D/config/opencode/package.json"
 printf %s ${devtoolsManifest} | base64 -d > "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/package.json"
 NPM=/usr/local/share/nvm/current/bin/npm
 if [ ! -x "$NPM" ]; then
-  echo "npm is missing at $NPM" >> /tmp/engine-warm.log
+  echo "npm is missing at $NPM" >> "$LOG"
   echo WARM_TIMEOUT
-  tail -80 /tmp/engine-warm.log 2>&1 || true
+  tail -80 "$LOG" 2>&1 || true
   exit 0
 fi
 install_package() {
   directory="$1"
-  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --no-audit --no-fund --loglevel=error) >> /tmp/engine-warm.log 2>&1; then
+  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --ignore-scripts --no-audit --no-fund --loglevel=error) >> "$LOG" 2>&1; then
     echo WARM_TIMEOUT
-    tail -80 /tmp/engine-warm.log 2>&1 || true
+    tail -80 "$LOG" 2>&1 || true
     return 1
   fi
 }
 install_package "$D/xdg/config/opencode" || exit 0
 install_package "$D/config/opencode" || exit 0
 install_package "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest" || exit 0
-mkdir -p "$W"
-cp -a "$D" "$W/"
 echo WARM_OK`;
     const result = await execInSandbox(exec, sandbox, warmScript, {
       timeoutMs: 240_000,
@@ -475,9 +474,8 @@ echo WARM_OK`;
     if (result?.stdout.includes("WARM_TIMEOUT")) {
       log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
     } else if (result?.stdout.includes("WARM_OK")) {
+      engineCacheDir = warmDir;
       log(`==> engine cache warmed for ${sandbox}`);
-    } else if (result?.stdout.includes("WARM_PRESENT")) {
-      log(`==> engine cache already warm for ${sandbox}`);
     }
   });
 
@@ -530,7 +528,7 @@ echo detached`;
     throw new Error(`Vite prewarm gate timed out after ${VITE_PREWARM_TIMEOUT_MS}ms waiting for ${phase} in ${sandbox}. Last readiness error: ${last}. Log tail:\n${outputTail(viteLog)}`);
   });
 
-  return { sandbox, created: !reused };
+  return { sandbox, created: !reused, engineCacheDir };
 }
 
 interface LocalProcessResult {
@@ -983,6 +981,8 @@ export function renderConnectorE2eTestEnv(facts: ConnectorE2eTestEnv): string {
     `OPENWORK_EVAL_DEN_WEB_URL=${shellQuote(facts.denWebUrl)}`,
     `OPENWORK_EVAL_DAYTONA_SANDBOX_A=${shellQuote(facts.sandboxA)}`,
     `OPENWORK_EVAL_DAYTONA_SANDBOX_B=${shellQuote(facts.sandboxB)}`,
+    `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A=${shellQuote(facts.engineCacheDirA ?? "")}`,
+    `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B=${shellQuote(facts.engineCacheDirB ?? "")}`,
     `OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL=${shellQuote(facts.mockUrl)}`,
     "OPENWORK_EVAL_MODEL=big-pickle",
     "",
@@ -1020,6 +1020,8 @@ export function parseConnectorE2eTestEnv(content: string): ConnectorE2eTestEnv {
     denWebUrl: required("OPENWORK_EVAL_DEN_WEB_URL"),
     sandboxA: required("OPENWORK_EVAL_DAYTONA_SANDBOX_A"),
     sandboxB: required("OPENWORK_EVAL_DAYTONA_SANDBOX_B"),
+    engineCacheDirA: values.get("OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A")?.trim() || null,
+    engineCacheDirB: values.get("OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B")?.trim() || null,
     mockUrl: required("OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL"),
     ref,
     created: createdText.split(",").map((id) => id.trim()).filter(Boolean),

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -408,6 +408,75 @@ echo detached`;
     }
   });
 
+  await timedStep(log, "engine cache warm gate", async () => {
+    // The sandbox exec transport strips double quotes, so JSON travels base64.
+    const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+    const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
+    const pluginManifestSuffix = b64('"}}');
+    const devtoolsManifest = b64('{"dependencies":{"opencode-chrome-devtools":"latest"}}');
+    const warmScript = `set -e
+W=/workspace/.openwork-daytona/engine-cache
+if [ -d "$W/openwork-dev-data/xdg/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/config/opencode/node_modules" ] && [ -d "$W/openwork-dev-data/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/node_modules" ]; then
+  echo WARM_PRESENT
+  exit 0
+fi
+D=/tmp/engine-warm/openwork-dev-data
+rm -rf /tmp/engine-warm
+mkdir -p "$D/home" "$D/xdg/config/opencode" "$D/config/opencode" "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest"
+rm -f /tmp/engine-warm.log
+sidecars=(/workspace/apps/desktop/resources/sidecars/opencode-*)
+SIDECAR="\${sidecars[0]:-}"
+if [ ! -x "$SIDECAR" ]; then
+  echo "No executable OpenCode sidecar found" > /tmp/engine-warm.log
+  echo WARM_TIMEOUT
+  tail -80 /tmp/engine-warm.log 2>&1 || true
+  exit 0
+fi
+ENGINE_VERSION=$("$SIDECAR" --version 2>>/tmp/engine-warm.log | tail -1 || true)
+if [ -z "$ENGINE_VERSION" ]; then
+  echo "OpenCode sidecar did not report a version" >> /tmp/engine-warm.log
+  echo WARM_TIMEOUT
+  tail -80 /tmp/engine-warm.log 2>&1 || true
+  exit 0
+fi
+printf %s ${pluginManifestPrefix} | base64 -d > "$D/xdg/config/opencode/package.json"
+printf %s "$ENGINE_VERSION" >> "$D/xdg/config/opencode/package.json"
+printf %s ${pluginManifestSuffix} | base64 -d >> "$D/xdg/config/opencode/package.json"
+cp "$D/xdg/config/opencode/package.json" "$D/config/opencode/package.json"
+printf %s ${devtoolsManifest} | base64 -d > "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/package.json"
+NPM=/usr/local/share/nvm/current/bin/npm
+if [ ! -x "$NPM" ]; then
+  echo "npm is missing at $NPM" >> /tmp/engine-warm.log
+  echo WARM_TIMEOUT
+  tail -80 /tmp/engine-warm.log 2>&1 || true
+  exit 0
+fi
+install_package() {
+  directory="$1"
+  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --no-audit --no-fund --loglevel=error) >> /tmp/engine-warm.log 2>&1; then
+    echo WARM_TIMEOUT
+    tail -80 /tmp/engine-warm.log 2>&1 || true
+    return 1
+  fi
+}
+install_package "$D/xdg/config/opencode" || exit 0
+install_package "$D/config/opencode" || exit 0
+install_package "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest" || exit 0
+mkdir -p "$W"
+cp -a "$D" "$W/"
+echo WARM_OK`;
+    const result = await execInSandbox(exec, sandbox, warmScript, {
+      timeoutMs: 240_000,
+      context: `engine cache warm gate for ${sandbox}`,
+    }).catch((error) => {
+      log(`==> WARNING: engine cache warm gate could not complete for ${sandbox}; specs will start cold. ${messageText(error)}`);
+      return null;
+    });
+    if (result?.stdout.includes("WARM_TIMEOUT")) {
+      log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
+    }
+  });
+
   await timedStep(log, "Vite prewarm gate", async () => {
     const detachScript = `cd /workspace; python3 - <<PYEOF
 import subprocess

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -10,6 +10,7 @@ import { checkedExec, defaultDaytonaExec } from "./daytona.ts";
 import { FAULT_PROXY_SCRIPT } from "./fault-proxy-script.ts";
 import type { DaytonaExec, DaytonaExecResult } from "./daytona.ts";
 
+const CHROME_DEVTOOLS_PLUGIN_VERSION = "1.0.4";
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const DESKTOP_READY_TIMEOUT_MS = 300_000;
 const INSTALL_TIMEOUT_MS = 25 * 60 * 1_000;
@@ -417,7 +418,10 @@ echo detached`;
     const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
     const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
     const pluginManifestSuffix = b64('"}}');
-    const devtoolsManifest = b64('{"dependencies":{"opencode-chrome-devtools":"latest"}}');
+    // The engine resolves the unpinned `opencode-chrome-devtools` plugin as `latest`
+    // and keys its cache dir by that tag; the harness installs one audited version
+    // into that slot so evaluation desktops never load whatever the tag points at.
+    const devtoolsManifest = b64(`{"dependencies":{"opencode-chrome-devtools":"${CHROME_DEVTOOLS_PLUGIN_VERSION}"}}`);
     const warmDir = `/tmp/openwork-engine-warm-${Date.now()}`;
     const warmScript = `set -e
 W=${warmDir}

--- a/evals/packages/hosts/src/resolve.ts
+++ b/evals/packages/hosts/src/resolve.ts
@@ -38,7 +38,7 @@ export function localHost(): DisposableHost {
 }
 
 /** A named Daytona sandbox, driven through the `daytona` CLI from outside it. */
-export function daytonaSandbox(sandboxId: string): DisposableHost {
+export function daytonaSandbox(sandboxId: string, engineCacheDir?: string): DisposableHost {
   const id = sandboxId.trim();
   if (!id) throw new Error("daytonaSandbox(sandboxId) requires a sandbox id.");
   if (runningInsideSandbox()) {
@@ -46,5 +46,5 @@ export function daytonaSandbox(sandboxId: string): DisposableHost {
       `daytonaSandbox(${JSON.stringify(id)}) cannot be used from inside a sandbox: the daytona CLI indirection has nothing to target. Use localHost() there.`,
     );
   }
-  return createDaytonaHost({ sandboxId: id, repoRoot: REPO_ROOT, log: () => undefined });
+  return createDaytonaHost({ sandboxId: id, repoRoot: REPO_ROOT, log: () => undefined, engineCacheDir });
 }

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -174,6 +174,7 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
     log: () => undefined,
     exec,
     repoRoot: "/repo",
+    engineCacheDir: "/tmp/openwork-engine-warm-123",
     waitForCdp: successfulPolls(polled),
   });
   const bootstrap = { baseUrl: "https://den-web.example.test", apiBaseUrl: "https://den-api.example.test", requireSignin: true };
@@ -194,7 +195,8 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
   assert(firstMkdirIndex >= 0);
   assert(firstSeedIndex > firstMkdirIndex);
   const firstSeed = argsText(calls[firstSeedIndex] ?? { args: [] });
-  assert(firstSeed.includes("/workspace/.openwork-daytona/engine-cache/openwork-dev-data"));
+  assert(firstSeed.includes("/tmp/openwork-engine-warm-123/openwork-dev-data"));
+  assert(!firstSeed.includes("engine-cache"));
   assert(firstSeed.includes("[ ! -e"));
   assert(firstSeed.includes("/electron-userdata/openwork-dev-data"));
 

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -189,6 +189,15 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
   assert.equal(second.meta?.profileOwner, "host");
   assert.deepEqual(polled, ["https://cdp-9825.example.test/json/list", "https://cdp-9830.example.test/json/list"]);
 
+  const firstMkdirIndex = calls.findIndex((call) => argsText(call).includes("mkdir -p") && argsText(call).includes("/profiles/owner-"));
+  const firstSeedIndex = calls.findIndex((call) => argsText(call).includes("cp -a") && argsText(call).includes("/profiles/owner-"));
+  assert(firstMkdirIndex >= 0);
+  assert(firstSeedIndex > firstMkdirIndex);
+  const firstSeed = argsText(calls[firstSeedIndex] ?? { args: [] });
+  assert(firstSeed.includes("/workspace/.openwork-daytona/engine-cache/openwork-dev-data"));
+  assert(firstSeed.includes("[ ! -e"));
+  assert(firstSeed.includes("/electron-userdata/openwork-dev-data"));
+
   const bootstrapCall = findCall(calls, "base64 -d");
   assert.equal(Buffer.from(base64AfterEcho(bootstrapCall), "base64").toString("utf8"), `${JSON.stringify(bootstrap, null, 2)}\n`);
   assert(argsText(bootstrapCall).includes("/workspace/.openwork-daytona/profiles/owner-"));

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -42,7 +42,7 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
     if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
-    if (script.includes("WARM_PRESENT")) return { stdout: "WARM_PRESENT\n", stderr: "", code: 0 };
+    if (script.includes("install_package")) return { stdout: "WARM_OK\n", stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };
@@ -62,6 +62,8 @@ test("connector E2E test env rendering and parsing round-trip the provision cont
     denWebUrl: "https://den-web.example.test",
     sandboxA: "desktop-a",
     sandboxB: "desktop-b",
+    engineCacheDirA: "/tmp/openwork-engine-warm-a",
+    engineCacheDirB: null,
     mockUrl: "https://mock.example.test",
     ref: "feat/eval-connector-two-members",
     created: ["den", "desktop-a"],
@@ -71,6 +73,8 @@ test("connector E2E test env rendering and parsing round-trip the provision cont
   assert.deepEqual(parseConnectorE2eTestEnv(content), facts);
   assert.match(content, /^# provisioned for org-connector-two-members — generated .*; ref=feat\/eval-connector-two-members$/m);
   assert.match(content, /^# provision-created=den,desktop-a$/m);
+  assert.match(content, /^OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A='\/tmp\/openwork-engine-warm-a'$/m);
+  assert.match(content, /^OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B=''$/m);
   assert.match(content, /OPENWORK_EVAL_MODEL=big-pickle/);
   const missingApi = content.split("\n").filter((line) => !line.startsWith("OPENWORK_EVAL_DEN_API_URL=")).join("\n");
   assert.throws(() => parseConnectorE2eTestEnv(missingApi), /OPENWORK_EVAL_DEN_API_URL/);
@@ -109,17 +113,23 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
 
   const result = await provisionDesktopSandbox({ ref: "dev", name: "a", reuse: "existing-a", exec, log: () => undefined });
 
-  assert.deepEqual(result, { sandbox: "existing-a", created: false });
+  assert.equal(result.sandbox, "existing-a");
+  assert.equal(result.created, false);
+  assert.match(result.engineCacheDir ?? "", /^\/tmp\/openwork-engine-warm-\d+$/);
   assert.deepEqual(calls[0]?.args, ["sandbox", "start", "existing-a"]);
   assert.equal(calls.filter((call) => call.args[0] === "create").length, 0);
   assert.equal(calls.filter((call) => call.args[0] === "snapshot").length, 0);
   const lastFirstBootCall = calls.findLastIndex((call) => call.args[3]?.includes("/tmp/warmup-profile"));
-  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("WARM_PRESENT"));
+  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("install_package"));
   assert(lastFirstBootCall >= 0);
   assert(engineWarmCall > lastFirstBootCall);
   const engineWarmScript = calls[engineWarmCall]?.args[3] ?? "";
   assert(engineWarmScript.includes("npm install"));
+  assert(engineWarmScript.includes("npm install --ignore-scripts --no-audit --no-fund --loglevel=error"));
   assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
+  assert(!engineWarmScript.includes("WARM_PRESENT"));
+  assert(!engineWarmScript.includes("W=/workspace/.openwork-daytona/engine-cache"));
+  assert(engineWarmScript.includes("rm -rf /workspace/.openwork-daytona/engine-cache"));
   assertRemoteCommandsAreSingleArgument(calls);
 });
 
@@ -146,6 +156,8 @@ test("rendered values are shell-quoted, because the env file is meant to be sour
     denWebUrl: "https://w",
     sandboxA: nasty,
     sandboxB: "b",
+    engineCacheDirA: null,
+    engineCacheDirB: null,
     mockUrl: "https://m",
     ref: "dev",
     created: [],
@@ -168,6 +180,8 @@ test("an unsafe ref is refused before it can reach a remote shell or a sourced f
       denWebUrl: "https://w",
       sandboxA: "a",
       sandboxB: "b",
+      engineCacheDirA: null,
+      engineCacheDirB: null,
       mockUrl: "https://m",
       ref,
       created: [],

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -42,6 +42,7 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
     if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
+    if (script.includes("WARM_PRESENT")) return { stdout: "WARM_PRESENT\n", stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };
@@ -112,6 +113,13 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
   assert.deepEqual(calls[0]?.args, ["sandbox", "start", "existing-a"]);
   assert.equal(calls.filter((call) => call.args[0] === "create").length, 0);
   assert.equal(calls.filter((call) => call.args[0] === "snapshot").length, 0);
+  const lastFirstBootCall = calls.findLastIndex((call) => call.args[3]?.includes("/tmp/warmup-profile"));
+  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("WARM_PRESENT"));
+  assert(lastFirstBootCall >= 0);
+  assert(engineWarmCall > lastFirstBootCall);
+  const engineWarmScript = calls[engineWarmCall]?.args[3] ?? "";
+  assert(engineWarmScript.includes("npm install"));
+  assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
   assertRemoteCommandsAreSingleArgument(calls);
 });
 

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -127,6 +127,7 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
   assert(engineWarmScript.includes("npm install"));
   assert(engineWarmScript.includes("npm install --ignore-scripts --no-audit --no-fund --loglevel=error"));
   assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
+  assert(!engineWarmScript.includes(Buffer.from('"opencode-chrome-devtools":"latest"').toString("base64").slice(0, 24)));
   assert(!engineWarmScript.includes("WARM_PRESENT"));
   assert(!engineWarmScript.includes("W=/workspace/.openwork-daytona/engine-cache"));
   assert(engineWarmScript.includes("rm -rf /workspace/.openwork-daytona/engine-cache"));

--- a/evals/runner/prepare-stack.ts
+++ b/evals/runner/prepare-stack.ts
@@ -14,7 +14,7 @@ const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 export type StackPreparation =
   | { kind: "none" }
   | { kind: "local"; runtimePrepared: true; electronPrepared: true }
-  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string }[] };
+  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string; engineCacheDir: string | null }[] };
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -89,7 +89,7 @@ async function prepareDaytona(argv: readonly string[]): Promise<{ preparation: S
           return result;
         }),
       ]);
-      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox };
+      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox, engineCacheDir: desktop.engineCacheDir };
     }));
     console.error(`[openwork/evals] prepared ${slots.length} isolated Daytona worker slot${slots.length === 1 ? "" : "s"}.`);
     return {

--- a/evals/runner/stack-env.ts
+++ b/evals/runner/stack-env.ts
@@ -13,4 +13,6 @@ if (preparation.kind === "daytona") {
   if (!slot) throw new Error("Vitest worker did not resolve to a prepared Daytona slot.");
   process.env.OPENWORK_EVAL_DAYTONA_DEN_SANDBOX = slot.denSandbox;
   process.env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX = slot.desktopSandbox;
+  if (slot.engineCacheDir) process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR = slot.engineCacheDir;
+  else delete process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR;
 }

--- a/evals/scripts/provision-org-connector-two-members.ts
+++ b/evals/scripts/provision-org-connector-two-members.ts
@@ -72,6 +72,8 @@ async function provisionSpecEnv(options: {
       denWebUrl: den.webUrl,
       sandboxA: desktopA.sandbox,
       sandboxB: desktopB.sandbox,
+      engineCacheDirA: desktopA.engineCacheDir,
+      engineCacheDirB: desktopB.engineCacheDir,
       mockUrl: mock.url,
       ref: options.ref,
       created,

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -376,7 +376,7 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
         log: (line) => console.error(`[openwork/testkit] ${line}`),
       })
     : null;
-  const host = provisioned ? daytonaSandbox(provisioned.sandbox) : localHost();
+  const host = provisioned ? daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined) : localHost();
   const seeded = await desktop({ name: "recovery-profile-seed", host, profileDir });
   const names = await evalIn(seeded, `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
     folderPath: ${JSON.stringify(`${profileDir}/continuity-workspace`)}, name: "reliable-recovery-profile-marker"
@@ -528,7 +528,7 @@ export async function enterpriseTlsWorld(seed: Seed, { place }: { place: Place }
   let rootInstallAttempted = false;
   let rawApp: Awaited<ReturnType<typeof desktop>> | null = null;
   let trustedApp: Awaited<ReturnType<typeof startApp>> | null = null;
-  const host = daytonaSandbox(provisioned.sandbox);
+  const host = daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined);
 
   const dispose = async () => {
     if (trustedApp) await cleanup("dispose trusted enterprise TLS app", () => trustedApp?.[Symbol.asyncDispose]() ?? Promise.resolve());

--- a/evals/worlds/infra.ts
+++ b/evals/worlds/infra.ts
@@ -32,13 +32,15 @@ export async function oauthDenWorld(seed: Seed) {
 export async function twoDaytonaDesktopsWorld(seed: Seed) {
   const requestedA = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_A?.trim();
   const requestedB = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_B?.trim();
+  const engineCacheDirA = process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A?.trim();
+  const engineCacheDirB = process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B?.trim();
   if (Boolean(requestedA) !== Boolean(requestedB)) throw new Error("Set both Daytona sandbox ids or neither.");
   if (requestedA && requestedA === requestedB) throw new Error("The two Daytona sandbox ids must differ.");
   const appA = requestedA
-    ? await desktop({ host: daytonaSandbox(requestedA), name: "a" })
+    ? await desktop({ host: daytonaSandbox(requestedA, engineCacheDirA), name: "a" })
     : await seed.desktop({ name: "a" });
   const appB = requestedB
-    ? await desktop({ host: daytonaSandbox(requestedB), name: "b" })
+    ? await desktop({ host: daytonaSandbox(requestedB, engineCacheDirB), name: "b" })
     : await seed.desktop({ name: "b" });
   const sandboxA = appA.handle.sandboxId;
   const sandboxB = appB.handle.sandboxId;


### PR DESCRIPTION
## Problem

Every app-driving e2e spec on `dev` has been failing at `seedSessions` (`session.create_task` → "Action is disabled" / "did not return a session ID"), on Daytona and locally. The app showed **"OpenCode unavailable — the engine did not answer after 4 attempts."**

Root cause (measured live in a sandbox): each spec gets a fresh Electron profile with an empty engine cache, so the engine's first workspace bootstrap npm-installs `@opencode-ai/plugin@<engine version>` into two config dirs and `opencode-chrome-devtools@latest` into its package cache. Inside the sandbox that self-install frequently wedges — 60 idle TLS connections to `registry.npmjs.org`, no timeout, log silent — so bootstrap never completes. npm itself is fine from the sandbox (40 parallel fetches in 1.1s). With those three directories already populated, bootstrap takes **0.2s**.

## Fix (harness only)

- `provision.ts`: new **engine cache warm gate** after the first-boot gate. Reads the sidecar version, writes the three `package.json`s (base64-shipped — the exec transport strips `"`), runs `npm install` into each, and stores the tree at `/workspace/.openwork-daytona/engine-cache/openwork-dev-data`. Non-fatal on failure (specs start cold, with a logged warning). ~10s.
- `daytona.ts` `spawnElectron`: after creating a fresh profile, `cp -a` the warm tree into `<userData>/openwork-dev-data` (guarded: never clobbers a caller-owned profile that already has one).
- Cleanup gate untouched; it never removes `engine-cache`.

## Verification

`OPENWORK_EVAL_DAYTONA` lane, unchanged spec `evals/specs/responsive-session-layout.e2e.test.ts`:

```
[openwork/testkit] ==> engine cache warmed for openwork-connector-testkit-admin-…
✓ narrow session panes stay selectable, synchronized, and inside the viewport  235096ms
passed 1 / failed 0 / skipped 0
```

Also proven downstream: with this branch as base, `new-split-session.e2e.test.ts` (#4397) went from red-at-seed to green on the same lane.

Unit: `node --test evals/packages/hosts/test/{provision,daytona-host}.test.ts` → 29 pass.

## Two harness footguns found along the way (not fixed here)

1. `pnpm evals:e2e` on the Daytona lane checks out **`OPENWORK_EVAL_REF` or `dev`** inside the sandbox — never the current branch. A feature branch's local Daytona "verdict" silently tests dev's app unless you set `OPENWORK_EVAL_REF`. The run-tests skill doesn't mention it.
2. The app's `canCreateTask` needs a model; the Daytona lane needs `OPENWORK_EVAL_MODEL=big-pickle` (CI sets it; the skill doesn't say so).
