### PR TITLE
Manage team invitations inside desktop Account

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -90,6 +90,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/apps/app/src/app/lib/den-team.ts
+++ b/apps/app/src/app/lib/den-team.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+// Validate the subset of /v1/org that the desktop needs. In particular, do not
+// retain invitation tokens in the people view or its query cache.
+export const denTeamSchema = z.object({
+  organization: z.object({ id: z.string(), name: z.string() }),
+  currentMember: z.object({ id: z.string(), role: z.string(), isOwner: z.boolean() }),
+  members: z.array(z.object({
+    id: z.string(),
+    role: z.string(),
+    isOwner: z.boolean(),
+    joinedAt: z.string().nullable(),
+    user: z.object({ name: z.string(), email: z.string() }),
+  })),
+  invitations: z.array(z.object({
+    id: z.string(),
+    email: z.string(),
+    role: z.string(),
+    status: z.string(),
+    expiresAt: z.string().nullable(),
+  })),
+});
+
+export type DenTeam = z.infer<typeof denTeamSchema>;

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -19,6 +19,7 @@ import type {
   UpdateAutomation,
 } from "@openwork/types/automations";
 import { generatedArtifactViewSchema, savedAppDetailSchema, savedAppSummarySchema, type SaveApp, type WorkflowDetail } from "@openwork/types/workflows";
+import { denTeamSchema, type DenTeam } from "./den-team";
 
 // Re-export the shared schema under the local alias so React consumers
 // (e.g. the cloud domain's desktop-config provider) can import it alongside
@@ -3002,6 +3003,35 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         organizationId: orgId,
       });
       return normalizeDenDesktopConfig(payload);
