### PR TITLE
ci: automatically merge verified clean revert PRs

### DIFF
--- a/.github/workflows/revert-fastlane.yml
+++ b/.github/workflows/revert-fastlane.yml
@@ -1,5 +1,8 @@
 # Repository prerequisite: enable Settings → Actions → General →
-# "Allow GitHub Actions to create and approve pull requests".
+# "Allow GitHub Actions to create and approve pull requests", plus
+# Settings → General → Pull Requests → "Allow auto-merge".
+# Merging uses the existing warden-clearance App credentials so the merge
+# triggers downstream push/release workflows. Required branch rules still apply.
 # The bot approval satisfies the "someone other than the last pusher" rule because
 # this workflow's bot never pushes. For SOC 2 four-eyes, this automated control
 # inherits the original human review of the commit already landed on protected dev.
@@ -29,7 +32,7 @@ name: Revert Fast Lane
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited, ready_for_review]
     branches: [dev]
 
 permissions:
@@ -42,13 +45,17 @@ concurrency:
 
 jobs:
   verify-and-approve:
-    if: startsWith(github.event.pull_request.title, 'Revert "') && github.event.pull_request.head.repo.full_name == github.repository
+    if: startsWith(github.event.pull_request.title, 'Revert "') && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: warden-clearance
     steps:
       - name: Checkout trusted base (dev)
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch PR commits as git data
         env:
@@ -93,6 +100,7 @@ jobs:
           echo "reason=$reason" >> "$GITHUB_OUTPUT"
 
       - name: Approve verified revert
+        id: approve
         if: steps.verify.outputs.verdict == 'pass'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -121,6 +129,36 @@ jobs:
             -f event=APPROVE \
             -f body="$body" > /dev/null
           printf '## Revert Fast Lane\n\nPASS: %s\n' "$body" >> "$GITHUB_STEP_SUMMARY"
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+
+      - name: Mint merge token
+        if: steps.approve.outputs.approved == 'true'
+        id: merge-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.WARDEN_APP_ID }}
+          private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Enable automatic merge of verified revert
+        if: steps.approve.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ steps.merge-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Re-check mutable PR metadata before opting into automatic merging.
+          eligible="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq \
+            '.state == "open" and .draft == false and .base.ref == "dev" and (.title | startswith("Revert \""))')"
+          if [[ "$eligible" != "true" ]]; then
+            printf 'Automatic merge withheld: PR is no longer an open, ready revert targeting dev.\n' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --auto --squash --match-head-commit "$HEAD_SHA"
+          printf 'Automatic merge requested for verified head %s; GitHub enforces required checks and reviews.\n' "$HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record ineligible revert
         if: steps.verify.outputs.verdict != 'pass'

