### PR TITLE
fix: survive disk-full logging and explain storage errors

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -73,7 +73,7 @@ import {
   messageHasVisibleAssistantOutput,
   resolveAdmissionOutcome,
 } from "./session-admission-outcome";
-import { interruptedTaskRecoveryPrompt, presentOpencodeSessionError } from "@/react-app/domains/session/sync/session-error";
+import { describeOpencodeSessionError, interruptedTaskRecoveryPrompt, presentOpencodeSessionError } from "@/react-app/domains/session/sync/session-error";
 import { createSessionErrorUIMessage } from "@/react-app/domains/session/sync/usechat-adapter";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
@@ -429,7 +429,7 @@ const SESSION_ERROR_EVAL_PAYLOAD = {
   },
 };
 
-function createSessionErrorEvalMessages(sessionId: string): UIMessage[] {
+function createSessionErrorEvalMessages(sessionId: string, error: unknown = SESSION_ERROR_EVAL_PAYLOAD): UIMessage[] {
   const now = Date.now();
   const turnId = `${sessionId}:eval-session-error-assistant`;
   return [
@@ -445,7 +445,7 @@ function createSessionErrorEvalMessages(sessionId: string): UIMessage[] {
       parts: [{ type: "text", text: "Looking at the repository now." }],
       metadata: { opencode: { created: now + 1, completed: now + 900 } },
     },
-    createSessionErrorUIMessage(turnId, presentOpencodeSessionError(SESSION_ERROR_EVAL_PAYLOAD), { created: now + 1_000 }),
+    createSessionErrorUIMessage(turnId, presentOpencodeSessionError(error), { created: now + 1_000 }),
   ];
 }
 
@@ -825,18 +825,23 @@ function parseSessionError(thrown: unknown): SessionError {
   return { message: raw || "Failed to send prompt." };
 }
 
-function SessionErrorCard({ error, onDismiss, onChangeModel, onOpenModelPicker }: {
+function SessionErrorCard({ error, developerMode, onDismiss, onChangeModel, onOpenModelPicker }: {
   error: SessionError;
+  developerMode: boolean;
   onDismiss: () => void;
   onChangeModel?: (model: { providerID: string; modelID: string }) => void;
   onOpenModelPicker?: () => void;
 }) {
+  const presentation = presentOpencodeSessionError(error.message);
   return (
     <div className="mx-auto max-w-[720px] px-3 py-3 sm:px-5" data-testid="session-error-card" role="alert">
       <div className="rounded-2xl border border-red-6/30 bg-red-3/15 px-5 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium text-red-11">{error.message}</div>
+            <div className="text-sm font-medium text-red-11">{developerMode ? error.message : presentation.title}</div>
+            {!developerMode && presentation.description ? (
+              <p className="mt-1 text-sm text-red-11">{presentation.description}</p>
+            ) : null}
             {error.kind === "model-not-found" ? (
               <div className="mt-2 flex flex-wrap gap-2">
                 {error.suggestions && error.suggestions.length > 0 ? (
@@ -1433,8 +1438,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
       description: "Dev-only eval hook that renders a failed turn with a provider API error (status, code, response body) through the live session-error presentation path.",
       sideEffect: "mutation",
       disabled: !props.sessionId,
-      execute: () => {
-        setEvalMarkdownMessages(createSessionErrorEvalMessages(props.sessionId));
+      args: [{ name: "kind", type: "string", description: "Optional disk-full or database-error fixture." }],
+      execute: (args) => {
+        const kind = args && typeof args === "object" && "kind" in args ? args.kind : null;
+        const error = kind === "disk-full" || kind === "database-error"
+          ? { name: "SqlError", data: { message: `effect/sql/SqlError: Failed to execute statement\n    at runLoop (/$bunfs/root/chunk.js:25:2045)${kind === "disk-full" ? "\nCaused by: ENOSPC: no space left on device, write" : ""}` } }
+          : SESSION_ERROR_EVAL_PAYLOAD;
+        setEvalMarkdownMessages(createSessionErrorEvalMessages(props.sessionId, error));
         return { ok: true };
       },
     };
@@ -2733,6 +2743,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
             ) : null}
             {error && snapshot && snapshot.messages.length > 0 ? (
               <SessionErrorCard
+                developerMode={props.developerMode}
                 error={error}
                 onDismiss={handleDismissError}
                 onChangeModel={handleModelChange}
@@ -2749,6 +2760,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
               <div className="px-6 py-8">
                 {error ? (
                   <SessionErrorCard
+                    developerMode={props.developerMode}
                     error={error}
                     onDismiss={handleDismissError}
                     onChangeModel={handleModelChange}
@@ -2756,7 +2768,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   />
                 ) : (
                   <div className="mx-auto max-w-xl rounded-3xl border border-red-6/40 bg-red-3/20 px-6 py-5 text-sm text-red-11">
-                    {snapshotQuery.error instanceof Error ? snapshotQuery.error.message : "Failed to load session."}
+                    {props.developerMode && snapshotQuery.error instanceof Error
+                      ? snapshotQuery.error.message
+                      : describeOpencodeSessionError(snapshotQuery.error, "Failed to load session.")}
                   </div>
                 )}
               </div>
@@ -2766,6 +2780,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
               </div>
             ) : renderedMessages.length === 0 && snapshot && snapshot.messages.length === 0 && error ? (
               <SessionErrorCard
+                developerMode={props.developerMode}
                 error={error}
                 onDismiss={handleDismissError}
                 onChangeModel={handleModelChange}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1438,13 +1438,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
       description: "Dev-only eval hook that renders a failed turn with a provider API error (status, code, response body) through the live session-error presentation path.",
       sideEffect: "mutation",
       disabled: !props.sessionId,
-      args: [{ name: "kind", type: "string", description: "Optional disk-full or database-error fixture." }],
+      args: [
+        { name: "kind", type: "string", description: "Optional disk-full or database-error fixture." },
+        { name: "surface", type: "string", description: "Optional banner instead of the transcript." },
+      ],
       execute: (args) => {
         const kind = args && typeof args === "object" && "kind" in args ? args.kind : null;
         const error = kind === "disk-full" || kind === "database-error"
           ? { name: "SqlError", data: { message: `effect/sql/SqlError: Failed to execute statement\n    at runLoop (/$bunfs/root/chunk.js:25:2045)${kind === "disk-full" ? "\nCaused by: ENOSPC: no space left on device, write" : ""}` } }
           : SESSION_ERROR_EVAL_PAYLOAD;
-        setEvalMarkdownMessages(createSessionErrorEvalMessages(props.sessionId, error));
+        if (args && typeof args === "object" && "surface" in args && args.surface === "banner") {
+          setEvalMarkdownMessages([]);
+          setError({ message: error.data.message });
+        } else {
+          setError(null);
+          setEvalMarkdownMessages(createSessionErrorEvalMessages(props.sessionId, error));
+        }
         return { ok: true };
       },
     };

--- a/apps/app/src/react-app/domains/session/sync/session-error.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-error.ts
@@ -3,7 +3,7 @@ import type { UIMessage } from "ai";
 import { safeStringify } from "../../../../app/utils";
 import { normalizeErrorText } from "../../../../lib/error-text";
 
-export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "generic";
+export type OpencodeSessionErrorKind = "aborted" | "provider-timeout" | "free-model-limit" | "disk-full" | "database-error" | "generic";
 
 export type OpencodeSessionErrorPresentation = {
   kind: OpencodeSessionErrorKind;
@@ -59,7 +59,13 @@ function sessionErrorKind(
   code: string | null,
   responseBody: string | null,
 ): OpencodeSessionErrorKind {
-  const searchable = [name, message, code].filter(Boolean).join(" ");
+  const searchable = [name, message, code, responseBody].filter(Boolean).join(" ");
+  if (/\b(?:ENOSPC|EDQUOT|SQLITE_FULL)\b|no space left on device|database or disk is full|disk quota exceeded/i.test(searchable)) {
+    return "disk-full";
+  }
+  if (/\bSqlError\b|\bSQLITE_(?:IOERR|CANTOPEN|CORRUPT)\b/i.test(searchable)) {
+    return "database-error";
+  }
   if (
     name === "MessageAbortedError" ||
     code === "ABORT_ERR" ||
@@ -81,6 +87,8 @@ function sessionErrorKind(
 }
 
 function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
+  if (kind === "disk-full") return "Not enough disk space";
+  if (kind === "database-error") return "OpenWork couldn’t access its saved data";
   if (kind === "aborted") return "Task interrupted";
   if (kind === "provider-timeout") return "Provider did not respond in time";
   if (kind === "free-model-limit") return "The free starter model is busy right now";
@@ -88,6 +96,12 @@ function errorTitle(kind: OpencodeSessionErrorKind, fallback: string) {
 }
 
 function errorDescription(kind: OpencodeSessionErrorKind) {
+  if (kind === "disk-full") {
+    return "The device running this task has run out of storage. Free up some disk space, then try again. If this is a cloud workspace, ask its administrator to check the storage.";
+  }
+  if (kind === "database-error") {
+    return "Try again. If this keeps happening, check the available disk space on the device running this task and restart OpenWork. For a cloud workspace, contact its administrator.";
+  }
   if (kind === "aborted") {
     return "OpenCode stopped before the task finished. Output and files already produced are kept.";
   }
@@ -121,17 +135,6 @@ function normalizeSessionError(text: string) {
 }
 
 function sessionErrorFields(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return {
-      name: error.name || null,
-      message: error.message.trim() || fallback,
-      status: null,
-      provider: null,
-      code: null,
-      retries: null,
-      responseBody: null,
-    };
-  }
   if (typeof error === "string") {
     return {
       name: null,

--- a/apps/app/tests/session-error-resilience.test.tsx
+++ b/apps/app/tests/session-error-resilience.test.tsx
@@ -47,6 +47,35 @@ describe("session error resilience", () => {
     expect(presentation.technicalDetails).toContain("FreeUsageLimitError")
   })
 
+  test.each(["ENOSPC", "EDQUOT", "SQLITE_FULL", "database or disk is full"])("explains %s without exposing the stack trace", (code) => {
+    const raw = `effect/sql/SqlError: Failed to execute statement\n at runLoop (/$bunfs/root/chunk.js:25:2045)\n${code}`
+    const presentation = presentOpencodeSessionError({ name: "SqlError", data: { message: raw } })
+    expect(presentation.kind).toBe("disk-full")
+    expect(presentation.title).toBe("Not enough disk space")
+    expect(presentation.description).toContain("Free up some disk space")
+    expect(presentation.description).toContain("cloud workspace")
+    expect(presentation.technicalDetails).toContain(code)
+    expect(presentation.technicalDetails).toContain("at runLoop")
+    expect(presentation.recoveryPrompt).toBeNull()
+  })
+
+  test("reads disk-full codes from native errors and nested causes", () => {
+    for (const error of [
+      Object.assign(new Error("write failed"), { code: "ENOSPC" }),
+      { name: "SqlError", message: "Failed to execute statement", cause: { code: "SQLITE_FULL" } },
+    ]) {
+      expect(presentOpencodeSessionError(error).kind).toBe("disk-full")
+    }
+  })
+
+  test("does not diagnose a generic database failure as a full disk", () => {
+    const presentation = presentOpencodeSessionError("effect/sql/SqlError: Failed to execute statement\n at runLoop (/$bunfs/root/chunk.js:25:2045)")
+    expect(presentation.kind).toBe("database-error")
+    expect(presentation.title).toBe("OpenWork couldn’t access its saved data")
+    expect(presentation.description).toContain("check the available disk space")
+    expect(presentation.description).not.toContain("has run out")
+  })
+
   test("classifies an OpenCode abort and retains its diagnostic payload", () => {
     const presentation = presentOpencodeSessionError({
       name: "MessageAbortedError",
@@ -416,6 +445,18 @@ describe("session error technical details", () => {
     // Collapsed by default: the payload is not in the DOM until opened.
     expect(html).not.toContain('data-testid="session-error-details"')
     expect(html).not.toContain("Status: 429")
+  })
+
+  test("storage errors show guidance without technical codes outside developer mode", () => {
+    const raw = "effect/sql/SqlError: Failed to execute statement\n at runLoop (/$bunfs/root/chunk.js:25:2045)\nENOSPC: no space left on device"
+    const html = renderErrorTranscript(raw, false)
+    expect(html).toContain("Not enough disk space")
+    expect(html).toContain("Free up some disk space")
+    expect(html).not.toContain("SqlError")
+    expect(html).not.toContain("runLoop")
+    expect(html).not.toContain("ENOSPC")
+    expect(html).not.toContain('data-testid="session-error-details-toggle"')
+    expect(renderErrorTranscript(raw, true)).toContain('data-testid="session-error-details-toggle"')
   })
 
   test("a bare error whose details only repeat the message gets no disclosure even in developer mode", () => {

--- a/apps/desktop/electron/stdio-errors.mjs
+++ b/apps/desktop/electron/stdio-errors.mjs
@@ -15,7 +15,10 @@ export function installStdioErrorHandlers({ stdout = process.stdout, stderr = pr
     if (!stream || typeof stream.on !== "function" || guardedStreams.has(stream)) continue;
 
     stream.on("error", (error) => {
-      if (isBrokenPipeError(error)) return;
+      // The in-process server also listens here. Do not rethrow expected
+      // output failures before its handler can disable the failed log sink.
+      if (isBrokenPipeError(error) || error?.code === "ERR_STREAM_DESTROYED"
+        || error?.code === "ENOSPC" || error?.code === "EDQUOT") return;
       throw error;
     });
     guardedStreams.add(stream);

--- a/apps/desktop/electron/stdio-errors.test.mjs
+++ b/apps/desktop/electron/stdio-errors.test.mjs
@@ -25,7 +25,10 @@ describe("stdio error handling", () => {
 
     installStdioErrorHandlers({ stdout, stderr });
 
-    assert.doesNotThrow(() => stdout.emit("error", streamError("EPIPE")));
+    for (const code of ["EPIPE", "ERR_STREAM_DESTROYED", "ENOSPC", "EDQUOT"]) {
+      assert.doesNotThrow(() => stdout.emit("error", streamError(code)));
+      assert.doesNotThrow(() => stderr.emit("error", streamError(code)));
+    }
     assert.throws(() => stderr.emit("error", streamError("ECONNRESET")), /stream failed/);
   });
 

--- a/apps/server/src/server-logger.test.ts
+++ b/apps/server/src/server-logger.test.ts
@@ -22,23 +22,25 @@ function serverConfig(logFormat: ServerConfig["logFormat"] = "pretty"): ServerCo
   };
 }
 
-function brokenPipeError() {
-  const error = new Error("write EPIPE");
-  Object.defineProperty(error, "code", { value: "EPIPE", enumerable: true });
+function logOutputError(code: string) {
+  const error = new Error(`write ${code}`);
+  Object.defineProperty(error, "code", { value: code, enumerable: true });
   return error;
 }
 
 describe("createServerLogger", () => {
-  test("disables log writes after stdout closes", () => {
+  test.each(["EPIPE", "ERR_STREAM_DESTROYED", "ENOSPC", "EDQUOT"])("disables log writes after %s while preserving the file sink", (code) => {
     let attempts = 0;
+    const fileLines: string[] = [];
     const logger = createServerLogger(serverConfig(), () => {
       attempts += 1;
-      throw brokenPipeError();
-    });
+      throw logOutputError(code);
+    }, { path: "unused", write: (line) => { fileLines.push(line); }, close: () => {} });
 
     expect(() => logger.log("info", "GET / 200 1ms")).not.toThrow();
     expect(() => logger.log("info", "GET /again 200 1ms")).not.toThrow();
     expect(attempts).toBe(1);
+    expect(fileLines).toHaveLength(2);
   });
 
   test("still throws unexpected log write failures", () => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -652,9 +652,12 @@ function toUnixNano(): string {
   return (BigInt(Date.now()) * 1_000_000n).toString();
 }
 
-function isBrokenLogPipeError(error: unknown): boolean {
+function isUnavailableLogOutputError(error: unknown): boolean {
   if (!isRecord(error)) return false;
-  return error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED";
+  // Redirected stdout can run out of space just like the optional file sink.
+  // Logging must not turn an otherwise successful request into a server crash.
+  return error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED"
+    || error.code === "ENOSPC" || error.code === "EDQUOT";
 }
 
 let stdoutLogWritesDisabled = false;
@@ -664,7 +667,7 @@ function ensureStdoutErrorHandler() {
   if (stdoutErrorHandlerInstalled) return;
   stdoutErrorHandlerInstalled = true;
   process.stdout.on("error", (error: unknown) => {
-    if (isBrokenLogPipeError(error)) {
+    if (isUnavailableLogOutputError(error)) {
       stdoutLogWritesDisabled = true;
       return;
     }
@@ -706,7 +709,7 @@ export function createServerLogger(
     try {
       writeLine(line);
     } catch (error) {
-      if (isBrokenLogPipeError(error)) {
+      if (isUnavailableLogOutputError(error)) {
         logWritesDisabled = true;
         if (writeLine === writeStdoutLogLine) {
           stdoutLogWritesDisabled = true;

--- a/evals/packages/labs/src/fixtures/stdout-storage-fault.mjs
+++ b/evals/packages/labs/src/fixtures/stdout-storage-fault.mjs
@@ -6,7 +6,7 @@ installStdioErrorHandlers();
 // Preloaded only in the server subprocess: fail request logging without
 // filling the host disk or affecting the test runner's own stdout.
 const write = process.stdout.write.bind(process.stdout);
-process.stdout.write = (...args: Parameters<typeof process.stdout.write>) => {
+process.stdout.write = (...args) => {
   if (!String(args[0]).includes("GET /health 200")) return write(...args);
   const code = process.env.OPENWORK_TEST_STDOUT_ERROR;
   const error = Object.assign(new Error(`write ${code}`), { code });

--- a/evals/packages/labs/src/fixtures/stdout-storage-fault.ts
+++ b/evals/packages/labs/src/fixtures/stdout-storage-fault.ts
@@ -1,3 +1,8 @@
+import { installStdioErrorHandlers } from "../../../../../apps/desktop/electron/stdio-errors.mjs";
+
+// Desktop installs its stream guard before starting the in-process server.
+installStdioErrorHandlers();
+
 // Preloaded only in the server subprocess: fail request logging without
 // filling the host disk or affecting the test runner's own stdout.
 const write = process.stdout.write.bind(process.stdout);

--- a/evals/packages/labs/src/fixtures/stdout-storage-fault.ts
+++ b/evals/packages/labs/src/fixtures/stdout-storage-fault.ts
@@ -1,0 +1,12 @@
+// Preloaded only in the server subprocess: fail request logging without
+// filling the host disk or affecting the test runner's own stdout.
+const write = process.stdout.write.bind(process.stdout);
+process.stdout.write = (...args: Parameters<typeof process.stdout.write>) => {
+  if (!String(args[0]).includes("GET /health 200")) return write(...args);
+  const code = process.env.OPENWORK_TEST_STDOUT_ERROR;
+  const error = Object.assign(new Error(`write ${code}`), { code });
+  process.stderr.write(`stdout-storage-fault:${code}\n`);
+  if (process.env.OPENWORK_TEST_STDOUT_MODE === "sync") throw error;
+  process.nextTick(() => process.stdout.emit("error", error));
+  return false;
+};

--- a/evals/specs/server-log-file.test.ts
+++ b/evals/specs/server-log-file.test.ts
@@ -178,7 +178,7 @@ for (const code of ["ENOSPC", "EDQUOT"]) {
         OPENWORK_SERVER_LOG_FILE: logFile,
         OPENWORK_TEST_STDOUT_ERROR: code,
         OPENWORK_TEST_STDOUT_MODE: mode,
-      }, root, "storage-fault-test-token", join(repoRoot, "evals/packages/labs/src/fixtures/stdout-storage-fault.ts"));
+      }, root, "storage-fault-test-token", join(repoRoot, "evals/packages/labs/src/fixtures/stdout-storage-fault.mjs"));
       try {
         const port = await eventually(() => listeningPort(server.output()), { within: 60_000, intervalMs: 250 });
         const url = `http://127.0.0.1:${port}/health`;

--- a/evals/specs/server-log-file.test.ts
+++ b/evals/specs/server-log-file.test.ts
@@ -15,7 +15,7 @@ const serverDir = join(repoRoot, "apps", "server");
 
 type BootedServer = { child: ChildProcess; output: () => string; stop: () => Promise<void> };
 
-function bootServer(env: NodeJS.ProcessEnv, workspace: string, token?: string): BootedServer {
+function bootServer(env: NodeJS.ProcessEnv, workspace: string, token?: string, preload?: string): BootedServer {
   const tokenArgs = token ? ["--token", token, "--host-token", `${token}-host`] : [];
   const child = spawn(
     "pnpm",
@@ -25,6 +25,7 @@ function bootServer(env: NodeJS.ProcessEnv, workspace: string, token?: string): 
       "exec",
       "bun",
       "--conditions=development",
+      ...(preload ? ["--preload", preload] : []),
       "src/cli.ts",
       "--host",
       "127.0.0.1",
@@ -167,3 +168,46 @@ test("openwork-server persists structured, credential-free logs when OPENWORK_SE
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+for (const code of ["ENOSPC", "EDQUOT"]) {
+  for (const mode of ["sync", "async"]) {
+    test(`openwork-server keeps serving requests after ${mode} stdout ${code}`, async ({ evidence }) => {
+      const root = mkdtempSync(join(tmpdir(), "openwork-stdout-storage-spec-"));
+      const logFile = join(root, "server.log");
+      const server = bootServer({
+        OPENWORK_SERVER_LOG_FILE: logFile,
+        OPENWORK_TEST_STDOUT_ERROR: code,
+        OPENWORK_TEST_STDOUT_MODE: mode,
+      }, root, "storage-fault-test-token", join(repoRoot, "evals/packages/labs/src/fixtures/stdout-storage-fault.ts"));
+      try {
+        const port = await eventually(() => listeningPort(server.output()), { within: 60_000, intervalMs: 250 });
+        const url = `http://127.0.0.1:${port}/health`;
+        expect((await fetch(url)).status).toBe(200);
+        await eventually(() => server.output(), {
+          within: 5_000,
+          intervalMs: 50,
+          until: (output) => output.includes(`stdout-storage-fault:${code}`),
+        });
+        // A second request proves the failed stdout cannot kill the server or
+        // prevent the independent structured file sink from recording requests.
+        expect((await fetch(url)).status).toBe(200);
+        const requests = await eventually(() => jsonLines(logFile).filter((entry) => String(entry.body).includes("GET /health 200")), {
+          within: 5_000,
+          intervalMs: 50,
+          until: (entries) => entries.length === 2,
+        });
+        expect(requests).toHaveLength(2);
+        expect(server.child.exitCode).toBeNull();
+        expect(server.output().split(`stdout-storage-fault:${code}`)).toHaveLength(2);
+        evidence.recordAssertionEvidence(
+          `Requests survive ${mode} stdout ${code}`,
+          "Two real HTTP health requests returned 200; the injected stdout failure occurred exactly once, the process stayed alive, and both requests reached the independent JSON file sink.",
+          true,
+        );
+      } finally {
+        await server.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+}

--- a/evals/specs/session-error-technical-details.e2e.test.ts
+++ b/evals/specs/session-error-technical-details.e2e.test.ts
@@ -89,6 +89,19 @@ test("session error cards expose provider diagnostics only in Developer mode", a
       await user.notSee(detailsPanel);
       await user.notSee({ text: /at runLoop/ });
     });
+    await step(`${kind} banner hides the stack trace outside Developer mode`, async () => {
+      await world.seedStorageError(kind, "banner");
+      const title = kind === "disk-full" ? "Not enough disk space" : "OpenWork couldn’t access its saved data";
+      await user.see({ testId: "session-error-card" });
+      await user.see({ text: title });
+      await user.notSee({ text: /at runLoop/ });
+      await toggleDeveloperMode("on");
+      await user.see({ text: /effect\/sql\/SqlError/ });
+      await user.see({ text: /at runLoop/ });
+      await toggleDeveloperMode("off");
+      await user.see({ text: title });
+      await user.notSee({ text: /at runLoop/ });
+    });
   }
 
 });

--- a/evals/specs/session-error-technical-details.e2e.test.ts
+++ b/evals/specs/session-error-technical-details.e2e.test.ts
@@ -17,11 +17,11 @@ const detailsPanel = { testId: "session-error-details" };
 const statusLine = { text: /Status: 429/ };
 const requestId = { text: new RegExp(REQUEST_ID) };
 
-test("session error cards expose provider diagnostics only in Developer mode", async ({ user, probe, step, world }) => {
+test("session error cards expose provider diagnostics only in Developer mode", async ({ user, probe, step, world, place }) => {
   // Toggle Developer mode the way a person does: command palette → "Enable/Disable Developer Mode".
   const toggleDeveloperMode = async (next: "on" | "off") => {
     const label = next === "on" ? /enable developer mode/i : /disable developer mode/i;
-    await user.press(process.platform === "darwin" ? "Meta+K" : "Control+K");
+    await user.press(place.kind !== "daytona" && process.platform === "darwin" ? "Meta+K" : "Control+K");
     await user.click({ role: "option", label });
     await probe.eventually(() => probe.storage("openwork.developerMode"), {
       until: (value) => String(value) === (next === "on" ? "1" : "0"),

--- a/evals/specs/session-error-technical-details.e2e.test.ts
+++ b/evals/specs/session-error-technical-details.e2e.test.ts
@@ -17,7 +17,7 @@ const detailsPanel = { testId: "session-error-details" };
 const statusLine = { text: /Status: 429/ };
 const requestId = { text: new RegExp(REQUEST_ID) };
 
-test("session error cards expose provider diagnostics only in Developer mode", async ({ user, probe, step }) => {
+test("session error cards expose provider diagnostics only in Developer mode", async ({ user, probe, step, world }) => {
   // Toggle Developer mode the way a person does: command palette → "Enable/Disable Developer Mode".
   const toggleDeveloperMode = async (next: "on" | "off") => {
     const label = next === "on" ? /enable developer mode/i : /disable developer mode/i;
@@ -67,4 +67,28 @@ test("session error cards expose provider diagnostics only in Developer mode", a
     await user.notSee(requestId);
     await user.notSee({ text: DEBUG_PANEL_TITLE });
   });
+
+  const storageErrors: Array<"disk-full" | "database-error"> = ["disk-full", "database-error"];
+  for (const kind of storageErrors) {
+    await step(`${kind} shows recovery guidance and keeps the stack trace in Developer mode`, async () => {
+      await world.seedStorageError(kind);
+      const title = kind === "disk-full" ? "Not enough disk space" : "OpenWork couldn’t access its saved data";
+      await user.see({ text: title });
+      await user.see({ text: kind === "disk-full" ? /Free up some disk space/ : /check the available disk space/ });
+      await user.notSee({ text: /effect\/sql\/SqlError/ });
+      await user.notSee({ text: /at runLoop/ });
+      await user.notSee(detailsToggle);
+      if (kind === "database-error") await user.notSee({ text: "Not enough disk space" });
+      await toggleDeveloperMode("on");
+      await user.click(detailsToggle);
+      await user.see({ text: /effect\/sql\/SqlError/ });
+      await user.see({ text: /at runLoop/ });
+      await user.see({ role: "button", label: /copy details/i });
+      await toggleDeveloperMode("off");
+      await user.see({ text: title });
+      await user.notSee(detailsPanel);
+      await user.notSee({ text: /at runLoop/ });
+    });
+  }
+
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1060,7 +1060,10 @@ export async function sessionErrorCard(seed: Seed) {
   const workspace = await seed.workspace(app, seed.tmpPath("session-error-details"));
   const session = await seedSessionRetry(seed, app, { title: "Session error proof" });
   await arrangeControl(seed, app, "eval.session_error.seed");
-  return { app, workspace, session };
+  return {
+    app, workspace, session,
+    seedStorageError: (kind: "disk-full" | "database-error") => arrangeControl(seed, app, "eval.session_error.seed", { kind }),
+  };
 }
 
 export async function snapshotFailure(seed: Seed) {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1062,7 +1062,7 @@ export async function sessionErrorCard(seed: Seed) {
   await arrangeControl(seed, app, "eval.session_error.seed");
   return {
     app, workspace, session,
-    seedStorageError: (kind: "disk-full" | "database-error") => arrangeControl(seed, app, "eval.session_error.seed", { kind }),
+    seedStorageError: (kind: "disk-full" | "database-error", surface: "transcript" | "banner" = "transcript") => arrangeControl(seed, app, "eval.session_error.seed", { kind, surface }),
   };
 }
 


### PR DESCRIPTION
A full disk can crash the desktop/server during request logging and expose a raw database stack trace in the UI. Handle expected stdout failures (`ENOSPC`, `EDQUOT`, closed streams) in both the server and desktop stream guards, disabling the failed server stdout sink while preserving independent file logging.

Normal mode now shows “Not enough disk space” with cleanup instructions for confirmed storage exhaustion. Other SQL errors show “OpenWork couldn’t access its saved data” with recovery guidance, without diagnosing a full disk. Failed-task messages, composer banners, and session-load errors use the friendly presentation. Developer mode retains technical details.

Verification on `03c7a6f54f6c4366f7cd8f1c8bcc50763d5b9aeb`:
- `OPENWORK_EVAL_REF=03c7a6f54f6c4366f7cd8f1c8bcc50763d5b9aeb pnpm evals:e2e session-error-technical-details` — Passed: 1 UI journey, no skips. Placement: daytona (daytona CLI authenticated). Checks both storage-error kinds in the transcript and composer banner, toggling Developer mode on and off.
- `pnpm evals:pr specs/server-log-file.test.ts` — Passed: 5 tests, no skips. Local PR lane emits no placement line. Sync/async ENOSPC and EDQUOT are injected with the desktop guard installed; subsequent HTTP requests succeed and independent file logging continues. Credential-redaction checks pass.
- `pnpm --filter @openwork/app exec bun test tests/session-error-resilience.test.tsx` — 23 passed.
- `pnpm --filter openwork-server exec bun --conditions=development test src/server-logger.test.ts src/server-log-file.test.ts` — 12 passed.
- `node --test apps/desktop/electron/stdio-errors.test.mjs` — 3 passed.
- App/server type checks and the spec boundary check passed. Journey evidence is attached in the PR comment below.

This does not free user storage or make database writes succeed on a full disk. Failed server stdout logging stays disabled until restart.
