### PR TITLE
Make connector setup intentional and keep ordinary searches quiet

### DIFF
--- a/apps/app/src/components/chat/connection-card.tsx
+++ b/apps/app/src/components/chat/connection-card.tsx
@@ -32,7 +32,7 @@ export function ConnectionCard({ part, action }: { part: DynamicToolUIPart; acti
         </span>
         <div className="min-w-0 flex-1">
           <p className="truncate text-[13px] font-medium" title={action.connectionName}>{action.connectionName}</p>
-          {waiting || opening ? <p className="mt-0.5 text-[11px] text-muted-foreground">{opening ? "Opening sign-in…" : "Waiting for authorization…"}</p> : null}
+          {waiting || opening ? <p className="mt-0.5 text-[11px] text-muted-foreground">{opening ? "Opening sign-in…" : "Finish sign-in in your browser"}</p> : null}
         </div>
         {connected ? (
           <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground"><Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />Connected</span>

--- a/apps/app/src/components/chat/connector-catalog.tsx
+++ b/apps/app/src/components/chat/connector-catalog.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { ArrowUpRight, Search } from "lucide-react"
+import type { ConnectorCatalog } from "@openwork/types/connection-action-app"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { openDesktopUrl } from "@/app/lib/desktop"
+import { createDenClient, readDenSettings } from "@/app/lib/den"
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider"
+import { isConnectAdminRole } from "@/react-app/domains/settings/connect-cloud-readiness"
+import { libraryConnectorIconUrls } from "@/react-app/domains/settings/library-connector-cues"
+import { useMessageList } from "./message-list-provider"
+
+const SETUP_LABELS: Record<ConnectorCatalog["entries"][number]["setup"], string> = {
+  oauth: "Sign in", oauth_client: "Admin setup", api_key: "API key", instant: "Ready to add", suite: "Guided setup",
+}
+
+function ConnectorIcon({ entry }: { entry: ConnectorCatalog["entries"][number] }) {
+  const [iconIndex, setIconIndex] = useState(0)
+  const icons = libraryConnectorIconUrls({
+    id: entry.id, name: entry.name, serviceUrl: entry.serviceUrl,
+    iconSrc: entry.id === "google-workspace" ? "/ext-google-workspace.svg" : undefined,
+    iconSlug: entry.id === "microsoft-365" ? "microsoft365" : entry.id,
+    faviconDomain: entry.id === "microsoft-365" ? "microsoft.com" : undefined,
+  })
+  const icon = icons[iconIndex]
+  return <span aria-hidden="true" className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted/40 text-xs font-medium">
+    {icon ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setIconIndex(index => index + 1)} /> : entry.name.charAt(0)}
+  </span>
+}
+
+export function ConnectorCatalogCard({ catalog }: { catalog: ConnectorCatalog }) {
+  const [showAll, setShowAll] = useState(catalog.selectedIds.length === 0)
+  const [query, setQuery] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const auth = useDenAuth()
+  const settings = readDenSettings()
+  const identity = auth.verifiedIdentity
+  const role = useQuery({
+    queryKey: ["connector-catalog-role", settings.baseUrl, identity?.principalId, identity?.organizationId],
+    enabled: auth.isSignedIn && Boolean(identity),
+    queryFn: async () => {
+      const result = await createDenClient({ baseUrl: settings.baseUrl, token: settings.authToken }).listOrgs()
+      return result.orgs.find(org => org.id === identity?.organizationId)?.role ?? null
+    },
+  })
+  const { connectorIdentities } = useMessageList()
+  const canManage = auth.isSignedIn && isConnectAdminRole(role.data)
+  const entries = catalog.entries.filter(entry => (showAll || catalog.selectedIds.includes(entry.id)) && `${entry.name} ${entry.description}`.toLowerCase().includes(query.toLowerCase()))
+  const setup = async (entry: ConnectorCatalog["entries"][number]) => {
+    if (!canManage) return
+    setError(null)
+    try {
+      const expected = new URL("/dashboard/mcp-connections", readDenSettings().baseUrl)
+      expected.searchParams.set("quickAdd", entry.id)
+      // The model cannot supply a new setup destination or extra query parameters.
+      if (entry.setupUrl !== expected.toString()) throw new Error("Your OpenWork server changed. Search for this connector again.")
+      await openDesktopUrl(expected.toString())
+    } catch (cause) { setError(cause instanceof Error ? cause.message : "Could not open setup.") }
+  }
+  return <section data-testid="connector-catalog" aria-label="Quick-add connectors" className="w-full max-w-md rounded-xl bg-muted/30 p-3">
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <p className="text-xs font-medium">{showAll ? "Quick-add connectors" : "Suggested connector"}</p>
+      {!showAll ? <Button variant="ghost" size="sm" className="h-6 px-1.5 text-xs text-muted-foreground" onClick={() => setShowAll(true)}>Browse all {catalog.entries.length}</Button> : <span className="text-xs text-muted-foreground">{catalog.entries.length} available</span>}
+    </div>
+    {showAll ? <div className="relative mb-2"><Search className="pointer-events-none absolute left-2 top-2 size-3.5 text-muted-foreground" /><Input aria-label="Filter connectors" value={query} onChange={event => setQuery(event.target.value)} placeholder="Find a connector…" className="h-8 border-0 bg-background/70 pl-7 text-xs shadow-none" /></div> : null}
+    <div className="max-h-80 overflow-y-auto">
+      {entries.map(entry => {
+        const added = Boolean(entry.serviceUrl && connectorIdentities.some(identity => identity.connectionId && identity.serviceUrl === entry.serviceUrl))
+        return <div key={entry.id} data-connector-preset={entry.id} className="flex items-center gap-2.5 rounded-lg px-1 py-2">
+          <ConnectorIcon entry={entry} />
+          <div className="min-w-0 flex-1"><p className="truncate text-[13px] font-medium">{entry.name}</p><p className="text-[11px] text-muted-foreground">{added ? "Added to your organization" : SETUP_LABELS[entry.setup]}</p></div>
+          {!added ? <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs" disabled={!canManage} onClick={() => void setup(entry)} aria-label={`Set up ${entry.name}`}>Set up<ArrowUpRight className="size-3.5 text-muted-foreground" /></Button> : null}
+        </div>
+      })}
+      {entries.length === 0 ? <p className="py-3 text-xs text-muted-foreground">No connectors match your search.</p> : null}
+    </div>
+    <p className="mt-2 text-[11px] text-muted-foreground">{canManage ? "Setup opens in organization settings." : "An organization admin can add these connectors for you."}</p>
+    {error ? <p role="alert" className="mt-2 text-xs text-destructive">{error}</p> : null}
+  </section>
+}

--- a/apps/app/src/components/chat/mcp-app-frame.tsx
+++ b/apps/app/src/components/chat/mcp-app-frame.tsx
@@ -6,6 +6,8 @@ import { AppBridge, PostMessageTransport } from "@modelcontextprotocol/ext-apps/
 import type { McpUiStyles, McpUiStyleVariableKey } from "@modelcontextprotocol/ext-apps"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 
+import { connectorCatalogSchema } from "@openwork/types/connection-action-app"
+import { ConnectorCatalogCard } from "./connector-catalog"
 import { ConnectionCard } from "./connection-card"
 import { reconnectActionFromChatToolResult } from "@/components/tools/error-attribution"
 import { AppChatArtifact } from "@/react-app/domains/apps/app-chat-artifact"
@@ -62,6 +64,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function preservedResult(part: DynamicToolUIPart): PreservedMcpAppResult | null {
+  if (part.toolName === "openwork-cloud_search_capabilities" && (!isRecord(part.input) || (part.input.intent !== "connect" && part.input.type !== "connectors"))) return null
   const openwork = isRecord(part.callProviderMetadata?.openwork) ? part.callProviderMetadata.openwork : null
   const result = openwork && isRecord(openwork.mcpResult)
     ? openwork.mcpResult
@@ -79,7 +82,20 @@ function preservedResult(part: DynamicToolUIPart): PreservedMcpAppResult | null 
 }
 
 export function hasPreservedMcpAppResult(part: DynamicToolUIPart): boolean {
-  return preservedResult(part) !== null
+  return preservedResult(part) !== null || connectorCatalogFromPart(part) !== null
+}
+
+export function connectorCatalogFromPart(part: DynamicToolUIPart) {
+  if (part.toolName !== "openwork-cloud_search_capabilities" || part.state !== "output-available") return null
+  if (!isRecord(part.input) || (part.input.intent !== "connect" && part.input.type !== "connectors")) return null
+  let value: unknown = preservedResult(part)?.structuredContent ?? part.output
+  if (typeof value === "string") {
+    if (value.length > 128 * 1024) return null
+    try { value = JSON.parse(value) } catch { return null }
+  }
+  if (!isRecord(value)) return null
+  const parsed = connectorCatalogSchema.safeParse(value.connectorCatalog)
+  return parsed.success ? parsed.data : null
 }
 
 export function gatewayMcpAppLaunch(meta: unknown): OpenworkMcpAppLaunchReference | null {
@@ -562,8 +578,10 @@ export function McpAppSandboxView({ app, toolName, inputArguments, result, unava
 
 export function McpAppFrame({ part }: { part: DynamicToolUIPart }) {
   const result = preservedResult(part)
-  const action = reconnectActionFromChatToolResult(part.toolName, result?.structuredContent ?? part.output)
+  const action = reconnectActionFromChatToolResult(part.toolName, result?.structuredContent ?? part.output, part.input)
   if (action) return <ConnectionCard part={part} action={action} />
+  const catalog = connectorCatalogFromPart(part)
+  if (catalog) return <ConnectorCatalogCard catalog={catalog} />
   return <EmbeddedMcpAppFrame part={part} />
 }
 

--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -209,3 +209,7 @@ export function useSessionErrorMessage() {
 
   return useSessionActivityStore(state => state.getSessionError(workspaceId, sessionId));
 }
+
+export function useOptionalMessageList() {
+  return React.useContext(MessageListContext)
+}

--- a/apps/app/src/components/tools/error-attribution.ts
+++ b/apps/app/src/components/tools/error-attribution.ts
@@ -76,12 +76,14 @@ function confirmed(label: string, description: string): ToolErrorAttribution {
 export function reconnectActionFromChatToolResult(
   toolName: string,
   result: unknown,
+  input?: unknown,
 ): ChatToolReconnectAction | null {
   // Tool output is otherwise untrusted. Only the two canonical OpenWork Cloud
   // capability tools may turn a structured Den response into a UI action.
-  // Discovery is included because it performs a live connection probe before
-  // the agent can safely proceed to execution.
+  // Discovery may offer authorization only for an explicit setup request;
+  // finding an unavailable connection is not itself a reason to prompt.
   if (!OPENWORK_CLOUD_CAPABILITY_TOOLS.has(toolName)) return null
+  if (toolName === "openwork-cloud_search_capabilities" && (!isRecord(input) || input.intent !== "connect")) return null
 
   const parsed = parseResultRecord(result)
   if (!parsed) return null

--- a/apps/app/src/components/tools/mcp-reconnect-state.ts
+++ b/apps/app/src/components/tools/mcp-reconnect-state.ts
@@ -23,8 +23,8 @@ type ChatMcpReconnectStore = {
 
 const READY_RECORD: ChatMcpReconnectRecord = { phase: "ready", error: null, authorizeUrl: null }
 
-export function chatMcpReconnectKey(toolCallId: string, connectionId: string): string {
-  return `${toolCallId}:${connectionId}`
+export function chatMcpReconnectKey(toolCallId: string, connectionId: string, scope = ""): string {
+  return JSON.stringify([scope, toolCallId, connectionId])
 }
 
 export const useChatMcpReconnectStore = create<ChatMcpReconnectStore>((set) => ({

--- a/apps/app/src/components/tools/use-chat-tool-reconnect.ts
+++ b/apps/app/src/components/tools/use-chat-tool-reconnect.ts
@@ -1,5 +1,7 @@
 "use client"
 
+import { useId } from "react"
+import { useOptionalMessageList } from "@/components/chat/message-list-provider"
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
 
 import {
@@ -33,6 +35,9 @@ export function useChatToolReconnect(
   { onReconnect, onReopenAuthorization, onRetry }: ChatToolReconnectCallbacks,
   actionOverride?: ChatToolReconnectAction,
 ) {
+  const messageList = useOptionalMessageList()
+  const instanceId = useId()
+  const scope = messageList ? JSON.stringify([messageList.workspaceId, messageList.sessionId]) : instanceId
   const isError = toolPart.state === "output-error"
   const reconnectResult = isError && toolPart.errorText
     ? toolPart.errorText
@@ -40,10 +45,10 @@ export function useChatToolReconnect(
       ? toolPart.output
       : undefined
   const reconnectAction = actionOverride ?? (toolPart.type === "dynamic-tool" && reconnectResult !== undefined
-    ? reconnectActionFromChatToolResult(toolPart.toolName, reconnectResult)
+    ? reconnectActionFromChatToolResult(toolPart.toolName, reconnectResult, toolPart.input)
     : null)
   const reconnectKey = reconnectAction
-    ? chatMcpReconnectKey(toolPart.toolCallId, reconnectAction.connectionId)
+    ? chatMcpReconnectKey(toolPart.toolCallId, reconnectAction.connectionId, scope)
     : null
   const reconnectState = useChatMcpReconnectStore((store) => (
     reconnectKey ? store.records[reconnectKey]?.phase ?? "ready" : "ready"

--- a/apps/app/tests/mcp-app-frame.test.ts
+++ b/apps/app/tests/mcp-app-frame.test.ts
@@ -9,6 +9,8 @@ import {
 import { formatMcpAppDiagnostic, safeMcpAppDiagnosticMessage } from "../src/components/chat/mcp-app-diagnostics"
 import {
   buildMcpAppCsp,
+  connectorCatalogFromPart,
+  hasPreservedMcpAppResult,
   gatewayMcpAppLaunch,
   isActionableMcpAppResolutionError,
   secureMcpAppHtml,
@@ -164,3 +166,15 @@ describe("MCP App iframe policy", () => {
     expect(csp).toContain("frame-src https://embed.example.com")
   })
 })
+
+
+test("only canonical completed gateway search results render connector setup suggestions", () => {
+  const catalog = { version: 1, selectedIds: ["slack"], entries: [{ id: "slack", name: "Slack", description: "Work chat", setup: "oauth_client", setupUrl: "https://example.com/dashboard/mcp-connections?quickAdd=slack" }] };
+  const part = { type: "dynamic-tool", toolName: "openwork-cloud_search_capabilities", toolCallId: "catalog", state: "output-available", input: { query: "Slack", intent: "connect" }, output: JSON.stringify({ connectorCatalog: catalog }) } satisfies import("ai").DynamicToolUIPart;
+  expect(connectorCatalogFromPart(part)).toEqual(catalog);
+  expect(hasPreservedMcpAppResult(part)).toBe(true);
+  expect(hasPreservedMcpAppResult({ ...part, input: { query: "Slack" } })).toBe(false);
+  expect(connectorCatalogFromPart({ ...part, toolName: "other_search_capabilities" })).toBeNull();
+  expect(connectorCatalogFromPart({ ...part, output: "invalid json" })).toBeNull();
+  expect(connectorCatalogFromPart({ ...part, output: { connectorCatalog: { ...catalog, version: 2 } } })).toBeNull();
+});

--- a/apps/app/tests/mcp-reconnect-state.test.ts
+++ b/apps/app/tests/mcp-reconnect-state.test.ts
@@ -70,3 +70,12 @@ describe("chat MCP reconnect state", () => {
     })
   })
 })
+
+
+test("authorization state does not leak across tasks with reused tool-call IDs", () => {
+  const first = chatMcpReconnectKey("call-1", "connection-1", "workspace/task-one");
+  const second = chatMcpReconnectKey("call-1", "connection-1", "workspace/task-two");
+  useChatMcpReconnectStore.getState().setRecord(first, { phase: "authorization_opened", authorizeUrl: "https://example.com/oauth", error: null });
+  expect(chatMcpReconnectRecord(second).phase).toBe("ready");
+  expect(chatMcpReconnectRecord(second).authorizeUrl).toBeNull();
+});

--- a/apps/app/tests/tool-error-attribution.test.ts
+++ b/apps/app/tests/tool-error-attribution.test.ts
@@ -139,7 +139,8 @@ describe("chat tool error attribution", () => {
       }],
     })
 
-    expect(reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", output)).toEqual({
+    expect(reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", output)).toBeNull()
+    expect(reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", output, { intent: "connect" })).toEqual({
       connectionId: "emc_knowledge",
       connectionName: "Knowledge Hub",
       label: "Reconnect",
@@ -184,7 +185,7 @@ describe("chat tool error attribution", () => {
 
   test("supports first-time member OAuth but rejects mismatched states and credentials", () => {
     const status = { ...reconnectStatus(), state: "needs_connection", action: { type: "connect", surface: "openwork_your_connections", retry: "search_capabilities" } }
-    const action = (value: unknown) => reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", { matches: [{ connectionStatus: value }] })
+    const action = (value: unknown) => reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", { matches: [{ connectionStatus: value }] }, { intent: "connect" })
     expect(action(status)).toEqual({ connectionId: "emc_knowledge", connectionName: "Knowledge Hub", label: "Connect" })
     expect(action({ ...status, authType: "apikey" })).toBeNull()
     expect(action({ ...status, credentialMode: "shared" })).toBeNull()
@@ -200,7 +201,7 @@ describe("chat tool error attribution", () => {
       })),
     }
 
-    expect(reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", output)).toBeNull()
+    expect(reconnectActionFromChatToolResult("openwork-cloud_search_capabilities", output, { intent: "connect" })).toBeNull()
   })
 
   test("rejects unversioned, shared, and admin-owned action shapes", () => {

--- a/evals/packages/hosts/src/browser.ts
+++ b/evals/packages/hosts/src/browser.ts
@@ -82,7 +82,7 @@ export async function captureExternalBrowserUrls(handle: SurfaceHandle): Promise
   }
   const sandbox = handle.sandboxId;
   async function python(source: string): Promise<string> {
-    const result = await execInSandbox(defaultDaytonaExec, sandbox, `python3 - <<'OPENWORK_CAPTURE_PY'\n${source}\nOPENWORK_CAPTURE_PY`, {
+    const result = await execInSandbox(defaultDaytonaExec, sandbox, `printf %s ${Buffer.from(source).toString("base64")} | base64 -d | python3`, {
       timeoutMs: 30_000,
       context: "desktop external-browser URL witness",
     });

--- a/evals/packages/hosts/src/browser.ts
+++ b/evals/packages/hosts/src/browser.ts
@@ -88,7 +88,7 @@ export async function captureExternalBrowserUrls(handle: SurfaceHandle): Promise
     });
     return result.stdout.trim();
   }
-  const state: unknown = JSON.parse(await python(String.raw`import json, os, pathlib, shutil, tempfile
+  const state: unknown = JSON.parse(await python(String.raw`import json, os, pathlib, shutil, subprocess, tempfile
 opener = shutil.which("xdg-open")
 if not opener:
     raise RuntimeError("xdg-open is missing")
@@ -99,8 +99,10 @@ backup = str(root / "xdg-open.original")
 shutil.copy2(opener, backup)
 import shlex
 script = "#!/bin/sh\nprintf '%s\\n' \"$1\" >> " + shlex.quote(str(log)) + "\nexec " + shlex.quote(backup) + " \"$@\"\n"
-pathlib.Path(opener).write_text(script)
-os.chmod(opener, 0o755)
+capture = root / "xdg-open.capture"
+capture.write_text(script)
+os.chmod(capture, 0o755)
+subprocess.run(["sudo", "-n", "cp", "--", str(capture), opener], check=True)
 print(json.dumps({"opener": opener, "root": str(root), "log": str(log), "backup": backup}))`));
   if (typeof state !== "object" || state === null || !("root" in state) || typeof state.root !== "string"
     || !("opener" in state) || typeof state.opener !== "string" || !("log" in state) || typeof state.log !== "string"
@@ -113,7 +115,7 @@ print(json.dumps({"opener": opener, "root": str(root), "log": str(log), "backup"
       return value;
     },
     async [Symbol.asyncDispose]() {
-      await python(`import shutil\nshutil.copy2(${JSON.stringify(backup)}, ${JSON.stringify(opener)})\nshutil.rmtree(${JSON.stringify(root)})`);
+      await python(`import shutil, subprocess\nsubprocess.run(["sudo", "-n", "cp", "--", ${JSON.stringify(backup)}, ${JSON.stringify(opener)}], check=True)\nshutil.rmtree(${JSON.stringify(root)})`);
     },
   };
 }

--- a/evals/packages/hosts/src/browser.ts
+++ b/evals/packages/hosts/src/browser.ts
@@ -1,5 +1,7 @@
 import { attachSurface } from "@openwork/cdp";
 import { resolveHost } from "./resolve.ts";
+import { defaultDaytonaExec } from "./daytona.ts";
+import { execInSandbox } from "./provision.ts";
 import type { AttachedSurface, SurfaceHandle } from "@openwork/cdp";
 import type { Host } from "./types.ts";
 
@@ -67,4 +69,51 @@ export async function chrome(opts: BrowserOptions = {}): Promise<AttachedSurface
     });
   };
   return surface;
+}
+
+/** Observe the actual OS browser handoff in a disposable Linux desktop sandbox.
+ * The real opener still runs; this never replaces the product click handler.
+ */
+export async function captureExternalBrowserUrls(handle: SurfaceHandle): Promise<{
+  opened(): Promise<string[]>;
+} & AsyncDisposable> {
+  if (handle.hostKind !== "daytona" || !handle.sandboxId) {
+    throw new Error("External browser URL capture requires a Daytona Linux desktop sandbox.");
+  }
+  const sandbox = handle.sandboxId;
+  async function python(source: string): Promise<string> {
+    const result = await execInSandbox(defaultDaytonaExec, sandbox, `python3 - <<'OPENWORK_CAPTURE_PY'\n${source}\nOPENWORK_CAPTURE_PY`, {
+      timeoutMs: 30_000,
+      context: "desktop external-browser URL witness",
+    });
+    return result.stdout.trim();
+  }
+  const state: unknown = JSON.parse(await python(String.raw`import json, os, pathlib, shutil, tempfile
+opener = shutil.which("xdg-open")
+if not opener:
+    raise RuntimeError("xdg-open is missing")
+root = pathlib.Path(tempfile.mkdtemp(prefix="openwork-browser-witness-"))
+log = root / "urls.log"
+log.write_text("")
+backup = str(root / "xdg-open.original")
+shutil.copy2(opener, backup)
+import shlex
+script = "#!/bin/sh\nprintf '%s\\n' \"$1\" >> " + shlex.quote(str(log)) + "\nexec " + shlex.quote(backup) + " \"$@\"\n"
+pathlib.Path(opener).write_text(script)
+os.chmod(opener, 0o755)
+print(json.dumps({"opener": opener, "root": str(root), "log": str(log), "backup": backup}))`));
+  if (typeof state !== "object" || state === null || !("root" in state) || typeof state.root !== "string"
+    || !("opener" in state) || typeof state.opener !== "string" || !("log" in state) || typeof state.log !== "string"
+    || !("backup" in state) || typeof state.backup !== "string") throw new Error("Invalid browser witness state");
+  const { root, opener, log, backup } = state;
+  return {
+    async opened() {
+      const value: unknown = JSON.parse(await python(`import json, pathlib\nprint(json.dumps(pathlib.Path(${JSON.stringify(log)}).read_text().splitlines()))`));
+      if (!Array.isArray(value) || !value.every((url): url is string => typeof url === "string")) throw new Error("Invalid captured URLs");
+      return value;
+    },
+    async [Symbol.asyncDispose]() {
+      await python(`import shutil\nshutil.copy2(${JSON.stringify(backup)}, ${JSON.stringify(opener)})\nshutil.rmtree(${JSON.stringify(root)})`);
+    },
+  };
 }

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -15,11 +15,11 @@ test("desktop connects an account directly with the provider and confirms author
   expect(discoveryCalls.filter(call => call.kind === "tool")).toHaveLength(1);
   await user.screenshot();
   evidence.recordAssertionEvidence("Ordinary discovery of an unconnected service stays quiet", "Dashboard capability search completed without a connection card, catalog, Connect button, or provider authorization request", true);
-  await user.click({ role: "button", label: "New task" });
+  await user.click({ role: "button", label: "New session" });
   await user.see({ text: "Try one of these:" });
   expect(connectionActionPrompt).not.toContain(world.connection.id);
   await agent.send(connectionActionPrompt);
-  await user.see({ text: connectionActionReply, ordinaryDiscoveryPrompt, ordinaryDiscoveryReply }, { timeoutMs: 120_000 });
+  await user.see({ text: connectionActionReply }, { timeoutMs: 120_000 });
   await user.see({ testId: "desktop-connection-card" });
   await user.see({ role: "button", label: "Connect Notion" });
   await user.notSee({ text: "Connected" });

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -1,16 +1,29 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { connectionActionMcpApp, connectionActionPrompt, connectionActionReply } from "../worlds/library.ts";
+import { connectionActionMcpApp, connectionActionPrompt, connectionActionReply, ordinaryDiscoveryPrompt, ordinaryDiscoveryReply } from "../worlds/library.ts";
 
 const test = spec.world(connectionActionMcpApp, { timeout: 600_000 });
 
 test("desktop connects an account directly with the provider and confirms authorization in chat", async ({ world, agent, user, probe, evidence }) => {
+  await agent.send(ordinaryDiscoveryPrompt);
+  await user.see({ text: ordinaryDiscoveryReply }, { timeoutMs: 120_000 });
+  await user.notSee({ testId: "desktop-connection-card" });
+  await user.notSee({ testId: "connector-catalog" });
+  await user.notSee({ role: "button", label: "Connect Notion" });
+  expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
+  const discoveryCalls = await world.den.mocks.connector.agentRequests({ promptMarker: ordinaryDiscoveryPrompt });
+  expect(discoveryCalls.filter(call => call.kind === "tool")).toHaveLength(1);
+  await user.screenshot();
+  evidence.recordAssertionEvidence("Ordinary discovery of an unconnected service stays quiet", "Dashboard capability search completed without a connection card, catalog, Connect button, or provider authorization request", true);
+  await user.click({ role: "button", label: "New task" });
+  await user.see({ text: "Try one of these:" });
   expect(connectionActionPrompt).not.toContain(world.connection.id);
   await agent.send(connectionActionPrompt);
-  await user.see({ text: connectionActionReply }, { timeoutMs: 120_000 });
+  await user.see({ text: connectionActionReply, ordinaryDiscoveryPrompt, ordinaryDiscoveryReply }, { timeoutMs: 120_000 });
   await user.see({ testId: "desktop-connection-card" });
   await user.see({ role: "button", label: "Connect Notion" });
   await user.notSee({ text: "Connected" });
+  await user.notSee({ text: "Finish sign-in in your browser" });
   const calls = await world.den.mocks.connector.agentRequests({ promptMarker: connectionActionPrompt });
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -1,0 +1,65 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { allConnectorsPrompt, allConnectorsReply, connectorCatalogDiscovery, connectorCatalogPrompt, connectorCatalogReply } from "../worlds/library.ts";
+
+const test = spec.world(connectorCatalogDiscovery, { timeout: 600_000 });
+
+test("chat suggests Slack setup and lets an admin browse every quick-add connector", async ({ world, agent, user, probe, evidence }) => {
+  const appUser = user.on(world.app);
+  const appProbe = probe.on(world.app);
+  const webUser = user.on(world.web);
+  expect(connectorCatalogPrompt).not.toContain(world.connection.id);
+  await agent.on(world.app).send(connectorCatalogPrompt);
+  await appUser.see({ text: connectorCatalogReply }, { timeoutMs: 120_000 });
+  await appUser.see({ testId: "connector-catalog" });
+  await appUser.see({ role: "button", label: "Set up Slack" });
+  await appUser.see({ text: "Admin setup" });
+  await appUser.notSee({ testId: "desktop-connection-card" });
+  const visibleIds = () => appProbe.eval(`Array.from(document.querySelectorAll('[data-connector-preset]'), element => element.getAttribute('data-connector-preset'))`);
+  expect(await visibleIds()).toEqual(["slack"]);
+  await appUser.screenshot();
+  evidence.recordAssertionEvidence("A Slack request offers setup without claiming the service is connected", "Only Slack is suggested with Admin setup; no account connection card is shown", true);
+
+  await appUser.click({ role: "button", label: `Browse all ${world.expectedIds.length}` });
+  await appUser.see({ role: "textbox", label: "Filter connectors" });
+  expect(await visibleIds()).toEqual(world.expectedIds);
+  await appUser.see({ role: "button", label: "Set up Linear" });
+  await appUser.screenshot();
+  evidence.recordAssertionEvidence("Browse all includes the complete Den preset catalog and both productivity suites", JSON.stringify(world.expectedIds), true);
+  await appUser.type({ role: "textbox", label: "Filter connectors" }, "no such connector", { replace: true });
+  await appUser.see({ text: "No connectors match your search." });
+  expect(await visibleIds()).toEqual([]);
+  await appUser.type({ role: "textbox", label: "Filter connectors" }, "slack", { replace: true });
+  expect(await visibleIds()).toEqual(["slack"]);
+  await probe.eventually(
+    () => appProbe.eval(`document.querySelector('button[aria-label="Set up Slack"]')?.disabled === false`),
+    { within: 15_000, label: "admin setup action is enabled", until: value => value === true },
+  );
+  await appUser.click({ role: "button", label: "Set up Slack" });
+  await appUser.notSee({ role: "alert" });
+
+  // Continue the external-browser handoff in the signed-in browser surface.
+  const setupUrl = new URL("/dashboard/mcp-connections", world.den.ref.webUrl);
+  setupUrl.searchParams.set("quickAdd", "slack");
+  await webUser.navigate(setupUrl.toString());
+  await webUser.see({ text: "OAuth app" }, { timeoutMs: 90_000 });
+  await webUser.see({ text: "Client ID (optional for now)" });
+  await webUser.see({ text: "Client secret (optional for now)" });
+  await webUser.screenshot();
+  const calls = await world.den.mocks.connector.agentRequests({ promptMarker: connectorCatalogPrompt });
+  expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);
+  expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
+  expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
+  await appUser.click({ role: "button", label: "New task" });
+  await appUser.see({ text: "Try one of these:" });
+  await agent.on(world.app).send(allConnectorsPrompt);
+  await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
+  const listed = await appProbe.eval(`(() => {
+    const cards = Array.from(document.querySelectorAll('[data-testid="connector-catalog"]'));
+    return Array.from(cards.at(-1)?.querySelectorAll('[data-connector-preset]') ?? [], entry => entry.getAttribute('data-connector-preset'));
+  })()`);
+  expect(listed).toEqual(world.expectedIds);
+  await appUser.screenshot();
+  evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);
+  evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Slack quickAdd deep link renders client fields; the agent only searched and did not execute setup or authorize an account", true);
+});

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -35,13 +35,23 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
     () => appProbe.eval(`document.querySelector('button[aria-label="Set up Slack"]')?.disabled === false`),
     { within: 15_000, label: "admin setup action is enabled", until: value => value === true },
   );
+  expect(await world.browserUrls.opened()).toEqual([]);
   await appUser.click({ role: "button", label: "Set up Slack" });
   await appUser.notSee({ role: "alert" });
 
-  // Continue the external-browser handoff in the signed-in browser surface.
-  const setupUrl = new URL("/dashboard/mcp-connections", world.den.ref.webUrl);
-  setupUrl.searchParams.set("quickAdd", "slack");
-  await webUser.navigate(setupUrl.toString());
+  // Observe the URL Electron actually handed to the OS before bridging that
+  // exact handoff into our signed-in browser. A no-op or wrong URL fails here.
+  const openedUrls = await probe.eventually(() => world.browserUrls.opened(), {
+    within: 30_000, label: "Slack setup asks the OS to open its destination", until: urls => urls.length > 0,
+  });
+  expect(openedUrls).toHaveLength(1);
+  const openedUrl = openedUrls[0];
+  if (!openedUrl) throw new Error("Slack setup did not open a URL");
+  const setupUrl = new URL(openedUrl);
+  expect(setupUrl.origin).toBe(new URL(world.den.ref.webUrl).origin);
+  expect(setupUrl.pathname).toBe("/dashboard/mcp-connections");
+  expect([...setupUrl.searchParams.entries()]).toEqual([["quickAdd", "slack"]]);
+  await webUser.navigate(openedUrl);
   await webUser.see({ text: "OAuth app" }, { timeoutMs: 90_000 });
   await webUser.see({ text: "Client ID (optional for now)" });
   await webUser.see({ text: "Client secret (optional for now)" });
@@ -50,7 +60,7 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
-  await appUser.click({ role: "button", label: "New task" });
+  await appUser.click({ role: "button", label: "New session" });
   await appUser.see({ text: "Try one of these:" });
   await agent.on(world.app).send(allConnectorsPrompt);
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
@@ -61,5 +71,5 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   expect(listed).toEqual(world.expectedIds);
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);
-  evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Slack quickAdd deep link renders client fields; the agent only searched and did not execute setup or authorize an account", true);
+  evidence.recordAssertionEvidence("Filtering selects Slack and its setup destination opens the OAuth client form", "Clicking Set up Slack emitted exactly one OS browser request for the expected Den origin, connector page, and quickAdd=slack. Navigating that captured URL renders client fields; the agent only searched and did not execute setup or authorize an account", true);
 });

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -891,7 +891,14 @@ async function reloadConfiguredApp(app: import("@openwork/cdp").Surface): Promis
 
 export const connectionActionResourceUri = "ui://openwork/connection-action/v1/view.html";
 export const connectionActionReply = "Connect your Notion account to continue.";
+export const ordinaryDiscoveryPrompt = "Create a dashboard using my notes.";
+export const ordinaryDiscoveryReply = "I found the available capabilities for the dashboard.";
 export const connectionActionPrompt = "I want to connect Notion.";
+
+export const allConnectorsPrompt = "Show me all the quick-add connectors.";
+export const allConnectorsReply = "Here are all the connectors available to add.";
+export const connectorCatalogPrompt = "I want to set up Slack.";
+export const connectorCatalogReply = "Choose Slack to set it up, or browse the available connectors.";
 
 export async function connectionActionMcpApp(seed: Seed) {
   const providerId = "connection-action-mcp-app-provider";
@@ -900,9 +907,21 @@ export async function connectionActionMcpApp(seed: Seed) {
     org: { name: `Connection Action ${Date.now()}`, admin: { name: "Connection Admin" } },
     mocks: {
       connector: seed.mock({ agentWorkloads: [{
+        promptMarker: ordinaryDiscoveryPrompt,
+        finalReply: ordinaryDiscoveryReply,
+        steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp" } }],
+      }, {
         promptMarker: connectionActionPrompt,
         finalReply: connectionActionReply,
-        steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp" } }],
+        steps: [{ tool: "search_capabilities", arguments: { query: "Notion", type: "mcp", intent: "connect" } }],
+      }, {
+        promptMarker: connectorCatalogPrompt,
+        finalReply: connectorCatalogReply,
+        steps: [{ tool: "search_capabilities", arguments: { query: "Slack", type: "mcp", intent: "connect" } }],
+      }, {
+        promptMarker: allConnectorsPrompt,
+        finalReply: allConnectorsReply,
+        steps: [{ tool: "search_capabilities", arguments: { query: "quick add connectors", type: "connectors" } }],
       }] }),
     },
   });
@@ -1320,4 +1339,16 @@ export async function remoteMcpApps(seed: Seed) {
     await rm(profileDir, { recursive: true, force: true });
     throw error;
   }
+}
+
+export async function connectorCatalogDiscovery(seed: Seed) {
+  const world = await connectionActionMcpApp(seed);
+  const response = await seed.api(world.den.admin, "/v1/mcp-connections/presets");
+  if (!isRecord(response.body) || !Array.isArray(response.body.presets)) throw new Error("Den did not return its connector presets.");
+  const presetIds = response.body.presets.map((preset: unknown) => {
+    if (!isRecord(preset) || typeof preset.presetId !== "string") throw new Error("Invalid connector preset.");
+    return preset.presetId;
+  });
+  const web = await seed.web({ den: world.den, signedInAs: world.den.admin, startPath: "/dashboard/mcp-connections", headless: true });
+  return { ...world, web, expectedIds: ["google-workspace", "microsoft-365", ...presetIds] };
 }

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -1,13 +1,13 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { app as startApp, faultProxy as startFaultProxy } from "@openwork/env";
+import { app as startApp, faultProxy as startFaultProxy, SkipError } from "@openwork/env";
 import type { Den, MockHandle, Seed } from "@openwork/env";
 import { denFetch, evalIn as rawEvalIn } from "@openwork/behaviors";
 import type { DenFetchResult, DenSession } from "@openwork/behaviors";
 import { allocateFreePort } from "@openwork/cdp";
 import { startMockMcp } from "@openwork/labs";
-import { electronProfilePaths } from "@openwork/hosts";
+import { captureExternalBrowserUrls, electronProfilePaths } from "@openwork/hosts";
 
 export const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -1343,6 +1343,7 @@ export async function remoteMcpApps(seed: Seed) {
 
 export async function connectorCatalogDiscovery(seed: Seed) {
   const world = await connectionActionMcpApp(seed);
+  if (world.app.handle.hostKind !== "daytona") throw new SkipError("connector setup OS handoff witness requires Daytona Linux");
   const response = await seed.api(world.den.admin, "/v1/mcp-connections/presets");
   if (!isRecord(response.body) || !Array.isArray(response.body.presets)) throw new Error("Den did not return its connector presets.");
   const presetIds = response.body.presets.map((preset: unknown) => {
@@ -1350,5 +1351,6 @@ export async function connectorCatalogDiscovery(seed: Seed) {
     return preset.presetId;
   });
   const web = await seed.web({ den: world.den, signedInAs: world.den.admin, startPath: "/dashboard/mcp-connections", headless: true });
-  return { ...world, web, expectedIds: ["google-workspace", "microsoft-365", ...presetIds] };
+  const browserUrls = await captureExternalBrowserUrls(world.app.handle);
+  return withDispose({ ...world, web, browserUrls, expectedIds: ["google-workspace", "microsoft-365", ...presetIds] }, async () => { await browserUrls[Symbol.asyncDispose](); });
 }


### PR DESCRIPTION
Ordinary capability discovery could surface a sign-in card merely because one result described an unconnected service. Desktop now requires explicit setup intent before rendering search-generated connection cards or connector suggestions, including older stored results. Real connection failures remain actionable.

Explicit setup offers the matching connector and the complete searchable quick-add catalog. Pending authorization is scoped to the workspace and task, preventing reused tool-call IDs from inheriting another task’s sign-in state.

The gateway and shared schema landed separately in #4493. Production `/health` and `/ready` confirmed that API deployment at `2b065c7` before this desktop consumer. Replaces #4483.

Validation — Passed on final head `d578c40937a4146910cb590f56464d3cfae6b1ed`:

- `pnpm --filter @openwork/app typecheck`: passed.
- Focused app tests (mcp-reconnect-state, tool-error-attribution, mcp-app-frame, mcp-chat-reconnect): 37 passed, 0 failed.
- `pnpm evals:e2e connector-catalog --daytona`: placement daytona (--daytona); 1 passed, 0 failed, 0 skipped. Verifies all 12 quick adds, filtering, and the actual OS browser request produced by Set up Slack, then continues to that captured URL to verify OAuth client fields.
- `pnpm evals:e2e connection-action-mcp-app --daytona`: placement daytona (--daytona); 1 passed, 0 failed, 0 skipped. Verifies ordinary discovery produces no connection UI or authorization request, followed by explicit setup that authorizes only after the user clicks.

Both journeys pin OPENWORK_EVAL_DAYTONA_REF and OPENWORK_EVAL_REF to the full final commit. Assertion evidence and screenshots are published below. Earlier attempts caught an outdated New task selector and a quoting restriction in the new OS witness; both were corrected. The witness also passed a direct Daytona open/restore smoke check. Browser continuation does not complete live Slack authorization.

Warden’s rollout and test-provenance findings are addressed; final-head Warden clearance is approved with no blocking findings.
