### PR TITLE
fix: remove automation and engine retirement test races

### DIFF
--- a/apps/desktop/electron/automation-runner.mjs
+++ b/apps/desktop/electron/automation-runner.mjs
@@ -181,14 +181,15 @@ export async function executeDesktopAutomation(assignment, options) {
       // suspends mid-request can leave this socket half-open with no error,
       // which would make the assignment timeout unreachable: bound each poll
       // by the remaining execution budget so the deadline always fires.
+      const timeoutSignal = AbortSignal.timeout(Math.max(1, deadlineAt - Date.now()))
       let snapshot
       try {
         snapshot = await client.getThreadSnapshot(sessionId, {
-          signal: AbortSignal.any([options.signal, AbortSignal.timeout(Math.max(1, deadlineAt - Date.now()))]),
+          signal: AbortSignal.any([options.signal, timeoutSignal]),
           limit: 200,
         })
       } catch (error) {
-        if (!options.signal.aborted && Date.now() >= deadlineAt) throw new Error("Desktop Automation execution timed out")
+        if (!options.signal.aborted && (timeoutSignal.aborted || Date.now() >= deadlineAt)) throw new Error("Desktop Automation execution timed out")
         throw error
       }
       const output = assistantResult(snapshot)

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -1059,7 +1059,7 @@ test("a work poll left hanging by a suspended machine times out and retries", as
 
 test("desktop Automation execution creates a normal visible local OpenWork thread", async () => {
   const requests = []
-  let snapshots = 0
+  const snapshotReads = new Map()
   const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const fetchImpl = async (url, options = {}) => {
     const parsed = new URL(url)
@@ -1073,7 +1073,9 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
     }
     if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
     if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
-      if (parsed.pathname === sessionPaths.get) snapshots += 1
+      // Snapshot routes run concurrently; each route advances its own fixture.
+      const snapshots = (snapshotReads.get(parsed.pathname) ?? 0) + 1
+      snapshotReads.set(parsed.pathname, snapshots)
       return respondToSnapshotRequest(parsed, sessionPaths, {
         status: { type: snapshots <= 1 ? "busy" : "idle" },
         messages: snapshots <= 1 ? [] : [{
@@ -1747,7 +1749,10 @@ test("consecutive heartbeat misses abort the run and still deliver terminal and 
   assert.equal(events.find((entry) => entry.type === "terminal")?.payload.status, "failed")
 })
 
-test("a snapshot poll left hanging by a suspended machine still honors the assignment timeout", async () => {
+test("a snapshot poll left hanging by a suspended machine still honors the assignment timeout", async (t) => {
+  // The timer can fire before the wall clock reaches the computed deadline.
+  // Hold that clock still to exercise the abort source deterministically.
+  t.mock.method(Date, "now", () => 1_000)
   const snapshotSignals = []
   const sessionPaths = opencodeSessionPaths("workspace-1", "session-1")
   const local = localExecutionRoutes(sessionPaths, (parsed, options) => {

--- a/apps/desktop/electron/automation-runner.test.mjs
+++ b/apps/desktop/electron/automation-runner.test.mjs
@@ -1073,6 +1073,8 @@ test("desktop Automation execution creates a normal visible local OpenWork threa
     }
     if (parsed.pathname === sessionPaths.prompt) return new Response(null, { status: 204 })
     if ([sessionPaths.get, sessionPaths.messages, sessionPaths.todo, sessionPaths.status].includes(parsed.pathname)) {
+      // Force the session route to finish last, as it can on either CI runner.
+      if (parsed.pathname === sessionPaths.get) await new Promise((resolve) => setImmediate(resolve))
       // Snapshot routes run concurrently; each route advances its own fixture.
       const snapshots = (snapshotReads.get(parsed.pathname) ?? 0) + 1
       snapshotReads.set(parsed.pathname, snapshots)

--- a/apps/server/src/engine-pool.test.ts
+++ b/apps/server/src/engine-pool.test.ts
@@ -576,7 +576,8 @@ describe("engine pool", () => {
     expect(primary.isAlive()).toBe(true);
     await fixture.setBusy(oldPort, []);
     expect(await waitUntil(() => !pool.hasDrainingGeneration(), 5_000)).toBe(true);
-    expect(primary.isAlive()).toBe(false);
+    // Retirement removes the draining status before asynchronous process exit.
+    expect(await waitUntil(() => !primary.isAlive(), 5_000)).toBe(true);
   });
 
   test("seeds the healthy standby before flipping and flips anyway when seeding fails", async () => {


### PR DESCRIPTION
Desktop automation and engine retirement tests could fail on unrelated PRs because they depended on timer and concurrent-request ordering.

- Recognize the snapshot timeout signal directly, even when it fires before the wall clock reaches the deadline. Preserve caller cancellation precedence.
- Give each concurrent snapshot route its own fixture progression. Force the session response to finish last and retain the exact two-poll assertions.
- Wait for the retiring engine process to exit after its draining status clears.

Validation on `63f328459e487509bacc74e0fd1cc1d6cfb5f14c`:
- [OpenWork Tests](https://github.com/different-ai/openwork/actions/runs/33916368857): both macOS/Linux unit/build/e2e jobs, both spec jobs, and `openwork-tests-required` succeeded.
- Each platform: app 1,235 passed; server 932 passed; Den API 24 passed; release scripts 29 passed; eval runner 233 passed. No failures.
- Desktop: macOS 302 passed / 1 platform skip; Linux 299 passed / 4 platform skips. No failures.
- Spec files: macOS 19 passed / 7 skipped; Linux 20 passed / 6 skipped. Skips are not counted as proof.
- Deterministic negative controls reproduce the original timeout `HeadlessThreadError` and the out-of-order snapshot `3 !== 2` failure before their fixes.

Reproduce with `pnpm --filter @openwork/desktop test`, `pnpm --filter openwork-server test src/engine-pool.test.ts`, and `pnpm test:eval-runner` using Node 24. Local desktop and eval-runner suites pass; the local Bun 1.3.8 engine run passed its tests but trapped during exit, while both CI server runs completed successfully.

Evidence verdict: Incomplete for the timeout behavior. The additional `automation-den-monitor` Daytona journey failed at sign-in (0 passed, 1 failed), before reaching automation assertions; see the verification comment. All requested CI checks are green; journey-level proof is recorded separately from CI status.

The aggregate required check correctly propagates failures from its selected lane. A separate recent landing-pricing failure is a branch-specific spec-boundary violation; that file is not present on this dev-based branch.
