### PR TITLE
feat(browser): give each conversation its own built-in browser tabs

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -47,6 +47,7 @@
     "@modelcontextprotocol/ext-apps": "^1.7.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.18.15",
+    "@openwork/browser-tabs": "workspace:*",
     "@openwork/install-config": "workspace:*",
     "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",

--- a/apps/app/src/app/lib/desktop-types.ts
+++ b/apps/app/src/app/lib/desktop-types.ts
@@ -54,15 +54,7 @@ export type {
 // Single source of truth: packages/types/src/workspace.ts.
 export type WorkspaceInfo = WorkspaceWire;
 
-// Browser tab state mirrored across the desktop IPC bridge. Owned here (the
-// framework-agnostic layer); the session panel store re-exports it.
-export type BrowserPanelTab = {
-  id: string;
-  type: "browser";
-  label: string;
-  url: string;
-  favicon: string | null;
-  status: "loading" | "ready";
-  canGoBack: boolean;
-  canGoForward: boolean;
-};
+// Browser tab state mirrored across the desktop IPC bridge. The shape is owned
+// by @openwork/browser-tabs (shared with the Electron main process); the
+// session panel store re-exports it from here.
+export type { BrowserPanelTab } from "@openwork/browser-tabs";

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -48,12 +48,14 @@ import type {
   NukeReceipt,
   WorkspaceList,
 } from "./desktop-types";
-import type { BrowserPanelTab } from "./desktop-types";
+import type {
+  BrowserPanelOwnerPayload,
+  BrowserPanelTab,
+  BrowserStatePayload,
+  OpenBrowserUrlResult,
+} from "@openwork/browser-tabs";
 
-export type BrowserStatePayload = {
-  activeTabId?: string | null;
-  tabs?: BrowserPanelTab[];
-};
+export type { BrowserStatePayload } from "@openwork/browser-tabs";
 
 export type BrowserProxyState = {
   proxy: { rules: string; authenticated: boolean } | null;
@@ -171,22 +173,21 @@ declare global {
         use?: (id: string) => Promise<RecoveryActionResult>;
       };
       browser?: {
-        show?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
+        show?: (bounds: { x: number; y: number; width: number; height: number }, sessionId?: string | null) => Promise<void>;
         hide?: () => Promise<void>;
-        openUrl?: (url: string, provider?: "auto" | "builtin" | "external") => Promise<{
-          provider: "builtin";
-          browser_url: string;
-          target_id: string;
-          tab_id: string;
-          url: string;
-        }>;
+        openUrl?: (
+          url: string,
+          provider?: "auto" | "builtin" | "external",
+          options?: { sessionId?: string | null },
+        ) => Promise<OpenBrowserUrlResult>;
+        setVisibleSession?: (sessionId: string | null) => Promise<string | null>;
         navigate?: (url: string) => Promise<void>;
         back?: () => Promise<void>;
         forward?: () => Promise<void>;
         reload?: () => Promise<void>;
         setBounds?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
         getState?: () => Promise<BrowserStatePayload | null>;
-        createTab?: (url?: string) => Promise<{ tabId: string }>;
+        createTab?: (url?: string, sessionId?: string | null) => Promise<{ tabId: string }>;
         closeTab?: (tabId: string) => Promise<string | null>;
         closeAllTabs?: () => Promise<string[]>;
         selectTab?: (tabId: string) => Promise<string>;
@@ -197,8 +198,8 @@ declare global {
         showTabContextMenu?: (tabId: string, point?: { x: number; y: number }) => Promise<void>;
         destroy?: () => Promise<void>;
         onStateChange?: (callback: (state: BrowserStatePayload) => void) => () => void;
-        onPanelOpened?: (callback: () => void) => () => void;
-        onPanelClosed?: (callback: () => void) => () => void;
+        onPanelOpened?: (callback: (payload?: BrowserPanelOwnerPayload) => void) => () => void;
+        onPanelClosed?: (callback: (payload?: BrowserPanelOwnerPayload) => void) => () => void;
       };
       terminal?: {
         create?: (options: { cwd: string; cols: number; rows: number }) => Promise<{ terminalId: string }>;

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -584,6 +584,26 @@ export function SessionPage(props: SessionPageProps) {
     toggleSidePanelState(sidePanelSessionKey, panel);
   }, [setSidePanelState, sidePanelSessionKey, toggleSidePanelState]);
 
+  // Which conversation's browser tabs may take the screen. Every other
+  // conversation's tabs keep loading silently in the background.
+  useEffect(() => {
+    if (!isElectronRuntime()) return;
+    void (window as Window).__OPENWORK_ELECTRON__?.browser?.setVisibleSession?.(props.selectedSessionId ?? null);
+  }, [props.selectedSessionId]);
+
+  // Open the side panel of the conversation that owns a browser event. For the
+  // conversation on screen that is the visible panel; for a background
+  // conversation only its own panel state is marked open, so its tabs are
+  // waiting when the user switches to it and nothing on screen moves.
+  const openOwnerSidePanel = useCallback((ownerSessionId: string | null | undefined) => {
+    const ownerKey = getSidePanelSessionKey(ownerSessionId ?? null);
+    if (ownerSessionId == null || ownerKey === sidePanelSessionKey) {
+      setCurrentSidePanel("panel");
+      return;
+    }
+    setSidePanelState(ownerKey, "panel");
+  }, [setCurrentSidePanel, setSidePanelState, sidePanelSessionKey]);
+
   // When the agent calls a built-in browser tool, the main process opens
   // the WebContentsView and sends panel-opened; when hide_browser is called
   // it sends panel-closed. Without this listener the React UI never knows
@@ -592,16 +612,24 @@ export function SessionPage(props: SessionPageProps) {
     if (!isElectronRuntime()) return;
     const browser = (window as Window).__OPENWORK_ELECTRON__?.browser;
     if (!browser) return;
-    const unsubOpen = browser.onPanelOpened?.(() => {
+    const unsubOpen = browser.onPanelOpened?.((payload) => {
       if (preserveSidePanelOnPanelOpenRef.current) {
         preserveSidePanelOnPanelOpenRef.current = false;
         return;
       }
-      setCurrentSidePanel("panel");
+      openOwnerSidePanel(payload?.ownerSessionId);
     });
-    const unsubClose = browser.onPanelClosed?.(() => setCurrentSidePanel(null));
+    const unsubClose = browser.onPanelClosed?.((payload) => {
+      const ownerSessionId = payload?.ownerSessionId ?? null;
+      const ownerKey = getSidePanelSessionKey(ownerSessionId);
+      if (ownerSessionId === null || ownerKey === sidePanelSessionKey) {
+        setCurrentSidePanel(null);
+        return;
+      }
+      setSidePanelState(ownerKey, null);
+    });
     return () => { unsubOpen?.(); unsubClose?.(); };
-  }, [setCurrentSidePanel]);
+  }, [openOwnerSidePanel, setCurrentSidePanel, setSidePanelState, sidePanelSessionKey]);
   const {
     leftSidebarResizing,
     leftSidebarWidth,
@@ -640,8 +668,9 @@ export function SessionPage(props: SessionPageProps) {
     if (target.kind === "url" || target.preview === "browser") {
       const url = browserUrlForTarget(target);
       if (isElectronRuntime()) {
-        setCurrentSidePanel("panel");
-        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(url);
+        const ownerSessionId = sourceSessionId ?? props.selectedSessionId ?? null;
+        openOwnerSidePanel(ownerSessionId);
+        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(url, ownerSessionId);
       } else {
         window.open(url, "_blank", "noopener,noreferrer");
       }
@@ -714,7 +743,7 @@ export function SessionPage(props: SessionPageProps) {
     }
 
     openFileTarget(target);
-  }, [activePanelTab?.id, browserUrlForTarget, openTab, props.selectedSessionId, setCurrentSidePanel]);
+  }, [activePanelTab?.id, browserUrlForTarget, openOwnerSidePanel, openTab, props.selectedSessionId, setCurrentSidePanel]);
   const openTarget = useCallback((target: OpenTarget, options?: OpenTargetOptions, sourceSessionId?: string) => {
     openTargetForRuntime({
       client: props.openworkServerClient,
@@ -753,17 +782,21 @@ export function SessionPage(props: SessionPageProps) {
     ],
     previewArgs: { url: "https://example.com", provider: "builtin" },
     disabled: !isElectronRuntime(),
-    execute: async (args) => {
+    execute: async (args, helpers) => {
       const url = controlStringArg(args, "url");
       if (!url) return { ok: false, error: "Missing URL." };
       const provider = controlStringArg(args, "provider") || "builtin";
       if (provider !== "auto" && provider !== "builtin") {
         return { ok: false, error: `Browser provider is not available yet: ${provider}` };
       }
-      setCurrentSidePanel("panel");
-      return window.__OPENWORK_ELECTRON__?.browser?.openUrl?.(url, provider);
+      // The tab belongs to the conversation whose agent asked for it. When that
+      // is a background conversation the page loads silently there; the
+      // conversation on screen is never interrupted.
+      const ownerSessionId = helpers.origin?.sessionId ?? props.selectedSessionId ?? null;
+      openOwnerSidePanel(ownerSessionId);
+      return window.__OPENWORK_ELECTRON__?.browser?.openUrl?.(url, provider, { sessionId: ownerSessionId });
     },
-  }), [setCurrentSidePanel]);
+  }), [openOwnerSidePanel, props.selectedSessionId]);
   useControlAction(openBrowserUrlControlAction);
   const setBrowserProxyControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "browser.set_proxy",

--- a/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
+++ b/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
@@ -151,7 +151,8 @@ function isSameTab(left: PanelTab, right: PanelTab) {
       left.favicon === right.favicon &&
       left.status === right.status &&
       left.canGoBack === right.canGoBack &&
-      left.canGoForward === right.canGoForward
+      left.canGoForward === right.canGoForward &&
+      left.ownerSessionId === right.ownerSessionId
     );
   }
 
