### PR TITLE
Explain desktop first use and make task starters safely editable

### DIFF
--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect } from "react";
-import { Dithering } from "@paper-design/shaders-react";
+import { FileText, FolderOpen, Globe } from "lucide-react";
 
 import { t } from "../../../i18n";
 import { useBootState } from "../../shell/boot-state";
@@ -56,23 +56,6 @@ export function WelcomePage({
       <ScrollArea className="relative z-10">
         <ScrollAreaViewport>
           <div className="relative flex min-h-dvh items-center justify-center px-6 py-16">
-            {/* Paper first-load spec: subtle black pixel-dither mosaic over a
-                near-white ground. `dark:invert` flips the pixels to white so
-                the texture survives dark mode. */}
-            <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-[0.1] dark:invert">
-              <Dithering
-                className="size-full"
-                speed={0.01}
-                shape="warp"
-                type="2x2"
-                size={20.3}
-                scale={1.19}
-                frame={264559.21}
-                colorBack="#00000000"
-                colorFront="#000000"
-              />
-            </div>
-
             <div className="relative z-10 w-full max-w-[720px] rounded-3xl border border-border bg-background px-8 pb-12 pt-10 sm:px-16 sm:pb-16 sm:pt-14">
               <div className="flex items-center gap-2.5">
                 <img
@@ -97,7 +80,23 @@ export function WelcomePage({
                 </p>
               </div>
 
-              <div className="mt-11 flex flex-col gap-3">
+              <div className="mt-7 grid gap-4 border-y border-border py-5" aria-label="What you can do">
+                {[
+                  { icon: FileText, title: "Turn notes into finished work", description: "Draft briefs, summarize documents, and work with spreadsheets." },
+                  { icon: FolderOpen, title: "Work in your own folders", description: "Keep each project’s files and tasks together in a workspace." },
+                  { icon: Globe, title: "Bring your tools into the conversation", description: "Use the browser and discover connections when a task needs them." },
+                ].map(({ icon: Icon, title, description }) => (
+                  <div key={title} className="flex items-start gap-3">
+                    <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{title}</p>
+                      <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-7 flex flex-col gap-3">
                 {onTeamSignIn ? (
                   <Button
                     type="button"
@@ -124,6 +123,10 @@ export function WelcomePage({
                     ? t("welcome.creating_workspace")
                     : (getStartedLabel || t("welcome.use_without_cloud"))}
                 </Button>
+
+                <p className="text-xs leading-5 text-muted-foreground">
+                  Without Cloud, choose a folder on this computer. Sign in to use your team’s shared tools and settings.
+                </p>
 
                 <div className="pt-2">
                   <button

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useState } from "react";
-import { ArrowRight, X, Zap } from "lucide-react";
+import { ArrowRight, FileText, FolderOpen, Globe, Table2, X, Zap } from "lucide-react";
 
 import { DEFAULT_MODEL } from "@/app/constants";
 import type { ComposerAttachment } from "@/app/types";
@@ -21,28 +21,33 @@ type HeroSuggestion = {
   title: string;
   description: string;
   prompt: string;
+  icon?: typeof FileText;
 };
 
 const DEFAULT_SUGGESTIONS: HeroSuggestion[] = [
   {
-    title: "Summarize my week",
-    description: "Pull highlights from email and calendar.",
-    prompt: "Summarize my week: pull the highlights from my connected email and calendar and give me a short digest of what happened and what needs my attention.",
+    title: "Explore this workspace",
+    description: "Find your bearings before making changes.",
+    prompt: "Give me an overview of the files in this workspace and suggest one useful first task. Don’t change any files yet.",
+    icon: FolderOpen,
   },
   {
     title: "Clean up a spreadsheet",
-    description: "Drop in a CSV and describe the result you want.",
-    prompt: "Create a sample CSV file with 20 rows of fake customer data (name, email, company, revenue). Then show me a summary of the data.",
+    description: "Start with your file and the result you want.",
+    prompt: "Help me clean up a spreadsheet. Ask me which file to use and what needs fixing, then show me the proposed changes before editing it.",
+    icon: Table2,
   },
   {
     title: "Draft a document",
-    description: "Reports, emails, or briefs from a few bullet points.",
+    description: "Turn rough notes into a brief or report.",
     prompt: "Draft a one-page project brief. Ask me for the bullet points you need, then turn them into a clear, well-structured document.",
+    icon: FileText,
   },
   {
-    title: "Automate a web task",
-    description: "Use the built-in browser for repetitive steps.",
-    prompt: "Open craigslist.org in the browser and search for couches for sale. Show me the top 5 results with prices.",
+    title: "Work with a website",
+    description: "Research or plan a repetitive browser task.",
+    prompt: "Help me with a browser task. Ask which website and what result I want, then propose the steps before taking action.",
+    icon: Globe,
   },
 ];
 
@@ -65,6 +70,7 @@ export type SessionEmptyHeroProps = {
  */
 export function SessionEmptyHero(props: SessionEmptyHeroProps) {
   const [prompt, setPrompt] = useState("");
+  const [selectedSuggestion, setSelectedSuggestion] = useState<string | null>(null);
   const orgRestrictions = useOrgRestrictions();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const canAddProviders = !checkDesktopRestriction({ restriction: "allowCustomProviders" });
@@ -107,8 +113,9 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     props.onRunTask(trimmedPrompt, attachments);
   };
 
-  const fillPrompt = (value: string) => {
-    setPrompt(value);
+  const fillPrompt = (suggestion: HeroSuggestion) => {
+    setPrompt(suggestion.prompt);
+    setSelectedSuggestion(suggestion.title);
     window.dispatchEvent(new Event("openwork:focusPrompt"));
   };
 
@@ -118,7 +125,7 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
         <h2 className="text-[24px] font-semibold leading-[30px] tracking-[-0.02em] text-foreground">
           What do you need done?
         </h2>
-        <p className="text-[13px] text-muted-foreground">Describe it in plain language</p>
+        <p className="text-[13px] text-muted-foreground">Start with the outcome. Add files or choose a tool when you need one.</p>
       </div>
 
       <NewTaskComposer
@@ -137,7 +144,7 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
           <span>Using the free starter model.</span>
           <button
             type="button"
-            className="flex items-center gap-1 font-medium text-blue-10 transition-colors hover:text-blue-11"
+            className="flex items-center gap-1 font-medium text-foreground transition-colors hover:underline"
             onClick={() => platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn, "sign-up"))}
           >
             Get frontier models with no API keys
@@ -157,10 +164,10 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
       {!showModelsHint && canAddProviders && props.providerCount === 0 && props.onOpenProviderAuth ? (
         <button
           type="button"
-          className="flex w-full items-start gap-3 rounded-xl border border-blue-7/50 bg-blue-2/40 p-3.5 text-left transition-colors hover:bg-blue-3/50"
+          className="flex w-full items-start gap-3 rounded-xl border border-border bg-background p-3.5 text-left transition-colors hover:bg-accent"
           onClick={props.onOpenProviderAuth}
         >
-          <Zap className="mt-0.5 size-4 shrink-0 text-blue-10" />
+          <Zap className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
           <div>
             <div className="text-[13px] font-medium text-foreground">Connect a model provider</div>
             <div className="mt-0.5 text-[12px] text-muted-foreground">
@@ -170,20 +177,37 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
         </button>
       ) : null}
 
-      <div className="grid gap-2 sm:grid-cols-2">
-        {suggestions.map((suggestion) => (
-          <button
-            key={suggestion.title}
-            type="button"
-            className="rounded-xl border border-border bg-background p-3.5 text-left transition-colors hover:bg-accent"
-            onClick={() => fillPrompt(suggestion.prompt)}
-          >
-            <div className="truncate text-[13px] font-medium text-foreground">{suggestion.title}</div>
-            <div className="mt-0.5 line-clamp-2 text-[12px] leading-[17px] text-muted-foreground">
-              {suggestion.description}
-            </div>
-          </button>
-        ))}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>Start with an example</span>
+          <span>Edit before you send</span>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion.title}
+              type="button"
+              className="rounded-xl border border-border bg-background p-3.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              disabled={Boolean(prompt.trim()) || props.busy}
+              onClick={() => fillPrompt(suggestion)}
+            >
+              <div className="flex items-center gap-2 text-[13px] font-medium text-foreground">
+                {suggestion.icon ? <suggestion.icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" /> : null}
+                <span className="truncate">{suggestion.title}</span>
+              </div>
+              <div className="mt-0.5 line-clamp-2 text-[12px] leading-[17px] text-muted-foreground">
+                {suggestion.description}
+              </div>
+            </button>
+          ))}
+        </div>
+        <p className="min-h-5 text-xs leading-5 text-muted-foreground" role="status" aria-live="polite">
+          {prompt.trim()
+            ? selectedSuggestion
+              ? "Example added to your draft. Make it yours, then choose Run task. Clear your draft to choose another."
+              : "Your draft is safe. Clear it to choose an example."
+            : "Examples fill your draft. Nothing runs until you choose Run task."}
+        </p>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
 import { canCreateWorkspaces } from "../../app/lib/workspace-creation-policy";
-import { createClient, unwrap } from "../../app/lib/opencode";
 import { useLocal } from "../kernel/local-provider";
 import { usePlatform } from "../kernel/platform";
 import { WelcomePage } from "../domains/onboarding/welcome-page";
@@ -32,11 +31,11 @@ import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { JoinOrganizationDialog } from "../domains/cloud/join-organization-dialog";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { captureAnalyticsEvent } from "../../app/lib/analytics";
-import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
+import { createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { buildDenAuthUrl, DEFAULT_DEN_BASE_URL, readDenSettings } from "../../app/lib/den";
 import { markDesktopSignInInitiated } from "../../app/lib/den-sign-in-intent";
 import { denSettingsChangedEvent } from "../../app/lib/den-session-events";
-import { writeActiveWorkspaceId, writeLastSessionFor, writeWorkspaceProjectDimension } from "./session-memory";
+import { writeActiveWorkspaceId, writeWorkspaceProjectDimension } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { shouldHoldWelcomeForDenSession } from "./welcome-den-session";
@@ -73,7 +72,6 @@ type WelcomeState = {
   attributionStep: boolean;
   pendingRoute: string | null;
   pendingWorkspaceId: string | null;
-  pendingSessionId: string | null;
 };
 
 type WelcomeAction =
@@ -85,7 +83,7 @@ type WelcomeAction =
   | { type: "remote:start" }
   | { type: "remote:error"; error: string }
   | { type: "remote:finish" }
-  | { type: "provider-step"; workspaceId: string; sessionId: string | null }
+  | { type: "provider-step"; workspaceId: string }
   | { type: "attribution-step"; route: string };
 
 const initialWelcomeState: WelcomeState = {
@@ -98,7 +96,6 @@ const initialWelcomeState: WelcomeState = {
   attributionStep: false,
   pendingRoute: null,
   pendingWorkspaceId: null,
-  pendingSessionId: null,
 };
 
 function welcomeReducer(state: WelcomeState, action: WelcomeAction): WelcomeState {
@@ -120,7 +117,7 @@ function welcomeReducer(state: WelcomeState, action: WelcomeAction): WelcomeStat
     case "remote:finish":
       return { ...state, remoteBusy: false };
     case "provider-step":
-      return { ...state, providerStep: true, pendingWorkspaceId: action.workspaceId, pendingSessionId: action.sessionId };
+      return { ...state, providerStep: true, pendingWorkspaceId: action.workspaceId };
     case "attribution-step":
       return { ...state, providerStep: false, attributionStep: true, pendingRoute: action.route };
   }
@@ -179,8 +176,6 @@ export function WelcomeRoute() {
       try {
         const workspaceName = folderNameFromPath(folder);
         let list: WorkspaceList | null = null;
-        let sessionBaseUrl = "";
-        let sessionToken = "";
         try {
           const { normalizedBaseUrl, resolvedToken, resolvedHostToken } =
             await resolveOpenworkConnection();
@@ -195,8 +190,6 @@ export function WelcomeRoute() {
               name: workspaceName,
               preset: "starter",
             });
-            sessionBaseUrl = normalizedBaseUrl;
-            sessionToken = resolvedToken;
           }
         } catch {
           list = null;
@@ -210,7 +203,6 @@ export function WelcomeRoute() {
           "";
         let targetWorkspaceId = createdId;
         let targetWorkspace = list.workspaces.find((workspace: WorkspaceInfo) => workspace.id === createdId) ?? null;
-        let targetSessionId: string | null = null;
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
           await workspaceSetRuntimeActive(createdId).catch(() => undefined);
@@ -222,25 +214,6 @@ export function WelcomeRoute() {
             workspace: targetWorkspace,
             allWorkspaces: list.workspaces,
           }).catch(() => undefined);
-          const fresh = await resolveOpenworkConnection().catch(() => null);
-          if (fresh?.normalizedBaseUrl && fresh.resolvedToken) {
-            sessionBaseUrl = fresh.normalizedBaseUrl;
-            sessionToken = fresh.resolvedToken;
-          }
-        }
-        if (targetWorkspaceId && sessionBaseUrl && sessionToken) {
-          try {
-            const workspacePath = targetWorkspace?.path?.trim() || folder;
-            const session = unwrap(await createClient(
-              `${(buildOpenworkWorkspaceBaseUrl(sessionBaseUrl, targetWorkspaceId) ?? sessionBaseUrl).replace(/\/+$/, "")}/opencode`,
-              workspacePath || undefined,
-              { token: sessionToken, mode: "openwork" },
-            ).session.create({ directory: workspacePath || undefined }));
-            targetSessionId = session.id;
-            captureAnalyticsEvent("task_created", { source: "onboarding", workspace_type: "local" });
-          } catch {
-            // Best-effort first task creation.
-          }
         }
         if (targetWorkspaceId) {
           writeActiveWorkspaceId(targetWorkspaceId);
@@ -249,11 +222,12 @@ export function WelcomeRoute() {
               label: projectLabel,
             });
           }
-          if (targetSessionId) writeLastSessionFor(targetWorkspaceId, targetSessionId);
         }
         dispatch({ type: "close" });
         // Show the provider selection step before navigating to the session.
-        dispatch({ type: "provider-step", workspaceId: targetWorkspaceId, sessionId: targetSessionId });
+        // Keep the new-task screen stable. The first explicit submission
+        // creates a session, just like any other empty workspace.
+        dispatch({ type: "provider-step", workspaceId: targetWorkspaceId });
 
       } catch (error) {
         dispatch({
@@ -363,8 +337,8 @@ export function WelcomeRoute() {
   const finishOnboarding = useCallback(() => {
     markOnboardingComplete();
     navigate(state.pendingRoute ?? "/session", { replace: true });
-    if (state.pendingSessionId) focusPromptSoon();
-  }, [markOnboardingComplete, navigate, state.pendingRoute, state.pendingSessionId]);
+    focusPromptSoon();
+  }, [markOnboardingComplete, navigate, state.pendingRoute]);
 
   const handleAttributionSubmit = useCallback(
     (source: AttributionSource, aiPrompt?: string) => {
@@ -440,7 +414,7 @@ export function WelcomeRoute() {
             // always opened a bare sign-up page — payment before value.
             platform.openLink(getOpenWorkModelsActionUrl(denAuth.isSignedIn, "sign-up"));
             const route = state.pendingWorkspaceId
-              ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
+              ? workspaceSessionRoute(state.pendingWorkspaceId)
               : "/session";
             dispatch({ type: "attribution-step", route });
           }}
@@ -448,13 +422,13 @@ export function WelcomeRoute() {
             markOpenWorkModelsStartupPromoShown();
             hideOpenWorkModelsPromo();
             const route = state.pendingWorkspaceId
-              ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
+              ? workspaceSessionRoute(state.pendingWorkspaceId)
               : "/session";
             dispatch({ type: "attribution-step", route: `${route}?onboarding=1` });
           }}
           onSkip={() => {
             const route = state.pendingWorkspaceId
-              ? workspaceSessionRoute(state.pendingWorkspaceId, state.pendingSessionId)
+              ? workspaceSessionRoute(state.pendingWorkspaceId)
               : "/session";
             dispatch({ type: "attribution-step", route });
           }}

--- a/evals/specs/first-run-local.e2e.test.ts
+++ b/evals/specs/first-run-local.e2e.test.ts
@@ -9,6 +9,10 @@ test("first use without an invite or cloud reaches local task UI with honest mod
   await step("Welcome", async () => {
     await user.see({ text: "Welcome to OpenWork" });
     await user.see("Use Without Cloud");
+    await user.see({ text: "Turn notes into finished work" });
+    await user.see({ text: "Work in your own folders" });
+    await user.see({ text: "Bring your tools into the conversation" });
+    await user.see({ text: "Without Cloud, choose a folder on this computer. Sign in to use your team’s shared tools and settings." });
     await user.notSee({ text: /Something went wrong/ });
   });
 
@@ -33,7 +37,23 @@ test("first use without an invite or cloud reaches local task UI with honest mod
   expect(composer.runTaskVisible).toBe(true);
   await user.notSee({ text: /Something went wrong/ });
   await user.see({ text: /Using the free starter model/ });
-  await user.type("composer", prompt);
+  await step("An example is an editable draft, not an automatic task", async () => {
+    const before = await probe.composer();
+    await user.click({ role: "button", text: "Explore this workspace" });
+    await user.see("composer", { editable: true, text: "Give me an overview of the files in this workspace and suggest one useful first task. Don’t change any files yet." });
+    await user.see({ text: "Example added to your draft. Make it yours, then choose Run task. Clear your draft to choose another." });
+    expect(await probe.eval(`Array.from(document.querySelectorAll("button")).find(button => button.textContent.includes("Draft a document"))?.disabled`)).toBe(true);
+    const selected = await probe.composer();
+    expect(selected.userMessageCount).toBe(before.userMessageCount);
+    expect(selected.route).toBe(before.route);
+    await user.type("composer", "", { replace: true });
+    expect(await probe.eval(`Array.from(document.querySelectorAll("button")).find(button => button.textContent.includes("Draft a document"))?.disabled`)).toBe(false);
+    await user.click({ role: "button", text: "Draft a document" });
+    await user.see("composer", { editable: true, text: "Draft a one-page project brief. Ask me for the bullet points you need, then turn them into a clear, well-structured document." });
+    await user.type("composer", prompt, { replace: true });
+    await user.see("composer", { editable: true, text: prompt });
+    expect((await probe.composer()).userMessageCount).toBe(before.userMessageCount);
+  });
 
   if (!(await probe.composer()).runTaskEnabled) {
     await user.see("Connect a model provider");

--- a/evals/specs/first-run-local.e2e.test.ts
+++ b/evals/specs/first-run-local.e2e.test.ts
@@ -39,7 +39,9 @@ test("first use without an invite or cloud reaches local task UI with honest mod
   await user.notSee({ text: /Something went wrong/ });
   await user.see({ text: /Using the free starter model/ });
   await step("An example is an editable draft, not an automatic task", async () => {
+    await user.looks(["The new-task screen offers workspace and document examples before the first task is submitted"]);
     const before = await probe.composer();
+    expect(before.route).toMatch(/\/session$/);
     await user.click({ role: "button", text: /^Explore this workspace/ });
     await user.see("composer", { editable: true, text: "Give me an overview of the files in this workspace and suggest one useful first task. Don’t change any files yet." });
     await user.see({ text: "Example added to your draft. Make it yours, then choose Run task. Clear your draft to choose another." });

--- a/evals/specs/first-run-local.e2e.test.ts
+++ b/evals/specs/first-run-local.e2e.test.ts
@@ -14,6 +14,7 @@ test("first use without an invite or cloud reaches local task UI with honest mod
     await user.see({ text: "Bring your tools into the conversation" });
     await user.see({ text: "Without Cloud, choose a folder on this computer. Sign in to use your team’s shared tools and settings." });
     await user.notSee({ text: /Something went wrong/ });
+    await user.looks(["The welcome screen explains documents, folders and tools alongside local and cloud entry options"]);
   });
 
   await step("Choose a local folder", async () => {
@@ -39,16 +40,18 @@ test("first use without an invite or cloud reaches local task UI with honest mod
   await user.see({ text: /Using the free starter model/ });
   await step("An example is an editable draft, not an automatic task", async () => {
     const before = await probe.composer();
-    await user.click({ role: "button", text: "Explore this workspace" });
+    await user.click({ role: "button", text: /^Explore this workspace/ });
     await user.see("composer", { editable: true, text: "Give me an overview of the files in this workspace and suggest one useful first task. Don’t change any files yet." });
     await user.see({ text: "Example added to your draft. Make it yours, then choose Run task. Clear your draft to choose another." });
     expect(await probe.eval(`Array.from(document.querySelectorAll("button")).find(button => button.textContent.includes("Draft a document"))?.disabled`)).toBe(true);
     const selected = await probe.composer();
     expect(selected.userMessageCount).toBe(before.userMessageCount);
     expect(selected.route).toBe(before.route);
+    await user.looks(["The new-task screen shows an editable workspace overview draft and explains that the example has not been run"]);
     await user.type("composer", "", { replace: true });
+    await user.press("Backspace");
     expect(await probe.eval(`Array.from(document.querySelectorAll("button")).find(button => button.textContent.includes("Draft a document"))?.disabled`)).toBe(false);
-    await user.click({ role: "button", text: "Draft a document" });
+    await user.click({ role: "button", text: /^Draft a document/ });
     await user.see("composer", { editable: true, text: "Draft a one-page project brief. Ask me for the bullet points you need, then turn them into a clear, well-structured document." });
     await user.type("composer", prompt, { replace: true });
     await user.see("composer", { editable: true, text: prompt });

--- a/evals/specs/first-run-local.e2e.test.ts
+++ b/evals/specs/first-run-local.e2e.test.ts
@@ -42,7 +42,7 @@ test("first use without an invite or cloud reaches local task UI with honest mod
     await user.looks(["The new-task screen offers workspace and document examples before the first task is submitted"]);
     const before = await probe.composer();
     expect(before.route).toMatch(/\/session$/);
-    await user.click({ role: "button", text: /^Explore this workspace/ });
+    await user.click({ role: "button", label: /^Explore this workspace/ });
     await user.see("composer", { editable: true, text: "Give me an overview of the files in this workspace and suggest one useful first task. Don’t change any files yet." });
     await user.see({ text: "Example added to your draft. Make it yours, then choose Run task. Clear your draft to choose another." });
     expect(await probe.eval(`Array.from(document.querySelectorAll("button")).find(button => button.textContent.includes("Draft a document"))?.disabled`)).toBe(true);
@@ -53,7 +53,7 @@ test("first use without an invite or cloud reaches local task UI with honest mod
     await user.type("composer", "", { replace: true });
     await user.press("Backspace");
     expect(await probe.eval(`Array.from(document.querySelectorAll("button")).find(button => button.textContent.includes("Draft a document"))?.disabled`)).toBe(false);
-    await user.click({ role: "button", text: /^Draft a document/ });
+    await user.click({ role: "button", label: /^Draft a document/ });
     await user.see("composer", { editable: true, text: "Draft a one-page project brief. Ask me for the bullet points you need, then turn them into a clear, well-structured document." });
     await user.type("composer", prompt, { replace: true });
     await user.see("composer", { editable: true, text: prompt });


### PR DESCRIPTION
First launch should explain what OpenWork can do before asking someone to choose a setup path. The welcome screen now shows compact document, workspace, and browser examples, and explains the difference between choosing a local folder and signing in for shared tools. Existing folder selection, provider setup, and organization sign-in remain the entry paths. Folder setup now lands on the stable new-task screen: it no longer creates a blank session that can replace the starter screen while the app loads. The first explicit submission creates the session.

The new-task screen offers work-focused examples that populate an editable draft. Selecting an example never submits it; examples are disabled while a draft exists so another click cannot erase someone’s work. A live status message explains the next step. The spreadsheet and browser prompts now ask for the user’s actual file or website instead of generating unrelated sample data or visiting an arbitrary site.

Uses existing monochrome surfaces, small line icons, focus rings, and light/dark tokens; removes the full-screen patterned welcome shader.

Validation:
- `pnpm typecheck` — passed on `452327974`.
- `OPENWORK_EVAL_REF=feat/desktop-first-use infisical run --silent --env dev -- pnpm evals:e2e first-run-local` — Passed: 1 passed, 0 failed, 0 skipped on `452327974`, cold boot. Placement: `daytona (daytona CLI authenticated)`.
- Existing first-run journey extended to assert explanations, editable examples, unchanged route/message count before submission, prevention of draft replacement, and clear/reselect/edit behavior.

`pnpm evals:typecheck` is blocked by 308 pre-existing errors: clean base `d25a9365a` and this branch produce identical errors, exit 2. First: `apps/server/src/agent-context-cloud-probe.ts(216,15): TS1294 This syntax is not allowed when erasableSyntaxOnly is enabled.` App typecheck passes.
