### PR TITLE
Add reusable in-app Daytona previews for Den and desktop

### DIFF
--- a/.opencode/skills/daytona/SKILL.md
+++ b/.opencode/skills/daytona/SKILL.md
@@ -19,6 +19,10 @@ To run tests, just use `pnpm evals:e2e <slug>` — it picks Daytona automaticall
 when the CLI is authenticated. `--local` forces local; `--daytona` requires
 Daytona and fails when it is unavailable.
 
+For a PR preview that should open inside Codex and support named scenarios,
+use [preview-my-work](../preview-my-work/SKILL.md). It composes the same maintained
+world and Daytona primitives with scoped ownership and teardown.
+
 ## Long-lived manual Electron sandbox
 
 Run `bash .devcontainer/test-on-daytona.sh <ref>`. The maintained helper uses

--- a/.opencode/skills/preview-my-work/SKILL.md
+++ b/.opencode/skills/preview-my-work/SKILL.md
@@ -29,7 +29,9 @@ Use a unique stage such as `pr-1234` to keep previews separate. First inspect
 An existing matching world should be reopened, not recreated. Compare its
 recorded scenario and ref before adopting it. A stage is not a git ref.
 
-Push the intended commit so Daytona can fetch it. Then:
+Use reviewed repository code: previews execute that ref’s build scripts. Do not
+load production credentials or attach shared secrets volumes. Push the intended
+commit and use its full SHA so Daytona can fetch it. Then:
 
 ```sh
 OPENWORK_EVAL_REF=<pushed-sha> infisical run --silent --env dev -- pnpm world up preview-den --stage pr-1234 --place daytona --detach --timeout 600000 -- --scenario fresh --lifetime 120

--- a/.opencode/skills/preview-my-work/SKILL.md
+++ b/.opencode/skills/preview-my-work/SKILL.md
@@ -31,7 +31,8 @@ recorded scenario and ref before adopting it. A stage is not a git ref.
 
 Use reviewed repository code: previews execute that ref’s build scripts. Do not
 load production credentials or attach shared secrets volumes. Push the intended
-commit and use its full SHA so Daytona can fetch it. Then:
+commit and use its full 40-character SHA so Daytona can fetch it. Both launch
+and update reject mutable branch names. Then:
 
 ```sh
 OPENWORK_EVAL_REF=<pushed-sha> infisical run --silent --env dev -- pnpm world up preview-den --stage pr-1234 --place daytona --detach --timeout 600000 -- --scenario fresh --lifetime 120

--- a/.opencode/skills/preview-my-work/SKILL.md
+++ b/.opencode/skills/preview-my-work/SKILL.md
@@ -57,6 +57,9 @@ Wait for world readiness and verify the preview responds before reporting it
 ready. If testing behavior, follow `run-tests`; a manually booted world is not a
 passing test. Do not print secret outputs or put them in a PR. Test account
 passwords are masked; read the owner-only receipt privately when signing in.
+For seeded Den scenarios, use the available browser controls to sign in with
+that test account before handing the preview to the user. Leave fresh Den at
+signup. The desktop team/workspace scenarios already sign in automatically.
 Mail stays in this world's development outbox; never send real invitations.
 
 ## Update without losing progress

--- a/.opencode/skills/preview-my-work/SKILL.md
+++ b/.opencode/skills/preview-my-work/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: preview-my-work
+description: Boot, reopen, update, or reset an isolated OpenWork PR preview inside Codex. Use Den in the in-app browser or the real Linux Electron app streamed through Daytona noVNC for hands-on testing.
+---
+
+# Preview my work
+
+Use the repository's world lifecycle. These are disposable test environments,
+not production or a user's installed desktop profile. Do not touch another
+world or an existing test sandbox. Run from the requested worktree.
+
+## Choose a preview
+
+- `preview-den`: signup, team administration, onboarding, connectors, policies.
+- `preview-desktop`: real Electron plus its own Den; workspaces, chat and native
+  app interactions. This is Linux Electron, not a macOS/Windows parity check.
+
+Choose `--scenario fresh` for signup/first use, `team` for an owner with Notion
+and Linear available (individual accounts remain unconnected), `restricted`
+for that team with the API's canonical restricted policy values, or `workspace`
+for a signed-in desktop workspace without pre-added tools. Fresh desktop creates
+its local workspace but does not sign into Den. No model credentials are seeded.
+Do not describe these fixtures as capable of live model/provider requests.
+
+## Start and open
+
+Use a unique stage such as `pr-1234` to keep previews separate. First inspect
+`pnpm world list` and `pnpm world outputs <world> --stage <stage> --json`.
+An existing matching world should be reopened, not recreated. Compare its
+recorded scenario and ref before adopting it. A stage is not a git ref.
+
+Push the intended commit so Daytona can fetch it. Then:
+
+```sh
+OPENWORK_EVAL_REF=<pushed-sha> infisical run --silent --env dev -- pnpm world up preview-den --stage pr-1234 --place daytona --detach --timeout 600000 -- --scenario fresh --lifetime 120
+```
+
+Substitute `preview-desktop` and the desired scenario as needed. The existing
+Daytona snapshots handle dependencies. A cold build takes minutes; reopening a
+ready world is quick. Never promise seconds for an unmeasured cold boot.
+
+Read the resulting world outputs. Open `preview` with Codex's `open_in_codex`
+browser target when available; do not launch the operating system browser.
+Den opens directly; desktop opens the noVNC viewer with automatic connection,
+fit-to-panel scaling and reconnect enabled. The viewer toolbar includes
+clipboard controls. Keep `denWeb` available for testing both surfaces.
+If this agent has no embedded-browser opening tool, give the preview link.
+
+For phone web layouts, use the browser tool's viewport controls if available;
+otherwise use the preview's responsive browser tools. Do not call a resized
+Electron viewer a mobile app preview.
+
+Wait for world readiness and verify the preview responds before reporting it
+ready. If testing behavior, follow `run-tests`; a manually booted world is not a
+passing test. Do not print secret outputs or put them in a PR. Test account
+passwords are masked; read the owner-only receipt privately when signing in.
+Mail stays in this world's development outbox; never send real invitations.
+
+## Update without losing progress
+
+For frontend-only changes, push the new commit and run:
+
+```sh
+pnpm exec python3 .opencode/skills/preview-my-work/scripts/update-preview.py preview-den --stage pr-1234 --ref <pushed-sha>
+```
+
+For `preview-desktop`, the helper updates both Den web and the desktop renderer.
+It preserves the Den database, accounts, Electron process and profile. Desktop
+renderer updates use the existing Vite hot reload; reload the viewer/app if
+needed. Verify the changed screen before claiming the update is visible.
+
+The helper deliberately does not restart Den API, migrate data, or restart
+Electron main/preload. For those changes, create a new stage on the new ref and
+explain that it is a fresh preview. Do not silently reset a working preview.
+
+## Reset, lifetime and stop
+
+“Start over” means stop this exact world/stage, then repeat its launch command.
+This deletes that preview's data. For a comparison, use another stage instead.
+
+```sh
+pnpm world down preview-den --stage pr-1234
+```
+
+The default lifetime is two hours from readiness, **not an idle timer**. Use
+`--lifetime 0` only when the user asks to keep it until explicitly stopped;
+otherwise accept 1–1440 minutes. The world process owns orderly teardown on
+expiry or `down`. An abruptly killed driver cannot run its cleanup; inspect the
+stage's resource ledger and use the existing world reaper for orphan recovery.
+Do not delete sandboxes by broad name patterns.
+
+Report the preview link, tested ref/scenario, expiry, and any actual limitation.
+Keep infrastructure IDs and startup logs out of the user-facing walkthrough.

