### PR TITLE
Run Warden on drafts and when PRs become ready

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -3,11 +3,10 @@ name: Warden
 # Trigger types must stay aligned with the warden.toml trigger actions:
 # an event that runs this workflow but matches no warden trigger would
 # produce findings_count=0 without analysis and wrongly grant clearance.
-# (ready_for_review is deliberately absent — warden does not support it;
-# draft-to-ready PRs get analyzed on their next push.)
+# Analyze drafts as they evolve, then refresh the review when they become ready.
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [dev]
 
 permissions:
@@ -24,10 +23,9 @@ concurrency:
 
 jobs:
   warden:
-    # Skip drafts and fork PRs: forks have no secrets, so analysis cannot
-    # run (and clearance is fork-blocked in warden-clearance.yml anyway).
+    # Fork PRs have no secrets, so analysis cannot run there (and clearance
+    # is fork-blocked in warden-clearance.yml anyway). Drafts are reviewed too.
     if: >-
-      !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/warden.toml
+++ b/warden.toml
@@ -29,8 +29,8 @@ name = "diff-security-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-draft = false
+# Omitting draft matches both draft and ready PRs.
+actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 # Lets developers run `warden` locally on uncommitted changes before pushing.
 [[skills.triggers]]
@@ -43,8 +43,7 @@ name = "confidentiality-review"
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-draft = false
+actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 [[skills.triggers]]
 type = "local"
@@ -55,8 +54,7 @@ paths = ["evals/specs/**", "evals/worlds/**"]
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-draft = false
+actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 [[skills.triggers]]
 type = "local"
@@ -72,8 +70,7 @@ paths = [
 
 [[skills.triggers]]
 type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-draft = false
+actions = ["opened", "synchronize", "reopened", "ready_for_review"]
 
 [[skills.triggers]]
 type = "local"


### PR DESCRIPTION
Warden previously skipped draft PRs and did not run when they became ready, leaving the latest commit unreviewed until another push or reopen. Review same-repository drafts on open, push, and reopen, and rerun the review on `ready_for_review`.

Keep the workflow events and all four skill trigger action lists aligned. Remove the draft-only exclusions from both layers while preserving the fork restriction and the existing trusted clearance rules.

Validation:
- `actionlint .github/workflows/warden.yml` passed.
- Confirmed the pinned Warden source accepts arbitrary PR action strings and that omitting `draft` matches both states.
- Live draft review passed: [run 33972076148](https://github.com/different-ai/openwork/actions/runs/33972076148) executed both applicable skills while `isDraft=true`.
- Live draft-to-ready review passed: [run 33972150484](https://github.com/different-ai/openwork/actions/runs/33972150484) started after marking the PR ready, without any push or reopen. Both applicable skills executed again.
- Both runs completed successfully with zero findings against the same commit, `e23aca9741ac268c50d1f7cf3d2c9aa9b6f29b0b`.

This is CI configuration; app/Den journey tests do not exercise GitHub PR lifecycle events. The two real GitHub workflow runs above are the runtime evidence.
