### PR TITLE
fix(server): ship opencode-chrome-devtools as a bundled local plugin so engine bootstrap never depends on npm

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -59,7 +59,6 @@
     "htmlparser2": "8.0.2",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.2.5",
-    "opencode-chrome-devtools": "1.0.4",
     "undici": "6.28.0",
     "yaml": "^2.9.0",
     "zod": "^4.3.6"
@@ -73,6 +72,7 @@
     "@types/minimatch": "^5.1.2",
     "@types/node": "^22.10.2",
     "bun-types": "^1.3.6",
+    "opencode-chrome-devtools": "1.0.4",
     "typescript": "^5.6.3"
   },
   "packageManager": "pnpm@10.27.0"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "bun --conditions=development test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "test:artifacts": "bun --conditions=development test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build:enterprise-mcp-client": "pnpm --filter @openwork/enterprise-mcp-client build",
-    "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-spreadsheets.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
+    "build": "pnpm build:enterprise-mcp-client && tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-chrome-devtools.ts src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-spreadsheets.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "pnpm build:enterprise-mcp-client && bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "pnpm build:enterprise-mcp-client && bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
     "prepare:npm": "pnpm build:bin && node scripts/publish-npm.mjs --prepare-only",
@@ -59,6 +59,7 @@
     "htmlparser2": "8.0.2",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.2.5",
+    "opencode-chrome-devtools": "1.0.4",
     "undici": "6.28.0",
     "yaml": "^2.9.0",
     "zod": "^4.3.6"

--- a/apps/server/src/opencode-plugins/opencode-chrome-devtools.d.ts
+++ b/apps/server/src/opencode-plugins/opencode-chrome-devtools.d.ts
@@ -1,0 +1,5 @@
+declare module "opencode-chrome-devtools" {
+  import type { Plugin } from "@opencode-ai/plugin";
+
+  export const server: Plugin;
+}

--- a/apps/server/src/opencode-plugins/openwork-chrome-devtools.ts
+++ b/apps/server/src/opencode-plugins/openwork-chrome-devtools.ts
@@ -1,0 +1,2 @@
+// Keep engine bootstrap independent of npm registry availability.
+export { server } from "opencode-chrome-devtools";

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -32,6 +32,7 @@ export function openworkPluginPath(name: string, here?: string): string {
 }
 
 export const openworkExtensionsPreviewPluginPath = () => openworkPluginPath("openwork-extensions-preview");