--- a/.opencode/skills/preview-my-work/scripts/update-preview.py
+++ b/.opencode/skills/preview-my-work/scripts/update-preview.py
@@ -47,7 +47,7 @@ if web:
             if pid is not None: raise RuntimeError("Multiple Next servers; refusing an ambiguous update")
             pid = int(proc.name)
             running = dict(item.decode().split("=", 1) for item in (proc / "environ").read_bytes().split(b"\0") if b"=" in item)
-            allowed = {"PATH", "HOME", "PNPM_HOME", "DEN_WEB_PORT", "DEN_API_BASE", "DEN_AUTH_ORIGIN", "DEN_AUTH_FALLBACK_BASE", "NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL", "DEN_ORG_MODE", "OPENWORK_DEV_MODE", "DEN_WEB_ALLOWED_DEV_ORIGINS"}
+            allowed = {"PATH", "HOME", "PNPM_HOME", "DEN_WEB_PORT", "DEN_BASE_URL", "DEN_API_BASE", "DEN_AUTH_ORIGIN", "DEN_AUTH_FALLBACK_BASE", "NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL", "DEN_ORG_MODE", "OPENWORK_DEV_MODE", "DEN_WEB_ALLOWED_DEV_ORIGINS"}
             env = {key: value for key, value in running.items() if key in allowed}
         except (FileNotFoundError, PermissionError): continue
     if pid is None: raise RuntimeError("No running preview web server")

--- a/.opencode/skills/preview-my-work/scripts/update-preview.py
+++ b/.opencode/skills/preview-my-work/scripts/update-preview.py
@@ -11,12 +11,12 @@ import subprocess
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("world", choices=["preview-den", "preview-desktop"])
 parser.add_argument("--stage", required=True)
-parser.add_argument("--ref", required=True, help="Pushed branch or full commit SHA")
+parser.add_argument("--ref", required=True, help="Reviewed, pushed full 40-character commit SHA")
 args = parser.parse_args()
 if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9._-]*", args.stage):
     parser.error("Use the normalized stage name from world outputs.")
-if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9/._-]*", args.ref):
-    parser.error("Use a pushed git ref or commit SHA.")
+if not re.fullmatch(r"[0-9a-f]{40}", args.ref):
+    parser.error("Use a reviewed, pushed full 40-character commit SHA; branch names are mutable.")
 root = Path(__file__).resolve().parents[4]
 receipt_dir = Path(os.environ.get("OPENWORK_WORLD_SNAPSHOT_DIR", root / "evals/results/.worlds/scripts"))
 receipt = receipt_dir / f"{args.world}--{args.stage}.json"
@@ -52,7 +52,9 @@ if web:
         except (FileNotFoundError, PermissionError): continue
     if pid is None: raise RuntimeError("No running preview web server")
 subprocess.run(["git", "fetch", "origin", ref], cwd=root, check=True)
-subprocess.run(["git", "checkout", "--detach", "FETCH_HEAD"], cwd=root, check=True)
+fetched = subprocess.check_output(["git", "rev-parse", "FETCH_HEAD"], cwd=root, text=True).strip()
+if fetched != ref: raise RuntimeError("Fetched commit does not match the requested SHA")
+subprocess.run(["git", "checkout", "--detach", ref], cwd=root, check=True)
 install_env = {key: value for key, value in os.environ.items() if key in {"PATH", "HOME", "PNPM_HOME"}}
 with open("/tmp/preview-update.log", "w") as log:
     subprocess.run(["pnpm", "install", "--frozen-lockfile"], cwd=root, env=install_env, stdout=log, stderr=subprocess.STDOUT, check=True)

