### PR TITLE
fix: focus composer for new sessions and splits

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-state-store.ts
@@ -24,6 +24,7 @@ export type ComposerSessionState = {
 };
 
 export type ComposerStateStore = {
+  pendingFocusSessionId: string | null;
   sessions: Record<string, ComposerSessionState>;
   queuedDrafts: Record<string, QueuedComposerItem[]>;
   /**
@@ -100,6 +101,7 @@ function createQueuedItem(draft: ComposerDraft, id?: string): QueuedComposerItem
 }
 
 export const useComposerStateStore = create<ComposerStateStore>((set) => ({
+  pendingFocusSessionId: null,
   sessions: {},
   queuedDrafts: {},
   history: {},

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/components/ui/sonner";
 import type { CloudImportedPlugin, CloudImportedPluginFile } from "@/app/cloud/import-state";
 import type { ComposerAttachment, McpServerEntry, McpStatus, McpStatusMap, ModelOption, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { t } from "@/i18n";
+import { useComposerStateStore } from "../composer-state-store";
 import {
   composerConfigureSectionForMenu,
   isLibraryCommand,
@@ -954,6 +955,23 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
     }
     return false;
   };
+
+  const focusRequested = useComposerStateStore((state) => (
+    Boolean(props.sessionId) && state.pendingFocusSessionId === props.sessionId
+  ));
+  useEffect(() => {
+    if (!focusRequested || props.disabled) return;
+    // Wait for the editor to mount and the creating menu to close. Keep the
+    // request until this session is ready, even when its snapshot loads slowly.
+    const frame = requestAnimationFrame(() => {
+      if (useComposerStateStore.getState().pendingFocusSessionId !== props.sessionId) return;
+      const editable = rootRef.current?.querySelector<HTMLElement>("[contenteditable='true']");
+      if (!editable) return;
+      editable.focus();
+      useComposerStateStore.setState({ pendingFocusSessionId: null });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [focusRequested, props.disabled, props.sessionId]);
 
   // Listen for cross-app focus + draft flush events. The Solid shell uses
   // these from deep-link handlers, the command palette, and the browser

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2122,6 +2122,7 @@ export function SessionRoute() {
         writeActiveWorkspaceId(workspaceId || null);
         writeLastSessionFor(workspaceId, session.id);
       }
+      useComposerStateStore.setState({ pendingFocusSessionId: session.id });
       rememberPendingCreatedSession(workspaceId, session.id);
       applyLastUsedModelToSession(session.id);
       setSessionsByWorkspaceId((current) => {
@@ -2134,7 +2135,6 @@ export function SessionRoute() {
       });
       if (openAs === "primary") {
         navigateToWorkspaceSession(workspaceId, session.id);
-        focusPromptSoon();
       } else {
         const tab = {
           workspaceId,

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -8,6 +8,7 @@ const paletteInput = { placeholder: "Search actions, settings, and sessions…" 
 type SplitFacts = {
   layoutKind: string;
   focusedPane: string;
+  focusedComposerSessionId: string;
   primarySessionId: string;
   secondarySessionId: string;
   primaryWorkspaceId: string;
@@ -29,6 +30,7 @@ function parseSplitFacts(value: unknown): SplitFacts {
   return {
     layoutKind: text("layoutKind"),
     focusedPane: text("focusedPane"),
+    focusedComposerSessionId: text("focusedComposerSessionId"),
     primarySessionId: text("primarySessionId"),
     secondarySessionId: text("secondarySessionId"),
     primaryWorkspaceId: text("primaryWorkspaceId"),
@@ -89,6 +91,12 @@ test("new split creates fresh same-workspace secondary sessions without moving t
       },
     });
     const firstFacts = parseSplitFacts(firstValue);
+    await probe.eventually(() => world.splitFacts(), {
+      within: 15_000,
+      label: "new secondary composer receives keyboard focus",
+      until: (candidate) => parseSplitFacts(candidate).focusedComposerSessionId === firstFacts.secondarySessionId,
+    });
+    expect(parseSplitFacts(await world.splitFacts()).focusedComposerSessionId).toBe(firstFacts.secondarySessionId);
     expect(firstFacts.layoutKind).toBe("split");
     expect(firstFacts.primarySessionId).toBe(primarySessionId);
     expect(firstFacts.primaryWorkspaceId).toBe(workspaceId);
@@ -146,6 +154,12 @@ test("new split creates fresh same-workspace secondary sessions without moving t
       },
     });
     const secondFacts = parseSplitFacts(secondValue);
+    await probe.eventually(() => world.splitFacts(), {
+      within: 15_000,
+      label: "new secondary composer receives keyboard focus",
+      until: (candidate) => parseSplitFacts(candidate).focusedComposerSessionId === secondFacts.secondarySessionId,
+    });
+    expect(parseSplitFacts(await world.splitFacts()).focusedComposerSessionId).toBe(secondFacts.secondarySessionId);
     expect(secondFacts.layoutKind).toBe("split");
     expect(secondFacts.primarySessionId).toBe(primarySessionId);
     expect(secondFacts.primaryWorkspaceId).toBe(workspaceId);
@@ -224,6 +238,12 @@ test("new split creates fresh same-workspace secondary sessions without moving t
       },
     });
     const focusedSecondaryFacts = parseSplitFacts(value);
+    await probe.eventually(() => world.splitFacts(), {
+      within: 15_000,
+      label: "new secondary composer receives keyboard focus",
+      until: (candidate) => parseSplitFacts(candidate).focusedComposerSessionId === focusedSecondaryFacts.secondarySessionId,
+    });
+    expect(parseSplitFacts(await world.splitFacts()).focusedComposerSessionId).toBe(focusedSecondaryFacts.secondarySessionId);
     expect(focusedSecondaryFacts.layoutKind).toBe("split");
     expect(focusedSecondaryFacts.primarySessionId).toBe(primarySessionId);
     expect(focusedSecondaryFacts.primarySurfaceSessionId).toBe(primarySessionId);
@@ -271,6 +291,12 @@ test("new split creates fresh same-workspace secondary sessions without moving t
       },
     });
     const focusedPrimaryFacts = parseSplitFacts(value);
+    await probe.eventually(() => world.splitFacts(), {
+      within: 15_000,
+      label: "new primary composer receives keyboard focus",
+      until: (candidate) => parseSplitFacts(candidate).focusedComposerSessionId === focusedPrimaryFacts.primarySessionId,
+    });
+    expect(parseSplitFacts(await world.splitFacts()).focusedComposerSessionId).toBe(focusedPrimaryFacts.primarySessionId);
     expect(focusedPrimaryFacts.primarySessionId).toMatch(/^ses_/);
     expect(focusedPrimaryFacts.primarySessionId).not.toBe(primarySessionId);
     expect(focusedPrimaryFacts.locationHash).toContain(`/workspace/${workspaceId}/session/${focusedPrimaryFacts.primarySessionId}`);

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -220,6 +220,9 @@ export async function newSplitPrimary(seed: Seed) {
     return {
       layoutKind: layout?.kind ?? "",
       focusedPane: layout?.focused ?? "",
+      focusedComposerSessionId: document.activeElement?.matches('[contenteditable="true"]')
+        ? document.activeElement.closest("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""
+        : "",
       primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
       secondarySessionId: layout?.secondarySessionId ?? "",
       primaryWorkspaceId: layout?.primaryWorkspaceId ?? "",


### PR DESCRIPTION
Creating a session or a new split now focuses that session’s composer when its editor is ready. Focus requests target the new session, so the other split pane cannot capture them, and slow snapshot loading does not miss a timed focus event.

Validation on `e65bf3e2ca31e7a947df7bfe35aad69b687efd84`:
- `pnpm typecheck` — passed.
- `OPENWORK_EVAL_REF=fix/new-session-composer-focus pnpm evals:e2e new-split-session` — Passed: 1 passed, 0 failed, 0 skipped; exit 0.
- Placement: `daytona (daytona CLI authenticated)`. The journey asserts keyboard focus after context-menu and palette splits and after replacing either focused pane, while preserving the opposite session.