+    },
+
+    async getTeam(orgId: string): Promise<DenTeam> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/org", {
+        token,
+        organizationId: orgId,
+      });
+      const parsed = denTeamSchema.safeParse(payload);
+      if (!parsed.success || parsed.data.organization.id !== orgId) {
+        throw new DenApiError(502, "invalid_team_response", "Could not load this organization's people. Try refreshing.");
+      }
+      return parsed.data;
+    },
+
+    async inviteTeamMember(orgId: string, email: string): Promise<void> {
+      await requestJson<unknown>(baseUrls, "/v1/invitations", {
+        method: "POST",
+        token,
+        organizationId: orgId,
+        body: { email: email.trim(), role: "member" },
+      });
+    },
+
+    async cancelTeamInvitation(orgId: string, invitationId: string): Promise<void> {
+      await requestJson<unknown>(baseUrls, `/v1/invitations/${encodeURIComponent(invitationId)}/cancel`, {
+        method: "POST",
+        token,
+        organizationId: orgId,
+      });
     },
 
     async getResourceSnapshot(orgId?: string | null): Promise<DenResourceSnapshot> {

--- a/apps/app/src/react-app/domains/settings/cloud/team-members-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/team-members-section.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { RefreshCcw, Users } from "lucide-react";
+
+import { DenApiError, formatDenOrgRoleLabel, isDenOrgAdminRole } from "@/app/lib/den";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  SettingsInset,
+  SettingsNotice,
+  SettingsSection,
+  SettingsSectionHeader,
+  SettingsSectionHeaderContent,
+  SettingsSectionHeaderDescription,
+  SettingsSectionHeaderTitle,
+} from "../settings-section";
+import { useCloudSession } from "./cloud-session-provider";
+
+type Props = {
+  orgId: string;
+  onConfirmSignIn: () => void;
+};
+
+function messageFor(error: unknown) {
+  return error instanceof Error ? error.message : "This action could not be completed. Please try again.";
+}
+
+export function TeamMembersSection({ orgId, onConfirmSignIn }: Props) {
+  const { client, baseUrl, user } = useCloudSession();
+  const queryClient = useQueryClient();
+  const [email, setEmail] = useState("");
+  const [completion, setCompletion] = useState<string | null>(null);
+  const queryKey = ["desktop-team", baseUrl, user?.id, orgId];
+  const team = useQuery({ queryKey, queryFn: () => client.getTeam(orgId) });
+  const invite = useMutation({
+    mutationFn: (address: string) => client.inviteTeamMember(orgId, address),
+    onSuccess: async (_, address) => {
+      setEmail("");
+      setCompletion(`Invitation sent to ${address}.`);
+      await queryClient.invalidateQueries({ queryKey });
+    },
+    // An email delivery failure can still persist the invitation. Refresh the
+    // list, but preserve the draft and error so retry never implies success.
+    onError: () => queryClient.invalidateQueries({ queryKey }),
+  });
+  const cancel = useMutation({
+    mutationFn: (invitationId: string) => client.cancelTeamInvitation(orgId, invitationId),
+    onSuccess: async () => {
+      setCompletion("Invitation cancelled.");
+      await queryClient.invalidateQueries({ queryKey });
+    },
+  });
+  const canInvite = team.data && (team.data.currentMember.isOwner || isDenOrgAdminRole(team.data.currentMember.role));
+  const busy = invite.isPending || cancel.isPending;
+  const error = invite.error ?? cancel.error;
+  const needsSignIn = error instanceof DenApiError && error.code === "reauth";
+  const members = team.data?.members.filter((member) => member.joinedAt !== null) ?? [];
+  const invitations = team.data?.invitations.filter((invitation) => invitation.status === "pending") ?? [];
+
+  return (
+    <SettingsSection>
+      <SettingsSectionHeader>
+        <SettingsSectionHeaderContent>
+          <SettingsSectionHeaderTitle><Users className="size-4" /> People</SettingsSectionHeaderTitle>
+          <SettingsSectionHeaderDescription>
+            {team.data?.organization.name ?? "Your organization"}. Manage invitations here; changes are saved to your team in Cloud.
+          </SettingsSectionHeaderDescription>
+        </SettingsSectionHeaderContent>
+        <Button variant="outline" size="sm" disabled={team.isFetching || busy} onClick={() => void team.refetch()}>
+          <RefreshCcw className="size-3.5" /> Refresh people
+        </Button>
+      </SettingsSectionHeader>
+
+      {team.isPending ? <p role="status" className="text-sm text-muted-foreground">Loading people…</p> : null}
+      {team.error ? <SettingsNotice tone="error">{messageFor(team.error)}</SettingsNotice> : null}
+      {team.data ? (
+        <>
+          {canInvite ? (
+            <SettingsInset>
+              <form className="flex flex-col gap-3" onSubmit={(event) => {
+                event.preventDefault();
+                if (busy || !email.trim()) return;
+                setCompletion(null);
+                cancel.reset();
+                invite.mutate(email.trim());
+              }}>
+                <Field>
+                  <FieldLabel htmlFor="team-invite-email">Invite a teammate</FieldLabel>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Input id="team-invite-email" type="email" required autoComplete="email" placeholder="name@company.com"
+                      value={email} disabled={busy} onChange={(event) => { setEmail(event.currentTarget.value); invite.reset(); setCompletion(null); }} />
+                    <Button type="submit" disabled={busy || !email.trim()}>{invite.isPending ? "Sending invitation…" : "Send invitation"}</Button>
+                  </div>
+                  <FieldDescription>They’ll join as a member and receive your team’s assigned tools and desktop permissions.</FieldDescription>
+                </Field>
+              </form>
+            </SettingsInset>
+          ) : <p className="text-sm text-muted-foreground">An owner or admin can invite teammates. Your own account connections stay yours.</p>}
+
+          {error ? (
+            <SettingsNotice tone="error">
+              <div role="alert" className="flex flex-col items-start gap-2">
+                {messageFor(error)}
+                {needsSignIn ? <Button variant="outline" size="sm" onClick={onConfirmSignIn}>Confirm sign-in</Button> : null}
+              </div>
+            </SettingsNotice>
+          ) : null}
+          {completion ? <p role="status" className="text-sm">{completion}</p> : null}
+
+          <div className="divide-y rounded-xl border" data-testid="desktop-team-members">
+            {members.map((member) => (
+              <div key={member.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0"><p className="truncate text-sm font-medium">{member.user.name || member.user.email}</p><p className="truncate text-xs text-muted-foreground">{member.user.email}</p></div>
+                <span className="shrink-0 text-xs text-muted-foreground">{member.isOwner ? "Owner" : formatDenOrgRoleLabel(member.role)}</span>
+              </div>
+            ))}
+          </div>
+
+          {invitations.length ? (
+            <div className="flex flex-col gap-3">
+              <h3 className="text-sm font-medium">Pending invitations</h3>
+              <div className="divide-y rounded-xl border" data-testid="desktop-team-invitations">
+                {invitations.map((invitation) => (
+                  <div key={invitation.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                    <div className="min-w-0"><p className="break-all text-sm">{invitation.email}</p><p className="text-xs text-muted-foreground">{formatDenOrgRoleLabel(invitation.role)} · {invitation.expiresAt && Date.parse(invitation.expiresAt) <= Date.now() ? "Expired" : "Invited"}</p></div>
+                    {canInvite ? <Button variant="ghost" size="sm" disabled={busy} aria-label={`Cancel invitation for ${invitation.email}`} onClick={() => { setCompletion(null); invite.reset(); cancel.mutate(invitation.id); }}>{cancel.isPending && cancel.variables === invitation.id ? "Cancelling…" : "Cancel invitation"}</Button> : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </SettingsSection>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
@@ -26,6 +26,7 @@ import { SignInFallbackNotice } from "@/react-app/domains/cloud/signin-fallback-
 import { CloudAccountSection } from "../cloud/cloud-account-section";
 import { useCloudSession } from "../cloud/cloud-session-provider";
 import { CloudDevMode } from "../cloud/dev-mode";
+import { TeamMembersSection } from "../cloud/team-members-section";
 import type { useDenSession } from "../cloud/use-den-session";
 import {
   SettingsInset,
@@ -230,7 +231,7 @@ function AppPermissionsView() {
 }
 
 export function CloudAccountView({ developerMode, session }: CloudAccountViewProps) {
-  const { activeOrganization, isSignedIn, statusMessage } = useCloudSession();
+  const { activeOrganization, isSignedIn, statusMessage, user } = useCloudSession();
   const navigate = useNavigate();
 
   React.useEffect(() => {
@@ -322,9 +323,11 @@ export function CloudAccountView({ developerMode, session }: CloudAccountViewPro
     <Tabs defaultValue="account" className="w-full max-w-3xl gap-y-6">
       <TabsList variant="line" aria-label="Account pages">
         <TabsTrigger value="account">Account</TabsTrigger>
+        {activeOrganization ? <TabsTrigger value="people">People</TabsTrigger> : null}
         <TabsTrigger value="permissions">App permissions</TabsTrigger>
       </TabsList>
       <TabsContent value="account">{accountContent}</TabsContent>
+      {activeOrganization ? <TabsContent value="people"><TeamMembersSection key={`${user?.id}:${activeOrganization.id}`} orgId={activeOrganization.id} onConfirmSignIn={() => session.onOpenBrowserAuth("sign-in")} /></TabsContent> : null}
       <TabsContent value="permissions"><AppPermissionsView /></TabsContent>
     </Tabs>
   );

--- a/evals/specs/desktop-team-invitations.e2e.test.ts
+++ b/evals/specs/desktop-team-invitations.e2e.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { desktopTeam } from "../worlds/desktop-team.ts";
+
+const test = spec.world(desktopTeam, { timeout: 900_000 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invitations(value: unknown) {
+  return isRecord(value) && Array.isArray(value.invitations) ? value.invitations.filter(isRecord) : [];
+}
+
+test("an owner manages invitations in desktop while a member can only view people", async ({ world, user, probe, seed, step, evidence }) => {
+  const owner = { user: user.on(world.app), probe: probe.on(world.app) };
+  const member = { user: user.on(world.member), probe: probe.on(world.member) };
+
+  await step("the owner opens people without leaving desktop Account", async () => {
+    await owner.user.click({ testId: "account-status-menu" });
+    await owner.user.click({ role: "menuitem", label: "Settings" });
+    await owner.user.click({ role: "button", label: /^Account$/ });
+    await owner.user.see({ role: "tab", label: "People" });
+    await owner.user.click({ role: "tab", label: "People" });
+    await owner.user.see({ text: world.den.members.teammate.email });
+    await owner.user.see({ role: "textbox", label: "Invite a teammate" });
+    await owner.user.notSee({ text: "Loading people…" });
+  });
+  const accountRoute = await owner.probe.hash();
+  expect(accountRoute).toContain("/settings/cloud-account");
+
+  await step("a rejected invitation keeps the email draft and does not claim success", async () => {
+    const existingEmail = world.den.members.teammate.email;
+    await owner.user.type({ role: "textbox", label: "Invite a teammate" }, existingEmail);
+    await owner.user.click({ role: "button", label: "Send invitation" });
+    await owner.user.see({ text: "That email address is already a member of this organization." });
+    await owner.user.see({ role: "textbox", label: "Invite a teammate" }, { value: existingEmail, editable: true });
+    await owner.user.notSee({ text: `Invitation sent to ${existingEmail}.` });
+    const result = await probe.api(world.den.admin, "/v1/org");
+    const pending = invitations(result.body).filter((entry) => entry.email === existingEmail && entry.status === "pending");
+    expect(pending).toHaveLength(0);
+    evidence.recordAssertionEvidence("An existing-member rejection preserves the draft without creating a pending invitation or claiming success", "existing-member error visible; original email still editable; success absent; no pending invitation saved", pending.length === 0);
+  });
+
+  await step("sending an invitation saves it in Den and keeps the Account route", async () => {
+    await owner.user.type({ role: "textbox", label: "Invite a teammate" }, world.inviteEmail, { replace: true });
+    await owner.user.click({ role: "button", label: "Send invitation" });
+    await owner.user.see({ text: `Invitation sent to ${world.inviteEmail}.` });
+    await owner.user.see({ role: "textbox", label: "Invite a teammate" }, { value: "" });
+    await owner.user.see({ role: "button", label: `Cancel invitation for ${world.inviteEmail}` });
+    expect(await owner.probe.hash()).toBe(accountRoute);
+    const result = await probe.api(world.den.admin, "/v1/org");
+    expect(result.response.status).toBe(200);
+    const saved = invitations(result.body).filter((entry) => entry.email === world.inviteEmail);
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({ role: "member", status: "pending" });
+    evidence.recordAssertionEvidence(
+      "Desktop invitation persists exactly once as a member invitation without navigating away",
+      `pending invitations for requested email=${saved.length}; role=member; route unchanged`,
+      saved.length === 1 && saved[0]?.role === "member" && await owner.probe.hash() === accountRoute,
+    );
+    await owner.user.looks(["The desktop Account People page shows the invited teammate, a pending invitation and a cancellation action"]);
+  });
+
+  await step("a regular member sees people but has no invitation controls", async () => {
+    await member.user.click({ testId: "account-status-menu" });
+    await member.user.click({ role: "menuitem", label: "Settings" });
+    await member.user.click({ role: "button", label: /^Account$/ });
+    await member.user.click({ role: "tab", label: "People" });
+    await member.user.see({ text: world.den.admin.email });
+    await member.user.see({ text: "An owner or admin can invite teammates. Your own account connections stay yours." });
+    await member.user.notSee({ role: "textbox", label: "Invite a teammate" });
+    await member.user.notSee({ role: "button", label: "Send invitation" });
+    await member.user.notSee({ role: "button", label: `Cancel invitation for ${world.inviteEmail}` });
+    const denied = await seed.api(world.den.members.teammate, "/v1/invitations", {
+      method: "POST",
+      body: JSON.stringify({ email: "not-authorized@openwork.test", role: "member" }),
+    });
+    expect(denied.response.status).toBe(403);
+    const unchanged = await probe.api(world.den.admin, "/v1/org");
+    expect(invitations(unchanged.body).some((entry) => entry.email === "not-authorized@openwork.test")).toBe(false);
+    expect(invitations(unchanged.body).some((entry) => entry.email === world.inviteEmail && entry.status === "pending")).toBe(true);
+    evidence.recordAssertionEvidence("Members cannot invite through the UI or API and do not alter the pending owner invitation", "member controls absent; invitation API returned 403; no unauthorized invitation persisted; owner's invitation remains pending", true);
+  });
+
+  await step("cancelling the invitation updates Den and does not remove another member", async () => {
+    await owner.user.click({ role: "button", label: `Cancel invitation for ${world.inviteEmail}` });
+    await owner.user.see({ text: "Invitation cancelled." });
+    await owner.user.notSee({ role: "button", label: `Cancel invitation for ${world.inviteEmail}` });
+    await owner.user.see({ text: world.den.members.teammate.email });
+    const result = await probe.api(world.den.admin, "/v1/org");
+    expect(invitations(result.body).some((entry) => entry.email === world.inviteEmail && entry.status === "pending")).toBe(false);
+    expect(await owner.probe.hash()).toBe(accountRoute);
+    evidence.recordAssertionEvidence("Desktop cancellation revokes only the pending invitation and keeps the existing teammate", "requested invitation no longer pending; existing member visible; Account route unchanged", true);
+  });
+});

--- a/evals/worlds/desktop-team.ts
+++ b/evals/worlds/desktop-team.ts
@@ -1,0 +1,17 @@
+import type { Seed } from "@openwork/env";
+
+export async function desktopTeam(seed: Seed) {
+  const den = await seed.den({
+    org: {
+      name: `Desktop team ${Date.now()}`,
+      admin: { name: "Team Owner" },
+      members: { teammate: { name: "Team Member" } },
+    },
+    // Only the dev outbox should receive invitations from this journey.
+    env: { RESEND_API_KEY: "", SMTP_HOST: "", EMAIL_FROM: "" },
+  });
+  if (!den.members.teammate) throw new Error("Team member fixture was not provisioned.");
+  const app = await seed.desktop({ den, name: "team-owner" });
+  const member = await seed.desktop({ den, as: "teammate", name: "team-member" });
+  return { den, app, member, inviteEmail: `new-teammate-${Date.now()}@openwork.test` };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))


### PR DESCRIPTION
Adds a People tab to desktop Account so owners and admins can view teammates, send member invitations, and cancel pending invitations without opening Cloud. Members get a read-only view with a clear explanation of who manages invitations. The UI reuses existing monochrome settings components and Den's organization-scoped APIs and permission checks.

The invitation form prevents duplicate submissions while busy, clears after success, and keeps the draft with an actionable error after rejection. Pending invitations remain separate from joined members. Query data is scoped by account and organization, and switching either resets the form.

Validation on `8dd6036ccbb2238d66de229f14f6ca791d370858`:

- **Passed:** `OPENWORK_EVAL_REF=feat/desktop-team-controls infisical run --silent --env dev -- pnpm evals:e2e desktop-team-invitations` — placement: Daytona (CLI authenticated), 1 passed / 0 failed / 0 skipped. The journey uses separate owner/member desktops and real Den witnesses for rejection with draft preservation, invitation creation, member UI/API denial, and cancellation without removing the existing teammate.
- App typecheck passed. Screenshot and assertion evidence are published in the sticky comment.
- Global `pnpm evals:typecheck` reports the same 308 diagnostics as the clean `d25a9365a` base. The channel/boundary checks also reproduce their existing clean-base failures; this journey introduces no additional violations.
