### PR TITLE
feat: delete saved apps from the dashboard

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -3073,6 +3073,11 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         method: "POST", token, organizationId: orgId, body: input,
       }));
     },
+    async deleteApp(orgId: string, appId: string) {
+      await requestJson<unknown>(baseUrls, `/v1/artifact-views/${encodeURIComponent(appId)}/retire`, {
+        method: "POST", token, organizationId: orgId,
+      });
+    },
     async setAppOnDashboard(orgId: string, appId: string, added: boolean) {
       await requestJson<unknown>(baseUrls, `/v1/apps/${encodeURIComponent(appId)}/dashboard`, {
         method: "POST", token, organizationId: orgId, body: { added },

--- a/apps/app/src/react-app/domains/apps/app-artifact.tsx
+++ b/apps/app/src/react-app/domains/apps/app-artifact.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useNavigate } from "react-router";
+import { DeleteAppButton } from "./delete-app-button";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Loader2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -13,6 +15,7 @@ export type AppReference = { appId: string; revisionId?: string; receiptId?: str
 
 export function AppArtifact({ appId, revisionId, receiptId, onClose, onAsk }: AppReference & { onClose?: () => void; onAsk?: (prompt: string) => Promise<void> }) {
   const { client, orgId, scope } = useAppsClient();
+  const navigate = useNavigate();
   const cache = useQueryClient();
   const [saveOpen, setSaveOpen] = useState(false);
   const [name, setName] = useState("");
@@ -65,6 +68,7 @@ export function AppArtifact({ appId, revisionId, receiptId, onClose, onAsk }: Ap
       }}>{saved ? <><Check className="size-4" />Saved</> : app.view.activeRevisionId ? "Save changes" : "Save"}</Button> : null}
       {onAsk && saved ? <Button size="sm" variant="outline" disabled={asking} onClick={() => void ask(`Run my saved app “${app.view.title}” using its existing workflow “${app.workflowTitle}”. Ask for any inputs you need, then show the new results in the saved app.`)}>Run again</Button> : null}
       {onAsk && app.canManage ? <Button size="sm" variant="ghost" disabled={asking} onClick={() => void ask(`Help me improve my saved app “${app.view.title}”. Read its existing app source and workflow “${app.workflowTitle}”, ask what I want to change, and show a draft preview for me to save.`)}>Ask for changes</Button> : null}
+      {app.canManage && app.view.status !== "retired" ? <DeleteAppButton appId={appId} title={app.view.title} onDeleted={onClose ?? (() => navigate("/dashboard"))} /> : null}
       {onClose ? <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close app"><X /></Button> : null}
     </header>
     <div className="min-h-0 flex-1 space-y-4 overflow-auto p-4">

--- a/apps/app/src/react-app/domains/apps/delete-app-button.tsx
+++ b/apps/app/src/react-app/domains/apps/delete-app-button.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useAppsClient } from "./use-apps";
+
+export function DeleteAppButton({ appId, title, onDeleted }: { appId: string; title: string; onDeleted?: () => void }) {
+  const [open, setOpen] = useState(false);
+  const { client, orgId, scope } = useAppsClient();
+  const cache = useQueryClient();
+  const deletion = useMutation({
+    mutationFn: async () => {
+      if (!client || !orgId) throw new Error("Sign in to delete this app.");
+      await client.deleteApp(orgId, appId);
+    },
+    onSuccess: async () => {
+      setOpen(false);
+      onDeleted?.();
+      await Promise.all([
+        cache.invalidateQueries({ queryKey: ["saved-apps", ...scope] }),
+        cache.invalidateQueries({ queryKey: ["app-preview", ...scope, appId] }),
+      ]);
+    },
+  });
+  return <>
+    <Button variant="ghost" size="sm" aria-label={`Delete ${title}`} onClick={() => { deletion.reset(); setOpen(true); }}><Trash2 className="size-4" />Delete</Button>
+    <Dialog open={open} onOpenChange={(next) => { if (!deletion.isPending) setOpen(next); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete “{title}”?</DialogTitle>
+          <DialogDescription>This removes the saved app from everyone’s dashboards and the app list. Its workflow and past results stay available.</DialogDescription>
+        </DialogHeader>
+        {deletion.error ? <p role="alert" className="text-sm text-destructive">{deletion.error.message}</p> : null}
+        <DialogFooter>
+          <Button variant="outline" disabled={deletion.isPending} onClick={() => setOpen(false)}>Cancel</Button>
+          <Button variant="destructive" disabled={deletion.isPending} onClick={() => deletion.mutate()}>{deletion.isPending ? "Deleting…" : "Delete app"}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  </>;
+}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useSavedApps, useAppsClient } from "../apps/use-apps";
+import { DeleteAppButton } from "../apps/delete-app-button";
 import { GeneratedAppPreview } from "../apps/generated-app-preview";
 
 export type CreateDashboardApp = (prompt: string) => Promise<void>;
@@ -93,6 +94,7 @@ function SavedDashboardApp({ app, onRemove, removing }: { app: SavedAppSummary; 
   return <article className="min-w-0 overflow-hidden rounded-xl border bg-background" data-personal-dashboard-app={app.view.id}>
     <header className="flex items-center gap-2 border-b p-3">
       <button className="min-w-0 flex-1 text-left" aria-label={`Open ${app.view.title}`} onClick={() => navigate(`/dashboard/apps/${app.view.id}`)}><span className="block truncate text-sm font-medium">{app.view.title}</span><span className="text-xs text-muted-foreground">Open app</span></button>
+      {app.canManage ? <DeleteAppButton appId={app.view.id} title={app.view.title} /> : null}
       <Button variant="ghost" size="icon-sm" aria-label={`Remove ${app.view.title} from dashboard`} disabled={removing} onClick={onRemove}><X className="size-4" /></Button>
     </header>
     <div className="max-h-[32rem] overflow-auto px-4 pb-4">

--- a/ee/apps/den-api/src/artifact-views.ts
+++ b/ee/apps/den-api/src/artifact-views.ts
@@ -290,9 +290,15 @@ export async function retireArtifactView(input: {
   artifactViewId: string
 }): Promise<GeneratedArtifactView> {
   const view = await accessibleView({ context: input.context, artifactViewId: input.artifactViewId, role: "manager" })
-  await db.update(ArtifactViewTable).set({ status: "retired", active_revision_id: null })
-    .where(eq(ArtifactViewTable.id, view.id))
-  const updated = { ...view, status: "retired" as const, active_revision_id: null, updated_at: new Date() }
+  await db.transaction(async (tx) => {
+    await tx.update(ArtifactViewTable).set({ status: "retired", active_revision_id: null, use_in_workflow: false })
+      .where(eq(ArtifactViewTable.id, view.id))
+    await tx.delete(DashboardAppTable).where(and(
+      eq(DashboardAppTable.organization_id, view.organization_id),
+      eq(DashboardAppTable.artifact_view_id, view.id),
+    ))
+  })
+  const updated = { ...view, status: "retired" as const, active_revision_id: null, use_in_workflow: false, updated_at: new Date() }
   return serializeView(updated, await revisionRows(view.id))
 }
 

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -240,6 +240,7 @@ test("create, preview, save and reopen an app without changing already-open resu
     await world.open(dashboardAppPath);
     await user.click("Delete Team briefing");
     await user.see({ text: "Delete “Team briefing”?" });
+    await user.see({ text: "This removes the saved app from everyone’s dashboards and the app list. Its workflow and past results stay available." });
     await user.screenshot();
     await user.click("Cancel");
     expect((await readApp()).onDashboard).toBe(true);

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "vitest";
+import { saveWorkflow, runWorkflow } from "@openwork/behaviors";
 import { spec } from "@openwork/testkit";
 import { creationPrompt, creationReply, field, record, savedAppCreation } from "../worlds/saved-apps.ts";
 
@@ -191,6 +192,73 @@ test("create, preview, save and reopen an app without changing already-open resu
   await seed.api(colleague, `/v1/apps/${appId}/dashboard`, { method: "POST", body: JSON.stringify({ added: false }) });
   expect((await readApp()).onDashboard).toBe(true);
   evidence.recordAssertionEvidence("Stale saves and members without workflow access cannot overwrite or read the saved app", "Stale activation returned 409 and kept the title; the ungranted colleague received 403 for missing workflow access without result content.", true);
+
+  const deniedDelete = await seed.api(colleague, `/v1/artifact-views/${appId}/retire`, { method: "POST" });
+  expect(deniedDelete.response.status).toBe(403);
+  expect((await readApp()).onDashboard).toBe(true);
+
+  await step("a regular member deletes their own saved app", async () => {
+    const memberCode = 'return { topic: input.topic, total: 7 };';
+    const memberInput = { topic: "Personal report" };
+    await world.rpc("execute_capability_script", { code: memberCode, input: memberInput }, colleague);
+    const memberSaved = await saveWorkflow(colleague, {
+      name: "Personal report", code: memberCode, currentInput: memberInput,
+      inputSchema: { type: "object", properties: { topic: { type: "string" } }, required: ["topic"] },
+      outputSchema: { type: "object", properties: { topic: { type: "string" }, total: { type: "number" } }, required: ["topic", "total"] },
+    });
+    expect(memberSaved.status, memberSaved.text).toBe(201);
+    const memberWorkflowId = field(memberSaved.body, "configObjectId");
+    await runWorkflow(colleague, memberWorkflowId, {
+      pluginId: field(memberSaved.body, "pluginId"), configObjectVersionId: field(memberSaved.body, "configObjectVersionId"), input: memberInput,
+    });
+    const memberBuilt = await world.rpc("save_artifact_view", {
+      configObjectId: memberWorkflowId, title: "Personal report", reactSource: 'export default function Report({data}) { return <p>{data.topic}</p> }',
+    }, colleague);
+    const memberView = record(record(memberBuilt.structuredContent).view);
+    const memberAppId = field(memberView, "id");
+    if (!Array.isArray(memberView.revisions)) throw new Error("Member app has no revisions");
+    const memberRevisionId = field(memberView.revisions[0], "id");
+    const memberSave = await seed.api(colleague, `/v1/apps/${memberAppId}/save`, {
+      method: "POST", body: JSON.stringify({ revisionId: memberRevisionId, title: "Personal report", useInWorkflow: true, expectedActiveRevisionId: null }),
+    });
+    expect(memberSave.response.status, memberSave.text).toBe(200);
+    expect((await probe.api(colleague, `/v1/apps/${memberAppId}`)).body).toMatchObject({ canManage: true, onDashboard: true });
+    const memberSnapshots = (await probe.api(colleague, `/v1/workflows/${memberWorkflowId}/snapshots`)).body;
+    const removed = await seed.api(colleague, `/v1/artifact-views/${memberAppId}/retire`, { method: "POST" });
+    expect(removed.response.status, removed.text).toBe(200);
+    expect(removed.body).toMatchObject({ status: "retired", activeRevisionId: null, useInWorkflow: false });
+    expect(record((await probe.api(colleague, "/v1/apps")).body).items).toEqual([]);
+    expect((await probe.api(colleague, `/v1/apps/${memberAppId}?revisionId=${memberRevisionId}`)).body).toMatchObject({ onDashboard: false, payload: { data: memberInput } });
+    expect((await probe.api(colleague, `/v1/workflows/${memberWorkflowId}/snapshots`)).body).toEqual(memberSnapshots);
+    expect((await readApp()).onDashboard).toBe(true);
+  });
+  evidence.recordAssertionEvidence("Members can delete their own apps but cannot delete another member's private app", "The member created and retired their own saved app, removing its placement and workflow selection while preserving historical results; deleting the admin's app was rejected and that app stayed saved.", true);
+
+  const beforeDelete = await readWorkflow();
+  const beforeDeleteSnapshots = (await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body;
+  await step("an admin cancels deletion in the app and confirms it on the dashboard", async () => {
+    await world.open(dashboardAppPath);
+    await user.click("Delete Team briefing");
+    await user.see({ text: "Delete “Team briefing”?" });
+    await user.screenshot();
+    await user.click("Cancel");
+    expect((await readApp()).onDashboard).toBe(true);
+    await world.open("/dashboard");
+    await user.click("Delete Team briefing");
+    await user.click("Delete app");
+    await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
+    await user.reload();
+    await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
+    expect(record((await probe.api(world.den.admin, "/v1/apps")).body).items).toEqual([]);
+    expect((await readApp(originalPath))).toMatchObject({ onDashboard: false, view: { status: "retired", activeRevisionId: null }, payload: { data: { topic: "Launch briefing" } } });
+    expect((await readWorkflow()).currentVersion).toEqual(beforeDelete.currentVersion);
+    expect((await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body).toEqual(beforeDeleteSnapshots);
+    expect((await probe.api(world.den.admin, `/v1/dashboards/${world.dashboardId}`)).body).toEqual(companyBefore);
+    const readd = await seed.api(world.den.admin, `/v1/apps/${appId}/dashboard`, { method: "POST", body: JSON.stringify({ added: true }) });
+    expect(readd.response.status).toBe(404);
+    await user.screenshot();
+  });
+  evidence.recordAssertionEvidence("Admins can delete their own apps from the dashboard after a clear confirmation", "Delete is available in the open app and dashboard. Cancel preserves it; confirming removes it across reloads while retaining the workflow, historical results, and unrelated company dashboard.", true);
 
   await step("Dashboard Add opens a creation conversation", async () => {
     await world.open("/dashboard");

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -53,9 +53,12 @@ export async function savedAppCreation(seed: Seed) {
   });
   const token = field(tokenResponse.body, "token");
   let requestId = 0;
-  const rpc = async (name: string, args: Record<string, unknown>) => {
+  const rpc = async (name: string, args: Record<string, unknown>, session = den.admin) => {
+    const sessionToken = session === den.admin ? token : field((await seed.api(session, "/v1/mcp/token", {
+      method: "POST", headers: { "x-openwork-org-id": orgId }, body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+    })).body, "token");
     const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
-      method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      method: "POST", headers: { authorization: `Bearer ${sessionToken}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
       body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: { name, arguments: args } }),
       signal: AbortSignal.timeout(90_000),
     });


### PR DESCRIPTION
Members and admins could remove a personal dashboard card, but there was no Delete action for apps they manage. Add Delete to saved app cards and the open app view, with a confirmation explaining that the workflow and historical results remain available.

The action uses the existing server-enforced app management permissions and retirement endpoint. Retirement now clears all dashboard placements and automatic workflow-view selection in the same transaction. Historical revision URLs and workflow results remain available.

Verification passed: `GODEBUG=tlsmlkem=0,http2client=0 OPENWORK_EVAL_REF=8ab8ff077912fcc0249e3aead7ab17ad8222fe9f pnpm evals:e2e saved-app-creation`. Placement: Daytona (daytona CLI authenticated), cold-boot server and desktop on the exact head. 1 passed, 0 failed, 0 skipped. Runtime evidence and screenshots are published on this PR.

The journey checks admin Delete/Cancel in the UI, the exact retention explanation, member deletion of their own app, rejection for another member’s private app, dashboard persistence across reload, and preservation of workflow history and unrelated company dashboards.

Warden’s confirmation-text test finding was addressed; the final head has 0 findings. Mac arm64 package built successfully with `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --filter @openwork/desktop package:electron:dir`.
