### PR TITLE
fix(connectors): explain Slack MCP readiness before authorization

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-presets.ts
@@ -79,7 +79,7 @@ export const EXTERNAL_MCP_PRESETS: ExternalMcpPreset[] = [
   {
     presetId: "slack",
     displayName: "Slack",
-    description: "Channels, DMs, and search. Slack has no automatic app registration — paste your Slack app's OAuth client once; each person then connects their own account.",
+    description: "Channels, DMs, and search. Enable Slack Model Context Protocol (MCP) Server in your Slack app’s Agents settings, then add its OAuth client. Each person authorizes their own account; OAuth authorization alone does not make MCP ready.",
     url: "https://mcp.slack.com/mcp",
     authType: "oauth",
     requiresOAuthClient: true,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -2830,6 +2830,16 @@ function AddConnectionDialog({
               <p className="mt-1 text-[12px] leading-5 text-gray-500">
                 Register this Den instance's redirect URL with the provider, then add its credentials here.
               </p>
+              {preset?.presetId === "slack" ? (
+                <p className="mt-2 text-[12px] leading-5 text-gray-600">
+                  In your Slack app’s Agents settings, turn on Slack Model Context Protocol (MCP) Server before connecting.
+                  OAuth authorization alone does not make MCP ready. If sign-in succeeds but tool initialization fails,
+                  ask your Slack app admin to check this setting, then retry loading tools.{" "}
+                  <Link href="https://docs.slack.dev/ai/slack-mcp-server/developing/" target="_blank" rel="noreferrer" className="underline underline-offset-2">
+                    Slack setup guide
+                  </Link>
+                </p>
+              ) : null}
               <div className="mt-3 space-y-3">
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID (optional for now)</label>

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -59,6 +59,10 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await webUser.see({ text: "OAuth app" }, { timeoutMs: 90_000 });
   await webUser.see({ text: "Client ID (optional for now)" });
   await webUser.see({ text: "Client secret (optional for now)" });
+  await webUser.see({ text: /In your Slack app’s Agents settings, turn on Slack Model Context Protocol/ });
+  await webUser.see({ text: /OAuth authorization alone does not make MCP ready/ });
+  await webUser.see({ text: /ask your Slack app admin to check this setting, then retry loading tools/ });
+  evidence.recordAssertionEvidence("Slack setup explains MCP readiness before authorization", "The OAuth form shows the Agents prerequisite and recovery guidance without authorizing an account.", true);
   await webUser.screenshot();
   const calls = await world.den.mocks.connector.agentRequests({ promptMarker: connectorCatalogPrompt });
   expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);

--- a/evals/specs/connector-search-intent.test.ts
+++ b/evals/specs/connector-search-intent.test.ts
@@ -79,6 +79,10 @@ test("gateway discovery stays quiet until connection setup is explicitly request
   expect(catalog.selectedIds).toEqual(["slack"]);
   expect(slack.payload.connectionAction).toBeUndefined();
   const entries = rows(catalog.entries);
+  expect(entries.find(entry => entry.id === "slack")?.description).toContain("Agents settings");
+  expect(entries.find(entry => entry.id === "slack")?.description).toContain("OAuth authorization alone does not make MCP ready");
+  expect(entries.find(entry => entry.id === "linear")?.description).not.toContain("Agents settings");
+  evidence.recordAssertionEvidence("Slack catalog setup distinguishes authorization from MCP readiness", "Slack describes the Agents prerequisite and OAuth distinction; Linear does not receive Slack guidance.", true);
   const ids = entries.map(entry => entry.id);
   expect(ids).toHaveLength(12);
   expect(new Set(ids).size).toBe(12);

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -130,7 +130,7 @@ Use this table to pick scopes by capability:
 
 ### Troubleshooting Slack
 
-If members cannot connect even though the client ID and secret are correct, check that MCP is enabled for the Slack app: open it in [Slack API apps](https://api.slack.com/apps), go to the `Agents` tab, and turn on the `MCP` toggle.
+OAuth authorization and MCP readiness are separate: successful sign-in does not mean Slack can initialize its MCP server. If sign-in succeeds but tool initialization fails, ask the Slack app admin to open the app in [Slack API apps](https://api.slack.com/apps), go to `Agents`, and turn on `Slack Model Context Protocol (MCP) Server`, then retry loading tools in OpenWork. This is a prerequisite to check, not proof that every initialization failure is caused by the toggle. See [Slack’s setup guide](https://docs.slack.dev/ai/slack-mcp-server/developing/). Never share tokens or client secrets in feedback.
 
 If Slack says the redirect URL is invalid, add this Den instance's OAuth redirect URL to the Slack app's `OAuth & Permissions` redirect URLs. If Slack says a scope is invalid or unavailable, remove it from the Slack app and the connection's scopes, then retry; Slack workspace policies and plan settings can limit which scopes an app may request. If the workspace blocks app installation, a Slack admin must approve the app first.
 


### PR DESCRIPTION
Slack setup currently asks for OAuth credentials without explaining that the Slack app must separately enable MCP. Add the Agents setting prerequisite to the preset and OAuth form, and explain how to recover when sign-in succeeds but tool initialization fails. OAuth success is explicitly separate from MCP readiness; guidance does not diagnose all failures as a disabled toggle.

The existing documentation from #4359/#4367 remains in place with clearer troubleshooting. #4305 is an open catalog UI change and does not supply this prerequisite in the current setup form. Slack primary source: https://docs.slack.dev/ai/slack-mcp-server/developing/.

Verification: **Incomplete** on `59d951f7ab40daf9a5d9a20c97859873d3614b01`. Existing connector-search-intent and connector-catalog journeys were extended. Local execution was blocked by disk pressure; the automatic browser journey awaits protected `pr-slow-specs` approval. Final reported PR checks: 28 passed, 7 skipped, none failed or pending. The separate Daytona journey is still waiting; skipped checks do not prove runtime behavior. [Sanitized verification record](https://github.com/different-ai/openwork/pull/4514#issuecomment-5553761953) includes exact commands, missing proof, and fresh-dev control evidence for unrelated ratchet failures. The PR stays draft until journey proof is complete. All examples and assertions use synthetic data. No source messages were accessed. This change supplies setup and troubleshooting guidance; it does not change provider-error classification or OAuth state.