--- a/scripts/ci/verify-clean-revert.test.mjs
+++ b/scripts/ci/verify-clean-revert.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, test } from "node:test";
@@ -90,4 +90,68 @@ test("fails when the head message does not identify a reverted commit", () => {
   assert.equal(result.status, 1);
   assert.match(result.stdout, /FAIL head commit message has no 'This reverts commit <40-hex>' line/);
   assert.match(result.stdout, /verdict=fail/);
+});
+
+// Exercise the actual workflow shell against a fake GitHub CLI boundary. No
+// credentials or live merges are used; jq still evaluates the real API filter.
+function runAutoMerge(overrides = {}, mergeStatus = 0) {
+  const directory = mkdtempSync(resolve(tmpdir(), "revert-auto-merge-test-"));
+  tempDirs.push(directory);
+  const workflow = readFileSync(resolve(import.meta.dirname, "../../.github/workflows/revert-fastlane.yml"), "utf8");
+  const step = workflow.split("      - name: Enable automatic merge of verified revert\n")[1]
+    .split("      - name: Record ineligible revert\n")[0];
+  const shell = step.split("        run: |\n")[1].split("\n")
+    .map((line) => line.replace(/^          /, "")).join("\n");
+  const calls = resolve(directory, "calls");
+  const summary = resolve(directory, "summary");
+  writeFileSync(calls, "");
+  writeFileSync(summary, "");
+  writeFileSync(resolve(directory, "gh"), `#!/bin/bash
+set -euo pipefail
+if [[ "$1" == "api" ]]; then
+  printf '%s' "$TEST_PR" | jq -r "$4"
+else
+  printf '%s\\n' "$@" > "$TEST_CALLS"
+  exit "$TEST_MERGE_STATUS"
+fi
+`, { mode: 0o755 });
+  const result = spawnSync("bash", ["-c", shell], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH}`,
+      GITHUB_REPOSITORY: "example/repo",
+      PR_NUMBER: "123",
+      HEAD_SHA: "a".repeat(40),
+      GITHUB_STEP_SUMMARY: summary,
+      TEST_CALLS: calls,
+      TEST_MERGE_STATUS: String(mergeStatus),
+      TEST_PR: JSON.stringify({ state: "open", draft: false, base: { ref: "dev" }, title: 'Revert "change"', ...overrides }),
+    },
+  });
+  return { ...result, calls: readFileSync(calls, "utf8"), summary: readFileSync(summary, "utf8") };
+}
+
+test("automatic merge requests the verified head without an admin bypass", () => {
+  const result = runAutoMerge();
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.calls.trim().split("\n"), [
+    "pr", "merge", "123", "--repo", "example/repo", "--auto", "--squash", "--match-head-commit", "a".repeat(40),
+  ]);
+  assert.match(result.summary, /Automatic merge requested/);
+});
+
+test("automatic merge is withheld after a draft, close, retarget, or title change", () => {
+  for (const change of [{ draft: true }, { state: "closed" }, { base: { ref: "main" } }, { title: "ordinary change" }]) {
+    const result = runAutoMerge(change);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.calls, "");
+    assert.match(result.summary, /Automatic merge withheld/);
+  }
+});
+
+test("merge API rejection fails the job without claiming success", () => {
+  const result = runAutoMerge({}, 1);
+  assert.equal(result.status, 1);
+  assert.doesNotMatch(result.summary, /Automatic merge requested/);
 });


### PR DESCRIPTION
Clean revert PRs currently receive automatic approval but still need someone to request the merge. Extend Revert Fast Lane to request squash auto-merge immediately after exact-tree verification and approval, bound to the verified head SHA. GitHub's required checks and reviews still gate landing; this does not provide an emergency bypass or roll back deployments directly.

Uses the existing `warden-clearance` App credentials so merges can trigger downstream push workflows. Runs trusted base code only, ignores drafts and forks, handles title/body edits and ready-for-review events, and rechecks PR eligibility before requesting auto-merge. Conflicts and additional edits retain the normal review path.

### Validation

- `actionlint .github/workflows/revert-fastlane.yml` — passed.
- `node --test scripts/ci/verify-clean-revert.test.mjs` — 8 passed, 0 failed, 0 skipped. Includes real temporary Git repositories for exact inverses, extra edits, conflicts and ancestry; exercises the actual merge shell against a mocked GitHub CLI for eligibility, head binding and API failure.
- `git diff --check` — passed.
- Read-only repository checks confirm auto-merge and squash merges are enabled, the required tests ruleset has no bypass actors, stale approvals are dismissed, last-push approval is required, and the existing environment permits `dev`.

Overall verdict: **Incomplete**. Draft per AGENTS.md: local tests are not live GitHub journey proof. This `pull_request_target` workflow executes from the trusted base, so this PR cannot prove its new behavior before the workflow lands. No app/Den journey is affected; no unrelated product E2E was run.

Live verification after rollout: open a same-repository, non-draft `Revert "..."` PR containing an exact clean `git revert` of a non-merge ancestor of `dev`; confirm verification and approval, App-token issuance, auto-merge registration for that head, required checks before landing, and the downstream push workflow run. Confirm an extra-edit or conflicting revert does not receive automatic merge. App token permissions and downstream execution remain unverified live.

References: [GitHub CLI auto-merge and head matching](https://cli.github.com/manual/gh_pr_merge), [GitHub workflow triggering with App tokens](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow).
