### PR TITLE
Offer connector setup and the full quick-add catalog in chat

### DIFF
--- a/apps/app/src/components/chat/connector-catalog.tsx
+++ b/apps/app/src/components/chat/connector-catalog.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useState } from "react"
+import { ArrowUpRight, Search } from "lucide-react"
+import type { ConnectorCatalog } from "@openwork/types/connection-action-app"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { openDesktopUrl } from "@/app/lib/desktop"
+import { readDenSettings } from "@/app/lib/den"
+import { useCloudSession } from "@/react-app/domains/settings/cloud/cloud-session-provider"
+import { isConnectAdminRole } from "@/react-app/domains/settings/connect-cloud-readiness"
+import { libraryConnectorIconUrls } from "@/react-app/domains/settings/library-connector-cues"
+import { useMessageList } from "./message-list-provider"
+
+const SETUP_LABELS: Record<ConnectorCatalog["entries"][number]["setup"], string> = {
+  oauth: "Sign in", oauth_client: "Admin setup", api_key: "API key", instant: "Ready to add", suite: "Guided setup",
+}
+
+function ConnectorIcon({ entry }: { entry: ConnectorCatalog["entries"][number] }) {
+  const [failed, setFailed] = useState(false)
+  const icon = libraryConnectorIconUrls({ id: entry.id, name: entry.name, serviceUrl: entry.serviceUrl, iconSlug: entry.id })[0]
+  return <span aria-hidden="true" className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-xs font-medium">
+    {icon && !failed ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setFailed(true)} /> : entry.name.charAt(0)}
+  </span>
+}
+
+export function ConnectorCatalogCard({ catalog }: { catalog: ConnectorCatalog }) {
+  const [showAll, setShowAll] = useState(catalog.selectedIds.length === 0)
+  const [query, setQuery] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const session = useCloudSession()
+  const { connectorIdentities } = useMessageList()
+  const canManage = isConnectAdminRole(session.activeOrganization?.role)
+  const entries = catalog.entries.filter(entry => (showAll || catalog.selectedIds.includes(entry.id)) && `${entry.name} ${entry.description}`.toLowerCase().includes(query.toLowerCase()))
+  const setup = async (entry: ConnectorCatalog["entries"][number]) => {
+    if (!canManage) return
+    setError(null)
+    try {
+      const expected = new URL("/dashboard/mcp-connections", readDenSettings().baseUrl)
+      expected.searchParams.set("quickAdd", entry.id)
+      // The model cannot supply a new setup destination or extra query parameters.
+      if (entry.setupUrl !== expected.toString()) throw new Error("Your OpenWork server changed. Search for this connector again.")
+      await openDesktopUrl(expected.toString())
+    } catch (cause) { setError(cause instanceof Error ? cause.message : "Could not open setup.") }
+  }
+  return <section data-testid="connector-catalog" aria-label="Quick-add connectors" className="w-full max-w-md rounded-xl bg-muted/30 p-3">
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <p className="text-xs font-medium">{showAll ? "Quick-add connectors" : "Suggested connector"}</p>
+      {!showAll ? <Button variant="ghost" size="sm" className="h-6 px-1.5 text-xs text-muted-foreground" onClick={() => setShowAll(true)}>Browse all {catalog.entries.length}</Button> : <span className="text-xs text-muted-foreground">{catalog.entries.length} available</span>}
+    </div>
+    {showAll ? <div className="relative mb-2"><Search className="pointer-events-none absolute left-2 top-2 size-3.5 text-muted-foreground" /><Input aria-label="Filter connectors" value={query} onChange={event => setQuery(event.target.value)} placeholder="Find a connector…" className="h-8 border-0 bg-background/70 pl-7 text-xs shadow-none" /></div> : null}
+    <div className="max-h-80 overflow-y-auto">
+      {entries.map(entry => {
+        const added = Boolean(entry.serviceUrl && connectorIdentities.some(identity => identity.serviceUrl === entry.serviceUrl))
+        return <div key={entry.id} data-connector-preset={entry.id} className="flex items-center gap-2.5 rounded-lg px-1 py-2">
+          <ConnectorIcon entry={entry} />
+          <div className="min-w-0 flex-1"><p className="truncate text-[13px] font-medium">{entry.name}</p><p className="text-[11px] text-muted-foreground">{added ? "Added to your organization" : SETUP_LABELS[entry.setup]}</p></div>
+          {!added ? <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs" disabled={!canManage} onClick={() => void setup(entry)} aria-label={`Set up ${entry.name}`}>Set up<ArrowUpRight className="size-3.5 text-muted-foreground" /></Button> : null}
+        </div>
+      })}
+      {entries.length === 0 ? <p className="py-3 text-xs text-muted-foreground">No connectors match your search.</p> : null}
+    </div>
+    <p className="mt-2 text-[11px] text-muted-foreground">{canManage ? "Setup opens in organization settings." : "An organization admin can add these connectors for you."}</p>
+    {error ? <p role="alert" className="mt-2 text-xs text-destructive">{error}</p> : null}
+  </section>
+}

--- a/apps/app/src/components/chat/connector-catalog.tsx
+++ b/apps/app/src/components/chat/connector-catalog.tsx
@@ -18,10 +18,16 @@ const SETUP_LABELS: Record<ConnectorCatalog["entries"][number]["setup"], string>
 }
 
 function ConnectorIcon({ entry }: { entry: ConnectorCatalog["entries"][number] }) {
-  const [failed, setFailed] = useState(false)
-  const icon = libraryConnectorIconUrls({ id: entry.id, name: entry.name, serviceUrl: entry.serviceUrl, iconSlug: entry.id })[0]
+  const [iconIndex, setIconIndex] = useState(0)
+  const icons = libraryConnectorIconUrls({
+    id: entry.id, name: entry.name, serviceUrl: entry.serviceUrl,
+    iconSrc: entry.id === "google-workspace" ? "/ext-google-workspace.svg" : undefined,
+    iconSlug: entry.id === "microsoft-365" ? "microsoft365" : entry.id,
+    faviconDomain: entry.id === "microsoft-365" ? "microsoft.com" : undefined,
+  })
+  const icon = icons[iconIndex]
   return <span aria-hidden="true" className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-xs font-medium">
-    {icon && !failed ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setFailed(true)} /> : entry.name.charAt(0)}
+    {icon ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setIconIndex(index => index + 1)} /> : entry.name.charAt(0)}
   </span>
 }
 
