### PR TITLE
fix(mcp): start the first cloud task without browser setup

### DIFF
--- a/docs/remote-chat-over-mcp-architecture.md
+++ b/docs/remote-chat-over-mcp-architecture.md
@@ -99,9 +99,14 @@ Execution path inside the source:
    via a shared internal helper; do not duplicate resolution logic.
 3. Call openwork-server using the `packages/headless-threads` client (or its
    underlying HTTP shape) with the resolved worker URL + token.
-4. Map worker errors to gateway error vocabulary: no worker provisioned →
-   actionable "needs cloud worker" result (relay the human step, mirroring
-   `needs_admin_setup` / `needs_signin` conventions), never a fake success.
+4. On the first `remote-session:create`, provision the member's workspace
+   through the browser's shared `ensureCloudWorker` path. Return
+   `cloud_runtime_provisioning`, `retryable: true`, and `retryAfterMs: 30000`
+   while it starts. No task is queued at this stage: the agent retries create
+   with the same arguments after the delay. Once ready, the normal native
+   session client creates the task and submits its prompt.
+   `read` and `send` never create a missing workspace; they return
+   `needs_cloud_setup` with guidance to start a new task using create.
 
 ### 2. Async model
 
@@ -134,13 +139,23 @@ without MCP Apps get text fallback with the same URL.
   `search_capabilities` and execute reports `unknown_capability`. Execution
   re-checks Web access live (`openwork_web_access_required`) and the runtime
   re-checks hosting availability (`cloud_not_available`) as defense in depth;
-  `needs_cloud_setup` is reserved for the member-facing "open OpenWork Cloud
-  once to provision" case.
+  first-use provisioning requires a valid `create` request with `mcp:write`
+  and active Web access. Concurrent first-use requests and browser access use
+  the same member-scoped worker and creation deduplication. This deduplicates
+  workspace provisioning, not subsequent successful session creation calls.
 - Member-scoped only: capabilities operate on the caller's resolved worker.
   `sessionId` from another member's worker must 404, not 403-leak.
 - Prompts transit the gateway but are stored only on the worker (same trust
   domain as existing web chat). No prompt content in gateway logs; log
   receipts/ids only.
+
+The first-use contract is exercised by
+`pnpm evals:pr specs/remote-session-first-use.test.ts`: an isolated Den and
+database handle real MCP requests, while an HTTP witness replaces Daytona
+and the worker's native session API. The journey checks access denial,
+read/write boundaries, concurrent provisioning, first prompt delivery after
+readiness, browser reuse, and separate workspaces for two members. It does
+not launch a live Daytona VM or run a model.
 
 ### 5. Desktop side (v1: zero code)
 