--- a/.opencode/skills/preview-my-work/scripts/update-preview.py
+++ b/.opencode/skills/preview-my-work/scripts/update-preview.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Update only the frontends of a live, owned preview world; preserve its data."""
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("world", choices=["preview-den", "preview-desktop"])
+parser.add_argument("--stage", required=True)
+parser.add_argument("--ref", required=True, help="Pushed branch or full commit SHA")
+args = parser.parse_args()
+if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9._-]*", args.stage):
+    parser.error("Use the normalized stage name from world outputs.")
+if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9/._-]*", args.ref):
+    parser.error("Use a pushed git ref or commit SHA.")
+root = Path(__file__).resolve().parents[4]
+receipt_dir = Path(os.environ.get("OPENWORK_WORLD_SNAPSHOT_DIR", root / "evals/results/.worlds/scripts"))
+receipt = receipt_dir / f"{args.world}--{args.stage}.json"
+state = json.loads(receipt.read_text())
+if state.get("kind") != "script" or state.get("place") != "daytona" or Path(state["sourcePath"]).resolve() != root / "worlds" / f"{args.world}.ts":
+    parser.error("Receipt is not an owned Daytona preview in this worktree.")
+os.kill(state["pid"], 0)
+outputs = state["outputs"]
+# All commands are argv-based locally, and one shell-quoted Python program remotely.
+# Reuse the running web process's environment without printing or serializing it.
+remote = r'''
+import os, signal, subprocess, time
+from pathlib import Path
+ref = REF
+web = WEB
+root = "/workspace"
+subprocess.run(["git", "diff", "--quiet", "--", ".", ":!ee/apps/den-web/next-env.d.ts", ":!ee/apps/den-web/tsconfig.tsbuildinfo"], cwd=root, check=True)
+subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=root, check=True)
+env = None
+pid = None
+if web:
+    for proc in Path("/proc").iterdir():
+        if not proc.name.isdigit(): continue
+        try:
+            command = (proc / "cmdline").read_bytes().split(b"\0")[0]
+            if not command.startswith(b"next-server"): continue
+            if str((proc / "cwd").resolve()) != root + "/ee/apps/den-web": continue
+            if pid is not None: raise RuntimeError("Multiple Next servers; refusing an ambiguous update")
+            pid = int(proc.name)
+            env = dict(item.decode().split("=", 1) for item in (proc / "environ").read_bytes().split(b"\0") if b"=" in item)
+        except (FileNotFoundError, PermissionError): continue
+    if pid is None: raise RuntimeError("No running preview web server")
+subprocess.run(["git", "fetch", "origin", ref], cwd=root, check=True)
+subprocess.run(["git", "checkout", "--detach", "FETCH_HEAD"], cwd=root, check=True)
+with open("/tmp/preview-update.log", "w") as log:
+    subprocess.run(["pnpm", "install", "--frozen-lockfile"], cwd=root, stdout=log, stderr=subprocess.STDOUT, check=True)
+    if web:
+        subprocess.run(["pnpm", "--filter", "@openwork-ee/den-web", "build"], cwd=root, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
+if web:
+    os.kill(pid, signal.SIGTERM)
+    for _ in range(100):
+        try: os.kill(pid, 0)
+        except ProcessLookupError: break
+        time.sleep(0.1)
+    else: raise RuntimeError("Previous web server did not stop")
+    with open("/tmp/den-web.log", "a") as log:
+        subprocess.Popen(["pnpm", "--filter", "@openwork-ee/den-web", "exec", "next", "start", "--hostname", "0.0.0.0", "--port", "3005"], cwd=root, env=env, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+print("Updated frontend; existing data preserved.")
+'''
+targets = [(outputs["denSandbox"], True)]
+if args.world == "preview-desktop":
+    targets.append((outputs["desktopSandbox"], False))
+for sandbox, web in targets:
+    if not re.fullmatch(r"[a-zA-Z0-9_-]+", sandbox):
+        parser.error("Invalid sandbox ID in receipt")
+    program = remote.replace("REF", repr(args.ref)).replace("WEB", repr(web))
+    subprocess.run(["daytona", "exec", sandbox, "--", "python3", "-c", shlex.quote(program)], check=True)
+# Keep boot ref distinct: the API/Electron main still run that version.
+outputs["frontendRef"] = args.ref
+receipt.write_text(json.dumps(state, indent=2) + "\n")
+print("Frontend update complete. Reopen the existing preview and verify the changed screen.")

--- a/.opencode/skills/preview-my-work/scripts/update-preview.py
+++ b/.opencode/skills/preview-my-work/scripts/update-preview.py
@@ -46,13 +46,16 @@ if web:
             if str((proc / "cwd").resolve()) != root + "/ee/apps/den-web": continue
             if pid is not None: raise RuntimeError("Multiple Next servers; refusing an ambiguous update")
             pid = int(proc.name)
-            env = dict(item.decode().split("=", 1) for item in (proc / "environ").read_bytes().split(b"\0") if b"=" in item)
+            running = dict(item.decode().split("=", 1) for item in (proc / "environ").read_bytes().split(b"\0") if b"=" in item)
+            allowed = {"PATH", "HOME", "PNPM_HOME", "DEN_WEB_PORT", "DEN_API_BASE", "DEN_AUTH_ORIGIN", "DEN_AUTH_FALLBACK_BASE", "NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL", "DEN_ORG_MODE", "OPENWORK_DEV_MODE", "DEN_WEB_ALLOWED_DEV_ORIGINS"}
+            env = {key: value for key, value in running.items() if key in allowed}
         except (FileNotFoundError, PermissionError): continue
     if pid is None: raise RuntimeError("No running preview web server")
 subprocess.run(["git", "fetch", "origin", ref], cwd=root, check=True)
 subprocess.run(["git", "checkout", "--detach", "FETCH_HEAD"], cwd=root, check=True)
+install_env = {key: value for key, value in os.environ.items() if key in {"PATH", "HOME", "PNPM_HOME"}}
 with open("/tmp/preview-update.log", "w") as log:
-    subprocess.run(["pnpm", "install", "--frozen-lockfile"], cwd=root, stdout=log, stderr=subprocess.STDOUT, check=True)
+    subprocess.run(["pnpm", "install", "--frozen-lockfile"], cwd=root, env=install_env, stdout=log, stderr=subprocess.STDOUT, check=True)
     if web:
         subprocess.run(["pnpm", "--filter", "@openwork-ee/den-web", "build"], cwd=root, env=env, stdout=log, stderr=subprocess.STDOUT, check=True)
 if web:
@@ -74,7 +77,14 @@ for sandbox, web in targets:
         parser.error("Invalid sandbox ID in receipt")
     program = remote.replace("REF", repr(args.ref)).replace("WEB", repr(web))
     subprocess.run(["daytona", "exec", sandbox, "--", "python3", "-c", shlex.quote(program)], check=True)
+# Never resurrect a receipt whose lifetime ended while the build was running.
+current = json.loads(receipt.read_text())
+if current["pid"] != state["pid"]:
+    raise RuntimeError("Preview ownership changed during update")
+os.kill(current["pid"], 0)
 # Keep boot ref distinct: the API/Electron main still run that version.
-outputs["frontendRef"] = args.ref
-receipt.write_text(json.dumps(state, indent=2) + "\n")
+current["outputs"]["frontendRef"] = args.ref
+with receipt.open("r+") as handle:
+    handle.write(json.dumps(current, indent=2) + "\n")
+    handle.truncate()
 print("Frontend update complete. Reopen the existing preview and verify the changed screen.")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,10 @@ escalate any leak instead of rewriting history.
 - Smallest possible diff, then make it smaller. Propose the simpler solution. No
   fallback expressions when types or control flow already guarantee a value.
 - If asked to do too much at once, stop and say so.
+
+## Hands-on PR previews
+
+For a preview the user can test inside Codex, use
+[preview-my-work](.opencode/skills/preview-my-work/SKILL.md): named Daytona
+worlds for Den or real Electron through noVNC, with isolated scenarios,
+frontend updates, reset and teardown.

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { main, readScriptWorldSnapshot } from "@openwork/world";
+import { main, isProcessAlive, readScriptWorldSnapshot } from "@openwork/world";
 import { denFetch, signIn } from "@openwork/behaviors";
 import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
 import { screenshot } from "@openwork/test-evidence";
@@ -34,7 +34,7 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
   process.env.OPENWORK_WORLD_SNAPSHOT_DIR = snapshots;
   const stage = `proof-${Date.now()}`;
   const options = { cwd: root, worldsDirectory: join(root, "worlds"), print: (line: string) => console.error(line) };
-  const up = (name: string, scenario: string) => main(["up", name, "--stage", stage, "--place", "daytona", "--detach", "--timeout", "600000", "--", "--scenario", scenario, "--lifetime", "30"], options);
+  const up = (name: string, scenario: string, lifetime = "30") => main(["up", name, "--stage", stage, "--place", "daytona", "--detach", "--timeout", "600000", "--", "--scenario", scenario, "--lifetime", lifetime], options);
   const down = (name: string) => main(["down", name, "--stage", stage], options);
   const snapshot = async (name: string) => {
     const value = await readScriptWorldSnapshot(join(snapshots, `${name}--${stage}.json`));
@@ -85,21 +85,35 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
     await screenshot(surface);
     evidence.recordAssertionEvidence("Desktop preview reaches real Electron through noVNC", "The viewer returns 200, its WebSocket speaks RFB, and the Electron renderer is on a workspace route. Restricted policy matches Den definitions; two team connectors use unconnected individual accounts.", true);
 
+    const buildId = async () => (await exec("daytona", ["exec", desktop.outputs.denSandbox, "--", "cat", "/workspace/ee/apps/den-web/.next/BUILD_ID"], { timeout: 30000 })).stdout.trim();
+    const previousBuild = await buildId();
+    assert.ok((await (await fetch(desktop.outputs.denWeb)).text()).includes(previousBuild));
     assert.ok(process.env.OPENWORK_EVAL_REF);
     await exec("python3", [join(root, ".opencode/skills/preview-my-work/scripts/update-preview.py"), "preview-desktop", "--stage", stage, "--ref", process.env.OPENWORK_EVAL_REF], { cwd: root, timeout: 300000, maxBuffer: 2_000_000 });
     await eventually(async () => (await fetch(desktop.outputs.denWeb)).status === 200, { within: 60000, intervalMs: 1000, label: "updated Den web responds" });
+    const nextBuild = await buildId();
+    assert.notEqual(nextBuild, previousBuild);
+    assert.ok((await (await fetch(desktop.outputs.denWeb)).text()).includes(nextBuild), "Den must serve the rebuilt frontend, not the old process");
     const after = await denFetch(ref, "/v1/mcp-connections?scope=manageable", { headers });
     assert.ok(record(after.body) && Array.isArray(after.body.connections));
     assert.deepEqual(after.body.connections, savedConnections);
     assert.equal(await evaluateOnSurface(surface, "localStorage.getItem('preview-proof')"), "preserved");
     assert.equal((await snapshot("preview-desktop")).pid, desktop.pid);
-    evidence.recordAssertionEvidence("Frontend update preserves the preview", "The real updater rebuilds Den web and updates the desktop checkout; the existing session still reads the same connectors, Electron retains its localStorage marker, and world ownership stays unchanged.", true);
+    evidence.recordAssertionEvidence("Frontend update preserves the preview", "The live HTTP response contains the new Next build ID, which differs from the previous build; the existing session still reads the same connectors, Electron retains its localStorage marker, and world ownership stays unchanged.", true);
     await surface[Symbol.asyncDispose]();
+    assert.equal(await down("preview-den"), 0);
+    assert.equal(await up("preview-den", "fresh", "1"), 0);
+    const reset = await snapshot("preview-den");
+    assert.notEqual(reset.outputs.denSandbox, den.outputs.denSandbox);
+    assert.equal((await fetch(reset.outputs.preview)).status, 200);
     assert.equal(await down("preview-desktop"), 0);
     assert.equal(await readScriptWorldSnapshot(join(snapshots, `preview-desktop--${stage}.json`)), undefined);
-    assert.equal((await fetch(den.outputs.preview)).status, 200);
-    assert.equal((await snapshot("preview-den")).pid, den.pid);
-    evidence.recordAssertionEvidence("Stopping desktop leaves the other preview intact", "Desktop teardown removes its receipt; the separate Den preview still responds and retains its original owner process.", true);
+    assert.equal((await fetch(reset.outputs.preview)).status, 200);
+    assert.equal((await snapshot("preview-den")).pid, reset.pid);
+    evidence.recordAssertionEvidence("Reset and stop are scoped to their stage", "Reset creates a new Den sandbox. Desktop teardown removes its receipt while the reset Den preview still responds and retains its owner process.", true);
+    await eventually(async () => !await readScriptWorldSnapshot(join(snapshots, `preview-den--${stage}.json`)), { within: 90000, intervalMs: 1000, label: "preview expires after its one-minute session lifetime" });
+    await eventually(() => !isProcessAlive(reset.pid), { within: 60000, intervalMs: 1000, label: "expired preview finishes disposal" });
+    evidence.recordAssertionEvidence("Session lifetime ends the preview", "A one-minute preview removes its live receipt and its owning process finishes disposal automatically without another down command.", true);
   } finally {
     for (const name of ["preview-desktop", "preview-den"]) {
       if (await readScriptWorldSnapshot(join(snapshots, `${name}--${stage}.json`))) await down(name);

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -33,7 +33,7 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
   const previous = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
   process.env.OPENWORK_WORLD_SNAPSHOT_DIR = snapshots;
   const stage = `proof-${Date.now()}`;
-  const options = { cwd: root, print: (line: string) => console.error(line) };
+  const options = { cwd: root, worldsDirectory: join(root, "worlds"), print: (line: string) => console.error(line) };
   const up = (name: string, scenario: string) => main(["up", name, "--stage", stage, "--place", "daytona", "--detach", "--timeout", "600000", "--", "--scenario", scenario, "--lifetime", "30"], options);
   const down = (name: string) => main(["down", name, "--stage", stage], options);
   const snapshot = async (name: string) => {

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { main, readScriptWorldSnapshot } from "@openwork/world";
+import { denFetch, signIn } from "@openwork/behaviors";
+import { attachSurface, evaluateOnSurface } from "@openwork/cdp";
+import { screenshot } from "@openwork/test-evidence";
+import { eventually, needs, test } from "@openwork/testkit";
+
+const exec = promisify(execFile);
+const root = fileURLToPath(new URL("../..", import.meta.url));
+function record(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+
+async function rfbHandshake(url: string): Promise<string> {
+  const endpoint = new URL("/websockify", url);
+  endpoint.protocol = "wss:";
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(endpoint, ["binary"]);
+    socket.binaryType = "arraybuffer";
+    const timer = setTimeout(() => { socket.close(); reject(new Error("noVNC did not reach the desktop RFB server")); }, 15000);
+    socket.onmessage = (event) => { clearTimeout(timer); socket.close(); resolve(new TextDecoder().decode(event.data)); };
+    socket.onerror = () => { clearTimeout(timer); socket.close(); reject(new Error("noVNC WebSocket failed")); };
+  });
+}
+
+test("preview worlds expose Den and real Electron, preserve progress on frontend update, and tear down only their own stage", { timeout: 1_500_000 }, async ({ evidence }) => {
+  needs({ placement: "daytona" });
+  const snapshots = await mkdtemp(join(tmpdir(), "openwork-preview-proof-"));
+  const previous = process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+  process.env.OPENWORK_WORLD_SNAPSHOT_DIR = snapshots;
+  const stage = `proof-${Date.now()}`;
+  const options = { cwd: root, print: (line: string) => console.error(line) };
+  const up = (name: string, scenario: string) => main(["up", name, "--stage", stage, "--place", "daytona", "--detach", "--timeout", "600000", "--", "--scenario", scenario, "--lifetime", "30"], options);
+  const down = (name: string) => main(["down", name, "--stage", stage], options);
+  const snapshot = async (name: string) => {
+    const value = await readScriptWorldSnapshot(join(snapshots, `${name}--${stage}.json`));
+    assert.ok(value);
+    return value;
+  };
+  try {
+    assert.equal(await up("preview-den", "fresh"), 0);
+    const den = await snapshot("preview-den");
+    assert.equal(den.outputs.scenario, "fresh");
+    assert.equal(den.outputs.password, undefined);
+    assert.equal((await fetch(den.outputs.preview)).status, 200);
+    const unauthed = await fetch(`${den.outputs.denApi}/v1/me`);
+    assert.equal(unauthed.status, 401);
+    assert.equal(await up("preview-den", "fresh"), 0);
+    assert.equal((await snapshot("preview-den")).pid, den.pid);
+    evidence.recordAssertionEvidence("Fresh Den is reachable and reopening preserves ownership", "The signup URL returns 200, protected identity returns 401, no account password is seeded, and a repeated launch adopts the same process.", true);
+
+    assert.equal(await up("preview-desktop", "restricted"), 0);
+    const desktop = await snapshot("preview-desktop");
+    assert.notEqual(desktop.outputs.denSandbox, den.outputs.denSandbox);
+    assert.ok(desktop.outputs.desktopSandbox);
+    assert.equal((await fetch(desktop.outputs.preview)).status, 200);
+    assert.match(await rfbHandshake(desktop.outputs.preview), /^RFB 003\./);
+    const ref = { apiUrl: desktop.outputs.denApi, webUrl: desktop.outputs.denWeb };
+    const session = await signIn(ref, { email: desktop.outputs.email, password: desktop.outputs.password });
+    const headers = { authorization: `Bearer ${session.token}` };
+    const connections = await denFetch(ref, "/v1/mcp-connections?scope=manageable", { headers });
+    assert.equal(connections.response.status, 200);
+    assert.ok(record(connections.body) && Array.isArray(connections.body.connections));
+    const savedConnections = connections.body.connections;
+    assert.equal(savedConnections.length, 2);
+    for (const connection of savedConnections) {
+      assert.ok(record(connection));
+      assert.equal(connection.credentialMode, "per_member");
+      assert.equal(connection.connectedForMe, false);
+    }
+    const policies = await denFetch(ref, "/v1/desktop-policies", { headers });
+    assert.ok(record(policies.body) && Array.isArray(policies.body.desktopPolicies) && Array.isArray(policies.body.definitions));
+    const policy = policies.body.desktopPolicies.find((entry: unknown) => record(entry) && entry.isDefault === true);
+    assert.ok(record(policy) && record(policy.policy));
+    for (const definition of policies.body.definitions) {
+      if (record(definition) && typeof definition.id === "string" && typeof definition.restrictedValue === "boolean") assert.equal(policy.policy[definition.id], definition.restrictedValue);
+    }
+    await using surface = await attachSurface({ name: "preview-proof", kind: "electron", hostKind: "daytona", cdpUrl: desktop.outputs.cdp });
+    const before = await evaluateOnSurface(surface, "({ route: location.hash, marker: localStorage.setItem('preview-proof', 'preserved') })");
+    assert.ok(record(before) && typeof before.route === "string" && before.route.includes("workspace"));
+    await screenshot(surface);
+    evidence.recordAssertionEvidence("Desktop preview reaches real Electron through noVNC", "The viewer returns 200, its WebSocket speaks RFB, and the Electron renderer is on a workspace route. Restricted policy matches Den definitions; two team connectors use unconnected individual accounts.", true);
+
+    assert.ok(process.env.OPENWORK_EVAL_REF);
+    await exec("python3", [join(root, ".opencode/skills/preview-my-work/scripts/update-preview.py"), "preview-desktop", "--stage", stage, "--ref", process.env.OPENWORK_EVAL_REF], { cwd: root, timeout: 300000, maxBuffer: 2_000_000 });
+    await eventually(async () => (await fetch(desktop.outputs.denWeb)).status === 200, { within: 60000, intervalMs: 1000, label: "updated Den web responds" });
+    const after = await denFetch(ref, "/v1/mcp-connections?scope=manageable", { headers });
+    assert.ok(record(after.body) && Array.isArray(after.body.connections));
+    assert.deepEqual(after.body.connections, savedConnections);
+    assert.equal(await evaluateOnSurface(surface, "localStorage.getItem('preview-proof')"), "preserved");
+    assert.equal((await snapshot("preview-desktop")).pid, desktop.pid);
+    evidence.recordAssertionEvidence("Frontend update preserves the preview", "The real updater rebuilds Den web and updates the desktop checkout; the existing session still reads the same connectors, Electron retains its localStorage marker, and world ownership stays unchanged.", true);
+    await surface[Symbol.asyncDispose]();
+    assert.equal(await down("preview-desktop"), 0);
+    assert.equal(await readScriptWorldSnapshot(join(snapshots, `preview-desktop--${stage}.json`)), undefined);
+    assert.equal((await fetch(den.outputs.preview)).status, 200);
+    assert.equal((await snapshot("preview-den")).pid, den.pid);
+    evidence.recordAssertionEvidence("Stopping desktop leaves the other preview intact", "Desktop teardown removes its receipt; the separate Den preview still responds and retains its original owner process.", true);
+  } finally {
+    for (const name of ["preview-desktop", "preview-den"]) {
+      if (await readScriptWorldSnapshot(join(snapshots, `${name}--${stage}.json`))) await down(name);
+    }
+    if (previous === undefined) delete process.env.OPENWORK_WORLD_SNAPSHOT_DIR;
+    else process.env.OPENWORK_WORLD_SNAPSHOT_DIR = previous;
+    await rm(snapshots, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -42,6 +42,17 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
     return value;
   };
   try {
+    const pinnedRef = process.env.OPENWORK_EVAL_REF;
+    assert.ok(pinnedRef);
+    try {
+      process.env.OPENWORK_EVAL_REF = "dev";
+      assert.equal(await up("preview-den", "fresh"), 1);
+      assert.equal(await readScriptWorldSnapshot(join(snapshots, `preview-den--${stage}.json`)), undefined);
+    } finally {
+      process.env.OPENWORK_EVAL_REF = pinnedRef;
+    }
+    await assert.rejects(exec("python3", [join(root, ".opencode/skills/preview-my-work/scripts/update-preview.py"), "preview-den", "--stage", stage, "--ref", "dev"], { cwd: root, timeout: 10000 }), (error: unknown) => record(error) && error.code === 2 && typeof error.stderr === "string" && error.stderr.includes("full 40-character commit SHA"));
+    evidence.recordAssertionEvidence("Mutable refs are rejected before preview execution", "Launch with a branch name fails without a live receipt; the updater rejects a branch name before reading a receipt or invoking Daytona.", true);
     assert.equal(await up("preview-den", "fresh"), 0);
     const den = await snapshot("preview-den");
     assert.equal(den.outputs.scenario, "fresh");

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -71,6 +71,7 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
       assert.ok(record(connection));
       assert.equal(connection.credentialMode, "per_member");
       assert.equal(connection.connectedForMe, false);
+      assert.ok(record(connection.access) && connection.access.orgWide === true);
     }
     const policies = await denFetch(ref, "/v1/desktop-policies", { headers });
     assert.ok(record(policies.body) && Array.isArray(policies.body.desktopPolicies) && Array.isArray(policies.body.definitions));

--- a/worlds/lib/preview.ts
+++ b/worlds/lib/preview.ts
@@ -1,0 +1,119 @@
+import { randomBytes } from "node:crypto";
+import { denFetch } from "../../evals/packages/behaviors/src/den.ts";
+import { app } from "../../evals/packages/env/src/desktop-app.ts";
+import { server } from "../../evals/packages/env/src/den.ts";
+import type { Den } from "../../evals/packages/env/src/den.ts";
+import { resolvePlace } from "../../evals/packages/env/src/place.ts";
+import type { Place } from "../../evals/packages/env/src/place.ts";
+import { daytonaSandbox } from "../../evals/packages/hosts/src/resolve.ts";
+import { hold } from "../../packages/world/src/hold.ts";
+import { output, secret } from "../../packages/world/src/outputs.ts";
+import type { WorldOutput } from "../../packages/world/src/outputs.ts";
+
+export type PreviewScenario = "fresh" | "team" | "restricted" | "workspace";
+export type PreviewSurface = "den" | "desktop";
+
+export function parsePreviewOptions(argv: readonly string[]) {
+  let scenario: PreviewScenario = "fresh";
+  let lifetimeMinutes = 120;
+  for (let i = 0; i < argv.length; i += 2) {
+    const value = argv[i + 1];
+    if (argv[i] === "--scenario" && (value === "fresh" || value === "team" || value === "restricted" || value === "workspace")) {
+      scenario = value;
+    } else if (argv[i] === "--lifetime" && value !== undefined && /^\d+$/.test(value) && Number(value) <= 1440) {
+      lifetimeMinutes = Number(value);
+    } else {
+      throw new Error("Use --scenario fresh|team|restricted|workspace and --lifetime <minutes, 0 keeps running, maximum 1440>.");
+    }
+  }
+  return { scenario, lifetimeMinutes };
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function setupTeam(den: Den, restricted: boolean): Promise<void> {
+  const headers = { authorization: `Bearer ${den.admin.token}` };
+  // OAuth metadata only: no live provider call or account authorization.
+  for (const [name, url] of [["Notion", "https://mcp.notion.com/mcp"], ["Linear", "https://mcp.linear.app/mcp"]]) {
+    const result = await denFetch(den.ref, "/v1/mcp-connections", {
+      method: "POST", headers,
+      body: JSON.stringify({ name, url, authType: "oauth", credentialMode: "per_member", access: { orgWide: true, memberIds: [], teamIds: [] } }),
+    });
+    if (!result.response.ok) throw new Error(`Could not seed ${name}: HTTP ${result.response.status}`);
+  }
+  if (!restricted) return;
+  const result = await denFetch(den.ref, "/v1/desktop-policies", { headers });
+  if (!result.response.ok || !record(result.body) || !Array.isArray(result.body.desktopPolicies) || !Array.isArray(result.body.definitions)) {
+    throw new Error("Could not load desktop policy definitions for this preview.");
+  }
+  const policy = result.body.desktopPolicies.find((entry: unknown) => record(entry) && entry.isDefault === true);
+  if (!record(policy) || typeof policy.id !== "string") throw new Error("Preview has no default desktop policy.");
+  const restrictedPolicy: Record<string, boolean> = {};
+  for (const definition of result.body.definitions) {
+    if (record(definition) && typeof definition.id === "string" && typeof definition.restrictedValue === "boolean") {
+      restrictedPolicy[definition.id] = definition.restrictedValue;
+    }
+  }
+  if (Object.keys(restrictedPolicy).length === 0) throw new Error("No restricted policy values returned by Den.");
+  const saved = await denFetch(den.ref, `/v1/desktop-policies/${encodeURIComponent(policy.id)}`, {
+    method: "PATCH", headers, body: JSON.stringify({ policyName: "Restricted preview", policy: restrictedPolicy }),
+  });
+  if (!saved.response.ok) throw new Error(`Could not apply restricted preview policy: HTTP ${saved.response.status}`);
+}
+
+/** Owned, disposable infrastructure only. Never attach a preview to an existing test or production sandbox. */
+export async function bootPreview(stack: AsyncDisposableStack, place: Place, surface: PreviewSurface, scenario: PreviewScenario) {
+  if (place.kind !== "daytona") throw new Error("Interactive previews require --place daytona.");
+  if (["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DAYTONA_DEN_SANDBOX", "OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX", "OPENWORK_EVAL_DAYTONA_SANDBOX"].some((key) => process.env[key]?.trim())) {
+    throw new Error("Preview worlds require isolated infrastructure. Remove existing sandbox/reuse overrides before starting.");
+  }
+  const fresh = scenario === "fresh";
+  const den = stack.use(await server({
+    place, provision: !fresh, web: true,
+    ...(!fresh ? { org: { name: "Preview team", admin: { name: "Preview owner", email: `preview-${randomBytes(6).toString("hex")}@example.test` } } } : {}),
+    env: { OPENWORK_DEV_MODE: "1", DEN_REQUIRE_EMAIL_VERIFICATION: "false", RESEND_API_KEY: "", SMTP_HOST: "" },
+  }));
+  if (scenario === "team" || scenario === "restricted") await setupTeam(den, scenario === "restricted");
+  const outputs: Record<string, WorldOutput> = {
+    preview: output(fresh ? `${den.ref.webUrl}/?mode=sign-up` : `${den.ref.webUrl}/dashboard`, { group: "Preview" }),
+    denWeb: output(den.ref.webUrl, { group: "Services" }),
+    denApi: output(den.ref.apiUrl, { group: "Services" }),
+    emailOutbox: output(`${den.ref.apiUrl}/v1/dev/emails`, { group: "Services", note: "Test mail only; no messages leave this world" }),
+    scenario: output(scenario, { group: "World" }),
+    ref: output(process.env.OPENWORK_EVAL_REF?.trim() || process.env.GITHUB_SHA?.trim() || "dev", { group: "World" }),
+  };
+  if (den.placement?.kind === "daytona") outputs.denSandbox = output(den.placement.sandboxId, { group: "World" });
+  if (!fresh) {
+    outputs.email = output(den.admin.email, { group: "Test account" });
+    outputs.password = secret(den.admin.password, { group: "Test account" });
+  }
+  const desktop = surface === "desktop" ? stack.use(await app({ den, place, ...(fresh ? { signIn: false } : { as: "admin" }) })) : undefined;
+  if (desktop) {
+    const sandbox = desktop.handle.sandboxId;
+    if (!sandbox) throw new Error("Desktop preview did not return its owned Daytona sandbox.");
+    const host = daytonaSandbox(sandbox);
+    if (!host.previewUrl) throw new Error("Daytona host cannot expose its viewer.");
+    const url = new URL(await host.previewUrl(6080));
+    url.search = "autoconnect=1&resize=scale&reconnect=1&reconnect_delay=2000";
+    outputs.preview = output(url.href, { group: "Preview", note: "Real Linux Electron app · noVNC · clipboard in the side toolbar" });
+    outputs.desktopSandbox = output(sandbox, { group: "World" });
+    outputs.cdp = secret(desktop.handle.cdpUrl, { group: "Services" });
+  }
+  return { den, desktop, outputs };
+}
+
+export async function runPreview(surface: PreviewSurface, argv = process.argv.slice(2)): Promise<void> {
+  const { scenario, lifetimeMinutes } = parsePreviewOptions(argv);
+  await using stack = new AsyncDisposableStack();
+  const { outputs } = await bootPreview(stack, resolvePlace(), surface, scenario);
+  const expires = lifetimeMinutes === 0 ? undefined : new Date(Date.now() + lifetimeMinutes * 60_000);
+  outputs.expires = output(expires?.toISOString() ?? "Until stopped", { group: "World", note: "Session lifetime, not an idle timer" });
+  const timer = expires ? setTimeout(() => process.kill(process.pid, "SIGTERM"), lifetimeMinutes * 60_000) : undefined;
+  try {
+    await hold({ name: `preview-${surface}`, outputs });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/worlds/lib/preview.ts
+++ b/worlds/lib/preview.ts
@@ -66,6 +66,10 @@ async function setupTeam(den: Den, restricted: boolean): Promise<void> {
 /** Owned, disposable infrastructure only. Never attach a preview to an existing test or production sandbox. */
 export async function bootPreview(stack: AsyncDisposableStack, place: Place, surface: PreviewSurface, scenario: PreviewScenario) {
   if (place.kind !== "daytona") throw new Error("Interactive previews require --place daytona.");
+  const base = place.denBase();
+  if (base.kind !== "daytona" || !/^[0-9a-f]{40}$/.test(base.ref)) {
+    throw new Error("Set OPENWORK_EVAL_REF to the reviewed, pushed full 40-character commit SHA before booting a preview.");
+  }
   if (["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DAYTONA_DEN_SANDBOX", "OPENWORK_EVAL_DAYTONA_DESKTOP_SANDBOX", "OPENWORK_EVAL_DAYTONA_SANDBOX"].some((key) => process.env[key]?.trim())) {
     throw new Error("Preview worlds require isolated infrastructure. Remove existing sandbox/reuse overrides before starting.");
   }
@@ -82,7 +86,7 @@ export async function bootPreview(stack: AsyncDisposableStack, place: Place, sur
     denApi: output(den.ref.apiUrl, { group: "Services" }),
     emailOutbox: output(`${den.ref.apiUrl}/v1/dev/emails`, { group: "Services", note: "Test mail only; no messages leave this world" }),
     scenario: output(scenario, { group: "World" }),
-    ref: output(process.env.OPENWORK_EVAL_REF?.trim() || process.env.GITHUB_SHA?.trim() || "dev", { group: "World" }),
+    ref: output(base.ref, { group: "World" }),
   };
   if (den.placement?.kind === "daytona") outputs.denSandbox = output(den.placement.sandboxId, { group: "World" });
   if (!fresh) {

--- a/worlds/preview-den.ts
+++ b/worlds/preview-den.ts
@@ -1,0 +1,3 @@
+import { runPreview } from "./lib/preview.ts";
+export async function main(): Promise<void> { await runPreview("den"); }
+if (import.meta.main) await main();

--- a/worlds/preview-desktop.ts
+++ b/worlds/preview-desktop.ts
@@ -1,0 +1,3 @@
+import { runPreview } from "./lib/preview.ts";
+export async function main(): Promise<void> { await runPreview("desktop"); }
+if (import.meta.main) await main();


### PR DESCRIPTION
Testing a PR manually currently requires assembling a sandbox and finding its browser or VNC URL. This adds `preview-den` and `preview-desktop` worlds plus a discoverable `preview-my-work` skill that opens the result inside Codex.

- Named stages isolate previews; reopening adopts the running world. Fresh, team, restricted, and signed-in workspace scenarios reuse existing Den and Electron APIs. The skill signs into seeded Den previews before handoff.
- Desktop is real Linux Electron through noVNC with automatic connect, scaling and reconnect. Test connectors remain unconnected; development emails stay in the world's outbox. No model credentials are seeded.
- A scoped frontend updater preserves Den data and Electron profiles. It uses an explicit environment allowlist and verifies the fetched commit. API, migrations, and Electron main changes require a fresh stage.
- Launch and update require a reviewed, pushed full commit SHA. Existing sandbox/reuse overrides are rejected. Shared secrets volumes are not mounted.
- Worlds default to a two-hour session lifetime and dispose their owned resources on expiry or teardown. This is a lifetime limit, not activity-based idle detection. Existing snapshots accelerate startup; cold builds still take minutes.

### Verification

**Passed** on `e07e3604b7c0f753fa4c99737f5e7f7d4c381f47`.

`OPENWORK_EVAL_REF=e07e3604b7c0f753fa4c99737f5e7f7d4c381f47 infisical run --silent --env dev -- pnpm evals:e2e preview-world` — placement **Daytona** (authenticated CLI), **1 passed, 0 failed, 0 skipped**, 567.53 seconds. The journey tests mutable-ref rejection, cold boots both worlds, checks the live RFB connection and Electron workspace, verifies connector/policy fixtures, runs the actual updater and checks the served Next build changes, proves session data survives, resets one preview, confirms isolated teardown, and waits for automatic lifetime disposal. The evidence comment below contains six passing assertions and the captured Electron screen. All review findings are resolved.

Focused strict TypeScript checks cover the new world and journey. The skill passes the skill validator. Repository-wide `pnpm --dir evals typecheck` reports the same 310 diagnostics on this head and clean base `85a5dfccb` (both exit 2; no added diagnostics after normalizing checkout paths).
