### PR TITLE
fix(desktop): build Computer Use helper for the macOS target

### DIFF
--- a/apps/desktop/electron/after-pack-paths.test.mjs
+++ b/apps/desktop/electron/after-pack-paths.test.mjs
@@ -27,3 +27,41 @@ describe("after-pack asar entry paths", () => {
     );
   });
 });
+
+// Real Mach-O fixtures prove the final package guard independently of TARGET
+// and any previously staged helper. No macOS permissions are requested.
+describe("Computer Use package architecture", { skip: process.platform !== "darwin" }, () => {
+  it("rejects cached helpers for the wrong CPU and validates numeric builder targets", async () => {
+    const { mkdtempSync, mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { execFileSync } = await import("node:child_process");
+    const { verifyComputerUseArchitecture } = require("../scripts/electron-after-pack.cjs");
+    const scratch = mkdtempSync(join(tmpdir(), "helper-arch-"));
+    const helper = join(scratch, "Helper.app");
+    const executable = join(helper, "Contents", "MacOS", "ComputerUse");
+    try {
+      mkdirSync(join(helper, "Contents", "MacOS"), { recursive: true });
+      const source = join(scratch, "main.c");
+      writeFileSync(source, "int main(void) { return 0; }\n");
+      for (const { native, accepted, rejected } of [
+        { native: "arm64", accepted: 3, rejected: 1 },
+        { native: "x86_64", accepted: 1, rejected: 3 },
+      ]) {
+        execFileSync("clang", ["-arch", native, source, "-o", executable]);
+        assert.doesNotThrow(() => verifyComputerUseArchitecture({ arch: accepted }, helper));
+        assert.throws(() => verifyComputerUseArchitecture({ arch: rejected }, helper), /must contain/);
+        assert.throws(() => verifyComputerUseArchitecture({ arch: 4 }, helper), /must contain/);
+      }
+      execFileSync("clang", ["-arch", "arm64", "-arch", "x86_64", source, "-o", executable]);
+      for (const arch of [1, 3, 4, "x64", "arm64", "universal"]) {
+        assert.doesNotThrow(() => verifyComputerUseArchitecture({ arch }, helper));
+      }
+      assert.throws(() => verifyComputerUseArchitecture({ arch: 0 }, helper), /Unsupported/);
+      rmSync(executable);
+      assert.throws(() => verifyComputerUseArchitecture({ arch: 1 }, helper), /must contain/);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/scripts/electron-after-pack.cjs
+++ b/apps/desktop/scripts/electron-after-pack.cjs
@@ -98,6 +98,20 @@ function verifyRuntimeDependencies(context) {
   }
 }
 
+function verifyComputerUseArchitecture(context, helperPath) {
+  // electron-builder uses the numeric Arch enum; accept names for callers too.
+  const arch = typeof context.arch === "number"
+    ? ["ia32", "x64", "armv7l", "arm64", "universal"][context.arch] : context.arch;
+  const required = { x64: ["x86_64"], arm64: ["arm64"], universal: ["x86_64", "arm64"] }[arch];
+  if (!required) throw new Error(`Unsupported Computer Use helper architecture: ${context.arch}`);
+  const executable = path.join(helperPath, "Contents", "MacOS", "ComputerUse");
+  const result = spawnSync("lipo", [executable, "-verify_arch", ...required], { encoding: "utf8" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Packaged Computer Use helper must contain ${required.join(" and ")}; rebuild it for the package target`);
+  }
+}
+
 function signComputerUseHelper(context) {
   const appPath = resolveMacAppPath(context);
   if (!appPath) return;
@@ -106,6 +120,8 @@ function signComputerUseHelper(context) {
   if (!fs.existsSync(helperPath)) {
     throw new Error(`Missing Computer Use helper app at ${helperPath}`);
   }
+
+  verifyComputerUseArchitecture(context, helperPath);
 
   const identity = process.env.OPENWORK_COMPUTER_USE_CODESIGN_IDENTITY
     || process.env.CSC_NAME
@@ -139,6 +155,7 @@ function copyExecutableTargetToAlias(sidecarsDir, targetName, aliasName) {
 
 async function afterPack(context) {
   verifyRuntimeDependencies(context);
+  signComputerUseHelper(context);
   const triple = targetTriple(context.electronPlatformName, context.arch);
   if (!triple) return;
 
@@ -172,10 +189,9 @@ async function afterPack(context) {
       fs.rmSync(path.join(sidecarsDir, entry), { force: true, recursive: true });
     }
   }
-
-  signComputerUseHelper(context);
 }
 
 module.exports = afterPack;
 module.exports.default = afterPack;
 module.exports.normalizeAsarEntryPath = normalizeAsarEntryPath;
+module.exports.verifyComputerUseArchitecture = verifyComputerUseArchitecture;

--- a/apps/desktop/scripts/prepare-computer-use-helper.mjs
+++ b/apps/desktop/scripts/prepare-computer-use-helper.mjs
@@ -26,6 +26,7 @@ const hasFlag = (name) => process.argv.slice(2).includes(name);
 const outDir = resolve(readArg("--outdir") ?? join(desktopRoot, "resources", "helpers"));
 const force = hasFlag("--force") || process.env.OPENWORK_COMPUTER_USE_FORCE_BUILD === "1";
 const appPath = join(outDir, helperAppName);
+const executablePath = join(appPath, "Contents", "MacOS", helperExecutableName);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -118,17 +119,35 @@ if (process.platform !== "darwin") {
   process.exit(0);
 }
 
-if (!force && existsSync(join(appPath, "Contents", "MacOS", helperExecutableName))) {
+// Use the same target contract as prepare-sidecar, including cross-builds.
+const target = readArg("--target") ?? process.env.TAURI_ENV_TARGET_TRIPLE
+  ?? process.env.CARGO_CFG_TARGET_TRIPLE ?? process.env.TARGET;
+const arch = target === undefined ? ({ arm64: "arm64", x64: "x86_64" })[process.arch]
+  : ({ "aarch64-apple-darwin": "arm64", "x86_64-apple-darwin": "x86_64" })[target];
+if (!arch) throw new Error(`Unsupported Computer Use helper target: ${target ?? process.arch}`);
+
+function hasTargetArchitecture(executable) {
+  const result = spawnSync("lipo", [executable, "-verify_arch", arch], { encoding: "utf8" });
+  if (result.error) throw result.error;
+  return result.status === 0;
+}
+
+if (!force && existsSync(executablePath) && hasTargetArchitecture(executablePath)) {
   process.stdout.write(JSON.stringify({ ok: true, skipped: true, appPath }, null, 2) + "\n");
   process.exit(0);
 }
 
-run("swift", ["build", "--package-path", packagePath, "-c", "release", "--product", productName], { stdio: "inherit" });
-const binPathResult = run("swift", ["build", "--package-path", packagePath, "-c", "release", "--show-bin-path"]);
+const buildArgs = ["build", "--package-path", packagePath, "-c", "release", "--arch", arch];
+run("swift", [...buildArgs, "--product", productName], { stdio: "inherit" });
+const binPathResult = run("swift", [...buildArgs, "--show-bin-path"]);
 const binDir = binPathResult.stdout.trim();
 const builtExecutable = join(binDir, productName);
 if (!existsSync(builtExecutable)) {
   throw new Error(`Swift build succeeded, but ${builtExecutable} was not found`);
+}
+
+if (!hasTargetArchitecture(builtExecutable)) {
+  throw new Error(`Built Computer Use helper does not contain ${arch}`);
 }
 
 rmSync(appPath, { recursive: true, force: true });

--- a/evals/specs/computer-use-helper.test.ts
+++ b/evals/specs/computer-use-helper.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { computerUseHelper } from "../worlds/computer-use-helper.ts";
+
+test("Computer Use starts after switching macOS distribution architectures", { timeout: 600_000 }, async ({ evidence }) => {
+  const helper = computerUseHelper();
+  console.log("placement: local (native macOS helper MCP boundary)");
+  try {
+    for (const [target, arch] of [
+      ["aarch64-apple-darwin", "arm64"],
+      ["x86_64-apple-darwin", "x86_64"],
+      ["aarch64-apple-darwin", "arm64"],
+    ]) {
+      expect(helper.stage(target)).toEqual({ architectures: [arch], reused: false });
+      expect(helper.initialize()).toEqual([
+        expect.objectContaining({ id: 1, result: expect.objectContaining({ serverInfo: expect.objectContaining({ name: "openwork-computer-use" }) }) }),
+        expect.objectContaining({ id: 2, result: expect.objectContaining({ tools: expect.any(Array) }) }),
+      ]);
+      expect(helper.stage(target)).toEqual({ architectures: [arch], reused: true });
+      evidence.recordAssertionEvidence(
+        `${arch} helper starts and answers MCP`,
+        `The ${target} helper contains only ${arch}, replaces the previous architecture, answers initialize and tools/list, and is reused only on the next same-target preparation.`,
+        true,
+      );
+    }
+  } finally {
+    helper.close();
+  }
+});

--- a/evals/worlds/computer-use-helper.ts
+++ b/evals/worlds/computer-use-helper.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { needs, SkipError } from "@openwork/env";
+
+// Exercise the shipped helper's MCP process, without requesting TCC permissions
+// or sending input to any app. Packaging is setup, not the assertion boundary.
+export function computerUseHelper() {
+  needs({ placement: "local" });
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new SkipError("Apple Silicon macOS host with Rosetta for both helper architectures");
+  }
+  needs({ commands: ["swift"] });
+  if (spawnSync("/usr/bin/arch", ["-x86_64", "/usr/bin/true"], { timeout: 10_000 }).status !== 0) {
+    throw new SkipError("Rosetta to execute the Intel helper on Apple Silicon");
+  }
+  const scratch = mkdtempSync(join(tmpdir(), "computer-use-helper-"));
+  const script = resolve(import.meta.dirname, "../../apps/desktop/scripts/prepare-computer-use-helper.mjs");
+  const executable = join(scratch, "OpenWork Computer Use.app", "Contents", "MacOS", "ComputerUse");
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) =>
+    !["TARGET", "TAURI_ENV_TARGET_TRIPLE", "CARGO_CFG_TARGET_TRIPLE", "OPENWORK_COMPUTER_USE_FORCE_BUILD", "OPENWORK_COMPUTER_USE_SIGN_IDENTITY"].includes(key),
+  ));
+  return {
+    stage(target: string) {
+      const result = spawnSync(process.execPath, [script, "--outdir", scratch], {
+        env: { ...inherited, TARGET: target, OPENWORK_COMPUTER_USE_SIGN_IDENTITY: "-" },
+        encoding: "utf8", timeout: 180_000,
+      });
+      if (result.status !== 0) throw new Error(`Helper staging failed for ${target} (status ${result.status})`);
+      const architectures = spawnSync("lipo", ["-archs", executable], { encoding: "utf8", timeout: 10_000 });
+      if (architectures.status !== 0) throw new Error("Cannot inspect staged helper architecture");
+      return { architectures: architectures.stdout.trim().split(/\s+/), reused: result.stdout.includes('"skipped": true') };
+    },
+    initialize() {
+      const requests = [
+        { jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "packaging-journey", version: "1" } } },
+        { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      ];
+      const result = spawnSync(executable, ["mcp"], { input: requests.map((request) => JSON.stringify(request)).join("\n") + "\n", encoding: "utf8", timeout: 20_000 });
+      if (result.status !== 0) throw new Error(`Helper MCP startup failed (status ${result.status})`);
+      return result.stdout.trim().split("\n").map((line): unknown => JSON.parse(line));
+    },
+    close() { rmSync(scratch, { recursive: true, force: true }); },
+  };
+}


### PR DESCRIPTION
An Intel macOS release built on Apple Silicon could bundle an ARM-only Computer Use helper and fail with “bad CPU type.” This reproduces on dev at `85a5dfccb4d74732593628ab4cc8912f8b88283d`: requesting `TARGET=x86_64-apple-darwin` produced an `arm64` executable.

The helper now uses the release target for both Swift compilation and executable lookup. Cached helpers are reused only when they contain the requested architecture. The final packaging hook also checks the actual Electron target, including numeric builder architecture values and universal packages, before signing; stale or incompatible artifacts stop packaging.

Fixes #4266. Inspected #4463: it replaces the native implementation but retains the host-only build and cache behavior. This fix leaves the native implementation unchanged; its packaging changes also apply to that replacement.

### Verification

Final head: `f772b122ba2e11e2d2926f19310bb5f453ed0f2a`. [Published native MCP assertion evidence](https://github.com/different-ai/openwork/pull/4512#issuecomment-5553734467).

- `pnpm evals:pr specs/computer-use-helper.test.ts` — Passed, 1 passed / 0 failed / 0 skipped. Printed placement: `placement: local (native macOS helper MCP boundary)`. Builds ARM → Intel → ARM into the same helper directory, verifies each architecture, starts each real helper through MCP initialize/tools/list, and checks same-target cache reuse.
- `node --test apps/desktop/electron/after-pack-paths.test.mjs` — 4 passed / 0 failed / 0 skipped. Real Mach-O fixtures cover wrong-CPU rejection, missing helpers, numeric and named targets, and universal slices.
- `pnpm --filter @openwork/desktop typecheck:electron` and `git diff --check` — passed.
- `node evals/scripts/spec-boundary-ratchet.mjs` — exit 1 with identical output on this branch and a clean control at `85a5dfccb4d74732593628ab4cc8912f8b88283d`. First failure: `bench-opencode-engines.test.ts: imports product source (../../apps/...)`. Existing violations are in the engine benchmark/preview/routing specs; the new native MCP boundary spec adds no violations.

The native journey uses Apple Silicon with Rosetta to execute the Intel binary. Physical Intel hardware, TCC permission grants, and a signed/notarized DMG are not covered. 

### Final-head GitHub checks

Completed successfully on the final head: [required tests, core regressions and packaged desktop build/smoke](https://github.com/different-ai/openwork/actions/runs/33982734806), [CodeQL](https://github.com/different-ai/openwork/actions/runs/33982732759), [Warden reviews](https://github.com/different-ai/openwork/actions/runs/33982734911), i18n audit, legacy eval guard, and preview deployments. No failed or pending checks remain. Workflow-inapplicable docs/model validation, extended scheduled tests and optional automation checks were skipped and are not counted as passing verification. No merge performed.
