### PR TITLE
Keep connector cards stable across sign-in states

### DIFF
--- a/apps/app/src/components/chat/connection-card.tsx
+++ b/apps/app/src/components/chat/connection-card.tsx
@@ -21,24 +21,25 @@ export function ConnectionCard({ part, action }: { part: DynamicToolUIPart; acti
   const connected = reconnectState === "connected"
   const opening = reconnectState === "opening"
   const waiting = reconnectState === "authorization_opened"
+  const status = connected ? "Ready to use" : opening ? "Opening sign-in…" : waiting ? "Finish sign-in in your browser" : reconnectState === "failed" ? "Sign-in could not finish" : "Sign in to continue"
   const label = reconnectState === "failed" ? "Try again" : waiting ? "Open sign-in" : action.label
 
   return (
     <section data-testid="desktop-connection-card" aria-label={`${action.connectionName} connection`} aria-live="polite"
-      className={cn("self-start max-w-full text-sm", connected ? "py-1" : "w-80 rounded-xl bg-muted/40 px-3 py-2.5")}>
-      <div className="flex min-w-0 items-center gap-2.5">
-        <span aria-hidden="true" className={cn("flex shrink-0 items-center justify-center overflow-hidden rounded-md", connected ? "size-5" : "size-7", !icon && "bg-muted text-xs font-medium")}>
-          {icon && icon !== failedIcon ? <img src={icon} alt="" className={connected ? "size-4 object-contain" : "size-5 object-contain"} onError={() => setFailedIcon(icon)} /> : action.connectionName.charAt(0).toUpperCase()}
+      className="w-96 max-w-full self-start rounded-xl bg-muted/40 px-3 py-2.5 text-sm">
+      <div className="flex min-h-10 min-w-0 items-center gap-2.5">
+        <span aria-hidden="true" className={cn("flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md", !icon && "bg-muted text-xs font-medium")}>
+          {icon && icon !== failedIcon ? <img src={icon} alt="" className="size-5 object-contain" onError={() => setFailedIcon(icon)} /> : action.connectionName.charAt(0).toUpperCase()}
         </span>
         <div className="min-w-0 flex-1">
           <p className="truncate text-[13px] font-medium" title={action.connectionName}>{action.connectionName}</p>
-          {waiting || opening ? <p className="mt-0.5 text-[11px] text-muted-foreground">{opening ? "Opening sign-in…" : "Finish sign-in in your browser"}</p> : null}
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground" title={status}>{status}</p>
         </div>
         {connected ? (
-          <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground"><Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />Connected</span>
+          <span className="flex h-7 w-24 shrink-0 items-center justify-center gap-1 text-xs text-muted-foreground"><Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />Connected</span>
         ) : (
-          <Button variant="ghost" size="sm" disabled={opening} onClick={() => void handleReconnect()} aria-label={`${label} ${action.connectionName}`} className="h-7 shrink-0 gap-1 rounded-lg px-2 text-xs font-medium hover:bg-background/80">
-            {opening ? <Loader2 className="size-3.5 animate-spin" /> : <>{label}<ArrowUpRight className="size-3.5 text-muted-foreground" /></>}
+          <Button variant="ghost" size="sm" disabled={opening} onClick={() => void handleReconnect()} aria-label={`${label} ${action.connectionName}`} className="h-7 w-24 shrink-0 gap-1 rounded-lg px-2 text-xs font-medium hover:bg-background/80">
+            {opening ? <><Loader2 className="size-3.5 animate-spin" />Opening</> : <>{label}<ArrowUpRight className="size-3.5 text-muted-foreground" /></>}
           </Button>
         )}
       </div>

--- a/apps/app/src/components/chat/connector-catalog.tsx
+++ b/apps/app/src/components/chat/connector-catalog.tsx
@@ -60,7 +60,7 @@ export function ConnectorCatalogCard({ catalog }: { catalog: ConnectorCatalog })
       await openDesktopUrl(expected.toString())
     } catch (cause) { setError(cause instanceof Error ? cause.message : "Could not open setup.") }
   }
-  return <section data-testid="connector-catalog" aria-label="Quick-add connectors" className="w-full max-w-md rounded-xl bg-muted/30 p-3">
+  return <section data-testid="connector-catalog" aria-label="Quick-add connectors" className="w-96 max-w-full self-start rounded-xl bg-muted/40 p-3">
     <div className="mb-2 flex items-center justify-between gap-3">
       <p className="text-xs font-medium">{showAll ? "Quick-add connectors" : "Suggested connector"}</p>
       {!showAll ? <Button variant="ghost" size="sm" className="h-6 px-1.5 text-xs text-muted-foreground" onClick={() => setShowAll(true)}>Browse all {catalog.entries.length}</Button> : <span className="text-xs text-muted-foreground">{catalog.entries.length} available</span>}
@@ -69,10 +69,10 @@ export function ConnectorCatalogCard({ catalog }: { catalog: ConnectorCatalog })
     <div className="max-h-80 overflow-y-auto">
       {entries.map(entry => {
         const added = Boolean(entry.serviceUrl && connectorIdentities.some(identity => identity.connectionId && identity.serviceUrl === entry.serviceUrl))
-        return <div key={entry.id} data-connector-preset={entry.id} className="flex items-center gap-2.5 rounded-lg px-1 py-2">
+        return <div key={entry.id} data-connector-preset={entry.id} className="flex min-h-14 items-center gap-2.5 rounded-lg px-1 py-2">
           <ConnectorIcon entry={entry} />
           <div className="min-w-0 flex-1"><p className="truncate text-[13px] font-medium">{entry.name}</p><p className="text-[11px] text-muted-foreground">{added ? "Added to your organization" : SETUP_LABELS[entry.setup]}</p></div>
-          {!added ? <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs" disabled={!canManage} onClick={() => void setup(entry)} aria-label={`Set up ${entry.name}`}>Set up<ArrowUpRight className="size-3.5 text-muted-foreground" /></Button> : null}
+          {!added ? <Button variant="ghost" size="sm" className="h-7 w-24 shrink-0 gap-1 px-2 text-xs" disabled={!canManage} onClick={() => void setup(entry)} aria-label={`Set up ${entry.name}`}>Set up<ArrowUpRight className="size-3.5 text-muted-foreground" /></Button> : <span aria-hidden="true" className="w-24 shrink-0" />}
         </div>
       })}
       {entries.length === 0 ? <p className="py-3 text-xs text-muted-foreground">No connectors match your search.</p> : null}

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -33,12 +33,20 @@ test("desktop connects an account directly with the provider and confirms author
     return { height: card?.getBoundingClientRect().height, width: card?.getBoundingClientRect().width, hasChecklist: Boolean(card?.querySelector('ol')), embeddedApp: Boolean(document.querySelector('[data-mcp-app-resource="ui://openwork/connection-action/v1/view.html"]')) };
   })()`);
   expect(compact).toMatchObject({ hasChecklist: false, embeddedApp: false });
-  if (!compact || typeof compact !== "object" || !("height" in compact) || typeof compact.height !== "number") throw new Error("The connection card was not rendered.");
+  if (!compact || typeof compact !== "object" || !("height" in compact) || typeof compact.height !== "number" || !("width" in compact) || typeof compact.width !== "number") throw new Error("The connection card was not rendered.");
   expect(compact.height).toBeLessThan(88);
   await user.screenshot();
   evidence.recordAssertionEvidence("Search shows one native connection card without a checklist or embedded setup", JSON.stringify(compact), true);
   evidence.recordAssertionEvidence("Authorization does not start before the user clicks Connect", "No provider authorization request before Connect", true);
 
+  await probe.eval(`(() => {
+    const card = document.querySelector('[data-testid="desktop-connection-card"]');
+    if (!card) throw new Error("Connection card missing");
+    const sizes = [];
+    const record = () => { const rect = card.getBoundingClientRect(); sizes.push({ width: rect.width, height: rect.height, text: card.textContent }); card.dataset.observedSizes = JSON.stringify(sizes); };
+    new MutationObserver(record).observe(card, { childList: true, subtree: true, characterData: true });
+    record();
+  })()`);
   const clickedAt = new Date().toISOString();
   await user.click({ role: "button", label: "Connect Notion" });
   const authorization = await world.den.mocks.connector.authorizeRequestSince(clickedAt, { timeoutMs: 60_000 });
@@ -53,7 +61,16 @@ test("desktop connects an account directly with the provider and confirms author
   })()`);
   expect(completed).toMatchObject({ buttons: 0 });
   if (!completed || typeof completed !== "object" || !("height" in completed) || typeof completed.height !== "number") throw new Error("The connected indicator was not rendered.");
