### PR TITLE
chore(evals): drop the engine cache warm gate now that the devtools plugin is bundled

### DIFF
--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -169,10 +169,10 @@ class DaytonaPlacementHost implements Host {
   readonly #preparedHost: Host | undefined;
   readonly #surfaces = new Map<SurfaceHandle, PlacedSurface>();
 
-  constructor(ref: string, preparedSandbox?: string, preparedEngineCacheDir?: string) {
+  constructor(ref: string, preparedSandbox?: string) {
     this.#ref = ref;
     this.#preparedSandbox = preparedSandbox;
-    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox, preparedEngineCacheDir) : undefined;
+    this.#preparedHost = preparedSandbox ? daytonaSandbox(preparedSandbox) : undefined;
   }
 
   async #provision(name: string): Promise<PlacedSurface> {
@@ -189,7 +189,7 @@ class DaytonaPlacementHost implements Host {
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });
     return {
-      host: daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined),
+      host: daytonaSandbox(provisioned.sandbox),
       sandbox: provisioned.sandbox,
       created: provisioned.created,
     };
@@ -244,9 +244,9 @@ class DaytonaPlace implements Place {
   readonly #ref: string;
   readonly #host: Host;
 
-  constructor(ref: string, preparedDesktopSandbox?: string, preparedEngineCacheDir?: string) {
+  constructor(ref: string, preparedDesktopSandbox?: string) {
     this.#ref = ref;
-    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox, preparedEngineCacheDir);
+    this.#host = new DaytonaPlacementHost(ref, preparedDesktopSandbox);
   }
 
   host(): Host {
@@ -280,7 +280,6 @@ export function resolvePlace(env: NodeJS.ProcessEnv = process.env): Place {
     return new DaytonaPlace(
       ref,
       env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX?.trim(),
-      env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR?.trim(),
     );
   }
   return new LocalPlace(env.OPENWORK_EVAL_MYSQL_URL?.trim() || DEFAULT_MYSQL_URL);

--- a/evals/packages/hosts/src/daytona.ts
+++ b/evals/packages/hosts/src/daytona.ts
@@ -24,8 +24,6 @@ export interface DaytonaHostOptions {
   reservedChromePorts?: number[];
   reservedElectronPorts?: number[];
   serverScript?: boolean;
-  /** Exact per-provision engine cache root to seed into fresh Electron profiles. */
-  engineCacheDir?: string;
   waitForCdp?: (url: string, timeoutMs: number, label: string) => Promise<void>;
 }
 
@@ -548,10 +546,6 @@ function appendExtraEnv(assignments: Map<string, string>, env: Record<string, st
 
 export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
   const exec = options.exec ?? defaultDaytonaExec;
-  const engineCacheDir = options.engineCacheDir?.trim();
-  if (options.engineCacheDir !== undefined && !engineCacheDir) {
-    throw new Error("Daytona engineCacheDir must not be empty.");
-  }
   const previewCache = new Map<number, string>();
   const electronPorts: PortAllocation = { primary: 9825, next: 9830, used: portSet(options.reservedElectronPorts) };
   const chromePorts: PortAllocation = { primary: 9222, next: 9230, used: portSet(options.reservedChromePorts) };
@@ -598,17 +592,6 @@ export function createDaytonaHost(options: DaytonaHostOptions): DaytonaHost {
 
     try {
       await checkedExec(exec, ["exec", sandbox, "--", "mkdir", "-p", shellQuote(userDataDir)], `mkdir Daytona Electron profile ${userDataDir}`, { timeoutMs: 30_000 });
-      if (engineCacheDir) {
-        const cachedDevData = `${engineCacheDir}/openwork-dev-data`;
-        const profileDevData = `${userDataDir}/openwork-dev-data`;
-        const seedCommand = `if [ -d ${shellQuote(cachedDevData)} ] && [ ! -e ${shellQuote(profileDevData)} ]; then cp -a ${shellQuote(cachedDevData)} ${shellQuote(userDataDir)}/; fi`;
-        await checkedExec(
-          exec,
-          ["exec", sandbox, "--", seedCommand],
-          `seed Daytona Electron engine cache ${userDataDir}`,
-          { timeoutMs: 60_000 },
-        );
-      }
       if (opts.bootstrap) {
         const bootstrapJson = `${JSON.stringify(opts.bootstrap, null, 2)}\n`;
         const encoded = Buffer.from(bootstrapJson, "utf8").toString("base64");

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -10,7 +10,6 @@ import { checkedExec, defaultDaytonaExec } from "./daytona.ts";
 import { FAULT_PROXY_SCRIPT } from "./fault-proxy-script.ts";
 import type { DaytonaExec, DaytonaExecResult } from "./daytona.ts";
 
-const CHROME_DEVTOOLS_PLUGIN_VERSION = "1.0.4";
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
 const DESKTOP_READY_TIMEOUT_MS = 300_000;
 const INSTALL_TIMEOUT_MS = 25 * 60 * 1_000;
@@ -44,7 +43,6 @@ export interface DesktopSandboxOptions {
 export interface DesktopSandbox {
   sandbox: string;
   created: boolean;
-  engineCacheDir: string | null;
 }
 
 export interface DenSandboxOptions {
@@ -96,8 +94,6 @@ export interface ConnectorE2eTestEnv {
   denWebUrl: string;
   sandboxA: string;
   sandboxB: string;
-  engineCacheDirA: string | null;
-  engineCacheDirB: string | null;
   mockUrl: string;
   ref: string;
   created: string[];
@@ -228,7 +224,6 @@ export async function provisionDesktopSandbox(options: DesktopSandboxOptions & P
   const ref = assertSafeRef(options.ref);
   const reused = options.reuse?.trim() || "";
   let sandbox = reused;
-  let engineCacheDir: string | null = null;
 
   await timedStep(log, "sandbox gate", async () => {
     if (reused) {
@@ -413,76 +408,6 @@ echo detached`;
     }
   });
 
-  await timedStep(log, "engine cache warm gate", async () => {
-    // The sandbox exec transport strips double quotes, so JSON travels base64.
-    const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
-    const pluginManifestPrefix = b64('{"dependencies":{"@opencode-ai/plugin":"');
-    const pluginManifestSuffix = b64('"}}');
-    // The engine resolves the unpinned `opencode-chrome-devtools` plugin as `latest`
-    // and keys its cache dir by that tag; the harness installs one audited version
-    // into that slot so evaluation desktops never load whatever the tag points at.
-    const devtoolsManifest = b64(`{"dependencies":{"opencode-chrome-devtools":"${CHROME_DEVTOOLS_PLUGIN_VERSION}"}}`);
-    const warmDir = `/tmp/openwork-engine-warm-${Date.now()}`;
-    const warmScript = `set -e
-W=${warmDir}
-rm -rf /workspace/.openwork-daytona/engine-cache "$W"
-D="$W/openwork-dev-data"
-mkdir -p "$D/home" "$D/xdg/config/opencode" "$D/config/opencode" "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest"
-LOG="$W/warm.log"
-sidecars=(/workspace/apps/desktop/resources/sidecars/opencode-*)
-SIDECAR="\${sidecars[0]:-}"
-if [ ! -x "$SIDECAR" ]; then
-  echo "No executable OpenCode sidecar found" > "$LOG"
-  echo WARM_TIMEOUT
-  tail -80 "$LOG" 2>&1 || true
-  exit 0
-fi
-ENGINE_VERSION=$("$SIDECAR" --version 2>>"$LOG" | tail -1 || true)
-if [ -z "$ENGINE_VERSION" ]; then
-  echo "OpenCode sidecar did not report a version" >> "$LOG"
-  echo WARM_TIMEOUT
-  tail -80 "$LOG" 2>&1 || true
-  exit 0
-fi
-printf %s ${pluginManifestPrefix} | base64 -d > "$D/xdg/config/opencode/package.json"
-printf %s "$ENGINE_VERSION" >> "$D/xdg/config/opencode/package.json"
-printf %s ${pluginManifestSuffix} | base64 -d >> "$D/xdg/config/opencode/package.json"
-cp "$D/xdg/config/opencode/package.json" "$D/config/opencode/package.json"
-printf %s ${devtoolsManifest} | base64 -d > "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest/package.json"
-NPM=/usr/local/share/nvm/current/bin/npm
-if [ ! -x "$NPM" ]; then
-  echo "npm is missing at $NPM" >> "$LOG"
-  echo WARM_TIMEOUT
-  tail -80 "$LOG" 2>&1 || true
-  exit 0
-fi
-install_package() {
-  directory="$1"
-  if ! (cd "$directory" && HOME="$D/home" /usr/local/share/nvm/current/bin/npm install --ignore-scripts --no-audit --no-fund --loglevel=error) >> "$LOG" 2>&1; then
-    echo WARM_TIMEOUT
-    tail -80 "$LOG" 2>&1 || true
-    return 1
-  fi
-}
-install_package "$D/xdg/config/opencode" || exit 0
-install_package "$D/config/opencode" || exit 0
-install_package "$D/xdg/cache/opencode/packages/opencode-chrome-devtools@latest" || exit 0
-echo WARM_OK`;
-    const result = await execInSandbox(exec, sandbox, warmScript, {
-      timeoutMs: 240_000,
-      context: `engine cache warm gate for ${sandbox}`,
-    }).catch((error) => {
-      log(`==> WARNING: engine cache warm gate could not complete for ${sandbox}; specs will start cold. ${messageText(error)}`);
-      return null;
-    });
-    if (result?.stdout.includes("WARM_TIMEOUT")) {
-      log(`==> WARNING: engine cache warm gate did not complete for ${sandbox}; specs will start cold. Log tail:\n${outputTail(result)}`);
-    } else if (result?.stdout.includes("WARM_OK")) {
-      engineCacheDir = warmDir;
-      log(`==> engine cache warmed for ${sandbox}`);
-    }
-  });
-
   await timedStep(log, "Vite prewarm gate", async () => {
     const detachScript = `cd /workspace; python3 - <<PYEOF
 import subprocess
@@ -532,7 +457,7 @@ echo detached`;
     throw new Error(`Vite prewarm gate timed out after ${VITE_PREWARM_TIMEOUT_MS}ms waiting for ${phase} in ${sandbox}. Last readiness error: ${last}. Log tail:\n${outputTail(viteLog)}`);
   });
 
-  return { sandbox, created: !reused, engineCacheDir };
+  return { sandbox, created: !reused };
 }
 
 interface LocalProcessResult {
@@ -985,8 +910,6 @@ export function renderConnectorE2eTestEnv(facts: ConnectorE2eTestEnv): string {
     `OPENWORK_EVAL_DEN_WEB_URL=${shellQuote(facts.denWebUrl)}`,
     `OPENWORK_EVAL_DAYTONA_SANDBOX_A=${shellQuote(facts.sandboxA)}`,
     `OPENWORK_EVAL_DAYTONA_SANDBOX_B=${shellQuote(facts.sandboxB)}`,
-    `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A=${shellQuote(facts.engineCacheDirA ?? "")}`,
-    `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B=${shellQuote(facts.engineCacheDirB ?? "")}`,
     `OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL=${shellQuote(facts.mockUrl)}`,
     "OPENWORK_EVAL_MODEL=big-pickle",
     "",
@@ -1024,8 +947,6 @@ export function parseConnectorE2eTestEnv(content: string): ConnectorE2eTestEnv {
     denWebUrl: required("OPENWORK_EVAL_DEN_WEB_URL"),
     sandboxA: required("OPENWORK_EVAL_DAYTONA_SANDBOX_A"),
     sandboxB: required("OPENWORK_EVAL_DAYTONA_SANDBOX_B"),
-    engineCacheDirA: values.get("OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A")?.trim() || null,
-    engineCacheDirB: values.get("OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B")?.trim() || null,
     mockUrl: required("OPENWORK_EVAL_CONNECTOR_MOCK_PUBLIC_URL"),
     ref,
     created: createdText.split(",").map((id) => id.trim()).filter(Boolean),

--- a/evals/packages/hosts/src/resolve.ts
+++ b/evals/packages/hosts/src/resolve.ts
@@ -38,7 +38,7 @@ export function localHost(): DisposableHost {
 }
 
 /** A named Daytona sandbox, driven through the `daytona` CLI from outside it. */
-export function daytonaSandbox(sandboxId: string, engineCacheDir?: string): DisposableHost {
+export function daytonaSandbox(sandboxId: string): DisposableHost {
   const id = sandboxId.trim();
   if (!id) throw new Error("daytonaSandbox(sandboxId) requires a sandbox id.");
   if (runningInsideSandbox()) {
@@ -46,5 +46,5 @@ export function daytonaSandbox(sandboxId: string, engineCacheDir?: string): Disp
       `daytonaSandbox(${JSON.stringify(id)}) cannot be used from inside a sandbox: the daytona CLI indirection has nothing to target. Use localHost() there.`,
     );
   }
-  return createDaytonaHost({ sandboxId: id, repoRoot: REPO_ROOT, log: () => undefined, engineCacheDir });
+  return createDaytonaHost({ sandboxId: id, repoRoot: REPO_ROOT, log: () => undefined });
 }

--- a/evals/packages/hosts/test/daytona-host.test.ts
+++ b/evals/packages/hosts/test/daytona-host.test.ts
@@ -174,7 +174,6 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
     log: () => undefined,
     exec,
     repoRoot: "/repo",
-    engineCacheDir: "/tmp/openwork-engine-warm-123",
     waitForCdp: successfulPolls(polled),
   });
   const bootstrap = { baseUrl: "https://den-web.example.test", apiBaseUrl: "https://den-api.example.test", requireSignin: true };
@@ -191,14 +190,7 @@ test("spawnElectron starts isolated Daytona Electron profiles and writes bootstr
   assert.deepEqual(polled, ["https://cdp-9825.example.test/json/list", "https://cdp-9830.example.test/json/list"]);
 
   const firstMkdirIndex = calls.findIndex((call) => argsText(call).includes("mkdir -p") && argsText(call).includes("/profiles/owner-"));
-  const firstSeedIndex = calls.findIndex((call) => argsText(call).includes("cp -a") && argsText(call).includes("/profiles/owner-"));
   assert(firstMkdirIndex >= 0);
-  assert(firstSeedIndex > firstMkdirIndex);
-  const firstSeed = argsText(calls[firstSeedIndex] ?? { args: [] });
-  assert(firstSeed.includes("/tmp/openwork-engine-warm-123/openwork-dev-data"));
-  assert(!firstSeed.includes("engine-cache"));
-  assert(firstSeed.includes("[ ! -e"));
-  assert(firstSeed.includes("/electron-userdata/openwork-dev-data"));
 
   const bootstrapCall = findCall(calls, "base64 -d");
   assert.equal(Buffer.from(base64AfterEcho(bootstrapCall), "base64").toString("utf8"), `${JSON.stringify(bootstrap, null, 2)}\n`);

--- a/evals/packages/hosts/test/provision.test.ts
+++ b/evals/packages/hosts/test/provision.test.ts
@@ -42,7 +42,6 @@ function desktopFake(diskUse = "40%"):
     if (script.includes("pgrep -f Xvfb")) return { stdout: "XVFB_OK\n", stderr: "", code: 0 };
     if (script.includes("xdg-open-proof")) return { stdout: "XDG_OPEN_WORKS\n", stderr: "", code: 0 };
     if (script.includes("json/version")) return { stdout: '{"Browser":"Chrome/144"}', stderr: "", code: 0 };
-    if (script.includes("install_package")) return { stdout: "WARM_OK\n", stderr: "", code: 0 };
     if (script.includes("%{http_code}")) return { stdout: "200", stderr: "", code: 0 };
     return { stdout: "", stderr: "", code: 0 };
   };
@@ -62,8 +61,6 @@ test("connector E2E test env rendering and parsing round-trip the provision cont
     denWebUrl: "https://den-web.example.test",
     sandboxA: "desktop-a",
     sandboxB: "desktop-b",
-    engineCacheDirA: "/tmp/openwork-engine-warm-a",
-    engineCacheDirB: null,
     mockUrl: "https://mock.example.test",
     ref: "feat/eval-connector-two-members",
     created: ["den", "desktop-a"],
@@ -73,8 +70,6 @@ test("connector E2E test env rendering and parsing round-trip the provision cont
   assert.deepEqual(parseConnectorE2eTestEnv(content), facts);
   assert.match(content, /^# provisioned for org-connector-two-members — generated .*; ref=feat\/eval-connector-two-members$/m);
   assert.match(content, /^# provision-created=den,desktop-a$/m);
-  assert.match(content, /^OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A='\/tmp\/openwork-engine-warm-a'$/m);
-  assert.match(content, /^OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B=''$/m);
   assert.match(content, /OPENWORK_EVAL_MODEL=big-pickle/);
   const missingApi = content.split("\n").filter((line) => !line.startsWith("OPENWORK_EVAL_DEN_API_URL=")).join("\n");
   assert.throws(() => parseConnectorE2eTestEnv(missingApi), /OPENWORK_EVAL_DEN_API_URL/);
@@ -115,22 +110,11 @@ test("provisionDesktopSandbox reuses a sandbox and keeps every remote command in
 
   assert.equal(result.sandbox, "existing-a");
   assert.equal(result.created, false);
-  assert.match(result.engineCacheDir ?? "", /^\/tmp\/openwork-engine-warm-\d+$/);
   assert.deepEqual(calls[0]?.args, ["sandbox", "start", "existing-a"]);
   assert.equal(calls.filter((call) => call.args[0] === "create").length, 0);
   assert.equal(calls.filter((call) => call.args[0] === "snapshot").length, 0);
   const lastFirstBootCall = calls.findLastIndex((call) => call.args[3]?.includes("/tmp/warmup-profile"));
-  const engineWarmCall = calls.findIndex((call) => call.args[3]?.includes("install_package"));
   assert(lastFirstBootCall >= 0);
-  assert(engineWarmCall > lastFirstBootCall);
-  const engineWarmScript = calls[engineWarmCall]?.args[3] ?? "";
-  assert(engineWarmScript.includes("npm install"));
-  assert(engineWarmScript.includes("npm install --ignore-scripts --no-audit --no-fund --loglevel=error"));
-  assert(engineWarmScript.includes("opencode-chrome-devtools@latest"));
-  assert(!engineWarmScript.includes(Buffer.from('"opencode-chrome-devtools":"latest"').toString("base64").slice(0, 24)));
-  assert(!engineWarmScript.includes("WARM_PRESENT"));
-  assert(!engineWarmScript.includes("W=/workspace/.openwork-daytona/engine-cache"));
-  assert(engineWarmScript.includes("rm -rf /workspace/.openwork-daytona/engine-cache"));
   assertRemoteCommandsAreSingleArgument(calls);
 });
 
@@ -157,8 +141,6 @@ test("rendered values are shell-quoted, because the env file is meant to be sour
     denWebUrl: "https://w",
     sandboxA: nasty,
     sandboxB: "b",
-    engineCacheDirA: null,
-    engineCacheDirB: null,
     mockUrl: "https://m",
     ref: "dev",
     created: [],
@@ -181,8 +163,6 @@ test("an unsafe ref is refused before it can reach a remote shell or a sourced f
       denWebUrl: "https://w",
       sandboxA: "a",
       sandboxB: "b",
-      engineCacheDirA: null,
-      engineCacheDirB: null,
       mockUrl: "https://m",
       ref,
       created: [],

--- a/evals/runner/prepare-stack.ts
+++ b/evals/runner/prepare-stack.ts
@@ -14,7 +14,7 @@ const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 export type StackPreparation =
   | { kind: "none" }
   | { kind: "local"; runtimePrepared: true; electronPrepared: true }
-  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string; engineCacheDir: string | null }[] };
+  | { kind: "daytona"; slots: { denSandbox: string; desktopSandbox: string }[] };
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -89,7 +89,7 @@ async function prepareDaytona(argv: readonly string[]): Promise<{ preparation: S
           return result;
         }),
       ]);
-      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox, engineCacheDir: desktop.engineCacheDir };
+      return { denSandbox: den.sandbox, desktopSandbox: desktop.sandbox };
     }));
     console.error(`[openwork/evals] prepared ${slots.length} isolated Daytona worker slot${slots.length === 1 ? "" : "s"}.`);
     return {

--- a/evals/runner/stack-env.ts
+++ b/evals/runner/stack-env.ts
@@ -13,6 +13,4 @@ if (preparation.kind === "daytona") {
   if (!slot) throw new Error("Vitest worker did not resolve to a prepared Daytona slot.");
   process.env.OPENWORK_EVAL_DAYTONA_DEN_SANDBOX = slot.denSandbox;
   process.env.OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX = slot.desktopSandbox;
-  if (slot.engineCacheDir) process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR = slot.engineCacheDir;
-  else delete process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR;
 }

--- a/evals/scripts/provision-org-connector-two-members.ts
+++ b/evals/scripts/provision-org-connector-two-members.ts
@@ -72,8 +72,6 @@ async function provisionSpecEnv(options: {
       denWebUrl: den.webUrl,
       sandboxA: desktopA.sandbox,
       sandboxB: desktopB.sandbox,
-      engineCacheDirA: desktopA.engineCacheDir,
-      engineCacheDirB: desktopB.engineCacheDir,
       mockUrl: mock.url,
       ref: options.ref,
       created,

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -376,7 +376,7 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
         log: (line) => console.error(`[openwork/testkit] ${line}`),
       })
     : null;
-  const host = provisioned ? daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined) : localHost();
+  const host = provisioned ? daytonaSandbox(provisioned.sandbox) : localHost();
   const seeded = await desktop({ name: "recovery-profile-seed", host, profileDir });
   const names = await evalIn(seeded, `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
     folderPath: ${JSON.stringify(`${profileDir}/continuity-workspace`)}, name: "reliable-recovery-profile-marker"
@@ -528,7 +528,7 @@ export async function enterpriseTlsWorld(seed: Seed, { place }: { place: Place }
   let rootInstallAttempted = false;
   let rawApp: Awaited<ReturnType<typeof desktop>> | null = null;
   let trustedApp: Awaited<ReturnType<typeof startApp>> | null = null;
-  const host = daytonaSandbox(provisioned.sandbox, provisioned.engineCacheDir ?? undefined);
+  const host = daytonaSandbox(provisioned.sandbox);
 
   const dispose = async () => {
     if (trustedApp) await cleanup("dispose trusted enterprise TLS app", () => trustedApp?.[Symbol.asyncDispose]() ?? Promise.resolve());

--- a/evals/worlds/infra.ts
+++ b/evals/worlds/infra.ts
@@ -32,15 +32,13 @@ export async function oauthDenWorld(seed: Seed) {
 export async function twoDaytonaDesktopsWorld(seed: Seed) {
   const requestedA = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_A?.trim();
   const requestedB = process.env.OPENWORK_EVAL_DAYTONA_SANDBOX_B?.trim();
-  const engineCacheDirA = process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_A?.trim();
-  const engineCacheDirB = process.env.OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR_B?.trim();
   if (Boolean(requestedA) !== Boolean(requestedB)) throw new Error("Set both Daytona sandbox ids or neither.");
   if (requestedA && requestedA === requestedB) throw new Error("The two Daytona sandbox ids must differ.");
   const appA = requestedA
-    ? await desktop({ host: daytonaSandbox(requestedA, engineCacheDirA), name: "a" })
+    ? await desktop({ host: daytonaSandbox(requestedA), name: "a" })
     : await seed.desktop({ name: "a" });
   const appB = requestedB
-    ? await desktop({ host: daytonaSandbox(requestedB, engineCacheDirB), name: "b" })
+    ? await desktop({ host: daytonaSandbox(requestedB), name: "b" })
     : await seed.desktop({ name: "b" });
   const sandboxA = appA.handle.sandboxId;
   const sandboxB = appB.handle.sandboxId;


### PR DESCRIPTION
## Why

#4397 added an "engine cache warm gate" to Daytona desktop provisioning: it pre-installed `opencode-chrome-devtools` via npm into each sandbox's OpenCode cache because the engine's in-process npm install could hang at bootstrap. #4423 bundles that plugin as a local file, so the engine no longer installs anything from npm at bootstrap and the gate — plus the `engineCacheDir` plumbing it needed through `provision → place → daytonaSandbox → spawnElectron`, the `OPENWORK_EVAL_DAYTONA_ENGINE_CACHE_DIR{,_A,_B}` facts, and the profile pre-seed copy — is dead weight (~10s per sandbox).

## Change

Removal only, `evals/` only: +14 / −145 across 11 files. First-boot and Vite-prewarm gates are untouched.

## Verification

Fresh Daytona sandbox on this branch (`checkout resolved 10829bce6ced`), no warm gate in the provisioning trace, engine boots, existing desktop journey passes:

```
OPENWORK_EVAL_REF=chore/evals-drop-engine-warm-gate node evals/bin/evals.mjs composer-draft-reload --daytona
# passed 1 / failed 0 / skipped 0 — verdict: passed
```

```
rg -n "engineCacheDir|ENGINE_CACHE_DIR|CHROME_DEVTOOLS_PLUGIN_VERSION|engine cache warm|install_package|engine-cache" evals .github   # no matches
pnpm --dir evals test              # exit 0 — 233 pass, 0 fail, 0 skip (lint:layers, channel ratchet, node --test)
pnpm --dir evals typecheck:spec-layer   # exit 0
```

`pnpm --dir evals typecheck` has 99 pre-existing errors on clean `dev` (unrelated `packages/headless-threads` / den types); unchanged by this PR.
