### PR TITLE
feat(app): New session opens in the focused pane instead of always replacing the primary

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2067,6 +2067,7 @@ export function SessionRoute() {
   const handleCreateTaskInWorkspaceWithOpenMode = useCallback(async (
     workspaceId: string,
     openAs: "primary" | "split",
+    source: "new_task" | "new_split" = openAs === "split" ? "new_split" : "new_task",
   ): Promise<string | null> => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
     if (
@@ -2111,7 +2112,7 @@ export function SessionRoute() {
         void refreshCloudProviderSync("new_chat");
       }
       captureAnalyticsEvent("task_created", {
-        source: openAs === "split" ? "new_split" : "new_task",
+        source,
         workspace_type: workspace.workspaceType ?? "unknown",
       });
       toast.dismiss(taskCreateUnavailableToastId(workspaceId));
@@ -2158,7 +2159,7 @@ export function SessionRoute() {
         description: failure.description,
         action: {
           label: "Retry",
-          onClick: () => void handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs),
+          onClick: () => void handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs, source),
         },
         // A blue/green reload brings up a fresh engine without killing live
         // sessions; the full desktop restart stays a last resort elsewhere.
@@ -2168,7 +2169,7 @@ export function SessionRoute() {
                 label: t("session.engine_reload_action"),
                 onClick: () => {
                   void reloadEngineWithDesktopFallback(endpoint.client, endpoint.workspaceId)
-                    .then(() => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs))
+                    .then(() => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs, source))
                     .catch(() => undefined);
                 },
               },
