### PR TITLE
Make cloud and desktop tasks clearer and add computer mentions

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -101,6 +101,7 @@ export type ComposerPart =
   | { type: "file"; path: string; label?: string }
   /** A macOS app targeted via Computer Use (composer "@App" mention). */
   | { type: "app"; name: string }
+  | { type: "computer"; target: "cloud" | "desktop" }
   | { type: "paste"; id: string; label: string; text: string; lines: number };
 
 export type ComposerAttachment = {

--- a/apps/app/src/react-app/domains/automations/automation-editor.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-editor.tsx
@@ -200,7 +200,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
               setInput((current) => ({ ...current, instructions }))
             }}
           />
-          <p className="text-xs text-muted-foreground">{cloud ? "Each run starts a fresh task in your OpenWork Cloud runtime." : "Each claimed run starts a fresh task in your desktop OpenCode runtime."}</p>
+          <p className="text-xs text-muted-foreground">{cloud ? "Each run starts a new task on your cloud computer." : "Each run starts a new task on your desktop computer."}</p>
         </div>
       )}
 
@@ -300,7 +300,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
             options={pickerOptions}
             query={modelQuery}
             setQuery={setModelQuery}
-            subtitle={cloud ? "Runs use this model and reasoning level in your OpenWork Cloud runtime." : "Runs use this model and reasoning level in your desktop runtime."}
+            subtitle={cloud ? "Your cloud computer uses this model and reasoning level." : "Your desktop computer uses this model and reasoning level."}
             target="default"
             current={{ providerID: input.model.providerId, modelID: input.model.modelId }}
             onSelect={(model) => {
@@ -324,8 +324,8 @@ export function AutomationEditor(props: AutomationEditorProps) {
 
       <div className="rounded-xl border border-border bg-muted/30 p-3 text-sm text-muted-foreground" data-automation-placement={props.placement}>
         {cloud
-          ? "Den keeps the schedule and run history. Each occurrence runs headlessly in OpenWork Cloud, even while your desktop is offline; a stopped Cloud container wakes automatically."
-          : "Den keeps the schedule and run history. Your signed-in desktop claims each occurrence and executes it with the selected model in its local OpenCode runtime. If the desktop is unavailable before the claim deadline, the occurrence is recorded as missed."}
+          ? "Runs on your cloud computer, even when your desktop is offline. You can check past runs here."
+          : "Runs on your desktop computer. Keep OpenWork open, signed in, and connected at the scheduled time. If your desktop stays unavailable, the run is marked as missed."}
       </div>
 
       <div className="flex justify-end gap-2">

--- a/apps/app/src/react-app/domains/automations/automations-page.tsx
+++ b/apps/app/src/react-app/domains/automations/automations-page.tsx
@@ -87,7 +87,7 @@ function runLabel(run: AutomationRun) {
   if (run.status === "skipped" && (run.error?.code === "model_access_lost" || run.error?.code === "provider_unavailable")) {
     return "Skipped — model unavailable"
   }
-  return run.status
+  return run.status === "succeeded" ? "Completed" : run.status.replaceAll("_", " ")
 }
 
 function ExecutionIcon({ run }: { run: AutomationRun }) {
@@ -287,7 +287,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
           <Cloud aria-hidden="true" />
           <AlertTitle>Sign in to Den to use Automations</AlertTitle>
           <AlertDescription>
-            Den keeps Automation schedules and history. Cloud Automations run headlessly while your desktop is offline; Desktop Automations run when that signed-in app is connected.
+            Cloud tasks run even when your desktop is offline. Desktop tasks need OpenWork open and connected.
           </AlertDescription>
         </Alert>
       </div>
@@ -335,7 +335,7 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
           <div>
             <h2 className="text-xl font-semibold">Create Automation</h2>
             <p className="text-sm text-muted-foreground">
-              {placement === "cloud" ? "It runs in OpenWork Cloud and becomes active as soon as you create it." : "It runs on this desktop and becomes active as soon as you create it."}
+              {placement === "cloud" ? "Runs on your cloud computer. The schedule starts as soon as you create it." : "Runs on your desktop computer. Keep OpenWork open and connected at the scheduled time."}
             </p>
           </div>
         </div>
@@ -568,8 +568,8 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
 
             <Card variant="outline">
               <CardHeader>
-                <CardTitle>{detail.revision.executionTarget === "cloud" ? "OpenWork Cloud execution" : "Desktop execution"}</CardTitle>
-                <CardDescription>{detail.revision.executionTarget === "cloud" ? "Den wakes the Cloud runtime and runs this task headlessly without a desktop." : "Den keeps the schedule and durable history; your connected desktop runs the task locally."}</CardDescription>
+                <CardTitle>{detail.revision.executionTarget === "cloud" ? "Cloud computer" : "Desktop computer"}</CardTitle>
+                <CardDescription>{detail.revision.executionTarget === "cloud" ? "Runs on your cloud computer, even when your desktop is offline." : "Runs on your desktop computer. Keep OpenWork open and connected at the scheduled time."}</CardDescription>
               </CardHeader>
               <CardContent className="grid gap-3 text-sm sm:grid-cols-2">
                 <div className="min-w-0"><span className="text-muted-foreground">Model</span><p className="break-words">{describeAutomationModel(detail.revision.model, models)}</p></div>
@@ -654,9 +654,9 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
                     {selectedReceipt.run.executionThread ? (
                       <Badge variant="outline"><ExecutionIcon run={selectedReceipt.run} />{automationExecutionIdentity(selectedReceipt.run.executionThread).label}</Badge>
                     ) : selectedReceipt.run.status === "queued" ? (
-                      <Badge variant="outline">{selectedReceipt.run.executionTarget === "cloud" ? "Waiting for OpenWork Cloud" : "Waiting for desktop runner"}</Badge>
+                      <Badge variant="outline">{selectedReceipt.run.executionTarget === "cloud" ? "Waiting for cloud computer" : "Waiting for desktop computer"}</Badge>
                     ) : (
-                      <Badge variant="outline">{selectedReceipt.run.executionTarget === "cloud" ? <Cloud className="mr-1 h-3 w-3" /> : <Monitor className="mr-1 h-3 w-3" />}{selectedReceipt.run.executionTarget === "cloud" ? "OpenWork Cloud" : "Desktop"}</Badge>
+                      <Badge variant="outline">{selectedReceipt.run.executionTarget === "cloud" ? <Cloud className="mr-1 h-3 w-3" /> : <Monitor className="mr-1 h-3 w-3" />}{selectedReceipt.run.executionTarget === "cloud" ? "Cloud computer" : "Desktop computer"}</Badge>
                     )}
                     {localSessionRoute ? (
                       <Button
@@ -722,8 +722,8 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
           <h2 className="text-xl font-semibold">Automations</h2>
           <p className="mt-1 text-sm text-muted-foreground">
             {placement === "cloud"
-              ? "Scheduled durably in Den. Automations created here run headlessly in OpenWork Cloud; Desktop-created Automations stay on Desktop."
-              : "Scheduled durably in Den, with each Automation executed in its fixed Desktop or OpenWork Cloud location."}
+              ? "Schedule tasks on your cloud computer. They keep running when your desktop is offline."
+              : "Schedule tasks on your desktop or cloud computer. See where each task runs and how it went."}
           </p>
         </div>
         <Button onClick={() => setSearchParams(new URLSearchParams({ create: "1" }))}><Plus />New Automation</Button>
@@ -741,8 +741,8 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
               {query
                 ? "Try a different search."
                 : placement === "cloud"
-                  ? "Create a Cloud Automation here; it runs headlessly in OpenWork Cloud even while your desktop is offline."
-                  : "Create a Desktop Automation here; it runs while this signed-in desktop is connected. Create headless Cloud Automations from OpenWork Web."}
+                  ? "Create a task that runs on your cloud computer, even when your desktop is offline."
+                  : "Create a task for this desktop computer. For tasks that run while it’s offline, create a cloud automation in OpenWork Web."}
             </EmptyDescription>
           </EmptyHeader>
           {!query ? <EmptyContent><Button onClick={() => setSearchParams(new URLSearchParams({ create: "1" }))}><Plus />New Automation</Button></EmptyContent> : null}
@@ -770,9 +770,13 @@ export function AutomationsPage(props: { providerCatalog?: AutomationProviderCat
                 </div>
                 <Badge variant={stateVariant(item.automation.state)}>{stateLabel(item.automation.state)}</Badge>
               </div>
+              <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground" data-automation-computer={item.revision.executionTarget ?? "desktop"}>
+                {item.revision.executionTarget === "cloud" ? <Cloud className="size-3.5" aria-hidden="true" /> : <Monitor className="size-3.5" aria-hidden="true" />}
+                <span>{item.revision.executionTarget === "cloud" ? "Cloud computer" : "Desktop computer"}</span>
+              </div>
               <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
                 <span>{formatAutomationSchedule(item.revision.schedule)}</span>
-                <span>{item.latestRun ? `Last run: ${item.latestRun.status}` : `Next: ${formatAutomationTime(item.automation.nextDueAt)}`}</span>
+                <span>{item.latestRun ? `Last run: ${runLabel(item.latestRun)}` : `Next: ${formatAutomationTime(item.automation.nextDueAt)}`}</span>
               </div>
             </button>
           ))}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -2,7 +2,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
-import { AppWindowMac, ArrowUp, Check, ChevronDown, ChevronRight, FileText, LoaderCircle, Paperclip, Plus, RefreshCw, Settings, Square, Terminal, X, Zap } from "lucide-react";
+import { AppWindowMac, Cloud, Monitor, ArrowUp, Check, ChevronDown, ChevronRight, FileText, LoaderCircle, Paperclip, Plus, RefreshCw, Settings, Square, Terminal, X, Zap } from "lucide-react";
 import fuzzysort from "fuzzysort";
 import { toast } from "@/components/ui/sonner";
 import type { CloudImportedPlugin, CloudImportedPluginFile } from "@/app/cloud/import-state";
@@ -17,6 +17,7 @@ import {
 import { ModelSelect } from "@/components/model-select";
 import { LexicalPromptEditor, syncAttachmentChipStatus, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
+import { COMPUTER_MENTIONS } from "./computer-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
 import {
   connectSkillSlashCommandOptions,
@@ -40,6 +41,7 @@ type MentionItem = {
   kind: ComposerMentionKind;
   value: string;
   label: string;
+  description?: string;
 };
 
 type ToolMenuSection = "agents" | "commands" | "skills" | "connections" | "plugins" | `plugin:${string}`;
@@ -523,10 +525,12 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
   useEffect(() => {
     if (!mentionOpen) return;
     let cancelled = false;
+    setMentionItems(COMPUTER_MENTIONS);
     void Promise.all([props.listAgents(), props.searchFiles(mentionQuery), listRunningAppsForMention()]).then(([agentList, files, apps]) => {
       if (cancelled) return;
       const recent = props.recentFiles.slice(0, 8);
       const next: MentionItem[] = [
+        ...COMPUTER_MENTIONS,
         ...agentList.map((agent) => ({ id: `agent:${agent.name}`, kind: "agent" as const, value: agent.name, label: agent.name })),
         ...recent.map((file) => ({ id: `file:${file}`, kind: "file" as const, value: file, label: file })),
         // Running macOS apps (Computer Use targets). Listed after recent files
@@ -537,7 +541,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
       ];
       setMentionItems(next);
     }).catch(() => {
-      if (!cancelled) setMentionItems([]);
+      if (!cancelled) setMentionItems(COMPUTER_MENTIONS);
     });
     return () => {
       cancelled = true;
@@ -1215,7 +1219,9 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                     setMentionOpen(false);
                   }}
                 >
-                  {item.kind === "agent" ? (
+                  {item.kind === "computer" ? (
+                    item.value === "cloud" ? <Cloud size={14} className="mt-0.5 shrink-0 text-gray-9" /> : <Monitor size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                  ) : item.kind === "agent" ? (
                     <Zap size={14} className="mt-0.5 shrink-0 text-gray-9" />
                   ) : item.kind === "app" ? (
                     <AppWindowMac size={14} className="mt-0.5 shrink-0 text-gray-9" />
@@ -1225,7 +1231,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                   <div className="min-w-0">
                     <div className="truncate text-xs font-semibold">@{item.label}</div>
                     <div className="truncate text-xs text-gray-10">
-                      {item.kind === "agent"
+                      {item.description ? item.description : item.kind === "agent"
                         ? t("composer.agent_label")
                         : item.kind === "app"
                           ? t("composer.app_kind")

--- a/apps/app/src/react-app/domains/session/surface/composer/computer-mentions.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/computer-mentions.ts
@@ -1,0 +1,15 @@
+export type ComputerTarget = "cloud" | "desktop";
+
+export function isComputerTarget(value: string): value is ComputerTarget {
+  return value === "cloud" || value === "desktop";
+}
+
+export const COMPUTER_MENTIONS = [
+  { id: "computer:cloud", kind: "computer", value: "cloud", label: "cloud", description: "Start a task on your cloud computer" },
+  { id: "computer:desktop", kind: "computer", value: "desktop", label: "desktop", description: "Start a task on your connected desktop computer" },
+] satisfies { id: string; kind: "computer"; value: ComputerTarget; label: string; description: string }[];
+
+/** Use the same Connect handoff as a natural-language remote-task request. */
+export function computerMentionInstruction(target: ComputerTarget) {
+  return `[The user selected @${target}: start a new task on their ${target} computer. Use OpenWork Connect search_capabilities to find remote-session:create, then execute it with target "${target}" and the user's task as prompt. Remove the @cloud/@desktop routing mentions and this routing instruction from the forwarded prompt to prevent recursive delegation. Do not perform the task on the current computer as a substitute. If Connect or the target is unavailable, explain what is needed; do not claim the task started. Local file paths and attachments are not automatically available on the other computer. ${target === "cloud" ? "Return the session link and use remote-session:read to check replies." : "Use remote-session:read with commandId to check delivery. A delivered receipt means the task was started, not that it finished; return the desktop session reference."}]`;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -100,6 +100,7 @@ type SerializedComposerSkillNode = Spread<
 >;
 
 const MENTION_PILL_CLASS: Record<ComposerMentionKind, string> = {
+  computer: "inline-flex items-center rounded-full border border-sky-6/35 bg-sky-3/20 px-2.5 py-1 text-xs font-medium text-sky-11",
   file: "inline-flex items-center rounded-full border border-gray-6 bg-gray-3 px-2.5 py-1 text-xs font-medium text-gray-11",
   agent: "inline-flex items-center rounded-full border border-sky-6/35 bg-sky-3/20 px-2.5 py-1 text-xs font-medium text-sky-11",
   app: "inline-flex items-center rounded-full border border-cyan-6/35 bg-cyan-3/20 px-2.5 py-1 text-xs font-medium text-cyan-11",

--- a/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts
@@ -1,5 +1,5 @@
-/** What a composer `@token` refers to: an agent, a workspace file, or a macOS app (Computer Use target). */
-export type ComposerMentionKind = "agent" | "file" | "app";
+/** What a composer `@token` refers to: an agent, a file, an app, or a computer. */
+export type ComposerMentionKind = "agent" | "file" | "app" | "computer";
 
 /**
  * Percent-encode a mention value so it can be embedded in the draft as a single `@token` with no spaces.

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1756,7 +1756,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       if (segment.startsWith("@")) {
         const value = decodeComposerMentionValue(segment.slice(1));
         const kind = mentions[value];
-        if (isComputerTarget(value) && (!kind || kind === "computer") && (index === 0 || /\s$/.test(segments[index - 1] ?? ""))) {
+        if (isComputerTarget(value) && (!kind || kind === "computer") && (index <= 1 && !segments[0] || /\s$/.test(segments[index - 1] ?? ""))) {
           return [{ type: "computer", target: value } satisfies ComposerDraft["parts"][number]];
         }
         if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -48,6 +48,7 @@ import { ReactSessionComposer } from "./composer/composer";
 import { useSessionModelSelection } from "./session-model-store";
 import type { ProviderCatalog } from "./use-model-behavior";
 import type { ModelAvailability } from "./model-availability";
+import { isComputerTarget } from "./composer/computer-mentions";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
@@ -1730,7 +1731,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useControlAction(props.isControlTarget ? failSessionSnapshotControlAction : null);
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
-    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
+    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment, index, segments) => {
       if (!segment) return [] as ComposerDraft["parts"];
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch) {
@@ -1755,6 +1756,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
       if (segment.startsWith("@")) {
         const value = decodeComposerMentionValue(segment.slice(1));
         const kind = mentions[value];
+        if (isComputerTarget(value) && (!kind || kind === "computer") && (index === 0 || /\s$/.test(segments[index - 1] ?? ""))) {
+          return [{ type: "computer", target: value } satisfies ComposerDraft["parts"][number]];
+        }
         if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];
         if (kind === "file") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
         if (kind === "app") return [{ type: "app", name: value } satisfies ComposerDraft["parts"][number]];

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -33,6 +33,7 @@ import { addOpencodeCacheHint, safeStringify } from "../../../../app/utils";
 import { clearSessionDraft, LOCAL_SESSION_DRAFT_SCOPE, saveSessionDraft } from "./draft-store";
 import { firstLineLocalFileParts, isReadInlineablePath } from "./prompt-file-parts";
 import { composerAttachmentToFilePart } from "./attachment-file-part";
+import { computerMentionInstruction } from "../surface/composer/computer-mentions";
 import { appMentionInstruction } from "../surface/composer/app-mentions";
 
 type SessionModelConfig = {
@@ -160,6 +161,10 @@ export function createSessionActionsStore(options: {
     for (const part of draft.parts) {
       if (part.type === "agent") {
         parts.push({ type: "agent", name: part.name } as AgentPartInput);
+        continue;
+      }
+      if (part.type === "computer") {
+        parts.push({ type: "text", text: computerMentionInstruction(part.target), synthetic: true });
         continue;
       }
       if (part.type === "app") {

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -15,6 +15,7 @@ import {
   joinWorkspaceRelativePath,
   toFileUrl,
 } from "./prompt-file-parts";
+import { computerMentionInstruction } from "../surface/composer/computer-mentions";
 import { appMentionInstruction } from "../surface/composer/app-mentions";
 import { connectSkillPrompt, parseConnectSkillToken } from "../surface/composer/connect-skill-token";
 import { decodeComposerMentionValue } from "../surface/composer/mention-encoding";
@@ -107,10 +108,16 @@ export async function draftToParts(
         const mentionPart = draft.parts.find((part) =>
           (part.type === "agent" && part.name === value)
           || (part.type === "app" && part.name === value)
+          || (part.type === "computer" && part.target === value)
           || (part.type === "file" && part.path === value),
         );
         if (mentionPart?.type === "agent") {
           parts.push({ type: "agent", name: mentionPart.name });
+          continue;
+        }
+        if (mentionPart?.type === "computer") {
+          parts.push({ type: "text", text: `@${mentionPart.target}` });
+          parts.push({ type: "text", text: computerMentionInstruction(mentionPart.target), synthetic: true });
           continue;
         }
         if (mentionPart?.type === "app") {
@@ -154,6 +161,11 @@ export async function draftToParts(
       }
       if (part.type === "skill") {
         parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
+        continue;
+      }
+      if (part.type === "computer") {
+        parts.push({ type: "text", text: `@${part.target}` });
+        parts.push({ type: "text", text: computerMentionInstruction(part.target), synthetic: true });
         continue;
       }
       if (part.type === "app") {

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -76,7 +76,8 @@ export async function draftToParts(
         .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
         .map((part) => [part.label, part.text] as const),
     );
-    for (const segment of draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/)) {
+    const segments = draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+    for (const [index, segment] of segments.entries()) {
       if (!segment) continue;
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch?.[1]) {
@@ -108,7 +109,8 @@ export async function draftToParts(
         const mentionPart = draft.parts.find((part) =>
           (part.type === "agent" && part.name === value)
           || (part.type === "app" && part.name === value)
-          || (part.type === "computer" && part.target === value)
+          || (part.type === "computer" && part.target === value
+            && (index <= 1 && !segments[0] || /\s$/.test(segments[index - 1] ?? "")))
           || (part.type === "file" && part.path === value),
         );
         if (mentionPart?.type === "agent") {

--- a/apps/app/tests/prompt-file-parts.test.ts
+++ b/apps/app/tests/prompt-file-parts.test.ts
@@ -218,3 +218,26 @@ describe("Connect skill slash commands", () => {
     expect(withoutProvenance?.description).toBe("");
   });
 });
+
+
+describe("computer task mentions", () => {
+  for (const target of ["cloud", "desktop"] satisfies Array<"cloud" | "desktop">) {
+    test(`${target} routing is hidden from the visible prompt and survives inline attachment parsing`, async () => {
+      for (const attachmentToken of ["", "[attachment removed]"]) {
+        const text = `@${target} Summarize notes for person@${target} ${attachmentToken}`;
+        const parts = await draftToParts({
+          mode: "prompt",
+          text,
+          parts: [{ type: "computer", target }, { type: "text", text: ` Summarize notes for person@${target} ` }],
+          attachments: [],
+        }, "/workspace", "ses_computer", null);
+        const instructions = parts.filter((part) => part.type === "text" && part.synthetic);
+        expect(instructions).toHaveLength(1);
+        expect(instructions[0]).toMatchObject({ text: expect.stringContaining(`target "${target}"`) });
+        expect(parts.filter((part) => part.type === "text" && !part.synthetic)
+          .map((part) => part.type === "text" ? part.text : "").join(""))
+          .toBe(`@${target} Summarize notes for person@${target} `);
+      }
+    });
+  }
+});

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -23,6 +23,8 @@ export interface MockToolCall {
 }
 
 export interface MockAgentToolStep {
+  /** Derive the handoff from the actual model input instead of fixture arguments. */
+  argumentsFrom?: "computer-mention";
   tool: string;
   arguments: Record<string, unknown>;
 }

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -76,7 +76,16 @@ export interface MockMcpHandle {
   [Symbol.asyncDispose](): Promise<void>;
 }
 
+export interface MockMcpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  result: { content: { type: "text"; text: string }[] };
+}
+
 export interface StartMockMcpOptions {
+  /** Replace the catalog with deterministic tools; served calls remain observable through toolCalls(). */
+  tools?: MockMcpTool[];
   port?: number;
   scriptPath?: string;
   publicUrl?: string;
@@ -326,6 +335,16 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
   }
 
   await waitForHealth(url, () => output, child);
+
+  if (options.tools) {
+    const response = await fetch(`${url}/admin/tools`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tools: options.tools }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) throw new Error(`Mock tool configuration failed: HTTP ${response.status}`);
+  }
 
   if (options.agentWorkloads) {
     const response = await fetch(`${url}/admin/agent-workloads`, {

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -21,23 +21,32 @@ test("computer mentions steer tasks through Connect and Automations names the co
   });
 
   await step("typing desktop directly works without selecting the menu", async () => {
+    await user.click({ role: "button", label: "New task" });
     await user.type("composer", "@desktop COMPUTER-DESKTOP-TASK Summarize my local project notes.");
     await user.press("Enter");
-    await user.see({ text: "Received computer task.", nth: 1 }, { timeoutMs: 90_000 });
+    await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
+    await user.click({ role: "button", label: "New task" });
     await user.type("composer", "COMPUTER-PLAIN-TASK Explain the address person@cloud and the word desktop.");
     await user.press("Enter");
-    await user.see({ text: "Received computer task.", nth: 2 }, { timeoutMs: 90_000 });
+    await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
   });
 
-  await step("the engine receives the chosen target, while ordinary text is not routed", async () => {
+  await step("computer handoffs reach Connect, while ordinary text makes no tool call", async () => {
     const messages = await world.submittedParts();
     expect(messages).toEqual([
-      { visible: expect.stringContaining("@cloud COMPUTER-CLOUD-TASK"), routing: [expect.stringContaining('target "cloud"')] },
-      { visible: expect.stringContaining("@desktop COMPUTER-DESKTOP-TASK"), routing: [expect.stringContaining('target "desktop"')] },
-      { visible: expect.stringContaining("person@cloud"), routing: [] },
+      { visible: "@cloud COMPUTER-CLOUD-TASK Summarize the project notes.", routing: [expect.stringContaining('target "cloud"')] },
+      { visible: "@desktop COMPUTER-DESKTOP-TASK Summarize my local project notes.", routing: [expect.stringContaining('target "desktop"')] },
+      { visible: "COMPUTER-PLAIN-TASK Explain the address person@cloud and the word desktop.", routing: [] },
+    ]);
+    const calls = await probe.toolCalls(world.den.mocks.agent);
+    expect(calls.map(({ name, args }) => ({ name, args }))).toEqual([
+      { name: "search_capabilities", args: { query: "remote-session:create" } },
+      { name: "execute_capability", args: { name: "remote-session:create", body: { target: "cloud", prompt: "COMPUTER-CLOUD-TASK Summarize the project notes." } } },
+      { name: "search_capabilities", args: { query: "remote-session:create" } },
+      { name: "execute_capability", args: { name: "remote-session:create", body: { target: "desktop", prompt: "COMPUTER-DESKTOP-TASK Summarize my local project notes." } } },
     ]);
     await user.notSee({ text: /Use OpenWork Connect search_capabilities/ });
-    evidence.recordAssertionEvidence("Computer mentions preserve the target at the engine boundary", "Menu-selected @cloud and typed @desktop submit distinct synthetic Connect routing instructions. An email address does not route, and implementation instructions stay out of the visible chat.", true);
+    evidence.recordAssertionEvidence("Computer mentions reach the Connect boundary", "Menu-selected @cloud and typed @desktop submit distinct synthetic Connect routing instructions. The Connect witness serves search and create calls with the matching target and full task. An email address makes no tool call, and routing instructions stay out of the visible chat.", true);
   });
 
   await step("Automations shows where the task runs and explains desktop availability", async () => {

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { computerMentions } from "../worlds/chat.ts";
+
+const test = spec.world(computerMentions);
+
+test("computer mentions steer tasks through Connect and Automations names the computer", async ({ world, user, probe, step, evidence }) => {
+  await step("the mention menu explains both computers without starting a task", async () => {
+    await user.type("composer", "@");
+    await user.see({ text: "Start a task on your cloud computer" });
+    await user.see({ text: "Start a task on your connected desktop computer" });
+    await user.screenshot();
+    expect((await probe.composer()).userMessageCount).toBe(0);
+    await user.type("composer", "cl", { replace: false });
+    await user.see({ text: "Start a task on your cloud computer" });
+    await user.notSee({ text: "Start a task on your connected desktop computer" });
+    await user.click({ role: "button", label: /@cloud/ });
+    await user.type("composer", "COMPUTER-CLOUD-TASK Summarize the project notes.");
+    await user.press("Enter");
+    await user.see({ text: "Received COMPUTER-CLOUD-TASK" }, { timeoutMs: 90_000 });
+  });
+
+  await step("typing desktop directly works without selecting the menu", async () => {
+    await user.type("composer", "@desktop COMPUTER-DESKTOP-TASK Summarize my local project notes.");
+    await user.press("Enter");
+    await user.see({ text: "Received COMPUTER-DESKTOP-TASK" }, { timeoutMs: 90_000 });
+    await user.type("composer", "COMPUTER-PLAIN-TASK Explain the address person@cloud and the word desktop.");
+    await user.press("Enter");
+    await user.see({ text: "Received COMPUTER-PLAIN-TASK" }, { timeoutMs: 90_000 });
+  });
+
+  await step("the engine receives the chosen target, while ordinary text is not routed", async () => {
+    // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
+    const messages = await probe.eval(`async (workspaceId, sessionId) => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
+        + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
+        headers: { Authorization: "Bearer " + token },
+      });
+      if (!response.ok) throw new Error("Transcript read failed: " + response.status);
+      const messages = await response.json();
+      return messages.filter((message) => message.info.role === "user").map((message) => ({
+        visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join(""),
+        routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
+      }));
+    }`, { args: [world.workspace.workspaceId, world.session.sessionId], awaitPromise: true });
+    expect(messages).toEqual([
+      { visible: expect.stringContaining("@cloud COMPUTER-CLOUD-TASK"), routing: [expect.stringContaining('target "cloud"')] },
+      { visible: expect.stringContaining("@desktop COMPUTER-DESKTOP-TASK"), routing: [expect.stringContaining('target "desktop"')] },
+      { visible: expect.stringContaining("person@cloud"), routing: [] },
+    ]);
+    await user.notSee({ text: /Use OpenWork Connect search_capabilities/ });
+    evidence.recordAssertionEvidence("Computer mentions preserve the target at the engine boundary", "Menu-selected @cloud and typed @desktop submit distinct synthetic Connect routing instructions. An email address does not route, and implementation instructions stay out of the visible chat.", true);
+  });
+
+  await step("Automations shows where the task runs and explains desktop availability", async () => {
+    await user.click({ role: "button", label: "Automations", exact: true });
+    await user.see({ text: "Schedule tasks on your desktop or cloud computer. See where each task runs and how it went." });
+    await user.see({ text: "Daily project summary" });
+    await user.see({ text: "Desktop computer", exact: true });
+    await user.notSee({ text: /Scheduled durably|headlessly|fixed Desktop/ });
+    await user.screenshot();
+    await user.click({ role: "button", label: /Daily project summary/ });
+    await user.see({ text: "Runs on your desktop computer. Keep OpenWork open and connected at the scheduled time." });
+    evidence.recordAssertionEvidence("Automation placement is visible and understandable", "The automation list labels its desktop computer; the detail explains that OpenWork must stay open and connected without runtime terminology.", true);
+  });
+});

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -17,16 +17,16 @@ test("computer mentions steer tasks through Connect and Automations names the co
     await user.click({ role: "button", label: /@cloud/ });
     await user.type("composer", "COMPUTER-CLOUD-TASK Summarize the project notes.");
     await user.press("Enter");
-    await user.see({ text: "Received COMPUTER-CLOUD-TASK" }, { timeoutMs: 90_000 });
+    await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
   });
 
   await step("typing desktop directly works without selecting the menu", async () => {
     await user.type("composer", "@desktop COMPUTER-DESKTOP-TASK Summarize my local project notes.");
     await user.press("Enter");
-    await user.see({ text: "Received COMPUTER-DESKTOP-TASK" }, { timeoutMs: 90_000 });
+    await user.see({ text: "Received computer task.", nth: 1 }, { timeoutMs: 90_000 });
     await user.type("composer", "COMPUTER-PLAIN-TASK Explain the address person@cloud and the word desktop.");
     await user.press("Enter");
-    await user.see({ text: "Received COMPUTER-PLAIN-TASK" }, { timeoutMs: 90_000 });
+    await user.see({ text: "Received computer task.", nth: 2 }, { timeoutMs: 90_000 });
   });
 
   await step("the engine receives the chosen target, while ordinary text is not routed", async () => {

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -30,21 +30,7 @@ test("computer mentions steer tasks through Connect and Automations names the co
   });
 
   await step("the engine receives the chosen target, while ordinary text is not routed", async () => {
-    // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
-    const messages = await probe.eval(`async (workspaceId, sessionId) => {
-      const port = localStorage.getItem("openwork.server.port");
-      const token = localStorage.getItem("openwork.server.token");
-      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
-        + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
-        headers: { Authorization: "Bearer " + token },
-      });
-      if (!response.ok) throw new Error("Transcript read failed: " + response.status);
-      const messages = await response.json();
-      return messages.filter((message) => message.info.role === "user").map((message) => ({
-        visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join(""),
-        routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
-      }));
-    }`, { args: [world.workspace.workspaceId, world.session.sessionId], awaitPromise: true });
+    const messages = await world.submittedParts();
     expect(messages).toEqual([
       { visible: expect.stringContaining("@cloud COMPUTER-CLOUD-TASK"), routing: [expect.stringContaining('target "cloud"')] },
       { visible: expect.stringContaining("@desktop COMPUTER-DESKTOP-TASK"), routing: [expect.stringContaining('target "desktop"')] },
@@ -55,10 +41,10 @@ test("computer mentions steer tasks through Connect and Automations names the co
   });
 
   await step("Automations shows where the task runs and explains desktop availability", async () => {
-    await user.click({ role: "button", label: "Automations", exact: true });
+    await user.click({ role: "button", label: /^Automations$/ });
     await user.see({ text: "Schedule tasks on your desktop or cloud computer. See where each task runs and how it went." });
     await user.see({ text: "Daily project summary" });
-    await user.see({ text: "Desktop computer", exact: true });
+    await user.see({ text: /^Desktop computer$/ });
     await user.notSee({ text: /Scheduled durably|headlessly|fixed Desktop/ });
     await user.screenshot();
     await user.click({ role: "button", label: /Daily project summary/ });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -4,6 +4,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { join, resolve } from "node:path";
 import { evalIn } from "@openwork/behaviors";
 import type { Seed } from "@openwork/env";
+import type { MockAgentWorkload } from "@openwork/labs";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
@@ -1272,16 +1273,13 @@ export async function computerMentions(seed: Seed) {
       },
     ],
     agentWorkloads: [
-      ...[
-        { target: "cloud", prompt: "COMPUTER-CLOUD-TASK Summarize the project notes." },
-        { target: "desktop", prompt: "COMPUTER-DESKTOP-TASK Summarize my local project notes." },
-      ].map(({ target, prompt }) => ({
+      ...["cloud", "desktop"].map((target): MockAgentWorkload => ({
         // Only the app's synthetic instruction contains this marker. Without routing, the model refuses the task.
         promptMarker: `[The user selected @${target}:`,
         finalReply: "Received computer task.",
         steps: [
           { tool: "computer_witness_search_capabilities", arguments: { query: "remote-session:create" } },
-          { tool: "computer_witness_execute_capability", arguments: { name: "remote-session:create", body: { target, prompt } } },
+          { tool: "computer_witness_execute_capability", arguments: {}, argumentsFrom: "computer-mention" },
         ],
       })),
       { promptMarker: "COMPUTER-PLAIN-TASK", finalReply: "Received computer task.", steps: [] },

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1256,7 +1256,36 @@ export async function computerMentions(seed: Seed) {
   const providerId = "computer-mentions-mock";
   const modelId = "computer-mentions-model";
   const mock = seed.mock({
-    agentWorkloads: [{ promptMarker: "COMPUTER-", finalReply: "Received computer task.", steps: [] }],
+    allowUnauthenticatedMcp: true,
+    tools: [
+      {
+        name: "search_capabilities",
+        description: "Find a computer task capability.",
+        inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+        result: { content: [{ type: "text", text: JSON.stringify({ items: [{ name: "remote-session:create" }] }) }] },
+      },
+      {
+        name: "execute_capability",
+        description: "Start a task on the selected computer.",
+        inputSchema: { type: "object", properties: { name: { type: "string" }, body: { type: "object", properties: { target: { type: "string", enum: ["cloud", "desktop"] }, prompt: { type: "string" } }, required: ["target", "prompt"] } }, required: ["name", "body"] },
+        result: { content: [{ type: "text", text: JSON.stringify({ state: "queued", commandId: "computer-task-witness" }) }] },
+      },
+    ],
+    agentWorkloads: [
+      ...[
+        { target: "cloud", prompt: "COMPUTER-CLOUD-TASK Summarize the project notes." },
+        { target: "desktop", prompt: "COMPUTER-DESKTOP-TASK Summarize my local project notes." },
+      ].map(({ target, prompt }) => ({
+        // Only the app's synthetic instruction contains this marker. Without routing, the model refuses the task.
+        promptMarker: `target "${target}"`,
+        finalReply: "Received computer task.",
+        steps: [
+          { tool: "computer_witness_search_capabilities", arguments: { query: "remote-session:create" } },
+          { tool: "computer_witness_execute_capability", arguments: { name: "remote-session:create", body: { target, prompt } } },
+        ],
+      })),
+      { promptMarker: "COMPUTER-PLAIN-TASK", finalReply: "Received computer task.", steps: [] },
+    ],
   });
   const den = await seed.den({ mocks: { agent: mock }, env: { DEN_AUTOMATIONS_ENABLED: "true" } });
   const created = await seed.api(den.admin, "/v1/automations", {
@@ -1272,6 +1301,8 @@ export async function computerMentions(seed: Seed) {
   const app = await seed.desktop({ den, as: "admin", model: `${providerId}/${modelId}` });
   const workspace = await seed.workspace(app, seed.tmpPath("computer-mentions"));
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    permission: { "computer_witness_*": "allow" },
+    mcp: { computer_witness: { type: "remote", url: den.mocks.agent.mcpUrl, enabled: true, oauth: false } },
     provider: {
       [providerId]: {
         npm: "@ai-sdk/openai-compatible",
@@ -1286,20 +1317,26 @@ export async function computerMentions(seed: Seed) {
     den, app, workspace, session,
     async submittedParts() {
       // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
-      return seed.evalIn(app, `async (workspaceId, sessionId) => {
+      return seed.evalIn(app, `async (workspaceId) => {
         const port = localStorage.getItem("openwork.server.port");
         const token = localStorage.getItem("openwork.server.token");
-        const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
-          + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
-          headers: { Authorization: "Bearer " + token },
-        });
-        if (!response.ok) throw new Error("Transcript read failed: " + response.status);
-        const messages = await response.json();
+        const base = "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/opencode/session";
+        const headers = { Authorization: "Bearer " + token };
+        const listed = await fetch(base, { headers });
+        if (!listed.ok) throw new Error("Session list failed: " + listed.status);
+        const sessions = await listed.json();
+        const messages = [];
+        for (const session of sessions) {
+          const response = await fetch(base + "/" + encodeURIComponent(session.id) + "/message", { headers });
+          if (!response.ok) throw new Error("Transcript read failed: " + response.status);
+          messages.push(...await response.json());
+        }
+        messages.sort((a, b) => a.info.time.created - b.info.time.created);
         return messages.filter((message) => message.info.role === "user").map((message) => ({
-          visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join(""),
+          visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join("").trim(),
           routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
         }));
-      }`, { args: [workspace.workspaceId, session.sessionId], awaitPromise: true });
+      }`, { args: [workspace.workspaceId], awaitPromise: true });
     },
   };
 }

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1277,7 +1277,7 @@ export async function computerMentions(seed: Seed) {
         { target: "desktop", prompt: "COMPUTER-DESKTOP-TASK Summarize my local project notes." },
       ].map(({ target, prompt }) => ({
         // Only the app's synthetic instruction contains this marker. Without routing, the model refuses the task.
-        promptMarker: `target "${target}"`,
+        promptMarker: `[The user selected @${target}:`,
         finalReply: "Received computer task.",
         steps: [
           { tool: "computer_witness_search_capabilities", arguments: { query: "remote-session:create" } },

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1255,9 +1255,8 @@ export async function suspendedTurn(seed: Seed, { place }: { place: import("@ope
 export async function computerMentions(seed: Seed) {
   const providerId = "computer-mentions-mock";
   const modelId = "computer-mentions-model";
-  const markers = ["COMPUTER-CLOUD-TASK", "COMPUTER-DESKTOP-TASK", "COMPUTER-PLAIN-TASK"];
   const mock = seed.mock({
-    agentWorkloads: markers.map((promptMarker) => ({ promptMarker, finalReply: `Received ${promptMarker}`, steps: [] })),
+    agentWorkloads: [{ promptMarker: "COMPUTER-", finalReply: "Received computer task.", steps: [] }],
   });
   const den = await seed.den({ mocks: { agent: mock }, env: { DEN_AUTOMATIONS_ENABLED: "true" } });
   const created = await seed.api(den.admin, "/v1/automations", {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1250,3 +1250,38 @@ export async function suspendedTurn(seed: Seed, { place }: { place: import("@ope
     },
   };
 }
+
+/** Signed-in chat with a deterministic model and a scheduled desktop task. */
+export async function computerMentions(seed: Seed) {
+  const providerId = "computer-mentions-mock";
+  const modelId = "computer-mentions-model";
+  const markers = ["COMPUTER-CLOUD-TASK", "COMPUTER-DESKTOP-TASK", "COMPUTER-PLAIN-TASK"];
+  const mock = seed.mock({
+    agentWorkloads: markers.map((promptMarker) => ({ promptMarker, finalReply: `Received ${promptMarker}`, steps: [] })),
+  });
+  const den = await seed.den({ mocks: { agent: mock } });
+  const created = await seed.api(den.admin, "/v1/automations", {
+    method: "POST",
+    body: JSON.stringify({
+      name: "Daily project summary",
+      instructions: "Summarize today's project notes.",
+      schedule: { kind: "daily", timezone: "UTC", hour: 23, minute: 59 },
+      model: { providerId: "opencode", modelId: "big-pickle", variant: null },
+    }),
+  });
+  if (created.response.status !== 201) throw new Error(`Automation setup failed: ${created.text}`);
+  const app = await seed.desktop({ den, as: "admin", model: `${providerId}/${modelId}` });
+  const workspace = await seed.workspace(app, seed.tmpPath("computer-mentions"));
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Computer mentions mock",
+        options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-computer-mentions" },
+        models: { [modelId]: { name: "Computer mentions model" } },
+      },
+    },
+  });
+  const session = await seedSessionRetry(seed, app, { title: "Computer task mentions" });
+  return { den, app, workspace, session };
+}

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1259,7 +1259,7 @@ export async function computerMentions(seed: Seed) {
   const mock = seed.mock({
     agentWorkloads: markers.map((promptMarker) => ({ promptMarker, finalReply: `Received ${promptMarker}`, steps: [] })),
   });
-  const den = await seed.den({ mocks: { agent: mock } });
+  const den = await seed.den({ mocks: { agent: mock }, env: { DEN_AUTOMATIONS_ENABLED: "true" } });
   const created = await seed.api(den.admin, "/v1/automations", {
     method: "POST",
     body: JSON.stringify({
@@ -1286,21 +1286,21 @@ export async function computerMentions(seed: Seed) {
   return {
     den, app, workspace, session,
     async submittedParts() {
-    // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
-    return seed.evalIn(app, `async (workspaceId, sessionId) => {
-      const port = localStorage.getItem("openwork.server.port");
-      const token = localStorage.getItem("openwork.server.token");
-      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
-        + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
-        headers: { Authorization: "Bearer " + token },
-      });
-      if (!response.ok) throw new Error("Transcript read failed: " + response.status);
-      const messages = await response.json();
-      return messages.filter((message) => message.info.role === "user").map((message) => ({
-        visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join(""),
-        routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
-      }));
-    }`, { args: [workspace.workspaceId, session.sessionId], awaitPromise: true });
+      // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
+      return seed.evalIn(app, `async (workspaceId, sessionId) => {
+        const port = localStorage.getItem("openwork.server.port");
+        const token = localStorage.getItem("openwork.server.token");
+        const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
+          + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
+          headers: { Authorization: "Bearer " + token },
+        });
+        if (!response.ok) throw new Error("Transcript read failed: " + response.status);
+        const messages = await response.json();
+        return messages.filter((message) => message.info.role === "user").map((message) => ({
+          visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join(""),
+          routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
+        }));
+      }`, { args: [workspace.workspaceId, session.sessionId], awaitPromise: true });
     },
   };
 }

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1283,5 +1283,24 @@ export async function computerMentions(seed: Seed) {
     },
   });
   const session = await seedSessionRetry(seed, app, { title: "Computer task mentions" });
-  return { den, app, workspace, session };
+  return {
+    den, app, workspace, session,
+    async submittedParts() {
+    // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
+    return seed.evalIn(app, `async (workspaceId, sessionId) => {
+      const port = localStorage.getItem("openwork.server.port");
+      const token = localStorage.getItem("openwork.server.token");
+      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId)
+        + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
+        headers: { Authorization: "Bearer " + token },
+      });
+      if (!response.ok) throw new Error("Transcript read failed: " + response.status);
+      const messages = await response.json();
+      return messages.filter((message) => message.info.role === "user").map((message) => ({
+        visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join(""),
+        routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
+      }));
+    }`, { args: [workspace.workspaceId, session.sessionId], awaitPromise: true });
+    },
+  };
 }

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -51,6 +51,7 @@ const refreshTokens = new Set();
 const requests = [];
 const drafts = [];
 let agentWorkloads = [];
+let configuredTools = [];
 
 const gmailThreadId = "thread-q3-launch";
 
@@ -629,6 +630,13 @@ function tokenFingerprint(req) {
 }
 
 function mcpResult(message) {
+  if (configuredTools.length && message.method === "tools/list") {
+    return { tools: configuredTools.map(({ result, ...tool }) => tool) };
+  }
+  if (message.method === "tools/call") {
+    const tool = configuredTools.find((candidate) => candidate.name === message.params?.name);
+    if (tool) return tool.result;
+  }
   switch (message.method) {
     case "initialize":
       return {
@@ -860,6 +868,17 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/requests") {
       json(res, 200, { requests });
+      return;
+    }
+
+    if (url.pathname === "/admin/tools" && req.method === "POST") {
+      const body = await readJson(req);
+      if (!Array.isArray(body?.tools) || body.tools.some((tool) => !tool || typeof tool.name !== "string" || !tool.inputSchema || !tool.result)) {
+        json(res, 400, { error: "tools must have a name, inputSchema, and result" });
+        return;
+      }
+      configuredTools = body.tools;
+      json(res, 200, { configured: configuredTools.length });
       return;
     }
 

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -194,7 +194,10 @@ function validateAgentWorkloads(value) {
       if (!step.arguments || typeof step.arguments !== "object" || Array.isArray(step.arguments)) {
         throw new Error(`agent workload ${promptMarker} tool ${step.tool} needs object arguments`);
       }
-      return { tool: step.tool.trim(), arguments: structuredClone(step.arguments) };
+      if (step.argumentsFrom !== undefined && step.argumentsFrom !== "computer-mention") {
+        throw new Error(`agent workload ${promptMarker} has an unknown argument source`);
+      }
+      return { tool: step.tool.trim(), arguments: structuredClone(step.arguments), argumentsFrom: step.argumentsFrom };
     });
     // Declared fault: the first N main completions stream their opening chunk
     // and then go quiet without ending, the way a half-open socket behaves
@@ -268,6 +271,23 @@ function agentChunk(model, delta, finishReason = null) {
   };
 }
 
+// A deterministic model that reads the submitted message, rather than replaying
+// an expected destination or task from the fixture.
+function computerMentionArguments(messages) {
+  const message = [...messages].reverse().find((candidate) => candidate?.role === "user"
+    && agentContentText(candidate).includes("[The user selected @"));
+  const text = agentContentText(message);
+  const instruction = text.match(/\[The user selected @(?:cloud|desktop):[\s\S]*?\]/)?.[0];
+  const target = instruction?.match(/execute it with target "(cloud|desktop)"/)?.[1];
+  if (!instruction || !target) throw new Error("computer task has no routing instruction");
+  const prompt = text.replace(instruction, "")
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+    .replace(/(^|\s)@(cloud|desktop)(?=\s|$)/g, "$1")
+    .replace(/\s+/g, " ").trim();
+  if (!prompt) throw new Error("computer task has no prompt");
+  return { name: "remote-session:create", body: { target, prompt } };
+}
+
 async function handleAgentCompletion(req, res, entry) {
   const body = await readJson(req);
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -321,13 +341,14 @@ async function handleAgentCompletion(req, res, entry) {
     json(res, 400, { error: { message: `tool ${step.tool} was not offered to the mock agent` } });
     return;
   }
+  const toolArguments = step.argumentsFrom === "computer-mention" ? computerMentionArguments(messages) : step.arguments;
   const callId = `call_${workload.promptMarker.replace(/[^a-zA-Z0-9_-]/g, "_")}_${completedTools + 1}`;
   entry.agentCompletion = {
     ...baseRequest,
     kind: "tool",
     promptMarker: workload.promptMarker,
     toolName,
-    arguments: step.arguments,
+    arguments: toolArguments,
   };
   agentStream(res, model, [
     agentChunk(model, { role: "assistant" }),
@@ -336,7 +357,7 @@ async function handleAgentCompletion(req, res, entry) {
         index: 0,
         id: callId,
         type: "function",
-        function: { name: toolName, arguments: JSON.stringify(step.arguments) },
+        function: { name: toolName, arguments: JSON.stringify(toolArguments) },
       }],
     }),
     agentChunk(model, {}, "tool_calls"),

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -126,6 +126,36 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     { name: "execute_capability", args: { target: "desktop" } },
   ]);
 
+  const workload = await fetch(`${origin}/admin/agent-workloads`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ workloads: [{
+      promptMarker: "[The user selected @",
+      finalReply: "Handoff received",
+      steps: [{ tool: "execute_capability", arguments: { ignored: true }, argumentsFrom: "computer-mention" }],
+    }] }),
+  });
+  assert.equal(workload.status, 200);
+  for (const [target, task] of [["cloud", "Summarize today's notes."], ["desktop", "Review the changed draft."]]) {
+    const completion = await fetch(`${origin}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "handoff-model",
+        messages: [{ role: "user", content: [
+          { type: "text", text: `@${target} ${task}` },
+          { type: "text", text: `[The user selected @${target}: execute it with target "${target}" and the user's task as prompt.]` },
+        ] }],
+        tools: [{ type: "function", function: { name: "execute_capability" } }],
+      }),
+    });
+    assert.equal(completion.status, 200);
+    const frames = (await completion.text()).split("\n")
+      .filter((line) => line.startsWith("data: {")).map((line) => JSON.parse(line.slice(6)));
+    const call = frames.flatMap((frame) => frame.choices[0].delta.tool_calls ?? [])[0];
+    assert.deepEqual(JSON.parse(call.function.arguments), { name: "remote-session:create", body: { target, prompt: task } });
+  }
+
   const failedResponse = await fetch(`${origin}/admin/agent-workloads`, {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -93,7 +93,38 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     body: "grant_type=refresh_token",
   });
   assert.equal(tokenResponse.status, 200);
-  assert.equal(typeof (await tokenResponse.json()).access_token, "string");
+  const accessToken = (await tokenResponse.json()).access_token;
+  assert.equal(typeof accessToken, "string");
+
+  const configured = await fetch(`${origin}/admin/tools`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tools: [{
+      name: "execute_capability",
+      description: "A deterministic handoff witness",
+      inputSchema: { type: "object", properties: { target: { type: "string" } } },
+      result: { content: [{ type: "text", text: "queued" }] },
+    }] }),
+  });
+  assert.equal(configured.status, 200);
+  const rpc = async (method, params) => {
+    const response = await fetch(`${origin}/mcp`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    assert.equal(response.status, 200);
+    return response.json();
+  };
+  const listed = await rpc("tools/list", {});
+  assert.deepEqual(listed.result.tools.map((tool) => tool.name), ["execute_capability"]);
+  assert.equal("result" in listed.result.tools[0], false);
+  const invoked = await rpc("tools/call", { name: "execute_capability", arguments: { target: "desktop" } });
+  assert.equal(invoked.result.content[0].text, "queued");
+  const log = await (await fetch(`${origin}/requests`)).json();
+  assert.deepEqual(log.requests.flatMap((entry) => entry.toolCalls ?? []).map(({ name, args }) => ({ name, args })), [
+    { name: "execute_capability", args: { target: "desktop" } },
+  ]);
 
   const failedResponse = await fetch(`${origin}/admin/agent-workloads`, {
     method: "POST",


### PR DESCRIPTION
Automations now labels each task’s Cloud computer or Desktop computer and explains availability in plain language. The composer offers `@cloud` and `@desktop` to ask OpenWork Connect to start a task on the selected computer, including when the mention is typed directly. Routing instructions stay out of the visible conversation, and email addresses remain ordinary text.

Validation on `3a2bcee72439cb63428249194e208967aedf3382`:
- `pnpm typecheck` — passed.
- `pnpm --filter @openwork/app exec bun test tests/prompt-file-parts.test.ts tests/mention-encoding.test.ts tests/app-mentions.test.ts` — 23 passed, 0 failed.
- `node --test scripts/mock-oauth-mcp-server.test.mjs` — passed (1 test), including configurable tool catalog, invocation, and observed arguments.
- `pnpm --dir evals exec tsc -p tsconfig.primitives.json` — passed.
- `OPENWORK_EVAL_REF=3a2bcee72439cb63428249194e208967aedf3382 pnpm evals:e2e computer-task-mentions` — placement: daytona (daytona CLI authenticated); Passed, 1 passed, 0 failed, 0 skipped. Evidence and screenshots are published in the test-evidence comment. The journey checks the menu, direct mentions from New task, and the actual search/create calls served by a deterministic Connect MCP witness. It asserts the target and complete forwarded task, verifies that an ordinary email address makes no tool call, and checks automation placement labels. The model derives the target and forwarded task from its actual received user message and routing instruction; expected task payloads are not preset in the fixture. Remote task execution itself reuses the existing Connect capabilities.

The broader `pnpm evals:typecheck` reports the same 296 errors as clean dev `2390c79ee` with no additional errors (both exit 2). The spec-channel ratchet also reproduces its existing sidebar-title-overflow-fade failure on that clean control (both exit 1). The new journey passes the boundary ratchet and adds no channel escapes.
