### PR TITLE
Share dashboard apps and simplify narrow app headers

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -3078,6 +3078,11 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         method: "POST", token, organizationId: orgId,
       });
     },
+    async shareSavedApp(orgId: string, appId: string, email: string) {
+      await requestJson<unknown>(baseUrls, `/v1/apps/${encodeURIComponent(appId)}/share`, {
+        method: "POST", token, organizationId: orgId, body: { email },
+      });
+    },
     async setAppOnDashboard(orgId: string, appId: string, added: boolean) {
       await requestJson<unknown>(baseUrls, `/v1/apps/${encodeURIComponent(appId)}/dashboard`, {
         method: "POST", token, organizationId: orgId, body: { added },

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -3058,7 +3058,7 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
       if (!isRecord(payload) || !Array.isArray(payload.items) || typeof payload.enabled !== "boolean") {
         throw new Error("Your apps could not be loaded.");
       }
-      return { enabled: payload.enabled, items: payload.items.map((item) => savedAppSummarySchema.parse(item)) };
+      return { enabled: payload.enabled, sharingEnabled: payload.sharingEnabled === true, items: payload.items.map((item) => savedAppSummarySchema.parse(item)) };
     },
     async getSavedApp(orgId: string, appId: string, options: { revisionId?: string; receiptId?: string } = {}) {
       const params = new URLSearchParams();

--- a/apps/app/src/react-app/domains/apps/app-actions-menu.tsx
+++ b/apps/app/src/react-app/domains/apps/app-actions-menu.tsx
@@ -1,11 +1,21 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Trash2 } from "lucide-react";
+import { Ellipsis, Play, Sparkles, Trash2, Minus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useAppsClient } from "./use-apps";
 
-export function DeleteAppButton({ appId, title, onDeleted }: { appId: string; title: string; onDeleted?: () => void }) {
+export function AppActionsMenu({ appId, title, canDelete, onDeleted, onRun, onEdit, onRemove, busy }: {
+  appId: string;
+  title: string;
+  canDelete: boolean;
+  onDeleted?: () => void;
+  onRun?: () => void;
+  onEdit?: () => void;
+  onRemove?: () => void;
+  busy?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const { client, orgId, scope } = useAppsClient();
   const cache = useQueryClient();
@@ -23,8 +33,18 @@ export function DeleteAppButton({ appId, title, onDeleted }: { appId: string; ti
       ]);
     },
   });
+  if (!canDelete && !onRun && !onEdit && !onRemove) return null;
   return <>
-    <Button variant="ghost" size="sm" aria-label={`Delete ${title}`} onClick={() => { deletion.reset(); setOpen(true); }}><Trash2 className="size-4" />Delete</Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" className="shrink-0 text-muted-foreground" aria-label={`App options for ${title}`} disabled={busy}><Ellipsis className="size-4" /></Button>} />
+      <DropdownMenuContent align="end">
+        {onRun ? <DropdownMenuItem onClick={onRun}><Play />Run again</DropdownMenuItem> : null}
+        {onEdit ? <DropdownMenuItem onClick={onEdit}><Sparkles />Ask for changes</DropdownMenuItem> : null}
+        {onRemove ? <DropdownMenuItem onClick={onRemove} aria-label={`Remove ${title} from dashboard`}><Minus />Remove from dashboard</DropdownMenuItem> : null}
+        {canDelete && (onRun || onEdit || onRemove) ? <DropdownMenuSeparator /> : null}
+        {canDelete ? <DropdownMenuItem variant="destructive" aria-label={`Delete ${title}`} onClick={() => { deletion.reset(); setOpen(true); }}><Trash2 />Delete app</DropdownMenuItem> : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
     <Dialog open={open} onOpenChange={(next) => { if (!deletion.isPending) setOpen(next); }}>
       <DialogContent>
         <DialogHeader>

--- a/apps/app/src/react-app/domains/apps/app-artifact.tsx
+++ b/apps/app/src/react-app/domains/apps/app-artifact.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import { DeleteAppButton } from "./delete-app-button";
+import { AppActionsMenu } from "./app-actions-menu";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Loader2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -61,15 +61,23 @@ export function AppArtifact({ appId, revisionId, receiptId, onClose, onAsk }: Ap
   if (query.isPending) return <p className="flex items-center gap-2 p-6 text-sm" role="status"><Loader2 className="size-4 animate-spin" />Preparing app preview…</p>;
   if (!app) return <div className="space-y-3 p-6"><p role="alert" className="text-sm">{query.error instanceof Error ? query.error.message : "This app could not be opened."}</p><Button variant="outline" onClick={() => void query.refetch()}>Try again</Button></div>;
   return <section className="flex h-full min-h-0 flex-col bg-background" aria-label={`${app.view.title} app`}>
-    <header className="flex flex-wrap items-center gap-3 border-b p-3">
-      <div className="min-w-0 flex-1"><h2 className="truncate text-sm font-medium">{app.view.title}</h2><p className="text-xs text-muted-foreground">{saved ? "Saved app" : app.view.activeRevisionId ? "Unsaved changes" : "App draft"}</p></div>
-      {app.canManage ? <Button size="sm" disabled={!revision || revision.buildStatus !== "ready" || saved} onClick={() => {
-        setName(app.view.title); setUseInWorkflow(app.view.activeRevisionId ? app.view.useInWorkflow !== false : true); setSaveOpen(true); save.reset();
-      }}>{saved ? <><Check className="size-4" />Saved</> : app.view.activeRevisionId ? "Save changes" : "Save"}</Button> : null}
-      {onAsk && saved ? <Button size="sm" variant="outline" disabled={asking} onClick={() => void ask(`Run my saved app “${app.view.title}” using its existing workflow “${app.workflowTitle}”. Ask for any inputs you need, then show the new results in the saved app.`)}>Run again</Button> : null}
-      {onAsk && app.canManage ? <Button size="sm" variant="ghost" disabled={asking} onClick={() => void ask(`Help me improve my saved app “${app.view.title}”. Read its existing app source and workflow “${app.workflowTitle}”, ask what I want to change, and show a draft preview for me to save.`)}>Ask for changes</Button> : null}
-      {app.canManage && app.view.status !== "retired" ? <DeleteAppButton appId={appId} title={app.view.title} onDeleted={onClose ?? (() => navigate("/dashboard"))} /> : null}
-      {onClose ? <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close app"><X /></Button> : null}
+    <header className="flex items-center gap-2 border-b px-4 py-3" data-app-header>
+      <div className="min-w-0 flex-1">
+        <h2 className="truncate text-sm font-medium" title={app.view.title}>{app.view.title}</h2>
+        <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground whitespace-nowrap">
+          {saved ? <><Check className="size-3 shrink-0" />Saved app</> : app.view.activeRevisionId ? "Unsaved changes" : "App draft"}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {app.canManage && !saved ? <Button size="sm" disabled={!revision || revision.buildStatus !== "ready"} onClick={() => {
+          setName(app.view.title); setUseInWorkflow(app.view.activeRevisionId ? app.view.useInWorkflow !== false : true); setSaveOpen(true); save.reset();
+        }}>{app.view.activeRevisionId ? "Save changes" : "Save"}</Button> : null}
+        <AppActionsMenu appId={appId} title={app.view.title} canDelete={app.canManage && app.view.status !== "retired"}
+          busy={asking} onDeleted={onClose ?? (() => navigate("/dashboard"))}
+          onRun={onAsk && saved ? () => void ask(`Run my saved app “${app.view.title}” using its existing workflow “${app.workflowTitle}”. Ask for any inputs you need, then show the new results in the saved app.`) : undefined}
+          onEdit={onAsk && app.canManage ? () => void ask(`Help me improve my saved app “${app.view.title}”. Read its existing app source and workflow “${app.workflowTitle}”, ask what I want to change, and show a draft preview for me to save.`) : undefined} />
+        {onClose ? <Button variant="ghost" size="icon-sm" className="text-muted-foreground" onClick={onClose} aria-label="Close app"><X className="size-4" /></Button> : null}
+      </div>
     </header>
     <div className="min-h-0 flex-1 space-y-4 overflow-auto p-4">
       {askError ? <p role="alert" className="text-sm text-destructive">{askError}</p> : null}

--- a/apps/app/src/react-app/domains/apps/use-apps.ts
+++ b/apps/app/src/react-app/domains/apps/use-apps.ts
@@ -33,7 +33,7 @@ export function useSavedApps() {
       if (!client || !orgId) throw new Error("Sign in to open your apps.");
       try { return await client.listSavedApps(orgId); }
       catch (error) {
-        if (error instanceof DenApiError && error.status === 404) return { enabled: false, items: [] };
+        if (error instanceof DenApiError && error.status === 404) return { enabled: false, sharingEnabled: false, items: [] };
         throw error;
       }
     },

--- a/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
@@ -9,6 +9,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { useSavedApps, useAppsClient } from "../apps/use-apps";
 import { DeleteAppButton } from "../apps/delete-app-button";
 import { GeneratedAppPreview } from "../apps/generated-app-preview";
+import { ShareDashboardButton } from "./share-dashboard-button";
 
 export type CreateDashboardApp = (prompt: string) => Promise<void>;
 
@@ -38,7 +39,7 @@ export function DashboardApps({ onCreateApp }: { onCreateApp: CreateDashboardApp
   return <>
     <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
       <div><h1 className="text-xl font-medium">Dashboard</h1><p className="mt-1 text-sm text-muted-foreground">Your apps and the tools your team shares with you.</p></div>
-      {available ? <Button onClick={() => { setChooser("add"); setError(null); placement.reset(); }}><Plus className="size-4" />Add</Button> : null}
+      {available ? <div className="flex items-center gap-2"><ShareDashboardButton apps={personal} /><Button onClick={() => { setChooser("add"); setError(null); placement.reset(); }}><Plus className="size-4" />Add</Button></div> : null}
     </header>
     {query.isError ? <div className="mb-5 flex items-center gap-3"><p role="alert" className="text-sm">Your apps could not be loaded.</p><Button variant="outline" onClick={() => void query.refetch()}>Try again</Button></div> : null}
     {placement.error && !chooser ? <p role="alert" className="mb-4 text-sm text-destructive">{placement.error.message}</p> : null}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
@@ -39,7 +39,7 @@ export function DashboardApps({ onCreateApp }: { onCreateApp: CreateDashboardApp
   return <>
     <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
       <div><h1 className="text-xl font-medium">Dashboard</h1><p className="mt-1 text-sm text-muted-foreground">Your apps and the tools your team shares with you.</p></div>
-      {available ? <div className="flex items-center gap-2"><ShareDashboardButton apps={personal} /><Button onClick={() => { setChooser("add"); setError(null); placement.reset(); }}><Plus className="size-4" />Add</Button></div> : null}
+      {available ? <div className="flex items-center gap-2">{query.data?.sharingEnabled ? <ShareDashboardButton apps={personal} /> : null}<Button onClick={() => { setChooser("add"); setError(null); placement.reset(); }}><Plus className="size-4" />Add</Button></div> : null}
     </header>
     {query.isError ? <div className="mb-5 flex items-center gap-3"><p role="alert" className="text-sm">Your apps could not be loaded.</p><Button variant="outline" onClick={() => void query.refetch()}>Try again</Button></div> : null}
     {placement.error && !chooser ? <p role="alert" className="mb-4 text-sm text-destructive">{placement.error.message}</p> : null}

--- a/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
+++ b/apps/app/src/react-app/domains/dashboard/dashboard-apps.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Blocks, Check, Loader2, Plus, Sparkles, X } from "lucide-react";
+import { ArrowLeft, Blocks, Check, Loader2, Plus, Sparkles } from "lucide-react";
 import type { SavedAppSummary } from "@openwork/types/workflows";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useSavedApps, useAppsClient } from "../apps/use-apps";
-import { DeleteAppButton } from "../apps/delete-app-button";
+import { AppActionsMenu } from "../apps/app-actions-menu";
 import { GeneratedAppPreview } from "../apps/generated-app-preview";
 import { ShareDashboardButton } from "./share-dashboard-button";
 
@@ -95,8 +95,7 @@ function SavedDashboardApp({ app, onRemove, removing }: { app: SavedAppSummary; 
   return <article className="min-w-0 overflow-hidden rounded-xl border bg-background" data-personal-dashboard-app={app.view.id}>
     <header className="flex items-center gap-2 border-b p-3">
       <button className="min-w-0 flex-1 text-left" aria-label={`Open ${app.view.title}`} onClick={() => navigate(`/dashboard/apps/${app.view.id}`)}><span className="block truncate text-sm font-medium">{app.view.title}</span><span className="text-xs text-muted-foreground">Open app</span></button>
-      {app.canManage ? <DeleteAppButton appId={app.view.id} title={app.view.title} /> : null}
-      <Button variant="ghost" size="icon-sm" aria-label={`Remove ${app.view.title} from dashboard`} disabled={removing} onClick={onRemove}><X className="size-4" /></Button>
+      <AppActionsMenu appId={app.view.id} title={app.view.title} canDelete={app.canManage} onRemove={onRemove} busy={removing} />
     </header>
     <div className="max-h-[32rem] overflow-auto px-4 pb-4">
       {detail.isPending ? <p role="status" className="py-4 text-sm text-muted-foreground">Loading app…</p>

--- a/apps/app/src/react-app/domains/dashboard/share-dashboard-button.tsx
+++ b/apps/app/src/react-app/domains/dashboard/share-dashboard-button.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from "react";
+import { Check, Loader2, Share2 } from "lucide-react";
+import type { SavedAppSummary } from "@openwork/types/workflows";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useAppsClient } from "../apps/use-apps";
+
+export function ShareDashboardButton({ apps }: { apps: SavedAppSummary[] }) {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  return <Dialog open={open} onOpenChange={(next) => { if (!pending) setOpen(next); }}>
+    <Button variant="outline" onClick={() => setOpen(true)}><Share2 className="size-4" />Share</Button>
+    {open ? <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Share your dashboard</DialogTitle>
+        <DialogDescription>Choose apps to add to a teammate’s dashboard. They must belong to your organization.</DialogDescription>
+      </DialogHeader>
+      <ShareDashboardForm apps={apps.filter((app) => app.canManage)} pending={pending} setPending={setPending} onClose={() => setOpen(false)} />
+    </DialogContent> : null}
+  </Dialog>;
+}
+
+function ShareDashboardForm({ apps, pending, setPending, onClose }: {
+  apps: SavedAppSummary[];
+  pending: boolean;
+  setPending: (pending: boolean) => void;
+  onClose: () => void;
+}) {
+  const { client, orgId } = useAppsClient();
+  const [email, setEmail] = useState("");
+  const [selected, setSelected] = useState(() => new Set(apps.map((app) => app.view.id)));
+  const [shared, setShared] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [complete, setComplete] = useState(false);
+  const share = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!client || !orgId || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      for (const app of apps.filter((app) => selected.has(app.view.id) && !shared.includes(app.view.id))) {
+        await client.shareSavedApp(orgId, app.view.id, email.trim());
+        setShared((current) => [...current, app.view.id]);
+      }
+      setComplete(true);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not share these apps. Try again.");
+    } finally {
+      setPending(false);
+    }
+  };
+  if (!apps.length) return <div className="space-y-4">
+    <p className="text-sm text-muted-foreground">Add an app you manage to your dashboard first. Company apps and apps shared with you keep their existing access settings.</p>
+    <Button variant="outline" onClick={onClose}>Done</Button>
+  </div>;
+  if (complete) return <div className="space-y-4">
+    <p role="status" className="text-sm">Shared {shared.length} {shared.length === 1 ? "app" : "apps"} with {email.trim()}. They’ll appear when your teammate opens or reloads their dashboard.</p>
+    <Button onClick={onClose}>Done</Button>
+  </div>;
+  return <form className="space-y-4" onSubmit={(event) => void share(event)}>
+    <label className="block space-y-2 text-sm font-medium">
+      <span>Teammate’s email</span>
+      <Input type="email" autoComplete="email" placeholder="teammate@company.com" required maxLength={320} value={email}
+        disabled={pending || shared.length > 0} onChange={(event) => setEmail(event.target.value)} />
+    </label>
+    <fieldset disabled={pending} className="space-y-2">
+      <legend className="mb-2 text-sm font-medium">Apps to share</legend>
+      <div className="max-h-60 space-y-2 overflow-auto">
+        {apps.map((app) => <label key={app.view.id} className="flex items-center gap-3 rounded-lg border p-3 text-sm">
+          <input type="checkbox" className="size-4" checked={selected.has(app.view.id)} disabled={shared.includes(app.view.id)}
+            onChange={(event) => setSelected((current) => { const next = new Set(current); if (event.target.checked) next.add(app.view.id); else next.delete(app.view.id); return next; })} />
+          <span className="min-w-0 flex-1 break-words">{app.view.title}</span>
+          {shared.includes(app.view.id) ? <span className="flex items-center gap-1 text-xs"><Check className="size-3.5" />Shared</span> : null}
+        </label>)}
+      </div>
+    </fieldset>
+    <p className="text-xs text-muted-foreground">Sharing gives view access to each app’s underlying workflow, its saved results, and other apps built from that workflow. Existing permissions stay in place. Company-managed apps are not included.</p>
+    {error ? <p role="alert" className="text-sm text-destructive">{error} Apps marked Shared are already available to your teammate. Retry to share the remaining apps.</p> : null}
+    <div className="flex justify-end gap-2">
+      <Button type="button" variant="outline" disabled={pending} onClick={onClose}>Cancel</Button>
+      <Button type="submit" disabled={pending || !selected.size || !email.trim() || !client || !orgId}>
+        {pending ? <><Loader2 className="size-4 animate-spin" />Sharing…</> : "Share apps"}
+      </Button>
+    </div>
+  </form>;
+}

--- a/ee/apps/den-api/src/routes/org/codemode-scripts.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-scripts.ts
@@ -44,7 +44,7 @@ import {
   retireArtifactView,
 } from "../../artifact-views.js"
 
-import { getSavedApp, listSavedApps, setAppOnDashboard } from "../../saved-apps.js"
+import { getSavedApp, listSavedApps, setAppOnDashboard, shareSavedApp } from "../../saved-apps.js"
 
 const capabilitySchema = z.object({ capabilityName: z.string(), scriptPath: z.string() })
 const scriptSchema = z.object({
@@ -179,6 +179,7 @@ function routeFailure(error: unknown) {
 function appRouteFailure(error: unknown) {
   const failure = routeFailure(error)
   const code = error instanceof Error ? error.message : ""
+  if (code === "teammate_not_found") return { ...failure, body: { error: code, message: "No teammate with that email belongs to this organization. Ask an admin to invite them first." } }
   const message = code.includes("not_found")
     ? "This app is unavailable or you no longer have access."
     : code === "artifact_view_schema_incompatible"
@@ -311,6 +312,28 @@ export function registerOrgWorkflowRoutes<T extends { Variables: OrgRouteVariabl
       try {
         const { actorContext } = await contextFor(c)
         return c.json({ enabled: true, items: await listSavedApps(actorContext) })
+      } catch (error) {
+        const failure = appRouteFailure(error)
+        return c.json(failure.body, failure.status)
+      }
+    },
+  )
+
+  app.post(
+    "/v1/apps/:appId/share",
+    describeRoute({ tags: ["Apps"], summary: "Share a saved app with a teammate", responses: {
+      200: jsonResponse("App shared to the teammate's dashboard.", z.object({ ok: z.literal(true) })),
+      403: jsonResponse("Only app managers can share.", forbiddenSchema),
+      404: jsonResponse("App or teammate not found.", notFoundSchema),
+    } }),
+    orgMemberRoute(),
+    jsonValidator(z.object({ email: z.string().trim().email().max(320) })),
+    async (c) => {
+      if (!env.generatedArtifactViewsEnabled) return c.json({ error: "artifact_view_not_found" }, 404)
+      try {
+        const { actorContext } = await contextFor(c)
+        await shareSavedApp(actorContext, c.req.param("appId"), c.req.valid("json").email)
+        return c.json({ ok: true })
       } catch (error) {
         const failure = appRouteFailure(error)
         return c.json(failure.body, failure.status)

--- a/ee/apps/den-api/src/routes/org/codemode-scripts.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-scripts.ts
@@ -304,14 +304,14 @@ export function registerOrgWorkflowRoutes<T extends { Variables: OrgRouteVariabl
   app.get(
     "/v1/apps",
     describeRoute({ tags: ["Apps"], summary: "List saved reusable apps", responses: {
-      200: jsonResponse("Saved apps returned.", z.object({ enabled: z.boolean(), items: z.array(savedAppSummarySchema) })),
+      200: jsonResponse("Saved apps returned.", z.object({ enabled: z.boolean(), sharingEnabled: z.boolean(), items: z.array(savedAppSummarySchema) })),
     } }),
     orgMemberRoute(),
     async (c) => {
-      if (!env.generatedArtifactViewsEnabled) return c.json({ enabled: false, items: [] })
+      if (!env.generatedArtifactViewsEnabled) return c.json({ enabled: false, sharingEnabled: false, items: [] })
       try {
         const { actorContext } = await contextFor(c)
-        return c.json({ enabled: true, items: await listSavedApps(actorContext) })
+        return c.json({ enabled: true, sharingEnabled: true, items: await listSavedApps(actorContext) })
       } catch (error) {
         const failure = appRouteFailure(error)
         return c.json(failure.body, failure.status)

--- a/ee/apps/den-api/src/saved-apps.ts
+++ b/ee/apps/den-api/src/saved-apps.ts
@@ -2,9 +2,11 @@ import type { SavedAppDetail, SavedAppSummary } from "@openwork/types/workflows"
 import { getArtifactView, getGeneratedArtifactViewRevision, listArtifactViews, loadArtifactViewRevision } from "./artifact-views.js"
 import { getWorkflowDetail, getWorkflowSnapshot } from "./workflows.js"
 import type { PluginArchActorContext } from "./routes/org/plugin-system/access.js"
-import { and, eq } from "@openwork-ee/den-db/drizzle"
-import { DashboardAppTable } from "@openwork-ee/den-db/schema"
-import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { AuthUserTable, DashboardAppTable, MemberTable } from "@openwork-ee/den-db/schema"
+import { requirePluginArchResourceRole } from "./routes/org/plugin-system/access.js"
+import { createResourceAccessGrant, listResourceAccess } from "./routes/org/plugin-system/store.js"
+import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
 
 function dashboardScope(context: PluginArchActorContext) {
@@ -12,6 +14,30 @@ function dashboardScope(context: PluginArchActorContext) {
     eq(DashboardAppTable.organization_id, context.organizationContext.organization.id),
     eq(DashboardAppTable.member_id, context.organizationContext.currentMember.id),
   )
+}
+
+/** Share through the workflow's existing access model; never copy result data. */
+export async function shareSavedApp(context: PluginArchActorContext, appId: string, email: string) {
+  const view = await getArtifactView({ context, artifactViewId: appId })
+  if (view.status !== "active" || !view.activeRevisionId) throw new Error("artifact_view_not_found")
+  const resource: { context: PluginArchActorContext; resourceId: DenTypeId<"configObject">; resourceKind: "config_object" } = {
+    context, resourceId: normalizeDenTypeId("configObject", view.configObjectId), resourceKind: "config_object",
+  }
+  await requirePluginArchResourceRole({ ...resource, role: "manager" })
+  const organizationId = context.organizationContext.organization.id
+  const [member] = await db.select({ id: MemberTable.id }).from(MemberTable)
+    .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .where(and(eq(MemberTable.organizationId, organizationId), eq(AuthUserTable.email, email.trim().toLowerCase()), isNull(MemberTable.removedAt)))
+    .limit(1)
+  if (!member) throw new Error("teammate_not_found")
+  const grants = await listResourceAccess(resource)
+  // Repeated shares must not downgrade an existing editor or manager grant.
+  if (!grants.items.some((grant) => grant.orgMembershipId === member.id && !grant.removedAt)) {
+    await createResourceAccessGrant({ ...resource, value: { orgMembershipId: member.id, orgWide: false, role: "viewer" } })
+  }
+  const id = normalizeDenTypeId("artifactView", view.id)
+  await db.insert(DashboardAppTable).values({ organization_id: organizationId, member_id: member.id, artifact_view_id: id })
+    .onDuplicateKeyUpdate({ set: { artifact_view_id: id } })
 }
 
 export async function setAppOnDashboard(context: PluginArchActorContext, appId: string, added: boolean) {

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -102,7 +102,7 @@ test("create, preview, save and reopen an app without changing already-open resu
   evidence.recordAssertionEvidence("Drafts stay off the dashboard until saved, and Cancel does not save them", "Draft list was empty; Cancel retained a null active revision; Save persisted the exact revision, workflow link, and personal dashboard placement without executing or scheduling a run.", true);
 
   await step("saved app header stays readable in a narrow preview", async () => {
-    await seed.eval(world.app, `document.querySelector('[data-app-header]').parentElement.style.width = '320px'`);
+    await seed.evalIn(world.app, `document.querySelector('[data-app-header]').parentElement.style.width = '320px'`);
     const header = await probe.eval(world.app, `(() => {
       const header = document.querySelector('[data-app-header]');
       const title = header.querySelector('h2');
@@ -123,7 +123,7 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.see("Delete Team briefing");
     await user.screenshot();
     await user.click("App options for Team briefing");
-    await seed.eval(world.app, `document.querySelector('[data-app-header]').parentElement.style.removeProperty('width')`);
+    await seed.evalIn(world.app, `document.querySelector('[data-app-header]').parentElement.style.removeProperty('width')`);
   });
   evidence.recordAssertionEvidence("The saved app header preserves the title at a 320px panel width", "The real preview header remains under 72px tall with over 180px for the fully visible title. Saved is status text; Run, Ask for changes, and Delete are reachable in the options menu.", true);
 

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -8,6 +8,22 @@ const test = spec.world(savedAppCreation, { timeout: 900_000 });
 test("create, preview, save and reopen an app without changing already-open results", async ({ world, user, probe, seed, step, evidence }) => {
   const viewsPath = `/v1/workflows/${world.configObjectId}/views`;
   expect(record((await probe.api(world.den.admin, viewsPath)).body).items).toEqual([]);
+  await step("only offer sharing when the server supports it", async () => {
+    for (const body of [{ enabled: true, items: [] }, { enabled: true, sharingEnabled: false, items: [] }]) {
+      await world.proxy.faults.status("/v1/apps", 200, { times: 100, body });
+      await world.proxy.faults.status("/api/den/v1/apps", 200, { times: 100, body });
+      await world.open("/dashboard");
+      await user.reload();
+      await user.see({ role: "button", label: "Add" });
+      await user.notSee({ role: "button", label: "Share" });
+      expect((await world.proxy.requestLog()).some((request) => request.path.endsWith("/v1/apps") && request.faulted)).toBe(true);
+      await world.proxy.faults.clear();
+    }
+    await user.reload();
+    await user.see({ role: "button", label: "Share" });
+    expect(record((await probe.api(world.den.admin, "/v1/apps")).body).sharingEnabled).toBe(true);
+  });
+  evidence.recordAssertionEvidence("Sharing requires explicit server support", "Older and disabled capability responses keep Add available but hide Share; the real supporting server exposes Share after reload.", true);
   await step("create an app through the Dashboard conversation", async () => {
     await world.open("/dashboard");
     await user.click({ role: "button", label: "Add" });
@@ -264,6 +280,31 @@ test("create, preview, save and reopen an app without changing already-open resu
   });
   evidence.recordAssertionEvidence("Members can delete their own apps but cannot delete another member's private app", "The member created and retired their own saved app, removing its placement and workflow selection while preserving historical results; deleting the admin's app was rejected and that app stayed saved.", true);
 
+  // Use a separate workflow so sharing the selected app cannot grant indirect access to this one.
+  const privateInput = { topic: "Private planning" };
+  const privateCode = 'return { topic: input.topic };';
+  await world.rpc("execute_capability_script", { code: privateCode, input: privateInput });
+  const privateWorkflow = await saveWorkflow(world.den.admin, {
+    name: "Private planning", code: privateCode, currentInput: privateInput,
+    inputSchema: { type: "object", properties: { topic: { type: "string" } }, required: ["topic"] },
+    outputSchema: { type: "object", properties: { topic: { type: "string" } }, required: ["topic"] },
+  });
+  expect(privateWorkflow.status, privateWorkflow.text).toBe(201);
+  const privateWorkflowId = field(privateWorkflow.body, "configObjectId");
+  await runWorkflow(world.den.admin, privateWorkflowId, {
+    pluginId: field(privateWorkflow.body, "pluginId"), configObjectVersionId: field(privateWorkflow.body, "configObjectVersionId"), input: privateInput,
+  });
+  const privateBuilt = await world.rpc("save_artifact_view", {
+    configObjectId: privateWorkflowId, title: "Private planning", reactSource: 'export default function Planning({data}) { return <p>{data.topic}</p> }',
+  });
+  const privateView = record(record(privateBuilt.structuredContent).view);
+  const privateAppId = field(privateView, "id");
+  if (!Array.isArray(privateView.revisions)) throw new Error("Private app has no revisions");
+  const privateSave = await seed.api(world.den.admin, `/v1/apps/${privateAppId}/save`, {
+    method: "POST", body: JSON.stringify({ revisionId: field(privateView.revisions[0], "id"), title: "Private planning", useInWorkflow: true, expectedActiveRevisionId: null }),
+  });
+  expect(privateSave.response.status, privateSave.text).toBe(200);
+
   await step("share dashboard apps with a teammate", async () => {
     await world.open("/dashboard");
     await user.click({ role: "button", label: "Share" });
@@ -275,6 +316,8 @@ test("create, preview, save and reopen an app without changing already-open resu
     });
     expect(deniedShare.response.status).toBe(403);
     await user.click({ role: "button", label: "Share" });
+    await user.click({ role: "checkbox", label: "Private planning" });
+    await user.screenshot();
     await user.type({ label: "Teammate’s email" }, "unknown@openwork.test");
     await user.click("Share apps");
     await user.see({ text: /No teammate with that email belongs to this organization/ });
@@ -291,6 +334,11 @@ test("create, preview, save and reopen an app without changing already-open resu
     expect(repeat.response.status, repeat.text).toBe(200);
     const listed = record((await probe.api(colleague, "/v1/apps")).body).items;
     expect(listed).toHaveLength(1);
+    if (!Array.isArray(listed)) throw new Error("Expected the recipient app list");
+    expect(record(record(listed[0]).view).id).toBe(appId);
+    expect((await probe.api(colleague, `/v1/apps/${privateAppId}`)).response.status).toBe(403);
+    expect((await probe.api(colleague, `/v1/workflows/${privateWorkflowId}`)).response.status).toBe(403);
+    expect((await probe.api(world.den.admin, `/v1/apps/${privateAppId}`)).body).toMatchObject({ onDashboard: true, canManage: true });
     const reshare = await seed.api(colleague, `/v1/apps/${appId}/share`, {
       method: "POST", body: JSON.stringify({ email: world.den.admin.email }),
     });
@@ -300,7 +348,10 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.screenshot();
     await user.click("Done");
   });
-  evidence.recordAssertionEvidence("Dashboard Share grants a teammate view access and adds the selected app to their dashboard", "Cancel and an unknown email left the app private. Sharing made one saved app visible on the recipient dashboard without manager access; repeat sharing did not duplicate it, viewers could not reshare, and company dashboards stayed unchanged.", true);
+  evidence.recordAssertionEvidence("Dashboard Share grants a teammate view access and adds the selected app to their dashboard", "Cancel and an unknown email left the app private. Sharing made one saved app visible on the recipient dashboard without manager access; repeat sharing did not duplicate it, the unchecked app and its separate workflow remained private, viewers could not reshare, and company dashboards stayed unchanged.", true);
+
+  const cleanupPrivate = await seed.api(world.den.admin, `/v1/artifact-views/${privateAppId}/retire`, { method: "POST" });
+  expect(cleanupPrivate.response.status, cleanupPrivate.text).toBe(200);
 
   const beforeDelete = await readWorkflow();
   const beforeDeleteSnapshots = (await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body;

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -118,21 +118,24 @@ test("create, preview, save and reopen an app without changing already-open resu
     expect(record(header).buttonLabels).not.toContain("Delete");
     await user.screenshot();
     await user.click("App options for Team briefing");
-    await user.see("Run again");
-    await user.see("Ask for changes");
     await user.see("Delete Team briefing");
     await user.screenshot();
     await user.click("App options for Team briefing");
     await seed.evalIn(world.app, `document.querySelector('[data-app-header]').parentElement.style.removeProperty('width')`);
   });
-  evidence.recordAssertionEvidence("The saved app header preserves the title at a 320px panel width", "The real preview header remains under 72px tall with over 180px for the fully visible title. Saved is status text; Run, Ask for changes, and Delete are reachable in the options menu.", true);
+  evidence.recordAssertionEvidence("The saved app header preserves the title at a 320px panel width", "The real preview header remains under 72px tall with over 180px for the fully visible title. Saved is status text and Delete remains reachable in the options menu.", true);
 
   await step("reopen the saved app after a reload", async () => {
     await world.open("/dashboard");
     await user.reload();
     await user.click("Open Team briefing");
     await user.see({ text: "Saved app" }, { timeoutMs: 30_000 });
+    await user.click("App options for Team briefing");
+    await user.see("Run again");
+    await user.see("Ask for changes");
+    await user.see("Delete Team briefing");
     await user.screenshot();
+    await user.click("App options for Team briefing");
   });
 
   const companyBefore = (await probe.api(world.den.admin, `/v1/dashboards/${world.dashboardId}`)).body;

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -101,6 +101,32 @@ test("create, preview, save and reopen an app without changing already-open resu
   });
   evidence.recordAssertionEvidence("Drafts stay off the dashboard until saved, and Cancel does not save them", "Draft list was empty; Cancel retained a null active revision; Save persisted the exact revision, workflow link, and personal dashboard placement without executing or scheduling a run.", true);
 
+  await step("saved app header stays readable in a narrow preview", async () => {
+    await seed.eval(world.app, `document.querySelector('[data-app-header]').parentElement.style.width = '320px'`);
+    const header = await probe.eval(world.app, `(() => {
+      const header = document.querySelector('[data-app-header]');
+      const title = header.querySelector('h2');
+      return { width: header.getBoundingClientRect().width, height: header.getBoundingClientRect().height,
+        titleWidth: title.getBoundingClientRect().width, titleFits: title.scrollWidth <= title.clientWidth,
+        buttonLabels: [...header.querySelectorAll('button')].map(button => button.textContent.trim()) };
+    })()`);
+    expect(record(header).width).toBe(320);
+    expect(record(header).height).toBeLessThan(72);
+    expect(record(header).titleWidth).toBeGreaterThan(180);
+    expect(record(header).titleFits).toBe(true);
+    expect(record(header).buttonLabels).not.toContain("Saved");
+    expect(record(header).buttonLabels).not.toContain("Delete");
+    await user.screenshot();
+    await user.click("App options for Team briefing");
+    await user.see("Run again");
+    await user.see("Ask for changes");
+    await user.see("Delete Team briefing");
+    await user.screenshot();
+    await user.click("App options for Team briefing");
+    await seed.eval(world.app, `document.querySelector('[data-app-header]').parentElement.style.removeProperty('width')`);
+  });
+  evidence.recordAssertionEvidence("The saved app header preserves the title at a 320px panel width", "The real preview header remains under 72px tall with over 180px for the fully visible title. Saved is status text; Run, Ask for changes, and Delete are reachable in the options menu.", true);
+
   await step("reopen the saved app after a reload", async () => {
     await world.open("/dashboard");
     await user.reload();
@@ -114,6 +140,7 @@ test("create, preview, save and reopen an app without changing already-open resu
     await world.open("/dashboard");
     await user.see({ text: "Project updates" });
     await user.see({ text: "From your company" });
+    await user.click("App options for Team briefing");
     await user.click("Remove Team briefing from dashboard");
     await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });
     expect(await readApp()).toMatchObject({ onDashboard: false, view: { activeRevisionId: revisionId } });
@@ -276,6 +303,7 @@ test("create, preview, save and reopen an app without changing already-open resu
   const beforeDeleteSnapshots = (await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body;
   await step("an admin cancels deletion in the app and confirms it on the dashboard", async () => {
     await world.open(dashboardAppPath);
+    await user.click("App options for Team briefing");
     await user.click("Delete Team briefing");
     await user.see({ text: "Delete “Team briefing”?" });
     await user.see({ text: "This removes the saved app from everyone’s dashboards and the app list. Its workflow and past results stay available." });
@@ -283,6 +311,7 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.click("Cancel");
     expect((await readApp()).onDashboard).toBe(true);
     await world.open("/dashboard");
+    await user.click("App options for Team briefing");
     await user.click("Delete Team briefing");
     await user.click("Delete app");
     await user.see({ text: "Make this dashboard yours" }, { timeoutMs: 30_000 });

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -234,6 +234,44 @@ test("create, preview, save and reopen an app without changing already-open resu
   });
   evidence.recordAssertionEvidence("Members can delete their own apps but cannot delete another member's private app", "The member created and retired their own saved app, removing its placement and workflow selection while preserving historical results; deleting the admin's app was rejected and that app stayed saved.", true);
 
+  await step("share dashboard apps with a teammate", async () => {
+    await world.open("/dashboard");
+    await user.click({ role: "button", label: "Share" });
+    await user.see({ text: "Share your dashboard" });
+    await user.click("Cancel");
+    expect((await probe.api(colleague, `/v1/apps/${appId}`)).response.status).toBe(403);
+    const deniedShare = await seed.api(colleague, `/v1/apps/${appId}/share`, {
+      method: "POST", body: JSON.stringify({ email: world.den.admin.email }),
+    });
+    expect(deniedShare.response.status).toBe(403);
+    await user.click({ role: "button", label: "Share" });
+    await user.type({ label: "Teammate’s email" }, "unknown@openwork.test");
+    await user.click("Share apps");
+    await user.see({ text: /No teammate with that email belongs to this organization/ });
+    expect((await probe.api(colleague, `/v1/apps/${appId}`)).response.status).toBe(403);
+    await user.type({ label: "Teammate’s email" }, colleague.email, { replace: true });
+    await user.click("Share apps");
+    await user.see({ text: `Shared 1 app with ${colleague.email}. They’ll appear when your teammate opens or reloads their dashboard.` }, { timeoutMs: 30_000 });
+    const sharedApp = await probe.api(colleague, `/v1/apps/${appId}`);
+    expect(sharedApp.response.status, sharedApp.text).toBe(200);
+    expect(sharedApp.body).toMatchObject({ onDashboard: true, canManage: false, view: { id: appId } });
+    const repeat = await seed.api(world.den.admin, `/v1/apps/${appId}/share`, {
+      method: "POST", body: JSON.stringify({ email: colleague.email }),
+    });
+    expect(repeat.response.status, repeat.text).toBe(200);
+    const listed = record((await probe.api(colleague, "/v1/apps")).body).items;
+    expect(listed).toHaveLength(1);
+    const reshare = await seed.api(colleague, `/v1/apps/${appId}/share`, {
+      method: "POST", body: JSON.stringify({ email: world.den.admin.email }),
+    });
+    expect(reshare.response.status).toBe(403);
+    expect((await probe.api(world.den.admin, `/v1/dashboards/${world.dashboardId}`)).body).toEqual(companyBefore);
+    expect((await readApp()).onDashboard).toBe(true);
+    await user.screenshot();
+    await user.click("Done");
+  });
+  evidence.recordAssertionEvidence("Dashboard Share grants a teammate view access and adds the selected app to their dashboard", "Cancel and an unknown email left the app private. Sharing made one saved app visible on the recipient dashboard without manager access; repeat sharing did not duplicate it, viewers could not reshare, and company dashboards stayed unchanged.", true);
+
   const beforeDelete = await readWorkflow();
   const beforeDeleteSnapshots = (await probe.api(world.den.admin, `/v1/workflows/${world.configObjectId}/snapshots`)).body;
   await step("an admin cancels deletion in the app and confirms it on the dashboard", async () => {

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -305,6 +305,20 @@ test("create, preview, save and reopen an app without changing already-open resu
   });
   expect(privateSave.response.status, privateSave.text).toBe(200);
 
+  const companionBuilt = await world.rpc("save_artifact_view", {
+    configObjectId: world.configObjectId, title: "Briefing companion", reactSource: 'export default function Companion({data}) { return <p>{data.topic}</p> }',
+  });
+  const companionView = record(record(companionBuilt.structuredContent).view);
+  const companionAppId = field(companionView, "id");
+  if (!Array.isArray(companionView.revisions)) throw new Error("Companion app has no revisions");
+  const companionSave = await seed.api(world.den.admin, `/v1/apps/${companionAppId}/save`, {
+    method: "POST", body: JSON.stringify({ revisionId: field(companionView.revisions[0], "id"), title: "Briefing companion", useInWorkflow: false, expectedActiveRevisionId: null }),
+  });
+  expect(companionSave.response.status, companionSave.text).toBe(200);
+  const unpinCompanion = await seed.api(world.den.admin, `/v1/apps/${companionAppId}/dashboard`, { method: "POST", body: JSON.stringify({ added: false }) });
+  expect(unpinCompanion.response.status, unpinCompanion.text).toBe(200);
+  expect((await probe.api(colleague, `/v1/apps/${companionAppId}`)).response.status).toBe(403);
+
   await step("share dashboard apps with a teammate", async () => {
     await world.open("/dashboard");
     await user.click({ role: "button", label: "Share" });
@@ -327,15 +341,21 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.see({ text: `Shared 1 app with ${colleague.email}. They’ll appear when your teammate opens or reloads their dashboard.` }, { timeoutMs: 30_000 });
     const sharedApp = await probe.api(colleague, `/v1/apps/${appId}`);
     expect(sharedApp.response.status, sharedApp.text).toBe(200);
-    expect(sharedApp.body).toMatchObject({ onDashboard: true, canManage: false, view: { id: appId } });
+    expect(sharedApp.body).toMatchObject({ onDashboard: true, canManage: false, view: { id: appId }, payload: { data: { topic: "Next week’s briefing" } } });
+    const sharedWorkflow = await probe.api(colleague, `/v1/workflows/${world.configObjectId}`);
+    expect(sharedWorkflow.response.status, sharedWorkflow.text).toBe(200);
+    const companion = await probe.api(colleague, `/v1/apps/${companionAppId}`);
+    expect(companion.response.status, companion.text).toBe(200);
+    expect(companion.body).toMatchObject({ onDashboard: false, canManage: false, view: { id: companionAppId }, payload: { data: { topic: "Next week’s briefing" } } });
     const repeat = await seed.api(world.den.admin, `/v1/apps/${appId}/share`, {
       method: "POST", body: JSON.stringify({ email: colleague.email }),
     });
     expect(repeat.response.status, repeat.text).toBe(200);
     const listed = record((await probe.api(colleague, "/v1/apps")).body).items;
-    expect(listed).toHaveLength(1);
+    expect(listed).toHaveLength(2);
     if (!Array.isArray(listed)) throw new Error("Expected the recipient app list");
-    expect(record(record(listed[0]).view).id).toBe(appId);
+    expect(listed.map((item) => field(record(item).view, "id")).sort()).toEqual([appId, companionAppId].sort());
+    expect(listed.filter((item) => record(item).onDashboard)).toHaveLength(1);
     expect((await probe.api(colleague, `/v1/apps/${privateAppId}`)).response.status).toBe(403);
     expect((await probe.api(colleague, `/v1/workflows/${privateWorkflowId}`)).response.status).toBe(403);
     expect((await probe.api(world.den.admin, `/v1/apps/${privateAppId}`)).body).toMatchObject({ onDashboard: true, canManage: true });
@@ -349,7 +369,10 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.click("Done");
   });
   evidence.recordAssertionEvidence("Dashboard Share grants a teammate view access and adds the selected app to their dashboard", "Cancel and an unknown email left the app private. Sharing made one saved app visible on the recipient dashboard without manager access; repeat sharing did not duplicate it, the unchecked app and its separate workflow remained private, viewers could not reshare, and company dashboards stayed unchanged.", true);
+  evidence.recordAssertionEvidence("Sharing includes the workflow, saved results, and sibling apps without adding every sibling to the dashboard", "The recipient could read the workflow and the latest saved result in both the selected app and its previously inaccessible companion. Both appeared in the accessible app list, but only the selected app was on their dashboard; the separate private workflow stayed inaccessible.", true);
 
+  const cleanupCompanion = await seed.api(world.den.admin, `/v1/artifact-views/${companionAppId}/retire`, { method: "POST" });
+  expect(cleanupCompanion.response.status, cleanupCompanion.text).toBe(200);
   const cleanupPrivate = await seed.api(world.den.admin, `/v1/artifact-views/${privateAppId}/retire`, { method: "POST" });
   expect(cleanupPrivate.response.status, cleanupPrivate.text).toBe(200);
 

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -15,9 +15,9 @@ test("create, preview, save and reopen an app without changing already-open resu
       await world.open("/dashboard");
       await user.reload();
       await user.see({ role: "button", label: "Add" });
-      await user.notSee({ role: "button", label: "Share" });
       expect((await world.proxy.requestLog()).some((request) => request.path.endsWith("/v1/apps") && request.faulted)).toBe(true);
-      await world.proxy.faults.clear();
+      await user.notSee({ role: "button", label: "Share" });
+      await world.resetProxy();
     }
     await user.reload();
     await user.see({ role: "button", label: "Share" });

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -101,7 +101,8 @@ export async function savedAppCreation(seed: Seed) {
   if (!configured.ok) throw new Error(`Model fixture setup failed: ${configured.status}`);
   const providerId = "saved-app-model";
   const modelId = "saved-app-model";
-  const app = await seed.desktop({ den, name: "saved-app-creation", model: `${providerId}/${modelId}` });
+  const proxy = await seed.faultProxy(den);
+  const app = await seed.desktop({ den: { ...den, ref: proxy.ref }, name: "saved-app-creation", model: `${providerId}/${modelId}` });
   const workspace = await seed.workspace(app, seed.tmpPath("saved-app-creation"));
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
     provider: { [providerId]: {
@@ -121,7 +122,7 @@ export async function savedAppCreation(seed: Seed) {
     finally { client.close(); }
   };
   return {
-    app, den, workspace, configObjectId, dashboardId, rpc, run,
+    app, den, proxy, workspace, configObjectId, dashboardId, rpc, run,
     open: (path: string) => go(app, path),
     previewText: async () => String(await inPreview("return appDocument.body.innerText")),
     showDetails: () => inPreview('appDocument.querySelector("button")?.click()'),

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -102,6 +102,12 @@ export async function savedAppCreation(seed: Seed) {
   const providerId = "saved-app-model";
   const modelId = "saved-app-model";
   const proxy = await seed.faultProxy(den);
+  // Keep runtime API discovery on the same proxy as the simulated old server.
+  const resetProxy = async () => {
+    await proxy.faults.clear();
+    await proxy.faults.status("/api/runtime-config", 200, { times: 1000, body: { denApiUrl: proxy.ref.apiUrl } });
+  };
+  await resetProxy();
   const app = await seed.desktop({ den: { ...den, ref: proxy.ref }, name: "saved-app-creation", model: `${providerId}/${modelId}` });
   const workspace = await seed.workspace(app, seed.tmpPath("saved-app-creation"));
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
@@ -122,7 +128,7 @@ export async function savedAppCreation(seed: Seed) {
     finally { client.close(); }
   };
   return {
-    app, den, proxy, workspace, configObjectId, dashboardId, rpc, run,
+    app, den, proxy, resetProxy, workspace, configObjectId, dashboardId, rpc, run,
     open: (path: string) => go(app, path),
     previewText: async () => String(await inPreview("return appDocument.body.innerText")),
     showDetails: () => inPreview('appDocument.querySelector("button")?.click()'),

--- a/packages/sdk/src/gen/sdk.gen.ts
+++ b/packages/sdk/src/gen/sdk.gen.ts
@@ -415,6 +415,8 @@ import type {
   PostV1ApiKeysResponses,
   PostV1AppsByAppIdDashboardResponses,
   PostV1AppsByAppIdSaveResponses,
+  PostV1AppsByAppIdShareErrors,
+  PostV1AppsByAppIdShareResponses,
   PostV1ArtifactViewsByArtifactViewIdRetireResponses,
   PostV1ArtifactViewsByArtifactViewIdRevisionsByRevisionIdActivateResponses,
   PostV1AuthBootstrapVerifyErrors,
@@ -2827,6 +2829,43 @@ export class DenClient extends HeyApiClient {
     return (options?.client ?? this.client).get<GetV1AppsResponses, unknown, ThrowOnError>({
       url: "/v1/apps",
       ...options,
+    });
+  }
+
+  /**
+   * Share a saved app with a teammate
+   */
+  public postV1AppsByAppIdShare<ThrowOnError extends boolean = false>(
+    parameters: {
+      appId: string;
+      email?: string;
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "appId" },
+            { in: "body", key: "email" },
+          ],
+        },
+      ],
+    );
+    return (options?.client ?? this.client).post<
+      PostV1AppsByAppIdShareResponses,
+      PostV1AppsByAppIdShareErrors,
+      ThrowOnError
+    >({
+      url: "/v1/apps/{appId}/share",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     });
   }
 

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -8446,6 +8446,41 @@ export type GetV1AppsResponses = {
 
 export type GetV1AppsResponse = GetV1AppsResponses[keyof GetV1AppsResponses];
 
+export type PostV1AppsByAppIdShareData = {
+  body: {
+    email: string;
+  };
+  path: {
+    appId: string;
+  };
+  query?: never;
+  url: "/v1/apps/{appId}/share";
+};
+
+export type PostV1AppsByAppIdShareErrors = {
+  /**
+   * Only app managers can share.
+   */
+  403: ForbiddenError;
+  /**
+   * App or teammate not found.
+   */
+  404: NotFoundError;
+};
+
+export type PostV1AppsByAppIdShareError = PostV1AppsByAppIdShareErrors[keyof PostV1AppsByAppIdShareErrors];
+
+export type PostV1AppsByAppIdShareResponses = {
+  /**
+   * App shared to the teammate's dashboard.
+   */
+  200: {
+    ok: true;
+  };
+};
+
+export type PostV1AppsByAppIdShareResponse = PostV1AppsByAppIdShareResponses[keyof PostV1AppsByAppIdShareResponses];
+
 export type GetV1AppsByAppIdData = {
   body?: never;
   path: {

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -8398,6 +8398,7 @@ export type GetV1AppsResponses = {
    */
   200: {
     enabled: boolean;
+    sharingEnabled: boolean;
     items: Array<{
       view: {
         id: string;


### PR DESCRIPTION
Add a Share button on Dashboard: choose apps you manage and enter an existing teammate’s email to add them to that teammate’s dashboard with viewer access. The dialog explains that sharing also grants access to the underlying workflow, saved results, and other apps from that workflow. Existing access and company-managed dashboards stay intact.

Simplify app preview headers for narrow panels. The title gets the available width, saved state appears as quiet metadata, and an overflow menu contains Run again, Ask for changes, and Delete. Save only appears for unsaved work. Dashboard cards use the same menu for removal and deletion, and destructive actions still require confirmation.

Only show Share when the saved-apps response explicitly advertises sharing support. Older servers with a missing or disabled capability retain Add but do not offer Share. Regenerate the Den SDK for the new sharing endpoint and capability. Deployment order: deploy the Den API route before distributing the desktop client that uses it.

Validation:
- `pnpm typecheck` — passed.
- `pnpm sdk:check` — passed, including generated SDK consistency and SDK typechecking.
- `OPENWORK_EVAL_REF=1241e749dd488e95b512d0c62a8b6321e328e2ba pnpm evals:e2e saved-app-creation` — placement: daytona (daytona CLI authenticated); Passed, 1 passed / 0 failed / 0 skipped. The journey verifies sharing, permission boundaries, cancellation, repeat sharing, deletion, and title space/menu actions at a 320px preview width. Final runtime evidence is in the test-evidence comment.


Review coverage: the journey now unchecks a second managed app backed by a separate workflow and verifies both remain inaccessible to the recipient. A fault proxy simulates missing and disabled server support, including runtime API discovery, and verifies Share appears only with explicit support.


The recipient assertions also verify non-null saved results, access to the shared workflow and a sibling app, and that only the explicitly selected app is placed on the recipient dashboard.
