### PR TITLE
Keep later connections available to saved workflows and apps

### DIFF
--- a/ee/apps/den-api/src/mcp/codemode-namespaces.ts
+++ b/ee/apps/den-api/src/mcp/codemode-namespaces.ts
@@ -71,8 +71,6 @@ export function isCodemodeEligibleConnection(
   return !connection.toolPolicy?.allDisabled && !connection.oauthIssuerReviewRequiredAt
 }
 
-export const CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT = 16
-
 export type CodemodeConnectionNamespaceContext = {
   nativeProviderEntries: NativeProviderConnectionEntry[]
   externalMcpConnections: ExternalMcpConnectionRow[]
@@ -117,9 +115,10 @@ export async function resolveCodemodeConnectionNamespaceContext(input: {
       }),
   ])
   const codemodeNativeProviderEntries = nativeProviderEntries.filter((entry) => entry.connectedForMe === true)
-  const codemodeExternalMcpConnections = externalMcpConnections
-    .filter(isCodemodeEligibleConnection)
-    .slice(0, CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT)
+  // Search chooses a bounded, query-ranked set to probe. Workflow namespaces
+  // must include every eligible connection, including those found beyond that
+  // search batch. Tool discovery already has a shared deadline and worker pool.
+  const codemodeExternalMcpConnections = externalMcpConnections.filter(isCodemodeEligibleConnection)
 
   return {
     nativeProviderEntries,

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -42,7 +42,6 @@ import {
 import { compareCapabilityMatches, tokenize } from "./search.js"
 import type { CapabilityMatch } from "./search.js"
 import {
-  CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT,
   codemodeScriptPath,
   resolveCodemodeConnectionNamespaceContext,
   type CodemodeConnectionNamespaceContext,
@@ -72,7 +71,7 @@ import {
  */
 
 const EXTERNAL_CAPABILITY_PREFIX = "mcp:"
-export const EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT = CODEMODE_EXTERNAL_MCP_CONNECTION_LIMIT
+export const EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT = 16
 export const EXTERNAL_MCP_SEARCH_CONCURRENCY = 8
 export const EXTERNAL_MCP_SEARCH_MATCH_LIMIT = 20
 const EXTERNAL_MCP_SEARCH_REQUEST_TIMEOUT_MS = 5_000

--- a/evals/specs/saved-script-automations.e2e.test.ts
+++ b/evals/specs/saved-script-automations.e2e.test.ts
@@ -478,8 +478,13 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   expect(refreshedApp.body).toMatchObject({ onDashboard: true, view: { configObjectId: externalConfigObjectId } })
   expect(JSON.stringify(requireRecord(refreshedApp.body, "refreshed app").payload)).toContain(refreshMarker)
   expect(JSON.stringify(requireRecord(refreshedApp.body, "refreshed app").payload)).not.toContain(externalMarker)
-  expect((await appRequest(den.members.colleague, externalAppPath)).response.status).toBe(404)
-  expect(JSON.stringify((await appRequest(den.admin, appPath)).body)).not.toContain(refreshMarker)
+  const forbiddenApp = await appRequest(colleague, externalAppPath)
+  expect(forbiddenApp.response.status).toBe(403)
+  expect(forbiddenApp.body).not.toHaveProperty("payload")
+  expect(forbiddenApp.body).not.toHaveProperty("view")
+  const unrelatedApp = await appRequest(den.admin, appPath)
+  expect(JSON.stringify(unrelatedApp.body)).toContain(scheduledMarker)
+  expect(JSON.stringify(unrelatedApp.body)).not.toContain(refreshMarker)
   evidence.recordAssertionEvidence(
     "A connection beyond the first 16 works from chat discovery through a saved and refreshed app",
     "Search returned the seventeenth connection's callable script path. Its procedure executed, saved, reran and produced an app whose latest payload changed on refresh; the unrelated app and colleague's access stayed unchanged.",

--- a/evals/specs/saved-script-automations.e2e.test.ts
+++ b/evals/specs/saved-script-automations.e2e.test.ts
@@ -100,6 +100,17 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
     "saved-script-automations spec exercises Cloud Automations",
   )
 
+  // A connection found by chat must remain callable in a saved Workflow even
+  // when it was added after the first search batch of 16 connections.
+  for (let index = 0; index < 16; index += 1) {
+    await createOrgConnection(den.admin, {
+      name: `Earlier source ${index}`,
+      url: den.mocks.reports.mcpUrl,
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true },
+    })
+  }
   const connection = await createOrgConnection(den.admin, {
     name: "Report source",
     url: den.mocks.reports.mcpUrl,
@@ -346,7 +357,17 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   )
 
   const externalMarker = `launch-external-${stamp}`
-  const externalCode = "return { briefing: await tools.report_source.mock_echo({ text: input.topic }) }"
+  const discovered = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "search_capabilities",
+    arguments: { query: "Report source mock_echo", type: "mcp", limit: 20 },
+  })
+  expect(discovered.isError).not.toBe(true)
+  const discoveryText = records(discovered.content).find((part) => part.type === "text")?.text
+  if (typeof discoveryText !== "string") throw new Error("Capability search returned no text result")
+  const matches = records(requireRecord(JSON.parse(discoveryText), "capability search").matches)
+  const externalMatch = matches.find((match) => match.name === `mcp:${connection.id}:mock_echo`)
+  expect(externalMatch?.scriptPath).toBe("tools.report_source.mock_echo")
+  const externalCode = `return { briefing: await ${externalMatch?.scriptPath}({ text: input.topic }) }`
   const externalRunStartedAt = new Date().toISOString()
   const externalExecuted = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
     name: "execute_capability_script",
@@ -429,6 +450,41 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
     input: { topic: externalMarker },
   })
   expect(externalManualRun.status).toBe("succeeded")
