### PR TITLE
feat(coworker): the work behind a reply is one line in the chat, with its steps in a popover

### DIFF
--- a/apps/coworker/src/lib/work-receipt.test.ts
+++ b/apps/coworker/src/lib/work-receipt.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { describeWorkStep, summarizeWork, technicalSections, workStepState } from "./work-receipt.ts";
+import { describeWorkLine, describeWorkProgress, describeWorkStep, summarizeWork, technicalSections, workStepState } from "./work-receipt.ts";
 
 test("tool calls become steps a person can read, with the tool name kept for details", () => {
   const edit = describeWorkStep({ tool: "edit", status: "completed", input: { filePath: "/Users/me/coworkers/yo/memory/index.md" } });
@@ -30,6 +30,22 @@ test("the collapsed line sums the work up and never hides a failure or a running
   assert.equal(summarizeWork([edited, searched]), "Worked with your files and OpenWork Connect · 2 steps");
   assert.equal(summarizeWork([edited, searched, failed]), "Worked with your files and OpenWork Connect and 1 more · 3 steps · 1 step didn't finish");
   assert.equal(summarizeWork([edited, running]), "Worked with your files and the terminal · 2 steps · still working");
+});
+
+test("the transcript line says what is happening now while a step runs, and sums the work up once it has settled", () => {
+  const edited = describeWorkStep({ tool: "edit", status: "completed", input: { filePath: "index.md" } });
+  const running = describeWorkStep({ tool: "bash", status: "running", input: {} });
+  const failed = describeWorkStep({ tool: "skill-studio_create_skill", status: "failed", input: {} });
+  assert.equal(describeWorkLine([]), "");
+  assert.equal(describeWorkLine([running]), "Running a command");
+  assert.equal(describeWorkLine([edited, running]), "Running a command · 2 of 2");
+  assert.equal(describeWorkLine([edited, running, describeWorkStep({ tool: "read", status: "pending", input: { filePath: "notes.md" } })]), "Reading notes.md · 3 of 3");
+  assert.equal(describeWorkLine([edited]), "Edited index.md");
+  assert.equal(describeWorkLine([edited, failed]), "Worked with your files and Skill Studio · 2 steps · 1 step didn't finish");
+  assert.equal(describeWorkProgress([edited, running]), "1 of 2 done");
+  assert.equal(describeWorkProgress([edited]), "1 step");
+  assert.equal(describeWorkProgress([edited, edited]), "2 steps");
+  assert.equal(describeWorkProgress([edited, failed]), "2 steps · 1 didn't finish");
 });
 
 test("technical details show a shell command on its own, other input as tidy JSON, then result and error, all clipped", () => {

--- a/apps/coworker/src/lib/work-receipt.ts
+++ b/apps/coworker/src/lib/work-receipt.ts
@@ -337,6 +337,29 @@ export function summarizeWork(steps: ReadonlyArray<WorkStep>): string {
   return line;
 }
 
+/**
+ * The one line the transcript shows for a turn's work. While a step runs it says
+ * what is happening now and where it sits in the run ("Running a command · 2 of
+ * 3"); once every step has settled it is the summary ("Worked with the terminal
+ * · 2 steps"). The steps themselves wait behind the line, never stacked in the chat.
+ */
+export function describeWorkLine(steps: ReadonlyArray<WorkStep>): string {
+  const position = steps.findLastIndex((step) => step.state === "running");
+  const running = position >= 0 ? steps[position] : undefined;
+  if (!running) return summarizeWork(steps);
+  const doing = running.doing.charAt(0).toUpperCase() + running.doing.slice(1);
+  return steps.length > 1 ? `${doing} · ${position + 1} of ${steps.length}` : doing;
+}
+
+/** The small print beside the steps: "2 of 3 done", "3 steps", "3 steps · 1 didn't finish". */
+export function describeWorkProgress(steps: ReadonlyArray<WorkStep>): string {
+  const done = steps.filter((step) => step.state === "done").length;
+  const failed = steps.filter((step) => step.state === "failed").length;
+  if (steps.some((step) => step.state === "running")) return `${done} of ${steps.length} done`;
+  const count = `${steps.length} step${steps.length === 1 ? "" : "s"}`;
+  return failed ? `${count} · ${failed} didn't finish` : count;
+}
+
 /** One labelled block inside a step's technical details. */
 export type TechnicalSection = { label: "Command" | "Input" | "Result" | "Error"; text: string };
 

--- a/apps/coworker/src/ui/threads.tsx
+++ b/apps/coworker/src/ui/threads.tsx
@@ -53,13 +53,10 @@ import { carryVariant, markAutoPicked, wasAutoPicked } from "@/lib/model-choice"
 import { describeReview, parseWorkerReview, parseWorkerTurn, workerNameFromTitle, type WorkerReview, type WorkerSummary } from "@/lib/workers";
 import { WorkerDecisionCards } from "@/ui/worker-decision";
 import { coworkerToolName } from "@/lib/coworker-tools";
-import { describeWorkStep, summarizeWork, technicalSections, type WorkStep } from "@/lib/work-receipt";
+import { describeWorkLine, describeWorkStep, type WorkStep } from "@/lib/work-receipt";
 import { isUnsettledToolStatus, livePhase, phaseWord, safeLiveMarkdown, writingText, type LivePhase } from "@/lib/live-phase";
 import { describeSpeed, firstWordsFor, rememberFirstWords } from "@/lib/turn-speed";
 import { LiveRow } from "@/ui/live-row";
-import { isServerTool, toolRefPath } from "@/lib/apps-tools";
-import { openPanelRoute } from "@/lib/panel-route";
-import { appsToolsRoute } from "@/lib/panel-views";
 import type { CoworkerSummaryLine, SummaryKind } from "@/lib/coworker-summary";
 import {
   EMPTY_THREAD_TURNS,
@@ -100,6 +97,7 @@ import { documentCardsFromCalls, isDocumentTool, shouldFoldReply, splitReplyLead
 import { newcomerLine, teamCardsFromCalls } from "@/lib/team";
 import { TeamCardsForTurn, type TeamHooks } from "@/ui/team-cards";
 import { McpAppFrame } from "@/ui/mcp-app-frame";
+import { WorkPopover, workPopoverPlacement, type WorkPopoverPlacement } from "@/ui/work-popover";
 
 type TranscriptToolCall = {
   partId: string;
@@ -1841,7 +1839,7 @@ function ThreadView({
           {freshDiscussion ? <QuietEmptyConversation coworker={coworker} proposerName={team?.coworkers.find((member) => member.slug === coworker.suggestedBy?.slug)?.name ?? ""} /> : null}
           {conversationBlocks(visibleMessages, (message, index) => working && message.role === "assistant" && index === lastAssistantIndex).map((block) => {
             if (block.kind === "actions") {
-              return <ActionLine key={block.id} review={block.review} reasoning={block.reasoning} calls={block.calls} settled={block.settled} client={mcpClient} />;
+              return <ActionLine key={block.id} review={block.review} reasoning={block.reasoning} calls={block.calls} client={mcpClient} />;
             }
             // A reply that ended without words stays in the transcript as one quiet line; the turn still
             // unresolved is told by the outcome below instead, with its actions.
@@ -1972,8 +1970,7 @@ function ThreadView({
 }
 
 type ConversationBlock =
-  /** `settled`: the person has written again since this turn, so its receipt may fold to one line. */
-  | { kind: "actions"; id: string; review: WorkerReview | null; reasoning: string; calls: TranscriptToolCall[]; settled: boolean }
+  | { kind: "actions"; id: string; review: WorkerReview | null; reasoning: string; calls: TranscriptToolCall[] }
   | { kind: "message"; message: TranscriptMessage; previous: TranscriptMessage | undefined; active: boolean; continued: boolean; tail: boolean; calls: TranscriptToolCall[] }
   /** A reply that ended without words — stopped or failed — kept as one quiet line where it happened. */
   | { kind: "ended"; message: TranscriptMessage; ended: "stopped" | "failed" };
@@ -1999,12 +1996,9 @@ export function conversationBlocks(
   let reasoning: string[] = [];
   let calls: TranscriptToolCall[] = [];
   let pendingId = "";
-  // A block flushed at `from` is settled once a person's message follows it (the message that
-  // triggers the flush counts, when it is the person's).
-  const flush = (from: number) => {
+  const flush = () => {
     if (!review && reasoning.length === 0 && calls.length === 0) return;
-    const settled = messages.slice(from).some((message) => message.role === "user" && !reviewTurn(message));
-    blocks.push({ kind: "actions", id: `actions-${pendingId}`, review, reasoning: reasoning.join("\n\n"), calls, settled });
+    blocks.push({ kind: "actions", id: `actions-${pendingId}`, review, reasoning: reasoning.join("\n\n"), calls });
     review = null;
     reasoning = [];
     calls = [];
@@ -2030,7 +2024,7 @@ export function conversationBlocks(
       const ended = active ? null : endedWithoutWords(message);
       if (ended) {
         // Whatever it thought or did before it ended stays on its own line; the ending is one more.
-        flush(index + 1);
+        flush();
         pendingId = "";
         blocks.push({ kind: "ended", message, ended });
         return;
@@ -2039,7 +2033,7 @@ export function conversationBlocks(
     }
     // The bubble keeps its own turn's calls too, so it can end with a document card.
     const turnCalls = message.role === "assistant" ? calls : [];
-    flush(index);
+    flush();
     pendingId = "";
     const position = bubbles.indexOf(message);
     const previous = position > 0 ? bubbles[position - 1] : undefined;
@@ -2054,18 +2048,18 @@ export function conversationBlocks(
       calls: turnCalls,
     });
   });
-  flush(messages.length);
+  flush();
   return blocks;
 }
 
 /** One small centered line between bubbles: what the coworker thought through and did. */
-function ActionLine({ review, reasoning, calls, settled, client }: { review: WorkerReview | null; reasoning: string; calls: TranscriptToolCall[]; settled: boolean; client: CoworkerMcpClient }) {
+function ActionLine({ review, reasoning, calls, client }: { review: WorkerReview | null; reasoning: string; calls: TranscriptToolCall[]; client: CoworkerMcpClient }) {
   return (
     <div className="flex justify-center py-0.5" data-testid="coworker-action-line">
       <div className="flex max-w-[80%] flex-wrap items-start justify-center gap-x-4 gap-y-1">
         {review ? <ReviewDisclosure review={review} /> : null}
         {reasoning ? <ThinkingDisclosure text={reasoning} /> : null}
-        {calls.length > 0 ? <WorkReceipt calls={calls} settled={settled} client={client} /> : null}
+        {calls.length > 0 ? <WorkReceipt calls={calls} client={client} /> : null}
       </div>
     </div>
   );
@@ -2505,101 +2499,48 @@ function describeUnavailableModel(model: string, available: EngineModelOption[],
 }
 
 /**
- * One receipt for all the tool work behind a reply. Collapsed, it is one line
- * ("Edited index.md", "Worked with your files and Calendar · 3 steps"); open,
- * it lists each step in plain words with the tool name behind Technical
- * details. A step that is still running or did not finish keeps the receipt
- * open so it never disappears into the fold. Documents and Apps the work
- * produced stay first-class as compact attachments beneath.
+ * One receipt for all the tool work behind a reply: a single quiet line in the
+ * transcript that says what is happening while steps run ("Running a command ·
+ * 2 of 3") and sums the work up once they have settled ("Worked with the
+ * terminal · 2 steps"). The steps never stack in the chat: the line opens a
+ * popover that lists them in plain words with the tool's name behind Technical
+ * details, and the person closes it. Documents and Apps the work produced stay
+ * first-class as compact attachments beneath.
  */
-function WorkReceipt({ calls, settled, client }: { calls: TranscriptToolCall[]; /** The person has written again since this turn. */ settled: boolean; client: CoworkerMcpClient }) {
+function WorkReceipt({ calls, client }: { calls: TranscriptToolCall[]; client: CoworkerMcpClient }) {
   const steps = calls.map((call) => describeWorkStep(call));
   const unsettled = steps.some((step) => step.state !== "done");
-  // The person's own tap wins; otherwise the steps stay in view while they run and until the person
-  // writes again — never snapping shut the moment the last step finishes, under the reader's eyes.
-  const [open, setOpen] = useState<"auto" | "open" | "closed">("auto");
-  const expanded = open === "open" || (open === "auto" && (unsettled || !settled));
-  const summary = summarizeWork(steps);
+  const [open, setOpen] = useState<WorkPopoverPlacement | null>(null);
+  const lineRef = useRef<HTMLButtonElement | null>(null);
+  const line = describeWorkLine(steps);
   const tone = steps.some((step) => step.state === "failed") ? "rose" : unsettled ? "spark" : "mint";
+  const toggle = () => {
+    if (open) {
+      setOpen(null);
+      return;
+    }
+    const rect = lineRef.current?.getBoundingClientRect();
+    setOpen(rect ? workPopoverPlacement(rect, window.innerHeight) : "below");
+  };
   return (
-    <div className="min-w-0 text-[11px]" data-testid="coworker-work-receipt" data-state={tone === "rose" ? "failed" : unsettled ? "working" : "done"}>
+    <div className="relative min-w-0 text-[11px]" data-testid="coworker-work-receipt" data-state={tone === "rose" ? "failed" : unsettled ? "working" : "done"}>
       <button
+        ref={lineRef}
         type="button"
         className="group mx-auto flex max-w-full items-center gap-1.5 py-0.5 text-left text-mist hover:text-snow"
-        aria-expanded={expanded}
-        onClick={() => setOpen(expanded ? "closed" : "open")}
+        title={open ? "Hide the steps" : "See the steps"}
+        aria-expanded={open !== null}
+        aria-haspopup="dialog"
+        onClick={toggle}
         data-testid="coworker-work-summary"
       >
         <ToolIcon className={`size-3.5 shrink-0 ${unsettled ? "motion-safe:animate-pulse" : ""}`} />
-        <span className="min-w-0 flex-1 truncate">{summary}</span>
+        <span className="min-w-0 flex-1 truncate">{line}</span>
         <StatusDot tone={tone} />
-        <span className={`text-mist/60 transition-transform ${expanded ? "rotate-90" : ""}`} aria-hidden="true">›</span>
+        <span className={`text-mist/60 transition-transform ${open ? "rotate-90" : ""}`} aria-hidden="true">›</span>
       </button>
-      {expanded ? (
-        // One card of steady width holds the steps; each step can open its technical view.
-        <ol className="mt-1.5 w-[min(100%,560px)] divide-y divide-line/60 overflow-hidden rounded-xl border border-line/70 bg-panel/50 text-left" data-testid="coworker-work-steps">
-          {calls.map((call) => {
-            const step = describeWorkStep(call);
-            return (
-              <li key={call.partId} className="px-3 py-2" data-testid="coworker-work-step" data-state={step.state}>
-                <div className="flex items-center gap-2">
-                  <StatusDot tone={step.state === "failed" ? "rose" : step.state === "done" ? "mint" : "spark"} />
-                  {isServerTool(call.tool) ? (
-                    // A step that used one of the coworker's tools or Apps opens that item in Apps & tools.
-                    <button
-                      type="button"
-                      className={`min-w-0 flex-1 truncate text-left hover:underline ${step.state === "failed" ? "text-rose" : "text-snow"}`}
-                      title="Open in Apps & tools"
-                      data-testid="coworker-work-step-open"
-                      onClick={() => openPanelRoute(appsToolsRoute(toolRefPath(call.tool, step.label)))}
-                    >
-                      {step.label}
-                    </button>
-                  ) : (
-                    <span className={`min-w-0 flex-1 truncate ${step.state === "failed" ? "text-rose" : "text-snow"}`}>{step.label}</span>
-                  )}
-                  <span className="shrink-0 text-mist">{step.state === "failed" ? "Didn't finish" : step.state === "done" ? "Done" : "Working on it"}</span>
-                </div>
-                <TechnicalDetails call={call} />
-              </li>
-            );
-          })}
-        </ol>
-      ) : null}
+      {open ? <WorkPopover calls={calls} steps={steps} anchor={lineRef.current} placement={open} onClose={() => setOpen(null)} /> : null}
       <ToolAttachments calls={calls} client={client} />
-    </div>
-  );
-}
-
-/**
- * The technical view of one step: the tool's name, then labelled blocks (Command, Input,
- * Result, Error) in a steady, readable layout. Closed by default; the error line stays visible.
- */
-function TechnicalDetails({ call }: { call: TranscriptToolCall }) {
-  const sections = technicalSections(call);
-  return (
-    <div className="pl-4">
-      {call.error ? <p className="mt-1 break-words text-rose">{call.error}</p> : null}
-      <details className="group/tech mt-0.5 text-[10px] text-mist/75" data-testid="coworker-work-technical">
-        <summary className="flex cursor-pointer select-none items-center gap-1 hover:text-mist">
-          <span className="text-mist/60 transition-transform group-open/tech:rotate-90" aria-hidden="true">›</span>
-          Technical details
-        </summary>
-        <dl className="mt-1.5 space-y-1.5 rounded-lg bg-ink/70 p-2.5">
-          <div className="flex items-baseline gap-2">
-            <dt className="w-14 shrink-0 text-mist/60">Tool</dt>
-            <dd className="min-w-0 break-all font-mono text-mist">{call.tool}</dd>
-          </div>
-          {sections.map((section) => (
-            <div key={section.label} className="flex items-baseline gap-2">
-              <dt className={`w-14 shrink-0 ${section.label === "Error" ? "text-rose/80" : "text-mist/60"}`}>{section.label}</dt>
-              <dd className="min-w-0 flex-1">
-                <pre className={`max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono leading-relaxed ${section.label === "Error" ? "text-rose" : "text-snow/85"}`}>{section.text}</pre>
-              </dd>
-            </div>
-          ))}
-        </dl>
-      </details>
     </div>
   );
 }

--- a/apps/coworker/src/ui/work-popover.tsx
+++ b/apps/coworker/src/ui/work-popover.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef } from "react";
+import { isServerTool, toolRefPath } from "@/lib/apps-tools";
+import { openPanelRoute } from "@/lib/panel-route";
+import { appsToolsRoute } from "@/lib/panel-views";
+import { describeWorkProgress, describeWorkStep, technicalSections, type WorkStep } from "@/lib/work-receipt";
+import { StatusDot, ToolIcon } from "@/ui/kit";
+
+/** A tool call as the transcript keeps it; the popover reads, never writes. */
+export type WorkPopoverCall = {
+  partId: string;
+  tool: string;
+  status: string;
+  input: Record<string, unknown>;
+  output: unknown;
+  error: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type WorkPopoverPlacement = "below" | "above";
+
+/** Room a popover wants under its line before it flips above instead. */
+export const WORK_POPOVER_ROOM_PX = 320;
+
+/**
+ * Where the steps popover opens for a line at `anchor`: under it when the
+ * viewport leaves room, above it when the line sits near the bottom and there
+ * is more room above.
+ */
+export function workPopoverPlacement(anchor: DOMRect, viewportHeight: number): WorkPopoverPlacement {
+  const below = viewportHeight - anchor.bottom;
+  return below < WORK_POPOVER_ROOM_PX && anchor.top > below ? "above" : "below";
+}
+
+const STATE_WORDS = { running: "Working on it", done: "Done", failed: "Didn't finish" } as const;
+
+/** The one detail worth seeing without opening the technical view: a shell step's command, on one line. */
+function stepGist(call: WorkPopoverCall): string {
+  const command = technicalSections(call).find((section) => section.label === "Command");
+  return command ? command.text.split("\n")[0] ?? "" : "";
+}
+
+/**
+ * The steps behind one receipt line, for a person who tapped it: each step in
+ * plain words with its state, a shell step's command as a quiet line, and the
+ * tool's name, input, and result behind Technical details. A light popover
+ * floating under (or over) the line — never a card in the transcript, never
+ * modal. Escape, a click outside, or the line itself closes it; it stays open
+ * while steps are still landing so the person can watch them settle.
+ */
+export function WorkPopover({
+  calls,
+  steps,
+  anchor,
+  placement,
+  onClose,
+}: {
+  calls: WorkPopoverCall[];
+  steps: WorkStep[];
+  /** The line the popover hangs from; a pointer on it is left to the line's own toggle. */
+  anchor: HTMLElement | null;
+  placement: WorkPopoverPlacement;
+  onClose: () => void;
+}) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (popoverRef.current?.contains(target) || anchor?.contains(target)) return;
+      onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("pointerdown", onPointerDown, true);
+    };
+  }, [anchor, onClose]);
+
+  const working = steps.some((step) => step.state === "running");
+
+  return (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-modal="false"
+      aria-label="The steps behind this reply"
+      className={`thinking-popover absolute left-1/2 z-40 w-[min(400px,calc(100vw-48px))] -translate-x-1/2 rounded-[14px] border border-line bg-panel text-left shadow-[0_12px_32px_rgba(0,0,0,0.35)] ${placement === "above" ? "bottom-full mb-1.5" : "top-full mt-1.5"}`}
+      data-testid="coworker-work-steps"
+      data-placement={placement}
+    >
+      <div className="flex items-center gap-2 px-3.5 pt-2.5 text-[11px]">
+        <ToolIcon className={`size-3.5 shrink-0 text-mist ${working ? "motion-safe:animate-pulse" : ""}`} />
+        <span className="font-semibold text-snow">Steps</span>
+        <span className="ml-auto text-mist/80" data-testid="coworker-work-progress">{describeWorkProgress(steps)}</span>
+      </div>
+      <ol className="max-h-[min(320px,60vh)] overflow-y-auto px-1.5 pb-1.5 pt-1.5">
+        {calls.map((call, index) => {
+          const step = steps[index] ?? describeWorkStep(call);
+          const gist = stepGist(call);
+          return (
+            <li key={call.partId} className="rounded-lg px-2 py-1.5 text-[11px] hover:bg-white/[0.03]" data-testid="coworker-work-step" data-state={step.state}>
+              <div className="flex items-center gap-2">
+                <StatusDot tone={step.state === "failed" ? "rose" : step.state === "done" ? "mint" : "spark"} />
+                {isServerTool(call.tool) ? (
+                  // A step that used one of the coworker's tools or Apps opens that item in Apps & tools.
+                  <button
+                    type="button"
+                    className={`min-w-0 flex-1 truncate text-left hover:underline ${step.state === "failed" ? "text-rose" : "text-snow"}`}
+                    title="Open in Apps & tools"
+                    data-testid="coworker-work-step-open"
+                    onClick={() => openPanelRoute(appsToolsRoute(toolRefPath(call.tool, step.label)))}
+                  >
+                    {step.label}
+                  </button>
+                ) : (
+                  <span className={`min-w-0 flex-1 truncate ${step.state === "failed" ? "text-rose" : "text-snow"}`}>{step.label}</span>
+                )}
+                <span className="shrink-0 text-mist">{STATE_WORDS[step.state]}</span>
+              </div>
+              {gist ? <p className="mt-0.5 truncate pl-4 font-mono text-[10.5px] text-mist/80" title={gist} data-testid="coworker-work-step-gist">{gist}</p> : null}
+              <TechnicalDetails call={call} />
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+/**
+ * The technical view of one step: the tool's name, then labelled blocks (Command, Input,
+ * Result, Error) in a steady, readable layout. Closed by default; the error line stays visible.
+ */
+function TechnicalDetails({ call }: { call: WorkPopoverCall }) {
+  const sections = technicalSections(call);
+  return (
+    <div className="pl-4">
+      {call.error ? <p className="mt-1 break-words text-rose">{call.error}</p> : null}
+      <details className="group/tech mt-0.5 text-[10px] text-mist/75" data-testid="coworker-work-technical">
+        <summary className="flex cursor-pointer select-none items-center gap-1 hover:text-mist">
+          <span className="text-mist/60 transition-transform group-open/tech:rotate-90" aria-hidden="true">›</span>
+          Technical details
+        </summary>
+        <dl className="mt-1.5 space-y-1.5 rounded-lg bg-ink/70 p-2.5">
+          <div className="flex items-baseline gap-2">
+            <dt className="w-14 shrink-0 text-mist/60">Tool</dt>
+            <dd className="min-w-0 break-all font-mono text-mist">{call.tool}</dd>
+          </div>
+          {sections.map((section) => (
+            <div key={section.label} className="flex items-baseline gap-2">
+              <dt className={`w-14 shrink-0 ${section.label === "Error" ? "text-rose/80" : "text-mist/60"}`}>{section.label}</dt>
+              <dd className="min-w-0 flex-1">
+                <pre className={`max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono leading-relaxed ${section.label === "Error" ? "text-rose" : "text-snow/85"}`}>{section.text}</pre>
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </details>
+    </div>
+  );
+}

--- a/evals/specs/open-coworker-local-first.e2e.test.ts
+++ b/evals/specs/open-coworker-local-first.e2e.test.ts
@@ -1955,8 +1955,8 @@ test.skipIf(!enabled)(title, async ({ evidence }) => {
   });
   if (!isRecord(chatScheduling) || typeof chatScheduling.collapsedText !== "string") throw new Error("Action line facts were unavailable.");
   expect(chatScheduling.collapsedText).not.toMatch(/coworker_|assignment_create|"kind"|\{/);
-  // The tool's name waits behind Technical details, never in the line itself. The receipt stays
-  // open on its own until the person writes again, so open it only if it is closed.
+  // The tool's name waits behind Technical details, never in the line itself. The steps wait in a
+  // popover the person opens from the line, so open it only if it is closed.
   await evalIn(app, `(() => {
     const summary = [...document.querySelectorAll('[data-testid="coworker-work-summary"]')].find((button) => (button.textContent ?? "").includes("Created assignment"));
     if (summary instanceof HTMLElement && summary.getAttribute("aria-expanded") !== "true") summary.click();

--- a/evals/specs/open-coworker-self-memory.e2e.test.ts
+++ b/evals/specs/open-coworker-self-memory.e2e.test.ts
@@ -169,38 +169,64 @@ async function waitForNovaReady(app: Awaited<ReturnType<typeof coworker>>): Prom
 }
 
 /** Send one message and wait for the coworker's reply text; returns the settled action line's collapsed words. */
-async function converse(app: Awaited<ReturnType<typeof coworker>>, prompt: string, reply: string): Promise<{ summary: string; steps: string[]; text: string }> {
+async function converse(app: Awaited<ReturnType<typeof coworker>>, prompt: string, reply: string): Promise<{ summary: string; steps: string[]; text: string; stackedBeforeOpen: number; expandedBeforeOpen: string; popover: string }> {
   await fill(app, 'textarea[aria-label="Message Nova"]', prompt);
   await clickButton(app, "Send");
   await waitFor(app, `[...document.querySelectorAll('[data-message-role="assistant"]')].some((message) => (message.textContent ?? "").includes(${json(reply)}))`, {
     timeoutMs: 300_000,
     label: `reply ${json(reply)}`,
   });
-  const facts = await waitFor(app, `(() => {
+  // The line between the prompt and its reply, read before anyone opens it: the chat holds one
+  // line and no steps stack beneath it.
+  const closed = await waitFor(app, `(() => {
     const bubbles = [...document.querySelectorAll('[data-message-role]')];
     const userIndex = bubbles.findIndex((bubble) => (bubble.textContent ?? "").includes(${json(prompt)}));
     const replyIndex = bubbles.findIndex((bubble) => (bubble.textContent ?? "").includes(${json(reply)}));
     if (userIndex === -1 || replyIndex === -1) return false;
     const top = bubbles[userIndex].getBoundingClientRect().bottom;
     const bottom = bubbles[replyIndex].getBoundingClientRect().top;
-    const line = [...document.querySelectorAll('[data-testid="coworker-action-line"]')].find((candidate) => {
+    const lines = [...document.querySelectorAll('[data-testid="coworker-action-line"]')];
+    const line = lines.find((candidate) => {
       const rect = candidate.getBoundingClientRect();
       return rect.top >= top - 1 && rect.bottom <= bottom + 1;
     });
     const receipt = line?.querySelector('[data-testid="coworker-work-receipt"]');
     if (!(line instanceof HTMLElement) || !(receipt instanceof HTMLElement) || receipt.dataset.state !== "done") return false;
     const summary = line.querySelector('[data-testid="coworker-work-summary"]');
-    if (summary instanceof HTMLElement && summary.getAttribute("aria-expanded") !== "true") summary.click();
     return {
+      lineIndex: lines.indexOf(line),
       summary: summary?.querySelector("span.truncate")?.textContent?.trim() ?? "",
-      steps: [...line.querySelectorAll('[data-testid="coworker-work-step"]')].map((step) => step.querySelector("span.truncate")?.textContent?.trim() ?? ""),
-      text: line.innerText,
+      stackedBeforeOpen: line.querySelectorAll('[data-testid="coworker-work-step"]').length,
+      expandedBeforeOpen: summary?.getAttribute("aria-expanded") ?? "",
     };
   })()`, { timeoutMs: 60_000, label: `the action line between ${json(prompt)} and its reply` });
-  if (!isRecord(facts) || typeof facts.summary !== "string" || !Array.isArray(facts.steps) || typeof facts.text !== "string") {
+  if (!isRecord(closed) || typeof closed.lineIndex !== "number" || typeof closed.summary !== "string" || typeof closed.stackedBeforeOpen !== "number" || typeof closed.expandedBeforeOpen !== "string") {
     throw new Error("Action line facts were unavailable.");
   }
-  return { summary: facts.summary, steps: facts.steps.map(String), text: facts.text };
+  // Tapping the line opens its steps in a popover; React paints it on its next tick, so it is read on a later poll.
+  const lineSelector = `document.querySelectorAll('[data-testid="coworker-action-line"]')[${closed.lineIndex}]`;
+  await evalIn(app, `(() => { const summary = ${lineSelector}?.querySelector('[data-testid="coworker-work-summary"]'); if (summary instanceof HTMLElement && summary.getAttribute("aria-expanded") !== "true") summary.click(); return true; })()`);
+  const opened = await waitFor(app, `(() => {
+    const line = ${lineSelector};
+    const popover = line?.querySelector('[data-testid="coworker-work-steps"]');
+    if (!(line instanceof HTMLElement) || !(popover instanceof HTMLElement)) return false;
+    return {
+      steps: [...line.querySelectorAll('[data-testid="coworker-work-step"]')].map((step) => step.querySelector("span.truncate")?.textContent?.trim() ?? ""),
+      text: line.innerText,
+      popover: popover.dataset.placement ?? "",
+    };
+  })()`, { timeoutMs: 30_000, label: `the steps behind ${json(closed.summary)}` });
+  if (!isRecord(opened) || !Array.isArray(opened.steps) || typeof opened.text !== "string" || typeof opened.popover !== "string") {
+    throw new Error("Receipt popover facts were unavailable.");
+  }
+  return {
+    summary: closed.summary,
+    steps: opened.steps.map(String),
+    text: opened.text,
+    stackedBeforeOpen: closed.stackedBeforeOpen,
+    expandedBeforeOpen: closed.expandedBeforeOpen,
+    popover: opened.popover,
+  };
 }
 
 async function openMemoryView(app: Awaited<ReturnType<typeof coworker>>): Promise<void> {
@@ -280,6 +306,16 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
   const remembered = await converse(app, FACT_PROMPT, FACT_REPLY);
   expect(remembered.summary).toBe("Remembered · You work in Product");
   expect(remembered.text).not.toMatch(/coworker_|memory_remember|"kind"|\{/);
+  // The chat holds one line; its steps wait in a popover the person opens from it and closes with Escape.
+  expect(remembered).toMatchObject({ stackedBeforeOpen: 0, expandedBeforeOpen: "false", popover: "below" });
+  expect(remembered.steps).toEqual(["Remembered · You work in Product"]);
+  const closedLine = await waitFor(app, `(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    const summary = document.querySelector('[data-testid="coworker-work-summary"]');
+    const closed = summary instanceof HTMLElement && summary.getAttribute("aria-expanded") === "false" && !document.querySelector('[data-testid="coworker-work-steps"]');
+    return closed ? summary.textContent?.trim() ?? "" : false;
+  })()`, { timeoutMs: 15_000, label: "the steps popover closed with Escape, leaving the line" });
+  expect(String(closedLine)).toContain("Remembered · You work in Product");
   const aboutYou = resultText(await invokeCoworker(app, "coworkers.files.read", { slug: "nova", path: "memory/long-term/about-you.md" }));
   expect(aboutYou).toBe("# About you\n\n- You work in Product\n");
   expect(resultText(await invokeCoworker(app, "coworkers.files.read", { slug: "nova", path: "memory/index.md" }))).toContain("- `long-term/about-you.md` — About you");
@@ -301,7 +337,7 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence }) => {
   expect(String(await evalIn(app, `[...document.querySelectorAll('[data-testid="coworker-work-summary"]')].map((button) => button.textContent?.trim()).join(" | ")`))).not.toMatch(/coworker_|\{/);
   evidence.recordAssertionEvidence(
     "The coworker records a fact, a way of working, and reads itself back in the same turns, each as one plain action line",
-    `Three turns produced three action lines — "Remembered · You work in Product", "Updated how I work · Shorter replies.", "Checked what I remember" — with no tool ids or JSON in them. The fact landed in memory/long-term/about-you.md and the index; the soul gained one Communication bullet with its other three sections byte for byte unchanged; the self read returned the memory files to the model.`,
+    `Three turns produced three action lines — "Remembered · You work in Product", "Updated how I work · Shorter replies.", "Checked what I remember" — with no tool ids or JSON in them and no steps stacked in the chat; the first line opened a popover below it listing its one step and closed again with Escape. The fact landed in memory/long-term/about-you.md and the index; the soul gained one Communication bullet with its other three sections byte for byte unchanged; the self read returned the memory files to the model.`,
     true,
   );
 


### PR DESCRIPTION
Stacked on #4330 (`feature/open-coworker`); this PR is only the receipt change.

## Summary
- The chat shows **one line** for a turn's tool work. While steps run it says what is happening and where the run stands ("Running a command · 2 of 3"); once they settle it sums the work up ("Worked with the terminal · 2 steps").
- The steps **never stack in the chat**. Tapping the line opens a light popover floating under it (above it when the line sits near the bottom of the window) that lists each step in plain words with its state, a shell step's command as one quiet line, and the tool's name, input, and result behind *Technical details*. Escape, a click outside, or the line itself closes it; it stays open while steps are still landing so the person can watch them settle.
- The receipt no longer opens itself or tracks whether the person has "written again since".

## Why
The receipt auto-opened and stayed open until the person wrote again, stacking a card of step rows between the bubbles; the same running turn reopened a line the person had just folded, so collapsing felt broken. The stacked rows also repeated ("Ran a command / Done / Technical details" ×N) with nothing to tell them apart. Details now live off the transcript, on demand, and each shell step shows its command so two "Ran a command" rows read differently.

## Scope
- `apps/coworker/src/ui/work-popover.tsx` (new): `WorkPopover` — the steps list, in-tree and absolutely positioned like `ActionMenu`, with the same close contract as `ThinkingPopover`; `workPopoverPlacement()` decides below/above from the line's rect; the per-step *Technical details* fold moved here unchanged.
- `apps/coworker/src/ui/threads.tsx`: `WorkReceipt` is one line + popover; `settled` is gone from `ConversationBlock`, `conversationBlocks()`, and `ActionLine`.
- `apps/coworker/src/lib/work-receipt.ts`: `describeWorkLine()` (present tense while a step runs, `summarizeWork` once settled) and `describeWorkProgress()` (the popover's small print), with unit tests.
- `evals/specs/open-coworker-self-memory.e2e.test.ts`: `converse()` reads the line before opening it, opens it, reads the popover, and the journey closes it with Escape.
- `evals/specs/open-coworker-local-first.e2e.test.ts`: comment only (the receipt no longer stays open on its own).

## Out of scope
- The live row's `ThinkingPopover` and the header/rail wording are unchanged.

## Testing
### Ran
- `pnpm evals:e2e open-coworker-self-memory --local`, `pnpm evals:e2e open-coworker-live-turn --local`, `pnpm evals:e2e open-coworker-local-first --local` at the PR head (`placement: local (--local)`).
- `pnpm --dir apps/coworker typecheck`, `pnpm --dir apps/coworker test`, `pnpm --dir apps/coworker build`.

### Result
- Journeys: all three `passed` at the PR head, 0 skipped — `self-memory` asserts the new claims and their negative halves: no `coworker-work-step` inside the line and `aria-expanded="false"` before the person opens it; the popover renders `below` the line with its one step; Escape closes it and the line stays. `live-turn` keeps the live row chip and the receipt reading "Read a web page" after the tool step. `local-first` opens the assignment receipt and finds the tool id only behind *Technical details* inside the step. Evidence for each run is in the test-evidence comments.
- Local lane because these journeys script the model through a loopback server on the test host, which a Daytona sandbox cannot reach; Daytona was not attempted with a red run.
- Unit: 369 pass (`work-receipt.test.ts` gained `describeWorkLine` / `describeWorkProgress` cases). Typecheck exit 0. Build clean.
- Not run: `open-coworker-documents`, `-workers`, `-discussion` (they need a real model). Their receipt reads either click a closed line and poll, or wait 500 ms after clicking, so they hold with the popover.

## CI status
- pass: pending
- code-related failures: none known
- external/env/auth blockers: none known

## Manual verification
1. Ask a coworker for something that runs two or three commands: the chat shows one line that reads "Running a command · 2 of 3" while it works, then "Worked with the terminal · 3 steps".
2. Tap the line: a popover opens under it with each step, its state, and the command; *Technical details* opens the tool name, input, and result. Nothing moves in the transcript.
3. Press Escape (or click elsewhere): the popover closes and the line stays. Tap the line near the bottom of the window: the popover opens above it.

## Evidence
- Test-evidence comments on this PR (three local runs at the PR head).

## Risk
- Specs that read `coworker-work-step` right after clicking the line must poll: React paints the popover on its next tick. `documents` already waits; `self-memory` now polls; `workers` and `local-first` poll through `waitFor`; `team` reads steps but asserts nothing on them.
- The popover is positioned inside the transcript's scroll container, so a very long step list near the bottom scrolls with the transcript rather than escaping it; its body caps at 320 px / 60 vh.
- Seen once during proof, unrelated to this change: `live-turn`'s "slow" step snapshots header and rail at the row's first `slow` tick, but both arrive one render later through `onActivityChange`; it passed on rerun and on a clean control at the parent head. Waiting for the three to agree would remove the race.

## Rollback
- Revert the commit; no data or config is involved.
