### PR TITLE
Add browser policy API before desktop adoption

### DIFF
--- a/ee/apps/den-api/src/desktop-policies.ts
+++ b/ee/apps/den-api/src/desktop-policies.ts
@@ -8,7 +8,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import {
-  allDesktopPolicies,
+  calculateEffectiveAllowedBrowserHosts,
   calculateEffectiveDesktopPolicy,
   desktopPolicyDefaults,
   normalizeDesktopPolicyDocument,
@@ -25,7 +25,8 @@ export type DesktopPolicyMemberRow = typeof DesktopPolicyMemberTable.$inferSelec
 export type OrgId = typeof DesktopPolicyTable.$inferSelect.organizationId
 export type OrgMemberId = typeof DesktopPolicyTable.$inferSelect.createdByOrgMemberId
 export type TeamId = typeof TeamTable.$inferSelect.id
-export type EffectiveDesktopPolicyConfig = Required<DesktopPolicyValue> & Pick<DesktopConfig, "onboardingPrompts" | "onboardingPromptDescriptions">
+export type EffectiveDesktopPolicyConfig = Required<DesktopPolicyValue> &
+  Pick<DesktopConfig, "onboardingPrompts" | "onboardingPromptDescriptions" | "allowedBrowserHosts">
 
 export const DEFAULT_DESKTOP_POLICY_NAME = "Default desktop policy"
 
@@ -98,7 +99,7 @@ export async function calculateDesktopPolicyForOrgMember(input: {
     .orderBy(asc(DesktopPolicyTable.createdAt))
 
   if (orgPolicies.length === 0) {
-    return allDesktopPolicies(true)
+    return { ...desktopPolicyDefaults }
   }
 
   const defaultPolicy = orgPolicies.find((policy) => policy.isDefault === true && policy.isEnabled === true) ?? null
@@ -164,9 +165,15 @@ export async function calculateDesktopPolicyForOrgMember(input: {
       policy: normalizeDesktopPolicyDocument(row.policy),
     })),
   })
