### PR TITLE
fix: make in-app UI control work in web and desktop through the server

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1340,7 +1340,9 @@ async function fetchWithTimeout(
 
   const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
   const signal = controller?.signal;
-  const initWithSignal = signal && !init.signal ? { ...init, signal } : init;
+  const initWithSignal = signal
+    ? { ...init, signal: init.signal ? AbortSignal.any([signal, init.signal]) : signal }
+    : init;
 
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -1370,7 +1372,7 @@ async function fetchWithTimeout(
 async function requestJson<T>(
   baseUrl: string,
   path: string,
-  options: { method?: string; token?: string; hostToken?: string; body?: unknown; timeoutMs?: number } = {},
+  options: { method?: string; token?: string; hostToken?: string; body?: unknown; timeoutMs?: number; signal?: AbortSignal } = {},
 ): Promise<T> {
   const url = `${baseUrl}${path}`;
   const fetchImpl = resolveFetch(url);
@@ -1379,6 +1381,7 @@ async function requestJson<T>(
     url,
     {
       method: options.method ?? "GET",
+      signal: options.signal,
       headers: buildHeaders(options.token, options.hostToken),
       body: options.body ? JSON.stringify(options.body) : undefined,
     },
@@ -1806,11 +1809,11 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         { token, hostToken },
       );
     },
-    listUiControlPending: (options?: { wait?: boolean }) =>
+    listUiControlPending: (options?: { wait?: boolean; signal?: AbortSignal }) =>
       requestJson<{ items: OpenworkUiControlRequest[] }>(
         baseUrl,
         `/experimental/ui-control/pending${options?.wait ? "?wait=1" : ""}`,
-        { token, hostToken, timeoutMs: 15_000 },
+        { token, hostToken, timeoutMs: 15_000, signal: options?.signal },
       ),
     replyUiControl: (id: string, result: unknown) =>
       requestJson<{ ok: boolean }>(baseUrl, `/experimental/ui-control/${encodeURIComponent(id)}/reply`, {

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -920,6 +920,13 @@ export type OpenworkReloadEvent = {
   timestamp: number;
 };
 
+export type OpenworkUiControlRequest = {
+  id: string;
+  kind: "context" | "query" | "command";
+  input: unknown;
+  createdAt: number;
+};
+
 export type OpenworkSessionGroupDefinition = {
   id: string;
   label: string;
@@ -1799,6 +1806,19 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         { token, hostToken },
       );
     },
+    listUiControlPending: (options?: { wait?: boolean }) =>
+      requestJson<{ items: OpenworkUiControlRequest[] }>(
+        baseUrl,
+        `/experimental/ui-control/pending${options?.wait ? "?wait=1" : ""}`,
+        { token, hostToken, timeoutMs: 15_000 },
+      ),
+    replyUiControl: (id: string, result: unknown) =>
+      requestJson<{ ok: boolean }>(baseUrl, `/experimental/ui-control/${encodeURIComponent(id)}/reply`, {
+        token,
+        hostToken,
+        method: "POST",
+        body: { result },
+      }),
     reloadEngine: (workspaceId: string) =>
       requestJson<{ ok: boolean; reloadedAt?: number }>(baseUrl, `/workspace/${workspaceId}/engine/reload`, {
         token,

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -18,6 +18,7 @@ import type {
   OpenworkAffordanceResult,
 } from "@openwork/types/openwork-affordance";
 import type { OpenworkContextSnapshot } from "@openwork/types/openwork-context";
+import { useUiControlMailbox } from "./use-ui-control-mailbox";
 
 export type OpenworkControlSideEffect = "none" | "navigation" | "mutation" | "external";
 
@@ -114,7 +115,7 @@ type OpenworkControlContextValue = {
   snapshot: () => OpenworkControlSnapshot;
 };
 
-type OpenworkControlAPI = {
+export type OpenworkControlAPI = {
   version: number;
   snapshot: () => OpenworkControlSnapshot;
   listActions: () => OpenworkControlActionMetadata[];
@@ -252,6 +253,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
   const busyActionIdRef = useRef<string | null>(null);
   const busyActorRef = useRef<string | null>(null);
   const spotlightRunRef = useRef(0);
+  const apiRef = useRef<OpenworkControlAPI | null>(null);
 
   const route = `${location.pathname}${location.search}${location.hash}`;
   const enabled = enabledState;
@@ -617,12 +619,18 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
     };
 
     window.__openworkControl = api;
+    apiRef.current = api;
     return () => {
       if (window.__openworkControl === api) {
         delete window.__openworkControl;
       }
+      if (apiRef.current === api) {
+        apiRef.current = null;
+      }
     };
   }, [contextSnapshot, executeAction, executeCommand, queryAffordance, setEnabled, snapshot]);
+
+  useUiControlMailbox(apiRef);
 
   useEffect(() => {
     busyActionIdRef.current = busyActionId;

--- a/apps/app/src/react-app/shell/control/use-ui-control-mailbox.ts
+++ b/apps/app/src/react-app/shell/control/use-ui-control-mailbox.ts
@@ -1,0 +1,78 @@
+import { useEffect, type RefObject } from "react";
+import type { OpenworkAffordanceRequest } from "@openwork/types/openwork-affordance";
+import {
+  createOpenworkServerClient,
+  type OpenworkUiControlRequest,
+} from "../../../app/lib/openwork-server";
+import { resolveOpenworkConnection } from "../openwork-connection";
+import type { OpenworkControlAPI } from "./control-provider";
+
+const wait = (ms: number) => new Promise<void>((resolve) => window.setTimeout(resolve, ms));
+
+function hasAffordanceId(input: unknown): input is OpenworkAffordanceRequest {
+  return input !== null
+    && typeof input === "object"
+    && "id" in input
+    && typeof input.id === "string"
+    && input.id.trim().length > 0;
+}
+
+async function handleRequest(item: OpenworkUiControlRequest, api: OpenworkControlAPI): Promise<unknown> {
+  if (item.kind === "context") return { ok: true, context: api.context() };
+  if (!hasAffordanceId(item.input)) {
+    return { ok: false, error: "Missing OpenWork affordance id." };
+  }
+  if (item.kind === "query") return api.query(item.input);
+  return api.command(item.input);
+}
+
+export function useUiControlMailbox(apiRef: RefObject<OpenworkControlAPI | null>): void {
+  useEffect(() => {
+    if (import.meta.env.MODE === "test") return;
+
+    let mounted = true;
+    let client: ReturnType<typeof createOpenworkServerClient> | null = null;
+
+    async function poll(): Promise<void> {
+      while (mounted) {
+        try {
+          if (!client) {
+            const connection = await resolveOpenworkConnection();
+            if (!mounted) return;
+            if (!connection.normalizedBaseUrl || !connection.resolvedToken) {
+              await wait(3_000);
+              continue;
+            }
+            client = createOpenworkServerClient({
+              baseUrl: connection.normalizedBaseUrl,
+              token: connection.resolvedToken,
+              hostToken: connection.resolvedHostToken,
+            });
+          }
+
+          const { items } = await client.listUiControlPending({ wait: true });
+          if (!mounted) return;
+          for (const item of items) {
+            let result: unknown;
+            try {
+              const api = apiRef.current;
+              if (!api) throw new Error("OpenWork control surface is not available yet.");
+              result = await handleRequest(item, api);
+            } catch (error) {
+              result = { ok: false, error: error instanceof Error ? error.message : String(error) };
+            }
+            await client.replyUiControl(item.id, result);
+          }
+        } catch {
+          client = null;
+          if (mounted) await wait(2_000);
+        }
+      }
+    }
+
+    void poll();
+    return () => {
+      mounted = false;
+    };
+  }, [apiRef]);
+}

--- a/apps/app/src/react-app/shell/control/use-ui-control-mailbox.ts
+++ b/apps/app/src/react-app/shell/control/use-ui-control-mailbox.ts
@@ -31,26 +31,25 @@ export function useUiControlMailbox(apiRef: RefObject<OpenworkControlAPI | null>
     if (import.meta.env.MODE === "test") return;
 
     let mounted = true;
-    let client: ReturnType<typeof createOpenworkServerClient> | null = null;
+    const controller = new AbortController();
 
     async function poll(): Promise<void> {
       while (mounted) {
         try {
-          if (!client) {
-            const connection = await resolveOpenworkConnection();
-            if (!mounted) return;
-            if (!connection.normalizedBaseUrl || !connection.resolvedToken) {
-              await wait(3_000);
-              continue;
-            }
-            client = createOpenworkServerClient({
-              baseUrl: connection.normalizedBaseUrl,
-              token: connection.resolvedToken,
-              hostToken: connection.resolvedHostToken,
-            });
+          // Resolve again after each poll so switching servers or signing in
+          // cannot leave this window answering a previous server's mailbox.
+          const connection = await resolveOpenworkConnection();
+          if (!mounted) return;
+          if (!connection.normalizedBaseUrl || !connection.resolvedToken) {
+            await wait(3_000);
+            continue;
           }
-
-          const { items } = await client.listUiControlPending({ wait: true });
+          const client = createOpenworkServerClient({
+            baseUrl: connection.normalizedBaseUrl,
+            token: connection.resolvedToken,
+            hostToken: connection.resolvedHostToken,
+          });
+          const { items } = await client.listUiControlPending({ wait: true, signal: controller.signal });
           if (!mounted) return;
           for (const item of items) {
             let result: unknown;
@@ -64,7 +63,6 @@ export function useUiControlMailbox(apiRef: RefObject<OpenworkControlAPI | null>
             await client.replyUiControl(item.id, result);
           }
         } catch {
-          client = null;
           if (mounted) await wait(2_000);
         }
       }
@@ -73,6 +71,7 @@ export function useUiControlMailbox(apiRef: RefObject<OpenworkControlAPI | null>
     void poll();
     return () => {
       mounted = false;
+      controller.abort();
     };
   }, [apiRef]);
 }

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -122,6 +122,12 @@ UI control mailbox (client auth):
 - `GET /experimental/ui-control/pending` (optional `?wait=1`)
 - `POST /experimental/ui-control/:id/reply`
 
+Desktop and web renderers poll the same server they are connected to. The first
+polling window claims each request; commands are never broadcast to every tab.
+Requests expire after five seconds, and a server with no recent renderer poll
+returns an explicit no-window result. The external desktop UI MCP bridge remains
+available; in-app tools no longer discover or fall back to that bridge.
+
 OpenCode proxy:
 
 - `GET|POST|... /opencode/*`

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -100,7 +100,7 @@ Sandbox advertisement (for capability discovery):
 - `GET /workspace/:id/audit`
 - `GET /workspace/:id/export`
 
-Token management (host/owner auth):
+Token management (collaborator or owner bearer token):
 
 - `GET /tokens`
 - `POST /tokens` (body: `{ "scope": "owner"|"collaborator"|"viewer", "label"?: string }`)
@@ -119,8 +119,8 @@ Inbox/outbox:
 UI control mailbox:
 
 - `POST /experimental/ui-control/request` (collaborator or owner bearer token)
-- `GET /experimental/ui-control/pending` (host/owner auth; optional `?wait=1`)
-- `POST /experimental/ui-control/:id/reply` (host/owner auth)
+- `GET /experimental/ui-control/pending` (collaborator or owner bearer token; optional `?wait=1`)
+- `POST /experimental/ui-control/:id/reply` (collaborator or owner bearer token)
 
 Desktop and web renderers poll the same server they are connected to. The first
 polling window claims each request; commands are never broadcast to every tab.

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -116,11 +116,11 @@ Inbox/outbox:
 - `GET /files/sessions/:sessionId/catalog/snapshot`
 - `POST /files/sessions/:sessionId/ops`
 
-UI control mailbox (client auth):
+UI control mailbox:
 
-- `POST /experimental/ui-control/request`
-- `GET /experimental/ui-control/pending` (optional `?wait=1`)
-- `POST /experimental/ui-control/:id/reply`
+- `POST /experimental/ui-control/request` (collaborator or owner bearer token)
+- `GET /experimental/ui-control/pending` (host/owner auth; optional `?wait=1`)
+- `POST /experimental/ui-control/:id/reply` (host/owner auth)
 
 Desktop and web renderers poll the same server they are connected to. The first
 polling window claims each request; commands are never broadcast to every tab.

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -116,6 +116,12 @@ Inbox/outbox:
 - `GET /files/sessions/:sessionId/catalog/snapshot`
 - `POST /files/sessions/:sessionId/ops`
 
+UI control mailbox (client auth):
+
+- `POST /experimental/ui-control/request`
+- `GET /experimental/ui-control/pending` (optional `?wait=1`)
+- `POST /experimental/ui-control/:id/reply`
+
 OpenCode proxy:
 
 - `GET|POST|... /opencode/*`

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -1,7 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { z } from "zod";
 
 import { OpenWorkExtensionsPreview } from "./openwork-extensions-preview.js";
@@ -95,6 +92,7 @@ async function transformedSystem(plugin: Awaited<ReturnType<typeof OpenWorkExten
 
 function startFakeOpenWorkServer(options: { failPromptText?: string; failSessionListWorkspaceId?: string } = {}) {
   const requests: Array<{ pathname: string; search: string; authorization: string | null; method: string; body?: unknown }> = [];
+  const uiControlRequests: Array<{ authorization: string | null; body: unknown }> = [];
   let createdCount = 0;
 
   const workspaceOne = { id: "ws_1", name: "Main", path: "/tmp/main" };
@@ -122,6 +120,11 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
 
       if (request.headers.get("authorization") !== "Bearer test-token") {
         return Response.json({ message: "Unauthorized" }, { status: 401 });
+      }
+
+      if (url.pathname === "/experimental/ui-control/request" && request.method === "POST") {
+        uiControlRequests.push({ authorization: record.authorization, body: record.body });
+        return Response.json({ ok: true });
       }
 
       if (url.pathname === "/experimental/connect/state") {
@@ -242,34 +245,7 @@ function startFakeOpenWorkServer(options: { failPromptText?: string; failSession
   stops.push(() => server.stop(true));
   process.env.OPENWORK_SERVER_URL = `http://127.0.0.1:${server.port}`;
   process.env.OPENWORK_SERVER_TOKEN = "test-token";
-  return { requests };
-}
-
-async function startFakeUiBridge() {
-  const commands: Array<{ authorization: string | null; body: unknown }> = [];
-  const server = Bun.serve({
-    hostname: "127.0.0.1",
-    port: 0,
-    async fetch(request) {
-      const url = new URL(request.url);
-      if (url.pathname === "/command" && request.method === "POST") {
-        commands.push({ authorization: request.headers.get("authorization"), body: await request.json() });
-        return Response.json({ ok: true });
-      }
-      return Response.json({ ok: false, error: "Not found" }, { status: 404 });
-    },
-  });
-  const discoveryPath = join(tmpdir(), `openwork-ui-control-${process.pid}-${Date.now()}.json`);
-  await writeFile(discoveryPath, JSON.stringify({ baseUrl: `http://127.0.0.1:${server.port}`, token: "bridge-token" }));
-  const originalDiscovery = process.env.OPENWORK_UI_CONTROL_DISCOVERY;
-  process.env.OPENWORK_UI_CONTROL_DISCOVERY = discoveryPath;
-  stops.push(() => {
-    server.stop(true);
-    if (originalDiscovery === undefined) delete process.env.OPENWORK_UI_CONTROL_DISCOVERY;
-    else process.env.OPENWORK_UI_CONTROL_DISCOVERY = originalDiscovery;
-    void rm(discoveryPath, { force: true });
-  });
-  return { commands };
+  return { requests, uiControlRequests };
 }
 
 describe("OpenWorkExtensionsPreview MCP Apps result preservation", () => {
@@ -650,7 +626,6 @@ describe("OpenWorkExtensionsPreview session tools", () => {
 
   test("asks the desktop to refetch the target workspace's sessions after creating them", async () => {
     const fake = startFakeOpenWorkServer();
-    const bridge = await startFakeUiBridge();
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
 
     const output = await plugin.tool.openwork_execute.execute({
@@ -663,8 +638,14 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(parsed.result.workspaceId).toBe("ws_2");
     // The sidebar only refetches the workspace that received the session; the
     // reload is issued once the engine has both created and started it.
-    expect(bridge.commands).toEqual([
-      { authorization: "Bearer bridge-token", body: { id: "workspace.reload_sessions", args: { workspaceId: "ws_2" } } },
+    expect(fake.uiControlRequests).toEqual([
+      {
+        authorization: "Bearer test-token",
+        body: {
+          kind: "command",
+          input: { id: "workspace.reload_sessions", args: { workspaceId: "ws_2" } },
+        },
+      },
     ]);
     const createIndex = fake.requests.findIndex((request) => request.pathname === "/workspace/ws_2/opencode/session" && request.method === "POST");
     const promptIndex = fake.requests.findIndex((request) => request.pathname.endsWith("/prompt_async"));
@@ -673,8 +654,7 @@ describe("OpenWorkExtensionsPreview session tools", () => {
   });
 
   test("still asks the desktop to refetch when a created session's prompt fails to start", async () => {
-    startFakeOpenWorkServer({ failPromptText: "Fail this prompt." });
-    const bridge = await startFakeUiBridge();
+    const fake = startFakeOpenWorkServer({ failPromptText: "Fail this prompt." });
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
 
     await plugin.tool.openwork_execute.execute({
@@ -683,14 +663,19 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     }, { sessionID: "ses_origin" });
 
     // The session exists on the engine even though its run never started.
-    expect(bridge.commands.map((command) => command.body)).toEqual([
-      { id: "workspace.reload_sessions", args: { workspaceId: "ws_2" } },
+    expect(fake.uiControlRequests).toEqual([
+      {
+        authorization: "Bearer test-token",
+        body: {
+          kind: "command",
+          input: { id: "workspace.reload_sessions", args: { workspaceId: "ws_2" } },
+        },
+      },
     ]);
   });
 
   test("does not ask the desktop to refetch when no session reached the engine", async () => {
     const fake = startFakeOpenWorkServer();
-    const bridge = await startFakeUiBridge();
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
 
     await expect(plugin.tool.openwork_execute.execute({
@@ -699,7 +684,7 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     }, { sessionID: "ses_origin" })).rejects.toThrow("No workspace matched ws_missing");
 
     expect(fake.requests.filter((request) => request.method === "POST")).toEqual([]);
-    expect(bridge.commands).toEqual([]);
+    expect(fake.uiControlRequests).toEqual([]);
   });
 
   test("stamps the requesting conversation on UI commands so the app acts for that thread, not the one on screen", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -688,7 +688,7 @@ describe("OpenWorkExtensionsPreview session tools", () => {
   });
 
   test("stamps the requesting conversation on UI commands so the app acts for that thread, not the one on screen", async () => {
-    const bridge = await startFakeUiBridge();
+    const fake = startFakeOpenWorkServer();
     const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
 
     await plugin.tool.openwork_execute.execute({
@@ -698,11 +698,17 @@ describe("OpenWorkExtensionsPreview session tools", () => {
       origin: { sessionId: "ses_spoofed" },
     }, { sessionID: "ses_origin", workspaceId: "ws_2" });
 
-    expect(bridge.commands.map((command) => command.body)).toEqual([
+    expect(fake.uiControlRequests).toEqual([
       {
-        id: "browser.open_url",
-        args: { url: "https://example.com" },
-        origin: { sessionId: "ses_origin", workspaceId: "ws_2" },
+        authorization: "Bearer test-token",
+        body: {
+          kind: "command",
+          input: {
+            id: "browser.open_url",
+            args: { url: "https://example.com" },
+            origin: { sessionId: "ses_origin", workspaceId: "ws_2" },
+          },
+        },
       },
     ]);
   });

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -1,6 +1,4 @@
-import { readFile, realpath } from "node:fs/promises";
-import { join } from "node:path";
-import { homedir, platform } from "node:os";
+import { realpath } from "node:fs/promises";
 import { z } from "zod";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import { automationProposalSchema } from "@openwork/types/automations";
@@ -131,15 +129,6 @@ const OPENWORK_BROWSER_INSTRUCTION =
   `## Built-in Browser (external websites)
 For web browsing tasks, ALWAYS start with openwork_execute id browser.open_url. It creates/selects a built-in OpenWork browser tab and returns browser_url plus target_id. Use that exact browser_url and target_id for every later browser_snapshot, browser_click, browser_fill, browser_eval, and browser_screenshot call.
 Do not call browser_navigate without a target_id returned by browser.open_url; a target titled "OpenWork" or whose URL contains ":5173/#/" is the app itself, not a web page.`;
-
-// ── UI control bridge discovery ──
-
-type UiBridge = { baseUrl: string; token: string };
-let cachedBridge: UiBridge | null = null;
-let cachedBridgeAt = 0;
-let cachedBridgeDiscovery: string | undefined;
-const BRIDGE_CACHE_MS = 2_000;
-const BRIDGE_TIMEOUT_MS = 5_000;
 
 type OpenWorkWorkspace = z.infer<typeof workspaceSchema>;
 type SessionInfo = z.infer<typeof sessionInfoSchema>;
@@ -285,61 +274,14 @@ const SESSION_SEARCH_CONCURRENCY = 6;
 const SESSION_SNIPPET_BEFORE = 36;
 const SESSION_SNIPPET_AFTER = 72;
 
-function userAppDataDir(): string {
-  if (platform() === "darwin") return join(homedir(), "Library", "Application Support");
-  if (platform() === "win32") return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
-  return process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
-}
-
-function uiControlDiscoveryPaths(): string[] {
-  return [
-    process.env.OPENWORK_UI_CONTROL_DISCOVERY?.trim(),
-    join(userAppDataDir(), "com.differentai.openwork", "openwork-ui-control.json"),
-    join(userAppDataDir(), "com.differentai.openwork.dev", "openwork-ui-control.json"),
-  ].filter((p): p is string => Boolean(p));
-}
-
-async function discoverUiBridge(): Promise<UiBridge | null> {
-  // A changed discovery override points at a different desktop; never reuse
-  // the bridge cached for the previous one.
-  const discovery = process.env.OPENWORK_UI_CONTROL_DISCOVERY?.trim();
-  if (cachedBridge && cachedBridgeDiscovery === discovery && Date.now() - cachedBridgeAt < BRIDGE_CACHE_MS) return cachedBridge;
-  for (const candidate of uiControlDiscoveryPaths()) {
-    try {
-      const raw = await readFile(candidate, "utf8");
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      if (typeof parsed.baseUrl === "string" && typeof parsed.token === "string") {
-        cachedBridge = { baseUrl: parsed.baseUrl, token: parsed.token };
-        cachedBridgeAt = Date.now();
-        cachedBridgeDiscovery = discovery;
-        return cachedBridge;
-      }
-    } catch {
-      // Try next
-    }
-  }
-  return null;
-}
-
-async function uiBridgeRequest(path: string, options: { method?: string; body?: unknown } = {}): Promise<unknown> {
-  const bridge = await discoverUiBridge();
-  if (!bridge) return { ok: false, error: "OpenWork UI bridge not available. The desktop app may not be running." };
+async function uiControlRequest(
+  kind: "context" | "query" | "command",
+  input?: unknown,
+): Promise<unknown> {
   try {
-    const response = await fetch(`${bridge.baseUrl}${path}`, {
-      method: options.method || "GET",
-      signal: AbortSignal.timeout(BRIDGE_TIMEOUT_MS),
-      headers: {
-        Authorization: `Bearer ${bridge.token}`,
-        ...(options.body ? { "Content-Type": "application/json" } : {}),
-      },
-      ...(options.body ? { body: JSON.stringify(options.body) } : {}),
-    });
-    const text = await response.text();
-    try { return JSON.parse(text); } catch { return { ok: false, error: text || `HTTP ${response.status}` }; }
+    return await postJson("/experimental/ui-control/request", { kind, input });
   } catch (error) {
-    cachedBridge = null;
-    cachedBridgeAt = 0;
-    return { ok: false, error: `UI bridge unreachable: ${error instanceof Error ? error.message : String(error)}` };
+    return { ok: false, error: unknownErrorMessage(error) };
   }
 }
 
@@ -389,7 +331,7 @@ async function readOpenworkAgentContext(
   engineMcpStatusDirectory: string | undefined,
 ): Promise<Record<string, unknown>> {
   const [uiResult, skills, mcps] = await Promise.all([
-    uiBridgeRequest("/context"),
+    uiControlRequest("context"),
     readConnectSkillDescriptors(),
     readEngineMcpDescriptors(engineMcpStatusClient, engineMcpStatusDirectory),
   ]);
@@ -449,10 +391,7 @@ async function queryOpenworkAffordance(rawArgs: unknown): Promise<unknown> {
       "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
     );
   }
-  const result = await uiBridgeRequest("/query", {
-    method: "POST",
-    body: request,
-  });
+  const result = await uiControlRequest("query", request);
   return isRecord(result) && typeof result.ok === "boolean"
     ? result
     : unavailableAffordance(request.id, "OpenWork UI query returned an invalid response.");
@@ -496,13 +435,8 @@ async function executeOpenworkAffordance(
       "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
     );
   }
-  const result = await uiBridgeRequest("/command", {
-    method: "POST",
-    // Stamp the requesting conversation so UI commands act for the agent's own
-    // thread (its browser tabs, its panel) rather than whichever thread is on
-    // screen. The agent never supplies this; it comes from the tool context.
-    body: { ...request, ...affordanceOrigin(context) },
-  });
+  // Keep the requesting conversation attached when commands cross the server.
+  const result = await uiControlRequest("command", { ...request, ...affordanceOrigin(context) });
   return isRecord(result) && typeof result.ok === "boolean"
     ? result
     : unavailableAffordance(request.id, "OpenWork UI command returned an invalid response.");
@@ -886,11 +820,12 @@ async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext
   // The desktop only receives engine events for its selected workspace, so a
   // session created here in any other workspace stays invisible until that
   // list is refetched. A session whose prompt failed still exists, so it is
-  // refetched too. Best effort: headless runs have no UI bridge.
+  // refetched too. Best effort: headless runs without a connected window get
+  // a soft error.
   if (createdOnEngine) {
-    await uiBridgeRequest("/command", {
-      method: "POST",
-      body: { id: "workspace.reload_sessions", args: { workspaceId: workspace.id } },
+    await uiControlRequest("command", {
+      id: "workspace.reload_sessions",
+      args: { workspaceId: workspace.id },
     });
   }
   return {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -279,7 +279,7 @@ async function uiControlRequest(
   input?: unknown,
 ): Promise<unknown> {
   try {
-    return await postJson("/experimental/ui-control/request", { kind, input });
+    return await postJson("/experimental/ui-control/request", { kind, input }, AbortSignal.timeout(7_000));
   } catch (error) {
     return { ok: false, error: unknownErrorMessage(error) };
   }
@@ -862,9 +862,10 @@ function proposeAutomation(rawArgs: unknown, context: OpenCodeContext): object {
   };
 }
 
-async function postJson(path: string, body: ExtensionActionPayload | Record<string, unknown>): Promise<unknown> {
+async function postJson(path: string, body: ExtensionActionPayload | Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
   const { url, token } = requireOpenWorkServer();
   const response = await fetch(url + path, {
+    signal,
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/apps/server/src/routes/registry.ts
+++ b/apps/server/src/routes/registry.ts
@@ -2,6 +2,7 @@ import type { ApprovalService } from "../approvals.js";
 import type { ReloadEventStore } from "../events.js";
 import type { TokenService } from "../tokens.js";
 import type { Actor, ServerConfig } from "../types.js";
+import type { UiControlMailbox } from "../ui-control.js";
 
 export type AuthMode = "none" | "client" | "host" | "host-token";
 
@@ -11,6 +12,7 @@ export interface RequestContext {
   params: Record<string, string>;
   config: ServerConfig;
   approvals: ApprovalService;
+  uiControl: UiControlMailbox;
   reloadEvents: ReloadEventStore;
   tokens: TokenService;
   actor?: Actor;

--- a/apps/server/src/routes/ui-control.ts
+++ b/apps/server/src/routes/ui-control.ts
@@ -32,7 +32,7 @@ export function registerUiControlRoutes(options: RegisterUiControlRoutesOptions)
   });
 
   addRoute(routes, "GET", "/experimental/ui-control/pending", "client", async (ctx) => {
-    const items = await ctx.uiControl.pending({ wait: ctx.url.searchParams.get("wait") === "1" });
+    const items = await ctx.uiControl.pending({ wait: ctx.url.searchParams.get("wait") === "1", signal: ctx.request.signal });
     return jsonResponse({ items });
   });
 

--- a/apps/server/src/routes/ui-control.ts
+++ b/apps/server/src/routes/ui-control.ts
@@ -19,6 +19,9 @@ export function registerUiControlRoutes(options: RegisterUiControlRoutesOptions)
   const { routes, jsonResponse, readJsonBody } = options;
 
   addRoute(routes, "POST", "/experimental/ui-control/request", "client", async (ctx) => {
+    if (ctx.actor?.scope === "viewer") {
+      throw new ApiError(403, "forbidden", "Viewer tokens cannot request UI control");
+    }
     const body = await readJsonBody(ctx.request);
     if (!isUiControlKind(body.kind)) {
       throw new ApiError(
@@ -31,12 +34,12 @@ export function registerUiControlRoutes(options: RegisterUiControlRoutesOptions)
     return jsonResponse(result);
   });
 
-  addRoute(routes, "GET", "/experimental/ui-control/pending", "client", async (ctx) => {
+  addRoute(routes, "GET", "/experimental/ui-control/pending", "host", async (ctx) => {
     const items = await ctx.uiControl.pending({ wait: ctx.url.searchParams.get("wait") === "1", signal: ctx.request.signal });
     return jsonResponse({ items });
   });
 
-  addRoute(routes, "POST", "/experimental/ui-control/:id/reply", "client", async (ctx) => {
+  addRoute(routes, "POST", "/experimental/ui-control/:id/reply", "host", async (ctx) => {
     const body = await readJsonBody(ctx.request);
     if (!ctx.uiControl.reply(ctx.params.id, body.result)) {
       throw new ApiError(404, "ui_control_request_not_found", "UI control request not found");

--- a/apps/server/src/routes/ui-control.ts
+++ b/apps/server/src/routes/ui-control.ts
@@ -1,0 +1,46 @@
+import { ApiError } from "../errors.js";
+import type { UiControlKind } from "../types.js";
+import { addRoute, type Route } from "./registry.js";
+
+type JsonResponse = (data: unknown, status?: number) => Response;
+type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
+
+interface RegisterUiControlRoutesOptions {
+  routes: Route[];
+  jsonResponse: JsonResponse;
+  readJsonBody: ReadJsonBody;
+}
+
+function isUiControlKind(value: unknown): value is UiControlKind {
+  return value === "context" || value === "query" || value === "command";
+}
+
+export function registerUiControlRoutes(options: RegisterUiControlRoutesOptions): void {
+  const { routes, jsonResponse, readJsonBody } = options;
+
+  addRoute(routes, "POST", "/experimental/ui-control/request", "client", async (ctx) => {
+    const body = await readJsonBody(ctx.request);
+    if (!isUiControlKind(body.kind)) {
+      throw new ApiError(
+        400,
+        "invalid_ui_control_request",
+        "UI control request kind must be context, query, or command",
+      );
+    }
+    const result = await ctx.uiControl.request(body.kind, body.input);
+    return jsonResponse(result);
+  });
+
+  addRoute(routes, "GET", "/experimental/ui-control/pending", "client", async (ctx) => {
+    const items = await ctx.uiControl.pending({ wait: ctx.url.searchParams.get("wait") === "1" });
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "POST", "/experimental/ui-control/:id/reply", "client", async (ctx) => {
+    const body = await readJsonBody(ctx.request);
+    if (!ctx.uiControl.reply(ctx.params.id, body.result)) {
+      throw new ApiError(404, "ui_control_request_not_found", "UI control request not found");
+    }
+    return jsonResponse({ ok: true });
+  });
+}

--- a/apps/server/src/routes/ui-control.ts
+++ b/apps/server/src/routes/ui-control.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "../errors.js";
-import type { UiControlKind } from "../types.js";
-import { addRoute, type Route } from "./registry.js";
+import type { TokenScope, UiControlKind } from "../types.js";
+import { addRoute, type RequestContext, type Route } from "./registry.js";
 
 type JsonResponse = (data: unknown, status?: number) => Response;
 type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
@@ -9,6 +9,7 @@ interface RegisterUiControlRoutesOptions {
   routes: Route[];
   jsonResponse: JsonResponse;
   readJsonBody: ReadJsonBody;
+  requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
 }
 
 function isUiControlKind(value: unknown): value is UiControlKind {
@@ -16,12 +17,10 @@ function isUiControlKind(value: unknown): value is UiControlKind {
 }
 
 export function registerUiControlRoutes(options: RegisterUiControlRoutesOptions): void {
-  const { routes, jsonResponse, readJsonBody } = options;
+  const { routes, jsonResponse, readJsonBody, requireClientScope } = options;
 
   addRoute(routes, "POST", "/experimental/ui-control/request", "client", async (ctx) => {
-    if (ctx.actor?.scope === "viewer") {
-      throw new ApiError(403, "forbidden", "Viewer tokens cannot request UI control");
-    }
+    requireClientScope(ctx, "collaborator");
     const body = await readJsonBody(ctx.request);
     if (!isUiControlKind(body.kind)) {
       throw new ApiError(
@@ -34,12 +33,14 @@ export function registerUiControlRoutes(options: RegisterUiControlRoutesOptions)
     return jsonResponse(result);
   });
 
-  addRoute(routes, "GET", "/experimental/ui-control/pending", "host", async (ctx) => {
+  addRoute(routes, "GET", "/experimental/ui-control/pending", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
     const items = await ctx.uiControl.pending({ wait: ctx.url.searchParams.get("wait") === "1", signal: ctx.request.signal });
     return jsonResponse({ items });
   });
 
-  addRoute(routes, "POST", "/experimental/ui-control/:id/reply", "host", async (ctx) => {
+  addRoute(routes, "POST", "/experimental/ui-control/:id/reply", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
     const body = await readJsonBody(ctx.request);
     if (!ctx.uiControl.reply(ctx.params.id, body.result)) {
       throw new ApiError(404, "ui_control_request_not_found", "UI control request not found");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -92,8 +92,10 @@ import { registerFileRoutes } from "./routes/files.js";
 import { registerOperationRoutes } from "./routes/operations.js";
 import { addRoute, matchRoute, type AuthMode, type RequestContext, type Route } from "./routes/registry.js";
 import { registerSessionGroupRoutes } from "./routes/session-groups.js";
+import { registerUiControlRoutes } from "./routes/ui-control.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import { registerCloudMcpRoutes } from "./routes/cloud-mcp.js";
+import { UiControlMailbox } from "./ui-control.js";
 import { captureServerException, isExpectedRequestCancellation } from "./telemetry.js";
 import {
   completeLocalManagedMcpAuthorization,
@@ -950,6 +952,7 @@ function isPromptAsyncProxyRequest(method: string, proxyPath: string) {
 
 export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const approvals = new ApprovalService(config.approval);
+  const uiControl = new UiControlMailbox();
   const reloadEvents = new ReloadEventStore();
   const tokens = new TokenService(config);
   const env = new EnvService();
@@ -1005,6 +1008,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const routes = createRoutes(
     config,
     approvals,
+    uiControl,
     tokens,
     env,
     restartReloadWatchers,
@@ -1170,6 +1174,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           params: route.params,
           config,
           approvals,
+          uiControl,
           reloadEvents,
           tokens,
           actor,
@@ -2179,6 +2184,7 @@ function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
 function createRoutes(
   config: ServerConfig,
   approvals: ApprovalService,
+  uiControl: UiControlMailbox,
   tokens: TokenService,
   env: EnvService,
   onWorkspacesChanged: () => void,
@@ -3009,6 +3015,8 @@ function createRoutes(
     reloadOpencodeEngine: (routeConfig, workspace) =>
       reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState, { reason: "operation_route" }),
   });
+
+  registerUiControlRoutes({ routes, jsonResponse, readJsonBody });
 
   registerFileRoutes({
     routes,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1008,7 +1008,6 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const routes = createRoutes(
     config,
     approvals,
-    uiControl,
     tokens,
     env,
     restartReloadWatchers,
@@ -2184,7 +2183,6 @@ function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
 function createRoutes(
   config: ServerConfig,
   approvals: ApprovalService,
-  uiControl: UiControlMailbox,
   tokens: TokenService,
   env: EnvService,
   onWorkspacesChanged: () => void,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3014,7 +3014,7 @@ function createRoutes(
       reloadOpencodeEngine(routeConfig, workspace, engineMcpServerState, { reason: "operation_route" }),
   });
 
-  registerUiControlRoutes({ routes, jsonResponse, readJsonBody });
+  registerUiControlRoutes({ routes, jsonResponse, readJsonBody, requireClientScope });
 
   registerFileRoutes({
     routes,

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -221,6 +221,15 @@ export interface ApprovalRequest {
   actor: Actor;
 }
 
+export type UiControlKind = "context" | "query" | "command";
+
+export interface UiControlRequest {
+  id: string;
+  kind: UiControlKind;
+  input?: unknown;
+  createdAt: number;
+}
+
 export interface AuditEntry {
   id: string;
   workspaceId: string;

--- a/apps/server/src/ui-control.ts
+++ b/apps/server/src/ui-control.ts
@@ -45,7 +45,8 @@ export class UiControlMailbox {
     });
   }
 
-  async pending(options: { wait: boolean }): Promise<UiControlRequest[]> {
+  async pending(options: { wait: boolean; signal: AbortSignal }): Promise<UiControlRequest[]> {
+    if (options.signal.aborted) return [];
     this.lastPollAt = Date.now();
     const items = this.takeUndelivered();
     if (items.length > 0 || !options.wait) return items;
@@ -54,13 +55,15 @@ export class UiControlMailbox {
       const wake = () => {
         clearTimeout(timeout);
         this.waiters.delete(wake);
+        options.signal.removeEventListener("abort", wake);
         resolve();
       };
       const timeout = setTimeout(wake, PENDING_WAIT_TIMEOUT_MS);
       this.waiters.add(wake);
+      options.signal.addEventListener("abort", wake, { once: true });
     });
 
-    return this.takeUndelivered();
+    return options.signal.aborted ? [] : this.takeUndelivered();
   }
 
   reply(id: string, result: unknown): boolean {

--- a/apps/server/src/ui-control.ts
+++ b/apps/server/src/ui-control.ts
@@ -1,0 +1,88 @@
+import type { UiControlKind, UiControlRequest } from "./types.js";
+import { shortId } from "./utils.js";
+
+const WINDOW_CONNECTED_TIMEOUT_MS = 20_000;
+const REQUEST_TIMEOUT_MS = 5_000;
+const PENDING_WAIT_TIMEOUT_MS = 10_000;
+
+interface PendingUiControlRequest {
+  request: UiControlRequest;
+  delivered: boolean;
+  resolve: (result: unknown) => void;
+  timeout: NodeJS.Timeout;
+}
+
+export class UiControlMailbox {
+  private requests = new Map<string, PendingUiControlRequest>();
+  private waiters = new Set<() => void>();
+  private lastPollAt = 0;
+
+  request(kind: UiControlKind, input?: unknown): Promise<unknown> {
+    if (!this.connected()) {
+      return Promise.resolve({
+        ok: false,
+        error: "No OpenWork window is connected to this server. Open the OpenWork app or its web tab and try again.",
+      });
+    }
+
+    const id = shortId();
+    const request: UiControlRequest = {
+      id,
+      kind,
+      input,
+      createdAt: Date.now(),
+    };
+
+    return new Promise<unknown>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.requests.delete(id);
+        resolve({ ok: false, error: "The OpenWork window did not answer within 5 seconds." });
+      }, REQUEST_TIMEOUT_MS);
+
+      this.requests.set(id, { request, delivered: false, resolve, timeout });
+      const waiters = [...this.waiters];
+      for (const wake of waiters) wake();
+    });
+  }
+
+  async pending(options: { wait: boolean }): Promise<UiControlRequest[]> {
+    this.lastPollAt = Date.now();
+    const items = this.takeUndelivered();
+    if (items.length > 0 || !options.wait) return items;
+
+    await new Promise<void>((resolve) => {
+      const wake = () => {
+        clearTimeout(timeout);
+        this.waiters.delete(wake);
+        resolve();
+      };
+      const timeout = setTimeout(wake, PENDING_WAIT_TIMEOUT_MS);
+      this.waiters.add(wake);
+    });
+
+    return this.takeUndelivered();
+  }
+
+  reply(id: string, result: unknown): boolean {
+    const pending = this.requests.get(id);
+    if (!pending) return false;
+    clearTimeout(pending.timeout);
+    this.requests.delete(id);
+    pending.resolve(result);
+    return true;
+  }
+
+  connected(): boolean {
+    return Date.now() - this.lastPollAt <= WINDOW_CONNECTED_TIMEOUT_MS;
+  }
+
+  private takeUndelivered(): UiControlRequest[] {
+    const items: UiControlRequest[] = [];
+    for (const pending of this.requests.values()) {
+      if (pending.delivered) continue;
+      pending.delivered = true;
+      items.push(pending.request);
+    }
+    return items;
+  }
+}

--- a/evals/specs/agent-ui-context-via-server.test.ts
+++ b/evals/specs/agent-ui-context-via-server.test.ts
@@ -1,0 +1,128 @@
+import { spec } from "@openwork/testkit";
+import { expect } from "vitest";
+import { agentUiContext, MOCK_REPLY } from "../worlds/agent-ui-context.ts";
+
+const test = spec.world(agentUiContext, { needs: { commands: ["bun"] }, timeout: 240_000 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sessionIdOf(value: unknown): string {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    throw new Error(`Expected a created session: ${JSON.stringify(value)}`);
+  }
+  return value.id;
+}
+
+function replyText(value: unknown): string {
+  if (!isRecord(value) || !Array.isArray(value.parts)) return "";
+  return value.parts
+    .filter(isRecord)
+    .filter((part) => part.type === "text")
+    .map((part) => typeof part.text === "string" ? part.text : "")
+    .join("");
+}
+
+function completedContextOutput(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  for (const message of value) {
+    if (!isRecord(message) || !Array.isArray(message.parts)) continue;
+    for (const part of message.parts) {
+      if (!isRecord(part) || part.type !== "tool" || part.tool !== "openwork_context" || !isRecord(part.state)) continue;
+      if (part.state.status === "completed" && typeof part.state.output === "string") return part.state.output;
+    }
+  }
+  return null;
+}
+
+function parseOutput(output: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(output);
+  if (!isRecord(parsed)) throw new Error(`Expected object tool output: ${output}`);
+  return parsed;
+}
+
+test("the in-app agent reads renderer context through openwork-server and gets an explicit result without a window", async ({ world, probe, step, evidence }) => {
+  await step("without a connected window the tool reports that no OpenWork window is connected and the turn completes", async () => {
+    const sessionId = sessionIdOf(await world.engine("POST", "/session", { title: "agent context without window" }));
+    const result = await world.engine("POST", `/session/${encodeURIComponent(sessionId)}/message`, {
+      model: { providerID: "mock", modelID: "mock" },
+      parts: [{ type: "text", text: "What is on my screen?" }],
+    });
+    const output = await probe.eventually(
+      async () => completedContextOutput(await world.engine("GET", `/session/${encodeURIComponent(sessionId)}/message`)),
+      {
+        within: 30_000,
+        label: "completed openwork_context tool without a window",
+        until: (value) => value !== null,
+      },
+    );
+    if (output === null) throw new Error("openwork_context did not complete");
+    const parsed = parseOutput(output);
+    const ui = isRecord(parsed.ui) ? parsed.ui : null;
+    const error = ui && typeof ui.error === "string" ? ui.error : "";
+
+    expect(parsed.context).toBeNull();
+    expect(ui?.ok).toBe(false);
+    expect(error).toContain("No OpenWork window is connected");
+    expect(error).not.toContain("desktop app may not be running");
+    expect(replyText(result)).toBe(MOCK_REPLY);
+    evidence.recordAssertionEvidence(
+      "Without a polling OpenWork window, the agent receives the server's explicit no-window result and still completes its turn",
+      `openwork_context returned context=null and ui.error=${JSON.stringify(error)}; the model's reply was ${JSON.stringify(replyText(result))}.`,
+      true,
+    );
+  });
+
+  await step("a connected window's split layout reaches both the tool transcript and the model", async () => {
+    const fakeWindow = await world.attachWindow({
+      screen: "session",
+      conversations: {
+        layout: {
+          kind: "split",
+          focused: "secondary",
+          primarySessionId: "ses_left",
+          secondarySessionId: "ses_right",
+        },
+      },
+      availableAffordances: [],
+    });
+    try {
+      const sessionId = sessionIdOf(await world.engine("POST", "/session", { title: "agent context with window" }));
+      const before = world.requests.length;
+      const result = await world.engine("POST", `/session/${encodeURIComponent(sessionId)}/message`, {
+        model: { providerID: "mock", modelID: "mock" },
+        parts: [{ type: "text", text: "What is on my screen?" }],
+      });
+      const output = await probe.eventually(
+        async () => completedContextOutput(await world.engine("GET", `/session/${encodeURIComponent(sessionId)}/message`)),
+        {
+          within: 30_000,
+          label: "completed openwork_context tool with a connected window",
+          until: (value) => value !== null,
+        },
+      );
+      if (output === null) throw new Error("openwork_context did not complete");
+      const parsed = parseOutput(output);
+      const context = isRecord(parsed.context) ? parsed.context : null;
+      const conversations = context && isRecord(context.conversations) ? context.conversations : null;
+      const layout = conversations && isRecord(conversations.layout) ? conversations.layout : null;
+      const providerRequests = world.requests.slice(before);
+
+      expect(layout?.secondarySessionId).toBe("ses_right");
+      expect(Array.isArray(context?.availableAffordances)).toBe(true);
+      expect(fakeWindow.handled).toHaveLength(1);
+      expect(fakeWindow.handled[0]?.kind).toBe("context");
+      expect(providerRequests).toHaveLength(2);
+      expect(providerRequests[1]?.toolResults.some((content) => content.includes("ses_right"))).toBe(true);
+      expect(replyText(result)).toBe(MOCK_REPLY);
+      evidence.recordAssertionEvidence(
+        "A renderer window's split layout crosses openwork-server into the agent tool result and the model's follow-up request",
+        `The fake window handled one context request; the transcript and provider tool result both contained secondarySessionId=ses_right, and the turn replied ${JSON.stringify(replyText(result))}.`,
+        true,
+      );
+    } finally {
+      await fakeWindow.detach();
+    }
+  });
+});

--- a/evals/specs/agent-ui-context-via-server.test.ts
+++ b/evals/specs/agent-ui-context-via-server.test.ts
@@ -155,18 +155,16 @@ test("the in-app agent reads renderer context through openwork-server and gets a
         method: "POST", headers: viewerHeaders, body: JSON.stringify({ kind, input: { id: "route.session" } }),
       })).status).toBe(403);
     }
-    for (const untrustedHeaders of [headers, viewerHeaders]) {
-      expect((await fetch(pendingPath, { headers: untrustedHeaders })).status).toBe(401);
-    }
+    expect((await fetch(pendingPath, { headers: viewerHeaders })).status).toBe(403);
 
     for (const kind of ["query", "command"]) {
-      await fetch(pendingPath, { headers: hostHeaders });
+      await fetch(pendingPath, { headers });
       const input = { id: "mailbox.witness", args: { marker: kind } };
       const result = { ok: true, result: { marker: kind } };
       const requested = fetch(requestPath, {
         method: "POST", headers, body: JSON.stringify({ kind, input }), signal: AbortSignal.timeout(10_000),
       });
-      const response = await fetch(`${pendingPath}?wait=1`, { headers: hostHeaders, signal: AbortSignal.timeout(12_000) });
+      const response = await fetch(`${pendingPath}?wait=1`, { headers, signal: AbortSignal.timeout(12_000) });
       const payload: unknown = await response.json();
       if (!isRecord(payload) || !Array.isArray(payload.items) || !isRecord(payload.items[0])) {
         throw new Error("Expected a delivered mailbox item");
@@ -175,21 +173,19 @@ test("the in-app agent reads renderer context through openwork-server and gets a
       const item = payload.items[0];
       expect(item.kind).toBe(kind);
       expect(item.input).toEqual(input);
-      expect(await (await fetch(pendingPath, { headers: hostHeaders })).json()).toEqual({ items: [] });
+      expect(await (await fetch(pendingPath, { headers })).json()).toEqual({ items: [] });
       const replyPath = `${world.base}/experimental/ui-control/${item.id}/reply`;
-      for (const untrustedHeaders of [headers, viewerHeaders]) {
-        expect((await fetch(replyPath, {
-          method: "POST", headers: untrustedHeaders, body: JSON.stringify({ result: { ok: true, forged: true } }),
-        })).status).toBe(401);
-      }
-      const reply = { method: "POST", headers: hostHeaders, body: JSON.stringify({ result }) };
+      expect((await fetch(replyPath, {
+        method: "POST", headers: viewerHeaders, body: JSON.stringify({ result: { ok: true, forged: true } }),
+      })).status).toBe(403);
+      const reply = { method: "POST", headers, body: JSON.stringify({ result }) };
       expect((await fetch(replyPath, reply)).status).toBe(200);
       expect(await (await requested).json()).toEqual(result);
       expect((await fetch(replyPath, reply)).status).toBe(404);
     }
     evidence.recordAssertionEvidence(
-      "Viewer tokens cannot control the UI; only host or owner tokens can claim or answer requests",
-      "Unauthenticated calls returned 401, viewer control requests returned 403, collaborator/viewer poll and forged replies returned 401, invalid kinds returned 400, host replies survived the relay, a second poll was empty, and duplicate replies returned 404.",
+      "Viewer tokens cannot control the UI, claim pending requests, or forge replies",
+      "Unauthenticated calls returned 401, viewer control requests returned 403, viewer poll and forged replies returned 403, invalid kinds returned 400, collaborator replies survived the relay, a second poll was empty, and duplicate replies returned 404.",
       true,
     );
   });

--- a/evals/specs/agent-ui-context-via-server.test.ts
+++ b/evals/specs/agent-ui-context-via-server.test.ts
@@ -109,6 +109,9 @@ test("the in-app agent reads renderer context through openwork-server and gets a
       const layout = conversations && isRecord(conversations.layout) ? conversations.layout : null;
       const providerRequests = world.requests.slice(before);
 
+      expect(layout?.kind).toBe("split");
+      expect(layout?.focused).toBe("secondary");
+      expect(layout?.primarySessionId).toBe("ses_left");
       expect(layout?.secondarySessionId).toBe("ses_right");
       expect(Array.isArray(context?.availableAffordances)).toBe(true);
       expect(fakeWindow.handled).toHaveLength(1);
@@ -125,4 +128,50 @@ test("the in-app agent reads renderer context through openwork-server and gets a
       await fakeWindow.detach();
     }
   });
+
+  await step("only authenticated clients can exchange requests, and each command is delivered once", async () => {
+    const headers = { authorization: `Bearer ${world.token}`, "content-type": "application/json" };
+    const requestPath = `${world.base}/experimental/ui-control/request`;
+    const pendingPath = `${world.base}/experimental/ui-control/pending`;
+    for (const [path, init] of [
+      [requestPath, { method: "POST", body: JSON.stringify({ kind: "context" }) }],
+      [pendingPath, {}],
+      [`${world.base}/experimental/ui-control/unknown/reply`, { method: "POST", body: JSON.stringify({ result: {} }) }],
+    ] satisfies [string, RequestInit][]) {
+      expect((await fetch(path, { ...init, signal: AbortSignal.timeout(5_000) })).status).toBe(401);
+    }
+    expect((await fetch(requestPath, {
+      method: "POST", headers, body: JSON.stringify({ kind: "invalid" }),
+    })).status).toBe(400);
+
+    for (const kind of ["query", "command"]) {
+      await fetch(pendingPath, { headers });
+      const input = { id: "mailbox.witness", args: { marker: kind } };
+      const result = { ok: true, result: { marker: kind } };
+      const requested = fetch(requestPath, {
+        method: "POST", headers, body: JSON.stringify({ kind, input }), signal: AbortSignal.timeout(10_000),
+      });
+      const response = await fetch(`${pendingPath}?wait=1`, { headers, signal: AbortSignal.timeout(12_000) });
+      const payload: unknown = await response.json();
+      if (!isRecord(payload) || !Array.isArray(payload.items) || !isRecord(payload.items[0])) {
+        throw new Error("Expected a delivered mailbox item");
+      }
+      expect(payload.items).toHaveLength(1);
+      const item = payload.items[0];
+      expect(item.kind).toBe(kind);
+      expect(item.input).toEqual(input);
+      expect(await (await fetch(pendingPath, { headers })).json()).toEqual({ items: [] });
+      const replyPath = `${world.base}/experimental/ui-control/${item.id}/reply`;
+      const reply = { method: "POST", headers, body: JSON.stringify({ result }) };
+      expect((await fetch(replyPath, reply)).status).toBe(200);
+      expect(await (await requested).json()).toEqual(result);
+      expect((await fetch(replyPath, reply)).status).toBe(404);
+    }
+    evidence.recordAssertionEvidence(
+      "Authentication protects all mailbox endpoints and queries and commands are claimed only once",
+      "Unauthenticated requests returned 401, invalid kinds returned 400, both payloads and replies survived the relay, a second poll was empty, and duplicate replies returned 404.",
+      true,
+    );
+  });
+
 });

--- a/evals/specs/agent-ui-context-via-server.test.ts
+++ b/evals/specs/agent-ui-context-via-server.test.ts
@@ -131,6 +131,7 @@ test("the in-app agent reads renderer context through openwork-server and gets a
 
   await step("only authenticated clients can exchange requests, and each command is delivered once", async () => {
     const headers = { authorization: `Bearer ${world.token}`, "content-type": "application/json" };
+    const hostHeaders = { ...headers, "x-openwork-host-token": world.hostToken };
     const requestPath = `${world.base}/experimental/ui-control/request`;
     const pendingPath = `${world.base}/experimental/ui-control/pending`;
     for (const [path, init] of [
@@ -144,14 +145,28 @@ test("the in-app agent reads renderer context through openwork-server and gets a
       method: "POST", headers, body: JSON.stringify({ kind: "invalid" }),
     })).status).toBe(400);
 
+    const issued: unknown = await (await fetch(`${world.base}/tokens`, {
+      method: "POST", headers: hostHeaders, body: JSON.stringify({ scope: "viewer", label: "UI read-only witness" }),
+    })).json();
+    if (!isRecord(issued) || typeof issued.token !== "string") throw new Error("Expected an issued viewer token");
+    const viewerHeaders = { authorization: `Bearer ${issued.token}`, "content-type": "application/json" };
+    for (const kind of ["context", "query", "command"]) {
+      expect((await fetch(requestPath, {
+        method: "POST", headers: viewerHeaders, body: JSON.stringify({ kind, input: { id: "route.session" } }),
+      })).status).toBe(403);
+    }
+    for (const untrustedHeaders of [headers, viewerHeaders]) {
+      expect((await fetch(pendingPath, { headers: untrustedHeaders })).status).toBe(401);
+    }
+
     for (const kind of ["query", "command"]) {
-      await fetch(pendingPath, { headers });
+      await fetch(pendingPath, { headers: hostHeaders });
       const input = { id: "mailbox.witness", args: { marker: kind } };
       const result = { ok: true, result: { marker: kind } };
       const requested = fetch(requestPath, {
         method: "POST", headers, body: JSON.stringify({ kind, input }), signal: AbortSignal.timeout(10_000),
       });
-      const response = await fetch(`${pendingPath}?wait=1`, { headers, signal: AbortSignal.timeout(12_000) });
+      const response = await fetch(`${pendingPath}?wait=1`, { headers: hostHeaders, signal: AbortSignal.timeout(12_000) });
       const payload: unknown = await response.json();
       if (!isRecord(payload) || !Array.isArray(payload.items) || !isRecord(payload.items[0])) {
         throw new Error("Expected a delivered mailbox item");
@@ -160,16 +175,21 @@ test("the in-app agent reads renderer context through openwork-server and gets a
       const item = payload.items[0];
       expect(item.kind).toBe(kind);
       expect(item.input).toEqual(input);
-      expect(await (await fetch(pendingPath, { headers })).json()).toEqual({ items: [] });
+      expect(await (await fetch(pendingPath, { headers: hostHeaders })).json()).toEqual({ items: [] });
       const replyPath = `${world.base}/experimental/ui-control/${item.id}/reply`;
-      const reply = { method: "POST", headers, body: JSON.stringify({ result }) };
+      for (const untrustedHeaders of [headers, viewerHeaders]) {
+        expect((await fetch(replyPath, {
+          method: "POST", headers: untrustedHeaders, body: JSON.stringify({ result: { ok: true, forged: true } }),
+        })).status).toBe(401);
+      }
+      const reply = { method: "POST", headers: hostHeaders, body: JSON.stringify({ result }) };
       expect((await fetch(replyPath, reply)).status).toBe(200);
       expect(await (await requested).json()).toEqual(result);
       expect((await fetch(replyPath, reply)).status).toBe(404);
     }
     evidence.recordAssertionEvidence(
-      "Authentication protects all mailbox endpoints and queries and commands are claimed only once",
-      "Unauthenticated requests returned 401, invalid kinds returned 400, both payloads and replies survived the relay, a second poll was empty, and duplicate replies returned 404.",
+      "Viewer tokens cannot control the UI; only host or owner tokens can claim or answer requests",
+      "Unauthenticated calls returned 401, viewer control requests returned 403, collaborator/viewer poll and forged replies returned 401, invalid kinds returned 400, host replies survived the relay, a second poll was empty, and duplicate replies returned 404.",
       true,
     );
   });

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -172,6 +172,19 @@ test("new split creates fresh same-workspace secondary sessions without moving t
     return { secondFacts, afterPalette };
   });
 
+  await step("the agent's server path sees the same layout", async () => {
+    const currentFacts = parseSplitFacts(await world.splitFacts());
+    const result = await world.agentContextViaServer();
+    if (!isRecord(result)) throw new Error(`Invalid server UI context: ${JSON.stringify(result)}`);
+    const context = isRecord(result.context) ? result.context : null;
+    const conversations = context && isRecord(context.conversations) ? context.conversations : null;
+    const layout = conversations && isRecord(conversations.layout) ? conversations.layout : null;
+    expect(result.ok).toBe(true);
+    expect(layout?.kind).toBe(currentFacts.layoutKind);
+    expect(layout?.primarySessionId).toBe(currentFacts.primarySessionId);
+    expect(layout?.secondarySessionId).toBe(currentFacts.secondarySessionId);
+  });
+
   await step("New session replaces the focused secondary pane", async () => {
     await agent.run("workbench.session.focus", { sessionId: secondFacts.secondarySessionId });
     await probe.eventually(() => world.splitFacts(), {

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -41,7 +41,7 @@ function parseSplitFacts(value: unknown): SplitFacts {
   };
 }
 
-test("new split creates fresh same-workspace secondary sessions without moving the primary; New session replaces the focused pane", async ({ world, user, agent, probe, step, place }) => {
+test("new split creates fresh same-workspace secondary sessions without moving the primary; New session replaces the focused pane", async ({ world, user, agent, probe, step, place, evidence }) => {
   // The key chord belongs to the machine running the app, not the one running the spec.
   const paletteShortcut = place.kind !== "daytona" && process.platform === "darwin" ? "Meta+K" : "Control+K";
   const workspaceId = world.workspace.workspaceId;
@@ -183,6 +183,12 @@ test("new split creates fresh same-workspace secondary sessions without moving t
     expect(layout?.kind).toBe(currentFacts.layoutKind);
     expect(layout?.primarySessionId).toBe(currentFacts.primarySessionId);
     expect(layout?.secondarySessionId).toBe(currentFacts.secondarySessionId);
+    expect(layout?.focused).toBe(currentFacts.focusedPane);
+    evidence.recordAssertionEvidence(
+      "Desktop split context reaches the agent through the server mailbox",
+      `The server returned ok=true with kind=${layout?.kind}, primarySessionId=${layout?.primarySessionId}, secondarySessionId=${layout?.secondarySessionId}, and focused=${layout?.focused}, all matching the rendered split.`,
+      true,
+    );
   });
 
   await step("New session replaces the focused secondary pane", async () => {
@@ -277,4 +283,10 @@ test("new split creates fresh same-workspace secondary sessions without moving t
     });
     expect(afterFocusedPrimary).toHaveLength(afterFocusedSecondary.length + 1);
   });
+  evidence.recordAssertionEvidence(
+    "New splits preserve the primary, and New session replaces only the focused pane",
+    "Context-menu and command-palette splits each created one distinct same-workspace secondary session. The focused-secondary and focused-primary New session actions each preserved the opposite pane and created exactly one session.",
+    true,
+  );
+
 });

--- a/evals/worlds/agent-ui-context.ts
+++ b/evals/worlds/agent-ui-context.ts
@@ -1,0 +1,225 @@
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+import type { Seed } from "@openwork/env";
+import {
+  bootManagedOpenworkServer,
+  close,
+  isRecord,
+  listen,
+  readBody,
+  sendJson,
+  sendStream,
+  type ManagedOpenworkServer,
+} from "./openwork-server-cli.ts";
+
+export const MOCK_REPLY = "MOCK OK";
+
+export type AgentUiContextProviderRequest = {
+  model: string;
+  toolResults: string[];
+};
+
+export type HandledUiControlItem = {
+  id: string;
+  kind: string;
+  input: unknown;
+  createdAt: number;
+};
+
+export interface FakeWindow {
+  handled: HandledUiControlItem[];
+  detach(): Promise<void>;
+}
+
+export interface AgentUiContextWorld extends AsyncDisposable {
+  base: string;
+  token: string;
+  workspaceId: string;
+  requests: AgentUiContextProviderRequest[];
+  engine(method: string, path: string, body?: unknown): Promise<unknown>;
+  output(): string;
+  attachWindow(context: Record<string, unknown>): Promise<FakeWindow>;
+}
+
+function toolResultContents(body: unknown): string[] {
+  if (!isRecord(body) || !Array.isArray(body.messages)) return [];
+  const results: string[] = [];
+  for (const message of body.messages) {
+    if (!isRecord(message) || message.role !== "tool") continue;
+    const serialized = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+    results.push(serialized ?? "");
+  }
+  return results;
+}
+
+function mockProvider(requests: AgentUiContextProviderRequest[]): Server {
+  return createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "POST" && url.pathname.endsWith("/chat/completions")) {
+        const body: unknown = JSON.parse(await readBody(request));
+        const toolResults = toolResultContents(body);
+        requests.push({
+          model: isRecord(body) && typeof body.model === "string" ? body.model : "?",
+          toolResults,
+        });
+        const id = `chatcmpl-agent-ui-context-${requests.length}`;
+        sendStream(response, toolResults.length === 0
+          ? [
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: `call_openwork_context_${requests.length}`, type: "function", function: { name: "openwork_context", arguments: JSON.stringify({}) } }] }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+          ]
+          : [
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: MOCK_REPLY }, finish_reason: null }] },
+            { id, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+          ]);
+        return;
+      }
+      sendJson(response, 200, { object: "list", data: [] });
+    })().catch((error: unknown) => {
+      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
+      else response.destroy(error instanceof Error ? error : undefined);
+    });
+  });
+}
+
+function uiControlItems(value: unknown): HandledUiControlItem[] {
+  if (!isRecord(value) || !Array.isArray(value.items)) {
+    throw new Error(`Invalid UI control pending response: ${JSON.stringify(value)}`);
+  }
+  return value.items.map((item) => {
+    if (!isRecord(item) || typeof item.id !== "string" || typeof item.kind !== "string" || typeof item.createdAt !== "number") {
+      throw new Error(`Invalid UI control item: ${JSON.stringify(item)}`);
+    }
+    return { id: item.id, kind: item.kind, input: item.input, createdAt: item.createdAt };
+  });
+}
+
+export async function agentUiContext(seed: Seed): Promise<AgentUiContextWorld> {
+  const root = seed.tmpPath("agent-ui-context");
+  await mkdir(root, { recursive: true });
+  const scratch = await realpath(root);
+  const workspace = join(scratch, "workspace");
+  await mkdir(workspace, { recursive: true });
+
+  const requests: AgentUiContextProviderRequest[] = [];
+  const provider = mockProvider(requests);
+  const providerUrl = await listen(provider);
+  await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      mock: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Mock provider",
+        options: { baseURL: `${providerUrl}/v1`, apiKey: "test" },
+        models: {
+          mock: {
+            name: "mock",
+            tool_call: true,
+            reasoning: false,
+            temperature: true,
+            modalities: { input: ["text"], output: ["text"] },
+            limit: { context: 128_000, output: 4_096 },
+            cost: { input: 0, output: 0 },
+          },
+        },
+      },
+    },
+  }, null, 2));
+
+  const token = "agent-ui-context-client-token";
+  let output = "";
+  const sink = (chunk: string) => { output += chunk; };
+  let managed: ManagedOpenworkServer | null = null;
+  const windows = new Set<FakeWindow>();
+
+  const dispose = async () => {
+    const detachResults = await Promise.allSettled([...windows].map((window) => window.detach()));
+    if (managed) await managed.stop();
+    await close(provider);
+    await rm(scratch, { recursive: true, force: true });
+    const failed = detachResults.find((result) => result.status === "rejected");
+    if (failed?.status === "rejected") throw failed.reason;
+  };
+
+  try {
+    managed = await bootManagedOpenworkServer({ scratch, workspace, token, sink });
+    const server = managed;
+    const headers = { authorization: `Bearer ${token}`, "content-type": "application/json" };
+
+    const request = async (path: string, init: RequestInit, timeoutMs: number): Promise<unknown> => {
+      const response = await fetch(`${server.base}${path}`, {
+        ...init,
+        headers,
+        signal: init.signal ? AbortSignal.any([init.signal, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs),
+      });
+      const text = await response.text();
+      if (!response.ok) throw new Error(`${init.method ?? "GET"} ${path} → ${response.status}: ${text.slice(0, 400)}`);
+      return text ? JSON.parse(text) : null;
+    };
+
+    const attachWindow = async (context: Record<string, unknown>): Promise<FakeWindow> => {
+      const handled: HandledUiControlItem[] = [];
+      const controller = new AbortController();
+      let detached = false;
+      let loopError: unknown = null;
+
+      const handle = async (items: HandledUiControlItem[]) => {
+        for (const item of items) {
+          handled.push(item);
+          const result = item.kind === "context"
+            ? { ok: true, context }
+            : { ok: false, error: "unsupported in fake window" };
+          await request(`/experimental/ui-control/${encodeURIComponent(item.id)}/reply`, {
+            method: "POST",
+            body: JSON.stringify({ result }),
+            signal: controller.signal,
+          }, 5_000);
+        }
+      };
+
+      // Establish the mailbox heartbeat before returning so an immediate context
+      // request cannot race the first long poll and look disconnected.
+      await handle(uiControlItems(await request("/experimental/ui-control/pending", { method: "GET", signal: controller.signal }, 5_000)));
+      const loop = (async () => {
+        while (!detached) {
+          const value = await request("/experimental/ui-control/pending?wait=1", { method: "GET", signal: controller.signal }, 15_000);
+          if (!detached) await handle(uiControlItems(value));
+        }
+      })().catch((error: unknown) => {
+        if (!detached) loopError = error;
+      });
+
+      const fakeWindow: FakeWindow = {
+        handled,
+        async detach() {
+          if (detached) return;
+          detached = true;
+          controller.abort();
+          await loop;
+          windows.delete(fakeWindow);
+          if (loopError) throw loopError;
+        },
+      };
+      windows.add(fakeWindow);
+      return fakeWindow;
+    };
+
+    return {
+      base: server.base,
+      token,
+      workspaceId: server.workspaceId,
+      requests,
+      engine: server.engine,
+      output: () => output,
+      attachWindow,
+      [Symbol.asyncDispose]: dispose,
+    };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+}

--- a/evals/worlds/agent-ui-context.ts
+++ b/evals/worlds/agent-ui-context.ts
@@ -149,7 +149,7 @@ export async function agentUiContext(seed: Seed): Promise<AgentUiContextWorld> {
   try {
     managed = await bootManagedOpenworkServer({ scratch, workspace, token, sink });
     const server = managed;
-    const headers = { authorization: `Bearer ${token}`, "x-openwork-host-token": `${token}-host`, "content-type": "application/json" };
+    const headers = { authorization: `Bearer ${token}`, "content-type": "application/json" };
 
     const request = async (path: string, init: RequestInit, timeoutMs: number): Promise<unknown> => {
       const response = await fetch(`${server.base}${path}`, {

--- a/evals/worlds/agent-ui-context.ts
+++ b/evals/worlds/agent-ui-context.ts
@@ -35,6 +35,7 @@ export interface FakeWindow {
 export interface AgentUiContextWorld extends AsyncDisposable {
   base: string;
   token: string;
+  hostToken: string;
   workspaceId: string;
   requests: AgentUiContextProviderRequest[];
   engine(method: string, path: string, body?: unknown): Promise<unknown>;
@@ -148,7 +149,7 @@ export async function agentUiContext(seed: Seed): Promise<AgentUiContextWorld> {
   try {
     managed = await bootManagedOpenworkServer({ scratch, workspace, token, sink });
     const server = managed;
-    const headers = { authorization: `Bearer ${token}`, "content-type": "application/json" };
+    const headers = { authorization: `Bearer ${token}`, "x-openwork-host-token": `${token}-host`, "content-type": "application/json" };
 
     const request = async (path: string, init: RequestInit, timeoutMs: number): Promise<unknown> => {
       const response = await fetch(`${server.base}${path}`, {
@@ -211,6 +212,7 @@ export async function agentUiContext(seed: Seed): Promise<AgentUiContextWorld> {
     return {
       base: server.base,
       token,
+      hostToken: `${token}-host`,
       workspaceId: server.workspaceId,
       requests,
       engine: server.engine,

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -233,7 +233,18 @@ export async function newSplitPrimary(seed: Seed) {
       locationHash: window.location.hash,
     };
   })()`);
-  return { app, workspace, session, splitFacts };
+  const agentContextViaServer = () => evalIn(app, `(async () => {
+    const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port") + "/experimental/ui-control/request", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer " + localStorage.getItem("openwork.server.token"),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ kind: "context" }),
+    });
+    return response.json();
+  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  return { app, workspace, session, splitFacts, agentContextViaServer };
 }
 
 export async function shimmerChat(seed: Seed) {

--- a/evals/worlds/openwork-server-cli.ts
+++ b/evals/worlds/openwork-server-cli.ts
@@ -1,0 +1,227 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { join, resolve } from "node:path";
+import { SkipError } from "@openwork/env";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const serverRoot = join(repoRoot, "apps", "server");
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function readBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+  return new Promise((resolveBody, reject) => {
+    let body = "";
+    request.on("data", (chunk: string) => { body += chunk; });
+    request.on("end", () => resolveBody(body));
+    request.on("error", reject);
+  });
+}
+
+export function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "content-type": "application/json", "cache-control": "no-store" });
+  response.end(JSON.stringify(body));
+}
+
+export function sendStream(response: ServerResponse, chunks: unknown[]): void {
+  response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+  for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  response.end("data: [DONE]\n\n");
+}
+
+export async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+export async function close(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
+}
+
+export function engineBinary(): string | null {
+  const fromEnv = process.env.OPENWORK_OPENCODE_BIN?.trim();
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  const platform = process.platform === "darwin" ? "apple-darwin" : process.platform === "win32" ? "pc-windows-msvc" : "unknown-linux-gnu";
+  const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
+  const sidecar = join(repoRoot, "apps", "desktop", "resources", "sidecars", `opencode-${arch}-${platform}${process.platform === "win32" ? ".exe" : ""}`);
+  if (existsSync(sidecar)) return sidecar;
+  const onPath = spawnSync(process.platform === "win32" ? "where" : "which", ["opencode"], { encoding: "utf8" });
+  const found = onPath.status === 0 ? onPath.stdout.split(/\r?\n/).find((line) => line.trim()) : undefined;
+  return found ? found.trim() : null;
+}
+
+export function stopChild(child: ChildProcess): Promise<void> {
+  return new Promise<void>((done) => {
+    if (child.exitCode !== null || child.signalCode !== null) return done();
+    child.once("exit", () => done());
+    child.kill("SIGTERM");
+    setTimeout(() => child.kill("SIGKILL"), 5_000).unref();
+  });
+}
+
+/**
+ * Spawns the openwork-server CLI with a managed engine. Every stdout/stderr
+ * chunk goes to `sink`; `listening` resolves with the base URL once the server
+ * reports its port, or rejects when the process exits first.
+ */
+export function bootServer(env: NodeJS.ProcessEnv, token: string, workspace: string, sink: (chunk: string) => void): { child: ChildProcess; listening: Promise<string> } {
+  const child = spawn("bun", [
+    "--conditions=development",
+    "src/cli.ts",
+    "--host", "127.0.0.1",
+    "--port", "0",
+    "--token", token,
+    "--host-token", `${token}-host`,
+    "--approval", "auto",
+    "--cors", "*",
+    "--workspace", workspace,
+  ], { cwd: serverRoot, env, stdio: ["ignore", "pipe", "pipe"] });
+  let seen = "";
+  const listening = new Promise<string>((resolveBase, reject) => {
+    const timer = setTimeout(() => reject(new Error(`openwork-server did not report a port within 60s:\n${seen.slice(-2_000)}`)), 60_000);
+    const onChunk = (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      seen += text;
+      sink(text);
+      const match = seen.match(/OpenWork server listening on (http:\/\/127\.0\.0\.1:\d+)/);
+      if (match?.[1]) {
+        clearTimeout(timer);
+        resolveBase(match[1]);
+      }
+    };
+    child.stdout?.on("data", onChunk);
+    child.stderr?.on("data", onChunk);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`openwork-server exited early (code ${code}):\n${seen.slice(-2_000)}`));
+    });
+    child.on("error", reject);
+  });
+  return { child, listening };
+}
+
+export interface ManagedOpenworkServer {
+  child: ChildProcess;
+  base: string;
+  binary: string;
+  workspaceId: string;
+  engine(method: string, path: string, body?: unknown): Promise<unknown>;
+  stop(): Promise<void>;
+}
+
+function firstWorkspaceId(value: unknown): string | null {
+  if (!isRecord(value) || !Array.isArray(value.items)) return null;
+  const first = value.items[0];
+  return isRecord(first) && typeof first.id === "string" ? first.id : null;
+}
+
+export async function bootManagedOpenworkServer(options: {
+  scratch: string;
+  workspace: string;
+  token: string;
+  sink: (chunk: string) => void;
+  binary?: string;
+}): Promise<ManagedOpenworkServer> {
+  const binary = options.binary ?? engineBinary();
+  if (!binary) throw new SkipError("set OPENWORK_OPENCODE_BIN or install opencode");
+
+  const home = join(options.scratch, "home");
+  await mkdir(home, { recursive: true });
+  // The spec may itself run under an OpenWork or OpenCode session. The parent's
+  // OPENCODE_* and OPENWORK_* variables (config path, models URL, credentials,
+  // workspaces) must not reach the isolated server and engine under test.
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENCODE") && !key.startsWith("OPENWORK_")));
+  const env = {
+    ...inherited,
+    HOME: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    XDG_CACHE_HOME: join(home, ".cache"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    OPENWORK_MANAGE_OPENCODE: "1",
+    OPENWORK_OPENCODE_BIN: binary,
+  };
+
+  let output = "";
+  const sink = (chunk: string) => {
+    output += chunk;
+    options.sink(chunk);
+  };
+  let child: ChildProcess | null = null;
+
+  try {
+    // The server spawns the managed engine with a fixed 15 s start budget; a slow
+    // moment on a fresh profile (plugin runtime install, cold transpile) can
+    // exceed it once and exit the server. Boot at most twice; the first attempt's
+    // output stays in the diagnostics.
+    let base = "";
+    for (let attempt = 1; ; attempt += 1) {
+      const booted = bootServer(env, options.token, options.workspace, sink);
+      child = booted.child;
+      try {
+        base = await booted.listening;
+        break;
+      } catch (error) {
+        await stopChild(booted.child);
+        child = null;
+        sink(`\n[world] boot attempt ${attempt} failed: ${error instanceof Error ? error.message.split("\n")[0] : String(error)}\n`);
+        if (attempt >= 2 || !(error instanceof Error && error.message.startsWith("openwork-server exited early"))) throw error;
+      }
+    }
+
+    const headers = { authorization: `Bearer ${options.token}`, "content-type": "application/json" };
+    const workspaces: unknown = await (await fetch(`${base}/workspaces`, { headers })).json();
+    const workspaceId = firstWorkspaceId(workspaces);
+    if (!workspaceId) throw new Error(`openwork-server reported no workspace: ${JSON.stringify(workspaces)}`);
+
+    const engine = async (method: string, path: string, body?: unknown): Promise<unknown> => {
+      const response = await fetch(`${base}/workspace/${encodeURIComponent(workspaceId)}/opencode${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: AbortSignal.timeout(90_000),
+      });
+      const text = await response.text();
+      if (!response.ok) throw new Error(`${method} ${path} → ${response.status}: ${text.slice(0, 400)}`);
+      return text ? JSON.parse(text) : null;
+    };
+
+    // The managed engine starts after the HTTP server binds; on a fresh profile it
+    // first installs its plugin runtime, so give the first proxied call time.
+    const deadline = Date.now() + 150_000;
+    let ready = false;
+    while (!ready && Date.now() < deadline) {
+      try {
+        const response = await fetch(`${base}/workspace/${encodeURIComponent(workspaceId)}/opencode/session`, { headers, signal: AbortSignal.timeout(5_000) });
+        ready = response.ok;
+      } catch {
+        // keep polling
+      }
+      if (!ready) await new Promise((wait) => setTimeout(wait, 500));
+    }
+    if (!ready) throw new Error(`The managed engine never answered through openwork-server:\n${output.slice(-3_000)}`);
+
+    const runningChild = child;
+    return {
+      child: runningChild,
+      base,
+      binary,
+      workspaceId,
+      engine,
+      stop: () => stopChild(runningChild),
+    };
+  } catch (error) {
+    if (child) await stopChild(child);
+    throw error;
+  }
+}

--- a/evals/worlds/pdf-attachments.ts
+++ b/evals/worlds/pdf-attachments.ts
@@ -1,11 +1,11 @@
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { mkdir, readdir, realpath, rm, writeFile } from "node:fs/promises";
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { join, resolve } from "node:path";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
 import { SkipError } from "@openwork/env";
 import type { Seed } from "@openwork/env";
 import { buildTestPdf, pdfDataUrl } from "../../apps/server/src/pdf-attachments/pdf-fixture.test-helper.ts";
+import { bootManagedOpenworkServer, close, engineBinary, isRecord, listen, readBody, sendJson, sendStream } from "./openwork-server-cli.ts";
 
 // A PDF attached in chat must work with every model the engine can run. The
 // engine forwards a PDF part to the provider untouched, so a model without PDF
@@ -19,9 +19,6 @@ import { buildTestPdf, pdfDataUrl } from "../../apps/server/src/pdf-attachments/
 // OpenCode engine against a workspace whose only provider is a loopback mock
 // that records exactly what each model received.
 
-const repoRoot = resolve(import.meta.dirname, "../..");
-const serverRoot = join(repoRoot, "apps", "server");
-
 export const READ_SCENARIO_MARKER = "Read the PDF on disk and summarize it.";
 export const MOCK_REPLY = "MOCK OK";
 export const ON_DISK_PDF = "on-disk.pdf";
@@ -29,10 +26,6 @@ export const ATTACHED_PDF = "report.pdf";
 
 export type ProviderRequest = { model: string; parts: string[]; toolResults: string[]; tools: string[] };
 export type PdfRoutingModel = "vision" | "text" | "native";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function summarizeToolResults(body: unknown): string[] {
   if (!isRecord(body) || !Array.isArray(body.messages)) return [];
@@ -81,54 +74,6 @@ function summarizeUserContent(body: unknown): string[] {
   return parts;
 }
 
-function readBody(request: IncomingMessage): Promise<string> {
-  request.setEncoding("utf8");
-  return new Promise((resolveBody, reject) => {
-    let body = "";
-    request.on("data", (chunk: string) => { body += chunk; });
-    request.on("end", () => resolveBody(body));
-    request.on("error", reject);
-  });
-}
-
-function sendJson(response: ServerResponse, status: number, body: unknown): void {
-  response.writeHead(status, { "content-type": "application/json", "cache-control": "no-store" });
-  response.end(JSON.stringify(body));
-}
-
-function sendStream(response: ServerResponse, chunks: unknown[]): void {
-  response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
-  for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
-  response.end("data: [DONE]\n\n");
-}
-
-async function listen(server: Server): Promise<string> {
-  await new Promise<void>((resolveListen, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolveListen);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") throw new Error("Mock provider did not bind a TCP port.");
-  return `http://127.0.0.1:${address.port}`;
-}
-
-async function close(server: Server): Promise<void> {
-  server.closeAllConnections();
-  await new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()));
-}
-
-function engineBinary(): string | null {
-  const fromEnv = process.env.OPENWORK_OPENCODE_BIN?.trim();
-  if (fromEnv && existsSync(fromEnv)) return fromEnv;
-  const platform = process.platform === "darwin" ? "apple-darwin" : process.platform === "win32" ? "pc-windows-msvc" : "unknown-linux-gnu";
-  const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
-  const sidecar = join(repoRoot, "apps", "desktop", "resources", "sidecars", `opencode-${arch}-${platform}${process.platform === "win32" ? ".exe" : ""}`);
-  if (existsSync(sidecar)) return sidecar;
-  const onPath = spawnSync(process.platform === "win32" ? "where" : "which", ["opencode"], { encoding: "utf8" });
-  const found = onPath.status === 0 ? onPath.stdout.split(/\r?\n/).find((line) => line.trim()) : undefined;
-  return found ? found.trim() : null;
-}
-
 /**
  * A mock OpenAI-compatible provider. Every chat completion replies MOCK OK,
  * except the first turn of the read scenario, which asks the engine to run its
@@ -170,56 +115,6 @@ function mockProvider(workspace: string, requests: ProviderRequest[]): Server {
   });
 }
 
-function stopChild(child: ChildProcess): Promise<void> {
-  return new Promise<void>((done) => {
-    if (child.exitCode !== null || child.signalCode !== null) return done();
-    child.once("exit", () => done());
-    child.kill("SIGTERM");
-    setTimeout(() => child.kill("SIGKILL"), 5_000).unref();
-  });
-}
-
-/**
- * Spawns the openwork-server CLI with a managed engine. Every stdout/stderr
- * chunk goes to `sink`; `listening` resolves with the base URL once the server
- * reports its port, or rejects when the process exits first.
- */
-function bootServer(env: NodeJS.ProcessEnv, token: string, workspace: string, sink: (chunk: string) => void): { child: ChildProcess; listening: Promise<string> } {
-  const child = spawn("bun", [
-    "--conditions=development",
-    "src/cli.ts",
-    "--host", "127.0.0.1",
-    "--port", "0",
-    "--token", token,
-    "--host-token", `${token}-host`,
-    "--approval", "auto",
-    "--cors", "*",
-    "--workspace", workspace,
-  ], { cwd: serverRoot, env, stdio: ["ignore", "pipe", "pipe"] });
-  let seen = "";
-  const listening = new Promise<string>((resolveBase, reject) => {
-    const timer = setTimeout(() => reject(new Error(`openwork-server did not report a port within 60s:\n${seen.slice(-2_000)}`)), 60_000);
-    const onChunk = (chunk: Buffer) => {
-      const text = chunk.toString("utf8");
-      seen += text;
-      sink(text);
-      const match = seen.match(/OpenWork server listening on (http:\/\/127\.0\.0\.1:\d+)/);
-      if (match?.[1]) {
-        clearTimeout(timer);
-        resolveBase(match[1]);
-      }
-    };
-    child.stdout?.on("data", onChunk);
-    child.stderr?.on("data", onChunk);
-    child.on("exit", (code) => {
-      clearTimeout(timer);
-      reject(new Error(`openwork-server exited early (code ${code}):\n${seen.slice(-2_000)}`));
-    });
-    child.on("error", reject);
-  });
-  return { child, listening };
-}
-
 export interface PdfRoutingWorld extends AsyncDisposable {
   /** openwork-server base URL. */
   base: string;
@@ -246,9 +141,8 @@ export async function pdfRouting(seed: Seed): Promise<PdfRoutingWorld> {
   await mkdir(root, { recursive: true });
   // Resolve symlinks (macOS /tmp -> /private/tmp) so the engine sees workspace files as inside the project.
   const scratch = await realpath(root);
-  const home = join(scratch, "home");
   const workspace = join(scratch, "workspace");
-  await Promise.all([mkdir(home, { recursive: true }), mkdir(workspace, { recursive: true })]);
+  await mkdir(workspace, { recursive: true });
 
   const requests: ProviderRequest[] = [];
   const provider = mockProvider(workspace, requests);
@@ -278,26 +172,11 @@ export async function pdfRouting(seed: Seed): Promise<PdfRoutingWorld> {
   }, null, 2));
 
   const token = "pdf-routing-client-token";
-  // The spec may itself run under an OpenWork or OpenCode session. The parent's
-  // OPENCODE_* and OPENWORK_* variables (config path, models URL, credentials,
-  // workspaces) must not reach the isolated server and engine under test.
-  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENCODE") && !key.startsWith("OPENWORK_")));
-  const env = {
-    ...inherited,
-    HOME: home,
-    XDG_CONFIG_HOME: join(home, ".config"),
-    XDG_DATA_HOME: join(home, ".local", "share"),
-    XDG_CACHE_HOME: join(home, ".cache"),
-    XDG_STATE_HOME: join(home, ".local", "state"),
-    OPENWORK_MANAGE_OPENCODE: "1",
-    OPENWORK_OPENCODE_BIN: binary,
-  };
-
   let output = "";
   const sink = (chunk: string) => { output += chunk; };
-  let child: ChildProcess | null = null;
+  let managed: Awaited<ReturnType<typeof bootManagedOpenworkServer>> | null = null;
   const dispose = async () => {
-    if (child) await stopChild(child);
+    if (managed) await managed.stop();
     await close(provider);
     // The engine installs its plugin runtime and packages cache into the scratch
     // HOME (hundreds of MB), so the world removes what it created.
@@ -305,68 +184,18 @@ export async function pdfRouting(seed: Seed): Promise<PdfRoutingWorld> {
   };
 
   try {
-    // The server spawns the managed engine with a fixed 15 s start budget; a slow
-    // moment on a fresh profile (plugin runtime install, cold transpile) can
-    // exceed it once and exit the server. Boot at most twice; the first attempt's
-    // output stays in the diagnostics.
-    let base = "";
-    for (let attempt = 1; ; attempt += 1) {
-      const booted = bootServer(env, token, workspace, sink);
-      child = booted.child;
-      try {
-        base = await booted.listening;
-        break;
-      } catch (error) {
-        await stopChild(booted.child);
-        child = null;
-        sink(`\n[world] boot attempt ${attempt} failed: ${error instanceof Error ? error.message.split("\n")[0] : String(error)}\n`);
-        if (attempt >= 2 || !(error instanceof Error && error.message.startsWith("openwork-server exited early"))) throw error;
-      }
-    }
-
-    const headers = { authorization: `Bearer ${token}`, "content-type": "application/json" };
-    const workspaces = await (await fetch(`${base}/workspaces`, { headers })).json() as { items?: { id?: string }[] };
-    const workspaceId = workspaces.items?.[0]?.id;
-    if (!workspaceId) throw new Error(`openwork-server reported no workspace: ${JSON.stringify(workspaces)}`);
-
-    const engine = async (method: string, path: string, body?: unknown): Promise<unknown> => {
-      const response = await fetch(`${base}/workspace/${encodeURIComponent(workspaceId)}/opencode${path}`, {
-        method,
-        headers,
-        body: body === undefined ? undefined : JSON.stringify(body),
-        signal: AbortSignal.timeout(90_000),
-      });
-      const text = await response.text();
-      if (!response.ok) throw new Error(`${method} ${path} → ${response.status}: ${text.slice(0, 400)}`);
-      return text ? JSON.parse(text) : null;
-    };
-
-    // The managed engine starts after the HTTP server binds; on a fresh profile it
-    // first installs its plugin runtime, so give the first proxied call time.
-    const deadline = Date.now() + 150_000;
-    let ready = false;
-    while (!ready && Date.now() < deadline) {
-      try {
-        const response = await fetch(`${base}/workspace/${encodeURIComponent(workspaceId)}/opencode/session`, { headers, signal: AbortSignal.timeout(5_000) });
-        ready = response.ok;
-      } catch {
-        // keep polling
-      }
-      if (!ready) await new Promise((wait) => setTimeout(wait, 500));
-    }
-    if (!ready) throw new Error(`The managed engine never answered through openwork-server:\n${output.slice(-3_000)}`);
-
-    const engineVersion = spawnSync(binary, ["--version"], { encoding: "utf8" }).stdout.trim();
-    const attachment = { type: "file" as const, mime: "application/pdf" as const, filename: ATTACHED_PDF, url: pdfDataUrl(buildTestPdf(["Quarterly revenue report", "Second page", null])) };
+    managed = await bootManagedOpenworkServer({ scratch, workspace, token, sink, binary });
+    const engineVersion = spawnSync(managed.binary, ["--version"], { encoding: "utf8" }).stdout.trim();
+    const attachment: PdfRoutingWorld["attachment"] = { type: "file", mime: "application/pdf", filename: ATTACHED_PDF, url: pdfDataUrl(buildTestPdf(["Quarterly revenue report", "Second page", null])) };
 
     return {
-      base,
-      workspaceId,
+      base: managed.base,
+      workspaceId: managed.workspaceId,
       workspacePath: workspace,
       engineVersion,
       attachment,
       requests,
-      engine,
+      engine: managed.engine,
       async derivedBundles() {
         return (await readdir(join(workspace, ".opencode", "openwork", "inbox", "pdf-pages")).catch(() => [])).sort();
       },


### PR DESCRIPTION
In OpenWork Web, `openwork_context`, UI queries, and UI commands could not reach the browser because they relied on Electron discovery files. Route in-app tools through an authenticated, short-lived mailbox on openwork-server, answered by the existing control surface in both desktop and web.

This removes desktop discovery and implicit user-data fallbacks from the in-app plugin. The external desktop UI MCP bridge remains compatible. Every mailbox route requires collaborator or owner scope: read-only tokens cannot submit work, claim requests, or forge replies. The browser uses its existing client token; host credentials stay out of headless web. Requests expire after five seconds, cancelled polls cannot claim work, and each request is delivered to one polling window. Multiple windows connected to one server use the first polling window; this change does not elect a focused tab.

Verification on this branch:

- Agent/server journey: passed, including no-window behavior, model-visible split context, authentication, and single delivery of queries/commands.
- Desktop split journey: passed on PR head in Daytona (1 passed, 0 failed, 0 skipped).
- Actual headless web: created a split in the browser, verified five server snapshots with both session IDs and secondary focus, queried capabilities, and opened Library through a server command.
- Plugin tests: 26 passed. App/server typechecks and packaged server build passed.

- PDF attachment model-routing regression: passed on PR head (1 passed, 0 failed, 0 skipped).

All journey evidence is published below for `553289a0a941aaa029ca1d9a718e5392f229ff42`. Reproduction:

```sh
pnpm evals:pr specs/agent-ui-context-via-server.test.ts
OPENWORK_EVAL_REF=553289a0a941aaa029ca1d9a718e5392f229ff42 pnpm evals:e2e new-split-session
pnpm evals:pr specs/pdf-attachments-model-routing.test.ts
pnpm --filter openwork-server test src/opencode-plugins/openwork-extensions-preview.test.ts
pnpm typecheck
pnpm --filter openwork-server typecheck
pnpm --filter openwork-server build
```

The E2E runner printed `placement: daytona (daytona CLI authenticated)`; server-boundary specs ran locally. The implementation and journey verdict is **Passed**.

The optional broad `pnpm evals:typecheck` exits 2 with 296 diagnostics on both this PR head and clean `origin/dev` at `2390c79ee06c2910b34ca3d49341409bce5dd2b9`, using Node 24.15.0 and the same installs/build prerequisites. All diagnostic signatures match after normalizing checkout paths and line numbers. First failure on both: `apps/server/src/agent-context-cloud-probe.ts(216,15): TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.` This check remains red on the base; app/server typechecks and required CI pass.