+
+  const externalDraft = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
+    name: "save_artifact_view",
+    arguments: {
+      configObjectId: externalConfigObjectId, title: "Report app",
+      reactSource: "export default function Report({ data }) { return <article><h1>Report</h1><pre>{JSON.stringify(data.briefing)}</pre></article> }",
+    },
+  })
+  expect(externalDraft.isError).not.toBe(true)
+  const externalView = requireRecord(requireRecord(externalDraft.structuredContent, "external app draft").view, "external view")
+  const externalRevision = records(externalView.revisions)[0]
+  expect(externalRevision?.buildStatus).toBe("ready")
+  const externalAppPath = `/v1/apps/${externalView.id}`
+  const externalAppSaved = await appRequest(den.admin, `${externalAppPath}/save`, {
+    method: "POST", body: JSON.stringify({ revisionId: externalRevision?.id, title: "Report app", useInWorkflow: false, expectedActiveRevisionId: null }),
+  })
+  expect(externalAppSaved.response.status, externalAppSaved.text).toBe(200)
+  const refreshMarker = `launch-refreshed-${stamp}`
+  const refreshedRun = await runWorkflow(den.admin, externalConfigObjectId, {
+    pluginId: externalPluginId, configObjectVersionId: externalConfigObjectVersionId,
+    input: { topic: refreshMarker },
+  })
+  expect(refreshedRun.status).toBe("succeeded")
+  const refreshedApp = await appRequest(den.admin, externalAppPath)
+  expect(refreshedApp.response.status, refreshedApp.text).toBe(200)
+  expect(refreshedApp.body).toMatchObject({ onDashboard: true, view: { configObjectId: externalConfigObjectId } })
+  expect(JSON.stringify(requireRecord(refreshedApp.body, "refreshed app").payload)).toContain(refreshMarker)
+  expect(JSON.stringify(requireRecord(refreshedApp.body, "refreshed app").payload)).not.toContain(externalMarker)
+  expect((await appRequest(den.members.colleague, externalAppPath)).response.status).toBe(404)
+  expect(JSON.stringify((await appRequest(den.admin, appPath)).body)).not.toContain(refreshMarker)
+  evidence.recordAssertionEvidence(
+    "A connection beyond the first 16 works from chat discovery through a saved and refreshed app",
+    "Search returned the seventeenth connection's callable script path. Its procedure executed, saved, reran and produced an app whose latest payload changed on refresh; the unrelated app and colleague's access stayed unchanged.",
+    true,
+  )
 
   const latestDetail = await readWorkflowDetail(den.admin, externalConfigObjectId)
   const latestScript = latestDetail.script


### PR DESCRIPTION
A connection added after the first 16 could work in chat but disappear when creating or running a saved Workflow, blocking reusable apps. Workflow namespaces now include every eligible connection. Capability search retains its query-ranked 16-connection probe budget; tool discovery retains its concurrency limit and shared deadline.

The existing saved-workflow journey now places its report connection seventeenth, discovers and executes its script path, saves a private app, and checks that a fresh workflow run updates that app without exposing it to another member or replacing an unrelated app's result. The unattended execution boundary is also exercised.

Validation on `85f4942a570631664b6fe8a23994c0374ccf07f7`:

- `GODEBUG=tlsmlkem=0,http2client=0 OPENWORK_EVAL_REF=85f4942a570631664b6fe8a23994c0374ccf07f7 pnpm evals:e2e saved-script-automations` — **Passed**, exit 0; 1 passed, 0 failed, 0 skipped. Placement: `daytona (daytona CLI authenticated)`. Runtime evidence is published below.
- `pnpm evals:typecheck` — exit 2 on this head and clean base `d25a9365a5701dec36f581b67f34b16b3601d014`, with identical 308 diagnostics and no added diagnostics. Both checkouts had root and evals dependencies installed from their frozen lockfiles. First matching error: `apps/server/src/agent-context-cloud-probe.ts(216,15): TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.`