+  const allowedBrowserHosts = calculateEffectiveAllowedBrowserHosts({
+    orgPolicyCount: orgPolicies.length,
+    defaultPolicy: defaultPolicy?.policy ?? {},
+    assignedPolicies: uniqueAssignedPolicies.map((row) => row.policy),
+  })
 
   return {
     ...effectivePolicy,
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
+    ...(allowedBrowserHosts !== undefined ? { allowedBrowserHosts } : {}),
   }
 }

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -372,6 +372,9 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
 
       return c.json({
         ...desktopPolicy,
+        // Explicit unrestricted policy distinguishes a current server from
+        // older deployments that cannot yet enforce browser restrictions.
+        allowedBrowserHosts: desktopPolicy.allowedBrowserHosts ?? ["*"],
         automationsEnabled: env.automations.enabled,
         dashboardEnabled: env.dashboardsEnabled,
         connectEnabled: memberFacingMcpConnectionsEnabled(organization.metadata, {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-permissions-panel.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-permissions-panel.tsx
@@ -17,6 +17,7 @@ const capabilityLabels: Record<(typeof capabilities)[number]["id"], string> = {
   allowControlSettings: "Change app settings",
   allowManageExtensions: "Add and manage local tools, skills & MCP servers",
   allowBuiltInExtensions: "Use built-in extensions",
+  allowBrowserLoginImport: "Import browser logins",
   allowAlphaUpdates: "Try experimental updates",
   showWelcomePage: "Show welcome page",
 };

--- a/evals/specs/browser-policy-api.test.ts
+++ b/evals/specs/browser-policy-api.test.ts
@@ -1,7 +1,11 @@
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
-import { server, test } from "@openwork/testkit";
+import { localMysqlIsRunning, localRedisIsRunning, server, test } from "@openwork/testkit";
+
+const remote = process.env.OPENWORK_EVAL_DAYTONA?.trim() === "1" || Boolean(process.env.OPENWORK_EVAL_DEN_API_URL?.trim());
+const databaseReady = remote || (await localMysqlIsRunning() && await localRedisIsRunning());
+const missing = databaseReady ? "" : " skipped — needs MySQL and Redis";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -14,7 +18,7 @@ function record(value: unknown): Record<string, unknown> {
 
 // The API is available before desktop adoption: an administrator can provision
 // browser permissions, while existing clients keep using the same request keys.
-test("an administrator provisions browser policy through the API while existing client requests remain compatible", { timeout: 300_000 }, async ({ evidence, place }) => {
+test.skipIf(!databaseReady)(`an administrator provisions browser policy through the API while existing client requests remain compatible${missing}`, { timeout: 300_000 }, async ({ evidence, place }) => {
   const name = `Browser policy API ${Date.now()}`;
   await using den = await server({
     place, web: false,

--- a/evals/specs/browser-policy-api.test.ts
+++ b/evals/specs/browser-policy-api.test.ts
@@ -1,0 +1,81 @@
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { server, test } from "@openwork/testkit";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a JSON object.");
+  return value;
+}
+
+// The API is available before desktop adoption: an administrator can provision
+// browser permissions, while existing clients keep using the same request keys.
+test("an administrator provisions browser policy through the API while existing client requests remain compatible", { timeout: 300_000 }, async ({ evidence, place }) => {
+  const name = `Browser policy API ${Date.now()}`;
+  await using den = await server({
+    place, web: false,
+    org: { name, members: { reader: {} } },
+    env: { DEN_PLAN_GATING_ENABLED: "false" },
+  });
+  const organizations = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  expect(organizations.response.status, organizations.text).toBe(200);
+  const entries = record(organizations.body).orgs;
+  if (!Array.isArray(entries)) throw new Error("Missing organizations.");
+  const organization = entries.map(record).find((entry) => entry.name === name);
+  if (!organization || typeof organization.id !== "string") throw new Error("Missing the fixture organization.");
+  const organizationId = organization.id;
+  async function request(identity: DenSession, path: string, init?: RequestInit) {
+    return denFetch(identity, path, {
+      ...init,
+      headers: { authorization: `Bearer ${identity.token}`, "x-openwork-org-id": organizationId },
+      signal: AbortSignal.timeout(30_000),
+    });
+  }
+  async function config() {
+    const result = await request(den.members.reader, "/v1/me/desktop-config");
+    expect(result.response.status, result.text).toBe(200);
+    return record(result.body);
+  }
+  const initial = await config();
+  expect(initial).toMatchObject({ allowBrowserLoginImport: false, allowedBrowserHosts: ["*"], allowBuiltInExtensions: true });
+  evidence.recordAssertionEvidence("The additive policy API defaults preserve existing browser access", "The member's existing desktop-config endpoint returned built-in browser access, an explicit unrestricted host policy, and login import disabled by default.", true);
+
+  const listed = await request(den.admin, "/v1/desktop-policies");
+  expect(listed.response.status, listed.text).toBe(200);
+  const policies = record(listed.body).desktopPolicies;
+  if (!Array.isArray(policies)) throw new Error("Missing desktop policies.");
+  const policy = policies.map(record).find((entry) => entry.isDefault === true);
+  if (!policy || typeof policy.id !== "string") throw new Error("Missing the default policy.");
+  const path = `/v1/desktop-policies/${policy.id}`;
+  async function update(value: Record<string, unknown>) {
+    const result = await request(den.admin, path, { method: "PATCH", body: JSON.stringify({ policyName: "Default desktop policy", policy: value }) });
+    expect(result.response.status, result.text).toBe(200);
+    return record(record(result.body).desktopPolicy);
+  }
+
+  const stored = await update({ allowBrowserLoginImport: true, allowedBrowserHosts: ["project.example"], allowBuiltInExtensions: true });
+  expect(stored.policy).toMatchObject({ allowBrowserLoginImport: true, allowedBrowserHosts: ["project.example"] });
+  expect(await config()).toMatchObject({ allowBrowserLoginImport: true, allowedBrowserHosts: ["project.example"], allowBuiltInExtensions: true });
+  evidence.recordAssertionEvidence("An administrator's browser grant reaches the member through the existing API", "The policy update persisted the explicit import grant and project.example allowlist. A separate member GET returned both effective values and preserved the existing built-in extension permission.", true);
+
+  const refused = await request(den.members.reader, path, { method: "PATCH", body: JSON.stringify({ policyName: "Default desktop policy", policy: { allowBrowserLoginImport: false, allowedBrowserHosts: ["*"] } }) });
+  expect(refused.response.status, refused.text).toBe(403);
+  expect(await config()).toMatchObject({ allowBrowserLoginImport: true, allowedBrowserHosts: ["project.example"] });
+  evidence.recordAssertionEvidence("A member cannot change the organization's browser permissions", "The member's update returned HTTP 403. A subsequent member config read retained the administrator's import grant and host restriction.", true);
+
+  await update({ allowBrowserLoginImport: false, allowedBrowserHosts: null });
+  expect(await config()).toMatchObject({ allowBrowserLoginImport: false, allowedBrowserHosts: ["*"] });
+  evidence.recordAssertionEvidence("Administrators can revoke import and explicitly clear a website restriction", "Updating the policy to deny import and clear the host list returned an effective false grant and explicit unrestricted hosts.", true);
+
+  await update({ allowZenModel: false });
+  const legacy = await config();
+  expect(legacy).toMatchObject({ allowZenModel: false, allowBuiltInExtensions: true, allowBrowserLoginImport: false, allowedBrowserHosts: ["*"] });
+  for (const key of ["allowCustomProviders", "allowMultipleWorkspaces", "allowControlSettings", "allowManageExtensions", "allowAlphaUpdates", "showWelcomePage"]) {
+    expect(legacy[key], key).toBe(initial[key]);
+  }
+  evidence.recordAssertionEvidence("Existing clients can still update policy without sending the new fields", "An update containing only the existing allowZenModel flag succeeded. That flag changed, the other existing flags retained their values, and the new fields used safe defaults without becoming required request fields.", true);
+});

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -367,6 +367,7 @@ export type CurrentUserDesktopConfigResponse = {
   allowControlSettings?: boolean;
   allowManageExtensions?: boolean;
   allowBuiltInExtensions?: boolean;
+  allowBrowserLoginImport?: boolean;
   allowAlphaUpdates?: boolean;
   showWelcomePage?: boolean;
   allowedDesktopVersions?: Array<string>;
@@ -401,6 +402,7 @@ export type CurrentUserDesktopConfigResponse = {
   connectEnabled?: boolean;
   onboardingPrompts?: Array<string>;
   onboardingPromptDescriptions?: Array<string>;
+  allowedBrowserHosts?: Array<string>;
 };
 
 export type AutomationOpenWorkWebAccessRequiredError = {
@@ -804,6 +806,7 @@ export type DenDesktopPolicyValue = {
   allowControlSettings?: boolean;
   allowManageExtensions?: boolean;
   allowBuiltInExtensions?: boolean;
+  allowBrowserLoginImport?: boolean;
   allowAlphaUpdates?: boolean;
   showWelcomePage?: boolean;
 };
@@ -815,6 +818,7 @@ export type DenDesktopPolicyDocumentWrite = {
   allowControlSettings?: boolean;
   allowManageExtensions?: boolean;
   allowBuiltInExtensions?: boolean;
+  allowBrowserLoginImport?: boolean;
   allowAlphaUpdates?: boolean;
   showWelcomePage?: boolean;
   access?: {
@@ -823,6 +827,7 @@ export type DenDesktopPolicyDocumentWrite = {
   };
   onboardingPrompts?: Array<string> | null;
   onboardingPromptDescriptions?: Array<string> | null;
+  allowedBrowserHosts?: Array<string> | null;
 };
 
 export type DesktopPolicyListResponse = {

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -88,6 +88,16 @@ export const desktopPolicyDefinitions = [
     restrictedValue: false,
   },
   {
+    id: "allowBrowserLoginImport",
+    name: "Import browser logins",
+    description:
+      "Allow users to import their existing logins (cookies) from Chrome, Edge, or Firefox into the built-in browser so the agent can work on sites they are already signed in to. Off until you turn it on; users are offered the import the next time they open the built-in browser.",
+    userNotice:
+      "Your organization administrator has not enabled importing browser logins.",
+    defaultValue: false,
+    restrictedValue: false,
+  },
+  {
     id: "allowAlphaUpdates",
     name: "Alpha updates",
     description:
@@ -155,11 +165,77 @@ function normalizeTeamAccess(value: unknown): TeamAccess | undefined {
   return parsed.success ? parsed.data : undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Browser URL allowlist: the websites the built-in browser may open.
+//
+// Each entry is a host pattern. `*` allows every website; a bare host such as
+// `example.com` allows that host and every subdomain. Schemes, ports, paths,
+// and a leading `*.` are dropped during normalization, so `*.example.com`,
+// `https://example.com/docs`, and `example.com:8443` all mean `example.com`.
+// An absent or empty list leaves the browser unrestricted.
+// ---------------------------------------------------------------------------
+export const ALLOWED_BROWSER_HOST_ANY = "*";
+export const ALLOWED_BROWSER_HOST_MAX_LENGTH = 253;
+export const ALLOWED_BROWSER_HOSTS_MAX_COUNT = 200;
+
+export function normalizeAllowedBrowserHost(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  let candidate = value.trim().toLowerCase();
+  if (!candidate) return null;
+  if (candidate === ALLOWED_BROWSER_HOST_ANY) return ALLOWED_BROWSER_HOST_ANY;
+  candidate = candidate.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
+  if (candidate.startsWith("*.")) candidate = candidate.slice(2);
+  if (!candidate || /\s/.test(candidate)) return null;
+
+  let hostname: string;
+  try {
+    hostname = new URL(`http://${candidate}`).hostname;
+  } catch {
+    return null;
+  }
+  hostname = hostname.replace(/\.$/, "");
+  if (
+    !hostname ||
+    hostname.includes("*") ||
+    hostname.length > ALLOWED_BROWSER_HOST_MAX_LENGTH
+  ) {
+    return null;
+  }
+  return hostname;
+}
+
+export const allowedBrowserHostsSchema = z
+  .array(
+    z
+      .string()
+      .trim()
+      .min(1)
+      .max(ALLOWED_BROWSER_HOST_MAX_LENGTH)
+      .refine((value) => normalizeAllowedBrowserHost(value) !== null, {
+        message: "Enter a website host such as example.com or *.example.com.",
+      }),
+  )
+  .max(ALLOWED_BROWSER_HOSTS_MAX_COUNT);
+
+/** Canonical, de-duplicated host list; `undefined` when nothing usable remains. */
+export function normalizeAllowedBrowserHosts(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const hosts = [
+    ...new Set(
+      value
+        .map((entry) => normalizeAllowedBrowserHost(entry))
+        .filter((entry): entry is string => entry !== null),
+    ),
+  ];
+  return hosts.length > 0 ? hosts : undefined;
+}
+
 export const desktopPolicyDocumentSchema = desktopPolicyValueSchema
   .extend({
     access: teamAccessSchema.optional(),
     onboardingPrompts: onboardingPromptsSchema.optional(),
     onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.optional(),
+    allowedBrowserHosts: allowedBrowserHostsSchema.optional(),
   })
   .meta({ ref: "DenDesktopPolicyDocument" });
 
@@ -170,6 +246,7 @@ export const desktopPolicyDocumentWriteSchema = desktopPolicyValueSchema
     onboardingPromptDescriptions: onboardingPromptDescriptionsSchema
       .nullable()
       .optional(),
+    allowedBrowserHosts: allowedBrowserHostsSchema.nullable().optional(),
   })
   .meta({ ref: "DenDesktopPolicyDocumentWrite" });
 
@@ -181,6 +258,7 @@ export type DefaultDesktopPolicyDocument = Required<DesktopPolicyValue> & {
   access?: TeamAccess;
   onboardingPrompts?: string[];
   onboardingPromptDescriptions?: string[];
+  allowedBrowserHosts?: string[];
 };
 
 export const desktopPolicyKeys = desktopPolicyDefinitions.map(
@@ -280,6 +358,7 @@ export const desktopConfigSchema = desktopPolicyValueSchema
     connectEnabled: z.boolean().optional(),
     onboardingPrompts: onboardingPromptsSchema.optional(),
     onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.optional(),
+    allowedBrowserHosts: allowedBrowserHostsSchema.optional(),
   })
   .meta({ ref: "DenDesktopConfig" });
 
@@ -395,18 +474,27 @@ export function normalizeDefaultDesktopPolicyValue(
   ) as Required<DesktopPolicyValue>;
 }
 
+function normalizeAllowedBrowserHostsField(value: unknown): string[] | undefined {
+  const coerced = coerceJsonRecord(value);
+  return isRecord(coerced)
+    ? normalizeAllowedBrowserHosts(coerced.allowedBrowserHosts)
+    : undefined;
+}
+
 export function normalizeDesktopPolicyDocument(
   value: unknown,
 ): DesktopPolicyDocument {
   const coerced = coerceJsonRecord(value);
   const policy = normalizeDesktopPolicyValue(coerced);
   const onboardingPromptConfig = normalizeOnboardingPromptConfig(coerced);
+  const allowedBrowserHosts = normalizeAllowedBrowserHostsField(coerced);
 
   const access = normalizeTeamAccess(coerced);
   return {
     ...policy,
     ...(access !== undefined ? { access } : {}),
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
+    ...(allowedBrowserHosts !== undefined ? { allowedBrowserHosts } : {}),
   };
 }
 
@@ -423,6 +511,8 @@ export function normalizeDesktopPolicyDocumentWrite(
     rawDescriptions,
     onboardingPrompts?.length,
   );
+  const rawHosts = raw?.allowedBrowserHosts;
+  const allowedBrowserHosts = normalizeAllowedBrowserHosts(rawHosts);
 
   const access = normalizeTeamAccess(coerced);
   return {
@@ -438,6 +528,12 @@ export function normalizeDesktopPolicyDocumentWrite(
       : onboardingPromptDescriptions !== undefined
         ? { onboardingPromptDescriptions }
         : {}),
+    // An empty list clears the allowlist the same way `null` does.
+    ...(rawHosts === null || (Array.isArray(rawHosts) && allowedBrowserHosts === undefined)
+      ? { allowedBrowserHosts: null }
+      : allowedBrowserHosts !== undefined
+        ? { allowedBrowserHosts }
+        : {}),
   };
 }
 
@@ -445,6 +541,7 @@ export function resolveDesktopPolicyDocumentWrite(input: {
   value: unknown;
   existingPolicy?: unknown;
   isDefault?: boolean;
+  /** Keep optional fields (prompts, browser allowlist) the write omits. */
   preserveExistingOnboardingPrompts?: boolean;
 }): DesktopPolicyDocument {
   const write = normalizeDesktopPolicyDocumentWrite(input.value);
@@ -454,6 +551,11 @@ export function resolveDesktopPolicyDocumentWrite(input: {
   const existingDocument = input.preserveExistingOnboardingPrompts === true
     ? normalizeDesktopPolicyDocument(input.existingPolicy ?? {})
     : undefined;
+  const allowedBrowserHosts = Array.isArray(write.allowedBrowserHosts)
+    ? write.allowedBrowserHosts
+    : write.allowedBrowserHosts === undefined
+      ? existingDocument?.allowedBrowserHosts
+      : undefined;
   const onboardingPrompts = Array.isArray(write.onboardingPrompts)
     ? write.onboardingPrompts
     : write.onboardingPrompts === undefined &&
@@ -484,6 +586,7 @@ export function resolveDesktopPolicyDocumentWrite(input: {
     ...(onboardingPromptDescriptions !== undefined
       ? { onboardingPromptDescriptions }
       : {}),
+    ...(allowedBrowserHosts !== undefined ? { allowedBrowserHosts } : {}),
   };
 }
 
@@ -493,12 +596,14 @@ export function normalizeDefaultDesktopPolicyDocument(
   const coerced = coerceJsonRecord(value);
   const policy = normalizeDefaultDesktopPolicyValue(coerced);
   const onboardingPromptConfig = normalizeOnboardingPromptConfig(coerced);
+  const allowedBrowserHosts = normalizeAllowedBrowserHostsField(coerced);
 
   const access = normalizeTeamAccess(coerced);
   return {
     ...policy,
     ...(access !== undefined ? { access } : {}),
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
+    ...(allowedBrowserHosts !== undefined ? { allowedBrowserHosts } : {}),
   };
 }
 
@@ -515,8 +620,11 @@ export function calculateEffectiveDesktopPolicy(input: {
   defaultPolicy?: unknown;
   assignedPolicies: unknown[];
 }): Required<DesktopPolicyValue> {
+  // Before an organization writes any policy every item sits at its catalog
+  // default: allow-style items are on, opt-in items such as importing browser
+  // logins stay off until an administrator turns them on.
   if (input.orgPolicyCount === 0) {
-    return allDesktopPolicies(true);
+    return { ...desktopPolicyDefaults };
   }
 
   const calculated = allDesktopPolicies(false);
@@ -547,6 +655,32 @@ export function calculateEffectiveDesktopPolicy(input: {
   }
 
   return calculated;
+}
+
+/**
+ * Effective browser allowlist for one member. Like the boolean keys this is a
+ * union of grants: the default policy decides whether the browser is
+ * restricted at all, and every matching targeted policy can only add hosts.
+ * `undefined` means every website is allowed.
+ */
+export function calculateEffectiveAllowedBrowserHosts(input: {
+  orgPolicyCount: number;
+  defaultPolicy?: unknown;
+  assignedPolicies: unknown[];
+}): string[] | undefined {
+  if (input.orgPolicyCount === 0) return undefined;
+
+  const defaultHosts = normalizeAllowedBrowserHostsField(input.defaultPolicy ?? {});
+  if (defaultHosts === undefined) return undefined;
+
+  const hosts = new Set(defaultHosts);
+  for (const policy of input.assignedPolicies) {
+    for (const host of normalizeAllowedBrowserHostsField(policy) ?? []) {
+      hosts.add(host);
+    }
+  }
+
+  return hosts.has(ALLOWED_BROWSER_HOST_ANY) ? undefined : [...hosts];
 }
 
 export type DesktopPolicyPromptCandidate = {
@@ -656,6 +790,7 @@ export function normalizeDesktopConfig(value: unknown): DesktopConfig {
   const connectEnabled =
     typeof raw?.connectEnabled === "boolean" ? raw.connectEnabled : undefined;
   const onboardingPromptConfig = normalizeOnboardingPromptConfig(raw);
+  const allowedBrowserHosts = normalizeAllowedBrowserHosts(raw?.allowedBrowserHosts);
 
   return {
     ...policy,
@@ -668,5 +803,6 @@ export function normalizeDesktopConfig(value: unknown): DesktopConfig {
     ...(dashboardEnabled !== undefined ? { dashboardEnabled } : {}),
     ...(connectEnabled !== undefined ? { connectEnabled } : {}),
     ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
+    ...(allowedBrowserHosts !== undefined ? { allowedBrowserHosts } : {}),
   };
 }


### PR DESCRIPTION
## Status — Superseded as a browser-task prerequisite

The refreshed #4468 no longer consumes this proposed API. Merged #4564 already supplies server-owned execution.browserOrigins with exact-origin matching, intersected restrictions and upload enforcement. Restoring the older allowedBrowserHosts host/union semantics would create a conflicting policy system.

#4468 also removes the old one-time login importer. It uses direct sign-in in the built-in tab or the separately approved login-sync feature merged in #4452, preserving its native consent and managed-desktop restrictions. Therefore allowBrowserLoginImport is not required by the completed browser-task path.

**Do not merge or deploy this stale API branch as a dependency of #4468.** No replacement API or migration is required for that path. This PR remains open for the owner to decide its disposition; it has not been closed or otherwise changed beyond this status description.

## Historical verification — not current readiness

The original API candidate at 119199ada22fcb8f88e7ae1f558659d2fe8753b6 had five passed compatibility assertions. That evidence does not validate the newer conflicting branch against current dev and is not a current readiness claim. Its previously proposed API-first rollout plan is superseded by the integration decision above.