### PR TITLE
test(v2): verify Cloud discovery and removed MCP rejection

### DIFF
--- a/evals/specs/opencode-v2-mcp-hot-reload.e2e.test.ts
+++ b/evals/specs/opencode-v2-mcp-hot-reload.e2e.test.ts
@@ -69,6 +69,21 @@ test("v2 uses an MCP added through OpenWork on the next call and removes it in t
   const data = record(created.json) ? created.json.data : undefined;
   if (!record(data) || typeof data.id !== "string") throw new Error("Missing v2 session");
   const sessionId = data.id;
+  if (live) {
+    const catalog = (await api(`${v2}/api/mcp`)).json;
+    const cloud = record(catalog) && Array.isArray(catalog.data) ? catalog.data.find((item) => record(item) && item.name === "openwork-cloud") : null;
+    expect(record(cloud) && record(cloud.status) ? cloud.status.status : null).toBe("connected");
+    const discovery = await liveV2Turn(api, v2, sessionId,
+      "Use OpenWork Cloud to discover whether any Slack capabilities are available to me, then summarize availability. "
+      + "Check the connected integration before answering. Do not read Slack messages, send anything, or use files or shell commands.");
+    const messages: unknown = JSON.parse(discovery.messages);
+    const parts = Array.isArray(messages) ? messages.filter(record).flatMap((message) => Array.isArray(message.content) ? message.content.filter(record) : []) : [];
+    expect(parts.some((part) => part.type === "tool" && part.name === "execute" && record(part.state)
+      && part.state.status === "completed" && record(part.state.metadata) && Array.isArray(part.state.metadata.toolCalls)
+      && part.state.metadata.toolCalls.some((call) => record(call) && call.tool === "openwork-cloud.search_capabilities" && call.status === "completed"))).toBe(true);
+    evidence.recordAssertionEvidence("the real model discovers OpenWork Cloud capabilities through the managed connection",
+      `${modelId} received the openwork-cloud connection created by normal sign-in and actually completed its discovery tool through native Code Mode when asked about Slack. This isolated organization does not establish access to a real user's Slack account; no Slack messages were read or sent.`, true);
+  }
   let executions = 0;
   const toolCode = 'return await tools["reload-witness"].read_report({});';
   async function turn(stage: string, useTool: boolean) {
@@ -87,12 +102,11 @@ test("v2 uses an MCP added through OpenWork on the next call and removes it in t
     const reply = `DONE-${stage}-${Date.now()}`;
     const prior = stage === "removed" ? (await api(`${v2}/api/session/${sessionId}/message`)).json : null;
     const priorIds = new Set(record(prior) && Array.isArray(prior.data) ? prior.data.filter(record).map((message) => message.id) : []);
-    const code = stage === "removed" ? 'return typeof tools["reload-witness"];' : toolCode;
     if (useTool) executions++;
     const setup = await fetch(`${den.mocks.witness.url}/admin/agent-workloads`, {
       method: "POST", headers: { "content-type": "application/json" },
       body: JSON.stringify({ workloads: [{ promptMarker: marker, finalReply: reply,
-        steps: useTool ? Array.from({ length: executions }, () => ({ tool: "execute", arguments: { code } })) : [] }] }),
+        steps: useTool ? Array.from({ length: executions }, () => ({ tool: "execute", arguments: { code: toolCode } })) : [] }] }),
     });
     expect(setup.ok).toBe(true);
     const sinceIso = new Date().toISOString();
@@ -121,8 +135,9 @@ test("v2 uses an MCP added through OpenWork on the next call and removes it in t
       const state = executions[0]?.state;
       if (!record(state)) throw new Error("Missing post-removal Code Mode result");
       expect(state.status).toBe("completed");
-      expect(record(state.metadata) && state.metadata.error === true).toBe(false);
-      expect(Array.isArray(state.content) ? state.content.filter(record).filter((part) => part.type === "text").map((part) => part.text) : []).toEqual(["undefined"]);
+      expect(record(state.metadata) && state.metadata.error === true).toBe(true);
+      const output = Array.isArray(state.content) ? state.content.filter(record).filter((part) => part.type === "text").map((part) => part.text).join("\n") : "";
+      expect(output).toContain("Unknown tool 'reload-witness.read_report'");
     }
     const next = (await request(desktop, "/experimental/engine-v2-preview/status")).json;
     expect(record(next) ? next.pid : null).toBe(pid);
@@ -188,5 +203,5 @@ test("v2 uses an MCP added through OpenWork on the next call and removes it in t
       `${modelId} made unscripted model/tool calls from the Daytona v2 process after managed credential delivery. Two reconnect/disable/enable cycles served actual MCP calls only while enabled, with the original session and process. The credential was absent from all observed public responses.`, true);
   }
   expect((await request(desktop, `${root}/opencode/global/health`)).status).toBe(200);