@@ -2189,10 +2190,11 @@ export function SessionRoute() {
     }
   }, [applyLastUsedModelToSession, developerMode, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
 
-  const handleCreateTaskInWorkspace = useCallback(
-    (workspaceId: string): Promise<string | null> => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, "primary"),
-    [handleCreateTaskInWorkspaceWithOpenMode],
-  );
+  const handleCreateTaskInWorkspace = useCallback((workspaceId: string): Promise<string | null> => {
+    const { focusedPane, secondary } = useWorkbenchStore.getState();
+    const openAs = focusedPane === "secondary" && secondary ? "split" : "primary";
+    return handleCreateTaskInWorkspaceWithOpenMode(workspaceId, openAs, "new_task");
+  }, [handleCreateTaskInWorkspaceWithOpenMode]);
 
   const handleCreateSplitTaskInWorkspace = useCallback(
     (workspaceId: string): Promise<string | null> => handleCreateTaskInWorkspaceWithOpenMode(workspaceId, "split"),

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -7,6 +7,7 @@ const paletteInput = { placeholder: "Search actions, settings, and sessions…" 
 
 type SplitFacts = {
   layoutKind: string;
+  focusedPane: string;
   primarySessionId: string;
   secondarySessionId: string;
   primaryWorkspaceId: string;
@@ -27,6 +28,7 @@ function parseSplitFacts(value: unknown): SplitFacts {
   const text = (key: string) => typeof value[key] === "string" ? value[key] : "";
   return {
     layoutKind: text("layoutKind"),
+    focusedPane: text("focusedPane"),
     primarySessionId: text("primarySessionId"),
     secondarySessionId: text("secondarySessionId"),
     primaryWorkspaceId: text("primaryWorkspaceId"),
@@ -44,18 +46,6 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   const paletteShortcut = place.kind !== "daytona" && process.platform === "darwin" ? "Meta+K" : "Control+K";
   const workspaceId = world.workspace.workspaceId;
   const primarySessionId = world.session.sessionId;
-  const runPaletteItem = async (itemId: string) => {
-    await user.press(paletteShortcut);
-    await user.see(paletteInput);
-    await user.type(paletteInput, itemId.replace("-", " "), { replace: true });
-    const selector = `[data-command-palette-item="${itemId}"]`;
-    await probe.eventually(() => probe.eval(`Boolean(document.querySelector(${JSON.stringify(selector)}))`), {
-      within: 15_000,
-      label: `${itemId} command is visible`,
-      until: (visible) => visible === true,
-    });
-    await probe.eval(`document.querySelector(${JSON.stringify(selector)})?.click()`);
-  };
 
   const { primaryHash, before } = await step("the seeded session is the single primary pane", async () => {
     await probe.eventually(() => world.splitFacts(), {
@@ -125,7 +115,11 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   });
 
   await step("New split in the command palette replaces the secondary with another fresh session", async () => {
-    await runPaletteItem("new-split");
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "new split", { replace: true });
+    await user.see({ role: "option", label: /^New split/ });
+    await user.press("Enter");
     await user.see({ text: "Split view" });
     await user.see({ text: "New session" });
   });
@@ -179,17 +173,17 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   });
 
   await step("New session replaces the focused secondary pane", async () => {
-    expect(await probe.eval(`(() => {
-      const pane = document.querySelector('[data-workbench-pane="secondary"]');
-      if (!pane) return false;
-      pane.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
-      return true;
-    })()`)).toBe(true);
-    await probe.eventually(
-      () => probe.eval(`window.__openworkControl?.context?.().conversations?.layout?.focused ?? ""`),
-      { within: 15_000, label: "secondary pane is focused", until: (focused) => focused === "secondary" },
-    );
-    await runPaletteItem("new-session");
+    await agent.run("workbench.session.focus", { sessionId: secondFacts.secondarySessionId });
+    await probe.eventually(() => world.splitFacts(), {
+      within: 15_000,
+      label: "secondary pane is focused",
+      until: (value) => parseSplitFacts(value).focusedPane === "secondary",
+    });
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "new task", { replace: true });
+    await user.see({ role: "option", label: /^New session/ });
+    await user.press("Enter");
   });
 
   const { focusedSecondaryFacts, afterFocusedSecondary } = await step("the focused secondary is replaced while the primary route stays put", async () => {
@@ -229,17 +223,17 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   });
 
   await step("New session replaces the focused primary pane", async () => {
-    expect(await probe.eval(`(() => {
-      const pane = document.querySelector('[data-workbench-pane="primary"]');
-      if (!pane) return false;
-      pane.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
-      return true;
-    })()`)).toBe(true);
-    await probe.eventually(
-      () => probe.eval(`window.__openworkControl?.context?.().conversations?.layout?.focused ?? ""`),
-      { within: 15_000, label: "primary pane is focused", until: (focused) => focused === "primary" },
-    );
-    await runPaletteItem("new-session");
+    await agent.run("workbench.session.focus", { sessionId: primarySessionId });
+    await probe.eventually(() => world.splitFacts(), {
+      within: 15_000,
+      label: "primary pane is focused",
+      until: (value) => parseSplitFacts(value).focusedPane === "primary",
+    });
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "new task", { replace: true });
+    await user.see({ role: "option", label: /^New session/ });
+    await user.press("Enter");
   });
 
   await step("the focused primary is replaced without changing the secondary", async () => {

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -39,11 +39,23 @@ function parseSplitFacts(value: unknown): SplitFacts {
   };
 }
 
-test("new split creates fresh same-workspace secondary sessions without moving the primary", async ({ world, user, agent, probe, step, place }) => {
+test("new split creates fresh same-workspace secondary sessions without moving the primary; New session replaces the focused pane", async ({ world, user, agent, probe, step, place }) => {
   // The key chord belongs to the machine running the app, not the one running the spec.
   const paletteShortcut = place.kind !== "daytona" && process.platform === "darwin" ? "Meta+K" : "Control+K";
   const workspaceId = world.workspace.workspaceId;
   const primarySessionId = world.session.sessionId;
+  const runPaletteItem = async (itemId: string) => {
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, itemId.replace("-", " "), { replace: true });
+    const selector = `[data-command-palette-item="${itemId}"]`;
+    await probe.eventually(() => probe.eval(`Boolean(document.querySelector(${JSON.stringify(selector)}))`), {
+      within: 15_000,
+      label: `${itemId} command is visible`,
+      until: (visible) => visible === true,
+    });
+    await probe.eval(`document.querySelector(${JSON.stringify(selector)})?.click()`);
+  };
 
   const { primaryHash, before } = await step("the seeded session is the single primary pane", async () => {
     await probe.eventually(() => world.splitFacts(), {
@@ -113,16 +125,12 @@ test("new split creates fresh same-workspace secondary sessions without moving t
   });
 
   await step("New split in the command palette replaces the secondary with another fresh session", async () => {
-    await user.press(paletteShortcut);
-    await user.see(paletteInput);
-    await user.type(paletteInput, "new split", { replace: true });
-    await user.see({ role: "option", label: /^New split/ });
-    await user.press("Enter");
+    await runPaletteItem("new-split");
     await user.see({ text: "Split view" });
     await user.see({ text: "New session" });
   });
 
-  await step("the palette creates one more session while preserving the primary route", async () => {
+  const { secondFacts, afterPalette } = await step("the palette creates one more session while preserving the primary route", async () => {
     const afterContextMenuIds = afterContextMenu.map((session) => session.sessionId);
     const secondValue = await probe.eventually(() => world.splitFacts(), {
       within: 60_000,
@@ -167,5 +175,99 @@ test("new split creates fresh same-workspace secondary sessions without moving t
     expect(afterPalette).toHaveLength(before.length + 2);
     expect(afterPalette.map((session) => session.sessionId)).toContain(secondFacts.secondarySessionId);
     await user.screenshot();
+    return { secondFacts, afterPalette };
+  });
+
+  await step("New session replaces the focused secondary pane", async () => {
+    expect(await probe.eval(`(() => {
+      const pane = document.querySelector('[data-workbench-pane="secondary"]');
+      if (!pane) return false;
+      pane.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+      return true;
+    })()`)).toBe(true);
+    await probe.eventually(
+      () => probe.eval(`window.__openworkControl?.context?.().conversations?.layout?.focused ?? ""`),
+      { within: 15_000, label: "secondary pane is focused", until: (focused) => focused === "secondary" },
+    );
+    await runPaletteItem("new-session");
+  });
+
+  const { focusedSecondaryFacts, afterFocusedSecondary } = await step("the focused secondary is replaced while the primary route stays put", async () => {
+    const previousIds = afterPalette.map((session) => session.sessionId);
+    const value = await probe.eventually(() => world.splitFacts(), {
+      within: 60_000,
+      label: "new session replaces the focused secondary",
+      until: (candidate) => {
+        const facts = parseSplitFacts(candidate);
+        return facts.layoutKind === "split"
+          && facts.primarySessionId === primarySessionId
+          && facts.primarySurfaceSessionId === primarySessionId
+          && /^ses_/.test(facts.secondarySessionId)
+          && facts.secondarySessionId !== secondFacts.secondarySessionId
+          && !previousIds.includes(facts.secondarySessionId)
+          && facts.secondarySurfaceSessionId === facts.secondarySessionId
+          && facts.secondaryPaneCount === 1
+          && facts.locationHash.includes(`/workspace/${workspaceId}/session/${primarySessionId}`);
+      },
+    });
+    const focusedSecondaryFacts = parseSplitFacts(value);
+    expect(focusedSecondaryFacts.layoutKind).toBe("split");
+    expect(focusedSecondaryFacts.primarySessionId).toBe(primarySessionId);
+    expect(focusedSecondaryFacts.primarySurfaceSessionId).toBe(primarySessionId);
+    expect(focusedSecondaryFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${primarySessionId}`);
+    expect(focusedSecondaryFacts.secondarySessionId).toMatch(/^ses_/);
+    expect(previousIds).not.toContain(focusedSecondaryFacts.secondarySessionId);
+    expect(focusedSecondaryFacts.secondarySurfaceSessionId).toBe(focusedSecondaryFacts.secondarySessionId);
+    expect(focusedSecondaryFacts.secondaryPaneCount).toBe(1);
+    const afterFocusedSecondary = await probe.eventually(() => agent.list(), {
+      within: 60_000,
+      label: "focused-secondary new session appears in the session list",
+      until: (sessions) => sessions.length === afterPalette.length + 1,
+    });
+    expect(afterFocusedSecondary).toHaveLength(afterPalette.length + 1);
+    return { focusedSecondaryFacts, afterFocusedSecondary };
+  });
+
+  await step("New session replaces the focused primary pane", async () => {
+    expect(await probe.eval(`(() => {
+      const pane = document.querySelector('[data-workbench-pane="primary"]');
+      if (!pane) return false;
+      pane.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+      return true;
+    })()`)).toBe(true);
+    await probe.eventually(
+      () => probe.eval(`window.__openworkControl?.context?.().conversations?.layout?.focused ?? ""`),
+      { within: 15_000, label: "primary pane is focused", until: (focused) => focused === "primary" },
+    );
+    await runPaletteItem("new-session");
+  });
+
+  await step("the focused primary is replaced without changing the secondary", async () => {
+    const value = await probe.eventually(() => world.splitFacts(), {
+      within: 60_000,
+      label: "new session replaces the focused primary",
+      until: (candidate) => {
+        const facts = parseSplitFacts(candidate);
+        return facts.layoutKind === "split"
+          && /^ses_/.test(facts.primarySessionId)
+          && facts.primarySessionId !== primarySessionId
+          && !facts.locationHash.includes(primarySessionId)
+          && facts.locationHash.includes(`/workspace/${workspaceId}/session/${facts.primarySessionId}`)
+          && facts.secondarySessionId === focusedSecondaryFacts.secondarySessionId
+          && facts.secondaryPaneCount === 1;
+      },
+    });
+    const focusedPrimaryFacts = parseSplitFacts(value);
+    expect(focusedPrimaryFacts.primarySessionId).toMatch(/^ses_/);
+    expect(focusedPrimaryFacts.primarySessionId).not.toBe(primarySessionId);
+    expect(focusedPrimaryFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${focusedPrimaryFacts.primarySessionId}`);
+    expect(focusedPrimaryFacts.secondarySessionId).toBe(focusedSecondaryFacts.secondarySessionId);
+    expect(focusedPrimaryFacts.secondaryPaneCount).toBe(1);
+    const afterFocusedPrimary = await probe.eventually(() => agent.list(), {
+      within: 60_000,
+      label: "focused-primary new session appears in the session list",
+      until: (sessions) => sessions.length === afterFocusedSecondary.length + 1,
+    });
+    expect(afterFocusedPrimary).toHaveLength(afterFocusedSecondary.length + 1);
   });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -219,6 +219,7 @@ export async function newSplitPrimary(seed: Seed) {
     const secondaryPane = secondaryPanes[0];
     return {
       layoutKind: layout?.kind ?? "",
+      focusedPane: layout?.focused ?? "",
       primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
       secondarySessionId: layout?.secondarySessionId ?? "",
       primaryWorkspaceId: layout?.primaryWorkspaceId ?? "",


### PR DESCRIPTION
## What

"New session" (Cmd+K → New session, Cmd+N, sidebar +, `session.create_task`) now opens the new session in the **focused pane**. In split view with the right/secondary pane focused, the fresh session replaces that pane and the primary/route stay put; with the primary focused it behaves as before. "New split" is unchanged and still always targets the secondary pane.

## Why

Cmd+K → New session always swapped the primary (left) pane, even when you were working in the secondary pane — the new session landed away from where you were looking.

## How

- `session-route.tsx`: `handleCreateTaskInWorkspace` reads `focusedPane`/`secondary` from the workbench store and picks the `"split"` open mode when the secondary pane is focused. Analytics `source` stays `new_task` for this path (only the explicit New split reports `new_split`).
- `evals/specs/new-split-session.e2e.test.ts`: extended (no new file) with two steps — focus secondary → New session replaces the secondary while primary/hash/pane count are unchanged; focus primary → New session replaces the primary while the secondary is unchanged.

## Verification

```
pnpm evals:e2e new-split-session
placement: daytona (daytona CLI authenticated)   # checkout 6f80e17cb654
Tests 1 passed (1) · verdict: passed
```

Test evidence is published in the sticky comment below.
