### PR TITLE
ci: verify packaged Electron startup on Blacksmith

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,6 +76,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Cache Electron and pinned sidecars
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            apps/desktop/resources/sidecars
+          key: ${{ runner.os }}-${{ runner.arch }}-desktop-smoke-${{ hashFiles('constants.json', 'pnpm-lock.yaml', 'apps/desktop/scripts/prepare-sidecar.mjs') }}
       - name: Setup tests
         id: setup
         uses: ./.github/actions/setup-tests
@@ -88,6 +96,28 @@ jobs:
           pnpm --filter openwork-server build
       - name: Typecheck Electron main against the IPC contract
         run: pnpm --filter @openwork/desktop typecheck:electron
+      - name: Prepare virtual display
+        run: |
+          if ! command -v xvfb-run >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y xvfb
+          fi
+      - name: Package and smoke-test the installed desktop
+        timeout-minutes: 7
+        env:
+          OPENWORK_PACKAGED_SMOKE_DIR: ${{ runner.temp }}/openwork-packaged-smoke
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: node apps/desktop/scripts/packaged-smoke.mjs --server-built
+      - name: Upload packaged smoke evidence and timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: packaged-desktop-smoke-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/openwork-packaged-smoke/timing.json
+            ${{ runner.temp }}/openwork-packaged-smoke/profiles/**/electron.log
+            evals/results/test-runs/**
+          retention-days: 7
 
   # Broad tests, source-layout guards, and test-framework checks remain visible
   # here without blocking unrelated PRs. No retries or ignored failures.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Cache Electron and pinned sidecars
         uses: actions/cache@v5
         with:
@@ -98,9 +100,9 @@ jobs:
         run: pnpm --filter @openwork/desktop typecheck:electron
       - name: Prepare virtual display
         run: |
-          if ! command -v xvfb-run >/dev/null; then
+          if ! command -v xvfb-run >/dev/null || ! command -v xdpyinfo >/dev/null; then
             sudo apt-get update -qq
-            sudo apt-get install -y xvfb
+            sudo apt-get install -y xvfb x11-utils
           fi
       - name: Package and smoke-test the installed desktop
         timeout-minutes: 7

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -51,7 +51,10 @@ run(nodeCmd, [resolve(__dirname, "prepare-computer-use-helper.mjs"), "--force", 
 run(nodeCmd, [resolve(__dirname, "prepare-runtime-node-modules.mjs"), "--outdir", packagedRuntimeRoot], desktopRoot);
 writeSentryBuildConfig();
 // Build the server TS → JS so Electron can import it in-process
-run(pnpmCmd, ["--filter", "openwork-server", "build"], repoRoot);
+// CI already compiles this exact checkout in the required build job.
+if (!process.argv.includes("--server-built")) {
+  run(pnpmCmd, ["--filter", "openwork-server", "build"], repoRoot);
+}
 // automation-runner.mjs imports @openwork/headless-threads through its
 // published "default" export (dist/index.js); build it so plain-node
 // consumers resolve it in packaged layouts.

--- a/apps/desktop/scripts/packaged-smoke.mjs
+++ b/apps/desktop/scripts/packaged-smoke.mjs
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { accessSync, appendFileSync, constants, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+if (process.platform !== "linux") throw new Error("The fast packaged smoke gate currently targets Linux.");
+const output = resolve(process.env.OPENWORK_PACKAGED_SMOKE_DIR || join(tmpdir(), `openwork-packaged-smoke-${process.pid}`));
+mkdirSync(output, { recursive: true });
+const report = { commit: process.env.GITHUB_SHA ?? null, phases: [], passed: false };
+const started = performance.now();
+
+function run(name, command, args, timeout, extraEnv = {}, cwd = repo) {
+  const phaseStarted = performance.now();
+  const result = spawnSync(command, args, {
+    cwd, stdio: "inherit", timeout,
+    env: { ...process.env, ...extraEnv },
+  });
+  const phase = { name, milliseconds: Math.round(performance.now() - phaseStarted), exitCode: result.status };
+  report.phases.push(phase);
+  console.log(`[packaged-smoke] ${JSON.stringify(phase)}`);
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`${name} failed (${result.signal || result.status})`);
+}
+
+try {
+  if (!process.argv.includes("--artifact-only")) {
+    run("prepare", process.execPath, ["apps/desktop/scripts/electron-build.mjs",
+      ...(process.argv.includes("--server-built") ? ["--server-built"] : [])], 240_000);
+    run("package", "pnpm", ["--dir", "apps/desktop", "exec", "electron-builder",
+      "--config", "electron-builder.yml", "--linux", "--dir", "--publish", "never",
+      `--config.directories.output=${output}`], 120_000,
+    { CSC_IDENTITY_AUTO_DISCOVERY: "false" });
+  }
+  const binary = join(output, "linux-unpacked/openwork");
+  const resources = join(output, "linux-unpacked/resources");
+  const archive = join(resources, "app.asar");
+  if (!existsSync(archive)) throw new Error(`Missing packaged archive: ${archive}`);
+  accessSync(binary, constants.X_OK);
+  const sidecar = join(resources, "sidecars/opencode");
+  accessSync(sidecar, constants.X_OK);
+  run("sidecar", sidecar, ["--version"], 10_000, {}, output);
+  const embedded = pathToFileURL(join(archive, "server/dist/embedded.js")).href;
+  run("server-import", binary, ["--input-type=module", "-e",
+    `const server = await import(${JSON.stringify(embedded)}); if (typeof server.startEmbeddedServer !== "function") throw new Error("Missing embedded server export");`],
+  15_000, { ELECTRON_RUN_AS_NODE: "1", NODE_PATH: "", NODE_OPTIONS: "" }, output);
+  run("desktop-boot", "xvfb-run", ["-a", "pnpm", "evals:e2e", "app-smoke", "--local"], 90_000, {
+    OPENWORK_EVAL_ELECTRON_BINARY: binary,
+    OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED: "1",
+    OPENWORK_EVAL_ENGINE: "v1",
+    OPENWORK_EVAL_SURFACES_DIR: join(output, "profiles"),
+    ELECTRON_RUN_AS_NODE: "",
+    NODE_PATH: "", NODE_OPTIONS: "",
+  });
+  report.passed = true;
+} finally {
+  report.totalMilliseconds = Math.round(performance.now() - started);
+  writeFileSync(join(output, "timing.json"), `${JSON.stringify(report, null, 2)}\n`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n### Packaged desktop smoke\n\n${report.passed ? "Passed" : "Failed"}; ${Math.round(report.totalMilliseconds / 1000)} seconds after dependency setup${process.argv.includes("--server-built") ? " and server compilation" : ""}. Target: under 120 seconds on a warm runner.\n\n| Phase | Seconds |\n| --- | ---: |\n${report.phases.map(p => `| ${p.name} | ${(p.milliseconds / 1000).toFixed(1)} |`).join("\n")}\n`);
+  }
+}

--- a/apps/desktop/scripts/packaged-smoke.mjs
+++ b/apps/desktop/scripts/packaged-smoke.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { accessSync, appendFileSync, constants, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -8,7 +8,7 @@ const repo = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 if (process.platform !== "linux") throw new Error("The fast packaged smoke gate currently targets Linux.");
 const output = resolve(process.env.OPENWORK_PACKAGED_SMOKE_DIR || join(tmpdir(), `openwork-packaged-smoke-${process.pid}`));
 mkdirSync(output, { recursive: true });
-const report = { commit: process.env.GITHUB_SHA ?? null, phases: [], passed: false };
+const report = { commit: execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim(), phases: [], passed: false };
 const started = performance.now();
 
 function run(name, command, args, timeout, extraEnv = {}, cwd = repo) {

--- a/evals/packages/hosts/src/local.ts
+++ b/evals/packages/hosts/src/local.ts
@@ -867,7 +867,8 @@ async function ensureDisplay(repoRoot: string, env: NodeJS.ProcessEnv, log: (mes
           throw new Error(`OPENWORK_EVAL_ELECTRON_BINARY does not exist: ${packagedBinary}`);
         });
         log(`Starting local Electron surface ${name} from packaged binary ${packagedBinary} (CDP :${cdpPort})...`);
-        spawned = spawnDetached(packagedBinary, [], { cwd: options.repoRoot, env, logPath });
+        // An installed artifact must not resolve assets from the checkout's cwd.
+        spawned = spawnDetached(packagedBinary, [], { cwd: profileRoot, env, logPath });
       } else {
         log(`Starting local Electron surface ${name} (Vite :${port}, CDP :${cdpPort})...`);
         spawned = spawnDetached(pnpmCommand(), [opts.devCommand ?? "dev:electron"], { cwd: options.repoRoot, env, logPath });

--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -19,8 +19,8 @@ test("app boots with a control route and meaningful visible content", async ({ w
   } else {
     expect(world.workspace?.workspaceId).toBeTruthy();
     await user.looks([
-    "A ready OpenWork workspace composer with meaningful visible content is on screen",
-    "No generic error or 'Something went wrong' crash message is visible",
+      "A ready OpenWork workspace composer with meaningful visible content is on screen",
+      "No generic error or 'Something went wrong' crash message is visible",
     ]);
   }
 });

--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -4,11 +4,20 @@ import { appSmokeWorld } from "../worlds/first-run.ts";
 
 const test = spec.world(appSmokeWorld);
 
-test("app boots with a control route and meaningful visible content", async ({ world, user, probe }) => {
+test("app boots with a control route and meaningful visible content", async ({ world, user, probe, evidence }) => {
   expect(world.workspace.workspaceId).toBeTruthy();
   expect(await probe.hash()).toBeTruthy();
   expect((await probe.text()).trim().length).toBeGreaterThan(40);
-  await user.looks([
+  if (world.packaged) {
+    expect(await world.packagedRuntime()).toEqual({
+      bridge: true, protocol: "file:", health: 200, composer: true, crash: false,
+    });
+    evidence.recordAssertionEvidence(
+      "The packaged desktop loads its renderer, preload bridge, and embedded server without a development server",
+      "The installed-layout binary reached a real workspace composer through file: assets; a preload IPC round trip returned its embedded server endpoint and HTTP health returned 200. No crash screen was present. The host used a fresh isolated profile.",
+      true,
+    );
+  } else await user.looks([
     "A ready OpenWork workspace composer with meaningful visible content is on screen",
     "No generic error or 'Something went wrong' crash message is visible",
   ]);

--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -5,20 +5,22 @@ import { appSmokeWorld } from "../worlds/first-run.ts";
 const test = spec.world(appSmokeWorld);
 
 test("app boots with a control route and meaningful visible content", async ({ world, user, probe, evidence }) => {
-  expect(world.workspace.workspaceId).toBeTruthy();
   expect(await probe.hash()).toBeTruthy();
   expect((await probe.text()).trim().length).toBeGreaterThan(40);
   if (world.packaged) {
     expect(await world.packagedRuntime()).toEqual({
-      bridge: true, protocol: "file:", health: 200, composer: true, crash: false,
+      bridge: true, protocol: "file:", health: 200, welcome: true, crash: false,
     });
     evidence.recordAssertionEvidence(
       "The packaged desktop loads its renderer, preload bridge, and embedded server without a development server",
-      "The installed-layout binary reached a real workspace composer through file: assets; a preload IPC round trip returned its embedded server endpoint and HTTP health returned 200. No crash screen was present. The host used a fresh isolated profile.",
+      "The installed-layout binary reached an interactive welcome screen through file: assets; a preload IPC round trip returned its embedded server endpoint and HTTP health returned 200. No crash screen was present. The host used a fresh isolated profile.",
       true,
     );
-  } else await user.looks([
+  } else {
+    expect(world.workspace?.workspaceId).toBeTruthy();
+    await user.looks([
     "A ready OpenWork workspace composer with meaningful visible content is on screen",
     "No generic error or 'Something went wrong' crash message is visible",
-  ]);
+    ]);
+  }
 });

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -68,9 +68,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export async function appSmokeWorld(seed: Seed) {
-  const app = await seed.desktop({ name: "app-smoke" });
+  const packaged = Boolean(process.env.OPENWORK_EVAL_ELECTRON_BINARY);
+  const app = packaged
+    ? await desktop({ name: "app-smoke", prepareSharedResources: false, timeoutMs: 60_000,
+      env: { OPENWORK_DEV_MODE: "0", OPENWORK_ELECTRON_START_URL: "", ELECTRON_START_URL: "" } })
+    : await seed.desktop({ name: "app-smoke" });
   const workspace = await seed.workspace(app, seed.tmpPath("app-smoke"));
-  return { app, workspace };
+  return {
+    app, workspace, packaged,
+    async packagedRuntime() {
+      return evalIn(app, `(async () => {
+        const bridge = window.__OPENWORK_ELECTRON__;
+        if (typeof bridge?.invokeDesktop !== "function") return { bridge: false };
+        const info = await bridge.invokeDesktop("openworkServerInfo");
+        const health = await fetch(info.baseUrl + "/health", { signal: AbortSignal.timeout(5000) });
+        return { bridge: true, protocol: location.protocol, health: health.status,
+          composer: Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')),
+          crash: /Something went wrong|Cannot find module|Maximum update depth exceeded/.test(document.body.innerText) };
+      })()`, { awaitPromise: true });
+    },
+    async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
+  };
 }
 
 export async function bareFirstRunWorld(seed: Seed, { place }: { place: Place }) {

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -73,7 +73,7 @@ export async function appSmokeWorld(seed: Seed) {
     ? await desktop({ name: "app-smoke", prepareSharedResources: false, timeoutMs: 60_000,
       env: { OPENWORK_DEV_MODE: "0", OPENWORK_ELECTRON_START_URL: "", ELECTRON_START_URL: "" } })
     : await seed.desktop({ name: "app-smoke" });
-  const workspace = await seed.workspace(app, seed.tmpPath("app-smoke"));
+  const workspace = packaged ? null : await seed.workspace(app, seed.tmpPath("app-smoke"));
   return {
     app, workspace, packaged,
     async packagedRuntime() {
@@ -83,7 +83,8 @@ export async function appSmokeWorld(seed: Seed) {
         const info = await bridge.invokeDesktop("openworkServerInfo");
         const health = await fetch(info.baseUrl + "/health", { signal: AbortSignal.timeout(5000) });
         return { bridge: true, protocol: location.protocol, health: health.status,
-          composer: Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')),
+          welcome: location.hash === "#/welcome" && [...document.querySelectorAll("button")]
+            .some(button => button.textContent.trim() === "Use Without Cloud" && !button.disabled),
           crash: /Something went wrong|Cannot find module|Maximum update depth exceeded/.test(document.body.innerText) };
       })()`, { awaitPromise: true });
     },


### PR DESCRIPTION
A PR can compile and pass development-mode tests while shipping a desktop app that cannot start. The missing `constants.json` import in the packaged v2 server escaped because the required build job never loaded or launched the installed artifact.

This adds an unsigned Linux packaged-app smoke check to the existing required build job on Blacksmith 16-vCPU runners. It reuses that job's server compilation, caches Electron and pinned sidecars, runs the release packaging path, checks the bundled executable, imports the embedded server from the actual ASAR, then runs the existing app smoke spec against the packaged binary with an isolated profile and working directory. Assertions cover file-based renderer assets, an interactive first-run welcome screen, preload IPC, HTTP server health, and absence of a crash screen. No production account, provider inference, signing, or notarization is required. The existing development workspace journey remains intact.

Validation on final head `5a638be1e66ff87237ce7b3c827af92322e084a9`: **Passed**. `node apps/desktop/scripts/packaged-smoke.mjs --server-built` ran `pnpm evals:e2e app-smoke --local`; placement: `local (--local)` on Blacksmith; **1 passed, 0 failed, 0 skipped**. Core product regressions and the required build job also passed. JavaScript syntax checks and `git diff --check` passed.

Measured packaged check: **28.9 seconds**; full build job including setup: **71 seconds**. The preceding successful run took 31.2 seconds / 78 seconds respectively. These are observed timings, not a guarantee for cold downloads or runner queues.

| Phase | Seconds |
| --- | ---: |
| Prepare release assets | 15.9 |
| Package unsigned directory | 8.8 |
| Execute bundled sidecar | 0.3 |
| Import ASAR embedded server | 0.5 |
| Launch desktop and assert startup | 3.5 |

[Final CI run](https://github.com/different-ai/openwork/actions/runs/33948318068) · [Download timing, Electron log, and assertion evidence](https://github.com/different-ai/openwork/actions/runs/33948318068/artifacts/9964028691). The sticky test-evidence comment records the assertion verdict for this exact PR head. Artifacts are retained for seven days.

The first CI iteration exposed a test arrangement mismatch (a development-only folder input) and a missing display diagnostic. The packaged branch now explicitly checks production startup, and the runner installs the diagnostic to avoid a 60-second display-probe delay.

Scope: Linux installed-layout startup. This does not validate macOS signing/notarization, Windows installers, the native folder picker, or provider inference. A failure in this smoke check fails the existing required gate.
