### PR TITLE
Keep the shared model catalog fresh with scheduled validated updates

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -5,6 +5,8 @@
 name: Update Models
 
 on:
+  schedule:
+    - cron: "17 4 * * *"
   workflow_dispatch:
     inputs:
       base_branch:
@@ -18,13 +20,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.base_branch }}
+  group: ${{ github.workflow }}-${{ inputs.base_branch || 'dev' }}
   cancel-in-progress: false
 
 env:
   MODELS_PATH: ee/apps/inference/src/models/base.json
   MODELS_URL: https://models.dev/api.json
-  BASE_BRANCH: ${{ inputs.base_branch }}
+  BASE_BRANCH: ${{ inputs.base_branch || 'dev' }}
   BRANCH_NAME: automation/update-models-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
@@ -51,103 +53,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          node --input-type=module <<'NODE'
-          import { writeFile } from "node:fs/promises"
-
-          const modelsPath = process.env.MODELS_PATH
-          const modelsUrl = process.env.MODELS_URL
-
-          function fail(message) {
-            throw new Error(`Refusing to update ${modelsPath}: ${message}`)
-          }
-
-          function isRecord(value) {
-            return Boolean(value) && typeof value === "object" && !Array.isArray(value)
-          }
-
-          function isStringArray(value) {
-            return Array.isArray(value) && value.every((item) => typeof item === "string")
-          }
-
-          function validateModel(providerId, modelId, model) {
-            if (!isRecord(model)) {
-              fail(`model ${providerId}.${modelId} was not an object`)
-            }
-
-            if (model.id !== modelId) {
-              fail(`model ${providerId}.${modelId} was missing a matching id`)
-            }
-
-            if (typeof model.name !== "string" || model.name.length === 0) {
-              fail(`model ${providerId}.${modelId} was missing a name`)
-            }
-
-            if (!isRecord(model.modalities)) {
-              fail(`model ${providerId}.${modelId} was missing modalities`)
-            }
-
-            if (!isStringArray(model.modalities.input) || model.modalities.input.length === 0) {
-              fail(`model ${providerId}.${modelId} was missing input modalities`)
-            }
-
-            if (!isStringArray(model.modalities.output) || model.modalities.output.length === 0) {
-              fail(`model ${providerId}.${modelId} was missing output modalities`)
-            }
-
-            if (!isRecord(model.limit)) {
-              fail(`model ${providerId}.${modelId} was missing limits`)
-            }
-          }
-
-          const response = await fetch(modelsUrl, {
-            headers: { accept: "application/json" },
-          })
-
-          if (!response.ok) {
-            fail(`GET ${modelsUrl} returned ${response.status} ${response.statusText}`)
-          }
-
-          const body = await response.text()
-          let parsed
-          try {
-            parsed = JSON.parse(body)
-          } catch (error) {
-            fail(error instanceof Error ? error.message : "response was not valid JSON")
-          }
-
-          if (!isRecord(parsed)) {
-            fail("response was not a JSON object")
-          }
-
-          const providers = Object.entries(parsed)
-          if (providers.length === 0) {
-            fail("response did not include any providers")
-          }
-
-          for (const [providerId, provider] of providers) {
-            if (!isRecord(provider)) {
-              fail(`provider ${providerId} was not an object`)
-            }
-
-            if (provider.id !== providerId) {
-              fail(`provider ${providerId} was missing a matching id`)
-            }
-
-            if (typeof provider.name !== "string" || provider.name.length === 0) {
-              fail(`provider ${providerId} was missing a name`)
-            }
-
-            if (!isRecord(provider.models) || Object.keys(provider.models).length === 0) {
-              fail(`provider ${providerId} did not include models`)
-            }
-
-            for (const [modelId, model] of Object.entries(provider.models)) {
-              validateModel(providerId, modelId, model)
-            }
-          }
-
-          await writeFile(modelsPath, `${JSON.stringify(parsed)}\n`)
-          NODE
+          node ee/apps/inference/scripts/update-models.mjs
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -50,6 +50,7 @@ jobs:
           node-version: 24
 
       - name: Download and validate models
+        id: catalog
         run: |
           set -euo pipefail
 
