### PR TITLE
Fix collapsed sidebar alignment on macOS

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1468,7 +1468,10 @@ export function SessionPage(props: SessionPageProps) {
             !shellConfig.sidebar && "mac:[&_header]:pl-34",
           )}
         >
-          <div className="flex min-h-0 flex-1 max-lg:p-0 lg:py-2 lg:pl-2">
+          <div className={cn(
+            "flex min-h-0 flex-1 max-lg:p-0 lg:py-2 lg:pl-2",
+            !sidebarOpen && "mac:lg:pt-0 mac:lg:pl-0",
+          )}>
           <ResizablePanelGroup
             orientation="horizontal"
             onLayoutChanged={sidePanelOpen ? commitBrowserPanelWidth : undefined}

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -100,7 +100,7 @@ async function titleState(probe: Probe, title: string): Promise<TitleState> {
   };
 }
 
-test("the sidebar title fade follows only the edges with hidden text", async ({ world, user, probe, step }) => {
+test("the sidebar title fade follows only the edges with hidden text", async ({ world, user, seed, probe, step }) => {
   const workspaceName = world.workspacePath.split("/").at(-1) ?? world.workspacePath;
   const resting = await probe.eventually(() => titleState(probe, world.longTitle), {
     within: 60_000,
@@ -108,6 +108,59 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
     until: (state) => state.scrollWidth > state.clientWidth && state.hiddenEdges === "end",
   });
   expect(resting.maskImage).not.toBe("none");
+
+  await step("collapsing the macOS sidebar aligns the pane with the window controls, and reopening restores its inset", async () => {
+    await user.see({ text: world.longTitle });
+    // Exercise the macOS titlebar layout even when the desktop host is Linux.
+    const platformClasses = await seed.evalIn(world.app, `document.documentElement.className`);
+    if (typeof platformClasses !== "string") throw new Error("Desktop platform classes were not readable.");
+    await seed.evalIn(world.app, `(() => {
+      document.documentElement.classList.remove('openwork-platform-linux', 'openwork-platform-windows');
+      document.documentElement.classList.add('openwork-electron', 'openwork-platform-mac');
+    })()`);
+    // TODO(primitive): probe.geometry should compare a pane and its visible titlebar trigger.
+    const geometry = () => probe.eval(`(() => {
+      const pane = document.querySelector('[data-session-pane]');
+      const header = pane?.querySelector('header');
+      const trigger = [...document.querySelectorAll('[data-sidebar="trigger"]')]
+        .find((element) => element.getBoundingClientRect().width > 0);
+      const sidebar = document.querySelector('[data-slot="sidebar"][data-state]');
+      if (!pane || !header || !trigger || !sidebar) return null;
+      const box = pane.getBoundingClientRect();
+      const headerBox = header.getBoundingClientRect();
+      const triggerBox = trigger.getBoundingClientRect();
+      return {
+        isMac: document.documentElement.classList.contains('openwork-platform-mac'),
+        state: sidebar.getAttribute('data-state'),
+        top: box.top,
+        left: box.left,
+        centerOffset: Math.abs(headerBox.top + headerBox.height / 2 - triggerBox.top - triggerBox.height / 2),
+      };
+    })()`);
+    const expanded = await geometry();
+    expect(expanded).toMatchObject({ state: "expanded", top: 8 });
+    if (!isRecord(expanded) || typeof expanded.isMac !== "boolean") throw new Error("Pane geometry was not readable.");
+    await user.press("Meta+b");
+    const collapsed = await probe.eventually(geometry, {
+      within: 10_000,
+      label: "collapsed pane settles against the macOS window edge",
+      until: (value) => isRecord(value) && value.state === "collapsed" && value.left === (expanded.isMac ? 0 : 8),
+    });
+    expect(collapsed).toMatchObject({ top: expanded.isMac ? 0 : 8, left: expanded.isMac ? 0 : 8 });
+    if (expanded.isMac) {
+      if (!isRecord(collapsed) || typeof collapsed.centerOffset !== "number") throw new Error("Titlebar geometry was not readable.");
+      expect(collapsed.centerOffset).toBeLessThanOrEqual(1);
+    }
+    await user.screenshot();
+    await user.press("Meta+b");
+    await probe.eventually(geometry, {
+      within: 10_000,
+      label: "reopened sidebar restores the original pane inset",
+      until: (value) => isRecord(value) && value.state === "expanded" && value.left === expanded.left,
+    });
+    expect(await geometry()).toMatchObject({ top: expanded.top, left: expanded.left });
+    await seed.evalIn(world.app, `(classes) => { document.documentElement.className = classes; }`, { args: [platformClasses] });
+  });
 
   await step("the list fits the sidebar and does not scroll sideways", async () => {
     await expectListFits(probe);


### PR DESCRIPTION
Collapsing the sidebar on macOS left an 8 px content inset behind the native window controls, putting the rounded pane corner under the controls and lowering the header. Remove the top and left inset in the collapsed macOS desktop layout so the header aligns with the sidebar toggle. Reopening restores the inset.

Extends the existing sidebar journey with a macOS layout check: collapse through the sidebar shortcut, measure the pane at the window edge and the header/toggle centers within 1 px, then reopen and verify the original spacing. The macOS CSS layout is exercised on the Linux test host; native macOS window chrome is not rendered by that host.

Verification: **Passed** — `OPENWORK_EVAL_REF=fix/collapsed-sidebar-alignment pnpm evals:e2e sidebar-title-overflow-fade` (exit 0; 1 passed, 0 failed, 0 skipped).
Placement: `daytona (daytona CLI authenticated)`.

`pnpm --dir evals typecheck` exits 2 with 296 errors, identical to a clean control checkout at base commit `6ca08d2776bb` after normalizing checkout paths. First error: `apps/server/src/agent-context-cloud-probe.ts(216,15): TS1294: This syntax is not allowed when erasableSyntaxOnly is enabled.` No new type errors remain. `git diff --check` passes.

Manual native check: on macOS at a desktop width, collapse the sidebar using its toggle or Cmd+B. The pane should meet the top and left window edges and the header should align with the toggle and traffic lights. Reopen to restore the inset.
