### PR TITLE
fix(den-web): keep dashboard button labels on one line

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/button.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/button.tsx
@@ -39,7 +39,7 @@ export function buttonVariants({
     className?: string;
 } = {}): string {
     return [
-        "inline-flex items-center justify-center rounded-lg font-medium transition-colors",
+        "inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors",
         variantClasses[variant],
         sizeClasses[size],
         className,
@@ -172,7 +172,7 @@ export function DenButton({
 }: DenButtonProps) {
     const isDisabled = disabled || loading;
     const classNames = [
-        "relative flex flex-row gap-2 items-center justify-center rounded-lg font-medium transition-colors",
+        "relative flex flex-row gap-2 items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors",
         variantClasses[variant],
         sizeClasses[size],
         isDisabled ? "cursor-not-allowed opacity-70" : "",

--- a/ee/apps/den-web/tests/dashboard-button-geometry.test.ts
+++ b/ee/apps/den-web/tests/dashboard-button-geometry.test.ts
@@ -13,4 +13,14 @@ describe("dashboard button geometry", () => {
     expect(source).toContain("rounded-lg");
     expect(source).not.toContain("rounded-full");
   });
+
+  test("shared action primitives keep labels on one line", () => {
+    const source = readFileSync(buttonPath, "utf8");
+
+    const baseClassLists = source.match(/"[^"]*rounded-lg font-medium transition-colors"/g) ?? [];
+    expect(baseClassLists.length).toBe(2);
+    for (const classList of baseClassLists) {
+      expect(classList).toContain("whitespace-nowrap");
+    }
+  });
 });


### PR DESCRIPTION
## Problem

In the Den Plugin Directory header the **Create plugin** link sits beside the six-tab row. At the `xl` breakpoint the header is `flex-row`, the tabs take most of the width, and the link gets shrunk as a flex item, so its label wraps onto two lines inside the fixed-height (`h-10`) button.

## Fix

Add `whitespace-nowrap` to the shared base classes in `buttonVariants` and `DenButton`. With `nowrap`, the item's `min-width: auto` already stops it shrinking below its label, so no per-call-site `shrink-0` is needed, and every dashboard button gets the same guarantee.

## Verification

- `pnpm --dir ee/apps/den-web typecheck` — exit 0
- `bun test --conditions development tests/dashboard-button-geometry.test.ts` (in `ee/apps/den-web`) — 2 pass, 0 fail; the new assertion fails against the pre-fix `button.tsx`.

Classification: Tailwind class-list change to a shared primitive, covered by extending the existing source-contract test for that primitive. No new test file; no journey spec was extended because no existing spec asserts button layout.