### PR TITLE
test(auth): prepare the MCP rate-limit journey in remote Den

### DIFF
--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -238,7 +238,7 @@ if [ "${RUN_SEED:-0}" = "1" ]; then
       BETTER_AUTH_URL="$BETTER_AUTH_URL" \
       DEN_API_PUBLIC_URL="$DEN_API_PUBLIC_URL" \
       DEN_ORG_MODE="$DEN_ORG_MODE" \
-      OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
+      OPENWORK_DEV_MODE=1 \
       DEN_DEMO_SEED_FETCH_GITHUB="${DEN_DEMO_SEED_FETCH_GITHUB:-0}" \
       node --conditions=development --import tsx scripts/seed-demo-org.ts) > /tmp/den-seed.log 2>&1
     if signin_ok; then

--- a/evals/packages/labs/src/den-loopback.ts
+++ b/evals/packages/labs/src/den-loopback.ts
@@ -1,0 +1,38 @@
+import { defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
+
+/** Send controlled proxy headers directly to Den, without the public preview proxy rewriting them. */
+export async function requestDenLoopback(sandbox: string, path: string, init: RequestInit): Promise<Response> {
+  const input = Buffer.from(JSON.stringify({
+    path,
+    method: init.method,
+    headers: [...new Headers(init.headers)],
+    body: init.body?.toString(),
+  })).toString("base64");
+  const source = `
+    const input = JSON.parse(Buffer.from(process.argv[2], "base64").toString());
+    const response = await fetch(new URL(input.path, "http://127.0.0.1:8788"), {
+      method: input.method, headers: input.headers, body: input.body,
+      redirect: "manual", signal: AbortSignal.timeout(15000),
+    });
+    const headers = [...response.headers].filter(([name]) => name !== "set-cookie");
+    for (const cookie of response.headers.getSetCookie()) headers.push(["set-cookie", cookie]);
+    console.log(JSON.stringify({ status: response.status, headers, body: await response.text() }));
+  `;
+  const encodedSource = Buffer.from(source).toString("base64");
+  const result = await execInSandbox(defaultDaytonaExec, sandbox,
+    `printf %s ${encodedSource} | base64 -d | node --input-type=module - ${input}`,
+    { timeoutMs: 20_000, context: "Den loopback HTTP request" });
+  const output: unknown = JSON.parse(result.stdout);
+  if (typeof output !== "object" || output === null
+    || !("status" in output) || typeof output.status !== "number"
+    || !("body" in output) || typeof output.body !== "string"
+    || !("headers" in output) || !Array.isArray(output.headers)) throw new Error("Invalid Den HTTP response");
+  const headers = new Headers();
+  for (const pair of output.headers) {
+    if (!Array.isArray(pair) || pair.length !== 2 || typeof pair[0] !== "string" || typeof pair[1] !== "string") {
+      throw new Error("Invalid Den HTTP response header");
+    }
+    headers.append(pair[0], pair[1]);
+  }
+  return new Response(output.body, { status: output.status, headers });
+}

--- a/evals/packages/labs/src/index.ts
+++ b/evals/packages/labs/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./egress.ts";
+export * from "./den-loopback.ts";
 export * from "./idp.ts";
 export * from "./mock-google.ts";
 export * from "./mock-github.ts";

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -1,4 +1,5 @@
 export { control, createDesktopHandoffGrant, evalIn, signInDesktopAs } from "@openwork/behaviors";
+export { requestDenLoopback } from "@openwork/labs";
 export { desktop as relaunchDesktop, electronProfilePaths } from "@openwork/hosts";
 export type { DesktopHandle } from "@openwork/hosts";
 export type { Surface } from "@openwork/cdp";

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -30,8 +30,21 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
     body: JSON.stringify({ email: den.admin.email, password: den.admin.password }),
   });
   expect(login.status).toBe(200);
-  const cookie = login.headers.getSetCookie().map((entry) => entry.split(";")[0]).join("; ");
+  let cookie = login.headers.getSetCookie().map((entry) => entry.split(";")[0]).join("; ");
   expect(cookie.length).toBeGreaterThan(0);