@@ -62,7 +68,7 @@ export function ConnectorCatalogCard({ catalog }: { catalog: ConnectorCatalog })
     {showAll ? <div className="relative mb-2"><Search className="pointer-events-none absolute left-2 top-2 size-3.5 text-muted-foreground" /><Input aria-label="Filter connectors" value={query} onChange={event => setQuery(event.target.value)} placeholder="Find a connector…" className="h-8 border-0 bg-background/70 pl-7 text-xs shadow-none" /></div> : null}
     <div className="max-h-80 overflow-y-auto">
       {entries.map(entry => {
-        const added = Boolean(entry.serviceUrl && connectorIdentities.some(identity => identity.serviceUrl === entry.serviceUrl))
+        const added = Boolean(entry.serviceUrl && connectorIdentities.some(identity => identity.connectionId && identity.serviceUrl === entry.serviceUrl))
         return <div key={entry.id} data-connector-preset={entry.id} className="flex items-center gap-2.5 rounded-lg px-1 py-2">
           <ConnectorIcon entry={entry} />
           <div className="min-w-0 flex-1"><p className="truncate text-[13px] font-medium">{entry.name}</p><p className="text-[11px] text-muted-foreground">{added ? "Added to your organization" : SETUP_LABELS[entry.setup]}</p></div>

--- a/apps/app/src/components/chat/connector-catalog.tsx
+++ b/apps/app/src/components/chat/connector-catalog.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { ArrowUpRight, Search } from "lucide-react"
 import type { ConnectorCatalog } from "@openwork/types/connection-action-app"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { openDesktopUrl } from "@/app/lib/desktop"
-import { readDenSettings } from "@/app/lib/den"
-import { useCloudSession } from "@/react-app/domains/settings/cloud/cloud-session-provider"
+import { createDenClient, readDenSettings } from "@/app/lib/den"
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
 import { isConnectAdminRole } from "@/react-app/domains/settings/connect-cloud-readiness"
 import { libraryConnectorIconUrls } from "@/react-app/domains/settings/library-connector-cues"
 import { useMessageList } from "./message-list-provider"
@@ -28,9 +29,19 @@ export function ConnectorCatalogCard({ catalog }: { catalog: ConnectorCatalog })
   const [showAll, setShowAll] = useState(catalog.selectedIds.length === 0)
   const [query, setQuery] = useState("")
   const [error, setError] = useState<string | null>(null)
-  const session = useCloudSession()
+  const auth = useDenAuth()
+  const settings = readDenSettings()
+  const identity = auth.verifiedIdentity
+  const role = useQuery({
+    queryKey: ["connector-catalog-role", settings.baseUrl, identity?.principalId, identity?.organizationId],
+    enabled: auth.isSignedIn && Boolean(identity),
+    queryFn: async () => {
+      const result = await createDenClient({ baseUrl: settings.baseUrl, token: settings.authToken }).listOrgs()
+      return result.orgs.find(org => org.id === identity?.organizationId)?.role ?? null
+    },
+  })
   const { connectorIdentities } = useMessageList()
-  const canManage = isConnectAdminRole(session.activeOrganization?.role)
+  const canManage = auth.isSignedIn && isConnectAdminRole(role.data)
   const entries = catalog.entries.filter(entry => (showAll || catalog.selectedIds.includes(entry.id)) && `${entry.name} ${entry.description}`.toLowerCase().includes(query.toLowerCase()))
   const setup = async (entry: ConnectorCatalog["entries"][number]) => {
     if (!canManage) return

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -6,6 +6,8 @@ import { AppBridge, PostMessageTransport } from "@modelcontextprotocol/ext-apps/
 import type { McpUiStyles, McpUiStyleVariableKey } from "@modelcontextprotocol/ext-apps"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 
+import { connectorCatalogSchema } from "@openwork/types/connection-action-app"
+import { ConnectorCatalogCard } from "./connector-catalog"
 import { ConnectionCard } from "./connection-card"
 import { reconnectActionFromChatToolResult } from "@/components/tools/error-attribution"
 import { AppChatArtifact } from "@/react-app/domains/apps/app-chat-artifact"
@@ -79,7 +81,19 @@ function preservedResult(part: DynamicToolUIPart): PreservedMcpAppResult | null 
 }
 
 export function hasPreservedMcpAppResult(part: DynamicToolUIPart): boolean {
-  return preservedResult(part) !== null
+  return preservedResult(part) !== null || connectorCatalogFromPart(part) !== null
+}
+
+export function connectorCatalogFromPart(part: DynamicToolUIPart) {
+  if (part.toolName !== "openwork-cloud_search_capabilities" || part.state !== "output-available") return null
+  let value: unknown = preservedResult(part)?.structuredContent ?? part.output
+  if (typeof value === "string") {
+    if (value.length > 128 * 1024) return null
+    try { value = JSON.parse(value) } catch { return null }
+  }
+  if (!isRecord(value)) return null
+  const parsed = connectorCatalogSchema.safeParse(value.connectorCatalog)
+  return parsed.success ? parsed.data : null
 }
 
 export function gatewayMcpAppLaunch(meta: unknown): OpenworkMcpAppLaunchReference | null {
@@ -564,6 +578,8 @@ export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const result = preservedResult(part)
   const action = reconnectActionFromChatToolResult(part.toolName, result?.structuredContent ?? part.output)
   if (action) return <ConnectionCard part={part} action={action} />
+  const catalog = connectorCatalogFromPart(part)
+  if (catalog) return <ConnectorCatalogCard catalog={catalog} />
   return <EmbeddedMcpAppFrame part={part} />
 }
 

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -9,6 +9,8 @@ import {
 import { formatMcpAppDiagnostic, safeMcpAppDiagnosticMessage } from "../src/components/chat/mcp-app-diagnostics"
 import {
   buildMcpAppCsp,
+  connectorCatalogFromPart,
+  hasPreservedMcpAppResult,
   gatewayMcpAppLaunch,
   isActionableMcpAppResolutionError,
   secureMcpAppHtml,
@@ -164,3 +166,14 @@ describe("MCP App iframe policy", () => {
     expect(csp).toContain("frame-src https://embed.example.com")
   })
 })
+
+
+test("only canonical completed gateway search results render connector setup suggestions", () => {
+  const catalog = { version: 1, selectedIds: ["slack"], entries: [{ id: "slack", name: "Slack", description: "Work chat", setup: "oauth_client", setupUrl: "https://example.com/dashboard/mcp-connections?quickAdd=slack" }] };
+  const part = { type: "dynamic-tool", toolName: "openwork-cloud_search_capabilities", toolCallId: "catalog", state: "output-available", input: { query: "Slack" }, output: JSON.stringify({ connectorCatalog: catalog }) } satisfies import("ai").DynamicToolUIPart;
+  expect(connectorCatalogFromPart(part)).toEqual(catalog);
+  expect(hasPreservedMcpAppResult(part)).toBe(true);
+  expect(connectorCatalogFromPart({ ...part, toolName: "other_search_capabilities" })).toBeNull();
+  expect(connectorCatalogFromPart({ ...part, output: "invalid json" })).toBeNull();
+  expect(connectorCatalogFromPart({ ...part, output: { connectorCatalog: { ...catalog, version: 2 } } })).toBeNull();
+});

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -13,6 +13,8 @@ import { openworkCloudMcpConnectionActionSchema } from "@openwork/types/den/mcp-
 import type { Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
 import { z } from "zod"
+import { connectorCatalogSchema, type ConnectorCatalog } from "@openwork/types/connection-action-app"
+import { connectorCatalogForQuery } from "./connector-catalog.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
@@ -110,7 +112,7 @@ export type { ExecuteCapabilityToolResult }
 
 export { EXECUTE_CAPABILITY_TOOL_NAME }
 export const EXECUTE_CAPABILITY_SCRIPT_TOOL_NAME = "execute_capability_script"
-const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
+const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills", "connectors"])
 export const EXECUTE_CAPABILITY_TIMEOUT_MS = 180_000
 
 export const SEARCH_CAPABILITIES_ANNOTATIONS: ToolAnnotations = {
@@ -164,10 +166,12 @@ const capabilityMatchOutputSchema = z.object({
 export const SEARCH_CAPABILITIES_OUTPUT_SCHEMA = z.object({
   matches: z.array(capabilityMatchOutputSchema),
   connectionAction: connectionActionPayloadSchema.optional(),
+  connectorCatalog: connectorCatalogSchema.optional(),
   hint: z.string().optional(),
 })
 
 export const AGENT_MCP_INSTRUCTIONS = [
+  "When asked what can be connected or to browse quick adds, call search_capabilities with type connectors and any descriptive query. This returns the complete curated setup catalog, including Google Workspace and Microsoft 365. A named-service search also includes matching setup suggestions. Suggestions are not executable capabilities or proof of connection; let the user choose Set up in the card. Never invent credentials or claim setup is finished. Existing connection actions take priority.",
   "This OpenWork Cloud MCP server uses standard MCP tools, resources, structured results, and list-changed notifications.",
   "Always call search_capabilities first with 2-4 keyword variants before concluding something is unavailable. Use execute_capability only with exact names returned by search_capabilities. A successful search_capabilities call proves this connection is authorized: Never tell the user to reconnect OpenWork Cloud because a downstream connector failed.",
   "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added. Allowlisted platform admins also discover namespaced OpenWork Admin capabilities here; other members cannot.",
@@ -232,9 +236,9 @@ function textContent(text: string): { text: string; type: "text" }[] {
   return [{ type: "text", text }]
 }
 
-export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T[], coverageHint?: string) {
+export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T[], coverageHint?: string, connectorCatalog?: ConnectorCatalog | null) {
   const hint = [
-    ...(matches.length === 0 ? ["No matches. Try broader or different keywords."] : []),
+    ...(matches.length === 0 ? [connectorCatalog ? "These are setup suggestions, not connected tools. Use their setup actions; adding a connector requires an organization admin." : "No matches. Try broader or different keywords."] : []),
     ...(coverageHint ? [coverageHint] : []),
   ].join(" ")
   const card = connectionActionSearchCard(matches)
@@ -242,6 +246,7 @@ export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T
     matches,
     ...(hint ? { hint } : {}),
     ...(card ? { connectionAction: card.connectionAction } : {}),
+    ...(connectorCatalog ? { connectorCatalog } : {}),
   }
   return {
     content: textContent(JSON.stringify(result, null, 2)),
@@ -547,15 +552,16 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         inputSchema: z.object({
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
           limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
-          type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every available source; api searches Den API capabilities; admin searches allowlisted platform-admin tools; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches built-in and marketplace skills. Defaults to all."),
+          type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every available source; api searches Den API capabilities; admin searches allowlisted platform-admin tools; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches built-in and marketplace skills; connectors lists the entire quick-add setup catalog without probing connected tools. Defaults to all."),
         }),
         outputSchema: SEARCH_CAPABILITIES_OUTPUT_SCHEMA,
       },
       async ({ query, limit, type }) => {
+        if (type === "connectors") return capabilitySearchToolResult([], undefined, connectorCatalogForQuery(query, true))
         const boundedLimit = limit ?? 5
         const result = await searchCapabilityRegistry(capabilityContext, { query, limit: boundedLimit, type })
         const matches = result.matches.sort(compareCapabilityMatches).slice(0, boundedLimit)
-        return capabilitySearchToolResult(matches, result.externalCoverageHint)
+        return capabilitySearchToolResult(matches, result.externalCoverageHint, (type === undefined || type === "all" || type === "mcp") && !matches.some(match => match.name.startsWith("mcp:")) ? connectorCatalogForQuery(query) : null)
       },
     )
 

--- a/ee/apps/den-api/src/mcp/connector-catalog.ts
+++ b/ee/apps/den-api/src/mcp/connector-catalog.ts
@@ -1,0 +1,27 @@
+import { connectorCatalogSchema, type ConnectorCatalog } from "@openwork/types/connection-action-app"
+import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
+import { openworkOrganizationConnectionsUrl } from "./connection-navigation.js"
+
+export function connectorCatalogForQuery(query: string, showAll = false): ConnectorCatalog | null {
+  const setupUrl = (id: string) => {
+    const url = new URL(openworkOrganizationConnectionsUrl())
+    url.searchParams.set("quickAdd", id)
+    return url.toString()
+  }
+  const entries: ConnectorCatalog["entries"] = [
+    { id: "google-workspace", name: "Google Workspace", description: "Gmail, Calendar, and Drive with your work account.", setup: "suite", setupUrl: setupUrl("google-workspace") },
+    { id: "microsoft-365", name: "Microsoft 365", description: "Outlook, Calendar, and OneDrive with your work account.", setup: "suite", setupUrl: setupUrl("microsoft-365") },
+    ...EXTERNAL_MCP_PRESETS.map(preset => ({
+      id: preset.presetId,
+      name: preset.displayName,
+      description: preset.description,
+      serviceUrl: preset.url,
+      setup: preset.requiresOAuthClient ? "oauth_client" : preset.authType === "apikey" ? "api_key" : preset.authType === "none" ? "instant" : "oauth",
+      setupUrl: setupUrl(preset.presetId),
+    } satisfies ConnectorCatalog["entries"][number])),
+  ]
+  const normalized = ` ${query.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()} `
+  const selectedIds = entries.filter(entry => [entry.id, entry.name].some(value => normalized.includes(` ${value.toLowerCase().replace(/[^a-z0-9]+/g, " ")} `))).map(entry => entry.id)
+  if (!showAll && selectedIds.length === 0 && !/\b(connectors?|integrations?|quick adds?|quick connect)\b/.test(normalized)) return null
+  return connectorCatalogSchema.parse({ version: 1, entries, selectedIds: showAll ? [] : selectedIds })
+}

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -119,7 +119,7 @@ test("agent MCP server exposes steering instructions during initialize", async (
   expect(client.getInstructions()).toContain("Use create_skill")
   expect(client.getInstructions()).toContain("do not route these flows through execute_capability, postPlugins, or postConfigObjectsVersions")
   expect(client.getInstructions()).toContain("update_skill to publish a new immutable version")
-  expect(client.getInstructions()).toContain("execute that exact match once: it returns the live status and renders an actionable connection card")
+  expect(client.getInstructions()).toContain("Do not execute the same status again when the search response includes connectionAction")
   expect(client.getInstructions()).toContain("create-skill")
   expect(client.getInstructions()).toContain("share-plugin")
   expect(client.getInstructions()).toContain("add-to-marketplace")
@@ -512,3 +512,21 @@ test("connection status only outranks equally relevant callable tools", () => {
   expect(matches[0]?.kind).toBe("connection_status")
   expect(matches[0]?.score).toBe(20)
 })
+
+
+test("connector discovery includes every preset and separates setup suggestions from tools", async () => {
+  const { connectorCatalogForQuery } = await import("../src/mcp/connector-catalog.js");
+  const { EXTERNAL_MCP_PRESETS } = await import("../src/capability-sources/external-mcp-presets.js");
+  const catalog = connectorCatalogForQuery("Please connect Slack");
+  expect(catalog?.selectedIds).toEqual(["slack"]);
+  expect(catalog?.entries.map(entry => entry.id)).toEqual(["google-workspace", "microsoft-365", ...EXTERNAL_MCP_PRESETS.map(preset => preset.presetId)]);
+  expect(catalog?.entries.find(entry => entry.id === "slack")?.setup).toBe("oauth_client");
+  expect(connectorCatalogForQuery("slacker")).toBeNull();
+  expect(connectorCatalogForQuery("write a report")).toBeNull();
+  expect(connectorCatalogForQuery("all quick adds")?.selectedIds).toEqual([]);
+  expect(connectorCatalogForQuery("Slack", true)?.selectedIds).toEqual([]);
+  const result = agentModule.capabilitySearchToolResult([], undefined, catalog);
+  expect(result.structuredContent.connectorCatalog).toEqual(catalog);
+  expect(result.structuredContent.hint).toContain("not connected tools");
+  for (const entry of catalog?.entries ?? []) expect(new URL(entry.setupUrl).searchParams.get("quickAdd")).toBe(entry.id);
+});

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -30,6 +30,10 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(await visibleIds()).toEqual([]);
   await appUser.type({ role: "textbox", label: "Filter connectors" }, "slack", { replace: true });
   expect(await visibleIds()).toEqual(["slack"]);
+  await probe.eventually(
+    () => appProbe.eval(`document.querySelector('button[aria-label="Set up Slack"]')?.disabled === false`),
+    { within: 15_000, label: "admin setup action is enabled", until: value => value === true },
+  );
   await appUser.click({ role: "button", label: "Set up Slack" });
   await appUser.notSee({ role: "alert" });
 

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -23,6 +23,7 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.click({ role: "button", label: `Browse all ${world.expectedIds.length}` });
   await appUser.see({ role: "textbox", label: "Filter connectors" });
   expect(await visibleIds()).toEqual(world.expectedIds);
+  await appUser.see({ role: "button", label: "Set up Linear" });
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Browse all includes the complete Den preset catalog and both productivity suites", JSON.stringify(world.expectedIds), true);
   await appUser.type({ role: "textbox", label: "Filter connectors" }, "no such connector", { replace: true });
@@ -49,13 +50,14 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
+  await appUser.click({ role: "button", label: "New task" });
   await agent.on(world.app).send(allConnectorsPrompt);
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
   const listed = await appProbe.eval(`(() => {
     const cards = Array.from(document.querySelectorAll('[data-testid="connector-catalog"]'));
-    return { count: cards.length, ids: Array.from(cards.at(-1)?.querySelectorAll('[data-connector-preset]') ?? [], entry => entry.getAttribute('data-connector-preset')) };
+    return Array.from(cards.at(-1)?.querySelectorAll('[data-connector-preset]') ?? [], entry => entry.getAttribute('data-connector-preset'));
   })()`);
-  expect(listed).toEqual({ count: 2, ids: world.expectedIds });
+  expect(listed).toEqual(world.expectedIds);
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);
   evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Slack quickAdd deep link renders client fields; the agent only searched and did not execute setup or authorize an account", true);

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -51,6 +51,7 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
   await appUser.click({ role: "button", label: "New task" });
+  await appUser.see({ text: "Try one of these:" });
   await agent.on(world.app).send(allConnectorsPrompt);
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
   const listed = await appProbe.eval(`(() => {

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { allConnectorsPrompt, allConnectorsReply, connectorCatalogDiscovery, connectorCatalogPrompt, connectorCatalogReply } from "../worlds/library.ts";
+
+const test = spec.world(connectorCatalogDiscovery, { timeout: 600_000 });
+
+test("chat suggests Slack setup and lets an admin browse every quick-add connector", async ({ world, agent, user, probe, evidence }) => {
+  const appUser = user.on(world.app);
+  const appProbe = probe.on(world.app);
+  const webUser = user.on(world.web);
+  expect(connectorCatalogPrompt).not.toContain(world.connection.id);
+  await agent.on(world.app).send(connectorCatalogPrompt);
+  await appUser.see({ text: connectorCatalogReply }, { timeoutMs: 120_000 });
+  await appUser.see({ testId: "connector-catalog" });
+  await appUser.see({ role: "button", label: "Set up Slack" });
+  await appUser.see({ text: "Admin setup" });
+  await appUser.notSee({ testId: "desktop-connection-card" });
+  const visibleIds = () => appProbe.eval(`Array.from(document.querySelectorAll('[data-connector-preset]'), element => element.getAttribute('data-connector-preset'))`);
+  expect(await visibleIds()).toEqual(["slack"]);
+  await appUser.screenshot();
+  evidence.recordAssertionEvidence("A Slack request offers setup without claiming the service is connected", "Only Slack is suggested with Admin setup; no account connection card is shown", true);
+
+  await appUser.click({ role: "button", label: `Browse all ${world.expectedIds.length}` });
+  await appUser.see({ role: "textbox", label: "Filter connectors" });
+  expect(await visibleIds()).toEqual(world.expectedIds);
+  await appUser.screenshot();
+  evidence.recordAssertionEvidence("Browse all includes the complete Den preset catalog and both productivity suites", JSON.stringify(world.expectedIds), true);
+  await appUser.type({ role: "textbox", label: "Filter connectors" }, "no such connector", { replace: true });
+  await appUser.see({ text: "No connectors match your search." });
+  expect(await visibleIds()).toEqual([]);
+  await appUser.type({ role: "textbox", label: "Filter connectors" }, "slack", { replace: true });
+  expect(await visibleIds()).toEqual(["slack"]);
+  await appUser.click({ role: "button", label: "Set up Slack" });
+  await appUser.notSee({ role: "alert" });
+
+  // Continue the external-browser handoff in the signed-in browser surface.
+  const setupUrl = new URL("/dashboard/mcp-connections", world.den.ref.webUrl);
+  setupUrl.searchParams.set("quickAdd", "slack");
+  await webUser.navigate(setupUrl.toString());
+  await webUser.see({ text: "OAuth app" }, { timeoutMs: 90_000 });
+  await webUser.see({ text: "Client ID (optional for now)" });
+  await webUser.see({ text: "Client secret (optional for now)" });
+  await webUser.screenshot();
+  const calls = await world.den.mocks.connector.agentRequests({ promptMarker: connectorCatalogPrompt });
+  expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);
+  expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
+  expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
+  await agent.on(world.app).send(allConnectorsPrompt);
+  await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
+  const listed = await appProbe.eval(`(() => {
+    const cards = Array.from(document.querySelectorAll('[data-testid="connector-catalog"]'));
+    return { count: cards.length, ids: Array.from(cards.at(-1)?.querySelectorAll('[data-connector-preset]') ?? [], entry => entry.getAttribute('data-connector-preset')) };
+  })()`);
+  expect(listed).toEqual({ count: 2, ids: world.expectedIds });
+  await appUser.screenshot();
+  evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);
+  evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Slack quickAdd deep link renders client fields; the agent only searched and did not execute setup or authorize an account", true);
+});

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -893,6 +893,11 @@ export const connectionActionResourceUri = "ui://openwork/connection-action/v1/v
 export const connectionActionReply = "Connect your Notion account to continue.";
 export const connectionActionPrompt = "I want to connect Notion.";
 
+export const allConnectorsPrompt = "Show me all the quick-add connectors.";
+export const allConnectorsReply = "Here are all the connectors available to add.";
+export const connectorCatalogPrompt = "I want to set up Slack.";
+export const connectorCatalogReply = "Choose Slack to set it up, or browse the available connectors.";
+
 export async function connectionActionMcpApp(seed: Seed) {
   const providerId = "connection-action-mcp-app-provider";
   const modelId = "connection-action-mcp-app-model";
@@ -903,6 +908,14 @@ export async function connectionActionMcpApp(seed: Seed) {
         promptMarker: connectionActionPrompt,
         finalReply: connectionActionReply,
         steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp" } }],
+      }, {
+        promptMarker: connectorCatalogPrompt,
+        finalReply: connectorCatalogReply,
+        steps: [{ tool: "search_capabilities", arguments: { query: "Slack", type: "mcp" } }],
+      }, {
+        promptMarker: allConnectorsPrompt,
+        finalReply: allConnectorsReply,
+        steps: [{ tool: "search_capabilities", arguments: { query: "quick add connectors", type: "connectors" } }],
       }] }),
     },
   });
@@ -1320,4 +1333,16 @@ export async function remoteMcpApps(seed: Seed) {
     await rm(profileDir, { recursive: true, force: true });
     throw error;
   }
+}
+
+export async function connectorCatalogDiscovery(seed: Seed) {
+  const world = await connectionActionMcpApp(seed);
+  const response = await seed.api(world.den.admin, "/v1/mcp-connections/presets");
+  if (!isRecord(response.body) || !Array.isArray(response.body.presets)) throw new Error("Den did not return its connector presets.");
+  const presetIds = response.body.presets.map((preset: unknown) => {
+    if (!isRecord(preset) || typeof preset.presetId !== "string") throw new Error("Invalid connector preset.");
+    return preset.presetId;
+  });
+  const web = await seed.web({ den: world.den, signedInAs: world.den.admin, startPath: "/dashboard/mcp-connections", headless: true });
+  return { ...world, web, expectedIds: ["google-workspace", "microsoft-365", ...presetIds] };
 }

--- a/packages/types/src/connection-action-app.ts
+++ b/packages/types/src/connection-action-app.ts
@@ -49,3 +49,18 @@ export const connectionActionPayloadSchema = z.object({
 })
 
 export type ConnectionActionPayload = z.infer<typeof connectionActionPayloadSchema>
+
+/** Curated setup suggestions, distinct from connected/executable capabilities. */
+export const connectorCatalogSchema = z.object({
+  version: z.literal(1),
+  selectedIds: z.array(z.string()),
+  entries: z.array(z.object({
+    id: z.string().regex(/^[a-z0-9-]+$/),
+    name: z.string(),
+    description: z.string(),
+    serviceUrl: z.string().url().optional(),
+    setup: z.enum(["oauth", "oauth_client", "api_key", "instant", "suite"]),
+    setupUrl: z.string().url(),
+  })),
+})
+export type ConnectorCatalog = z.infer<typeof connectorCatalogSchema>


### PR DESCRIPTION
When someone asks to set up Slack before it has been added, chat now offers a compact setup card with **Browse all**. Asking for quick adds opens the complete catalog: every Den MCP preset plus Google Workspace and Microsoft 365, with filtering and each service’s setup requirements.

The gateway returns versioned setup suggestions separately from executable capabilities. Desktop validates the payload and setup destination, enables setup for organization admins, and opens the existing Den quick-add form. Only real organization connections receive the “Added” label. Existing account authorization cards retain priority.

Validation — Passed on `6633221802a48a91c6eab7da717507ccf51ae157`:

- `pnpm --filter @openwork/app typecheck` — passed.
- `pnpm --filter @openwork/app exec bun test tests/mcp-app-frame.test.ts tests/mcp-chat-reconnect.test.ts` — 16 passed.
- `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/mcp-agent-timeouts.test.ts` — 16 passed.
- `OPENWORK_EVAL_DAYTONA_REF=6633221802a48a91c6eab7da717507ccf51ae157 OPENWORK_EVAL_REF=6633221802a48a91c6eab7da717507ccf51ae157 pnpm evals:e2e connector-catalog --daytona` — `placement: daytona (--daytona)`; 1 passed, 0 failed, 0 skipped.

The journey verifies Slack discovery, all 12 quick adds against Den’s catalog, filtering, setup controls for unconfigured services, the Slack OAuth-client form, and an explicit full-catalog request. The external-browser continuation uses a signed-in browser fixture at the quick-add URL; it does not complete live Slack authorization. Screenshots and assertion evidence are published in the test-evidence comment.