@@ -194,6 +195,7 @@ function mergePersistedSessions(
         status: "ready",
         canGoBack: false,
         canGoForward: false,
+        ownerSessionId: sessionId,
       }));
 
     sessions[sessionId] = {

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -159,11 +159,13 @@ function SidePanelTab({ tab, active, onSelect, onClose }: SidePanelTabProps) {
 }
 
 type BrowserPanelContentProps = {
+  sessionId: string;
   tab: BrowserPanelTab;
   onClose: () => void;
 };
 
 function BrowserPanelContent({
+  sessionId,
   tab,
   onClose,
 }: BrowserPanelContentProps) {
@@ -267,7 +269,10 @@ function BrowserPanelContent({
       }
 
       if (!shownRef.current) {
-        browser.show?.(bounds);
+        // Naming the conversation lets the native browser put that
+        // conversation's tabs on screen and keep every other conversation's
+        // tabs silently in the background.
+        browser.show?.(bounds, sessionId);
         shownRef.current = true;
         lastBoundsRef.current = bounds;
         return;
@@ -307,7 +312,7 @@ function BrowserPanelContent({
       shownRef.current = false;
       lastBoundsRef.current = null;
     };
-  }, [isAvailable]);
+  }, [isAvailable, sessionId]);
 
   return (
     <>
@@ -665,7 +670,7 @@ export function SidePanel({
           />
         ) : null}
         {activeTab?.type === "browser" ? (
-          <BrowserPanelContent tab={activeTab} onClose={onClose} />
+          <BrowserPanelContent sessionId={sessionId} tab={activeTab} onClose={onClose} />
         ) : activeTab?.type === "artifact" ? (
           <div className="min-h-0 flex-1 overflow-hidden">
             <ArtifactPanel

--- a/apps/app/src/react-app/domains/session/panel/use-side-panel-tabs.ts
+++ b/apps/app/src/react-app/domains/session/panel/use-side-panel-tabs.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { activeBrowserTabIdForSession, browserTabsForSession } from "@openwork/browser-tabs";
 
 import type { BrowserStatePayload } from "@/app/lib/desktop";
 
@@ -11,9 +12,11 @@ import { getElectronBrowser } from "./utils";
 export function useSidePanelTabs(sessionId: string) {
   const syncBrowserTabs = usePanelTabStore((state) => state.syncBrowserTabs);
 
+  // Every conversation only sees the tabs it opened (plus shared tabs): the
+  // native browser is one surface, but ownership decides what each panel shows.
   const applyBrowserState = React.useCallback((browserState: BrowserStatePayload) => {
-    const tabs = browserState.tabs ?? [];
-    const activeTabId = browserState.activeTabId ?? tabs[0]?.id ?? null;
+    const tabs = browserTabsForSession(browserState.tabs ?? [], sessionId);
+    const activeTabId = activeBrowserTabIdForSession(browserState, sessionId, tabs);
 
     syncBrowserTabs(sessionId, tabs, activeTabId);
   }, [sessionId, syncBrowserTabs]);
@@ -45,7 +48,7 @@ export function useSidePanelTabs(sessionId: string) {
   const reorderTabs = useReorderTabs();
 
   return {
-    createTab: (url?: string) => createTab(url),
+    createTab: (url?: string) => createTab(url, sessionId),
     closeTab: (tab: PanelTab) => closeTab(sessionId, tab),
     selectTab: (tabId: string) => selectTab(sessionId, tabId),
     reorderTabs: (tabIds: string[]) => reorderTabs(sessionId, tabIds),
@@ -53,8 +56,8 @@ export function useSidePanelTabs(sessionId: string) {
 }
 
 export function useCreateTab() {
-  return React.useCallback((url?: string) => {
-    void getElectronBrowser()?.createTab?.(url);
+  return React.useCallback((url?: string, sessionId?: string | null) => {
+    void getElectronBrowser()?.createTab?.(url, sessionId);
   }, []);
 }
 

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -13,6 +13,7 @@ import { useLocation, useNavigate } from "react-router";
 import type {
   OpenworkAffordanceDescriptor,
   OpenworkAffordanceEffects,
+  OpenworkAffordanceOrigin,
   OpenworkAffordanceRequest,
   OpenworkAffordanceResult,
 } from "@openwork/types/openwork-affordance";
@@ -59,6 +60,8 @@ export type OpenworkControlResult =
 
 export type OpenworkControlHelpers = {
   setNarration: (text: string) => void;
+  /** The conversation whose agent issued the request, when it came through the agent bridge. */
+  origin?: OpenworkAffordanceOrigin;
 };
 
 export type OpenworkControlTargetRef = {
@@ -106,7 +109,7 @@ type OpenworkControlContextValue = {
   busyActionId: string | null;
   actions: OpenworkControlActionMetadata[];
   registerAction: (actionId: string, actionRef: ControlActionRef) => () => void;
-  executeAction: (actionId: string, args?: unknown) => Promise<OpenworkControlResult>;
+  executeAction: (actionId: string, args?: unknown, origin?: OpenworkAffordanceOrigin) => Promise<OpenworkControlResult>;
   publishContext: (context: OpenworkContextSnapshot) => void;
   snapshot: () => OpenworkControlSnapshot;
 };
@@ -391,7 +394,11 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
     await wait(SPOTLIGHT_TIMING_MS.release);
   }, []);
 
-  const executeAction = useCallback(async (actionId: string, args?: unknown): Promise<OpenworkControlResult> => {
+  const executeAction = useCallback(async (
+    actionId: string,
+    args?: unknown,
+    origin?: OpenworkAffordanceOrigin,
+  ): Promise<OpenworkControlResult> => {
     const registered = actionsRef.current.get(actionId);
     const action = registered?.ref.current;
     if (!registered || !action) return { ok: false, actionId, error: `Unknown action: ${actionId}` };
@@ -418,7 +425,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
       await playTargetChoreography(action, runId);
       setNarration(`Running ${action.label}…`);
       const effectiveArgs = args === undefined ? action.previewArgs : args;
-      const result = await action.execute(effectiveArgs, { setNarration });
+      const result = await action.execute(effectiveArgs, { setNarration, origin });
       const resultError = returnedActionError(result);
       if (resultError) {
         setNarration(`Could not ${action.label}: ${resultError}`);
@@ -535,7 +542,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
       };
     }
     busyActorRef.current = request.actor ?? null;
-    const result = await executeAction(request.id, request.args);
+    const result = await executeAction(request.id, request.args, request.origin);
     if (!busyActionIdRef.current) busyActorRef.current = null;
     if (!result.ok) {
       return {

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -5,6 +5,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { app, WebContentsView, clipboard, session, shell } from "electron";
+import {
+  BACKGROUND_TAB_PRESENCE_BOUNDS,
+  backgroundTabEmulationCommands,
+  createBrowserTabRegistry,
+  foregroundTabEmulationCommands,
+} from "@openwork/browser-tabs";
 import { runDetachedTask } from "./process-resilience.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -21,9 +27,11 @@ const MENU_OVERLAY_HEIGHT = 176;
 const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
 
 export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
+  // tabId -> { tabId, view, favicon, background }. Order, ownership, the active
+  // tab per conversation, and which conversation is on screen live in the
+  // registry; this map only holds the native views.
   const browserTabs = new Map();
-  let browserTabOrder = [];
-  let activeBrowserTabId = null;
+  const registry = createBrowserTabRegistry();
   let browserViewVisible = false;
   // Last browser panel bounds reported by the renderer, in renderer CSS pixels.
   // Converted to window device-independent pixels at every setBounds call.
@@ -106,7 +114,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
 
   function routeBlockedMainWindowNavigation(url) {
     if (!/^https?:\/\//i.test(String(url ?? ""))) return;
-    void openBrowserUrlForAutomation(url).catch((error) => {
+    void openBrowserUrlForAutomation(url, "auto", { ownerSessionId: registry.visibleSessionId() }).catch((error) => {
       console.warn("[browser] failed to route blocked main-window navigation", error);
     });
   }
@@ -147,7 +155,13 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     throw new Error("Could not resolve built-in browser CDP target.");
   }
 
-  async function openBrowserUrlForAutomation(rawUrl, provider = "auto") {
+  /**
+   * Open a URL for an agent. The tab belongs to the conversation that asked
+   * (`ownerSessionId`). When that conversation is on screen the tab surfaces as
+   * before; otherwise it loads silently in the background — sized, focused,
+   * and painting — without disturbing whatever the user is reading.
+   */
+  async function openBrowserUrlForAutomation(rawUrl, provider = "auto", { ownerSessionId = null } = {}) {
     const requestedProvider = String(provider || "auto").trim().toLowerCase();
     if (requestedProvider && requestedProvider !== "auto" && requestedProvider !== "builtin") {
       throw new Error(`Browser provider is not available yet: ${requestedProvider}`);
@@ -156,7 +170,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     // The marker page is loaded right away, so skip the blank initialize load:
     // a queued about:blank navigation would abort this awaited load with
     // ERR_ABORTED and fail the agent's request before the page ever opens.
-    const tab = createBrowserTab("about:blank", { select: true, initializeBlank: false });
+    const tab = createBrowserTab("about:blank", { select: true, initializeBlank: false, ownerSessionId });
     await tab.view.webContents.loadURL(browserTargetMarkerUrl(tab.tabId));
     const targetId = await resolveBrowserCdpTargetId(tab.tabId);
     await tab.view.webContents.loadURL(url);
@@ -166,11 +180,20 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       target_id: targetId,
       tab_id: tab.tabId,
       url,
+      owner_session_id: registry.ownerOf(tab.tabId),
+      visible: registry.surfacingFor(tab.tabId) === "foreground",
     };
   }
 
-  function getBrowserTab(tabId = activeBrowserTabId) {
+  function getBrowserTab(tabId = registry.onScreenTabId()) {
     return tabId ? browserTabs.get(tabId) ?? null : null;
+  }
+
+  function tabForView(view) {
+    for (const tab of browserTabs.values()) {
+      if (tab.view === view) return tab;
+    }
+    return null;
   }
 
   function getActiveBrowserView() {
@@ -208,12 +231,14 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       status: isLoading ? "loading" : "ready",
       canGoBack: webContents.canGoBack(),
       canGoForward: webContents.canGoForward(),
+      ownerSessionId: registry.ownerOf(tabId),
     };
   }
 
   function listBrowserTabs() {
-    return browserTabOrder
-      .map((tabId) => {
+    return registry
+      .list()
+      .map(({ tabId }) => {
         const tab = browserTabs.get(tabId);
         if (!tab || tab.view.webContents.isDestroyed()) return null;
         return browserTabToPanelTab(tabId, tab);
@@ -223,7 +248,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
 
   function browserStatePayload() {
     return {
-      activeTabId: activeBrowserTabId,
+      activeTabId: registry.onScreenTabId(),
+      activeTabIdByOwner: registry.activeTabIdByOwner(),
+      visibleSessionId: registry.visibleSessionId(),
       tabs: listBrowserTabs(),
     };
   }
@@ -475,7 +502,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     callback(browserProxy.username, browserProxy.password);
   });
 
-  function createBrowserTab(url = "about:blank", { select = true, initializeBlank = true } = {}) {
+  function createBrowserTab(url = "about:blank", { select = true, initializeBlank = true, ownerSessionId = null } = {}) {
     const tabId = createBrowserTabId();
     const view = new WebContentsView({
       webPreferences: {
@@ -487,9 +514,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         partition: BROWSER_SESSION_PARTITION,
       },
     });
-    const tab = { tabId, view, favicon: null };
+    const tab = { tabId, view, favicon: null, background: false };
     browserTabs.set(tabId, tab);
-    browserTabOrder.push(tabId);
+    registry.add({ tabId, ownerSessionId });
     // Load about:blank immediately to preempt persistent-session restore.
     // Cookies live on the session object, not the document — they survive this.
     // Callers that load their own page synchronously opt out, because this
@@ -526,17 +553,24 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         }, 200);
         return;
       }
-      // Agent-driven CDP navigation can target a background tab whose view is
-      // detached. Bring that tab on screen, otherwise navigation "succeeds"
-      // while the visible tab stays on about:blank (#2015).
-      if (activeBrowserTabId !== tabId) {
+      // Agent-driven CDP navigation can target a tab whose view is detached.
+      // If the tab's conversation is on screen, bring the tab on screen,
+      // otherwise navigation "succeeds" while the visible tab stays on
+      // about:blank (#2015). A tab that belongs to another conversation only
+      // becomes that conversation's active tab: it must never steal the
+      // screen from what the user is reading.
+      const surfacing = registry.surfacingFor(tabId);
+      if (surfacing === "foreground" && registry.onScreenTabId() !== tabId) {
         try {
           selectBrowserTab(tabId);
         } catch {
           // The tab may be mid-close; the panel-opened event below still fires.
         }
+      } else if (surfacing === "background") {
+        registry.select(tabId);
+        sendBrowserState();
       }
-      sendToRenderer("openwork:browser:panel-opened");
+      sendToRenderer("openwork:browser:panel-opened", { ownerSessionId: registry.ownerOf(tabId) });
     });
     view.webContents.on("did-navigate", () => sendBrowserState());
     view.webContents.on("did-navigate-in-page", () => sendBrowserState());
@@ -550,11 +584,15 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     view.webContents.on("focus", () => resetViewportEmulation(view));
     view.webContents.once("destroyed", () => {
       browserTabs.delete(tabId);
-      browserTabOrder = browserTabOrder.filter((id) => id !== tabId);
-      if (activeBrowserTabId === tabId) activeBrowserTabId = browserTabOrder[0] ?? null;
+      registry.remove(tabId);
       sendBrowserState();
     });
-    if (select || !activeBrowserTabId) {
+    if (registry.surfacingFor(tabId) === "background") {
+      // Silent: the owner is not on screen. Keep the page real while unseen.
+      if (select) registry.select(tabId);
+      enterBackgroundMode(tab);
+      sendBrowserState();
+    } else if (select || !registry.onScreenTabId()) {
       selectBrowserTab(tabId);
     } else {
       sendBrowserState();
@@ -576,6 +614,76 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     } catch {
       // already removed
     }
+  }
+
+  // A tab whose conversation is not on screen must still behave like a real
+  // page for the agent driving it: lay out at a real viewport, accept typing as
+  // a focused page, and paint so CDP screenshots work. Chromium only paints a
+  // page it considers visible, so the view keeps a one-pixel presence in the
+  // window corner (under the rounded-corner mask) while a DevTools session of
+  // ours emulates a full viewport and focus. Both are undone when the tab
+  // returns to the screen. This is the headless-browser recipe applied to a
+  // headful window.
+  function enterBackgroundMode(tab) {
+    if (!tab || tab.background) return;
+    const webContents = tab.view.webContents;
+    if (webContents.isDestroyed()) return;
+    tab.background = true;
+    const mainWindow = window();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (!mainWindow.contentView.children.includes(tab.view)) {
+        mainWindow.contentView.addChildView(tab.view);
+      }
+      tab.view.setBounds({ ...BACKGROUND_TAB_PRESENCE_BOUNDS });
+    }
+    const cdp = webContents.debugger;
+    runDetachedTask("emulate background browser tab", async () => {
+      if (webContents.isDestroyed() || !tab.background) return;
+      if (!cdp.isAttached()) cdp.attach("1.3");
+      for (const { method, params } of backgroundTabEmulationCommands()) {
+        if (!tab.background) return;
+        await cdp.sendCommand(method, params);
+      }
+    });
+  }
+
+  function exitBackgroundMode(tab) {
+    if (!tab || !tab.background) return;
+    tab.background = false;
+    const webContents = tab.view.webContents;
+    detachBrowserView(tab.view);
+    if (webContents.isDestroyed()) return;
+    const cdp = webContents.debugger;
+    if (!cdp.isAttached()) return;
+    runDetachedTask("restore foreground browser tab", async () => {
+      try {
+        for (const { method, params } of foregroundTabEmulationCommands()) {
+          if (webContents.isDestroyed()) return;
+          await cdp.sendCommand(method, params);
+        }
+      } finally {
+        if (!webContents.isDestroyed() && cdp.isAttached()) cdp.detach();
+      }
+    });
+  }
+
+  /** Re-evaluate every tab after the on-screen conversation changed. */
+  function applySurfacing() {
+    for (const tab of browserTabs.values()) {
+      if (registry.surfacingFor(tab.tabId) === "background") enterBackgroundMode(tab);
+      else exitBackgroundMode(tab);
+    }
+  }
+
+  function setVisibleSession(sessionId) {
+    const previous = registry.visibleSessionId();
+    const next = registry.setVisibleSession(sessionId);
+    if (next === previous) return next;
+    hideMenuOverlay();
+    applySurfacing();
+    attachActiveBrowserView();
+    sendBrowserState();
+    return next;
   }
 
   // The renderer reports bounds in CSS pixels, which Electron scales by the main
@@ -620,6 +728,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   function resetViewportEmulation(view) {
     const webContents = view?.webContents;
     if (!webContents || webContents.isDestroyed()) return;
+    // A background tab's viewport is ours on purpose; it is restored when the
+    // tab comes back on screen.
+    if (tabForView(view)?.background) return;
     const cdp = webContents.debugger;
     if (cdp.isAttached()) return;
     runDetachedTask("reset browser viewport emulation", async () => {
@@ -638,56 +749,62 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     });
   }
 
+  /** Detach every view that is neither on screen nor a background presence. */
+  function detachIdleBrowserViews(keepView = null) {
+    for (const tab of browserTabs.values()) {
+      if (tab.view !== keepView && !tab.background) detachBrowserView(tab.view);
+    }
+  }
+
   function attachActiveBrowserView() {
     const mainWindow = window();
     if (!mainWindow || !browserViewVisible) return;
-    const view = getActiveBrowserView();
-    if (!view) return;
-    for (const tab of browserTabs.values()) {
-      if (tab.view !== view) detachBrowserView(tab.view);
-    }
-    if (!mainWindow.contentView.children.includes(view)) {
-      mainWindow.contentView.addChildView(view);
+    const tab = getBrowserTab();
+    if (!tab) return;
+    exitBackgroundMode(tab);
+    detachIdleBrowserViews(tab.view);
+    if (!mainWindow.contentView.children.includes(tab.view)) {
+      mainWindow.contentView.addChildView(tab.view);
     }
     if (lastBrowserBounds && lastBrowserBounds.width > 0 && lastBrowserBounds.height > 0) {
-      view.setBounds(scaleRendererBounds(lastBrowserBounds));
+      tab.view.setBounds(scaleRendererBounds(lastBrowserBounds));
     }
   }
 
   function selectBrowserTab(tabId) {
-    if (!browserTabs.has(tabId)) throw new Error(`Unknown browser tab: ${tabId}`);
+    const tab = browserTabs.get(tabId);
+    if (!tab) throw new Error(`Unknown browser tab: ${tabId}`);
     hideMenuOverlay();
     const previousView = getActiveBrowserView();
-    activeBrowserTabId = tabId;
-    if (previousView && previousView !== getActiveBrowserView()) {
-      detachBrowserView(previousView);
+    registry.select(tabId);
+    if (registry.surfacingFor(tabId) === "foreground") {
+      if (previousView && previousView !== tab.view && !tabForView(previousView)?.background) {
+        detachBrowserView(previousView);
+      }
+      attachActiveBrowserView();
     }
-    attachActiveBrowserView();
     sendBrowserState();
-    return getBrowserTab(tabId);
+    return tab;
   }
 
-  function closeBrowserTab(tabId = activeBrowserTabId) {
+  function closeBrowserTab(tabId = registry.onScreenTabId()) {
     const tab = getBrowserTab(tabId);
     if (!tab) return null;
     if (menuOverlayRequest?.tabId === tabId) hideMenuOverlay();
-    const closingIndex = browserTabOrder.indexOf(tabId);
-    const wasActive = activeBrowserTabId === tabId;
+    const wasOnScreen = registry.onScreenTabId() === tabId;
+    tab.background = false;
     detachBrowserView(tab.view);
     browserTabs.delete(tabId);
-    browserTabOrder = browserTabOrder.filter((id) => id !== tabId);
-    if (wasActive) {
-      const nextTabId =
-        browserTabOrder[Math.min(closingIndex, browserTabOrder.length - 1)] ??
-        browserTabOrder[closingIndex - 1] ??
-        null;
-      activeBrowserTabId = nextTabId;
-      if (nextTabId) {
+    const removed = registry.remove(tabId);
+    if (wasOnScreen) {
+      if (registry.onScreenTabId()) {
         attachActiveBrowserView();
       } else {
         hideBrowserView();
-        sendToRenderer("openwork:browser:panel-closed");
       }
+    }
+    if (removed && !removed.ownerHasTabs) {
+      sendToRenderer("openwork:browser:panel-closed", { ownerSessionId: removed.tab.ownerSessionId });
     }
     try { tab.view.webContents.close(); } catch { /* already destroyed */ }
     sendBrowserState();
@@ -695,37 +812,29 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   }
 
   function closeAllBrowserTabs() {
-    const closedTabIds = [...browserTabOrder];
+    const closedTabIds = registry.list().map((tab) => tab.tabId);
     if (closedTabIds.length === 0) return [];
     hideMenuOverlay();
     const tabsToClose = closedTabIds
       .map((tabId) => browserTabs.get(tabId))
       .filter(Boolean);
+    const owners = new Set(closedTabIds.map((tabId) => registry.ownerOf(tabId)));
+    for (const tab of tabsToClose) tab.background = false;
     hideBrowserView();
     browserTabs.clear();
-    browserTabOrder = [];
-    activeBrowserTabId = null;
+    registry.clear();
     for (const tab of tabsToClose) {
       try { tab.view.webContents.close(); } catch { /* already destroyed */ }
     }
-    sendToRenderer("openwork:browser:panel-closed");
+    for (const ownerSessionId of owners) {
+      sendToRenderer("openwork:browser:panel-closed", { ownerSessionId });
+    }
     sendBrowserState();
     return closedTabIds;
   }
 
   function reorderBrowserTabs(tabIds) {
-    const nextOrder = Array.isArray(tabIds) ? tabIds.map(String) : [];
-    if (nextOrder.length !== browserTabOrder.length) {
-      throw new Error("Tab order must include every open tab.");
-    }
-    if (new Set(nextOrder).size !== nextOrder.length) {
-      throw new Error("Tab order must not contain duplicate tabs.");
-    }
-    const current = new Set(browserTabOrder);
-    if (nextOrder.some((tabId) => !current.has(tabId))) {
-      throw new Error("Tab order contains an unknown tab.");
-    }
-    browserTabOrder = nextOrder;
+    registry.reorder(tabIds);
     sendBrowserState();
     return listBrowserTabs();
   }
@@ -740,12 +849,19 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
    * @param {object} [opts]
    * @param {boolean} [opts.preloadDefault=false] - load default URL if the view has no URL
    * @param {boolean} [opts.ensureTab=false] - create a blank tab if needed
+   * @param {string | null} [opts.sessionId] - the conversation whose panel is showing
    */
-  function attachBrowserView(bounds, { preloadDefault = false, ensureTab = false } = {}) {
+  function attachBrowserView(bounds, { preloadDefault = false, ensureTab = false, sessionId } = {}) {
     if (!window()) return;
     lastBrowserBounds = bounds;
     browserViewVisible = true;
-    if (ensureTab && !activeBrowserTabId) createBrowserTab("about:blank");
+    if (sessionId !== undefined) {
+      const previous = registry.visibleSessionId();
+      if (registry.setVisibleSession(sessionId) !== previous) applySurfacing();
+    }
+    if (ensureTab && !registry.onScreenTabId()) {
+      createBrowserTab("about:blank", { ownerSessionId: registry.visibleSessionId() });
+    }
     const view = getActiveBrowserView();
     attachActiveBrowserView();
     if (bounds.width > 0 && bounds.height > 0) {
@@ -763,9 +879,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     hideMenuOverlay();
     browserViewVisible = false;
     if (!window()) return;
-    for (const tab of browserTabs.values()) {
-      detachBrowserView(tab.view);
-    }
+    detachIdleBrowserViews();
   }
 
   function destroyBrowserView() {
@@ -775,21 +889,34 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     menuOverlayRequest = null;
     try { overlayView?.webContents.close(); } catch { /* already destroyed */ }
     for (const tab of browserTabs.values()) {
+      tab.background = false;
+      detachBrowserView(tab.view);
       try { tab.view.webContents.close(); } catch { /* already destroyed */ }
     }
     browserTabs.clear();
-    browserTabOrder = [];
-    activeBrowserTabId = null;
+    registry.clear();
     lastBrowserBounds = null;
     sendBrowserState();
   }
 
+  function normalizeSessionId(value) {
+    return typeof value === "string" && value.trim() ? value : null;
+  }
+
   function registerIpc(ipcMain) {
-    ipcMain.handle("openwork:browser:show", (_event, bounds) => attachBrowserView(bounds));
+    ipcMain.handle("openwork:browser:show", (_event, bounds, sessionId) => (
+      attachBrowserView(bounds, sessionId === undefined ? {} : { sessionId: normalizeSessionId(sessionId) })
+    ));
     ipcMain.handle("openwork:browser:hide", () => hideBrowserView());
-    ipcMain.handle("openwork:browser:openUrl", (_event, url, provider) => openBrowserUrlForAutomation(url, provider));
+    ipcMain.handle("openwork:browser:setVisibleSession", (_event, sessionId) => setVisibleSession(normalizeSessionId(sessionId)));
+    ipcMain.handle("openwork:browser:openUrl", (_event, url, provider, options) => (
+      openBrowserUrlForAutomation(url, provider, {
+        ownerSessionId: normalizeSessionId(options && typeof options === "object" ? options.sessionId : null),
+      })
+    ));
     ipcMain.handle("openwork:browser:navigate", (_event, url) => {
-      const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true }).view;
+      const view = getActiveBrowserView()
+        ?? createBrowserTab("about:blank", { select: true, ownerSessionId: registry.visibleSessionId() }).view;
       runDetachedTask("navigate browser tab", () => view.webContents.loadURL(normalizeBrowserUrl(url)));
     });
     ipcMain.handle("openwork:browser:back", () => {
@@ -809,9 +936,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
       }
     });
     ipcMain.handle("openwork:browser:state", () => browserStatePayload());
-    ipcMain.handle("openwork:browser:createTab", (_event, url) => {
+    ipcMain.handle("openwork:browser:createTab", (_event, url, sessionId) => {
       const target = typeof url === "string" && url.trim() ? url : BROWSER_NEW_TAB_URL;
-      const tab = createBrowserTab(target, { select: true });
+      const ownerSessionId = sessionId === undefined ? registry.visibleSessionId() : normalizeSessionId(sessionId);
+      const tab = createBrowserTab(target, { select: true, ownerSessionId });
       return { tabId: tab.tabId };
     });
     ipcMain.handle("openwork:browser:closeTab", (_event, tabId) => closeBrowserTab(tabId == null ? undefined : String(tabId)));

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -67,13 +67,14 @@ const RESET_SEQUENCE = [
 
 function createPanel() {
   const children = [];
+  const sent = [];
   const mainWindow = {
     contentView: {
       children,
       addChildView(view) { children.push(view); },
       removeChildView(view) { children.splice(children.indexOf(view), 1); },
     },
-    webContents: { getZoomFactor: () => 1, isDestroyed: () => false, send() {} },
+    webContents: { getZoomFactor: () => 1, isDestroyed: () => false, send(channel, payload) { sent.push({ channel, payload }); } },
     isDestroyed: () => false,
   };
   const handlers = new Map();
@@ -83,9 +84,12 @@ function createPanel() {
   };
   createBrowserPanel({ getWindow: () => mainWindow, remoteDebugPort: 0, onDeepLink: () => {} }).registerIpc(ipcMain);
   const invoke = (channel, ...args) => handlers.get(channel)(null, ...args);
-  const onScreen = () => children[0] ?? null;
+  // The on-screen tab is the attached view with real panel bounds; background
+  // presences are attached too, but only ever one pixel large.
+  const onScreen = () => children.find((view) => view.getBounds().width > 1) ?? null;
   const commands = (view) => view.webContents.debugger.commands;
-  return { invoke, onScreen, commands };
+  const messages = (channel) => sent.filter((entry) => entry.channel === channel).map((entry) => entry.payload);
+  return { invoke, onScreen, commands, children, messages };
 }
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
@@ -160,4 +164,110 @@ test("agent navigation that brings a background tab on screen leaves its viewpor
 
   assert.equal(onScreen(), firstView, "the navigating tab is brought on screen");
   assert.deepEqual(commands(firstView), [], "a capture viewport set before navigating is preserved");
+});
+
+const BACKGROUND_SEQUENCE = [
+  { method: "Emulation.setDeviceMetricsOverride", params: { width: 1280, height: 800, deviceScaleFactor: 0, mobile: false } },
+  { method: "Emulation.setFocusEmulationEnabled", params: { enabled: true } },
+];
+const FOREGROUND_SEQUENCE = [
+  { method: "Emulation.setFocusEmulationEnabled", params: { enabled: false } },
+  { method: "Emulation.clearDeviceMetricsOverride", params: undefined },
+];
+
+test("a tab opened for a background conversation loads silently and leaves the visible conversation's tab on screen", async () => {
+  const { invoke, onScreen, commands, children, messages } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "https://a.example", "A");
+  const visibleView = onScreen();
+  await flush();
+  commands(visibleView).length = 0;
+
+  const { tabId } = invoke("openwork:browser:createTab", "https://b.example", "B");
+  await flush();
+
+  const state = invoke("openwork:browser:state");
+  const backgroundTab = state.tabs.find((tab) => tab.id === tabId);
+  const backgroundView = children.find((view) => view !== visibleView);
+  assert.equal(onScreen(), visibleView, "the visible conversation keeps its tab on screen");
+  assert.equal(state.activeTabId, state.tabs.find((tab) => tab.ownerSessionId === "A").id);
+  assert.equal(backgroundTab.ownerSessionId, "B");
+  assert.equal(state.activeTabIdByOwner.B, tabId, "the tab is B's active tab, ready for when B is opened");
+  assert.deepEqual(backgroundView.getBounds(), { x: 0, y: 0, width: 1, height: 1 }, "a one-pixel presence keeps the page painting");
+  assert.deepEqual(commands(backgroundView), BACKGROUND_SEQUENCE, "the page lays out and focuses like a visible one");
+  assert.equal(backgroundView.webContents.debugger.isAttached(), true, "our emulation session stays open while unseen");
+  assert.deepEqual(commands(visibleView), [], "the visible tab is untouched");
+  assert.deepEqual(messages("openwork:browser:panel-opened"), [], "no panel pops for a silent tab until it navigates");
+});
+
+test("navigating a background conversation's tab reports its owner instead of taking the screen", async () => {
+  const { invoke, onScreen, children, messages } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "https://a.example", "A");
+  const visibleView = onScreen();
+  invoke("openwork:browser:createTab", "https://b.example", "B");
+  const backgroundView = children.find((view) => view !== visibleView);
+  await flush();
+
+  backgroundView.webContents.emit("did-start-navigation", "https://b.example/next", false, true);
+  await flush();
+
+  assert.equal(onScreen(), visibleView, "A's tab stays on screen");
+  assert.deepEqual(messages("openwork:browser:panel-opened"), [{ ownerSessionId: "B" }]);
+});
+
+test("switching to the background conversation swaps its tab on screen and restores a normal viewport", async () => {
+  const { invoke, onScreen, commands, children } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "https://a.example", "A");
+  const aView = onScreen();
+  invoke("openwork:browser:createTab", "https://b.example", "B");
+  const bView = children.find((view) => view !== aView);
+  await flush();
+  commands(aView).length = 0;
+  commands(bView).length = 0;
+
+  invoke("openwork:browser:setVisibleSession", "B");
+  await flush();
+
+  assert.equal(onScreen(), bView, "B's tab takes the screen");
+  assert.deepEqual(bView.getBounds(), PANEL_BOUNDS);
+  assert.deepEqual(commands(bView), FOREGROUND_SEQUENCE, "B's emulation is undone before it is shown");
+  assert.equal(bView.webContents.debugger.isAttached(), false, "our session is released for the user-driven reset path");
+  assert.deepEqual(commands(aView), BACKGROUND_SEQUENCE, "A's tab now keeps painting in the background");
+  assert.deepEqual(aView.getBounds(), { x: 0, y: 0, width: 1, height: 1 });
+  const state = invoke("openwork:browser:state");
+  assert.equal(state.visibleSessionId, "B");
+  assert.equal(state.activeTabId, state.activeTabIdByOwner.B);
+});
+
+test("closing a conversation's last tab tells only that conversation its panel is empty", async () => {
+  const { invoke, onScreen, messages } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS, "A");
+  invoke("openwork:browser:createTab", "https://a.example", "A");
+  const aView = onScreen();
+  const { tabId } = invoke("openwork:browser:createTab", "https://b.example", "B");
+  await flush();
+
+  invoke("openwork:browser:closeTab", tabId);
+
+  assert.equal(onScreen(), aView, "A keeps browsing");
+  assert.deepEqual(messages("openwork:browser:panel-closed"), [{ ownerSessionId: "B" }]);
+  assert.deepEqual(invoke("openwork:browser:state").tabs.map((tab) => tab.ownerSessionId), ["A"]);
+});
+
+test("tabs created without a conversation stay shared and behave as before", async () => {
+  const { invoke, onScreen, messages } = createPanel();
+  invoke("openwork:browser:show", PANEL_BOUNDS);
+  invoke("openwork:browser:createTab", "https://shared.example");
+  await flush();
+
+  const state = invoke("openwork:browser:state");
+  assert.equal(state.tabs[0].ownerSessionId, null);
+  assert.ok(onScreen(), "a shared tab is on screen");
+
+  invoke("openwork:browser:setVisibleSession", "A");
+  assert.ok(onScreen(), "a shared tab stays on screen for every conversation");
+  invoke("openwork:browser:closeAllTabs");
+  assert.deepEqual(messages("openwork:browser:panel-closed"), [{ ownerSessionId: null }]);
 });

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -163,16 +163,17 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     },
   },
   browser: {
-    show(bounds) { return ipcRenderer.invoke("openwork:browser:show", bounds); },
+    show(bounds, sessionId) { return ipcRenderer.invoke("openwork:browser:show", bounds, sessionId); },
     hide() { return ipcRenderer.invoke("openwork:browser:hide"); },
-    openUrl(url, provider) { return ipcRenderer.invoke("openwork:browser:openUrl", url, provider); },
+    openUrl(url, provider, options) { return ipcRenderer.invoke("openwork:browser:openUrl", url, provider, options); },
+    setVisibleSession(sessionId) { return ipcRenderer.invoke("openwork:browser:setVisibleSession", sessionId); },
     navigate(url) { return ipcRenderer.invoke("openwork:browser:navigate", url); },
     back() { return ipcRenderer.invoke("openwork:browser:back"); },
     forward() { return ipcRenderer.invoke("openwork:browser:forward"); },
     reload() { return ipcRenderer.invoke("openwork:browser:reload"); },
     setBounds(bounds) { return ipcRenderer.invoke("openwork:browser:bounds", bounds); },
     getState() { return ipcRenderer.invoke("openwork:browser:state"); },
-    createTab(url) { return ipcRenderer.invoke("openwork:browser:createTab", url); },
+    createTab(url, sessionId) { return ipcRenderer.invoke("openwork:browser:createTab", url, sessionId); },
     closeTab(tabId) { return ipcRenderer.invoke("openwork:browser:closeTab", tabId); },
     closeAllTabs() { return ipcRenderer.invoke("openwork:browser:closeAllTabs"); },
     selectTab(tabId) { return ipcRenderer.invoke("openwork:browser:selectTab", tabId); },
@@ -188,12 +189,12 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
       return () => ipcRenderer.removeListener("openwork:browser:state", handler);
     },
     onPanelOpened(callback) {
-      const handler = () => callback();
+      const handler = (_event, payload) => callback(payload);
       ipcRenderer.on("openwork:browser:panel-opened", handler);
       return () => ipcRenderer.removeListener("openwork:browser:panel-opened", handler);
     },
     onPanelClosed(callback) {
-      const handler = () => callback();
+      const handler = (_event, payload) => callback(payload);
       ipcRenderer.on("openwork:browser:panel-closed", handler);
       return () => ipcRenderer.removeListener("openwork:browser:panel-closed", handler);
     },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.18.15",
+    "@openwork/browser-tabs": "workspace:*",
     "@openwork/enterprise-mcp-client": "workspace:*",
     "@openwork/headless-threads": "workspace:*",
     "@openwork/paths": "workspace:*",

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -702,6 +702,26 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(bridge.commands).toEqual([]);
   });
 
+  test("stamps the requesting conversation on UI commands so the app acts for that thread, not the one on screen", async () => {
+    const bridge = await startFakeUiBridge();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
+
+    await plugin.tool.openwork_execute.execute({
+      id: "browser.open_url",
+      args: { url: "https://example.com" },
+      // An agent cannot claim to be another conversation.
+      origin: { sessionId: "ses_spoofed" },
+    }, { sessionID: "ses_origin", workspaceId: "ws_2" });
+
+    expect(bridge.commands.map((command) => command.body)).toEqual([
+      {
+        id: "browser.open_url",
+        args: { url: "https://example.com" },
+        origin: { sessionId: "ses_origin", workspaceId: "ws_2" },
+      },
+    ]);
+  });
+
   test("reports a created session as failed when its native prompt does not start", async () => {
     const fake = startFakeOpenWorkServer({ failPromptText: "Fail this prompt." });
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -498,11 +498,21 @@ async function executeOpenworkAffordance(
   }
   const result = await uiBridgeRequest("/command", {
     method: "POST",
-    body: request,
+    // Stamp the requesting conversation so UI commands act for the agent's own
+    // thread (its browser tabs, its panel) rather than whichever thread is on
+    // screen. The agent never supplies this; it comes from the tool context.
+    body: { ...request, ...affordanceOrigin(context) },
   });
   return isRecord(result) && typeof result.ok === "boolean"
     ? result
     : unavailableAffordance(request.id, "OpenWork UI command returned an invalid response.");
+}
+
+function affordanceOrigin(context: OpenCodeContext): { origin?: { sessionId: string; workspaceId?: string } } {
+  const sessionId = context.sessionID?.trim();
+  if (!sessionId) return {};
+  const workspaceId = (context.workspaceId ?? context.workspaceID)?.trim();
+  return { origin: { sessionId, ...(workspaceId ? { workspaceId } : {}) } };
 }
 
 function collapseWhitespace(value: string): string {

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "vitest";
+import type { Target } from "@openwork/cdp";
+import { eventually, spec } from "@openwork/testkit";
+import { builtinBrowserWorld } from "../worlds/browser-panel.ts";
+
+const test = spec.world(builtinBrowserWorld);
+
+// A user reads one conversation while another conversation's agent browses the
+// web. The browser tab belongs to the conversation whose agent opened it: it
+// must never pop into the conversation on screen, yet the agent must still be
+// able to read, click, type, and screenshot the hidden page. Switching to the
+// owning conversation shows its page already loaded.
+const tabButton = (name: string): Target => ({ role: "button", label: new RegExp(`^Select tab: .*viewport-probe=${name}$`) });
+// The desktop lays a hidden conversation's tab out at this viewport (see
+// @openwork/browser-tabs) so the agent sees a desktop-sized page.
+const BACKGROUND_TAB_VIEWPORT = { width: 1280, height: 800 };
+
+test("a background conversation's agent browses silently and its page is waiting when the user switches to it", async ({ world, user, step }) => {
+  const reading = world.session;
+  const researching = await world.openSession("Background research");
+  await world.showSession(reading.sessionId);
+  const readingTab = await world.openTabAs("reading", reading.sessionId);
+  await user.see(tabButton(readingTab.name), { timeoutMs: 30_000 });
+  const panelViewport = await world.readViewport(readingTab);
+  expect(panelViewport.width).toBeGreaterThan(0);
+  expect(panelViewport.width).toBeLessThan(BACKGROUND_TAB_VIEWPORT.width);
+
+  const researchTab = await step("The background conversation opens a page without touching the screen", async () => {
+    const opened = await world.openTabAs("research", researching.sessionId);
+    expect(opened).toMatchObject({ ownerSessionId: researching.sessionId, visible: false });
+
+    const state = await world.readBrowserState();
+    expect(state.visibleSessionId).toBe(reading.sessionId);
+    expect(state.activeTabId).toBe(readingTab.tabId);
+    expect(state.tabs.find((tab) => tab.id === opened.tabId)?.ownerSessionId).toBe(researching.sessionId);
+    await user.see(tabButton(readingTab.name));
+    await user.notSee(tabButton(opened.name));
+    expect(await world.readViewport(readingTab)).toEqual(panelViewport);
+    return opened;
+  });
+
+  await step("The hidden page is real for the agent: viewport, focus, clicks, typing, screenshot", async () => {
+    const probe = await eventually(() => world.readPageProbe(researchTab), {
+      within: 15_000,
+      until: (value) => value.width === BACKGROUND_TAB_VIEWPORT.width && value.hasFocus,
+      label: "background tab lays out at the background viewport and believes it is focused",
+    });
+    expect(probe).toMatchObject({ ...BACKGROUND_TAB_VIEWPORT, hasFocus: true });
+
+    await world.loadInputProbe(researchTab);
+    expect(await world.clickAndType(researchTab, "ok")).toEqual({ clicks: 1, value: "ok" });
+
+    const screenshot = await world.screenshotSize(researchTab);
+    expect(screenshot.width).toBeGreaterThanOrEqual(BACKGROUND_TAB_VIEWPORT.width);
+    expect(screenshot.height).toBeGreaterThanOrEqual(BACKGROUND_TAB_VIEWPORT.height);
+  });
+
+  await step("Switching to the background conversation shows its page at the panel's size", async () => {
+    await world.showSession(researching.sessionId);
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: (value) => value.visibleSessionId === researching.sessionId && value.activeTabId === researchTab.tabId,
+      label: "the research conversation's tab takes the screen",
+    });
+    expect(state.tabs.map((tab) => tab.ownerSessionId).sort()).toEqual([reading.sessionId, researching.sessionId].sort());
+    await user.notSee(tabButton(readingTab.name));
+
+    const restored = await eventually(() => world.readViewport(researchTab), {
+      within: 15_000,
+      until: (viewport) => viewport.width === panelViewport.width,
+      label: "the shown tab lays out for the panel again",
+    });
+    expect(restored).toEqual(panelViewport);
+  });
+
+  await step("Returning to the first conversation brings back only its own tab", async () => {
+    await world.showSession(reading.sessionId);
+    await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: (value) => value.visibleSessionId === reading.sessionId && value.activeTabId === readingTab.tabId,
+      label: "the reading conversation's tab is back on screen",
+    });
+    await user.see(tabButton(readingTab.name), { timeoutMs: 30_000 });
+    expect(await world.readViewport(readingTab)).toEqual(panelViewport);
+  });
+});

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -11,14 +11,17 @@ const test = spec.world(builtinBrowserWorld);
 // able to read, click, type, and screenshot the hidden page. Switching to the
 // owning conversation shows its page already loaded.
 const tabButton = (name: string): Target => ({ role: "button", label: new RegExp(`^Select tab: .*viewport-probe=${name}$`) });
+// A conversation's row in the sidebar, found by the title the user reads there.
+const conversation = (title: string): Target => ({ text: title });
 // The desktop lays a hidden conversation's tab out at this viewport (see
 // @openwork/browser-tabs) so the agent sees a desktop-sized page.
 const BACKGROUND_TAB_VIEWPORT = { width: 1280, height: 800 };
 
 test("a background conversation's agent browses silently and its page is waiting when the user switches to it", async ({ world, user, step }) => {
-  const reading = world.session;
+  const reading = { ...world.session, title: "Reading the news" };
+  await world.renameSession(reading.sessionId, reading.title);
   const researching = await world.openSession("Background research");
-  await world.showSession(reading.sessionId);
+  await user.click(conversation(reading.title));
   const readingTab = await world.openTabAs("reading", reading.sessionId);
   await user.see(tabButton(readingTab.name), { timeoutMs: 30_000 });
   const panelViewport = await world.readViewport(readingTab);
@@ -56,7 +59,7 @@ test("a background conversation's agent browses silently and its page is waiting
   });
 
   await step("Switching to the background conversation shows its page at the panel's size", async () => {
-    await world.showSession(researching.sessionId);
+    await user.click(conversation(researching.title));
     const state = await eventually(() => world.readBrowserState(), {
       within: 30_000,
       until: (value) => value.visibleSessionId === researching.sessionId && value.activeTabId === researchTab.tabId,
@@ -74,7 +77,7 @@ test("a background conversation's agent browses silently and its page is waiting
   });
 
   await step("Returning to the first conversation brings back only its own tab", async () => {
-    await world.showSession(reading.sessionId);
+    await user.click(conversation(reading.title));
     await eventually(() => world.readBrowserState(), {
       within: 30_000,
       until: (value) => value.visibleSessionId === reading.sessionId && value.activeTabId === readingTab.tabId,

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -136,7 +136,15 @@ export async function builtinBrowserWorld(seed: Seed) {
       return seed.session(app, { title });
     },
 
-    /** Bring a conversation on screen, as the user does from the sidebar. */
+    /** Give a conversation a stable title so a spec can find it in the sidebar. */
+    async renameSession(sessionId: string, title: string): Promise<void> {
+      await control(app, "session.rename", { sessionId, title });
+    },
+
+    /**
+     * Bring a conversation on screen programmatically. Arrangement only: a
+     * claim about the user switching conversations must click the sidebar.
+     */
     async showSession(sessionId: string): Promise<void> {
       await control(app, "session.open", { sessionId });
     },

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -1,4 +1,5 @@
-import { connect, debuggerUrlFor, evaluate, listTargets } from "@openwork/cdp";
+import { control } from "@openwork/behaviors";
+import { captureScreenshot, connect, debuggerUrlFor, evaluate, listTargets, navigate } from "@openwork/cdp";
 import type { CdpClient, Surface } from "@openwork/cdp";
 import type { Seed } from "@openwork/env";
 
@@ -12,6 +13,61 @@ export interface BuiltinBrowserTab {
 export interface Viewport {
   width: number;
   height: number;
+}
+
+/** What the page inside a tab experiences: its viewport and whether it believes it is focused. */
+export interface PageProbe extends Viewport {
+  hasFocus: boolean;
+}
+
+export interface BrowserTabState {
+  id: string;
+  label: string;
+  ownerSessionId: string | null;
+}
+
+export interface BrowserState {
+  activeTabId: string | null;
+  visibleSessionId: string | null;
+  tabs: BrowserTabState[];
+}
+
+export interface OpenedTab extends BuiltinBrowserTab {
+  ownerSessionId: string | null;
+  visible: boolean;
+}
+
+/**
+ * A page with a full-window button and a text field, so a spec can prove a
+ * tab accepts real clicks and typing. Loaded over CDP the way an agent
+ * navigates; the marker-style `data:` URL never surfaces a panel.
+ */
+export const INPUT_PROBE_PAGE = `data:text/html;charset=utf-8,${encodeURIComponent(
+  '<!doctype html><title>input-probe</title>'
+  + '<body style="margin:0"><button id="hit" style="position:fixed;inset:0 0 50% 0;font-size:24px">hit</button>'
+  + '<input id="field" style="position:fixed;top:60%;left:10px;width:300px;font-size:24px">'
+  + '<script>window.__clicks=0;document.getElementById("hit").addEventListener("click",()=>{window.__clicks+=1});</script>',
+)}`;
+
+function pngSize(png: Buffer): Viewport {
+  if (png.length < 24 || png.toString("ascii", 1, 4) !== "PNG") throw new Error("Screenshot is not a PNG.");
+  return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
+}
+
+function parseBrowserState(value: unknown): BrowserState {
+  if (!isRecord(value) || !Array.isArray(value.tabs)) throw new Error("The desktop bridge did not report browser state.");
+  return {
+    activeTabId: typeof value.activeTabId === "string" ? value.activeTabId : null,
+    visibleSessionId: typeof value.visibleSessionId === "string" ? value.visibleSessionId : null,
+    tabs: value.tabs.map((tab) => {
+      if (!isRecord(tab)) throw new Error("Browser state listed a malformed tab.");
+      return {
+        id: stringField(tab.id),
+        label: stringField(tab.label),
+        ownerSessionId: typeof tab.ownerSessionId === "string" ? tab.ownerSessionId : null,
+      };
+    }),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -52,6 +108,14 @@ function parseViewport(value: unknown): Viewport {
   return { width: value.width, height: value.height };
 }
 
+function parsePageProbe(value: unknown): PageProbe {
+  const viewport = parseViewport(value);
+  if (!isRecord(value) || typeof value.hasFocus !== "boolean") {
+    throw new Error("The built-in browser tab did not report its focus state.");
+  }
+  return { ...viewport, hasFocus: value.hasFocus };
+}
+
 /**
  * A desktop with one session open, so the built-in browser side panel has a
  * home, plus helpers that play an automation client against its tabs.
@@ -67,6 +131,16 @@ export async function builtinBrowserWorld(seed: Seed) {
     workspace,
     session,
 
+    /** Create another conversation in the same workspace; the app shows it. */
+    async openSession(title: string): Promise<{ sessionId: string; title: string }> {
+      return seed.session(app, { title });
+    },
+
+    /** Bring a conversation on screen, as the user does from the sidebar. */
+    async showSession(sessionId: string): Promise<void> {
+      await control(app, "session.open", { sessionId });
+    },
+
     /** Open a page in the built-in browser the way the agent's browser tool does. */
     async openTab(name: string): Promise<BuiltinBrowserTab> {
       const url = `${origin}/?viewport-probe=${encodeURIComponent(name)}`;
@@ -81,6 +155,87 @@ export async function builtinBrowserWorld(seed: Seed) {
         targetId: stringField(result.target_id),
         name,
       };
+    },
+
+    /**
+     * Open a page the way an agent in a given conversation does: the request
+     * reaches the UI command bus stamped with that conversation as its origin,
+     * exactly as the OpenWork bridge stamps `openwork_execute` calls.
+     */
+    async openTabAs(name: string, ownerSessionId: string): Promise<OpenedTab> {
+      const url = `${origin}/?viewport-probe=${encodeURIComponent(name)}`;
+      const result = await seed.evalIn(
+        app,
+        `window.__openworkControl.command(${JSON.stringify({
+          id: "browser.open_url",
+          args: { url, provider: "builtin" },
+          origin: { sessionId: ownerSessionId },
+        })})`,
+        { awaitPromise: true, timeoutMs: 30_000 },
+      );
+      if (!isRecord(result) || result.ok !== true || !isRecord(result.result)) {
+        throw new Error(`browser.open_url failed: ${isRecord(result) ? String(result.error ?? "unknown") : "no response"}`);
+      }
+      const handle = result.result;
+      return {
+        tabId: stringField(handle.tab_id),
+        targetId: stringField(handle.target_id),
+        name,
+        ownerSessionId: typeof handle.owner_session_id === "string" ? handle.owner_session_id : null,
+        visible: handle.visible === true,
+      };
+    },
+
+    /** Every tab the native browser holds, who owns it, and which conversation is on screen. */
+    async readBrowserState(): Promise<BrowserState> {
+      return parseBrowserState(await seed.evalIn(
+        app,
+        "window.__OPENWORK_ELECTRON__.browser.getState()",
+        { awaitPromise: true },
+      ));
+    },
+
+    /** The viewport a tab lays out for and whether its page believes it has focus. */
+    async readPageProbe(tab: BuiltinBrowserTab): Promise<PageProbe> {
+      return withTabClient(app, tab.targetId, async (client) => parsePageProbe(
+        await evaluate(client, "({ width: window.innerWidth, height: window.innerHeight, hasFocus: document.hasFocus() })"),
+      ));
+    },
+
+    /** A CDP screenshot of the tab, as the agent's browser_screenshot tool takes it. */
+    async screenshotSize(tab: BuiltinBrowserTab): Promise<Viewport> {
+      return withTabClient(app, tab.targetId, async (client) => pngSize(await captureScreenshot(client)));
+    },
+
+    /** Navigate a tab over CDP to the input probe page and wait for it. */
+    async loadInputProbe(tab: BuiltinBrowserTab): Promise<void> {
+      await withTabClient(app, tab.targetId, async (client) => {
+        await navigate(client, INPUT_PROBE_PAGE);
+        const deadline = Date.now() + 15_000;
+        while (Date.now() < deadline) {
+          if ((await evaluate(client, "document.title")) === "input-probe") return;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        throw new Error("The input probe page did not load in the built-in browser tab.");
+      });
+    },
+
+    /** Click the probe page's button and type into its field the way the agent's tools do. */
+    async clickAndType(tab: BuiltinBrowserTab, text: string): Promise<{ clicks: number; value: string }> {
+      return withTabClient(app, tab.targetId, async (client) => {
+        await client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: 100, y: 100, button: "left", clickCount: 1 });
+        await client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: 100, y: 100, button: "left", clickCount: 1 });
+        await evaluate(client, "document.getElementById('field').focus()");
+        for (const char of text) {
+          await client.send("Input.dispatchKeyEvent", { type: "keyDown", text: char });
+          await client.send("Input.dispatchKeyEvent", { type: "keyUp", text: char });
+        }
+        const result = await evaluate(client, "({ clicks: window.__clicks, value: document.getElementById('field').value })");
+        if (!isRecord(result) || typeof result.clicks !== "number" || typeof result.value !== "string") {
+          throw new Error("The input probe page did not report clicks and typed text.");
+        }
+        return { clicks: result.clicks, value: result.value };
+      });
     },
 
     /**

--- a/packages/browser-tabs/README.md
+++ b/packages/browser-tabs/README.md
@@ -1,0 +1,28 @@
+# @openwork/browser-tabs
+
+The policy layer for OpenWork's built-in browser. The desktop app has one
+native browser surface shared by every conversation, but each tab belongs to
+the conversation that opened it. This package decides, without Electron or
+React:
+
+- **Ownership** — which conversation a tab belongs to, and which tab is active
+  for each conversation (`createBrowserTabRegistry`).
+- **Surfacing** — whether a tab may take the screen right now (`foreground`)
+  or must stay silent because its conversation is not the one on screen
+  (`background`).
+- **Background rendering** — the recipe that keeps a hidden tab behaving like
+  a real page for the agent driving it: a full emulated viewport, focus
+  emulation, and a one-pixel on-window presence so Chromium keeps painting
+  (`backgroundTabEmulationCommands`, `BACKGROUND_TAB_PRESENCE_BOUNDS`).
+- **What a conversation sees** — the renderer-side filters that give each
+  side panel only its own tabs (`browserTabsForSession`,
+  `activeBrowserTabIdForSession`).
+
+Consumers: `apps/desktop/electron/browser-panel.mjs` (main process) and the
+session side panel in `apps/app`. The shared IPC shapes (`BrowserPanelTab`,
+`BrowserStatePayload`, `OpenBrowserUrlResult`) live in `index.d.ts`.
+
+Run `bun test` here for the policy tests; `apps/desktop/electron/browser-panel.test.mjs`
+covers the Electron wiring with a stubbed `WebContentsView`, and
+`evals/specs/browser-tabs-owned-by-thread.e2e.test.ts` proves the user journey
+on the real app.

--- a/packages/browser-tabs/index.d.ts
+++ b/packages/browser-tabs/index.d.ts
@@ -1,0 +1,103 @@
+export type BrowserTabSurfacing = "foreground" | "background";
+
+export type CdpCommand = {
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+export type Bounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type Viewport = {
+  width: number;
+  height: number;
+};
+
+/** Browser tab state mirrored across the desktop IPC bridge. */
+export type BrowserPanelTab = {
+  id: string;
+  type: "browser";
+  label: string;
+  url: string;
+  favicon: string | null;
+  status: "loading" | "ready";
+  canGoBack: boolean;
+  canGoForward: boolean;
+  /** Conversation (session) that opened the tab; null for shared/legacy tabs. */
+  ownerSessionId: string | null;
+};
+
+export type BrowserStatePayload = {
+  /** The tab currently on screen, if any. */
+  activeTabId?: string | null;
+  /** Active tab per owner session id (or `SHARED_OWNER_KEY`). */
+  activeTabIdByOwner?: Record<string, string>;
+  /** The conversation whose tabs may take the screen. */
+  visibleSessionId?: string | null;
+  tabs?: BrowserPanelTab[];
+};
+
+export type BrowserPanelOwnerPayload = {
+  ownerSessionId: string | null;
+};
+
+export type OpenBrowserUrlResult = {
+  provider: "builtin";
+  browser_url: string;
+  target_id: string;
+  tab_id: string;
+  url: string;
+  owner_session_id: string | null;
+  /** False when the tab loads silently for a conversation that is not on screen. */
+  visible: boolean;
+};
+
+export type RegistryTab = {
+  tabId: string;
+  ownerSessionId: string | null;
+};
+
+export type RemovedRegistryTab = {
+  tab: RegistryTab;
+  wasActive: boolean;
+  nextActiveTabId: string | null;
+  ownerHasTabs: boolean;
+};
+
+export type BrowserTabRegistry = {
+  add(tab: { tabId: string; ownerSessionId?: string | null }): RegistryTab;
+  select(tabId: string): RegistryTab;
+  remove(tabId: string): RemovedRegistryTab | null;
+  reorder(tabIds: string[]): RegistryTab[];
+  get(tabId: string): RegistryTab | null;
+  has(tabId: string): boolean;
+  list(): RegistryTab[];
+  tabsFor(ownerSessionId: string | null | undefined): RegistryTab[];
+  ownerOf(tabId: string): string | null;
+  surfacingFor(tabId: string): BrowserTabSurfacing | null;
+  setVisibleSession(sessionId: string | null | undefined): string | null;
+  visibleSessionId(): string | null;
+  onScreenTabId(): string | null;
+  activeTabIdFor(ownerSessionId: string | null | undefined): string | null;
+  activeTabIdByOwner(): Record<string, string>;
+  clear(): void;
+  size(): number;
+};
+
+export const SHARED_OWNER_KEY: "*";
+export const BACKGROUND_TAB_VIEWPORT: Readonly<Viewport>;
+export const BACKGROUND_TAB_PRESENCE_BOUNDS: Readonly<Bounds>;
+
+export function backgroundTabEmulationCommands(viewport?: Viewport): CdpCommand[];
+export function foregroundTabEmulationCommands(): CdpCommand[];
+export function createBrowserTabRegistry(): BrowserTabRegistry;
+export function browserTabsForSession<Tab extends { ownerSessionId: string | null }>(tabs: Tab[], sessionId: string): Tab[];
+export function activeBrowserTabIdForSession(
+  payload: BrowserStatePayload,
+  sessionId: string,
+  tabs: Array<{ id: string }>,
+): string | null;

--- a/packages/browser-tabs/index.mjs
+++ b/packages/browser-tabs/index.mjs
@@ -1,0 +1,250 @@
+// @openwork/browser-tabs
+//
+// The built-in browser is one native surface shared by every conversation in
+// the desktop app, but each tab belongs to the conversation that opened it.
+// This module is the framework-free heart of that rule: which tab is on
+// screen, which tabs a conversation may see, and how a tab that belongs to a
+// background conversation keeps behaving like a real page while nobody is
+// looking at it. The Electron main process and the React renderer both consume
+// it; neither owns the policy.
+
+/** Owner key used for tabs that no conversation claimed (legacy/shared tabs). */
+export const SHARED_OWNER_KEY = "*";
+
+/** Viewport a background tab lays out and paints at while it is off screen. */
+export const BACKGROUND_TAB_VIEWPORT = Object.freeze({ width: 1280, height: 800 });
+
+/**
+ * Bounds of the on-window presence that keeps a background tab's compositor
+ * producing frames. One device pixel in the window's top-left corner sits under
+ * the rounded corner mask on macOS and Windows 11, so it is never seen.
+ */
+export const BACKGROUND_TAB_PRESENCE_BOUNDS = Object.freeze({ x: 0, y: 0, width: 1, height: 1 });
+
+/**
+ * DevTools commands that make a background tab behave like a page the user is
+ * looking at: a real viewport for layout, clicks, and screenshots, and focus
+ * emulation so typing and `:focus` behave as on a focused page. This is the
+ * same recipe headless browsers rely on.
+ */
+export function backgroundTabEmulationCommands(viewport = BACKGROUND_TAB_VIEWPORT) {
+  return [
+    {
+      method: "Emulation.setDeviceMetricsOverride",
+      params: { width: viewport.width, height: viewport.height, deviceScaleFactor: 0, mobile: false },
+    },
+    { method: "Emulation.setFocusEmulationEnabled", params: { enabled: true } },
+  ];
+}
+
+/** Undo `backgroundTabEmulationCommands` before a tab returns to the screen. */
+export function foregroundTabEmulationCommands() {
+  return [
+    { method: "Emulation.setFocusEmulationEnabled", params: { enabled: false } },
+    { method: "Emulation.clearDeviceMetricsOverride", params: undefined },
+  ];
+}
+
+function ownerKey(ownerSessionId) {
+  return ownerSessionId ?? SHARED_OWNER_KEY;
+}
+
+function normalizeOwner(ownerSessionId) {
+  return typeof ownerSessionId === "string" && ownerSessionId.trim() ? ownerSessionId : null;
+}
+
+/**
+ * Bookkeeping for every open tab: order, owner, the active tab per owner, and
+ * the conversation currently on screen. Pure state; no Electron, no React.
+ */
+export function createBrowserTabRegistry() {
+  /** @type {Map<string, { tabId: string, ownerSessionId: string | null }>} */
+  const tabs = new Map();
+  /** @type {string[]} */
+  let order = [];
+  /** @type {Map<string, string>} owner key -> active tab id */
+  const activeByOwner = new Map();
+  /** @type {string | null} */
+  let visibleSessionId = null;
+  /** The last tab explicitly selected while it could take the screen. */
+  /** @type {string | null} */
+  let onScreenSelection = null;
+
+  function get(tabId) {
+    return tabs.get(tabId) ?? null;
+  }
+
+  function has(tabId) {
+    return tabs.has(tabId);
+  }
+
+  function list() {
+    return order.map((tabId) => tabs.get(tabId)).filter(Boolean);
+  }
+
+  function tabsFor(ownerSessionId) {
+    const owner = normalizeOwner(ownerSessionId);
+    return list().filter((tab) => tab.ownerSessionId === owner);
+  }
+
+  function ownerOf(tabId) {
+    return tabs.get(tabId)?.ownerSessionId ?? null;
+  }
+
+  function isOwnerOnScreen(ownerSessionId) {
+    return ownerSessionId === null || ownerSessionId === visibleSessionId;
+  }
+
+  /**
+   * Whether a tab may take the screen right now. Tabs owned by the visible
+   * conversation (and shared tabs) surface; everything else stays background.
+   */
+  function surfacingFor(tabId) {
+    const tab = tabs.get(tabId);
+    if (!tab) return null;
+    return isOwnerOnScreen(tab.ownerSessionId) ? "foreground" : "background";
+  }
+
+  function add({ tabId, ownerSessionId = null }) {
+    if (tabs.has(tabId)) throw new Error(`Duplicate browser tab: ${tabId}`);
+    const tab = { tabId, ownerSessionId: normalizeOwner(ownerSessionId) };
+    tabs.set(tabId, tab);
+    order.push(tabId);
+    const key = ownerKey(tab.ownerSessionId);
+    if (!activeByOwner.has(key)) activeByOwner.set(key, tabId);
+    return tab;
+  }
+
+  /**
+   * Make a tab the active one for its owner. A tab that may take the screen
+   * also becomes the on-screen tab, so a shared tab picked from a
+   * conversation's tab strip really shows up.
+   */
+  function select(tabId) {
+    const tab = tabs.get(tabId);
+    if (!tab) throw new Error(`Unknown browser tab: ${tabId}`);
+    activeByOwner.set(ownerKey(tab.ownerSessionId), tabId);
+    if (isOwnerOnScreen(tab.ownerSessionId)) onScreenSelection = tabId;
+    return tab;
+  }
+
+  /**
+   * Forget a tab. Returns which tab should become active for that owner (the
+   * neighbour to the right, else the left, else none) and whether the owner
+   * has any tabs left.
+   */
+  function remove(tabId) {
+    const tab = tabs.get(tabId);
+    if (!tab) return null;
+    const key = ownerKey(tab.ownerSessionId);
+    const siblings = order.filter((id) => tabs.get(id)?.ownerSessionId === tab.ownerSessionId);
+    const index = siblings.indexOf(tabId);
+    const wasActive = activeByOwner.get(key) === tabId;
+    tabs.delete(tabId);
+    order = order.filter((id) => id !== tabId);
+    if (onScreenSelection === tabId) onScreenSelection = null;
+    const remaining = siblings.filter((id) => id !== tabId);
+    let nextActiveTabId = activeByOwner.get(key) ?? null;
+    if (wasActive) {
+      nextActiveTabId = remaining[Math.min(index, remaining.length - 1)] ?? remaining[index - 1] ?? null;
+      if (nextActiveTabId) activeByOwner.set(key, nextActiveTabId);
+      else activeByOwner.delete(key);
+    }
+    return { tab, wasActive, nextActiveTabId, ownerHasTabs: remaining.length > 0 };
+  }
+
+  function reorder(tabIds) {
+    const nextOrder = Array.isArray(tabIds) ? tabIds.map(String) : [];
+    if (nextOrder.length !== order.length) {
+      throw new Error("Tab order must include every open tab.");
+    }
+    if (new Set(nextOrder).size !== nextOrder.length) {
+      throw new Error("Tab order must not contain duplicate tabs.");
+    }
+    if (nextOrder.some((tabId) => !tabs.has(tabId))) {
+      throw new Error("Tab order contains an unknown tab.");
+    }
+    order = nextOrder;
+    return list();
+  }
+
+  function setVisibleSession(sessionId) {
+    const next = normalizeOwner(sessionId);
+    if (next !== visibleSessionId) onScreenSelection = null;
+    visibleSessionId = next;
+    return visibleSessionId;
+  }
+
+  function getVisibleSessionId() {
+    return visibleSessionId;
+  }
+
+  function activeTabIdFor(ownerSessionId) {
+    return activeByOwner.get(ownerKey(normalizeOwner(ownerSessionId))) ?? null;
+  }
+
+  /**
+   * The tab that belongs on screen: the last tab picked while it could take
+   * the screen, else the visible conversation's active tab, else the shared one.
+   */
+  function onScreenTabId() {
+    if (onScreenSelection && tabs.has(onScreenSelection) && surfacingFor(onScreenSelection) === "foreground") {
+      return onScreenSelection;
+    }
+    if (visibleSessionId !== null) {
+      const owned = activeByOwner.get(visibleSessionId);
+      if (owned) return owned;
+    }
+    return activeByOwner.get(SHARED_OWNER_KEY) ?? null;
+  }
+
+  function activeTabIdByOwner() {
+    return Object.fromEntries(activeByOwner);
+  }
+
+  function clear() {
+    tabs.clear();
+    order = [];
+    activeByOwner.clear();
+    onScreenSelection = null;
+  }
+
+  return {
+    add,
+    select,
+    remove,
+    reorder,
+    get,
+    has,
+    list,
+    tabsFor,
+    ownerOf,
+    surfacingFor,
+    setVisibleSession,
+    visibleSessionId: getVisibleSessionId,
+    onScreenTabId,
+    activeTabIdFor,
+    activeTabIdByOwner,
+    clear,
+    size: () => tabs.size,
+  };
+}
+
+/** Tabs a conversation's side panel may show: its own, plus shared (unowned) tabs. */
+export function browserTabsForSession(tabs, sessionId) {
+  return tabs.filter((tab) => tab.ownerSessionId == null || tab.ownerSessionId === sessionId);
+}
+
+/**
+ * The active browser tab for a conversation from a state payload: its own
+ * active tab, else the shared active tab, else the global on-screen tab, else
+ * the first tab it may see.
+ */
+export function activeBrowserTabIdForSession(payload, sessionId, tabs) {
+  const byOwner = payload.activeTabIdByOwner ?? {};
+  const candidates = [byOwner[sessionId], byOwner[SHARED_OWNER_KEY], payload.activeTabId];
+  for (const candidate of candidates) {
+    if (candidate && tabs.some((tab) => tab.id === candidate)) return candidate;
+  }
+  return tabs[0]?.id ?? null;
+}

--- a/packages/browser-tabs/package.json
+++ b/packages/browser-tabs/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openwork/browser-tabs",
+  "private": true,
+  "type": "module",
+  "description": "Ownership, surfacing, and background-rendering policy for OpenWork's built-in browser tabs.",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    }
+  },
+  "files": [
+    "index.d.ts",
+    "index.mjs"
+  ],
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/browser-tabs/test/browser-tabs.test.mjs
+++ b/packages/browser-tabs/test/browser-tabs.test.mjs
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BACKGROUND_TAB_PRESENCE_BOUNDS,
+  BACKGROUND_TAB_VIEWPORT,
+  SHARED_OWNER_KEY,
+  activeBrowserTabIdForSession,
+  backgroundTabEmulationCommands,
+  browserTabsForSession,
+  createBrowserTabRegistry,
+  foregroundTabEmulationCommands,
+} from "../index.mjs";
+
+describe("tab ownership", () => {
+  test("a tab opened by a background conversation never takes the screen from the visible one", () => {
+    const registry = createBrowserTabRegistry();
+    registry.setVisibleSession("A");
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.add({ tabId: "b1", ownerSessionId: "B" });
+    registry.select("b1");
+
+    expect(registry.surfacingFor("a1")).toBe("foreground");
+    expect(registry.surfacingFor("b1")).toBe("background");
+    expect(registry.onScreenTabId()).toBe("a1");
+    expect(registry.activeTabIdFor("B")).toBe("b1");
+  });
+
+  test("switching conversations brings that conversation's active tab on screen", () => {
+    const registry = createBrowserTabRegistry();
+    registry.setVisibleSession("A");
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.add({ tabId: "b1", ownerSessionId: "B" });
+    registry.add({ tabId: "b2", ownerSessionId: "B" });
+    registry.select("b2");
+
+    registry.setVisibleSession("B");
+
+    expect(registry.onScreenTabId()).toBe("b2");
+    expect(registry.surfacingFor("a1")).toBe("background");
+    expect(registry.surfacingFor("b2")).toBe("foreground");
+  });
+
+  test("shared tabs without an owner stay visible to every conversation", () => {
+    const registry = createBrowserTabRegistry();
+    registry.add({ tabId: "s1" });
+    registry.setVisibleSession("A");
+    expect(registry.surfacingFor("s1")).toBe("foreground");
+    expect(registry.onScreenTabId()).toBe("s1");
+
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.select("a1");
+    expect(registry.onScreenTabId()).toBe("a1");
+    expect(registry.activeTabIdByOwner()).toEqual({ [SHARED_OWNER_KEY]: "s1", A: "a1" });
+  });
+
+  test("picking a shared tab from a conversation's tab strip puts it on screen, and switching conversations forgets that pick", () => {
+    const registry = createBrowserTabRegistry();
+    registry.setVisibleSession("A");
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.add({ tabId: "s1" });
+    expect(registry.onScreenTabId()).toBe("a1");
+
+    registry.select("s1");
+    expect(registry.onScreenTabId()).toBe("s1");
+
+    registry.add({ tabId: "b1", ownerSessionId: "B" });
+    registry.select("b1");
+    expect(registry.onScreenTabId()).toBe("s1");
+
+    registry.setVisibleSession("B");
+    expect(registry.onScreenTabId()).toBe("b1");
+  });
+
+  test("closing the active tab hands the owner its right neighbour, then its left, then nothing", () => {
+    const registry = createBrowserTabRegistry();
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.add({ tabId: "b1", ownerSessionId: "B" });
+    registry.add({ tabId: "a2", ownerSessionId: "A" });
+    registry.add({ tabId: "a3", ownerSessionId: "A" });
+    registry.select("a2");
+
+    expect(registry.remove("a2")).toEqual({
+      tab: { tabId: "a2", ownerSessionId: "A" },
+      wasActive: true,
+      nextActiveTabId: "a3",
+      ownerHasTabs: true,
+    });
+    expect(registry.remove("a3")).toMatchObject({ wasActive: true, nextActiveTabId: "a1" });
+    expect(registry.remove("a1")).toMatchObject({ wasActive: true, nextActiveTabId: null, ownerHasTabs: false });
+    expect(registry.activeTabIdFor("B")).toBe("b1");
+    expect(registry.list().map((tab) => tab.tabId)).toEqual(["b1"]);
+  });
+
+  test("closing a background tab leaves the visible conversation untouched", () => {
+    const registry = createBrowserTabRegistry();
+    registry.setVisibleSession("A");
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.add({ tabId: "b1", ownerSessionId: "B" });
+
+    const removed = registry.remove("b1");
+
+    expect(removed).toMatchObject({ wasActive: true, ownerHasTabs: false });
+    expect(registry.onScreenTabId()).toBe("a1");
+  });
+
+  test("reordering validates the full tab set", () => {
+    const registry = createBrowserTabRegistry();
+    registry.add({ tabId: "a1", ownerSessionId: "A" });
+    registry.add({ tabId: "a2", ownerSessionId: "A" });
+
+    expect(registry.reorder(["a2", "a1"]).map((tab) => tab.tabId)).toEqual(["a2", "a1"]);
+    expect(() => registry.reorder(["a2"])).toThrow("every open tab");
+    expect(() => registry.reorder(["a2", "a2"])).toThrow("duplicate");
+    expect(() => registry.reorder(["a2", "zz"])).toThrow("unknown tab");
+  });
+
+  test("blank or missing owners normalize to shared", () => {
+    const registry = createBrowserTabRegistry();
+    registry.add({ tabId: "s1", ownerSessionId: "  " });
+    expect(registry.ownerOf("s1")).toBe(null);
+    expect(registry.setVisibleSession("")).toBe(null);
+  });
+});
+
+describe("renderer helpers", () => {
+  const tabs = [
+    { id: "a1", ownerSessionId: "A" },
+    { id: "s1", ownerSessionId: null },
+    { id: "b1", ownerSessionId: "B" },
+  ];
+
+  test("a conversation sees its own tabs and shared tabs only", () => {
+    expect(browserTabsForSession(tabs, "A").map((tab) => tab.id)).toEqual(["a1", "s1"]);
+    expect(browserTabsForSession(tabs, "C").map((tab) => tab.id)).toEqual(["s1"]);
+  });
+
+  test("the active tab comes from the owner, then shared, then on-screen, then first visible", () => {
+    const visible = browserTabsForSession(tabs, "A");
+    expect(activeBrowserTabIdForSession({ activeTabIdByOwner: { A: "a1" }, activeTabId: "b1" }, "A", visible)).toBe("a1");
+    expect(activeBrowserTabIdForSession({ activeTabIdByOwner: { [SHARED_OWNER_KEY]: "s1" } }, "A", visible)).toBe("s1");
+    expect(activeBrowserTabIdForSession({ activeTabId: "b1" }, "A", visible)).toBe("a1");
+    expect(activeBrowserTabIdForSession({}, "C", [])).toBe(null);
+  });
+});
+
+describe("background rendering recipe", () => {
+  test("a background tab gets a real viewport and focus; the foreground undoes both in reverse", () => {
+    expect(backgroundTabEmulationCommands()).toEqual([
+      {
+        method: "Emulation.setDeviceMetricsOverride",
+        params: { ...BACKGROUND_TAB_VIEWPORT, deviceScaleFactor: 0, mobile: false },
+      },
+      { method: "Emulation.setFocusEmulationEnabled", params: { enabled: true } },
+    ]);
+    expect(foregroundTabEmulationCommands().map((command) => command.method)).toEqual([
+      "Emulation.setFocusEmulationEnabled",
+      "Emulation.clearDeviceMetricsOverride",
+    ]);
+  });
+
+  test("the on-window presence is a single corner pixel", () => {
+    expect(BACKGROUND_TAB_PRESENCE_BOUNDS).toEqual({ x: 0, y: 0, width: 1, height: 1 });
+  });
+});

--- a/packages/browser-tabs/tsconfig.json
+++ b/packages/browser-tabs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["index.d.ts", "index.mjs"]
+}

--- a/packages/types/src/openwork-affordance.ts
+++ b/packages/types/src/openwork-affordance.ts
@@ -58,11 +58,24 @@ export const openworkAffordanceDescriptorSchema = z.object({
 })
 export type OpenworkAffordanceDescriptor = z.infer<typeof openworkAffordanceDescriptorSchema>
 
+/**
+ * Where a request came from: the conversation (session) whose agent issued
+ * it. Set by the OpenWork bridge, never by the agent, so UI commands such as
+ * opening a browser tab can act for the requesting conversation instead of
+ * whichever one happens to be on screen.
+ */
+export const openworkAffordanceOriginSchema = z.object({
+  sessionId: z.string().trim().min(1),
+  workspaceId: z.string().trim().min(1).optional(),
+})
+export type OpenworkAffordanceOrigin = z.infer<typeof openworkAffordanceOriginSchema>
+
 export const openworkAffordanceRequestSchema = z.object({
   id: z.string().trim().min(1),
   args: z.record(z.string(), z.unknown()).optional(),
   expectedRevision: z.number().int().nonnegative().optional(),
   actor: z.string().trim().min(1).optional(),
+  origin: openworkAffordanceOriginSchema.optional(),
 })
 export type OpenworkAffordanceRequest = z.infer<typeof openworkAffordanceRequestSchema>
 

--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -25,8 +25,10 @@ COPY packages/connect-link/package.json /app/packages/connect-link/package.json
 COPY packages/headless-threads/package.json /app/packages/headless-threads/package.json
 COPY packages/mcp-apps/package.json /app/packages/mcp-apps/package.json
 # apps/desktop/package.json is copied below for version metadata, and it depends
-# on @openwork/paths, so the package must exist for workspace resolution.
+# on @openwork/paths and @openwork/browser-tabs, so those packages must exist for
+# workspace resolution.
 COPY packages/paths/package.json /app/packages/paths/package.json
+COPY packages/browser-tabs/package.json /app/packages/browser-tabs/package.json
 # The root workspace declares the shared evaluator helpers as dev dependencies.
 # Their manifests must be present even though the Den API image does not build
 # or ship their source.
@@ -52,6 +54,7 @@ COPY packages/connect-link /app/packages/connect-link
 COPY packages/headless-threads /app/packages/headless-threads
 COPY packages/mcp-apps /app/packages/mcp-apps
 COPY packages/paths /app/packages/paths
+COPY packages/browser-tabs /app/packages/browser-tabs
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/packages/telemetry-contracts /app/ee/packages/telemetry-contracts

--- a/packaging/docker/Dockerfile.den-gateway
+++ b/packaging/docker/Dockerfile.den-gateway
@@ -26,6 +26,7 @@ COPY packages/types/package.json /app/packages/types/package.json
 COPY packages/ui/package.json /app/packages/ui/package.json
 COPY packages/install-config/package.json /app/packages/install-config/package.json
 COPY packages/workbook/package.json /app/packages/workbook/package.json
+COPY packages/browser-tabs/package.json /app/packages/browser-tabs/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/apps/den-gateway/package.json /app/ee/apps/den-gateway/package.json
 COPY apps/app/package.json /app/apps/app/package.json
@@ -36,6 +37,7 @@ COPY packages/types /app/packages/types
 COPY packages/ui /app/packages/ui
 COPY packages/install-config /app/packages/install-config
 COPY packages/workbook /app/packages/workbook
+COPY packages/browser-tabs /app/packages/browser-tabs
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/apps/den-gateway /app/ee/apps/den-gateway
 COPY apps/app /app/apps/app

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.18.15
         version: 1.18.18
+      '@openwork/browser-tabs':
+        specifier: workspace:*
+        version: link:../../packages/browser-tabs
       '@openwork/install-config':
         specifier: workspace:*
         version: link:../../packages/install-config
@@ -328,6 +331,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.18.15
         version: 1.18.18
+      '@openwork/browser-tabs':
+        specifier: workspace:*
+        version: link:../../packages/browser-tabs
       '@openwork/enterprise-mcp-client':
         specifier: workspace:*
         version: link:../../packages/enterprise-mcp-client
@@ -1123,6 +1129,15 @@ importers:
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  packages/browser-tabs:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.7
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## Problem

You read one conversation while another conversation's agent needs a web page. The browser pops open in the conversation you are reading, showing a page that has nothing to do with it, and the working conversation shows nothing. The built-in browser kept one global tab list with no owner, `openwork_execute` dropped the agent's session id before the UI command bridge, and the side panel mirrored every native tab into whichever conversation was mounted. Any navigation of a hidden tab also auto-selected it onto the screen.

## What changes

- **Tabs belong to the conversation that opened them.** The bridge stamps UI commands with the requesting session (`origin`, set from the tool context, never by the agent), the control bus hands that origin to the action, and the Electron browser keeps an owner per tab. Each side panel shows only its own tabs.
- **Background conversations browse silently.** Only the on-screen conversation's tabs may take the screen. A tab opened for a background conversation loads there, its panel state is marked open, and it is waiting when the user switches. The navigation auto-select is owner-aware; `panel-opened` / `panel-closed` name the owner.
- **Hidden tabs stay real pages for the agent.** Chromium only paints a page it considers visible, so a hidden tab keeps a one-pixel presence in the window corner (under the rounded-corner mask) while a main-process DevTools session emulates a 1280×800 viewport and focus. Reads, clicks, typing, and CDP screenshots work before anyone looks; both are undone when the tab returns to the screen and the existing viewport-reset path takes over.
- **New `@openwork/browser-tabs` package** holds the ownership, surfacing, and background-rendering policy, shared by the main process and the renderer and unit-tested on its own.

## What stays the same

Tabs opened without a conversation (no session on screen) stay shared and behave exactly as before. The visible conversation's own tabs surface as before. `browser_*` tools and the CDP handle contract are unchanged; `open_url` additionally returns `owner_session_id` and `visible`.

## Proof

New journey `evals/specs/browser-tabs-owned-by-thread.e2e.test.ts`: a background conversation opens a page — the on-screen conversation's tab, panel, and viewport are untouched; the hidden page lays out at 1280×800, reports focus, accepts a dispatched click and typed text, and screenshots at full size; switching to the owner shows its tab at the panel's viewport; switching back restores the first conversation's own tab only.

- `OPENWORK_EVAL_REF=fb940de88f0acef07a99cf2641f7215d9170a518 pnpm evals:e2e browser-tabs-owned-by-thread` — `placement: daytona (daytona CLI authenticated)`, checkout resolved `fb940de88f0a`, **1 passed / 0 failed / 0 skipped**.
- `pnpm evals:e2e browser-panel-viewport-recovery --local` — 1 passed (the existing built-in browser journey, same world).
- `packages/browser-tabs`: 12 policy tests; `apps/desktop/electron/browser-panel.test.mjs`: 9 (5 new, stubbed `WebContentsView`); `apps/server` plugin tests: 26 (1 new: origin stamping cannot be spoofed by the agent).
- `@openwork/app`, `openwork-server`, `typecheck:electron`, `check:electron`, `evals lint:layers`, boundary and channel ratchets: clean.
