### PR TITLE
fix: save manually tested provider workflows for dashboard apps

### DIFF
--- a/ee/apps/den-api/src/routes/org/codemode-scripts.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-scripts.ts
@@ -173,18 +173,6 @@ function routeFailure(error: unknown) {
       },
     } as const
   }
-  const readOnlyPrefix = "workflow_requires_read_only_capabilities:"
-  if (message.startsWith(readOnlyPrefix)) {
-    const capability = message.slice(readOnlyPrefix.length)
-    return {
-      status: 400,
-      body: {
-        error: "workflow_requires_read_only_capabilities",
-        capability,
-        message: `${capability} can change data, so it cannot run unattended in a Workflow. Workflows may only call read-only tools; keep write actions in interactive Code Mode runs.`,
-      },
-    } as const
-  }
   return { status: 400, body: { error: "workflow_rejected", message } } as const
 }
 

--- a/ee/apps/den-api/src/workflows.ts
+++ b/ee/apps/den-api/src/workflows.ts
@@ -412,6 +412,7 @@ export async function createWorkflowVersion(input: {
   )).limit(1)
   if (consumed[0]) throw new Error("workflow_test_receipt_already_used")
 
+  // Saving does not authorize unattended execution; executeWorkflow checks that at run time.
   const built = await input.buildTools()
   const manifestByPath = new Map(built.manifest.flatMap((entry) => [
     [entry.scriptPath, entry] as const,
@@ -422,7 +423,6 @@ export async function createWorkflowVersion(input: {
     if (!current || current.capabilityName !== required.capabilityName) {
       throw new Error(`workflow_capability_unavailable:${required.scriptPath}`)
     }
-    if (current.readOnly !== true) throw new Error(`workflow_requires_read_only_capabilities:${required.scriptPath}`)
   }
   for (const call of parseCodemodeToolCalls(receipt.tool_calls)) {
     if (!payload.parsed.requiredCapabilities.some((required) => {
@@ -634,6 +634,7 @@ export async function saveWorkflow(input: {
   const receipt = receipts[0]
   if (!receipt) throw new Error("workflow_recent_receipt_required")
 
+  // Saving does not authorize unattended execution; executeWorkflow checks that at run time.
   const built = await input.buildTools()
   const manifestByPath = new Map(built.manifest.flatMap((entry) => [
     [entry.scriptPath, entry] as const,
@@ -643,7 +644,6 @@ export async function saveWorkflow(input: {
   for (const call of parseCodemodeToolCalls(receipt.tool_calls)) {
     const resolved = manifestByPath.get(call.name)
     if (!resolved) throw new Error(`workflow_capability_unavailable:${call.name}`)
-    if (resolved.readOnly !== true) throw new Error(`workflow_requires_read_only_capabilities:${call.name}`)
     if (!requiredCapabilities.some((entry) => entry.scriptPath === resolved.scriptPath)) {
       requiredCapabilities.push({
         capabilityName: resolved.capabilityName,

--- a/evals/specs/saved-script-automations.e2e.test.ts
+++ b/evals/specs/saved-script-automations.e2e.test.ts
@@ -367,7 +367,10 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   const matches = records(requireRecord(JSON.parse(discoveryText), "capability search").matches)
   const externalMatch = matches.find((match) => match.name === `mcp:${connection.id}:mock_echo`)
   expect(externalMatch?.scriptPath).toBe("tools.report_source.mock_echo")
-  const externalCode = `return { briefing: await ${externalMatch?.scriptPath}({ text: input.topic }) }`
+  const batchTool = catalogTools.find((tool) => tool.name === "mock_batch")
+  expect(batchTool).toBeDefined()
+  expect(isRecord(batchTool?.annotations) ? batchTool.annotations.readOnlyHint : undefined).not.toBe(true)
+  const externalCode = `await tools.report_source.mock_batch({ items: [{ text: input.topic }] }); return { briefing: await ${externalMatch?.scriptPath}({ text: input.topic }) }`
   const externalRunStartedAt = new Date().toISOString()
   const externalExecuted = await agentRpc(den.ref.apiUrl, mcpToken, "tools/call", {
     name: "execute_capability_script",
@@ -421,7 +424,7 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   const externalSaved = requireRecord(externalSavedResponse.body, "external saved Workflow")
   const externalPluginId = typeof externalSaved.pluginId === "string" ? externalSaved.pluginId : ""
   const externalConfigObjectId = typeof externalSaved.configObjectId === "string" ? externalSaved.configObjectId : ""
-  const externalConfigObjectVersionId = typeof externalSaved.configObjectVersionId === "string" ? externalSaved.configObjectVersionId : ""
+  let externalConfigObjectVersionId = typeof externalSaved.configObjectVersionId === "string" ? externalSaved.configObjectVersionId : ""
   expect(externalPluginId).not.toBe("")
   expect(externalConfigObjectId).not.toBe("")
   expect(externalConfigObjectVersionId).not.toBe("")
@@ -442,6 +445,48 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
     "A saved Workflow exposes a structural step graph for visual rendering",
     "The save response and the Workflow detail carry the same tool/input/return graph plus a Mermaid flowchart.",
     true,
+  )
+
+  const editedDraft = {
+    name: `${scriptName} edited external`,
+    description: "A manually refreshed report using an unclassified provider tool.",
+    code: externalCode,
+    exampleInput: { topic: externalMarker },
+    inputSchema,
+    outputSchema,
+    requiredCapabilities: [
+      { capabilityName: `mcp:${connection.id}:mock_batch`, scriptPath: "tools.report_source.mock_batch" },
+      { capabilityName: `mcp:${connection.id}:mock_echo`, scriptPath: "tools.report_source.mock_echo" },
+    ],
+  }
+  const testedDraft = await denFetch(den.admin, "/v1/workflows/test", {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({ ...editedDraft, configObjectId: externalConfigObjectId }),
+  })
+  expect(testedDraft.response.status, testedDraft.text).toBe(200)
+  const testReceipt = requireRecord(testedDraft.body, "draft test receipt")
+  const rejectedEdit = await denFetch(den.admin, `/v1/workflows/${externalConfigObjectId}/versions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({ ...editedDraft, code: `${externalCode}\n`, receiptId: testReceipt.receiptId }),
+  })
+  expect(rejectedEdit.response.status, rejectedEdit.text).toBe(400)
+  expect(rejectedEdit.text).toContain("workflow_matching_test_receipt_required")
+  const editedVersion = await denFetch(den.admin, `/v1/workflows/${externalConfigObjectId}/versions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${den.admin.token}` },
+    body: JSON.stringify({ ...editedDraft, receiptId: testReceipt.receiptId }),
+  })
+  expect(editedVersion.response.status, editedVersion.text).toBe(201)
+  const editedDetail = requireRecord(editedVersion.body, "edited Workflow")
+  const editedCurrentVersion = requireRecord(editedDetail.currentVersion, "edited current version")
+  expect(typeof editedCurrentVersion.id).toBe("string")
+  externalConfigObjectVersionId = String(editedCurrentVersion.id)
+  evidence.recordAssertionEvidence(
+    "A successful manual report can be saved and edited with an unclassified provider tool",
+    "Both initial save and a tested new version succeed without granting unattended execution.",
+    externalSavedResponse.status === 201 && editedVersion.response.status === 201,
   )
 
   const externalManualRun = await runWorkflow(den.admin, externalConfigObjectId, {
@@ -495,7 +540,7 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   const latestScript = latestDetail.script
   const latest = requireRecord(latestScript.latestSnapshot, "latest snapshot")
   const externalToolCallNames = records(latest.toolCalls).map((call) => call.name)
-  expect(externalToolCallNames).toEqual(["report_source.mock_echo"])
+  expect(externalToolCallNames).toEqual(["report_source.mock_batch", "report_source.mock_echo"])
 
   const internalDetail = await readWorkflowDetail(den.admin, configObjectId)
   const internalScript = internalDetail.script
@@ -504,9 +549,10 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   expect(internalToolCallNames).toEqual(["den.getWorkers"])
   evidence.recordAssertionEvidence(
     "Each Workflow run records the tool calls it made for step-level replay",
-    "The latest snapshot lists report_source.mock_echo for the external Workflow and only den.getWorkers for the internal one.",
-    externalToolCallNames.length === 1
-      && externalToolCallNames[0] === "report_source.mock_echo"
+    "The latest snapshot lists both external tools for the external Workflow and only den.getWorkers for the internal one.",
+    externalToolCallNames.length === 2
+      && externalToolCallNames[0] === "report_source.mock_batch"
+      && externalToolCallNames[1] === "report_source.mock_echo"
       && internalToolCallNames.length === 1
       && internalToolCallNames[0] === "den.getWorkers",
   )
@@ -586,7 +632,6 @@ test("a Code Mode result becomes a cloud Automation and a durable artifact resul
   let unattendedExternalCalls = 0
   try {
     unattendedExternalCalls = (await den.mocks.reports.toolCalls({
-      name: "mock_echo",
       atLeast: 1,
       sinceIso: unattendedRunStartedAt,
       timeoutMs: 5_000,


### PR DESCRIPTION
## Problem and change

Creating a dashboard app from a successful provider query failed while saving its backing workflow when the provider used a generic tool without a read-only annotation. Saving and editing now accept the exact tested workflow and current accessible capabilities. The existing execution-time guard continues to reject external provider calls in unattended Cloud runs.

## Verification

Passed: `GODEBUG=tlsmlkem=0,http2client=0 OPENWORK_EVAL_REF=becbb591b3ee50bfb146537efbe7200224171798 pnpm evals:e2e saved-script-automations`.

Placement: Daytona (daytona CLI authenticated), cold boot on the exact PR head. 1 passed, 0 failed, 0 skipped. The journey covers an unclassified provider tool, initial save, tested version editing, byte-exact receipt rejection, manual app refresh, privacy, and unattended rejection before provider I/O. Runtime evidence is published on this PR.

Warden reviewed the same head: 0 findings, including 0 security or blocking findings.