+  const organizations = await request("/api/auth/organization/list", { headers: { cookie } });
+  expect(organizations.status).toBe(200);
+  const availableOrganizations: unknown = await organizations.json();
+  if (!Array.isArray(availableOrganizations)) throw new Error("Missing organization list");
+  const organization = availableOrganizations.find((entry) => stringField(entry, "name") === "MCP Auth Regression");
+  const selected = await request("/api/auth/organization/set-active", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ organizationId: stringField(organization, "id") }),
+  });
+  expect(selected.status).toBe(200);
+  const updatedCookies = selected.headers.getSetCookie();
+  if (updatedCookies.length > 0) cookie = updatedCookies.map((entry) => entry.split(";")[0]).join("; ");
   const redirectUri = "http://127.0.0.1:19876/callback";
   const scope = "mcp:read mcp:write offline_access";
   const registration = await request("/register", {

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -53,7 +53,7 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
     headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ accept: true, scope, oauth_query: new URL(consentLocation, origin).search.slice(1) }),
   });
-  expect(consent.status).toBe(200);
+  expect(consent.status, await consent.clone().text()).toBe(200);
   const callback = new URL(stringField(await consent.json(), "url"));
   const code = callback.searchParams.get("code");
   if (!code) throw new Error("Missing authorization code");

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -1,7 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { expect } from "vitest";
-import { server, test } from "@openwork/testkit";
-import { requestDenLoopback } from "@openwork/labs";
+import { requestDenLoopback, server, test } from "@openwork/testkit";
 
 function stringField(value: unknown, key: string): string {
   if (typeof value !== "object" || value === null || !(key in value)) throw new Error(`Missing ${key}`);

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { expect } from "vitest";
 import { server, test } from "@openwork/testkit";
+import { requestDenLoopback } from "@openwork/labs";
 
 function stringField(value: unknown, key: string): string {
   if (typeof value !== "object" || value === null || !(key in value)) throw new Error(`Missing ${key}`);
@@ -18,12 +19,11 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
   });
   const origin = den.ref.webUrl;
   const forwarded = { "x-forwarded-for": "198.51.100.10, 192.0.2.10" };
-  const request = (path: string, init: RequestInit = {}) => fetch(`${den.ref.apiUrl}${path}`, {
-    ...init,
-    redirect: "manual",
-    signal: AbortSignal.timeout(15_000),
-    headers: { origin, ...forwarded, ...init.headers },
-  });
+  const request = (path: string, init: RequestInit = {}) => {
+    const options = { ...init, headers: { origin, ...forwarded, ...init.headers } };
+    if (den.placement?.kind === "daytona") return requestDenLoopback(den.placement.sandboxId, path, options);
+    return fetch(`${den.ref.apiUrl}${path}`, { ...options, redirect: "manual", signal: AbortSignal.timeout(15_000) });
+  };
   const login = await request("/api/auth/sign-in/email", {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -43,8 +43,12 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
     body: JSON.stringify({ organizationId: stringField(organization, "id") }),
   });
   expect(selected.status).toBe(200);
-  const updatedCookies = selected.headers.getSetCookie();
-  if (updatedCookies.length > 0) cookie = updatedCookies.map((entry) => entry.split(";")[0]).join("; ");
+  const cookies = new Map<string, string>();
+  for (const entry of [...login.headers.getSetCookie(), ...selected.headers.getSetCookie()]) {
+    const pair = entry.split(";")[0];
+    cookies.set(pair.slice(0, pair.indexOf("=")), pair);
+  }
+  cookie = [...cookies.values()].join("; ");
   const redirectUri = "http://127.0.0.1:19876/callback";
   const scope = "mcp:read mcp:write offline_access";
   const registration = await request("/register", {


### PR DESCRIPTION
The MCP rate-limit journey moved to the provisioned E2E lane in #4438, but three remote setup assumptions prevented it from reaching its assertions: the demo seeder rejected production mode, a fresh session had no selected organization, and the public preview proxy rewrote the synthetic client addresses.

Run only the isolated demo seeder in development mode while the Den API retains production rate limits. Select the test organization before OAuth consent and preserve session cookies. In Daytona, send the HTTP requests from inside the Den sandbox so the controlled proxy-header chains reach the actual API unchanged. Local execution continues to call its local API directly.

Validation on `38a0146b6`:
- `OPENWORK_EVAL_REF=fix/mcp-auth-e2e-provisioning pnpm evals:e2e mcp-auth-rate-limit-recovery` — placement: daytona (daytona CLI authenticated); Passed, 1 test, 0 failed, 0 skipped, fresh isolated Den. Proves production throttling, separate client buckets, forged-prefix rejection, 25 successful signed MCP requests within the same minute, and invalid-token rejection.
- `pnpm test:eval-runner` with Node 24 — 234 passed, 0 failed, 0 skipped; layer and spec boundary checks pass.
- Shell syntax and diff whitespace checks pass.

Assertion evidence is published in the PR test-evidence comment.
