### PR TITLE
Add explicit connector setup discovery to Den gateway

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -13,6 +13,8 @@ import { openworkCloudMcpConnectionActionSchema } from "@openwork/types/den/mcp-
 import type { Hono } from "hono"
 import type { RequestIdVariables } from "hono/request-id"
 import { z } from "zod"
+import { connectorCatalogSchema, type ConnectorCatalog } from "@openwork/types/connection-action-app"
+import { connectorCatalogForQuery } from "./connector-catalog.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
@@ -110,7 +112,7 @@ export type { ExecuteCapabilityToolResult }
 
 export { EXECUTE_CAPABILITY_TOOL_NAME }
 export const EXECUTE_CAPABILITY_SCRIPT_TOOL_NAME = "execute_capability_script"
-const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
+const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills", "connectors"])
 export const EXECUTE_CAPABILITY_TIMEOUT_MS = 180_000
 
 export const SEARCH_CAPABILITIES_ANNOTATIONS: ToolAnnotations = {
@@ -164,10 +166,12 @@ const capabilityMatchOutputSchema = z.object({
 export const SEARCH_CAPABILITIES_OUTPUT_SCHEMA = z.object({
   matches: z.array(capabilityMatchOutputSchema),
   connectionAction: connectionActionPayloadSchema.optional(),
+  connectorCatalog: connectorCatalogSchema.optional(),
   hint: z.string().optional(),
 })
 
 export const AGENT_MCP_INSTRUCTIONS = [
+  "When asked what can be connected or to browse quick adds, call search_capabilities with type connectors and any descriptive query. This returns the complete curated setup catalog, including Google Workspace and Microsoft 365. A named-service search includes setup suggestions only with intent connect, when the user explicitly requested setup. Suggestions are not executable capabilities or proof of connection; let the user choose Set up in the card. Never invent credentials or claim setup is finished. Existing connection actions take priority.",
   "This OpenWork Cloud MCP server uses standard MCP tools, resources, structured results, and list-changed notifications.",
   "Always call search_capabilities first with 2-4 keyword variants before concluding something is unavailable. Use execute_capability only with exact names returned by search_capabilities. A successful search_capabilities call proves this connection is authorized: Never tell the user to reconnect OpenWork Cloud because a downstream connector failed.",
   "Capabilities include native Google Workspace operations (Gmail read/search, Calendar list/create, Drive search/read, and Gmail draft creation) executed with the signed-in member's organization credentials, plus any MCP connections the organization has added. Allowlisted platform admins also discover namespaced OpenWork Admin capabilities here; other members cannot.",
@@ -182,7 +186,7 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "Do not invent OAuth-client, credential, or local-extension setup. Organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect; when a connection or marketplace readiness state requires administrator setup or member sign-in, relay that exact action.",
   "External MCP matches include the provider-advertised argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest. OpenWork always attempts the downstream provider call even when local schema checks find a mismatch; schemaGuidance is advisory: if the provider succeeded, accept the result and do not retry because of the warning; if it failed, use the warning to correct the arguments or search again.",
   "If the provider returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns unknown_capability, call search_capabilities again before retrying.",
-  "When the user asks to connect a service, search for that service by name. When a match has kind connection_status, search already renders its connection card in compatible hosts when the result identifies one connection. Do not execute the same status again when the search response includes connectionAction. Otherwise execute that exact match once to render its card. When execute_capability fails with needs_connection or connection_not_connected, execute that connection's status capability (mcp:<connectionId>:*) once for the same card. For member-owned OAuth connections in OpenWork desktop, ask the user to click Connect or Reconnect on the inline card; desktop handles authorization directly, so do not send them to Den. For other actions, name connectionStatus.connectionName and relay connectionStatus.action exactly in text, distinguishing the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console. Probes are live: after the human fixes the connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
+  "When the user explicitly asks to connect or reconnect a service, search for that service by name with intent connect. Ordinary capability searches must omit intent connect: blocked connection matches are informational and must not trigger sign-in cards or automatic status calls. Only propose authorization when an explicitly requested operation actually depends on that connection. Explicit connection searches render a card when the result identifies one connection. Do not execute the same status again when the search response includes connectionAction. For an explicit connection request without a card, execute that exact status match once. When execute_capability fails with needs_connection or connection_not_connected, execute that connection's status capability (mcp:<connectionId>:*) once for the same card. For member-owned OAuth connections in OpenWork desktop, ask the user to click Connect or Reconnect on the inline card; desktop handles authorization directly, so do not send them to Den. For other actions, name connectionStatus.connectionName and relay connectionStatus.action exactly in text, distinguishing the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console. Probes are live: after the human fixes the connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
   "Successful postMarketplacesPlugins, postPluginsAccess, and postMarketplacesAccess calls render a confirmation card automatically in compatible hosts; report the outcome in text as well.",
 ].join("\n")
 
@@ -232,16 +236,17 @@ function textContent(text: string): { text: string; type: "text" }[] {
   return [{ type: "text", text }]
 }
 
-export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T[], coverageHint?: string) {
+export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T[], coverageHint?: string, connectorCatalog?: ConnectorCatalog | null, connectionIntent = false) {
   const hint = [
-    ...(matches.length === 0 ? ["No matches. Try broader or different keywords."] : []),
+    ...(matches.length === 0 ? [connectorCatalog ? "These are setup suggestions, not connected tools. Use their setup actions; adding a connector requires an organization admin." : "No matches. Try broader or different keywords."] : []),
     ...(coverageHint ? [coverageHint] : []),
   ].join(" ")
-  const card = connectionActionSearchCard(matches)
+  const card = connectionIntent ? connectionActionSearchCard(matches) : null
   const result = {
     matches,
     ...(hint ? { hint } : {}),
     ...(card ? { connectionAction: card.connectionAction } : {}),
+    ...(connectorCatalog ? { connectorCatalog } : {}),
   }
   return {
     content: textContent(JSON.stringify(result, null, 2)),
@@ -545,17 +550,19 @@ export function registerAgentMcpRoutes<T extends { Variables: RequestIdVariables
         annotations: SEARCH_CAPABILITIES_ANNOTATIONS,
         _meta: { ui: { visibility: ["model", "app"] } },
         inputSchema: z.object({
+          intent: z.enum(["discover", "connect"]).optional().describe("Use connect only when the user explicitly asks to connect, reconnect, or set up a service. Ordinary capability discovery must omit this or use discover; it will not show sign-in cards."),
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
           limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
-          type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every available source; api searches Den API capabilities; admin searches allowlisted platform-admin tools; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches built-in and marketplace skills. Defaults to all."),
+          type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every available source; api searches Den API capabilities; admin searches allowlisted platform-admin tools; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches built-in and marketplace skills; connectors lists the entire quick-add setup catalog without probing connected tools. Defaults to all."),
         }),
         outputSchema: SEARCH_CAPABILITIES_OUTPUT_SCHEMA,
       },
-      async ({ query, limit, type }) => {
+      async ({ query, limit, type, intent }) => {
+        if (type === "connectors") return capabilitySearchToolResult([], undefined, connectorCatalogForQuery(query, true))
         const boundedLimit = limit ?? 5
         const result = await searchCapabilityRegistry(capabilityContext, { query, limit: boundedLimit, type })
         const matches = result.matches.sort(compareCapabilityMatches).slice(0, boundedLimit)
-        return capabilitySearchToolResult(matches, result.externalCoverageHint)
+        return capabilitySearchToolResult(matches, result.externalCoverageHint, intent === "connect" && (type === undefined || type === "all" || type === "mcp") && !matches.some(match => match.name.startsWith("mcp:")) ? connectorCatalogForQuery(query) : null, intent === "connect")
       },
     )
 

--- a/ee/apps/den-api/src/mcp/connector-catalog.ts
+++ b/ee/apps/den-api/src/mcp/connector-catalog.ts
@@ -1,0 +1,27 @@
+import { connectorCatalogSchema, type ConnectorCatalog } from "@openwork/types/connection-action-app"
+import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
+import { openworkOrganizationConnectionsUrl } from "./connection-navigation.js"
+
+export function connectorCatalogForQuery(query: string, showAll = false): ConnectorCatalog | null {
+  const setupUrl = (id: string) => {
+    const url = new URL(openworkOrganizationConnectionsUrl())
+    url.searchParams.set("quickAdd", id)
+    return url.toString()
+  }
+  const entries: ConnectorCatalog["entries"] = [
+    { id: "google-workspace", name: "Google Workspace", description: "Gmail, Calendar, and Drive with your work account.", setup: "suite", setupUrl: setupUrl("google-workspace") },
+    { id: "microsoft-365", name: "Microsoft 365", description: "Outlook, Calendar, and OneDrive with your work account.", setup: "suite", setupUrl: setupUrl("microsoft-365") },
+    ...EXTERNAL_MCP_PRESETS.map(preset => ({
+      id: preset.presetId,
+      name: preset.displayName,
+      description: preset.description,
+      serviceUrl: preset.url,
+      setup: preset.requiresOAuthClient ? "oauth_client" : preset.authType === "apikey" ? "api_key" : preset.authType === "none" ? "instant" : "oauth",
+      setupUrl: setupUrl(preset.presetId),
+    } satisfies ConnectorCatalog["entries"][number])),
+  ]
+  const normalized = ` ${query.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()} `
+  const selectedIds = entries.filter(entry => [entry.id, entry.name].some(value => normalized.includes(` ${value.toLowerCase().replace(/[^a-z0-9]+/g, " ")} `))).map(entry => entry.id)
+  if (!showAll && selectedIds.length === 0 && !/\b(connectors?|integrations?|quick adds?|quick connect)\b/.test(normalized)) return null
+  return connectorCatalogSchema.parse({ version: 1, entries, selectedIds: showAll ? [] : selectedIds })
+}

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -119,7 +119,7 @@ test("agent MCP server exposes steering instructions during initialize", async (
   expect(client.getInstructions()).toContain("Use create_skill")
   expect(client.getInstructions()).toContain("do not route these flows through execute_capability, postPlugins, or postConfigObjectsVersions")
   expect(client.getInstructions()).toContain("update_skill to publish a new immutable version")
-  expect(client.getInstructions()).toContain("execute that exact match once: it returns the live status and renders an actionable connection card")
+  expect(client.getInstructions()).toContain("Do not execute the same status again when the search response includes connectionAction")
   expect(client.getInstructions()).toContain("create-skill")
   expect(client.getInstructions()).toContain("share-plugin")
   expect(client.getInstructions()).toContain("add-to-marketplace")
@@ -304,7 +304,11 @@ test("capability search results include structured output alongside text compati
     action: { type: "connect", label: "Connect Notes", surface: "openwork_your_connections", retry: "search_capabilities" },
   }
   const blocked = [{ ...matches[0], kind: "connection_status", connectionStatus }]
-  const actionable = agentModule.capabilitySearchToolResult(blocked)
+  const quiet = agentModule.capabilitySearchToolResult(blocked)
+  expect(quiet.structuredContent.matches).toEqual(blocked)
+  expect(quiet.structuredContent.connectionAction).toBeUndefined()
+  expect(quiet._meta).toBeUndefined()
+  const actionable = agentModule.capabilitySearchToolResult(blocked, undefined, null, true)
   expect(actionable.structuredContent.matches).toEqual(blocked)
   expect(actionable.structuredContent.connectionAction?.connectionId).toBe("emc_notes")
   expect(actionable._meta?.["openwork/mcpApp"].arguments).toEqual({ connectionId: "emc_notes" })
@@ -512,3 +516,21 @@ test("connection status only outranks equally relevant callable tools", () => {
   expect(matches[0]?.kind).toBe("connection_status")
   expect(matches[0]?.score).toBe(20)
 })
+
+
+test("connector discovery includes every preset and separates setup suggestions from tools", async () => {
+  const { connectorCatalogForQuery } = await import("../src/mcp/connector-catalog.js");
+  const { EXTERNAL_MCP_PRESETS } = await import("../src/capability-sources/external-mcp-presets.js");
+  const catalog = connectorCatalogForQuery("Please connect Slack");
+  expect(catalog?.selectedIds).toEqual(["slack"]);
+  expect(catalog?.entries.map(entry => entry.id)).toEqual(["google-workspace", "microsoft-365", ...EXTERNAL_MCP_PRESETS.map(preset => preset.presetId)]);
+  expect(catalog?.entries.find(entry => entry.id === "slack")?.setup).toBe("oauth_client");
+  expect(connectorCatalogForQuery("slacker")).toBeNull();
+  expect(connectorCatalogForQuery("write a report")).toBeNull();
+  expect(connectorCatalogForQuery("all quick adds")?.selectedIds).toEqual([]);
+  expect(connectorCatalogForQuery("Slack", true)?.selectedIds).toEqual([]);
+  const result = agentModule.capabilitySearchToolResult([], undefined, catalog);
+  expect(result.structuredContent.connectorCatalog).toEqual(catalog);
+  expect(result.structuredContent.hint).toContain("not connected tools");
+  for (const entry of catalog?.entries ?? []) expect(new URL(entry.setupUrl).searchParams.get("quickAdd")).toBe(entry.id);
+});

--- a/evals/specs/connector-search-intent.test.ts
+++ b/evals/specs/connector-search-intent.test.ts
@@ -1,0 +1,101 @@
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { mcpMock, server, test } from "@openwork/testkit";
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected an object");
+  return value;
+}
+
+function rows(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error("Expected a list");
+  return value.map(record);
+}
+
+// This is a distinct gateway journey: discovering a blocked connection must be
+// informational until the caller explicitly requests connection setup.
+test("gateway discovery stays quiet until connection setup is explicitly requested", { timeout: 300_000 }, async ({ evidence, place }) => {
+  const orgName = `Connector Search ${Date.now()}`;
+  await using den = await server({
+    place,
+    web: false,
+    org: { name: orgName, members: {} },
+    mocks: { connector: mcpMock({ port: 3986 }) },
+  });
+  const orgs = await denFetch(den.admin, "/v1/me/orgs", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  expect(orgs.response.status).toBe(200);
+  const orgId = rows(record(orgs.body).orgs).find(org => org.name === orgName)?.id;
+  expect(typeof orgId).toBe("string");
+  const headers = { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": String(orgId) };
+  const created = await denFetch(den.admin, "/v1/mcp-connections/by-key/search-intent-notes", {
+    method: "PUT", headers,
+    body: JSON.stringify({ name: "Notes Search Fixture", url: den.mocks.connector.mcpUrl, authType: "oauth", credentialMode: "per_member", access: { orgWide: true } }),
+  });
+  expect(created.response.status, created.text).toBe(201);
+  const connectionId = record(created.body).id;
+  const minted = await denFetch(den.admin, "/v1/mcp/token", { method: "POST", headers, body: "{}" });
+  expect(minted.response.status).toBe(200);
+  const token = record(minted.body).token;
+  expect(typeof token).toBe("string");
+  let requestId = 0;
+  async function search(args: Record<string, unknown>) {
+    const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: { name: "search_capabilities", arguments: args } }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    expect(response.status).toBe(200);
+    const raw = await response.text();
+    const line = raw.split("\n").find(value => value.startsWith("data:"));
+    const rpc = record(JSON.parse(line ? line.slice(5) : raw));
+    expect(rpc.error).toBeUndefined();
+    const result = record(rpc.result);
+    expect(result.isError).not.toBe(true);
+    const content = rows(result.content);
+    const text = content[0]?.text;
+    if (typeof text !== "string") throw new Error("Missing search text");
+    const payload = record(JSON.parse(text));
+    expect(result.structuredContent).toEqual(payload);
+    return { result, payload };
+  }
+
+  const quiet = await search({ query: "Notes Search Fixture", type: "mcp" });
+  expect(rows(quiet.payload.matches).some(match => String(match.name).startsWith(`mcp:${connectionId}:`))).toBe(true);
+  expect(quiet.payload.connectionAction).toBeUndefined();
+  expect(quiet.payload.connectorCatalog).toBeUndefined();
+  expect(quiet.result._meta).toBeUndefined();
+  const explicit = await search({ query: "Notes Search Fixture", type: "mcp", intent: "connect" });
+  expect(record(explicit.payload.connectionAction).connectionId).toBe(connectionId);
+  expect(explicit.payload.connectorCatalog).toBeUndefined();
+  evidence.recordAssertionEvidence("Blocked connection discovery stays informational until explicit connect intent", "The same blocked Notes connection appeared in both real gateway searches. Default discovery returned neither action nor catalog nor UI metadata; intent connect returned that connection's action and no unrelated catalog.", true);
+
+  const slackQuiet = await search({ query: "slack" });
+  expect(slackQuiet.payload.connectorCatalog).toBeUndefined();
+  expect(slackQuiet.payload.connectionAction).toBeUndefined();
+  const slack = await search({ query: "slack", intent: "connect" });
+  const catalog = record(slack.payload.connectorCatalog);
+  expect(catalog.version).toBe(1);
+  expect(catalog.selectedIds).toEqual(["slack"]);
+  expect(slack.payload.connectionAction).toBeUndefined();
+  const entries = rows(catalog.entries);
+  const ids = entries.map(entry => entry.id);
+  expect(ids).toHaveLength(12);
+  expect(new Set(ids).size).toBe(12);
+  expect(ids).toEqual(expect.arrayContaining(["slack", "google-workspace", "microsoft-365", "linear"]));
+  for (const entry of entries) {
+    expect(typeof entry.name).toBe("string");
+    const setupUrl = new URL(String(entry.setupUrl));
+    expect(["http:", "https:"]).toContain(setupUrl.protocol);
+    expect(setupUrl.searchParams.get("quickAdd")).toBe(entry.id);
+  }
+  evidence.recordAssertionEvidence("Explicit named setup exposes the complete curated catalog without pretending a tool is connected", "Ordinary Slack search returned no setup UI. Explicit connect selected Slack in a versioned 12-entry catalog, including both suites and Linear, with a matching quickAdd setup URL for every entry and no connection action.", true);
+
+  const full = await search({ query: "available services", type: "connectors" });
+  const fullCatalog = record(full.payload.connectorCatalog);
+  expect(fullCatalog.selectedIds).toEqual([]);
+  expect(fullCatalog.entries).toEqual(entries);
+  expect(full.payload.matches).toEqual([]);
+  expect(full.payload.connectionAction).toBeUndefined();
+  evidence.recordAssertionEvidence("Explicit catalog browsing returns all quick adds without selecting or authorizing an account", "type connectors returned all 12 entries, no selected IDs, no executable capability matches, and no connection action.", true);
+});

--- a/packages/types/src/connection-action-app.ts
+++ b/packages/types/src/connection-action-app.ts
@@ -49,3 +49,18 @@ export const connectionActionPayloadSchema = z.object({
 })
 
 export type ConnectionActionPayload = z.infer<typeof connectionActionPayloadSchema>
+
+/** Curated setup suggestions, distinct from connected/executable capabilities. */
+export const connectorCatalogSchema = z.object({
+  version: z.literal(1),
+  selectedIds: z.array(z.string()),
+  entries: z.array(z.object({
+    id: z.string().regex(/^[a-z0-9-]+$/),
+    name: z.string(),
+    description: z.string(),
+    serviceUrl: z.string().url().optional(),
+    setup: z.enum(["oauth", "oauth_client", "api_key", "instant", "suite"]),
+    setupUrl: z.string().url(),
+  })),
+})
+export type ConnectorCatalog = z.infer<typeof connectorCatalogSchema>


### PR DESCRIPTION
Ordinary gateway capability discovery can currently offer sign-in just because a blocked connection matched a broad search. Default discovery now stays informational. An explicit `intent: "connect"` returns the existing connection action or a curated setup catalog; `type: "connectors"` returns every quick add.

This is the server-first rollout for #4490: it adds the optional versioned catalog schema and gateway behavior only. Desktop consumption remains in the follow-up and will wait for this API change to land and deploy.

Validation:
- `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/mcp-agent-timeouts.test.ts`: 16 passed, 0 failed.
- `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_DAYTONA_REF=c6c4884803615b3891558422c0aa06e9332dfc25 OPENWORK_EVAL_REF=c6c4884803615b3891558422c0aa06e9332dfc25 pnpm evals:pr specs/connector-search-intent.test.ts`: Daytona cold boot, 1 passed, 0 failed, 0 skipped. Real authenticated gateway requests verify quiet blocked-connection discovery, explicit connection action, quiet Slack discovery, explicit Slack setup, and the full 12-entry catalog.
- Boundary ratchet reports existing violations in six unrelated specs. Clean `origin/dev` at `89558a987` reproduces the same failures; the new server-boundary journey introduces no violation.

The gateway journey is new because existing connection UI specs drive desktop consumers, while the existing plugin parity journey tests plugin provisioning. This journey verifies the independent server contract before any desktop consumer lands.