-  evidence.recordAssertionEvidence("removal reaches the next call and v1 remains available", (live ? "Real OpenAI reported UNAVAILABLE after DELETE; " : "A fresh, successfully completed Code Mode execution returned typeof tools[\"reload-witness\"] as undefined after DELETE; ") + "the native catalog no longer contained the connection and the original conversation served no new MCP calls. The same v2 process and the v1 health endpoint remained available. Direct v2 MCP mutation was denied.", true);
+  evidence.recordAssertionEvidence("removal reaches the next call and v1 remains available", (live ? "Real OpenAI reported UNAVAILABLE after DELETE; " : "A fresh Code Mode attempt to invoke the removed tool returned the explicit Unknown tool 'reload-witness.read_report' error after DELETE; ") + "the native catalog no longer contained the connection and the original conversation served no new MCP calls. The same v2 process and the v1 health endpoint remained available. Direct v2 MCP mutation was denied.", true);
 });

--- a/evals/specs/opencode-v2-mcp-hot-reload.e2e.test.ts
+++ b/evals/specs/opencode-v2-mcp-hot-reload.e2e.test.ts
@@ -74,15 +74,20 @@ test("v2 uses an MCP added through OpenWork on the next call and removes it in t
     const cloud = record(catalog) && Array.isArray(catalog.data) ? catalog.data.find((item) => record(item) && item.name === "openwork-cloud") : null;
     expect(record(cloud) && record(cloud.status) ? cloud.status.status : null).toBe("connected");
     const discovery = await liveV2Turn(api, v2, sessionId,
-      "Use OpenWork Cloud to discover whether any Slack capabilities are available to me, then summarize availability. "
+      "Use OpenWork Cloud to discover whether connected Slack capabilities are available to me. "
+      + "Report SLACK_CONNECTED only if discovery confirms access, otherwise report SLACK_NOT_CONNECTED, followed by a brief explanation. "
       + "Check the connected integration before answering. Do not read Slack messages, send anything, or use files or shell commands.");
     const messages: unknown = JSON.parse(discovery.messages);
     const parts = Array.isArray(messages) ? messages.filter(record).flatMap((message) => Array.isArray(message.content) ? message.content.filter(record) : []) : [];
     expect(parts.some((part) => part.type === "tool" && part.name === "execute" && record(part.state)
       && part.state.status === "completed" && record(part.state.metadata) && Array.isArray(part.state.metadata.toolCalls)
-      && part.state.metadata.toolCalls.some((call) => record(call) && call.tool === "openwork-cloud.search_capabilities" && call.status === "completed"))).toBe(true);
+      && part.state.metadata.toolCalls.some((call) => record(call) && call.tool === "openwork-cloud.search_capabilities" && call.status === "completed"
+        && record(call.input) && typeof call.input.query === "string" && /slack/i.test(call.input.query)))).toBe(true);
+    // This fresh organization has no Slack connection or account credentials.
+    expect(discovery.text).toContain("SLACK_NOT_CONNECTED");
+    expect(discovery.text).not.toContain("SLACK_CONNECTED");
     evidence.recordAssertionEvidence("the real model discovers OpenWork Cloud capabilities through the managed connection",
-      `${modelId} received the openwork-cloud connection created by normal sign-in and actually completed its discovery tool through native Code Mode when asked about Slack. This isolated organization does not establish access to a real user's Slack account; no Slack messages were read or sent.`, true);
+      `${modelId} received openwork-cloud from normal sign-in, completed native Code Mode discovery with a Slack query, and correctly reported SLACK_NOT_CONNECTED for the fresh organization without a Slack account. This does not establish access to a real user's Slack; no Slack messages were read or sent.`, true);
   }
   let executions = 0;
   const toolCode = 'return await tools["reload-witness"].read_report({});';


### PR DESCRIPTION
The MCP removal test used `typeof` on a native Code Mode tool proxy, which remains callable even when its target is gone. It now invokes the removed tool and requires the specific Unknown tool error in the fresh execution result, alongside zero MCP calls and removal from the catalog.

The real-OpenAI lane also verifies OpenWork Cloud after normal managed sign-in: v2 must expose the connection, and the model must complete Cloud discovery when asked about Slack. The isolated test organization has no real Slack account; no Slack messages are read or sent. This is a test-only follow-up to merged #4500.

Validation at `2f3af0096edb9f68e957e5ffbfd076dc232db77c`:
- Real GPT-5.6 Luna / cold-boot Daytona: **Passed**, 1 passed / 0 failed / 0 skipped, 329.95s. Eleven turns verified a real Slack discovery query and correct unconnected-account answer, add/update/delete, credential replacement, workspace isolation, and repeated reconnect/disable/enable behavior in the same v2 process. Exact-head assertion evidence is published. The live key was absent from all scanned artifacts; temporary providers and both instances were cleaned up.
- Deterministic cold-boot Daytona: **Passed**, 1 passed / 0 failed / 0 skipped, 254.31s. A forced call to the deleted MCP returned its specific Unknown tool error, with no MCP request served. Add, credential replacement, workspace isolation, unchanged session/process, and v1 health also passed.

The earlier GPT-4.1/mini failures remain documented in #4500; this does not claim model-independent reliability. The evidence header's v1 label describes desktop bootstrap, while the conversation targets the enabled pinned v2 process.

Reproduce: `OPENWORK_EVAL_REF=test/v2-cloud-live-proof pnpm evals:e2e opencode-v2-mcp-hot-reload --daytona`. For real inference, securely inject `OPENAI_API_KEY` and set `OPENWORK_EVAL_LIVE_OPENAI=1 OPENWORK_EVAL_OPENAI_MODEL=gpt-5.6-luna`.
