### PR TITLE
fix: keep pasted video attachments visible in chat

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -60,6 +60,12 @@ const EXTENSION_MIME_TYPES: Record<string, string> = {
   png: "image/png",
   gif: "image/gif",
   webp: "image/webp",
+  mp4: "video/mp4",
+  mov: "video/quicktime",
+  webm: "video/webm",
+  m4v: "video/x-m4v",
+  avi: "video/x-msvideo",
+  mkv: "video/x-matroska",
   pdf: "application/pdf",
   docx: DOCX_MIME,
   pptx: PPTX_MIME,
@@ -298,6 +304,11 @@ function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInp
   return {
     type: "text",
     synthetic: true,
+    metadata: {
+      openworkAttachments: uploaded
+        .filter((item) => modelFacingAttachmentMime(item.mime) === null)
+        .map((item) => ({ filename: item.filename, mime: item.mime, url: item.url })),
+    },
     text: [
       "Attached files were copied into this worker workspace for tool access:",
       ...uploaded.map((item) => `- ${item.filename}: ${item.workspacePath} (${item.url})`),

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -12,6 +12,7 @@ import { isGeneratedSessionTitle } from "@/app/lib/session-title";
 import { normalizeEvent } from "@/app/utils";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX, type OpencodeEvent, type PendingPermission, type PendingQuestion } from "@/app/types";
 import {
+  attachmentNoteToUIParts,
   createSessionErrorUIMessage,
   snapshotToUIMessages,
 } from "./usechat-adapter";
@@ -745,6 +746,7 @@ function toUIPart(part: Part): UIMessage["parts"][number] | null {
 }
 
 function toUIParts(part: Part): UIMessage["parts"] {
+  if (part.type === "text" && part.synthetic) return attachmentNoteToUIParts(part);
   if (part.type === "file") return toFileUIParts(part);
   const mapped = toUIPart(part);
   if (!mapped) return [];

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import type { UIMessage } from "ai";
-import type { FilePart, Part, ToolPart } from "@opencode-ai/sdk/v2/client";
+import type { FilePart, Part, TextPart, ToolPart } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../../../../app/types";
@@ -120,6 +120,27 @@ function mapSnapshotToolParts(part: ToolPart): UIMessage["parts"] {
   return [mapped];
 }
 
+/** Recover display-only attachments without sending unsupported binary parts to the model. */
+export function attachmentNoteToUIParts(part: TextPart): UIMessage["parts"] {
+  if (!part.synthetic || part.ignored) return [];
+  const attachments = part.metadata?.openworkAttachments;
+  if (!Array.isArray(attachments)) return [];
+  return attachments.flatMap<UIMessage["parts"][number]>((attachment: unknown, index) => {
+    if (!attachment || typeof attachment !== "object"
+      || !("filename" in attachment) || typeof attachment.filename !== "string"
+      || !("mime" in attachment) || typeof attachment.mime !== "string"
+      || !("url" in attachment) || typeof attachment.url !== "string"
+      || !attachment.url.startsWith("file://")) return [];
+    return [{
+      type: "file",
+      filename: attachment.filename,
+      mediaType: attachment.mime,
+      url: attachment.url,
+      providerMetadata: { opencode: { partId: `${part.id}:attachment:${index}` } },
+    }];
+  });
+}
+
 export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessage[] {
   return snapshot.messages.flatMap((message) => {
     const created = message.info.time?.created;
@@ -133,7 +154,7 @@ export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessa
         : {}),
       parts: message.parts.flatMap<UIMessage["parts"][number]>((part) => {
         if (part.type === "text") {
-          if (part.synthetic || part.ignored) return [];
+          if (part.synthetic || part.ignored) return attachmentNoteToUIParts(part);
           return [{
             type: "text",
             text: getTextPartValue(part),

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { attachmentNoteToUIParts } from "../src/react-app/domains/session/sync/usechat-adapter";
 import type { ComposerAttachment } from "../src/app/types";
 import {
   buildChatAttachmentInboxPath,
@@ -502,4 +503,28 @@ describe("composer attachment file parts", () => {
       createId: () => "nonce-a",
     })).rejects.toThrow("Failed to copy attachment \"scan.pdf\" into this worker workspace: upload was rejected");
   });
+});
+
+test("video upload preserves a display card without a model-facing binary part", async () => {
+  const { endpoint } = uploadRecorder("workspace-a");
+  const parts = await composerAttachmentsToWorkspaceFileParts({
+    attachments: [attachmentFor(new File([new Uint8Array([0, 1, 2, 3])], "recording.MOV"))],
+    endpoint,
+    sessionId: "ses_video",
+    workspaceRoot: "/workspace",
+    createId: () => "video",
+  });
+  if (!parts) throw new Error("Expected uploaded attachment");
+  expect(parts.files).toEqual([null]);
+  const note = { ...parts.note, id: "note", sessionID: "ses_video", messageID: "msg_video" };
+  expect(attachmentNoteToUIParts(note)).toEqual([{
+    type: "file",
+    filename: "recording.MOV",
+    mediaType: "video/quicktime",
+    url: "file:///workspace/.opencode/openwork/inbox/chat-attachments/ses_video/video-recording.MOV",
+    providerMetadata: { opencode: { partId: "note:attachment:0" } },
+  }]);
+  expect(attachmentNoteToUIParts({ ...note, ignored: true })).toEqual([]);
+  expect(attachmentNoteToUIParts({ ...note, synthetic: false })).toEqual([]);
+  expect(attachmentNoteToUIParts({ ...note, metadata: { openworkAttachments: [{ url: "javascript:alert(1)" }] } })).toEqual([]);
 });

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -353,3 +353,37 @@ describe("tool part mapper", () => {
     }
   });
 });
+
+test("live attachment notes render once across repeated updates", () => {
+  const syncInput = { workspaceId: "workspace-video", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+  const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+  const release = trackWorkspaceSessionSync(syncInput, "session-video");
+  try {
+    __applySessionSyncEventForTest(syncInput, {
+      type: "message.updated",
+      properties: { info: { id: "msg-video", role: "user", sessionID: "session-video" } },
+    });
+    const event = {
+      type: "message.part.updated",
+      properties: { part: {
+        id: "note-video", type: "text", synthetic: true,
+        messageID: "msg-video", sessionID: "session-video", text: "Hidden workspace paths",
+        metadata: { openworkAttachments: [
+          { filename: "recording.mp4", mime: "video/mp4", url: "file:///workspace/recording.mp4" },
+          { filename: "recording.mov", mime: "video/quicktime", url: "file:///workspace/recording.mov" },
+        ] },
+      } },
+    };
+    __applySessionSyncEventForTest(syncInput, event);
+    __applySessionSyncEventForTest(syncInput, event);
+    const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-video", "session-video"));
+    expect(transcript?.[0]?.parts).toMatchObject([
+      { type: "file", filename: "recording.mp4", mediaType: "video/mp4" },
+      { type: "file", filename: "recording.mov", mediaType: "video/quicktime" },
+    ]);
+    expect(transcript?.[0]?.parts).toHaveLength(2);
+  } finally {
+    release();
+    cleanup();
+  }
+});

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -64,6 +64,18 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   expect(attached.chipStatus).toBe("ready");
   await user.screenshot();
 
+  await step("paste a video alongside the image", async () => {
+    expect(await seed.evalIn(world.app, `(() => {
+      const editor = document.querySelector('[contenteditable="true"]');
+      if (!(editor instanceof HTMLElement)) return false;
+      const transfer = new DataTransfer();
+      transfer.items.add(new File([new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112])], "pasted-recording.mp4", { type: "video/mp4" }));
+      editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: transfer }));
+      return true;
+    })()`)).toBe(true);
+    await user.see({ text: "pasted-recording.mp4" });
+  });
+
   // TODO(primitive): observe a transient attachment status during a user send.
   await seed.evalIn(world.app, `(() => {
     globalThis.__attachmentUploadingSeen = false;
@@ -89,5 +101,13 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   // TODO(primitive): inspect attachment cleanup and error-toast state after send.
   expect(await probe.eval(`!document.querySelector("[data-attachment-id]")
     && !document.querySelector('[data-sonner-toast][data-type="error"]')`)).toBe(true);
+  await step("sent video remains visible without a binary model error", async () => {
+    await user.see({ text: "pasted-recording.mp4" });
+    await user.see({ text: "attachment upload loading proof" });
+    await user.notSee({ text: /Cannot read binary file|UnsupportedFunctionalityError/ });
+  });
+  await user.reload();
+  await user.see({ text: "pasted-recording.mp4" });
+  expect(await probe.eval(`document.querySelectorAll('button[title="Open pasted-recording.mp4 in Artifacts"]').length`)).toBe(1);
   await user.screenshot();
 });


### PR DESCRIPTION
Pasted videos uploaded successfully but disappeared from the sent message because unsupported binary types have no model-facing file part. Preserve display metadata on the existing workspace-path note and use it to render attachment cards in both live updates and saved history. Video bytes remain available to tools without passing unsupported file parts to the model.

Verification:
- `OPENWORK_EVAL_REF=fix/pasted-video-preview pnpm evals:e2e attachment-upload-loading-state` — placement: daytona (daytona CLI authenticated); Passed: 1 passed, 0 failed, 0 skipped. The extended journey pastes a video alongside an image, sends it, confirms the video card and successful reply, and reloads to verify exactly one card.
- The same extended journey against `dev` at `85a5dfccb` failed on the missing sent video card, reproducing the bug.
- `pnpm --filter @openwork/app exec bun test tests/attachment-file-part.test.ts tests/session-sync-tool-parts.test.ts` — 37 passed, 0 failed.
- `pnpm --filter @openwork/app typecheck` — passed.
