### PR TITLE
Fix overlapping composer controls in narrow panes

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -422,7 +422,7 @@ export function ModelSelect({
               disabled={disabled}
               aria-label="Change model"
               aria-keyshortcuts="Meta+Alt+/"
-              className="flex h-9 max-h-9 items-center gap-1.5 rounded-md px-2.5 text-sm text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12 disabled:pointer-events-none disabled:opacity-60"
+              className="flex h-9 max-h-9 min-w-0 max-w-fit flex-1 items-center gap-1.5 rounded-md px-2.5 text-sm text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12 disabled:pointer-events-none disabled:opacity-60"
             />
           }
         >

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1282,7 +1282,7 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
       <div className={props.flush ? "" : "max-w-[800px] mx-auto"}>
         {/* Main composer panel */}
         <div
-          className={`relative overflow-visible rounded-[18px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}
+          className={`@container/composer relative overflow-visible rounded-[18px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}
         >
           {props.topAccessory ? <div className="relative z-10">{props.topAccessory}</div> : null}
 
@@ -1400,9 +1400,10 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
               }}
             />
 
-            {/* Action row — tools, attachments, model, and send stay on one line */}
-            <div className="mt-2 flex items-center gap-1.5">
-              <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            {/* Respond to the pane width, including desktop split views. */}
+            <div data-composer-toolbar className="mt-2 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1.5 gap-y-2 @min-[560px]/composer:flex">
+              <div className="contents">
+                <div className="col-start-1 row-start-2 flex shrink-0 items-center gap-1.5">
                 <input
                   ref={(element) => {
                     fileInput = element ?? undefined;
@@ -1664,13 +1665,16 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                   <Paperclip size={16} />
                 </button>
 
+                </div>
+
+                <div data-composer-settings className="col-span-2 row-start-1 flex min-w-0 flex-wrap items-center gap-1 border-b border-dls-border pb-2 @min-[560px]/composer:flex-1 @min-[560px]/composer:border-0 @min-[560px]/composer:pb-0">
                 {/* Agent picker (#2101/#1971). Only shown once a non-default
                     agent is selected. Switching back to Default agent lives in
                     this menu and in the + tools menu. */}
-                <div ref={agentMenuRef} className={showAgentPicker ? "relative" : "hidden"}>
+                <div ref={agentMenuRef} className={showAgentPicker ? "relative min-w-0 max-w-full shrink-0" : "hidden"}>
                   <button
                     type="button"
-                    className="flex h-9 max-h-9 items-center gap-1 rounded-md px-1.5 text-[12px] font-medium text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+                    className="flex h-9 max-h-9 max-w-full items-center gap-1 rounded-md px-1.5 text-[12px] font-medium text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
                     onClick={() => setAgentMenuOpen((value) => !value)}
                     disabled={props.busy}
                     aria-expanded={agentMenuOpen}
@@ -1767,10 +1771,11 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                     </span>
                   </button>
                 ) : (
-                  <span className="max-w-[20rem] truncate text-xs font-medium text-red-10">
+                  <span className="min-w-0 max-w-full truncate text-xs font-medium text-red-10">
                     {props.modelUnavailableMessage ?? t("models.model_unavailable_short")}
                   </span>
                 ) : null}
+                </div>
 
               </div>
 