-  expect(completed.height).toBeLessThan(48);
+  expect(completed.height).toBe(compact.height);
+  expect(completed).toMatchObject({ width: compact.width });
+  evidence.recordAssertionEvidence("Connection completion preserves the card dimensions", JSON.stringify({ ready: compact, connected: completed }), true);
+  const transitions = await probe.eval(`JSON.parse(document.querySelector('[data-testid="desktop-connection-card"]')?.getAttribute("data-observed-sizes") ?? "[]")`);
+  if (!Array.isArray(transitions)) throw new Error("No card transition measurements were recorded");
+  for (const dimensions of transitions) expect(dimensions).toMatchObject({ width: compact.width, height: compact.height });
+  for (const status of ["Opening sign-in…", "Finish sign-in in your browser", "Ready to use"]) {
+    expect(transitions).toEqual(expect.arrayContaining([expect.objectContaining({ text: expect.stringContaining(status) })]));
+  }
+  evidence.recordAssertionEvidence("Sign-in transitions keep the card dimensions stable", JSON.stringify(transitions), true);
   await user.screenshot();
   evidence.recordAssertionEvidence("Desktop opens the provider directly and confirms completion without a Den screen", "Provider /authorize received the browser handoff; the native card shows Connected and removes Connect", true);
 });

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -17,12 +17,16 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.notSee({ testId: "desktop-connection-card" });
   const visibleIds = () => appProbe.eval(`Array.from(document.querySelectorAll('[data-connector-preset]'), element => element.getAttribute('data-connector-preset'))`);
   expect(await visibleIds()).toEqual(["slack"]);
