### PR TITLE
fix(app): keep sidebar titles clear of always-visible row actions

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -2304,7 +2304,9 @@ function SessionMenuItem({
   const rowButtonClass = cn(
     // Soft pill @ 11px radius from Paper; overlay tint adapts to theme
     // (light: --ow-light-hover ≈ black/5, dark: #FFFFFF17 ≈ white/9).
-    "relative h-8 rounded-md transition-[padding,background-color] duration-75 pe-7 group-hover/menu-sub-item:pe-18 group-has-data-popup-open/menu-sub-item:pe-18 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-[13px] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
+    // The end padding tracks SessionHoverQuickActions: reserve their width
+    // whenever they show, including the layouts that show them without hover.
+    "relative h-8 rounded-md transition-[padding,background-color] duration-75 pe-7 group-hover/menu-sub-item:pe-18 group-has-data-popup-open/menu-sub-item:pe-18 max-lg:pe-18 pointer-coarse:pe-18 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-[13px] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
   );
   const rowButtonStyle = {
     paddingInlineStart: sidebarRowPaddingInlineStart(0),
@@ -2319,7 +2321,7 @@ function SessionMenuItem({
   const trailing = (
     <>
       <SessionOutcomeIndicator
-        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-100 group-hover/menu-sub-item:opacity-0 pointer-events-none select-none"
+        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-100 group-hover/menu-sub-item:opacity-0 max-lg:opacity-0 pointer-coarse:opacity-0 pointer-events-none select-none"
         status={sessionActivityStatus}
         isActiveWork={resolvedActiveWork}
         isUnread={isUnread}

--- a/evals/specs/channel-ratchet.baseline.json
+++ b/evals/specs/channel-ratchet.baseline.json
@@ -22,7 +22,7 @@
   "reliable-app-recovery.e2e.test.ts": 1,
   "responsive-session-layout.e2e.test.ts": 10,
   "saved-script-automations.e2e.test.ts": 3,
-  "sidebar-title-overflow-fade.e2e.test.ts": 5,
+  "sidebar-title-overflow-fade.e2e.test.ts": 7,
   "task-activity-shimmer.e2e.test.ts": 1,
   "welcome-one-field.e2e.test.ts": 1,
   "workspace-new-task-hit-target.e2e.test.ts": 3,

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -11,8 +11,39 @@ interface TitleState {
   scrollWidth: number;
 }
 
+interface RowState {
+  title: string;
+  titleRight: number;
+  actionsLeft: number;
+  actionsOpacity: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function rowStates(probe: Probe): Promise<RowState[]> {
+  // TODO(primitive): probe.geometry should read the boxes of a row's title and actions.
+  const value = await probe.eval(`(() => [...document.querySelectorAll("[data-sidebar-session-id]")].map((row) => {
+    const title = row.querySelector("[data-session-title-slot]");
+    const actions = row.querySelector("[data-session-hover-actions]");
+    if (!(title instanceof HTMLElement) || !(actions instanceof HTMLElement)) return null;
+    return {
+      title: (title.textContent ?? "").trim(),
+      titleRight: title.getBoundingClientRect().right,
+      actionsLeft: actions.getBoundingClientRect().left,
+      actionsOpacity: getComputedStyle(actions).opacity,
+    };
+  }))()`);
+  if (!Array.isArray(value)) throw new Error(`Unexpected sidebar rows: ${JSON.stringify(value)}`);
+  return value.map((row) => {
+    if (!isRecord(row)
+      || typeof row.title !== "string"
+      || typeof row.titleRight !== "number"
+      || typeof row.actionsLeft !== "number"
+      || typeof row.actionsOpacity !== "string") throw new Error(`Unexpected sidebar row: ${JSON.stringify(row)}`);
+    return { title: row.title, titleRight: row.titleRight, actionsLeft: row.actionsLeft, actionsOpacity: row.actionsOpacity };
+  });
 }
 
 async function titleState(probe: Probe, title: string): Promise<TitleState> {
@@ -108,6 +139,19 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
     const workspaceAfterResize = await titleState(probe, workspaceName);
     expect(workspaceAfterResize.hiddenEdges).toBe("none");
     expect(workspaceAfterResize.maskImage).toBe("none");
+    await user.screenshot();
+  });
+
+  await step("below the hover breakpoint, titles stop before the always-visible row actions", async () => {
+    // TODO(primitive): user.resizeViewport should narrow a desktop surface below the hover breakpoint.
+    await world.app.client.send("Emulation.setDeviceMetricsOverride", { width: 900, height: 800, deviceScaleFactor: 1, mobile: false });
+    await user.press("Meta+b");
+    const rows = await probe.eventually(() => rowStates(probe), {
+      within: 15_000,
+      label: "session rows with visible actions",
+      until: (rows) => rows.length > 0 && rows.every((row) => row.actionsOpacity === "1"),
+    });
+    for (const row of rows) expect(row.titleRight, row.title).toBeLessThanOrEqual(row.actionsLeft);
     await user.screenshot();
   });
 });


### PR DESCRIPTION
## Summary

- Below the hover breakpoint (`max-lg`) and on touch (`pointer-coarse`), a session row's pin/archive/time actions are always shown (#3773), but the row still only reserved their width on hover — so titles ran underneath the icons.
- Reserve the actions' width (`pe-18`) and let them replace the outcome dot in those layouts, exactly as they already do on hover. Two class-string changes in `SessionMenuItem`.

## Verification

Journey spec `sidebar-title-overflow-fade` gains a step that narrows the viewport below the breakpoint, opens the sidebar, and asserts every title stops before its row actions (`titleRight <= actionsLeft`) once the actions are visible.

- `pnpm evals:e2e sidebar-title-overflow-fade --local` on `90aa8d919` — `placement: local (--local)` — 1 passed, 0 failed, 0 skipped. Local lane because the Daytona CLI was not authenticated in this session.
- Negative half: the same spec against unfixed `dev` fails at the new step with `expected 323 to be less than or equal to 280` (the title ran 43px under the icons).
- `pnpm --filter @openwork/app typecheck`, the spec channel/boundary ratchets, and the evals layer lint pass. The channel baseline for this spec moves 5 → 7 for the viewport override and the one added geometry probe, both marked `TODO(primitive)`.

Independent of #4420 (sideways scroll); both touch the same spec file, so whichever lands second needs a rebase.