--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -107,7 +107,7 @@ const REMOTE_SESSION_DEFINITIONS: RemoteSessionDefinition[] = [
   {
     action: "create",
     summary:
-      "Start a remote session: a native OpenWork chat on your OpenWork Web instance (runs in the cloud, visible in the browser). Give it the task to run as prompt. target \"desktop\" runs it on your connected OpenWork desktop instead.",
+      "Start a remote session: a native OpenWork chat on your OpenWork Web instance (runs in the cloud, visible in the browser). Automatically sets up your workspace on first use; on cloud_runtime_provisioning, wait retryAfterMs before retrying with the same arguments. Give it the task to run as prompt. target \"desktop\" runs it on your connected OpenWork desktop instead.",
     searchExtraTokens:
       "remote session sessions chat thread cloud web instance browser openwork desktop create start new open run do task work delegate hand off handoff background continue workspace",
     argumentsSchema: {
@@ -202,16 +202,17 @@ export type RemoteSessionRuntimeResult =
   | { ok: true; runtime: RemoteSessionRuntime }
   | {
       ok: false
-      error: "cloud_not_available" | "needs_cloud_setup" | "cloud_runtime_failed" | "cloud_runtime_waking" | "cloud_runtime_unreachable"
+      error: "cloud_not_available" | "needs_cloud_setup" | "cloud_runtime_provisioning" | "cloud_runtime_failed" | "cloud_runtime_waking" | "cloud_runtime_unreachable"
       message: string
       retryable: boolean
+      retryAfterMs?: number
     }
 
 export type RemoteSessionThreadClient = Pick<AgentSessionClient, "createThread" | "sendTurn" | "getThreadSnapshot">
 
 export type RemoteSessionExecuteDeps = {
   getOpenWorkWebAccess: OpenWorkWebRuntimeAccessResolver
-  resolveRuntime: (scope: { organizationId: DenTypeId<"organization">; userId: string }) => Promise<RemoteSessionRuntimeResult>
+  resolveRuntime: (scope: { organizationId: DenTypeId<"organization">; userId: string; provisionIfMissing?: boolean }) => Promise<RemoteSessionRuntimeResult>
   createClient: (runtime: RemoteSessionRuntime) => RemoteSessionThreadClient
   commandStore: RemoteSessionCommandStore
   desktopPresence: (scope: {
@@ -234,7 +235,17 @@ const READ_MESSAGE_TEXT_LIMIT = 4_000
 const FINAL_TEXT_LIMIT = 20_000
 
 const NEEDS_SETUP_MESSAGE =
-  "No OpenWork Cloud workspace is available for your account yet. Open OpenWork Cloud in the browser once (the Web tab in OpenWork, or your organization's OpenWork Web URL) so it can be provisioned, then retry this capability."
+  "No OpenWork Cloud workspace exists for your account yet. Use remote-session:create to start a new task and set up your workspace automatically."
+
+function provisioningResult(): RemoteSessionRuntimeResult {
+  return {
+    ok: false,
+    error: "cloud_runtime_provisioning",
+    message: "Your OpenWork Cloud workspace is being set up. No task has been submitted yet. Retry remote-session:create with the same arguments in about 30 seconds; you do not need to open the web app.",
+    retryable: true,
+    retryAfterMs: 30_000,
+  }
+}
 
 const CLOUD_NOT_AVAILABLE_MESSAGE =
   "OpenWork Cloud is not available on this deployment, so remote sessions are unavailable."
@@ -301,7 +312,7 @@ export async function resolveRemoteSessionWorkspace(
 }
 
 async function defaultResolveRuntime(
-  scope: { organizationId: DenTypeId<"organization">; userId: string },
+  scope: { organizationId: DenTypeId<"organization">; userId: string; provisionIfMissing?: boolean },
 ): Promise<RemoteSessionRuntimeResult> {
   // Defense in depth: the registry already hides these capabilities when the
   // deployment cannot host Cloud, but the runtime re-checks so the runtime
@@ -318,8 +329,19 @@ async function defaultResolveRuntime(
       userId: normalizeDenTypeId("user", scope.userId),
     })
     if (access.status === "missing") {
+      if (scope.provisionIfMissing) {
+        // Load on first use to avoid a startup cycle through the route and MCP
+        // registries. Browser and MCP creation share one store and in-flight map.
+        const { ensureMemberCloudWorker } = await import("../routes/cloud/index.js")
+        await ensureMemberCloudWorker({
+          orgId: scope.organizationId,
+          createdByUserId: normalizeDenTypeId("user", scope.userId),
+        })
+        return provisioningResult()
+      }
       return { ok: false, error: "needs_cloud_setup", message: NEEDS_SETUP_MESSAGE, retryable: false }
     }
+    if (access.status === "provisioning" && scope.provisionIfMissing) return provisioningResult()
     if (access.status !== "ready" && access.reason === "unreachable") {
       return {
         ok: false,
@@ -547,12 +569,17 @@ export async function executeRemoteSessionCapability(
     }
   }
 
-  const runtime = await deps.resolveRuntime({ organizationId: input.organizationId, userId: input.userId })
+  const runtime = await deps.resolveRuntime({
+    organizationId: input.organizationId,
+    userId: input.userId,
+    provisionIfMissing: input.action === "create",
+  })
   if (!runtime.ok) {
     return errorResult({
       error: runtime.error,
       message: runtime.message,
       retryable: runtime.retryable,
+      ...(runtime.retryAfterMs === undefined ? {} : { retryAfterMs: runtime.retryAfterMs }),
     })
   }
 

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -492,6 +492,16 @@ async function ensureCloudWorker(input: {
   return promise
 }
 
+/** Share the browser's member-scoped creation and race handling with MCP. */
+export function ensureMemberCloudWorker(input: { orgId: OrgId; createdByUserId: UserId }) {
+  return ensureCloudWorker({
+    ...input,
+    name: CLOUD_INSTANCE_NAME,
+    continueProvisioning: continueCloudProvisioning,
+    store: databaseCloudWorkerStore,
+  })
+}
+
 function workerNeedsUserRequestedUpdate(worker: CloudWorker) {
   const snapshot = env.daytona.snapshot
   return Boolean(snapshot && (worker.image_version ?? null) !== snapshot)

--- a/evals/packages/labs/src/index.ts
+++ b/evals/packages/labs/src/index.ts
@@ -2,6 +2,7 @@ export * from "./egress.ts";
 export * from "./idp.ts";
 export * from "./mock-google.ts";
 export * from "./mock-github.ts";
+export * from "./mock-cloud-runtime.ts";
 export * from "./mock-mcp.ts";
 export * from "./not-implemented.ts";
 export * from "./release-feed.ts";

--- a/evals/packages/labs/src/mock-cloud-runtime.ts
+++ b/evals/packages/labs/src/mock-cloud-runtime.ts
@@ -1,0 +1,107 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a JSON object");
+  return value;
+}
+
+async function body(request: IncomingMessage): Promise<Record<string, unknown>> {
+  let raw = "";
+  for await (const chunk of request) raw += String(chunk);
+  return raw ? record(JSON.parse(raw)) : {};
+}
+
+function json(response: ServerResponse, status: number, value: unknown) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
+/** HTTP witness for Daytona and its native session endpoint; no real cloud resources. */
+export async function startCloudRuntimeWitness() {
+  const sandboxes: Array<{ id: string; name: string; workerId: string }> = [];
+  const sessions: Array<{ id: string; sandboxId: string; title: string; prompts: string[] }> = [];
+  const unexpected: string[] = [];
+  let healthy = false;
+  let url = "";
+
+  function sandboxDto(sandbox: typeof sandboxes[number]) {
+    return {
+      id: sandbox.id, name: sandbox.name, state: "started", target: "test",
+      toolboxProxyUrl: `${url}/toolbox/${sandbox.id}`, labels: {},
+    };
+  }
+
+  async function handle(request: IncomingMessage, response: ServerResponse) {
+    const path = new URL(request.url ?? "/", "http://localhost").pathname;
+    const method = request.method ?? "GET";
+    if (method === "GET" && /\/volumes?\//.test(path)) {
+      return json(response, 200, { id: "volume_witness", name: "witness", state: "ready" });
+    }
+    if (method === "POST" && path === "/sandbox") {
+      const input = await body(request);
+      const env = record(input.env);
+      const sandbox = { id: `sandbox_${sandboxes.length + 1}`, name: String(input.name), workerId: String(env.DEN_WORKER_ID) };
+      sandboxes.push(sandbox);
+      return json(response, 201, sandboxDto(sandbox));
+    }
+    const preview = path.match(/^\/sandbox\/([^/]+)\/.*preview/);
+    if (method === "GET" && preview) return json(response, 200, { url: `${url}/runtime/${preview[1]}` });
+    const lookup = path.match(/^\/sandbox\/([^/]+)$/);
+    if (method === "GET" && lookup) {
+      const sandbox = sandboxes.find((entry) => entry.id === lookup[1] || entry.name === lookup[1]);
+      return json(response, sandbox ? 200 : 404, sandbox ? sandboxDto(sandbox) : { message: "Sandbox not found" });
+    }
+    if (path.includes("/process/session")) {
+      if (method === "POST" && path.endsWith("/exec")) return json(response, 200, { cmdId: "boot_witness" });
+      return json(response, 200, {});
+    }
+    const runtime = path.match(/^\/runtime\/([^/]+)(.*)$/);
+    if (runtime) {
+      const sandboxId = runtime[1];
+      const route = runtime[2];
+      if (route === "/health") return json(response, healthy ? 200 : 503, { ready: healthy });
+      if (route === "/workspaces") return json(response, 200, { activeId: "workspace_witness", items: [] });
+      if (method === "POST" && route === "/workspace/workspace_witness/opencode/session") {
+        const input = await body(request);
+        const session = { id: `ses_witness_${sessions.length + 1}`, sandboxId, title: String(input.title), prompts: [] };
+        sessions.push(session);
+        return json(response, 200, { id: session.id, title: session.title, directory: "/workspace", time: { created: 1 } });
+      }
+      const prompt = route?.match(/^\/workspace\/workspace_witness\/opencode\/session\/([^/]+)\/prompt_async$/);
+      if (method === "POST" && prompt) {
+        const session = sessions.find((entry) => entry.id === prompt[1] && entry.sandboxId === sandboxId);
+        if (!session) return json(response, 404, { message: "Session not found" });
+        const input = await body(request);
+        for (const part of Array.isArray(input.parts) ? input.parts : []) session.prompts.push(String(record(part).text));
+        return json(response, 200, {});
+      }
+      // The isolated organization has no model providers to materialize.
+      if (route === "/opencode/config") return json(response, 200, {});
+    }
+    unexpected.push(`${method} ${path}`);
+    json(response, 404, { message: `Unimplemented witness route: ${method} ${path}` });
+  }
+
+  const server = createServer((request, response) => {
+    void handle(request, response).catch((error: unknown) => {
+      unexpected.push(error instanceof Error ? error.message : String(error));
+      json(response, 500, { message: "Cloud witness failed" });
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Cloud witness has no listening address");
+  url = `http://127.0.0.1:${address.port}`;
+  return {
+    url, sandboxes, sessions, unexpected,
+    ready() { healthy = true; },
+    async [Symbol.asyncDispose]() {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}

--- a/evals/specs/remote-session-first-use.test.ts
+++ b/evals/specs/remote-session-first-use.test.ts
@@ -1,0 +1,147 @@
+import { expect } from "vitest";
+import { denFetch, type DenSession } from "@openwork/behaviors";
+import { queryDenDatabase } from "@openwork/env";
+import { startCloudRuntimeWitness } from "@openwork/labs";
+import { eventually, localMysqlIsRunning, localRedisIsRunning, needs, server, test } from "@openwork/testkit";
+
+const available = await localMysqlIsRunning() && await localRedisIsRunning();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a JSON object");
+  return value;
+}
+
+async function mint(session: DenSession, scopes: string[]) {
+  const result = await denFetch(session, "/v1/mcp/token", {
+    method: "POST", headers: { authorization: `Bearer ${session.token}` }, body: JSON.stringify({ scopes }),
+  });
+  expect(result.response.status, result.text).toBe(200);
+  const token = record(result.body).token;
+  if (typeof token !== "string") throw new Error("MCP token missing");
+  return token;
+}
+
+test("first cloud task provisions once over MCP, preserves access boundaries, and runs without a browser setup step", { timeout: 300_000 }, async ({ place, evidence, skip }) => {
+  needs({ placement: "local" });
+  if (!available) skip("needs: local MySQL and Redis");
+  await using witness = await startCloudRuntimeWitness();
+  await using den = await server({
+    place,
+    web: false,
+    org: { name: "Remote Task Activation", members: { colleague: {} } },
+    env: {
+      PROVISIONER_MODE: "daytona", DAYTONA_API_KEY: "witness-not-a-real-key", DAYTONA_API_URL: witness.url,
+      DAYTONA_SNAPSHOT: "witness-snapshot", DAYTONA_SHARED_VOLUME_NAME: "witness-volume",
+      DAYTONA_USE_DEPRECATED_POLLING: "true", DAYTONA_HEALTHCHECK_TIMEOUT_MS: "120000",
+      WORKER_PROVISIONING_RECONCILE_INTERVAL_MS: "0", CLOUD_IDLE_LOOP_SECONDS: "0",
+      DEN_OPENWORK_WEB_ENABLED: "true",
+      STRIPE_OPENWORK_WEB_PRICE_ID: "price_first_use_witness",
+    },
+  });
+  if (!den.database) throw new Error("This isolated HTTP journey requires its own database");
+  const databaseUrl = den.database.url;
+  const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  const organizations = record(orgs.body).orgs;
+  if (!Array.isArray(organizations) || organizations.length !== 1) throw new Error("Expected one isolated organization");
+  const orgId = record(organizations[0]).id;
+  if (typeof orgId !== "string") throw new Error("Organization id missing");
+  const writeToken = await mint(den.admin, ["mcp:read", "mcp:write"]);
+  const readToken = await mint(den.admin, ["mcp:read"]);
+  let requestId = 0;
+
+  async function call(token: string, action: string, body: unknown) {
+    const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
+      method: "POST", signal: AbortSignal.timeout(40_000),
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: {
+        name: "execute_capability", arguments: { name: `remote-session:${action}`, body },
+      } }),
+    });
+    const raw = await response.text();
+    expect(response.status, raw).toBe(200);
+    const data = raw.split("\n").find((line) => line.startsWith("data:"));
+    const rpc = record(JSON.parse(data ? data.slice(5) : raw));
+    expect(rpc.error, raw).toBeUndefined();
+    const result = record(rpc.result);
+    expect(result.structuredContent, JSON.stringify(result)).toBeDefined();
+    return { result, payload: record(result.structuredContent) };
+  }
+
+  async function workers() {
+    return queryDenDatabase(databaseUrl, "SELECT id, created_by_user_id, status FROM worker WHERE org_id = ?", [orgId]);
+  }
+
+  expect((await call(writeToken, "create", {})).payload.error).toBe("openwork_web_access_required");
+  expect(await workers()).toEqual([]);
+  expect(witness.sandboxes).toHaveLength(0);
+  evidence.recordAssertionEvidence("Paid access is checked before provisioning", "A valid write token in an organization without Web access was denied; zero worker rows and zero provider creates.", true);
+
+  // Seed the paid entitlement, not a Stripe charge. All access checks and
+  // provisioning still use the real API, subscription resolver, and database.
+  await queryDenDatabase(databaseUrl,
+    "INSERT INTO org_subscriptions (id, organization_id, type, status, stripe_customer_id, stripe_subscription_id, stripe_price_id, quantity) VALUES (?, ?, 'web', 'active', ?, ?, ?, 2)",
+    ["osub_00000000000000000000000001", orgId, "cus_first_use_witness", "sub_first_use_witness", "price_first_use_witness"],
+  );
+  expect((await call(readToken, "create", {})).payload.error).toBe("insufficient_mcp_scope");
+  expect((await call(writeToken, "create", { prompt: "" })).payload.error).toBe("invalid_capability_arguments");
+  expect((await call(readToken, "read", { sessionId: "ses_unknown" })).payload.error).toBe("needs_cloud_setup");
+  expect((await call(writeToken, "send", { sessionId: "ses_unknown", prompt: "Continue" })).payload.error).toBe("needs_cloud_setup");
+  expect(await workers()).toEqual([]);
+  expect(witness.sandboxes).toHaveLength(0);
+  evidence.recordAssertionEvidence("Only a valid write-scoped create can allocate a workspace", "Read-only create, invalid input, read, and send allocated no workers and made no provider creates.", true);
+
+  const task = { title: "First cloud task", prompt: "Summarize this workspace" };
+  const first = await Promise.all(Array.from({ length: 6 }, () => call(writeToken, "create", task)));
+  for (const response of first) {
+    expect(response.result.isError).toBe(true);
+    expect(response.payload).toMatchObject({ error: "cloud_runtime_provisioning", retryable: true, retryAfterMs: 30_000 });
+    expect(response.payload.sessionId).toBeUndefined();
+  }
+  await eventually(() => witness.sandboxes.length, { within: 20_000, label: "one provider sandbox create", until: (value) => value === 1 });
+  const startedWorkers = await workers();
+  expect(startedWorkers).toHaveLength(1);
+  expect(witness.sandboxes).toHaveLength(1);
+  expect(witness.sandboxes[0]?.workerId).toBe(record(startedWorkers[0]).id);
+  expect(witness.sessions).toHaveLength(0);
+  evidence.recordAssertionEvidence("Concurrent first requests share one provisioning attempt", "Six MCP create calls returned retryable provisioning with no submitted session; one worker row and one Daytona HTTP create were observed, before any browser endpoint was called.", true);
+
+  witness.ready();
+  await eventually(async () => (await workers()).map((entry) => record(entry).status), { within: 60_000, label: "real provisioner records ready after witness health", until: (statuses) => statuses.length === 1 && statuses[0] === "healthy" });
+  const created = await call(writeToken, "create", task);
+  expect(created.result.isError).toBeUndefined();
+  expect(created.payload).toMatchObject({ target: "cloud", started: true, workerId: record(startedWorkers[0]).id });
+  expect(witness.sessions).toHaveLength(1);
+  expect(witness.sessions[0]?.prompts).toEqual([task.prompt]);
+  expect(witness.sandboxes).toHaveLength(1);
+  const browser = await denFetch(den.admin, "/v1/cloud/instance", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  expect(browser.response.status, browser.text).toBe(200);
+  expect(record(browser.body).status).toBe("ready");
+  expect(await workers()).toHaveLength(1);
+  expect(witness.sandboxes).toHaveLength(1);
+  evidence.recordAssertionEvidence("Retry runs the first task without browser setup, and the browser reuses its workspace", "The real provisioner observed healthy HTTP, persisted ready state, and the MCP retry created one native session with the original prompt. A subsequent browser request reused that ready workspace without another sandbox.", true);
+
+  const colleague = den.members.colleague;
+  if (!colleague) throw new Error("Colleague session missing");
+  const colleagueToken = await mint(colleague, ["mcp:read", "mcp:write"]);
+  expect((await call(colleagueToken, "create", task)).payload.error).toBe("cloud_runtime_provisioning");
+  await eventually(() => witness.sandboxes.length, { within: 20_000, label: "separate member worker", until: (value) => value === 2 });
+  const memberWorkers = await workers();
+  expect(memberWorkers).toHaveLength(2);
+  expect(new Set(memberWorkers.map((entry) => record(entry).created_by_user_id)).size).toBe(2);
+  expect(new Set(witness.sandboxes.map((entry) => entry.workerId)).size).toBe(2);
+  expect(witness.sessions).toHaveLength(1);
+  await eventually(async () => (await workers()).map((entry) => record(entry).status), { within: 60_000, label: "both member workspaces healthy", until: (statuses) => statuses.length === 2 && statuses.every((status) => status === "healthy") });
+  expect(witness.unexpected).toEqual([]);
+  evidence.recordAssertionEvidence("Members get distinct workspaces", "A second member's first call created a different worker and sandbox without creating a session on the first member's runtime.", true);
+
+  await queryDenDatabase(databaseUrl, "UPDATE org_subscriptions SET status = 'canceled' WHERE organization_id = ?", [orgId]);
+  expect((await call(writeToken, "create", task)).payload.error).toBe("openwork_web_access_required");
+  expect(witness.sessions).toHaveLength(1);
+  expect(witness.sandboxes).toHaveLength(2);
+  expect(await workers()).toHaveLength(2);
+  evidence.recordAssertionEvidence("Lapsed paid access blocks new work even with an existing workspace", "After the seeded subscription was canceled, the same token was denied and session, worker, and sandbox counts remained unchanged.", true);
+});


### PR DESCRIPTION
## Summary
- Start a member's first Cloud workspace from `remote-session:create`, using the same creation and deduplication path as the Web app.
- Return `cloud_runtime_provisioning`, `retryable: true`, and `retryAfterMs: 30000` until the workspace is ready. The response explicitly says no task has been submitted; retrying then creates the native session with the original prompt.

## Why
A member can have paid OpenWork Web access and a connected MCP client, yet their first task returns a non-retryable `needs_cloud_setup` asking them to open the browser manually. This removes that activation barrier so a connected agent can get the member to their first Cloud task directly. Self-service checkout is being addressed separately in #4448; this PR addresses use after access is granted.

## Issue
Closes #4139.

## Scope
The MCP runtime resolver, a small wrapper around the existing Cloud creation helper, the architecture documentation, and one new HTTP journey with a deterministic provider witness.

## Out of scope
Pricing, subscription purchase, live deployment, and idempotency of successful session creation.

## Testing
### Ran
- `pnpm evals:pr specs/remote-session-first-use.test.ts`
- `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/remote-session-capabilities.test.ts test/remote-session-capability-wire.test.ts test/cloud-instance-route.test.ts`
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir evals run lint:layers`
- `node evals/scripts/spec-boundary-ratchet.mjs`
- Standalone strict TypeScript check of the HTTP witness and `git diff --check`.

### Result
**Passed** on `a15f948aa5273f499700d19348c31a24527a5812`: the HTTP journey passed with six assertion-evidence sections and no skips; all 62 existing cloud/remote-session tests passed; API typechecking and the boundary/dependency checks passed. Final journey and dependency checks used the repository-supported Node 24 runtime.

Placement: local, with a cold isolated Den and MySQL database. The PR-lane command does not print the E2E CLI's placement line. The paid subscription is seeded in the isolated database; HTTP witnesses replace Daytona and the worker's session API. No real payment, VM, or model call occurs.

The pre-change product at `1612d3540` fails the new journey at the first-create assertion: actual `{error: "needs_cloud_setup", retryable: false}` versus expected retryable provisioning.

## CI status
Pending GitHub checks at creation; local verification above is complete.

## Manual verification
1. Use an organization with active OpenWork Web access and a member who has never opened Web.
2. From that member's MCP client, call `execute_capability` with `name: "remote-session:create"` and a title/prompt in `body`.
3. Observe retryable provisioning and no session receipt. Wait the indicated interval, then retry with the same arguments.
4. Once ready, observe the new native session and its submitted prompt. Opening Web afterward uses that same workspace.

## Evidence
The attached `<!-- test-evidence -->` comment contains the final commit's completed journey and each assertion: access denial, read/write/input boundaries, six concurrent creates converging on one workspace, first prompt delivery and browser reuse, member isolation, and denial after subscription cancellation.

## Risk
A valid write-scoped create now allocates a sandbox for an entitled member on first use. Access checks run before allocation, and the existing provisioning flow checks entitlement again. The change reuses the existing worker lifecycle and creation race handling. Verification covers real Den/SDK HTTP behavior against deterministic witnesses; it does not certify live Daytona startup or model execution.

## Rollback
Revert this commit to restore the manual first-use setup requirement.
