### PR TITLE
feat(den): add the cloud runtime provider contract and move the sandbox bootstrap out of the Daytona module

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -43,6 +43,7 @@
     "@opentelemetry/sdk-node": "0.220.0",
     "@opentelemetry/sdk-trace-node": "2.9.0",
     "@opentelemetry/semantic-conventions": "1.42.0",
+    "@openwork-ee/cloud-runtime": "workspace:*",
     "@openwork-ee/den-db": "workspace:*",
     "@openwork-ee/telemetry": "workspace:*",
     "@openwork-ee/utils": "workspace:*",

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -1,5 +1,14 @@
 import { randomUUID } from "node:crypto"
 import { Daytona, DaytonaConflictError, DaytonaNotFoundError, type CreateSandboxFromImageParams, type CreateSandboxFromSnapshotParams, type Sandbox } from "@daytonaio/sdk"
+import {
+  renderCheckpointExistsCommand,
+  renderCheckpointFlushCommand,
+  renderOpenWorkBootstrapCommand,
+  renderRestoreMarkerExistsCommand,
+  shellQuote,
+  type OpenWorkBootstrapConfig,
+  type OpenWorkCheckpointConfig,
+} from "@openwork-ee/cloud-runtime/bootstrap"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { DaytonaSandboxTable, WorkerTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
@@ -105,10 +114,6 @@ const slug = (value: string) =>
     .replace(/[^a-z0-9-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
-
-function shellQuote(value: string) {
-  return `'${value.replace(/'/g, `'"'"'`)}'`
-}
 
 function createDaytonaClient() {
   return new Daytona({
@@ -323,251 +328,41 @@ function sharedVolumeMounts(workerId: WorkerId, volumeId: string) {
   ]
 }
 
-function checkpointRestoreMarkerPath() {
-  return `${env.daytona.runtimeDataPath}/.openwork-restore-marker`
+function checkpointConfig(): OpenWorkCheckpointConfig {
+  return {
+    dataMountPath: env.daytona.dataMountPath,
+    runtimeDataPath: env.daytona.runtimeDataPath,
+    runtimeWorkspacePath: env.daytona.runtimeWorkspacePath,
+    sidecarDir: env.daytona.sidecarDir,
+    intervalSeconds: env.daytona.checkpointIntervalSeconds,
+    keep: env.daytona.checkpointKeep,
+  }
 }
 
-function checkpointStateManifest() {
-  return `${env.daytona.runtimeDataPath} ${env.daytona.runtimeWorkspacePath}`
-}
-
-function checkpointDir() {
-  return `${env.daytona.dataMountPath}/checkpoints`
-}
-
-function checkpointLastFlushMarkerPath() {
-  return `${env.daytona.sidecarDir}/checkpoint.last-flush`
-}
-
-function checkpointEnvironmentScript() {
-  // The engine keeps its sessions in a SQLite database under its own data dir
-  // (opencode.db), which lives on the container overlay rather than a volume.
-  // It was missing from the checkpoint, so every recycle onto a new snapshot
-  // started the user from scratch. Resolved from $HOME in-shell so it tracks
-  // the image instead of a hardcoded /root.
-  return `ENGINE_STATE_PATH=\${OPENWORK_ENGINE_STATE_PATH:-\$HOME/.local/share/opencode}
-OPENWORK_STATE_MANIFEST="${checkpointStateManifest()} \$ENGINE_STATE_PATH"
-CHECKPOINT_DIR=${shellQuote(checkpointDir())}
-RESTORE_MARKER=${shellQuote(checkpointRestoreMarkerPath())}
-LAST_FLUSH_MARKER=${shellQuote(checkpointLastFlushMarkerPath())}
-DEN_CKPT_INTERVAL_SECONDS=\${DEN_CKPT_INTERVAL_SECONDS:-${shellQuote(String(env.daytona.checkpointIntervalSeconds))}}
-DEN_CKPT_KEEP=\${DEN_CKPT_KEEP:-${shellQuote(String(env.daytona.checkpointKeep))}}`
-}
-
-function checkpointFlushFunctions(input: { failOnError: boolean }) {
-  const failureReturn = input.failOnError ? "1" : "0"
-  return `checkpoint_changed() {
-  if [ ! -e "$LAST_FLUSH_MARKER" ]; then
-    return 0
-  fi
-  for state_path in $OPENWORK_STATE_MANIFEST; do
-    changed_entry=$(find "$state_path" -newer "$LAST_FLUSH_MARKER" -print -quit 2>/dev/null || true)
-    if [ -n "$changed_entry" ]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-prune_checkpoints() {
-  keep_count=$DEN_CKPT_KEEP
-  if ! [ "$keep_count" -gt 0 ] 2>/dev/null; then
-    keep_count=3
-  fi
-  checkpoint_count=0
-  find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort -r | while IFS= read -r checkpoint_path; do
-    checkpoint_count=$((checkpoint_count + 1))
-    if [ "$checkpoint_count" -gt "$keep_count" ]; then
-      rm -f "$checkpoint_path" || echo "checkpoint prune failed for $checkpoint_path" >&2
-    fi
-  done
-}
-
-flush_checkpoint() {
-  mkdir -p "$CHECKPOINT_DIR" ${shellQuote(env.daytona.sidecarDir)}
-  if ! checkpoint_changed; then
-    return 0
-  fi
-  epoch=$(date +%s)
-  tmp_checkpoint=${shellQuote(env.daytona.sidecarDir)}/ckpt-$epoch.tar
-  set --
-  for state_path in $OPENWORK_STATE_MANIFEST; do
-    set -- "$@" "\${state_path#/}"
-  done
-  # Collapse the WAL so the copied database is self-consistent and small. Best
-  # effort: a locked or absent database must never fail the flush.
-  if [ -f "$ENGINE_STATE_PATH/opencode.db" ]; then
-    node -e 'const{DatabaseSync}=require("node:sqlite");const db=new DatabaseSync(process.argv[1]);db.exec("PRAGMA wal_checkpoint(TRUNCATE)");db.close()' "$ENGINE_STATE_PATH/opencode.db" >/dev/null 2>&1 || true
-  fi
-  # Credentials are re-materialized and re-delivered on every start, so they are
-  # deliberately not persisted to the shared volume. Logs are noise.
-  if tar -C / --exclude="\${ENGINE_STATE_PATH#/}/auth.json" --exclude="\${ENGINE_STATE_PATH#/}/log" -cf "$tmp_checkpoint" "$@"; then
-    if cp "$tmp_checkpoint" "$CHECKPOINT_DIR/ckpt-$epoch.tar"; then
-      touch "$LAST_FLUSH_MARKER"
-      rm -f "$tmp_checkpoint"
-      prune_checkpoints
-      return 0
-    fi
-    echo "checkpoint flush copy failed for $CHECKPOINT_DIR/ckpt-$epoch.tar" >&2
-  else
-    echo "checkpoint flush tar failed for $tmp_checkpoint" >&2
-  fi
-  rm -f "$tmp_checkpoint"
-  return ${failureReturn}
-}`
+function bootstrapConfig(input: ProvisionInput): OpenWorkBootstrapConfig {
+  return {
+    ...checkpointConfig(),
+    workspaceMountPath: env.daytona.workspaceMountPath,
+    port: env.daytona.openworkPort,
+    workerId: input.workerId,
+    clientToken: input.clientToken,
+    hostToken: input.hostToken,
+    activityHeartbeat: {
+      url: workerActivityHeartbeatUrl(input.workerId),
+      token: input.activityToken,
+    },
+    runtimeProvider: "daytona",
+    imageDescription: "Daytona runtime image",
+    rebuildHint: "rebuild and republish the Daytona snapshot",
+  }
 }
 
 export function checkpointFlushCommand() {
-  return `set -u
-${checkpointEnvironmentScript()}
-${checkpointFlushFunctions({ failOnError: true })}
-flush_checkpoint`
+  return renderCheckpointFlushCommand(checkpointConfig())
 }
 
 export function buildOpenWorkStartCommand(input: ProvisionInput) {
-  const verifyRuntimeStep = [
-    "if ! command -v openwork-server >/dev/null 2>&1; then echo 'openwork-server binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
-    "if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
-  ].join("; ")
-  const openworkServe = [
-    "OPENWORK_DATA_DIR=",
-    shellQuote(env.daytona.runtimeDataPath),
-    " OPENWORK_SERVER_CONFIG=",
-    shellQuote(`${env.daytona.runtimeDataPath}/server.json`),
-    " OPENWORK_TOKEN=",
-    shellQuote(input.clientToken),
-    " OPENWORK_HOST_TOKEN=",
-    shellQuote(input.hostToken),
-    " OPENWORK_MANAGE_OPENCODE=",
-    shellQuote("1"),
-    " OPENWORK_OPENCODE_BIN=",
-    shellQuote("/usr/local/bin/opencode"),
-    " OPENWORK_WEB_ROOT=",
-    shellQuote("/opt/openwork/web"),
-    // The instance still serves its own SPA copy for direct/debug access, but
-    // without a bootstrap token that path is intentionally inert; the gateway
-    // is the supported entry.
-    " OPENWORK_WEB_BOOTSTRAP_TOKEN=",
-    shellQuote("0"),
-    " OPENWORK_EXTENSIONS_PLUGIN_DIR=",
-    shellQuote("/opt/openwork/opencode-plugins"),
-    " DEN_RUNTIME_PROVIDER=",
-    shellQuote("daytona"),
-    " DEN_WORKER_ID=",
-    shellQuote(input.workerId),
-    " DEN_ACTIVITY_HEARTBEAT_ENABLED=",
-    shellQuote("1"),
-    " DEN_ACTIVITY_HEARTBEAT_URL=",
-    shellQuote(workerActivityHeartbeatUrl(input.workerId)),
-    " DEN_ACTIVITY_HEARTBEAT_TOKEN=",
-    shellQuote(input.activityToken),
-    " openwork-server",
-    ` --workspace ${shellQuote(env.daytona.runtimeWorkspacePath)}`,
-    ` --host 0.0.0.0`,
-    ` --port ${shellQuote(String(env.daytona.openworkPort))}`,
-    ` --cors '*'`,
-    // This single-user worker's SPA has no approvals responder, so manual mode makes gated writes such as chat-attachment uploads time out to 403.
-    // Auto matches the desktop sidecar's approvalMode; viewer tokens remain blocked by scope checks.
-    ` --approval auto`,
-    ` --verbose`,
-  ].join("")
-  const script = `
-set -u
-mkdir -p ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)} ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.sidecarDir)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
-ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
-ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
-${verifyRuntimeStep}
-${checkpointEnvironmentScript()}
-
-state_dirs_pristine() {
-  if [ -e "$RESTORE_MARKER" ]; then
-    return 1
-  fi
-  data_entry=$(find ${shellQuote(env.daytona.runtimeDataPath)} -mindepth 1 -print -quit 2>/dev/null || true)
-  if [ -n "$data_entry" ]; then
-    return 1
-  fi
-  workspace_entry=$(find ${shellQuote(env.daytona.runtimeWorkspacePath)} -mindepth 1 ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)} ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/*`)} -print -quit 2>/dev/null || true)
-  if [ -n "$workspace_entry" ]; then
-    return 1
-  fi
-  return 0
-}
-
-hydrate_checkpoint() {
-  mkdir -p "$CHECKPOINT_DIR"
-  latest_checkpoint=$(find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort | tail -n 1 || true)
-  if [ -z "$latest_checkpoint" ]; then
-    return 0
-  fi
-  if ! state_dirs_pristine; then
-    echo "checkpoint hydrate skipped; local OpenWork state is not pristine or was already restored"
-    return 0
-  fi
-  echo "checkpoint hydrate restoring $latest_checkpoint"
-  if tar -C / -xf "$latest_checkpoint"; then
-    printf '%s\n' "$latest_checkpoint" > "$RESTORE_MARKER"
-    return 0
-  fi
-  echo "checkpoint hydrate failed for $latest_checkpoint; continuing with fresh OpenWork state" >&2
-  rm -rf ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)}
-  mkdir -p ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
-  ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
-  ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
-}
-
-${checkpointFlushFunctions({ failOnError: false })}
-
-checkpoint_loop() {
-  while true; do
-    sleep "$DEN_CKPT_INTERVAL_SECONDS"
-    flush_checkpoint
-  done
-}
-
-server_pid=""
-checkpoint_pid=""
-on_term() {
-  echo "termination requested; flushing OpenWork checkpoint"
-  flush_checkpoint
-  if [ -n "$server_pid" ]; then
-    kill -TERM "$server_pid" 2>/dev/null || true
-    wait "$server_pid" 2>/dev/null || true
-  fi
-  if [ -n "$checkpoint_pid" ]; then
-    kill "$checkpoint_pid" 2>/dev/null || true
-    wait "$checkpoint_pid" 2>/dev/null || true
-  fi
-  exit 143
-}
-trap on_term TERM INT
-
-hydrate_checkpoint
-attempt=0
-while [ "$attempt" -lt 3 ]; do
-  attempt=$((attempt + 1))
-  ${openworkServe} &
-  server_pid=$!
-  checkpoint_loop &
-  checkpoint_pid=$!
-  wait "$server_pid"
-  status=$?
-  kill "$checkpoint_pid" 2>/dev/null || true
-  wait "$checkpoint_pid" 2>/dev/null || true
-  server_pid=""
-  checkpoint_pid=""
-  if [ "$status" -eq 0 ]; then
-    flush_checkpoint
-    exit 0
-  fi
-  echo "openwork-server failed (attempt $attempt, exit $status); rebuild and republish the Daytona snapshot if this persists; retrying in 3s"
-  sleep 3
-done
-flush_checkpoint
-exit 1
-`.trim()
-
-  return `sh -lc ${shellQuote(script)}`
+  return renderOpenWorkBootstrapCommand(bootstrapConfig(input))
 }
 
 async function waitForVolumeReady(getVolume: DaytonaProvisioningRuntime["getVolume"], name: string, timeoutMs: number) {
@@ -748,11 +543,11 @@ async function runSandboxShellCommand(sandbox: DaytonaSandboxRuntime, sessionId:
 }
 
 function checkpointExistsCommand() {
-  return `test -n "$(find ${shellQuote(`${env.daytona.dataMountPath}/checkpoints`)} -maxdepth 1 -type f -name 'ckpt-*.tar' -print -quit 2>/dev/null)"`
+  return renderCheckpointExistsCommand(checkpointConfig())
 }
 
 function restoreMarkerExistsCommand() {
-  return `test -s ${shellQuote(checkpointRestoreMarkerPath())}`
+  return renderRestoreMarkerExistsCommand(checkpointConfig())
 }
 
 async function verifyRestoreMarker(sandbox: DaytonaSandboxRuntime) {

--- a/ee/packages/cloud-runtime/package.json
+++ b/ee/packages/cloud-runtime/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@openwork-ee/cloud-runtime",
+  "private": true,
+  "type": "module",
+  "description": "Provider-neutral contract, bootstrap, and conformance suite for OpenWork Cloud sandbox hosts.",
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
+  "source": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./contract": {
+      "types": "./src/contract/index.ts",
+      "development": "./src/contract/index.ts",
+      "default": "./dist/contract/index.js"
+    },
+    "./bootstrap": {
+      "types": "./src/bootstrap/index.ts",
+      "development": "./src/bootstrap/index.ts",
+      "default": "./dist/bootstrap/index.js"
+    },
+    "./testing": {
+      "types": "./src/testing/index.ts",
+      "development": "./src/testing/index.ts",
+      "default": "./dist/testing/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc -p tsconfig.json --noEmit --pretty false",
+    "test": "bun test src"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsup": "^8.5.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/ee/packages/cloud-runtime/src/bootstrap/index.ts
+++ b/ee/packages/cloud-runtime/src/bootstrap/index.ts
@@ -1,0 +1,1 @@
+export * from "./openwork-runtime"

--- a/ee/packages/cloud-runtime/src/bootstrap/openwork-runtime.test.ts
+++ b/ee/packages/cloud-runtime/src/bootstrap/openwork-runtime.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import {
+  checkpointDirectory,
+  checkpointRestoreMarkerPath,
+  renderCheckpointExistsCommand,
+  renderCheckpointFlushCommand,
+  renderOpenWorkBootstrapCommand,
+  renderOpenWorkBootstrapScript,
+  renderRestoreMarkerExistsCommand,
+  shellQuote,
+  type OpenWorkBootstrapConfig,
+} from "./openwork-runtime"
+
+const config: OpenWorkBootstrapConfig = {
+  dataMountPath: "/persist/openwork",
+  workspaceMountPath: "/workspace",
+  runtimeDataPath: "/tmp/openwork-data",
+  runtimeWorkspacePath: "/tmp/openwork-workspace",
+  sidecarDir: "/tmp/openwork-sidecars",
+  intervalSeconds: 300,
+  keep: 3,
+  port: 8787,
+  workerId: "worker_01test",
+  clientToken: "client-token",
+  hostToken: "host's-token",
+  activityHeartbeat: { url: "https://den.example/v1/workers/worker_01test/activity-heartbeat", token: "activity-token" },
+  runtimeProvider: "fake",
+  imageDescription: "fake runtime image",
+  rebuildHint: "rebuild the fake image",
+}
+
+describe("OpenWork bootstrap renderer", () => {
+  test("quotes shell values safely", () => {
+    expect(shellQuote("plain")).toBe("'plain'")
+    expect(shellQuote("it's")).toBe(`'it'"'"'s'`)
+  })
+
+  test("renders the supervised server with hydrate before start and flush on exit", () => {
+    const command = renderOpenWorkBootstrapScript(config)
+    expect(renderOpenWorkBootstrapCommand(config)).toBe(`sh -lc ${shellQuote(command)}`)
+    expect(command.startsWith("set -u\n")).toBe(true)
+    expect(command).toContain(`OPENWORK_HOST_TOKEN='host'"'"'s-token'`)
+    expect(command).toContain("DEN_RUNTIME_PROVIDER='fake'")
+    expect(command).toContain("openwork-server binary missing from fake runtime image; rebuild the fake image")
+    expect(command).toContain('OPENWORK_STATE_MANIFEST="/tmp/openwork-data /tmp/openwork-workspace $ENGINE_STATE_PATH"')
+    expect(command).toContain("trap on_term TERM INT")
+    const hydrateCall = command.indexOf("\nhydrate_checkpoint\n")
+    const serverStart = command.indexOf(" openwork-server --workspace")
+    expect(hydrateCall).toBeGreaterThan(-1)
+    expect(serverStart).toBeGreaterThan(hydrateCall)
+    // The restore marker is written with a real newline, matching the shell the
+    // script has always produced.
+    expect(command).toContain("printf '%s\n' \"$latest_checkpoint\"")
+  })
+
+  test("flush and probe commands share the checkpoint layout", () => {
+    expect(checkpointDirectory(config)).toBe("/persist/openwork/checkpoints")
+    expect(checkpointRestoreMarkerPath(config)).toBe("/tmp/openwork-data/.openwork-restore-marker")
+    const flush = renderCheckpointFlushCommand(config)
+    expect(flush.startsWith("set -u\n")).toBe(true)
+    expect(flush.endsWith("\nflush_checkpoint")).toBe(true)
+    expect(flush).toContain("return 1\n}")
+    expect(renderCheckpointExistsCommand(config)).toContain("'/persist/openwork/checkpoints'")
+    expect(renderRestoreMarkerExistsCommand(config)).toBe("test -s '/tmp/openwork-data/.openwork-restore-marker'")
+  })
+})

--- a/ee/packages/cloud-runtime/src/bootstrap/openwork-runtime.ts
+++ b/ee/packages/cloud-runtime/src/bootstrap/openwork-runtime.ts
@@ -1,0 +1,308 @@
+/**
+ * The shell bootstrap every provider runs inside a Cloud sandbox: mount
+ * layout, checkpoint hydrate/flush, and the supervised `openwork-server`
+ * process. It is provider-neutral; a provider only supplies the paths its
+ * mounts land on and the process credentials, then `exec`s the rendered
+ * command.
+ */
+
+export function shellQuote(value: string) {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+export type OpenWorkCheckpointConfig = {
+  /** Persistent mount that receives `checkpoints/ckpt-*.tar`. */
+  dataMountPath: string
+  /** Where the running server keeps its state (checkpointed). */
+  runtimeDataPath: string
+  /** The workspace root the server serves (checkpointed). */
+  runtimeWorkspacePath: string
+  /** Scratch directory for in-progress checkpoint tars and markers. */
+  sidecarDir: string
+  intervalSeconds: number
+  keep: number
+}
+
+export type OpenWorkBootstrapConfig = OpenWorkCheckpointConfig & {
+  /** Persistent mount exposed to the agent as the workspace volume. */
+  workspaceMountPath: string
+  port: number
+  workerId: string
+  clientToken: string
+  hostToken: string
+  activityHeartbeat: {
+    url: string
+    token: string
+  }
+  /** Value of `DEN_RUNTIME_PROVIDER` inside the sandbox. */
+  runtimeProvider: string
+  /** Wording for the runtime-image verification failure, e.g. "Daytona runtime image". */
+  imageDescription: string
+  /** Operator hint appended to start failures, e.g. "rebuild and republish the Daytona snapshot". */
+  rebuildHint: string
+}
+
+export function checkpointDirectory(config: Pick<OpenWorkCheckpointConfig, "dataMountPath">) {
+  return `${config.dataMountPath}/checkpoints`
+}
+
+export function checkpointRestoreMarkerPath(config: Pick<OpenWorkCheckpointConfig, "runtimeDataPath">) {
+  return `${config.runtimeDataPath}/.openwork-restore-marker`
+}
+
+function checkpointStateManifest(config: OpenWorkCheckpointConfig) {
+  return `${config.runtimeDataPath} ${config.runtimeWorkspacePath}`
+}
+
+function checkpointLastFlushMarkerPath(config: OpenWorkCheckpointConfig) {
+  return `${config.sidecarDir}/checkpoint.last-flush`
+}
+
+function checkpointEnvironmentScript(config: OpenWorkCheckpointConfig) {
+  // The engine keeps its sessions in a SQLite database under its own data dir
+  // (opencode.db), which lives on the container overlay rather than a volume.
+  // It was missing from the checkpoint, so every recycle onto a new snapshot
+  // started the user from scratch. Resolved from $HOME in-shell so it tracks
+  // the image instead of a hardcoded /root.
+  return `ENGINE_STATE_PATH=\${OPENWORK_ENGINE_STATE_PATH:-\$HOME/.local/share/opencode}
+OPENWORK_STATE_MANIFEST="${checkpointStateManifest(config)} \$ENGINE_STATE_PATH"
+CHECKPOINT_DIR=${shellQuote(checkpointDirectory(config))}
+RESTORE_MARKER=${shellQuote(checkpointRestoreMarkerPath(config))}
+LAST_FLUSH_MARKER=${shellQuote(checkpointLastFlushMarkerPath(config))}
+DEN_CKPT_INTERVAL_SECONDS=\${DEN_CKPT_INTERVAL_SECONDS:-${shellQuote(String(config.intervalSeconds))}}
+DEN_CKPT_KEEP=\${DEN_CKPT_KEEP:-${shellQuote(String(config.keep))}}`
+}
+
+function checkpointFlushFunctions(config: OpenWorkCheckpointConfig, input: { failOnError: boolean }) {
+  const failureReturn = input.failOnError ? "1" : "0"
+  return `checkpoint_changed() {
+  if [ ! -e "$LAST_FLUSH_MARKER" ]; then
+    return 0
+  fi
+  for state_path in $OPENWORK_STATE_MANIFEST; do
+    changed_entry=$(find "$state_path" -newer "$LAST_FLUSH_MARKER" -print -quit 2>/dev/null || true)
+    if [ -n "$changed_entry" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+prune_checkpoints() {
+  keep_count=$DEN_CKPT_KEEP
+  if ! [ "$keep_count" -gt 0 ] 2>/dev/null; then
+    keep_count=3
+  fi
+  checkpoint_count=0
+  find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort -r | while IFS= read -r checkpoint_path; do
+    checkpoint_count=$((checkpoint_count + 1))
+    if [ "$checkpoint_count" -gt "$keep_count" ]; then
+      rm -f "$checkpoint_path" || echo "checkpoint prune failed for $checkpoint_path" >&2
+    fi
+  done
+}
+
+flush_checkpoint() {
+  mkdir -p "$CHECKPOINT_DIR" ${shellQuote(config.sidecarDir)}
+  if ! checkpoint_changed; then
+    return 0
+  fi
+  epoch=$(date +%s)
+  tmp_checkpoint=${shellQuote(config.sidecarDir)}/ckpt-$epoch.tar
+  set --
+  for state_path in $OPENWORK_STATE_MANIFEST; do
+    set -- "$@" "\${state_path#/}"
+  done
+  # Collapse the WAL so the copied database is self-consistent and small. Best
+  # effort: a locked or absent database must never fail the flush.
+  if [ -f "$ENGINE_STATE_PATH/opencode.db" ]; then
+    node -e 'const{DatabaseSync}=require("node:sqlite");const db=new DatabaseSync(process.argv[1]);db.exec("PRAGMA wal_checkpoint(TRUNCATE)");db.close()' "$ENGINE_STATE_PATH/opencode.db" >/dev/null 2>&1 || true
+  fi
+  # Credentials are re-materialized and re-delivered on every start, so they are
+  # deliberately not persisted to the shared volume. Logs are noise.
+  if tar -C / --exclude="\${ENGINE_STATE_PATH#/}/auth.json" --exclude="\${ENGINE_STATE_PATH#/}/log" -cf "$tmp_checkpoint" "$@"; then
+    if cp "$tmp_checkpoint" "$CHECKPOINT_DIR/ckpt-$epoch.tar"; then
+      touch "$LAST_FLUSH_MARKER"
+      rm -f "$tmp_checkpoint"
+      prune_checkpoints
+      return 0
+    fi
+    echo "checkpoint flush copy failed for $CHECKPOINT_DIR/ckpt-$epoch.tar" >&2
+  else
+    echo "checkpoint flush tar failed for $tmp_checkpoint" >&2
+  fi
+  rm -f "$tmp_checkpoint"
+  return ${failureReturn}
+}`
+}
+
+/** Flush the running server's state to the persistent checkpoint directory now. */
+export function renderCheckpointFlushCommand(config: OpenWorkCheckpointConfig) {
+  return `set -u
+${checkpointEnvironmentScript(config)}
+${checkpointFlushFunctions(config, { failOnError: true })}
+flush_checkpoint`
+}
+
+/** `test` succeeds when at least one checkpoint tar exists on the data mount. */
+export function renderCheckpointExistsCommand(config: Pick<OpenWorkCheckpointConfig, "dataMountPath">) {
+  return `test -n "$(find ${shellQuote(checkpointDirectory(config))} -maxdepth 1 -type f -name 'ckpt-*.tar' -print -quit 2>/dev/null)"`
+}
+
+/** `test` succeeds when the running instance hydrated from a checkpoint. */
+export function renderRestoreMarkerExistsCommand(config: Pick<OpenWorkCheckpointConfig, "runtimeDataPath">) {
+  return `test -s ${shellQuote(checkpointRestoreMarkerPath(config))}`
+}
+
+/** The supervised OpenWork server process with checkpoint hydrate and flush, as a POSIX sh script. */
+export function renderOpenWorkBootstrapScript(config: OpenWorkBootstrapConfig) {
+  const verifyRuntimeStep = [
+    `if ! command -v openwork-server >/dev/null 2>&1; then echo 'openwork-server binary missing from ${config.imageDescription}; ${config.rebuildHint}' >&2; exit 1; fi`,
+    `if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from ${config.imageDescription}; ${config.rebuildHint}' >&2; exit 1; fi`,
+  ].join("; ")
+  const openworkServe = [
+    "OPENWORK_DATA_DIR=",
+    shellQuote(config.runtimeDataPath),
+    " OPENWORK_SERVER_CONFIG=",
+    shellQuote(`${config.runtimeDataPath}/server.json`),
+    " OPENWORK_TOKEN=",
+    shellQuote(config.clientToken),
+    " OPENWORK_HOST_TOKEN=",
+    shellQuote(config.hostToken),
+    " OPENWORK_MANAGE_OPENCODE=",
+    shellQuote("1"),
+    " OPENWORK_OPENCODE_BIN=",
+    shellQuote("/usr/local/bin/opencode"),
+    " OPENWORK_WEB_ROOT=",
+    shellQuote("/opt/openwork/web"),
+    // The instance still serves its own SPA copy for direct/debug access, but
+    // without a bootstrap token that path is intentionally inert; the gateway
+    // is the supported entry.
+    " OPENWORK_WEB_BOOTSTRAP_TOKEN=",
+    shellQuote("0"),
+    " OPENWORK_EXTENSIONS_PLUGIN_DIR=",
+    shellQuote("/opt/openwork/opencode-plugins"),
+    " DEN_RUNTIME_PROVIDER=",
+    shellQuote(config.runtimeProvider),
+    " DEN_WORKER_ID=",
+    shellQuote(config.workerId),
+    " DEN_ACTIVITY_HEARTBEAT_ENABLED=",
+    shellQuote("1"),
+    " DEN_ACTIVITY_HEARTBEAT_URL=",
+    shellQuote(config.activityHeartbeat.url),
+    " DEN_ACTIVITY_HEARTBEAT_TOKEN=",
+    shellQuote(config.activityHeartbeat.token),
+    " openwork-server",
+    ` --workspace ${shellQuote(config.runtimeWorkspacePath)}`,
+    ` --host 0.0.0.0`,
+    ` --port ${shellQuote(String(config.port))}`,
+    ` --cors '*'`,
+    // This single-user worker's SPA has no approvals responder, so manual mode makes gated writes such as chat-attachment uploads time out to 403.
+    // Auto matches the desktop sidecar's approvalMode; viewer tokens remain blocked by scope checks.
+    ` --approval auto`,
+    ` --verbose`,
+  ].join("")
+  const volumesDir = `${config.runtimeWorkspacePath}/volumes`
+  const script = `
+set -u
+mkdir -p ${shellQuote(config.workspaceMountPath)} ${shellQuote(config.dataMountPath)} ${shellQuote(config.runtimeWorkspacePath)} ${shellQuote(config.runtimeDataPath)} ${shellQuote(config.sidecarDir)} ${shellQuote(volumesDir)}
+ln -sfn ${shellQuote(config.workspaceMountPath)} ${shellQuote(`${volumesDir}/workspace`) }
+ln -sfn ${shellQuote(config.dataMountPath)} ${shellQuote(`${volumesDir}/data`) }
+${verifyRuntimeStep}
+${checkpointEnvironmentScript(config)}
+
+state_dirs_pristine() {
+  if [ -e "$RESTORE_MARKER" ]; then
+    return 1
+  fi
+  data_entry=$(find ${shellQuote(config.runtimeDataPath)} -mindepth 1 -print -quit 2>/dev/null || true)
+  if [ -n "$data_entry" ]; then
+    return 1
+  fi
+  workspace_entry=$(find ${shellQuote(config.runtimeWorkspacePath)} -mindepth 1 ! -path ${shellQuote(volumesDir)} ! -path ${shellQuote(`${volumesDir}/*`)} -print -quit 2>/dev/null || true)
+  if [ -n "$workspace_entry" ]; then
+    return 1
+  fi
+  return 0
+}
+
+hydrate_checkpoint() {
+  mkdir -p "$CHECKPOINT_DIR"
+  latest_checkpoint=$(find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort | tail -n 1 || true)
+  if [ -z "$latest_checkpoint" ]; then
+    return 0
+  fi
+  if ! state_dirs_pristine; then
+    echo "checkpoint hydrate skipped; local OpenWork state is not pristine or was already restored"
+    return 0
+  fi
+  echo "checkpoint hydrate restoring $latest_checkpoint"
+  if tar -C / -xf "$latest_checkpoint"; then
+    printf '%s\n' "$latest_checkpoint" > "$RESTORE_MARKER"
+    return 0
+  fi
+  echo "checkpoint hydrate failed for $latest_checkpoint; continuing with fresh OpenWork state" >&2
+  rm -rf ${shellQuote(config.runtimeDataPath)} ${shellQuote(config.runtimeWorkspacePath)}
+  mkdir -p ${shellQuote(config.runtimeDataPath)} ${shellQuote(volumesDir)}
+  ln -sfn ${shellQuote(config.workspaceMountPath)} ${shellQuote(`${volumesDir}/workspace`) }
+  ln -sfn ${shellQuote(config.dataMountPath)} ${shellQuote(`${volumesDir}/data`) }
+}
+
+${checkpointFlushFunctions(config, { failOnError: false })}
+
+checkpoint_loop() {
+  while true; do
+    sleep "$DEN_CKPT_INTERVAL_SECONDS"
+    flush_checkpoint
+  done
+}
+
+server_pid=""
+checkpoint_pid=""
+on_term() {
+  echo "termination requested; flushing OpenWork checkpoint"
+  flush_checkpoint
+  if [ -n "$server_pid" ]; then
+    kill -TERM "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  if [ -n "$checkpoint_pid" ]; then
+    kill "$checkpoint_pid" 2>/dev/null || true
+    wait "$checkpoint_pid" 2>/dev/null || true
+  fi
+  exit 143
+}
+trap on_term TERM INT
+
+hydrate_checkpoint
+attempt=0
+while [ "$attempt" -lt 3 ]; do
+  attempt=$((attempt + 1))
+  ${openworkServe} &
+  server_pid=$!
+  checkpoint_loop &
+  checkpoint_pid=$!
+  wait "$server_pid"
+  status=$?
+  kill "$checkpoint_pid" 2>/dev/null || true
+  wait "$checkpoint_pid" 2>/dev/null || true
+  server_pid=""
+  checkpoint_pid=""
+  if [ "$status" -eq 0 ]; then
+    flush_checkpoint
+    exit 0
+  fi
+  echo "openwork-server failed (attempt $attempt, exit $status); ${config.rebuildHint} if this persists; retrying in 3s"
+  sleep 3
+done
+flush_checkpoint
+exit 1
+`.trim()
+
+  return script
+}
+
+/** `renderOpenWorkBootstrapScript` wrapped for a provider that execs one command line. */
+export function renderOpenWorkBootstrapCommand(config: OpenWorkBootstrapConfig) {
+  return `sh -lc ${shellQuote(renderOpenWorkBootstrapScript(config))}`
+}

--- a/ee/packages/cloud-runtime/src/contract/errors.ts
+++ b/ee/packages/cloud-runtime/src/contract/errors.ts
@@ -1,0 +1,50 @@
+/**
+ * The only error a provider may let escape. Den classifies startup failures
+ * from `code`, so a new host never needs Den to learn its message strings.
+ */
+export type RuntimeProviderErrorCode =
+  | "not_found"
+  | "conflict"
+  | "invalid_state"
+  | "rate_limited"
+  | "capacity"
+  | "transient"
+  | "timeout"
+  | "auth"
+  | "unknown"
+
+const retryableByDefault: ReadonlySet<RuntimeProviderErrorCode> = new Set([
+  "invalid_state",
+  "rate_limited",
+  "transient",
+  "timeout",
+])
+
+export class RuntimeProviderError extends Error {
+  readonly code: RuntimeProviderErrorCode
+  readonly retryable: boolean
+  readonly providerId: string
+
+  constructor(input: {
+    providerId: string
+    code: RuntimeProviderErrorCode
+    message: string
+    retryable?: boolean
+    cause?: unknown
+  }) {
+    super(input.message, input.cause === undefined ? undefined : { cause: input.cause })
+    this.name = "RuntimeProviderError"
+    this.code = input.code
+    this.providerId = input.providerId
+    this.retryable = input.retryable ?? retryableByDefault.has(input.code)
+  }
+}
+
+export function isRuntimeProviderError(error: unknown): error is RuntimeProviderError {
+  return error instanceof RuntimeProviderError
+    || (error instanceof Error && error.name === "RuntimeProviderError" && "code" in error)
+}
+
+export function runtimeProviderErrorCode(error: unknown): RuntimeProviderErrorCode | null {
+  return isRuntimeProviderError(error) ? error.code : null
+}

--- a/ee/packages/cloud-runtime/src/contract/index.ts
+++ b/ee/packages/cloud-runtime/src/contract/index.ts
@@ -1,0 +1,2 @@
+export * from "./errors"
+export * from "./provider"

--- a/ee/packages/cloud-runtime/src/contract/provider.ts
+++ b/ee/packages/cloud-runtime/src/contract/provider.ts
@@ -1,0 +1,177 @@
+/**
+ * Provider-neutral contract between Den and the host that runs an OpenWork
+ * Cloud sandbox (Daytona today; Fly Machines, Firecracker, Kubernetes, or a
+ * local process tomorrow).
+ *
+ * Den's lifecycle policy (provision, wake, recycle, idle stop, prewarm) is
+ * written against this contract only. A provider package implements it and
+ * must pass `sandboxProviderConformanceCases` before Den can select it.
+ *
+ * Requirements the shapes below encode:
+ * 1. Capability negotiation: the orchestrator adapts to `describe()`.
+ * 2. Opaque references: Den persists `SandboxRef.ref` as JSON and never
+ *    interprets it.
+ * 3. Normalized state and error taxonomy: no message-string matching outside a
+ *    provider package (see `errors.ts`).
+ * 4. Endpoint abstraction with expiry: consumers learn `kind`/`expiresAt`,
+ *    never a host name.
+ * 5. Exec with logs and exit codes, so bootstrap failures stay diagnosable.
+ * 6. Storage attach; checkpoint metadata is owned by Den, never probed with
+ *    compute.
+ * 7. Idempotent create: a retried `create` with the same `idempotencyKey` must
+ *    either return the existing instance or throw `conflict`, never make two.
+ */
+
+export type ProviderEndpointKind = "signed-expiring" | "stable" | "den-tunnel"
+
+export type ProviderCapabilities = {
+  /** A stopped instance keeps its disk and can be started again. */
+  stopResume: boolean
+  /** Storage can outlive the instance (volumes, PVCs, external checkpoints). */
+  persistentStorage: boolean
+  /** Wake restores memory state; the bootstrap can be skipped on resume. */
+  memorySnapshotRestore: boolean
+  /** The host can hold pre-created instances for instant assignment. */
+  warmPool: boolean
+  endpointKind: ProviderEndpointKind
+  /** `exec` is implemented; every current provider needs it for the bootstrap. */
+  exec: boolean
+  regions: readonly string[]
+}
+
+export type SandboxState =
+  | "creating"
+  | "running"
+  | "stopping"
+  | "stopped"
+  | "archived"
+  | "missing"
+  | "error"
+
+/** What the host should boot. Daytona: snapshot name. OCI hosts: image digest. */
+export type ImageRef = {
+  id: string
+  version: string
+}
+
+/** Opaque to Den. Persisted as JSON, echoed back to the same provider. */
+export type SandboxRef = {
+  providerId: string
+  ref: Readonly<Record<string, string>>
+}
+
+export type VolumeRef = {
+  providerId: string
+  id: string
+  name: string
+}
+
+export type StorageAttachment = {
+  volume: VolumeRef
+  mountPath: string
+  subpath?: string
+}
+
+export type SandboxResources = {
+  cpu: number
+  memoryGb: number
+  diskGb: number
+}
+
+export type SandboxLifecyclePolicy = {
+  autoStopMinutes?: number
+  autoArchiveMinutes?: number
+  autoDeleteMinutes?: number
+}
+
+export type SandboxSpec = {
+  workerId: string
+  /**
+   * Stable per worker and image version. Providers map it to whatever makes a
+   * create idempotent on their side (a name, a label, a request token).
+   */
+  idempotencyKey: string
+  /** `null` asks the provider for its configured base image. */
+  image: ImageRef | null
+  resources?: SandboxResources
+  labels: Readonly<Record<string, string>>
+  env: Readonly<Record<string, string>>
+  storage: readonly StorageAttachment[]
+  exposePorts: readonly number[]
+  lifecycle?: SandboxLifecyclePolicy
+  /** Short-lived helper instance (cleanup, probes); never adopted as a worker. */
+  ephemeral?: boolean
+  public?: boolean
+}
+
+export type SandboxHandle = {
+  ref: SandboxRef
+  state: SandboxState
+  region: string | null
+  /** When `state` was last read from the host; the orchestrator caches on it. */
+  observedAt: number
+}
+
+export type ExecSpec = {
+  command: string
+  /** Return once the process is started instead of waiting for exit. */
+  detach: boolean
+  timeoutMs: number
+  /** Provider-visible grouping for log retrieval (Daytona sessions). */
+  sessionId?: string
+}
+
+export interface ExecHandle {
+  id: string
+  /** `null` while the process is still running. */
+  exitCode(): Promise<number | null>
+  logs(): Promise<{ stdout: string; stderr: string }>
+}
+
+export type Endpoint = {
+  url: string
+  /** `null` for stable endpoints. */
+  expiresAt: Date | null
+  kind: ProviderEndpointKind
+}
+
+export type ProviderTimeout = {
+  timeoutMs: number
+}
+
+export type SandboxQuery = {
+  idempotencyKey?: string
+  labels?: Readonly<Record<string, string>>
+}
+
+export interface SandboxStorage {
+  /** Idempotent; resolves once the volume is usable for attachment. */
+  ensureVolume(name: string, opts: ProviderTimeout): Promise<VolumeRef>
+  /** Erase worker data at deprovision; must not touch other subpaths. */
+  eraseSubpaths(volume: VolumeRef, subpaths: readonly string[], opts: ProviderTimeout): Promise<void>
+  /**
+   * Optional metadata probe. Den keeps its own checkpoint ledger; this exists
+   * only for records that predate the ledger and may cost compute.
+   */
+  exists?(volume: VolumeRef, path: string, opts: ProviderTimeout): Promise<boolean>
+}
+
+export interface SandboxProvider {
+  readonly id: string
+  describe(): ProviderCapabilities
+  /** The image new instances should boot, or `null` when the provider has no pin. */
+  currentImage(): ImageRef | null
+  /** Throws `conflict` when `idempotencyKey` already names a live instance. */
+  create(spec: SandboxSpec, opts: ProviderTimeout): Promise<SandboxHandle>
+  find(query: SandboxQuery): Promise<SandboxHandle | null>
+  /** `null` for a missing instance; never throws `not_found`. */
+  get(ref: SandboxRef): Promise<SandboxHandle | null>
+  /** One state refresh. Must be cheap; the orchestrator decides how often. */
+  inspect(handle: SandboxHandle): Promise<SandboxHandle>
+  start(handle: SandboxHandle, opts: ProviderTimeout): Promise<void>
+  stop(handle: SandboxHandle, opts: ProviderTimeout): Promise<void>
+  destroy(handle: SandboxHandle, opts: ProviderTimeout): Promise<void>
+  exec(handle: SandboxHandle, spec: ExecSpec): Promise<ExecHandle>
+  endpoint(handle: SandboxHandle, port: number, opts?: { ttlSeconds?: number }): Promise<Endpoint>
+  readonly storage: SandboxStorage
+}

--- a/ee/packages/cloud-runtime/src/index.ts
+++ b/ee/packages/cloud-runtime/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./bootstrap"
+export * from "./contract"

--- a/ee/packages/cloud-runtime/src/testing/conformance.test.ts
+++ b/ee/packages/cloud-runtime/src/testing/conformance.test.ts
@@ -1,0 +1,16 @@
+import { describe, test } from "bun:test"
+import { sandboxProviderConformanceCases } from "./conformance"
+import { createFakeProvider } from "./fake-provider"
+
+describe("fake provider conformance", () => {
+  for (const conformanceCase of sandboxProviderConformanceCases(() => createFakeProvider())) {
+    test(conformanceCase.name, conformanceCase.run)
+  }
+})
+
+describe("fake provider with stable endpoints", () => {
+  const factory = () => createFakeProvider({ capabilities: { endpointKind: "stable", stopResume: false } })
+  for (const conformanceCase of sandboxProviderConformanceCases(factory)) {
+    test(conformanceCase.name, conformanceCase.run)
+  }
+})

--- a/ee/packages/cloud-runtime/src/testing/conformance.ts
+++ b/ee/packages/cloud-runtime/src/testing/conformance.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict"
+import { isRuntimeProviderError } from "../contract/errors"
+import type { SandboxProvider, SandboxSpec } from "../contract/provider"
+
+export type ConformanceCase = {
+  name: string
+  run: () => Promise<void>
+}
+
+export type ConformanceOptions = {
+  /** Per-operation budget handed to the provider. */
+  timeoutMs?: number
+  /** A volume name the provider may create and erase during the run. */
+  volumeName?: string
+  /** A shell command that exits 0 quickly on this provider (default `true`). */
+  trivialCommand?: string
+}
+
+type ProviderFactory = () => Promise<SandboxProvider> | SandboxProvider
+
+function specFor(provider: SandboxProvider, key: string, extra: Partial<SandboxSpec> = {}): SandboxSpec {
+  return {
+    workerId: `worker-${key}`,
+    idempotencyKey: `conformance-${key}`,
+    image: provider.currentImage(),
+    labels: { "openwork.den.conformance": key },
+    env: { DEN_CONFORMANCE: "1" },
+    storage: [],
+    exposePorts: [8787],
+    ...extra,
+  }
+}
+
+async function expectProviderError(
+  operation: () => Promise<unknown>,
+  code: string,
+  providerId: string,
+) {
+  let caught: unknown = null
+  try {
+    await operation()
+  } catch (error) {
+    caught = error
+  }
+  assert.ok(caught !== null, `expected the provider to throw ${code}`)
+  assert.ok(isRuntimeProviderError(caught), `expected a RuntimeProviderError, got ${String(caught)}`)
+  assert.equal(caught.code, code)
+  assert.equal(caught.providerId, providerId)
+}
+
+/**
+ * Behaviour every `SandboxProvider` must exhibit before Den can select it.
+ * Runner-agnostic: iterate the cases with `test(name, run)` in any framework.
+ */
+export function sandboxProviderConformanceCases(
+  factory: ProviderFactory,
+  options: ConformanceOptions = {},
+): ConformanceCase[] {
+  const timeout = { timeoutMs: options.timeoutMs ?? 30_000 }
+  const volumeName = options.volumeName ?? "openwork-conformance"
+  const trivialCommand = options.trivialCommand ?? "true"
+
+  return [
+    {
+      name: "describes capabilities consistent with its behaviour",
+      async run() {
+        const provider = await factory()
+        const capabilities = provider.describe()
+        assert.equal(typeof provider.id, "string")
+        assert.ok(provider.id.length > 0)
+        assert.equal(typeof capabilities.stopResume, "boolean")
+        assert.equal(typeof capabilities.exec, "boolean")
+        assert.ok(["signed-expiring", "stable", "den-tunnel"].includes(capabilities.endpointKind))
+        const image = provider.currentImage()
+        if (image !== null) {
+          assert.ok(image.id.length > 0)
+          assert.ok(image.version.length > 0)
+        }
+      },
+    },
+    {
+      name: "creates a running instance and finds it again by idempotency key",
+      async run() {
+        const provider = await factory()
+        const spec = specFor(provider, `create-${Date.now()}`)
+        const created = await provider.create(spec, timeout)
+        try {
+          assert.equal(created.ref.providerId, provider.id)
+          assert.ok(Object.keys(created.ref.ref).length > 0, "ref must carry provider identity")
+          assert.equal(created.state, "running")
+          const found = await provider.find({ idempotencyKey: spec.idempotencyKey })
+          assert.ok(found, "find by idempotency key must return the created instance")
+          assert.deepEqual(found.ref, created.ref)
+          const byLabel = await provider.find({ labels: spec.labels })
+          assert.ok(byLabel)
+          assert.deepEqual(byLabel.ref, created.ref)
+          const fetched = await provider.get(created.ref)
+          assert.ok(fetched)
+          assert.deepEqual(fetched.ref, created.ref)
+        } finally {
+          await provider.destroy(created, timeout)
+        }
+      },
+    },
+    {
+      name: "refuses to create a second instance for the same idempotency key",
+      async run() {
+        const provider = await factory()
+        const spec = specFor(provider, `idempotent-${Date.now()}`)
+        const created = await provider.create(spec, timeout)
+        try {
+          await expectProviderError(() => provider.create(spec, timeout), "conflict", provider.id)
+          const found = await provider.find({ idempotencyKey: spec.idempotencyKey })
+          assert.ok(found)
+          assert.deepEqual(found.ref, created.ref)
+        } finally {
+          await provider.destroy(created, timeout)
+        }
+      },
+    },
+    {
+      name: "returns null for a missing instance instead of throwing",
+      async run() {
+        const provider = await factory()
+        const missing = await provider.get({ providerId: provider.id, ref: { sandboxId: `missing-${Date.now()}` } })
+        assert.equal(missing, null)
+        const notFound = await provider.find({ idempotencyKey: `never-created-${Date.now()}` })
+        assert.equal(notFound, null)
+      },
+    },
+    {
+      name: "stops and resumes when it claims stopResume, and reports the state through inspect",
+      async run() {
+        const provider = await factory()
+        if (!provider.describe().stopResume) return
+        const created = await provider.create(specFor(provider, `resume-${Date.now()}`), timeout)
+        try {
+          await provider.stop(created, timeout)
+          const stopped = await provider.inspect(created)
+          assert.equal(stopped.state, "stopped")
+          assert.ok(stopped.observedAt >= created.observedAt)
+          await provider.start(stopped, timeout)
+          const running = await provider.inspect(stopped)
+          assert.equal(running.state, "running")
+        } finally {
+          await provider.destroy(created, timeout)
+        }
+      },
+    },
+    {
+      name: "destroy makes the instance missing and later operations fail with not_found",
+      async run() {
+        const provider = await factory()
+        const created = await provider.create(specFor(provider, `destroy-${Date.now()}`), timeout)
+        await provider.destroy(created, timeout)
+        assert.equal(await provider.get(created.ref), null)
+        const inspected = await provider.inspect(created)
+        assert.equal(inspected.state, "missing")
+        await expectProviderError(() => provider.start(created, timeout), "not_found", provider.id)
+      },
+    },
+    {
+      name: "exec reports exit codes and logs",
+      async run() {
+        const provider = await factory()
+        if (!provider.describe().exec) return
+        const created = await provider.create(specFor(provider, `exec-${Date.now()}`), timeout)
+        try {
+          const exec = await provider.exec(created, { command: trivialCommand, detach: false, timeoutMs: timeout.timeoutMs })
+          assert.ok(exec.id.length > 0)
+          const exitCode = await exec.exitCode()
+          assert.equal(exitCode, 0)
+          const logs = await exec.logs()
+          assert.equal(typeof logs.stdout, "string")
+          assert.equal(typeof logs.stderr, "string")
+        } finally {
+          await provider.destroy(created, timeout)
+        }
+      },
+    },
+    {
+      name: "endpoint kind and expiry match the declared capability",
+      async run() {
+        const provider = await factory()
+        const created = await provider.create(specFor(provider, `endpoint-${Date.now()}`), timeout)
+        try {
+          const endpoint = await provider.endpoint(created, 8787, { ttlSeconds: 600 })
+          assert.equal(endpoint.kind, provider.describe().endpointKind)
+          assert.ok(endpoint.url.startsWith("http"), `endpoint url must be absolute, got ${endpoint.url}`)
+          if (endpoint.kind === "stable") {
+            assert.equal(endpoint.expiresAt, null)
+          } else {
+            assert.ok(endpoint.expiresAt instanceof Date, "expiring endpoints must carry expiresAt")
+            assert.ok(endpoint.expiresAt.getTime() > Date.now())
+          }
+        } finally {
+          await provider.destroy(created, timeout)
+        }
+      },
+    },
+    {
+      name: "storage volumes are idempotent and subpath erasure is scoped",
+      async run() {
+        const provider = await factory()
+        if (!provider.describe().persistentStorage) return
+        const first = await provider.storage.ensureVolume(volumeName, timeout)
+        const second = await provider.storage.ensureVolume(volumeName, timeout)
+        assert.equal(first.providerId, provider.id)
+        assert.deepEqual(second, first)
+        await provider.storage.eraseSubpaths(first, [`workers/conformance-${Date.now()}`], timeout)
+        if (provider.storage.exists) {
+          assert.equal(await provider.storage.exists(first, `workers/never-written-${Date.now()}`, timeout), false)
+        }
+      },
+    },
+  ]
+}

--- a/ee/packages/cloud-runtime/src/testing/fake-provider.ts
+++ b/ee/packages/cloud-runtime/src/testing/fake-provider.ts
@@ -1,0 +1,258 @@
+import { RuntimeProviderError } from "../contract/errors"
+import type {
+  Endpoint,
+  ExecHandle,
+  ExecSpec,
+  ImageRef,
+  ProviderCapabilities,
+  ProviderTimeout,
+  SandboxHandle,
+  SandboxProvider,
+  SandboxQuery,
+  SandboxRef,
+  SandboxSpec,
+  SandboxState,
+  SandboxStorage,
+  VolumeRef,
+} from "../contract/provider"
+
+export type FakeExecResult = {
+  exitCode: number | null
+  stdout?: string
+  stderr?: string
+}
+
+export type FakeProviderOptions = {
+  id?: string
+  capabilities?: Partial<ProviderCapabilities>
+  image?: ImageRef | null
+  region?: string
+  endpointTtlSeconds?: number
+  now?: () => number
+  /** Decide what a command does; defaults to exit 0 with no output. */
+  onExec?: (input: { sandboxId: string; spec: ExecSpec }) => FakeExecResult | Promise<FakeExecResult>
+}
+
+export type FakeSandboxRecord = {
+  id: string
+  spec: SandboxSpec
+  state: SandboxState
+  region: string
+  createdAt: number
+  execs: Array<{ id: string; spec: ExecSpec; result: FakeExecResult }>
+}
+
+export type FakeProvider = SandboxProvider & {
+  /** Test-side controls that no production caller sees. */
+  readonly fake: {
+    sandboxes(): FakeSandboxRecord[]
+    sandbox(idempotencyKey: string): FakeSandboxRecord | null
+    setState(sandboxId: string, state: SandboxState): void
+    volumeFiles(volumeName: string): Set<string>
+    /** Simulate a file the bootstrap wrote onto a persistent volume. */
+    writeVolumeFile(volumeName: string, path: string): void
+    calls: string[]
+  }
+}
+
+const defaultCapabilities: ProviderCapabilities = {
+  stopResume: true,
+  persistentStorage: true,
+  memorySnapshotRestore: false,
+  warmPool: false,
+  endpointKind: "signed-expiring",
+  exec: true,
+  regions: ["fake-1"],
+}
+
+export function createFakeProvider(options: FakeProviderOptions = {}): FakeProvider {
+  const providerId = options.id ?? "fake"
+  const capabilities: ProviderCapabilities = { ...defaultCapabilities, ...options.capabilities }
+  const region = options.region ?? capabilities.regions[0] ?? "fake-1"
+  const now = options.now ?? Date.now
+  const endpointTtlSeconds = options.endpointTtlSeconds ?? 3600
+  const image = options.image === undefined ? { id: "fake-image", version: "fake-image" } : options.image
+  const sandboxes = new Map<string, FakeSandboxRecord>()
+  const volumes = new Map<string, { ref: VolumeRef; files: Set<string> }>()
+  const calls: string[] = []
+  let sequence = 0
+
+  function fail(code: RuntimeProviderError["code"], message: string, retryable?: boolean): never {
+    throw new RuntimeProviderError({ providerId, code, message, retryable })
+  }
+
+  function handleOf(record: FakeSandboxRecord): SandboxHandle {
+    return {
+      ref: { providerId, ref: { sandboxId: record.id } },
+      state: record.state,
+      region: record.region,
+      observedAt: now(),
+    }
+  }
+
+  function recordFor(ref: SandboxRef) {
+    if (ref.providerId !== providerId) {
+      fail("unknown", `sandbox reference belongs to provider ${ref.providerId}, not ${providerId}`, false)
+    }
+    const id = ref.ref.sandboxId
+    return id ? sandboxes.get(id) ?? null : null
+  }
+
+  function requireRecord(handle: SandboxHandle) {
+    const record = recordFor(handle.ref)
+    if (!record || record.state === "missing") {
+      fail("not_found", `sandbox ${handle.ref.ref.sandboxId ?? "?"} not found`, false)
+    }
+    return record
+  }
+
+  function volumeRecord(volume: VolumeRef) {
+    const entry = volumes.get(volume.name)
+    if (!entry || entry.ref.id !== volume.id) {
+      fail("not_found", `volume ${volume.name} not found`, false)
+    }
+    return entry
+  }
+
+  const storage: SandboxStorage = {
+    async ensureVolume(name, _opts: ProviderTimeout) {
+      calls.push(`storage.ensureVolume:${name}`)
+      const existing = volumes.get(name)
+      if (existing) return existing.ref
+      const ref: VolumeRef = { providerId, id: `vol-${++sequence}`, name }
+      volumes.set(name, { ref, files: new Set() })
+      return ref
+    },
+    async eraseSubpaths(volume, subpaths, _opts) {
+      calls.push(`storage.eraseSubpaths:${volume.name}:${subpaths.join(",")}`)
+      const entry = volumeRecord(volume)
+      for (const file of Array.from(entry.files)) {
+        if (subpaths.some((subpath) => file === subpath || file.startsWith(`${subpath}/`))) {
+          entry.files.delete(file)
+        }
+      }
+    },
+    async exists(volume, path, _opts) {
+      calls.push(`storage.exists:${volume.name}:${path}`)
+      return volumeRecord(volume).files.has(path)
+    },
+  }
+
+  const provider: FakeProvider = {
+    id: providerId,
+    describe: () => capabilities,
+    currentImage: () => image,
+    async create(spec, _opts) {
+      calls.push(`create:${spec.idempotencyKey}`)
+      for (const record of sandboxes.values()) {
+        if (record.spec.idempotencyKey === spec.idempotencyKey && record.state !== "missing") {
+          fail("conflict", `sandbox ${spec.idempotencyKey} already exists`, false)
+        }
+      }
+      for (const attachment of spec.storage) {
+        volumeRecord(attachment.volume)
+      }
+      const record: FakeSandboxRecord = {
+        id: `sbx-${++sequence}`,
+        spec,
+        state: "running",
+        region,
+        createdAt: now(),
+        execs: [],
+      }
+      sandboxes.set(record.id, record)
+      return handleOf(record)
+    },
+    async find(query: SandboxQuery) {
+      calls.push(`find:${query.idempotencyKey ?? JSON.stringify(query.labels ?? {})}`)
+      for (const record of sandboxes.values()) {
+        if (record.state === "missing") continue
+        if (query.idempotencyKey !== undefined && record.spec.idempotencyKey !== query.idempotencyKey) continue
+        if (query.labels && Object.entries(query.labels).some(([key, value]) => record.spec.labels[key] !== value)) continue
+        return handleOf(record)
+      }
+      return null
+    },
+    async get(ref) {
+      calls.push(`get:${ref.ref.sandboxId ?? "?"}`)
+      const record = recordFor(ref)
+      return record && record.state !== "missing" ? handleOf(record) : null
+    },
+    async inspect(handle) {
+      calls.push(`inspect:${handle.ref.ref.sandboxId ?? "?"}`)
+      const record = recordFor(handle.ref)
+      return record ? handleOf(record) : { ...handle, state: "missing", observedAt: now() }
+    },
+    async start(handle, _opts) {
+      calls.push(`start:${handle.ref.ref.sandboxId ?? "?"}`)
+      const record = requireRecord(handle)
+      if (record.state === "stopping" || record.state === "creating") {
+        fail("invalid_state", `sandbox ${record.id} state change in progress`)
+      }
+      record.state = "running"
+    },
+    async stop(handle, _opts) {
+      calls.push(`stop:${handle.ref.ref.sandboxId ?? "?"}`)
+      const record = requireRecord(handle)
+      record.state = "stopped"
+    },
+    async destroy(handle, _opts) {
+      calls.push(`destroy:${handle.ref.ref.sandboxId ?? "?"}`)
+      const record = requireRecord(handle)
+      record.state = "missing"
+    },
+    async exec(handle, spec) {
+      calls.push(`exec:${handle.ref.ref.sandboxId ?? "?"}`)
+      const record = requireRecord(handle)
+      if (record.state !== "running") {
+        fail("invalid_state", `sandbox ${record.id} is ${record.state}`, false)
+      }
+      const result = options.onExec
+        ? await options.onExec({ sandboxId: record.id, spec })
+        : { exitCode: 0 }
+      const exec = { id: `exec-${++sequence}`, spec, result }
+      record.execs.push(exec)
+      const execHandle: ExecHandle = {
+        id: exec.id,
+        exitCode: async () => exec.result.exitCode,
+        logs: async () => ({ stdout: exec.result.stdout ?? "", stderr: exec.result.stderr ?? "" }),
+      }
+      return execHandle
+    },
+    async endpoint(handle, port, opts) {
+      calls.push(`endpoint:${handle.ref.ref.sandboxId ?? "?"}:${port}`)
+      const record = requireRecord(handle)
+      const ttl = opts?.ttlSeconds ?? endpointTtlSeconds
+      const endpoint: Endpoint = {
+        url: `http://${record.id}.${providerId}.invalid:${port}`,
+        expiresAt: capabilities.endpointKind === "stable" ? null : new Date(now() + ttl * 1000),
+        kind: capabilities.endpointKind,
+      }
+      return endpoint
+    },
+    storage,
+    fake: {
+      sandboxes: () => Array.from(sandboxes.values()),
+      sandbox: (idempotencyKey) =>
+        Array.from(sandboxes.values()).find((record) => record.spec.idempotencyKey === idempotencyKey && record.state !== "missing") ?? null,
+      setState: (sandboxId, state) => {
+        const record = sandboxes.get(sandboxId)
+        if (!record) throw new Error(`fake sandbox ${sandboxId} does not exist`)
+        record.state = state
+      },
+      volumeFiles: (volumeName) => {
+        const entry = volumes.get(volumeName)
+        if (!entry) throw new Error(`fake volume ${volumeName} does not exist`)
+        return entry.files
+      },
+      writeVolumeFile: (volumeName, path) => {
+        const entry = volumes.get(volumeName)
+        if (!entry) throw new Error(`fake volume ${volumeName} does not exist`)
+        entry.files.add(path)
+      },
+      calls,
+    },
+  }
+
+  return provider
+}

--- a/ee/packages/cloud-runtime/src/testing/index.ts
+++ b/ee/packages/cloud-runtime/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from "./conformance"
+export * from "./fake-provider"

--- a/ee/packages/cloud-runtime/tsconfig.json
+++ b/ee/packages/cloud-runtime/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/ee/packages/cloud-runtime/tsup.config.ts
+++ b/ee/packages/cloud-runtime/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "contract/index": "src/contract/index.ts",
+    "bootstrap/index": "src/bootstrap/index.ts",
+    "testing/index": "src/testing/index.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "es2022",
+  platform: "node",
+  sourcemap: false,
+  splitting: false,
+  treeshake: true,
+})

--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -37,6 +37,7 @@ COPY evals/packages/cdp/package.json /app/evals/packages/cdp/package.json
 COPY evals/packages/labs/package.json /app/evals/packages/labs/package.json
 COPY evals/packages/matchers/package.json /app/evals/packages/matchers/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
+COPY ee/packages/cloud-runtime/package.json /app/ee/packages/cloud-runtime/package.json
 COPY ee/packages/den-db/package.json /app/ee/packages/den-db/package.json
 COPY ee/packages/telemetry-contracts/package.json /app/ee/packages/telemetry-contracts/package.json
 COPY ee/packages/telemetry/package.json /app/ee/packages/telemetry/package.json
@@ -56,6 +57,7 @@ COPY packages/mcp-apps /app/packages/mcp-apps
 COPY packages/paths /app/packages/paths
 COPY packages/browser-tabs /app/packages/browser-tabs
 COPY ee/packages/utils /app/ee/packages/utils
+COPY ee/packages/cloud-runtime /app/ee/packages/cloud-runtime
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/packages/telemetry-contracts /app/ee/packages/telemetry-contracts
 COPY ee/packages/telemetry /app/ee/packages/telemetry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,6 +580,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: 1.42.0
         version: 1.42.0
+      '@openwork-ee/cloud-runtime':
+        specifier: workspace:*
+        version: link:../../packages/cloud-runtime
       '@openwork-ee/den-db':
         specifier: workspace:*
         version: link:../../packages/den-db
@@ -1007,6 +1010,18 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+
+  ee/packages/cloud-runtime:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.12.12
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.3
 
   ee/packages/den-admin-mcp:
     dependencies:
@@ -8850,10 +8865,6 @@ packages:
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -17703,11 +17714,6 @@ snapshots:
 
   tinyexec@1.1.2: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -17789,7 +17795,7 @@ snapshots:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.23


### PR DESCRIPTION
## Current verification — September 5

**Verification verdict: Passed for the hermetic runtime regression.** Exact head: `58f23127b28dca50ab4457d2f9837ded28237e7a`. The stack is based on `dev@d9f7e12ad`. This section supersedes the historical verification below.

- Removed the added CI workflow commit completely. There are no `.github/` changes anywhere in the stack; existing repository CI and review rules are unchanged.
- Retained the provider contract, adapter correction, neutral-store backfill, generated SDK field and all regression tests. Range comparison confirms the CI commit is the only dropped change.
- Ran `pnpm evals:pr specs/remote-session-first-use.test.ts` independently on this exact head: **1 passed, 0 failed, 0 skipped**. The matching test-evidence comment has been updated, rather than reusing the previous head’s result. The three layers have 6, 10 and 11 passing assertion artifacts respectively.
- Placement: isolated local Den with MySQL/Redis. The PR runner prints no placement line. The HTTP witness simulates provider infrastructure; live Linux bootstrap, tar/SQLite and provider-volume durability are not exercised. No live provider or production data is used.
- On #4446’s exact head, `pnpm --filter @openwork-ee/den-db test` against isolated MySQL passes **31/31 with zero skips**, including seeded backfill, unchanged rollback rows and full migration replay.

Keep the original human-review hold and merge order #4444 → #4445 → #4446. Retarget and refresh each child after its parent lands. No merge or deployment is included in this update.

---

## Stack
- Part 1 — contract + bootstrap renderer: #4444 (base `dev`)
- Part 2 — Daytona adapter + neutral orchestrator: #4445 (base #4444)
- Part 3 — neutral instance store + `endpointKind`: #4446 (base #4445)

Merge bottom-up; each layer carries its own checks. After #4444 merges, retarget #4445 to `dev`; after #4445 merges, retarget #4446 to `dev`.

## Summary
- Part 1 of 3 (stack: this PR → Daytona adapter → neutral instance store). Introduces `@openwork-ee/cloud-runtime`, the provider-neutral contract every OpenWork Cloud sandbox host implements: capability descriptor, normalized instance states, error taxonomy (`RuntimeProviderError` codes instead of message matching), opaque provider references, exec with logs/exit codes, endpoint with expiry, storage attachment.
- Moves the sandbox bootstrap and checkpoint shell script out of `workers/daytona.ts` into a renderer over an explicit config (`renderOpenWorkBootstrapCommand`, `renderCheckpointFlushCommand`, probe/marker commands). The Daytona provisioner now renders through it; the rendered scripts are byte-identical to `dev` (sha256 compared for the start and flush commands).
- Ships an in-memory fake provider and a runner-agnostic conformance suite (`sandboxProviderConformanceCases`) that any future host must pass before Den can select it.
- Adds the package to the Den API image so the production build's export check covers it.

## Why
- Den's Cloud lifecycle (provision, wake, recycle, idle stop) is written directly against the Daytona SDK, and the bootstrap script lives inside the Daytona module even though nothing in it is Daytona-specific. A neutral contract is the precondition for evaluating other hosts and for the wake/prewarm speed work that follows, without rewriting policy per host.

## Scope
- New package `ee/packages/cloud-runtime` (contract, bootstrap renderer, testing utilities).
- `ee/apps/den-api/src/workers/daytona.ts` delegates script rendering to the package.
- `packaging/docker/Dockerfile.den` copies the new package; lockfile importer added.

## Out of scope
- Any lifecycle behaviour change, the Daytona adapter, the orchestrator, persistence, client changes (later PRs in the stack).

## Testing
### Ran
- `ee/packages/cloud-runtime`: `pnpm typecheck`, `bun test src` (renderer + conformance against the fake, incl. a stable-endpoint variant)
- `ee/apps/den-api`: `pnpm exec tsc -p tsconfig.json --noEmit`; `bun test --conditions development test/daytona-provisioning.test.ts test/daytona-checkpoint-command.test.ts test/cloud-lifecycle.test.ts test/cloud-runtime-access.test.ts test/cloud-instance-route.test.ts test/worker-runtime-signed-preview.test.ts test/cloud-failure.test.ts`; `pnpm test`
- Byte-for-byte check: dumped `buildOpenWorkStartCommand`/`checkpointFlushCommand` output for a fixed env before and after; `cmp` identical.

### Result
- pass/fail: pass — package 21/21; den-api typecheck clean; 20/1/14/10/40/13/3 pass in the listed files; CI `test` script 24/24; rendered scripts identical.
- if fail, exact files/errors: none.

## CI status
- pass: pending at open
- code-related failures: none known
- external/env/auth blockers: none

## Manual verification
1. `bun --conditions development -e` a script that imports `ee/apps/den-api/src/workers/daytona.ts` with `DAYTONA_*` env set and prints `buildOpenWorkStartCommand(...)`; compare with `dev`.
2. `pnpm --filter @openwork-ee/cloud-runtime test` and `build`; confirm `dist/{contract,bootstrap,testing}` exist.
3. `pnpm --filter @openwork-ee/den-api run build:workspace-dependencies` then the export check in `scripts/build.mjs` reports no missing production exports for the new package.

## Evidence
- Verdict: **Incomplete** for runtime journey proof — no `evals/specs` journey drives the Cloud instance lifecycle (every spec runs Den with the stub provisioner), so there is no exact-head testkit tape to attach. Behaviour preservation rests on the byte-identical rendered scripts and the unit suites above. No Daytona API call changes in this PR.

## Risk
- Low: script rendering is a pure move (verified byte-identical); the new package has no consumers beyond the renderer.

## Rollback
- Revert the PR; `daytona.ts` returns to its inline templates. No data or config changes.