@@ -1780,9 +1785,9 @@ export const ReactSessionComposer = memo(function ReactSessionComposer(props: Co
                 - Busy: stop icon in that same slot (Enter still queues;
                   Cmd/Ctrl+Enter still steers).
               */}
-              <div className="ml-auto flex shrink-0 items-center gap-1.5">
+              <div data-composer-actions className="col-start-2 row-start-2 ml-auto flex shrink-0 items-center gap-1.5">
                 {props.busy && escapeArmed ? (
-                  <span className="self-center pr-1 text-[12px] font-medium text-gray-10 max-lg:hidden">
+                  <span className="self-center pr-1 text-[12px] font-medium text-gray-10 hidden @min-[720px]/composer:inline">
                     {t("composer.escape_to_stop")}
                   </span>
                 ) : null}

--- a/evals/specs/responsive-session-layout.e2e.test.ts
+++ b/evals/specs/responsive-session-layout.e2e.test.ts
@@ -2,6 +2,7 @@ import { expect } from "vitest";
 import { control, evalIn, go, listSessions, seedSessions, waitFor } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
 import { setViewport } from "@openwork/cdp";
+import { screenshot } from "@openwork/test-evidence";
 import {
   localMysqlIsRunning,
   localRedisIsRunning,
@@ -132,6 +133,33 @@ test.skipIf(!runnable)(
     await waitFor(app, `Boolean(document.querySelector(
       '[data-workbench-pane="secondary"] [data-session-surface-id="${secondary.sessionId}"]'
     ))`, { timeoutMs: 60_000, label: "desktop split session" });
+
+    // Exercise desktop split panes as well as the single-pane mobile layout.
+    for (const width of [1440, 1100, 390, 320]) {
+      await setViewport(app, { width, height: 844, deviceScaleFactor: 1 });
+      await waitFor(app, `(() => {
+        const toolbars = [...document.querySelectorAll('[data-composer-toolbar]')]
+          .filter((toolbar) => toolbar.getBoundingClientRect().width > 0);
+        return toolbars.length > 0 && toolbars.every((toolbar) => {
+          const bounds = toolbar.getBoundingClientRect();
+          const buttons = [...toolbar.querySelectorAll('button')]
+            .map((button) => button.getBoundingClientRect())
+            .filter((rect) => rect.width > 0 && rect.height > 0);
+          return buttons.length >= 4 && buttons.every((rect, index) =>
+            rect.left >= bounds.left - 1 && rect.right <= bounds.right + 1
+            && rect.top >= bounds.top - 1 && rect.bottom <= bounds.bottom + 1
+            && buttons.slice(index + 1).every((other) =>
+              rect.right <= other.left + 1 || other.right <= rect.left + 1
+              || rect.bottom <= other.top + 1 || other.bottom <= rect.top + 1));
+        });
+      })()`, { timeoutMs: 30_000, label: `composer controls fit without overlap at ${width}px` });
+      await screenshot(app);
+      evidence.recordAssertionEvidence(
+        `Composer controls remain contained and do not overlap at ${width}px`,
+        "Measured every visible toolbar button against the toolbar bounds and every other button.",
+        true,
+      );
+    }
 
     await setViewport(app, { width: 390, height: 844, deviceScaleFactor: 1 });
     await waitFor(app, `(() => {


### PR DESCRIPTION
Narrow chat panes forced tools, the agent, model/effort, and send/stop into one row, allowing labels to overlap the action button. The composer now uses its own width to place settings above a divider and attachments/send below it; wide composers retain one row. Model labels can shrink within the available space, and the Escape hint only appears when the composer has room.

Extended the existing responsive session journey to check every visible toolbar button for containment and pairwise overlap at 1440, 1100, 390, and 320 pixels, with screenshots at each width.

Validation:
- `pnpm --filter @openwork/app typecheck` — passed.
- `pnpm --filter @openwork/app build` — passed.
- `pnpm --dir evals exec node scripts/spec-boundary-ratchet.mjs` — passed, 90 specs checked.
- Browser review: two 316.5px composer toolbars at a 1100px split viewport had no overlapping or out-of-bounds buttons; a 320px mobile viewport contained model/effort and send; a 766px toolbar at 1440px stayed on one row.
- `OPENWORK_EVAL_REF=bc5f5cc22aa81e229075b4ab6bdde280f9cf37c0 pnpm evals:e2e responsive-session-layout` — **Passed**, 1 passed / 0 failed / 0 skipped, exit 0. Placement: `daytona (daytona CLI authenticated)`.