@@ -100,7 +101,7 @@ jobs:
             --base "$BASE_BRANCH" \
             --head "$BRANCH_NAME" \
             --title "chore: update models snapshot" \
-            --body "Updates \`$MODELS_PATH\` from \`$MODELS_URL\`.\n\nThe workflow validated the response before replacing the file and wrote the snapshot as minified JSON.")"
+            --body "Updates \`$MODELS_PATH\` from \`$MODELS_URL\`.\n\nThe workflow validated the response before replacing the file and wrote the snapshot as minified JSON. Automatic approval is allowed only when provider and model routing are unchanged; otherwise human review is required.")"
           {
             echo "pr_url=$pr_url"
             echo "pr_number=$(gh pr view "$pr_url" --json number --jq .number)"
@@ -108,7 +109,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Mint approval token
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.changes.outputs.changed == 'true' && steps.catalog.outputs.safe_to_approve == 'true'
         id: app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
@@ -116,7 +117,7 @@ jobs:
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
 
       - name: Approve snapshot update
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.changes.outputs.changed == 'true' && steps.catalog.outputs.safe_to_approve == 'true'
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           REPO: ${{ github.repository }}
@@ -145,7 +146,7 @@ jobs:
             -f body="$BODY"
 
       - name: Enable auto-merge
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.changes.outputs.changed == 'true' && steps.catalog.outputs.safe_to_approve == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_URL: ${{ steps.pr.outputs.pr_url }}

--- a/docs/model-catalog-freshness.md
+++ b/docs/model-catalog-freshness.md
@@ -1,0 +1,52 @@
+# Model catalog freshness
+
+OpenWork keeps the shared `models.openworklabs.com` mirror. Both managed engine
+lanes use it through `resolveOpencodeModelsUrl`; an explicit catalog override
+and the development inference server retain priority. Provider credentials and
+OpenWork's curated managed-model overlay are unchanged.
+
+The Update Models workflow runs daily at 04:17 UTC and still accepts manual
+runs against an explicit base branch. Scheduled runs target `dev`. Both kinds
+of run use the same concurrency group for that branch. The updater validates
+an entire upstream response before replacing the snapshot; an unchanged
+response produces no diff. Updates continue through the existing snapshot PR,
+required checks, approval and deployment process. This is eventual freshness,
+not an instant or guaranteed daily deployment: GitHub scheduling, checks,
+merge gates, and the catalog site's deployment must succeed.
+
+## Investigation of #4035
+
+At dev `85a5dfccb`, the Go catalog's identifiers and metadata match models.dev.
+The snapshot refresh in #4340 restored the reported additions. A fresh isolated
+cache with the pinned v1.18.18 engine and the production mirror exposes
+GLM-5.3 and GLM-5.3 Flash after `models opencode-go --refresh`. The engine filters
+out deprecated entries, including the snapshot's ox-alpha entry. Discovery was
+tested with a synthetic credential; no generation or paid account access was
+tested. A model's presence cannot establish account-specific availability.
+
+The recurrent problem remained: snapshot updates required manual dispatch and
+the broader mirror already differed from upstream. #4112 was closed unmerged
+because bypassing the shared mirror was unwanted. This change automates the
+existing refresh flow instead. #4471 changes managed inference capabilities
+and settlement; #4388 and #4489 add v2 and organization-provider behavior.
+None schedules this mirror's refresh.
+
+The pinned engine versions are v1.18.18 and v2 0.0.0-beta-19086. In upstream
+v1.18.18, `packages/core/src/models-dev.ts` keys disk caches by catalog URL,
+checks a five-minute disk freshness window, refreshes on startup and hourly,
+and invalidates its in-memory catalog after refresh. OpenWork's picker query
+cache is five minutes; reconnecting cannot make an unchanged mirror newer.
+This patch changes neither engine nor picker cache policy, and does not
+certify v2 cache timing or existing installed clients.
+
+## Verification
+
+`pnpm evals:pr specs/model-catalog-refresh.test.ts` drives the production updater
+CLI against a loopback HTTP catalog. Synthetic successive snapshots prove
+additions and removals, retained metadata, unchanged output on repeated refresh,
+and preservation of valid output after empty, invalid, or failed responses.
+The world owns temporary output; it never writes the repository snapshot.
+No existing journey covered the snapshot publication boundary, so this is a
+new journey. It does not dispatch a production workflow or prove a live merge
+or deployment. Scheduled dispatch can only be observed after this workflow
+lands on the default branch.

--- a/docs/model-catalog-freshness.md
+++ b/docs/model-catalog-freshness.md
@@ -10,7 +10,10 @@ runs against an explicit base branch. Scheduled runs target `dev`. Both kinds
 of run use the same concurrency group for that branch. The updater validates
 an entire upstream response before replacing the snapshot; an unchanged
 response produces no diff. Updates continue through the existing snapshot PR,
-required checks, approval and deployment process. This is eventual freshness,
+required checks and deployment process. Automatic approval and auto-merge are
+withheld when provider metadata or a model routing override changes, when a
+provider is added or removed, or when no baseline exists. Those snapshots
+remain reviewable PRs requiring human approval. This is eventual freshness,
 not an instant or guaranteed daily deployment: GitHub scheduling, checks,
 merge gates, and the catalog site's deployment must succeed.
 
@@ -44,7 +47,8 @@ certify v2 cache timing or existing installed clients.
 `pnpm evals:pr specs/model-catalog-refresh.test.ts` drives the production updater
 CLI against a loopback HTTP catalog. Synthetic successive snapshots prove
 additions and removals, retained metadata, unchanged output on repeated refresh,
-and preservation of valid output after empty, invalid, or failed responses.
+preservation of valid output after empty, invalid, or failed responses, and
+mandatory human review for changed provider routing or credential mappings.
 The world owns temporary output; it never writes the repository snapshot.
 No existing journey covered the snapshot publication boundary, so this is a
 new journey. It does not dispatch a production workflow or prove a live merge

--- a/ee/apps/inference/scripts/update-models.mjs
+++ b/ee/apps/inference/scripts/update-models.mjs
@@ -1,0 +1,96 @@
+import { writeFile } from "node:fs/promises"
+
+const modelsPath = process.env.MODELS_PATH
+const modelsUrl = process.env.MODELS_URL
+
+function fail(message) {
+  throw new Error(`Refusing to update ${modelsPath}: ${message}`)
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function isStringArray(value) {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function validateModel(providerId, modelId, model) {
+  if (!isRecord(model)) {
+    fail(`model ${providerId}.${modelId} was not an object`)
+  }
+
+  if (model.id !== modelId) {
+    fail(`model ${providerId}.${modelId} was missing a matching id`)
+  }
+
+  if (typeof model.name !== "string" || model.name.length === 0) {
+    fail(`model ${providerId}.${modelId} was missing a name`)
+  }
+
+  if (!isRecord(model.modalities)) {
+    fail(`model ${providerId}.${modelId} was missing modalities`)
+  }
+
+  if (!isStringArray(model.modalities.input) || model.modalities.input.length === 0) {
+    fail(`model ${providerId}.${modelId} was missing input modalities`)
+  }
+
+  if (!isStringArray(model.modalities.output) || model.modalities.output.length === 0) {
+    fail(`model ${providerId}.${modelId} was missing output modalities`)
+  }
+
+  if (!isRecord(model.limit)) {
+    fail(`model ${providerId}.${modelId} was missing limits`)
+  }
+}
+
+const response = await fetch(modelsUrl, {
+  headers: { accept: "application/json" },
+  signal: AbortSignal.timeout(30_000),
+})
+
+if (!response.ok) {
+  fail(`GET ${modelsUrl} returned ${response.status} ${response.statusText}`)
+}
+
+const body = await response.text()
+let parsed
+try {
+  parsed = JSON.parse(body)
+} catch (error) {
+  fail(error instanceof Error ? error.message : "response was not valid JSON")
+}
+
+if (!isRecord(parsed)) {
+  fail("response was not a JSON object")
+}
+
+const providers = Object.entries(parsed)
+if (providers.length === 0) {
+  fail("response did not include any providers")
+}
+
+for (const [providerId, provider] of providers) {
+  if (!isRecord(provider)) {
+    fail(`provider ${providerId} was not an object`)
+  }
+
+  if (provider.id !== providerId) {
+    fail(`provider ${providerId} was missing a matching id`)
+  }
+
+  if (typeof provider.name !== "string" || provider.name.length === 0) {
+    fail(`provider ${providerId} was missing a name`)
+  }
+
+  if (!isRecord(provider.models) || Object.keys(provider.models).length === 0) {
+    fail(`provider ${providerId} did not include models`)
+  }
+
+  for (const [modelId, model] of Object.entries(provider.models)) {
+    validateModel(providerId, modelId, model)
+  }
+}
+
+await writeFile(modelsPath, `${JSON.stringify(parsed)}\n`)

--- a/ee/apps/inference/scripts/update-models.mjs
+++ b/ee/apps/inference/scripts/update-models.mjs
@@ -1,4 +1,6 @@
-import { writeFile } from "node:fs/promises"
+import { appendFile, readFile, writeFile } from "node:fs/promises"
+
+import { isDeepStrictEqual } from "node:util"
 
 const modelsPath = process.env.MODELS_PATH
 const modelsUrl = process.env.MODELS_URL
@@ -93,4 +95,32 @@ for (const [providerId, provider] of providers) {
   }
 }
 
+// Catalog routing controls where credentials are sent. Unattended refreshes
+// may update model metadata, but new providers or changed routing need review.
+function sameRouting(previous, next) {
+  if (!isRecord(previous)) return false
+  if (!isDeepStrictEqual(Object.keys(previous).sort(), Object.keys(next).sort())) return false
+  for (const [id, provider] of Object.entries(next)) {
+    const old = previous[id]
+    if (!isRecord(old) || !isRecord(old.models)) return false
+    const { models: _oldModels, ...oldProvider } = old
+    const { models: _newModels, ...newProvider } = provider
+    if (!isDeepStrictEqual(oldProvider, newProvider)) return false
+    for (const [modelId, model] of Object.entries(provider.models)) {
+      if (!isDeepStrictEqual(old.models[modelId]?.provider, model.provider)) return false
+    }
+  }
+  return true
+}
+
+let previous
+try {
+  previous = JSON.parse(await readFile(modelsPath, "utf8"))
+} catch {
+  // Without a trusted baseline, require review of the proposed snapshot.
+}
+const safeToApprove = sameRouting(previous, parsed)
 await writeFile(modelsPath, `${JSON.stringify(parsed)}\n`)
+if (process.env.GITHUB_OUTPUT) {
+  await appendFile(process.env.GITHUB_OUTPUT, `safe_to_approve=${safeToApprove}\n`)
+}

--- a/evals/specs/model-catalog-refresh.test.ts
+++ b/evals/specs/model-catalog-refresh.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { modelCatalogRefresh } from "../worlds/model-catalog-refresh.ts";
+
+const test = spec.world(modelCatalogRefresh, { timeout: 60_000 });
+
+function catalog(ids: string[]) {
+  return {
+    "fixture-provider": {
+      id: "fixture-provider",
+      name: "Fixture provider",
+      models: Object.fromEntries(ids.map((id) => [id, {
+        id, name: id,
+        modalities: { input: ["text"], output: ["text"] },
+        limit: { context: 8192, output: 1024 },
+      }])),
+    },
+  };
+}
+
+test("catalog refresh replaces retired models, keeps unchanged models, and rejects bad upstream responses", async ({ world, evidence }) => {
+  expect(await world.refresh(catalog(["retired", "retained"]))).toBe(true);
+  const next = catalog(["new-model", "retained"]);
+  expect(await world.refresh(next)).toBe(true);
+  const saved = await world.snapshot();
+  expect(JSON.parse(saved)).toEqual(next);
+  expect(saved).not.toContain("retired");
+  evidence.recordAssertionEvidence(
+    "A valid upstream snapshot adds new models and removes retired models while preserving retained metadata",
+    "Two real updater processes fetched successive HTTP catalogs. The saved snapshot equals the second catalog exactly; the retired identifier is absent.", true,
+  );
+  expect(await world.refresh(next)).toBe(true);
+  expect(await world.snapshot()).toBe(saved);
+  evidence.recordAssertionEvidence("An unchanged catalog produces no snapshot diff", "A third refresh produced identical bytes.", true);
+
+  for (const [payload, status] of [[{}, 200], [catalog([]), 200], [next, 503], [{ broken: true }, 200]] as const) {
+    expect(await world.refresh(payload, status)).toBe(false);
+    expect(await world.snapshot()).toBe(saved);
+  }
+  expect(world.requests()).toBe(7);
+  evidence.recordAssertionEvidence(
+    "An empty, malformed, or unavailable upstream cannot replace the last valid snapshot",
+    "All four rejected responses left the saved catalog byte-for-byte unchanged; all seven attempts reached the HTTP boundary.", true,
+  );
+});

--- a/evals/specs/model-catalog-refresh.test.ts
+++ b/evals/specs/model-catalog-refresh.test.ts
@@ -20,8 +20,10 @@ function catalog(ids: string[]) {
 
 test("catalog refresh replaces retired models, keeps unchanged models, and rejects bad upstream responses", async ({ world, evidence }) => {
   expect(await world.refresh(catalog(["retired", "retained"]))).toBe(true);
+  expect(await world.automaticApproval()).toBe(false);
   const next = catalog(["new-model", "retained"]);
   expect(await world.refresh(next)).toBe(true);
+  expect(await world.automaticApproval()).toBe(true);
   const saved = await world.snapshot();
   expect(JSON.parse(saved)).toEqual(next);
   expect(saved).not.toContain("retired");
@@ -41,5 +43,25 @@ test("catalog refresh replaces retired models, keeps unchanged models, and rejec
   evidence.recordAssertionEvidence(
     "An empty, malformed, or unavailable upstream cannot replace the last valid snapshot",
     "All four rejected responses left the saved catalog byte-for-byte unchanged; all seven attempts reached the HTTP boundary.", true,
+  );
+  const routingChanges = [
+    { ...next, "new-provider": { ...next["fixture-provider"], id: "new-provider" } },
+    { "fixture-provider": { ...next["fixture-provider"], api: "https://routing.example.test" } },
+    { "fixture-provider": { ...next["fixture-provider"], env: ["FIXTURE_CHANGED_KEY"] } },
+    { "fixture-provider": { ...next["fixture-provider"], npm: "fixture-adapter" } },
+    { "fixture-provider": { ...next["fixture-provider"], models: {
+      ...next["fixture-provider"].models,
+      "new-model": { ...next["fixture-provider"].models["new-model"], provider: { api: "https://routing.example.test" } },
+    } } },
+  ];
+  for (const changed of routingChanges) {
+    expect(await world.refresh(next)).toBe(true);
+    expect(await world.refresh(changed)).toBe(true);
+    expect(JSON.parse(await world.snapshot())).toEqual(changed);
+    expect(await world.automaticApproval()).toBe(false);
+  }
+  evidence.recordAssertionEvidence(
+    "New providers and changed endpoints, credential mappings, adapters, or model routing require human review",
+    "Five structurally valid routing changes produced reviewable snapshots but each emitted safe_to_approve=false. A missing baseline also required review; ordinary model additions and removals emitted true.", true,
   );
 });

--- a/evals/worlds/model-catalog-refresh.ts
+++ b/evals/worlds/model-catalog-refresh.ts
@@ -31,7 +31,7 @@ export async function modelCatalogRefresh(seed: Seed) {
       try {
         await run(process.execPath, [updater], {
           cwd: root,
-          env: { ...process.env, MODELS_URL: `${url}/api.json`, MODELS_PATH: destination },
+          env: { ...process.env, MODELS_URL: `${url}/api.json`, MODELS_PATH: destination, GITHUB_OUTPUT: join(root, "outputs") },
           timeout: 40_000,
         });
         return true;
@@ -39,6 +39,7 @@ export async function modelCatalogRefresh(seed: Seed) {
         return false;
       }
     },
+    automaticApproval: async () => (await readFile(join(root, "outputs"), "utf8")).trim().split("\n").at(-1) === "safe_to_approve=true",
     snapshot: () => readFile(destination, "utf8"),
     requests: () => requests,
     async [Symbol.asyncDispose]() { await close(upstream); },

--- a/evals/worlds/model-catalog-refresh.ts
+++ b/evals/worlds/model-catalog-refresh.ts
@@ -1,0 +1,46 @@
+import { execFile } from "node:child_process";
+import { mkdir, readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import type { Seed } from "@openwork/env";
+import { close, listen, sendJson } from "./openwork-server-cli.ts";
+
+const run = promisify(execFile);
+const updater = resolve(import.meta.dirname, "../../ee/apps/inference/scripts/update-models.mjs");
+
+// Exercise the same updater CLI that the scheduled workflow runs. Only the
+// upstream HTTP catalog is a fixture; snapshot validation/replacement is real.
+export async function modelCatalogRefresh(seed: Seed) {
+  const root = seed.tmpPath("model-catalog-refresh");
+  await mkdir(root, { recursive: true });
+  const destination = join(root, "base.json");
+  let payload: unknown = {};
+  let status = 200;
+  let requests = 0;
+  const upstream = createServer((request, response) => {
+    if (request.url !== "/api.json") return sendJson(response, 404, {});
+    requests++;
+    sendJson(response, status, payload);
+  });
+  const url = await listen(upstream);
+  return {
+    async refresh(next: unknown, responseStatus = 200) {
+      payload = next;
+      status = responseStatus;
+      try {
+        await run(process.execPath, [updater], {
+          cwd: root,
+          env: { ...process.env, MODELS_URL: `${url}/api.json`, MODELS_PATH: destination },
+          timeout: 40_000,
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    snapshot: () => readFile(destination, "utf8"),
+    requests: () => requests,
+    async [Symbol.asyncDispose]() { await close(upstream); },
+  };
+}


### PR DESCRIPTION
OpenWork's shared model mirror only advanced after a manual refresh, so catalog changes could remain unavailable indefinitely. Schedule the existing validated snapshot flow daily at 04:17 UTC, targeting `dev` when no manual input exists and sharing concurrency with manual runs.

The updater is extracted into a directly executable script with a 30-second fetch timeout so its HTTP-to-snapshot behavior can be verified. Automatic approval and auto-merge are withheld for provider metadata or model routing changes, added/removed providers, or a missing baseline; those updates remain reviewable PRs requiring human approval. No model list is hardcoded. Engine versions, cache policy, provider credentials, the managed-model overlay, and deployment behavior are unchanged.

Relates to #4035. #4340 restored the specifically reported Go additions: today's Go mirror matches upstream, and pinned v1.18.18 exposes GLM-5.3 and GLM-5.3 Flash after refresh while filtering deprecated entries. The recurring freshness gap remained. #4112 was closed in favor of keeping the mirror; #4471 and merged v2 work do not automate it. Investigation and limits: `docs/model-catalog-freshness.md`.

## Verification

- `pnpm --config.verify-deps-before-run=false --dir evals run test:pr specs/model-catalog-refresh.test.ts`: one runtime journey, four recorded assertions, zero failures and zero skips on final head `8efea4aab55c26c42bfb2ec5d693e0410ba25e54`. This is the same explicit PR lane as `pnpm evals:pr`; automatic dependency installation was disabled to reuse existing dependencies during disk pressure. The real updater fetches synthetic HTTP catalogs; assertions cover added/retired/retained models, idempotence, preservation of the valid snapshot after rejected responses, and refusal to auto-approve routing changes. The explicit PR lane runs locally and does not print an E2E placement banner. Commit-bound evidence is published below.
- Workflow syntax validated with `actionlint`, allowing only the existing custom Blacksmith runner label. `git diff --check` passes.
- Repository boundary ratchet is **Failed, pre-existing**: the exact command `node evals/scripts/spec-boundary-ratchet.mjs` exits 1 on both this branch and a clean control at `85a5dfccb`. The same five v2 specs violate the boundary policy; this new journey does not. No baseline exceptions were added.
- Final-head GitHub verification completed on `8efea4aab55c26c42bfb2ec5d693e0410ba25e54`: required tests, core tests/build, all service image builds, CodeQL, confidentiality, security and spec-provenance checks passed. No failed or pending checks remain. Conditional snapshot/docs validation, extended tests and automatic approval were skipped, not counted as passed; the Vercel advisory and inapplicable Desktop/Den review are neutral. The local boundary-ratchet failure remains separately disclosed above.

The test does not dispatch, merge, or deploy production updates. Scheduled dispatch becomes active only after landing on the default branch; scheduling, snapshot PR gates and site deployment can delay availability. Paid generation and account-specific access were not tested. No PR is merged by this work.
