### PR TITLE
fix(server): preserve active MCP clients during runtime sync

### DIFF
--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -109,6 +109,7 @@ function startMockOpencode(options: MockOpencodeOptions = {}) {
         return Response.json({ healthy: true, version: "1.17.11" });
       }
       if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      if (url.pathname === "/session/status") return Response.json({});
       if (url.pathname === "/mcp" && request.method === "POST") {
         if (options.postFailure) return Response.json(options.postFailure.body, { status: options.postFailure.status });
         registerCount += 1;
@@ -407,7 +408,9 @@ describe("openwork-cloud MCP strict reconcile", () => {
 
   test("live status read heals a failed registration record after reconcile returns early", async () => {
     const root = await createRoot();
-    const mock = startMockOpencode({ connectAfterStatusReads: 2 });
+    // Registration now probes liveness before POSTing; keep the first
+    // post-registration health read failed, then heal on the next read.
+    const mock = startMockOpencode({ connectAfterStatusReads: 3 });
     const baseUrl = `http://127.0.0.1:${mock.server.port}`;
     const openwork = await startOpenwork([workspace("ws_1", root, baseUrl)]);
     registerTrustedOpencodeProcess(openwork.config, {

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -45,6 +45,7 @@ function startMockOpencode(options?: {
   failMcpNames?: string[];
   mcpStatusByName?: Record<string, unknown>;
   liveMcpStatusByName?: () => Record<string, unknown>;
+  sessionStatus?: () => Record<string, unknown>;
   mcpResponseForName?: (name: string) => Response | Promise<Response> | null;
   disposeResponse?: () => Response | null;
 }) {
@@ -76,6 +77,7 @@ function startMockOpencode(options?: {
       if (url.pathname === "/mcp" && request.method === "GET") {
         return Response.json(options?.liveMcpStatusByName?.() ?? {});
       }
+      if (url.pathname === "/session/status") return Response.json(options?.sessionStatus?.() ?? {});
       if (url.pathname.match(/^\/mcp\/[^/]+\/disconnect$/) && request.method === "POST") return Response.json({});
       return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
     },
@@ -163,6 +165,68 @@ const POSTHOG_CONFIG = {
 };
 
 describe("runtime MCP engine sync", () => {
+  test("reuses unchanged healthy clients but retries disconnected and changed configurations", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    let status = "connected";
+    try {
+      const mock = startMockOpencode({ liveMcpStatusByName: () => ({ posthog: { status } }) });
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({ ...current, mcp: { posthog: POSTHOG_CONFIG } }));
+      const posts = () => mock.requests.filter((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config);
+      expect(posts()).toHaveLength(1);
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config);
+      expect(posts()).toHaveLength(1);
+      status = "failed";
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config);
+      expect(posts()).toHaveLength(2);
+      status = "connected";
+      const changedConfig = { ...POSTHOG_CONFIG, headers: { Authorization: "Bearer replacement-fixture" } };
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({ ...current, mcp: { posthog: changedConfig } }));
+      // A health observer can see connected while desired credentials have
+      // changed. That observation alone must not suppress their delivery.
+      refreshEngineMcpRegistrationFromLiveStatus(openwork.config, openwork.config.workspaces[0]!, "posthog", changedConfig, "connected");
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config);
+      expect(posts()).toHaveLength(3);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("keeps a bootstrapped client alive across repeated deferred syncs until its task finishes", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    const previousDelay = process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS = "10";
+    let busy = true;
+    try {
+      const mock = startMockOpencode({
+        liveMcpStatusByName: () => ({ posthog: { status: "connected" } }),
+        sessionStatus: () => busy ? { task: { type: "busy" } } : {},
+      });
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({ ...current, mcp: { posthog: POSTHOG_CONFIG } }));
+      const posts = () => mock.requests.filter((entry) => entry.method === "POST" && entry.pathname === "/mcp");
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config);
+      await waitForRegistration(() => String(mock.requests.filter((entry) => entry.pathname === "/session/status").length >= 3), "true");
+      expect(posts()).toHaveLength(0);
+      expect(inspectEngineMcpRegistration(openwork.config, openwork.config.workspaces[0]!, "posthog", POSTHOG_CONFIG)).not.toBe("connected");
+      busy = false;
+      await waitForRegistration(() => String(posts().length), "1");
+      await syncAllWorkspacesRuntimeMcpToEngine(openwork.config);
+      expect(posts()).toHaveLength(1);
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+      if (previousDelay === undefined) delete process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS;
+      else process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS = previousDelay;
+    }
+  });
+
   test("hot-adds a runtime MCP into the running engine when added", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const previousDb = process.env.OPENWORK_RUNTIME_DB;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1801,7 +1801,7 @@ export async function proxyOpencodeRequest(input: {
     return sanitizeProxyResponse(response);
   };
 
-  if (workspace && workspace.workspaceType !== "remote" && !pool && isPromptAsyncProxyRequest(method, proxyPath)) {
+  if (workspace && workspace.workspaceType !== "remote" && isPromptAsyncProxyRequest(method, proxyPath)) {
     return withEngineDirectoryFence(input.config, workspace, forward);
   }
   return forward();
@@ -4794,7 +4794,9 @@ async function runRuntimeMcpSyncToOpencodeEngine(
   const failures: EngineMcpSyncFailure[] = [];
   const registrations: EngineMcpRegistrationResult[] = [];
   for (const [name, mcpConfig] of entries) {
-    const registration = await postMcpEntryWithRetry(config, workspace, url, headers, name, mcpConfig);
+    const registration = await withEngineDirectoryFence(config, workspace, () =>
+      registerRuntimeMcpEntry(config, workspace, url, headers, name, mcpConfig)
+    );
     registrations.push(registration);
     if (registration.failure) failures.push(registration.failure);
   }
@@ -4816,7 +4818,7 @@ async function runRuntimeMcpSyncToOpencodeEngine(
   );
 
   if (failures.length > 0) {
-    if (activeState && !options?.deferred && hasRetryableMcpSyncFailure(failures)) {
+    if (activeState && (!options?.deferred || failures.some((failure) => failure.deferredForActivity)) && hasRetryableMcpSyncFailure(failures)) {
       scheduleDeferredEngineMcpSync({
         config,
         state: activeState,
@@ -4867,9 +4869,59 @@ async function withEngineMcpRegistrationLock<Result>(
   }
 }
 
-// POST one MCP entry to the engine, retrying once on 5xx/network errors
-// (the engine is often mid-rebuild right after a dispose). 4xx responses
-// are not retried — they won't change.
+// Reuse verified clients and fence necessary replacements against local prompt
+// admission. A health observation alone is not proof of config delivery.
+async function registerRuntimeMcpEntry(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  url: URL,
+  headers: Record<string, string>,
+  name: string,
+  mcpConfig: Record<string, unknown>,
+): Promise<EngineMcpRegistrationResult> {
+  // Explicit disabling still takes effect immediately.
+  if (mcpConfig.enabled === false) return postMcpEntryWithRetry(config, workspace, url, headers, name, mcpConfig);
+  try {
+    const response = await loopbackFetch(url, { headers, signal: AbortSignal.timeout(5_000) });
+    if (!response.ok) throw new Error("MCP status probe failed");
+    const statuses: unknown = JSON.parse(await readBoundedEngineMcpRegistrationResponse(response));
+    if (!isRecord(statuses)) throw new Error("Invalid MCP status response");
+    const live = statuses[name];
+    if (isRecord(live) && live.status === "connected") {
+      const recorded = inspectEngineMcpRegistrationDetails(config, workspace, name, mcpConfig);
+      const receipt = activeEngineMcpServerState(config)?.registrationByWorkspace.get(workspace.id)?.get(name);
+      if (recorded.status === "connected" && receipt?.configDelivered) {
+        // OpenCode's add endpoint replaces and closes even an unchanged client.
+        // Keep the client already captured by a model turn or in-flight tool.
+        return { name, status: "connected", source: "engine_status", errorSummary: null, failure: null };
+      }
+      const activityUrl = new URL(url);
+      activityUrl.pathname = "/session/status";
+      const activity = await loopbackFetch(activityUrl, { headers, signal: AbortSignal.timeout(5_000) });
+      if (!activity.ok) throw new Error("Session activity probe failed");
+      const sessions: unknown = JSON.parse(await readBoundedEngineMcpRegistrationResponse(activity));
+      if (!isRecord(sessions)) throw new Error("Invalid session activity response");
+      if (Object.values(sessions).some((session) => !isRecord(session) || session.type !== "idle")) {
+        // The directory fence also covers prompt admission, so a task cannot
+        // start between this activity check and replacing its client's tools.
+        return {
+          name, status: "failed", source: "transport_failure", errorSummary: null,
+          failure: { name, status: 503, deferredForActivity: true, message: "MCP replacement deferred until active tasks finish" },
+        };
+      }
+    }
+  } catch {
+    // Unknown liveness must not turn a background refresh into a destructive
+    // replacement. Let the existing deferred-sync path retry the probe.
+    return {
+      name, status: "failed", source: "transport_failure", errorSummary: null,
+      failure: { name, status: 503, message: "Could not verify MCP connection activity before registration" },
+    };
+  }
+  return postMcpEntryWithRetry(config, workspace, url, headers, name, mcpConfig);
+}
+
+// POST one MCP entry to the engine, retrying once on 5xx/network errors.
 async function postMcpEntryWithRetry(
   config: ServerConfig,
   workspace: WorkspaceInfo,
@@ -5131,6 +5183,7 @@ function scheduleDeferredEngineMcpSync(input: {
 export type EngineMcpSyncFailure = {
   name: string;
   status?: number;
+  deferredForActivity?: boolean;
   registrationStatus?: EngineMcpRegistrationStatus;
   message?: string;
 };
@@ -5143,6 +5196,7 @@ export type EngineMcpSyncState = { status: "ok" | "failed"; at: number; failures
 
 type EngineMcpRegistrationRecord = {
   fingerprint: string;
+  configDelivered: boolean;
   status: EngineMcpRegistrationStatus;
   source: EngineMcpRegistrationSource;
   errorSummary: string | null;
@@ -5566,6 +5620,7 @@ function recordEngineMcpSyncResult(
     }
     registrations.set(name, {
       fingerprint,
+      configDelivered: registration.failure === null,
       status: registration.status,
       source: registration.source,
       errorSummary: registration.errorSummary,
@@ -5682,8 +5737,15 @@ export function refreshEngineMcpRegistrationFromLiveStatus(
     return false;
   }
   const registrations = new Map(state.registrationByWorkspace.get(workspace.id) ?? []);
+  const previous = registrations.get(name);
   registrations.set(name, {
     fingerprint,
+    // A health probe observes status, not the engine's effective credentials.
+    // It must not manufacture a delivery receipt for a changed desired config.
+    configDelivered: previous?.configDelivered === true
+      && previous.fingerprint === fingerprint
+      && previous.registrationIdentity === registrationIdentity
+      && previous.generation === state.generation,
     status,
     source: "engine_status",
     errorSummary: sanitizeEngineMcpRegistrationErrorSummary(liveError, status),

--- a/evals/specs/mcp-registration-active-task.test.ts
+++ b/evals/specs/mcp-registration-active-task.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "vitest";
+import { eventually, spec } from "@openwork/testkit";
+import { mcpRegistration } from "../worlds/mcp-registration.ts";
+
+// New boundary journey: an active task must retain its MCP client while
+// OpenWork delivers runtime configuration to the real managed engine.
+const test = spec.world(mcpRegistration, { needs: { commands: ["bun"] }, timeout: 180_000 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test("runtime MCP synchronization preserves captured and in-flight tools, then applies changes and recovers", async ({ world, evidence }) => {
+  const stages: Array<"model" | "tool"> = ["model", "tool"];
+  for (const stage of stages) {
+    world.pause(stage);
+    const session = await world.engine("POST", "/session", {});
+    if (!isRecord(session) || typeof session.id !== "string") throw new Error("Session id missing");
+    const id = session.id;
+    await world.engine("POST", `/session/${id}/prompt_async`, {
+      model: { providerID: "mock", modelID: "mock" },
+      parts: [{ type: "text", text: "Check the connection." }],
+    });
+    await world.entered();
+    const before = world.initializations();
+    // The first call has only a disk-bootstrapped client (no registration
+    // receipt). The second has a known client whose fingerprint is unchanged.
+    await world.register();
+    expect(world.initializations()).toBe(before);
+    if (stage === "tool") {
+      await world.register("changed");
+      expect(world.initializations()).toBe(before);
+    }
+    world.release();
+    const states = await eventually(async () => {
+      const messages = await world.engine("GET", `/session/${id}/message`);
+      if (!Array.isArray(messages)) return [];
+      return messages.filter(isRecord).flatMap((message) => Array.isArray(message.parts) ? message.parts.filter(isRecord) : [])
+        .filter((part) => part.type === "tool" && isRecord(part.state)).map((part) => part.state);
+    }, { within: 30_000, label: `${stage} paused tool completes`, until: (states) => states.length === 1 && isRecord(states[0]) && ["completed", "error"].includes(String(states[0].status)) });
+    expect(states).toMatchObject([{ status: "completed", output: "pong" }]);
+    await eventually(() => world.engine("GET", "/session/status"), {
+      within: 10_000, label: "task finishes before idle registration",
+      until: (statuses) => isRecord(statuses) && (!isRecord(statuses[id]) || statuses[id].type === "idle"),
+    });
+    const calls = await world.toolCalls();
+    expect(calls.filter((call) => call.name === "ping")).toHaveLength(stage === "model" ? 1 : 2);
+    evidence.recordAssertionEvidence(
+      `Registration preserves the ${stage === "model" ? "client captured before a call" : "in-flight tool call"}`,
+      `No new MCP initialization during registration; the real engine persisted one completed pong tool and the connector witnessed exactly ${stage === "model" ? 1 : 2} total invocations.`,
+      true,
+    );
+    await world.register(stage === "tool" ? "changed" : "original");
+    expect(world.initializations()).toBe(before + 1);
+    const after = world.initializations();
+    await world.register(stage === "tool" ? "changed" : "original");
+    expect(world.initializations()).toBe(after);
+  }
+  const beforeRecovery = world.initializations();
+  await world.engine("POST", "/mcp/race/disconnect", {});
+  await world.register("changed");
+  expect(world.initializations()).toBe(beforeRecovery + 1);
+  expect(await world.engine("GET", "/mcp")).toMatchObject({ race: { status: "connected" } });
+  evidence.recordAssertionEvidence(
+    "Idle changes apply once, unchanged registrations are no-ops, and disconnected clients recover",
+    "Each deferred change caused exactly one initialization after idle; an identical repeat caused none. After an explicit disconnect, registration initialized once and the real engine reported connected.",
+    true,
+  );
+  const session = await world.engine("POST", "/session", {});
+  if (!isRecord(session) || typeof session.id !== "string") throw new Error("Session id missing");
+  const id = session.id;
+  world.pause("initialize");
+  const replacement = world.register("admission-check");
+  await world.entered();
+  let admitted = false;
+  const prompt = world.engine("POST", `/session/${id}/prompt_async`, {
+    model: { providerID: "mock", modelID: "mock" },
+    parts: [{ type: "text", text: "Check the connection." }],
+  }).then(() => { admitted = true; });
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  const admittedDuringReplacement = admitted;
+  world.release();
+  await Promise.all([replacement, prompt]);
+  expect(admittedDuringReplacement).toBe(false);
+  expect(admitted).toBe(true);
+  await eventually(() => world.toolCalls(), {
+    within: 15_000, label: "admitted task invokes the replacement connection",
+    until: (calls) => calls.filter((call) => call.name === "ping").length === 3,
+  });
+  evidence.recordAssertionEvidence(
+    "Managed-engine prompt admission waits for an ongoing connection replacement",
+    "The async prompt remained unacknowledged while initialization was paused, was acknowledged after replacement finished, and invoked the connector exactly once.",
+    true,
+  );
+});

--- a/evals/specs/mcp-registration-active-task.test.ts
+++ b/evals/specs/mcp-registration-active-task.test.ts
@@ -60,7 +60,8 @@ test("runtime MCP synchronization preserves captured and in-flight tools, then a
   }
   const changedSession = await world.engine("POST", "/session", {});
   if (!isRecord(changedSession) || typeof changedSession.id !== "string") throw new Error("Session id missing");
-  await world.engine("POST", `/session/${changedSession.id}/prompt_async`, {
+  const changedId = changedSession.id;
+  await world.engine("POST", `/session/${changedId}/prompt_async`, {
     model: { providerID: "mock", modelID: "mock" },
     parts: [{ type: "text", text: "Check the connection." }],
   });
@@ -71,7 +72,7 @@ test("runtime MCP synchronization preserves captured and in-flight tools, then a
   expect(world.requests().filter((request) => request.method === "tools/call").at(-1)?.revision).toBe("changed");
   await eventually(() => world.engine("GET", "/session/status"), {
     within: 10_000, label: "changed connection task finishes before recovery",
-    until: (statuses) => isRecord(statuses) && (!isRecord(statuses[String(changedSession.id)]) || statuses[String(changedSession.id)].type === "idle"),
+    until: (statuses) => isRecord(statuses) && (!isRecord(statuses[changedId]) || statuses[changedId].type === "idle"),
   });
   evidence.recordAssertionEvidence(
     "The replacement receives and uses the changed configuration",

--- a/evals/specs/mcp-registration-active-task.test.ts
+++ b/evals/specs/mcp-registration-active-task.test.ts
@@ -43,6 +43,7 @@ test("runtime MCP synchronization preserves captured and in-flight tools, then a
       within: 10_000, label: "task finishes before idle registration",
       until: (statuses) => isRecord(statuses) && (!isRecord(statuses[id]) || statuses[id].type === "idle"),
     });
+    expect(world.requests().filter((request) => request.method === "tools/call").at(-1)?.revision).toBe(stage === "model" ? null : "original");
     const calls = await world.toolCalls();
     expect(calls.filter((call) => call.name === "ping")).toHaveLength(stage === "model" ? 1 : 2);
     evidence.recordAssertionEvidence(
@@ -52,14 +53,36 @@ test("runtime MCP synchronization preserves captured and in-flight tools, then a
     );
     await world.register(stage === "tool" ? "changed" : "original");
     expect(world.initializations()).toBe(before + 1);
+    expect(world.requests().filter((request) => request.method === "initialize").at(-1)?.revision).toBe(stage === "tool" ? "changed" : "original");
     const after = world.initializations();
     await world.register(stage === "tool" ? "changed" : "original");
     expect(world.initializations()).toBe(after);
   }
+  const changedSession = await world.engine("POST", "/session", {});
+  if (!isRecord(changedSession) || typeof changedSession.id !== "string") throw new Error("Session id missing");
+  await world.engine("POST", `/session/${changedSession.id}/prompt_async`, {
+    model: { providerID: "mock", modelID: "mock" },
+    parts: [{ type: "text", text: "Check the connection." }],
+  });
+  await eventually(() => world.toolCalls(), {
+    within: 15_000, label: "changed connection invokes the connector",
+    until: (calls) => calls.filter((call) => call.name === "ping").length === 3,
+  });
+  expect(world.requests().filter((request) => request.method === "tools/call").at(-1)?.revision).toBe("changed");
+  await eventually(() => world.engine("GET", "/session/status"), {
+    within: 10_000, label: "changed connection task finishes before recovery",
+    until: (statuses) => isRecord(statuses) && (!isRecord(statuses[String(changedSession.id)]) || statuses[String(changedSession.id)].type === "idle"),
+  });
+  evidence.recordAssertionEvidence(
+    "The replacement receives and uses the changed configuration",
+    "The MCP endpoint observed x-fixture-revision=changed on initialization and a subsequent real engine tools/call; earlier active calls retained their previous revision.",
+    true,
+  );
   const beforeRecovery = world.initializations();
   await world.engine("POST", "/mcp/race/disconnect", {});
   await world.register("changed");
   expect(world.initializations()).toBe(beforeRecovery + 1);
+  expect(world.requests().filter((request) => request.method === "initialize").at(-1)?.revision).toBe("changed");
   expect(await world.engine("GET", "/mcp")).toMatchObject({ race: { status: "connected" } });
   evidence.recordAssertionEvidence(
     "Idle changes apply once, unchanged registrations are no-ops, and disconnected clients recover",
@@ -85,8 +108,10 @@ test("runtime MCP synchronization preserves captured and in-flight tools, then a
   expect(admitted).toBe(true);
   await eventually(() => world.toolCalls(), {
     within: 15_000, label: "admitted task invokes the replacement connection",
-    until: (calls) => calls.filter((call) => call.name === "ping").length === 3,
+    until: (calls) => calls.filter((call) => call.name === "ping").length === 4,
   });
+  expect(world.requests().filter((request) => request.method === "initialize").at(-1)?.revision).toBe("admission-check");
+  expect(world.requests().filter((request) => request.method === "tools/call").at(-1)?.revision).toBe("admission-check");
   evidence.recordAssertionEvidence(
     "Managed-engine prompt admission waits for an ongoing connection replacement",
     "The async prompt remained unacknowledged while initialization was paused, was acknowledged after replacement finished, and invoked the connector exactly once.",

--- a/evals/worlds/mcp-registration.ts
+++ b/evals/worlds/mcp-registration.ts
@@ -1,0 +1,126 @@
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import type { Seed } from "@openwork/env";
+import { startMockMcp } from "@openwork/labs";
+import { bootManagedOpenworkServer, close, isRecord, listen, readBody, sendJson, sendStream } from "./openwork-server-cli.ts";
+
+function gate() {
+  let release: () => void = () => {};
+  const promise = new Promise<void>((resolve) => { release = resolve; });
+  return { promise, release };
+}
+
+/** Real managed engine and server, with the existing MCP witness and a paused model/tool response. */
+export async function mcpRegistration(seed: Seed) {
+  const root = seed.tmpPath("mcp-registration");
+  await mkdir(root, { recursive: true });
+  const scratch = await realpath(root);
+  const workspace = join(scratch, "workspace");
+  await mkdir(workspace);
+  const witness = await startMockMcp({
+    allowUnauthenticatedMcp: true,
+    tools: [{ name: "ping", description: "Check the connection", inputSchema: { type: "object", properties: {} }, result: { content: [{ type: "text", text: "pong" }] } }],
+  });
+  let pause: "model" | "tool" | "initialize" | null = null;
+  let entered = gate();
+  let release = gate();
+  let initializations = 0;
+  const wait = async (stage: "model" | "tool" | "initialize") => {
+    if (pause !== stage) return;
+    entered.release();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([release.promise, new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out at ${stage} gate`)), 30_000);
+      })]);
+    } finally { clearTimeout(timer); }
+  };
+  const proxy = createServer(async (request, response) => {
+    try {
+      if (request.method !== "POST") return sendJson(response, 405, {});
+      const raw = await readBody(request);
+      const body: unknown = JSON.parse(raw);
+      if (isRecord(body) && body.method === "initialize") {
+        initializations += 1;
+        await wait("initialize");
+      }
+      if (isRecord(body) && body.method === "tools/call") await wait("tool");
+      const upstream = await fetch(witness.mcpUrl, {
+        method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+        body: raw, signal: AbortSignal.timeout(15_000),
+      });
+      response.writeHead(upstream.status, Object.fromEntries(upstream.headers));
+      response.end(await upstream.text());
+    } catch (error) { sendJson(response, 500, { error: String(error) }); }
+  });
+  const mcpUrl = await listen(proxy);
+  const provider = createServer(async (request, response) => {
+    try {
+      const body: unknown = JSON.parse(await readBody(request));
+      if (!isRecord(body)) throw new Error("Expected model request");
+      const tools = Array.isArray(body.tools) ? body.tools.filter(isRecord) : [];
+      const tool = tools.find((item) => isRecord(item.function) && item.function.name === "race_ping");
+      const hasResult = Array.isArray(body.messages) && body.messages.some((message) => isRecord(message) && message.role === "tool");
+      const call = Boolean(tool) && !hasResult;
+      if (call) await wait("model");
+      const delta = call
+        ? { tool_calls: [{ index: 0, id: "call_ping", type: "function", function: { name: "race_ping", arguments: "{}" } }] }
+        : { content: "Done." };
+      sendStream(response, [
+        { id: "fixture", object: "chat.completion.chunk", choices: [{ index: 0, delta, finish_reason: null }] },
+        { id: "fixture", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: call ? "tool_calls" : "stop" }] },
+      ]);
+    } catch (error) { sendJson(response, 500, { error: String(error) }); }
+  });
+  const providerUrl = await listen(provider);
+  const mcpConfig = { type: "remote", url: mcpUrl, oauth: false, enabled: true };
+  await writeFile(join(workspace, "opencode.json"), JSON.stringify({
+    permission: "allow", mcp: { race: mcpConfig },
+    model: "mock/mock", small_model: "mock/mock",
+    provider: { mock: { npm: "@ai-sdk/openai-compatible", name: "Mock", options: { baseURL: `${providerUrl}/v1`, apiKey: "fixture" }, models: { mock: { name: "Mock", tool_call: true, limit: { context: 32_768, output: 4_096 } } } } },
+  }));
+  const token = "mcp-registration-fixture";
+  let output = "";
+  let managed: Awaited<ReturnType<typeof bootManagedOpenworkServer>> | undefined;
+  const dispose = async () => {
+    release.release();
+    if (managed) await managed.stop();
+    await close(provider);
+    await close(proxy);
+    await witness.stop();
+    await rm(scratch, { recursive: true, force: true });
+  };
+  try {
+    managed = await bootManagedOpenworkServer({ scratch, workspace, token, sink: (chunk) => { output += chunk; } });
+    const running = managed;
+    return {
+      engine: running.engine,
+      initializations: () => initializations,
+      toolCalls: () => witness.toolCalls(),
+      output: () => output,
+      pause(stage: "model" | "tool" | "initialize") { pause = stage; entered = gate(); release = gate(); },
+      async entered() {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([entered.promise, new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(`No ${pause} request arrived:\n${output.slice(-3_000)}`)), 30_000);
+          })]);
+        } finally { clearTimeout(timer); }
+      },
+      release() { pause = null; release.release(); },
+      async register(revision = "original") {
+        const response = await fetch(`${running.base}/workspace/${running.workspaceId}/mcp`, {
+          method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+          body: JSON.stringify({ name: "race", config: { ...mcpConfig, headers: { "x-fixture-revision": revision } } }),
+          signal: AbortSignal.timeout(20_000),
+        });
+        if (!response.ok) throw new Error(`MCP registration failed: ${response.status} ${await response.text()}`);
+      },
+      [Symbol.asyncDispose]: dispose,
+    };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+}

--- a/evals/worlds/mcp-registration.ts
+++ b/evals/worlds/mcp-registration.ts
@@ -26,6 +26,7 @@ export async function mcpRegistration(seed: Seed) {
   let entered = gate();
   let release = gate();
   let initializations = 0;
+  const requests: Array<{ method: string; revision: string | null }> = [];
   const wait = async (stage: "model" | "tool" | "initialize") => {
     if (pause !== stage) return;
     entered.release();
@@ -41,13 +42,16 @@ export async function mcpRegistration(seed: Seed) {
       if (request.method !== "POST") return sendJson(response, 405, {});
       const raw = await readBody(request);
       const body: unknown = JSON.parse(raw);
+      const header = request.headers["x-fixture-revision"];
+      const revision = typeof header === "string" ? header : null;
+      if (isRecord(body) && typeof body.method === "string") requests.push({ method: body.method, revision });
       if (isRecord(body) && body.method === "initialize") {
         initializations += 1;
         await wait("initialize");
       }
       if (isRecord(body) && body.method === "tools/call") await wait("tool");
       const upstream = await fetch(witness.mcpUrl, {
-        method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+        method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream", ...(revision === null ? {} : { "x-fixture-revision": revision }) },
         body: raw, signal: AbortSignal.timeout(15_000),
       });
       response.writeHead(upstream.status, Object.fromEntries(upstream.headers));
@@ -97,6 +101,7 @@ export async function mcpRegistration(seed: Seed) {
     return {
       engine: running.engine,
       initializations: () => initializations,
+      requests: () => requests.slice(),
       toolCalls: () => witness.toolCalls(),
       output: () => output,
       pause(stage: "model" | "tool" | "initialize") { pause = stage; entered = gate(); release = gate(); },


### PR DESCRIPTION
Runtime MCP synchronization can replace a connection after an active model turn has captured its tools. OpenCode closes the previous client, producing `Not connected` before a call or `Connection closed` during one, even while the replacement reports connected.

This change reuses a live, connected client only when OpenWork has a matching config-delivery receipt for the current engine process. Necessary replacements wait until active tasks finish, with deferred retries and a shared fence against local prompt admission (including managed engine pools). Changed credentials still require delivery; a health observation cannot manufacture a receipt. Explicit disabling and failed-client recovery remain available.

The introducing paths are background startup re-registration in #2184 (`c1192c8c3`, June 11) and the additional Cloud reconciliation registration in #2726 (`899f75051`, July 13). Both corresponding engine versions already closed replaced clients. This is a long-standing race, not an alpha 2716-only change; the exact original production replacement was not traced.

Verification (boundary journey rerun on final head `c26e882e0`; unchanged server checks from `4adbb925b`):

- `pnpm evals:pr specs/mcp-registration-active-task.test.ts` — **Passed**, local PR lane, 1 test, 5 assertion-evidence sections, no skips. Uses a real managed OpenWork server and the installed pinned OpenCode 1.18.18 with a mock connector/model. Proves preservation before invocation and in flight, idle configuration delivery verified by revision headers on initialization and a real tool call, unchanged no-op, disconnected recovery, and prompt admission during replacement.
- Same boundary spec against clean `dev` at `a6bc24cdc` — **Failed as expected**: observed 2 MCP initializations where the active task required 1.
- `pnpm --filter openwork-server exec tsc --noEmit` — passed.
- MCP sync and Cloud reconciliation suites: 24 and 27 tests respectively pass their assertions, but Bun 1.3.8 exits with SIGTRAP at shutdown. The clean control also exhibits the shutdown crash; these commands are not reported as successful exits.
- Full eval typecheck and spec-boundary ratchet have identical failures on branch and clean `dev` (336 and 16 output lines respectively); the new boundary spec introduces no ratchet violation.

The published test-evidence comment contains the final-head assertion records and reproduction command. No real provider accounts or production settings are used by the test.