+  const suggestedWidth = await appProbe.eval(`document.querySelector('[data-testid="connector-catalog"]')?.getBoundingClientRect().width`);
   await appUser.screenshot();
   evidence.recordAssertionEvidence("A Slack request offers setup without claiming the service is connected", "Only Slack is suggested with Admin setup; no account connection card is shown", true);
 
   await appUser.click({ role: "button", label: `Browse all ${world.expectedIds.length}` });
   await appUser.see({ role: "textbox", label: "Filter connectors" });
   expect(await visibleIds()).toEqual(world.expectedIds);
+  const expandedWidth = await appProbe.eval(`document.querySelector('[data-testid="connector-catalog"]')?.getBoundingClientRect().width`);
+  expect(expandedWidth).toBe(suggestedWidth);
+  evidence.recordAssertionEvidence("Browsing all connectors preserves the suggestion card width", JSON.stringify({ suggestedWidth, expandedWidth }), true);
   await appUser.see({ role: "button", label: "Set up Linear" });
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Browse all includes the complete Den preset catalog and both productivity suites", JSON.stringify(world.expectedIds), true);


### PR DESCRIPTION
Connection cards changed width and shrank their icon after sign-in, while connector suggestions used a wider container. Both now use a responsive 384px shell with a stable icon, action column, and status line. Ready, opening, waiting, and connected states keep the same 384×60 dimensions; error details and expanded catalogs can grow vertically.

Verification on `01df84b5cd599c9f9680bf1cbe01318ac77b07aa`:
- `pnpm --filter @openwork/app typecheck` — passed.
- Three focused app suites — 33 passed.
- `pnpm evals:e2e connection-action-mcp-app --daytona` — Passed, 1 passed, 0 failed/skipped; observed all four states at 384×60.
- `pnpm evals:e2e connector-catalog --daytona` — Passed, 1 passed, 0 failed/skipped; browsing every quick add preserves width and Slack setup reaches the actual captured destination.

Both journeys ran with the full head SHA in `OPENWORK_EVAL_DAYTONA_REF` and `OPENWORK_EVAL_REF`. Screenshots and assertion evidence are published below.