+export const openworkChromeDevtoolsPluginPath = () => openworkPluginPath("openwork-chrome-devtools");
 export const openworkCapabilitiesKnowledgePluginPath = () => openworkPluginPath("openwork-capabilities-knowledge");
 export const openworkAnthropicAdaptiveThinkingPluginPath = () => openworkPluginPath("openwork-anthropic-adaptive-thinking");
 export const openworkAnthropicToolSchemaPluginPath = () => openworkPluginPath("openwork-anthropic-tool-schema");

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -74,6 +74,11 @@ describe("openwork runtime config file", () => {
     expect(mcp["openwork-connect-stale"]).toBeUndefined();
     expect(parsed.default_agent).toBe("openwork");
     expect(Array.isArray(parsed.plugin)).toBe(true);
+    if (!Array.isArray(parsed.plugin)) throw new Error("Expected runtime plugins");
+    expect(parsed.plugin).not.toContain("opencode-chrome-devtools");
+    expect(parsed.plugin.some(
+      (plugin) => typeof plugin === "string" && /openwork-chrome-devtools\.(?:ts|js)$/.test(plugin),
+    )).toBe(true);
     expect(parsed.agent).toMatchObject({
       openwork: {
         permission: {

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -22,6 +22,7 @@ import {
   openworkAnthropicToolSchemaPluginPath,
   openworkOfficeAttachmentsPluginPath,
   openworkSpreadsheetsPluginPath,
+  openworkChromeDevtoolsPluginPath,
 } from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
 import { runtimeStorageDir } from "./runtime-db.js";
@@ -78,7 +79,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
       },
     },
     plugin: [
-      "opencode-chrome-devtools",
+      openworkChromeDevtoolsPluginPath(),
       // Registration order is prompt order: the knowledge plugin appends the
       // operating rules first, then the extensions plugin adds app-control
       // mechanics, live Connect steering, and the remote skill and Automation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,9 +425,6 @@ importers:
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
-      opencode-chrome-devtools:
-        specifier: 1.0.4
-        version: 1.0.4(@opencode-ai/plugin@1.18.25)
       undici:
         specifier: 6.28.0
         version: 6.28.0
@@ -462,6 +459,9 @@ importers:
       bun-types:
         specifier: ^1.3.6
         version: 1.3.6
+      opencode-chrome-devtools:
+        specifier: 1.0.4
+        version: 1.0.4(@opencode-ai/plugin@1.18.25)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
+      opencode-chrome-devtools:
+        specifier: 1.0.4
+        version: 1.0.4(@opencode-ai/plugin@1.18.25)
       undici:
         specifier: 6.28.0
         version: 6.28.0
@@ -2880,8 +2883,25 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opencode-ai/plugin@1.18.25':
+    resolution: {integrity: sha512-Kb34zFqYosFNiMd1IuYiZGjX17z+18Srm7tHZMCz+uMVRTYNkEw1FTrfAK2FLbggwYdgzifGwKMNF1slLT8eLw==}
+    peerDependencies:
+      '@opentui/core': '>=0.4.5'
+      '@opentui/keymap': '>=0.4.5'
+      '@opentui/solid': '>=0.4.5'
+    peerDependenciesMeta:
+      '@opentui/core':
+        optional: true
+      '@opentui/keymap':
+        optional: true
+      '@opentui/solid':
+        optional: true
+
   '@opencode-ai/sdk@1.18.18':
     resolution: {integrity: sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA==}
+
+  '@opencode-ai/sdk@1.18.25':
+    resolution: {integrity: sha512-GwgwhW+vE8FWSDw730SjzqNhsWXB0uJjbFOiqFkmM+USFuG13HuTlGe6SR2ixt+WXxoD6FV1hILWqsXyqej9hQ==}
 
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
@@ -7555,6 +7575,12 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
+  opencode-chrome-devtools@1.0.4:
+    resolution: {integrity: sha512-BKYEoUSI4actm3RkSJb0Ujv7P0RK2QvfbUcET+HfdSdVfdRNFLxh8PhufrDtBju+WRVsn19bEJCo7W3xdiY8RQ==}
+    hasBin: true
+    peerDependencies:
+      '@opencode-ai/plugin': '*'
+
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -8993,6 +9019,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -10942,7 +10971,18 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opencode-ai/plugin@1.18.25':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@opencode-ai/sdk': 1.18.25
+      effect: 4.0.0-beta.83
+      zod: 4.1.8
+
   '@opencode-ai/sdk@1.18.18':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@opencode-ai/sdk@1.18.25':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -15848,6 +15888,14 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
+  opencode-chrome-devtools@1.0.4(@opencode-ai/plugin@1.18.25):
+    dependencies:
+      '@opencode-ai/plugin': 1.18.25
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -17430,6 +17478,8 @@ snapshots:
       zod: 4.3.6
 
   zod@3.25.76: {}
+
+  zod@4.1.8: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Problem

`openwork-server`'s runtime config listed one **npm** plugin, `"opencode-chrome-devtools"` (`apps/server/src/openwork-runtime-config.ts:81`); the other six are local files. On any fresh profile (first install, new eval desktop) the bundled OpenCode engine installs that package during bootstrap through its **in-process npm installer** (Arborist on the embedded Bun 1.3.14 — no child process, writes `package-lock.json`). That install intermittently hangs forever: dozens of idle keep-alive sockets to the registry, no timeout, no error. Bootstrap never returns, every `/session*` proxy call 502s after 5s, and the app shows **"OpenCode unavailable — the engine did not answer after 4 attempts"**.

Minimal repro with no OpenWork code, on macOS and Linux, on opencode 1.18.18 and 1.18.27:

```
# fresh XDG_* dirs, opencode.json = {"plugin":["opencode-chrome-devtools"]}
POST /session  →  hangs >100s  (passes in 24–34s on a lucky attempt)
# same, plugin removed
POST /session  →  200 in 0.16s
```

This is what has been keeping the Daytona desktop E2E lane red today (#4397 added an eval-host "engine cache warm gate" to pre-seed the cache; that fixes evals but not users).

## Change

Bundle the plugin like the other six:

- `apps/server/package.json`: exact **dev** dep `opencode-chrome-devtools@1.0.4` (build-time only — `bun build` inlines it, so it is not a runtime dep and does not need mirroring into `apps/desktop/package.json`; the `server-dependency-mirror` ratchet stays green); added `src/opencode-plugins/openwork-chrome-devtools.ts` to the `bun build` list (ws is inlined; no bare imports remain in the output).
- `apps/server/src/opencode-plugins/openwork-chrome-devtools.ts`: `export { server } from "opencode-chrome-devtools";` — exactly one exported function so OpenCode registers the tools once. Minimal `.d.ts` for the untyped package.
- `openwork-extensions-plugin-path.ts`: `openworkChromeDevtoolsPluginPath()`; runtime config uses it in place of the npm specifier.
- Desktop packaging already copies `server/dist/opencode-plugins` → `resources/opencode-plugins` (`electron-builder.base.yml:17`), so the new file ships automatically.
- No change to `evals/` (the warm gate stays and becomes redundant), and no change to the app's Library detection (it keys off MCP servers, not the plugin array).

## Verification

Engine-boundary proof, fresh profile, no registry access on PATH (`env -i PATH=/usr/bin:/bin`):

```
opencode.json = {"plugin":["<repo>/apps/server/dist/opencode-plugins/openwork-chrome-devtools.js"]}
POST /session?directory=…  →  200 in 3.45s
GET  /experimental/tool/ids →  8 browser_* tools registered
```

```
pnpm --filter openwork-server build                       # exit 0
grep -c 'from "ws"' apps/server/dist/opencode-plugins/openwork-chrome-devtools.js   # 0
node -e 'import("./apps/server/dist/opencode-plugins/openwork-chrome-devtools.js").then(m=>console.log(Object.keys(m)))'   # [ 'server' ]
pnpm --filter openwork-server exec bun test src/openwork-runtime-config.test.ts src/openwork-extensions-plugin-path.test.ts src/workspace-init.test.ts   # 24 pass, 0 fail
pnpm --filter openwork-server typecheck                   # exit 0
```

`openwork-runtime-config.test.ts` now asserts the plugin list contains no bare `opencode-chrome-devtools` specifier and does contain the local `openwork-chrome-devtools.(ts|js)` path.

E2E lane: running an existing desktop journey on Daytona against this branch to show nothing regressed; result to follow in a comment.

Related: #4392 (composer stays editable) was blocked on this.

