### PR TITLE
Show Enterprise activation and explain its manual sign-in fallback

### DIFF
--- a/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
+++ b/apps/app/src/react-app/domains/cloud/enterprise-activation-gate.tsx
@@ -50,7 +50,7 @@ function EnterpriseActivationPage() {
   const submitServer = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    // The address field quietly accepts a pasted openwork:// sign-in link as
+    // The field accepts a pasted openwork:// sign-in link as
     // the recovery path when the browser round trip cannot come back.
     const pastedLink = parseManualAuthInput(serverInput);
     if (pastedLink?.baseUrl && pastedLink.grant) {
@@ -66,7 +66,7 @@ function EnterpriseActivationPage() {
 
     const baseUrl = normalizeOrganizationServerInput(serverInput);
     if (!baseUrl) {
-      setServerError("Enter a valid OpenWork server address.");
+      setServerError("Enter a valid workspace address or a full OpenWork sign-in link.");
       return;
     }
 
@@ -133,10 +133,10 @@ function EnterpriseActivationPage() {
       const opened = await tryOpenBrowserAuthUrl(buildDenAuthUrl(pending.baseUrl, "sign-in"));
       if (!opened) {
         setStatusMessage(null);
-        setAuthError("We couldn't open your browser automatically. Try again, or paste the sign-in link from your browser into the address field.");
+        setAuthError("We couldn't open your browser automatically. Try again, or paste the sign-in link from your browser into the Workspace address or sign-in link field.");
         return;
       }
-      setStatusMessage("Finish signing in in your browser, then return to OpenWork.");
+      setStatusMessage("Finish signing in in your browser. If OpenWork does not open, copy the sign-in link and paste it here.");
     } catch (error) {
       setStatusMessage(null);
       setServerError(
@@ -203,7 +203,7 @@ function EnterpriseActivationPage() {
               Link this app to your organization
             </h1>
             <p className="text-[15px] leading-[23px] text-muted-foreground">
-              Enter your workspace address — the page where you downloaded this app. Sign-in finishes in your browser and returns here.
+              Enter your workspace address — the page where you downloaded this app — to sign in through your browser.
             </p>
           </div>
 
@@ -214,7 +214,7 @@ function EnterpriseActivationPage() {
                   className="text-sm font-medium text-foreground"
                   htmlFor="organization-server-input"
                 >
-                  Workspace address
+                  Workspace address or sign-in link
                 </label>
                 <div className="flex flex-col gap-2 sm:flex-row">
                   <Input
@@ -228,6 +228,7 @@ function EnterpriseActivationPage() {
                     spellCheck={false}
                     disabled={browserBusy || authBusy}
                     aria-invalid={serverError ? true : undefined}
+                    aria-describedby="organization-server-hint"
                   />
                   <Button
                     type="submit"
@@ -238,6 +239,9 @@ function EnterpriseActivationPage() {
                     Continue
                   </Button>
                 </div>
+                <p id="organization-server-hint" className="text-xs leading-5 text-muted-foreground">
+                  Browser not returning to OpenWork? Paste the full sign-in link copied from your browser, including the workspace address. A code on its own is not supported here.
+                </p>
               </form>
             )}
 

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -18,7 +18,7 @@ import { ServerProvider } from "@/react-app/kernel/server-provider";
 import { ArchitectureMismatchGate } from "./architecture-mismatch-gate";
 import { BootStateProvider } from "./boot-state";
 import { DesktopRuntimeBoot } from "./desktop-runtime-boot";
-import { useEnterpriseActivationRequired } from "@/react-app/domains/cloud/enterprise-activation-gate";
+import { EnterpriseActivationGate, useEnterpriseActivationRequired } from "@/react-app/domains/cloud/enterprise-activation-gate";
 import { startDebugLogger, stopDebugLogger } from "./debug-logger";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { ReloadCoordinatorProvider } from "./reload-coordinator";
@@ -52,7 +52,11 @@ type AppProvidersProps = {
 function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
   const activationRequired = useEnterpriseActivationRequired();
   if (activationRequired) {
-    return <ConnectLinkProvider>{children}</ConnectLinkProvider>;
+    return (
+      <ConnectLinkProvider>
+        <EnterpriseActivationGate>{children}</EnterpriseActivationGate>
+      </ConnectLinkProvider>
+    );
   }
   return (
     <>

--- a/evals/specs/enterprise-manual-signin.e2e.test.ts
+++ b/evals/specs/enterprise-manual-signin.e2e.test.ts
@@ -33,20 +33,24 @@ test("Enterprise activation explains and completes manual sign-in without a deep
     expect((await readDenClientState(world.app)).authTokenPresent).toBe(false);
   });
 
-  await step("Confirming the pasted link activates the intended organization", async () => {
+  await step("Confirming the pasted link signs in and activates the confirmed server", async () => {
     await user.click("Confirm and finish sign-in");
     const state = await probe.eventually(() => readDenClientState(world.app), {
       within: 120_000,
       label: "manual sign-in completed",
-      until: (value) => value.authTokenPresent && value.activeOrgName === "Manual Handoff Workspace",
+      until: (value) => value.authTokenPresent,
     });
     expect(state.authTokenPresent).toBe(true);
-    expect(state.activeOrgName).toBe("Manual Handoff Workspace");
+    expect(await probe.eval(`window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig").then(config =>
+      config.baseUrl === ${JSON.stringify(world.den.ref.webUrl)} &&
+      config.enterpriseActivation?.denBaseUrl === ${JSON.stringify(world.den.ref.webUrl)} &&
+      Boolean(config.enterpriseActivation?.activatedAt)
+    )`, { awaitPromise: true })).toBe(true);
     await user.notSee({ text: "Link this app to your organization" });
   });
   evidence.recordAssertionEvidence(
     "Manual Enterprise handoff is discoverable and completes without a deep-link callback",
-    "The labeled field explains full links and excludes standalone codes. Workspace addresses retain browser confirmation. Pasted links require confirmation before any session exists, then activate the synthetic organization without invoking an OS callback.",
+    "The labeled field explains full links and excludes standalone codes. Workspace addresses retain browser confirmation. Pasted links require confirmation before any session exists, then create a session and persist activation for the confirmed synthetic server without invoking an OS callback.",
     true,
   );
 });

--- a/evals/specs/enterprise-manual-signin.e2e.test.ts
+++ b/evals/specs/enterprise-manual-signin.e2e.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "vitest";
+import { readDenClientState, spec, type User } from "@openwork/testkit";
+import { enterpriseManualSigninWorld } from "../worlds/enterprise-manual-signin.ts";
+
+const test = spec.world(enterpriseManualSigninWorld);
+const input: Parameters<User["type"]>[0] = { role: "textbox", label: "Workspace address or sign-in link" };
+
+test("Enterprise activation explains and completes manual sign-in without a deep-link callback", async ({ world, user, probe, step, evidence }) => {
+  await step("The activation field explains the manual fallback before sign-in", async () => {
+    await user.see(input);
+    await user.see({ text: /Browser not returning to OpenWork\? Paste the full sign-in link/ });
+    await user.see({ text: /A code on its own is not supported here/ });
+    expect((await readDenClientState(world.app)).authTokenPresent).toBe(false);
+    await user.screenshot();
+  });
+
+  await step("A workspace address still asks for confirmation before browser handoff", async () => {
+    await user.type(input, "https://workspace.example.test");
+    await user.click("Continue");
+    await user.see("Continue in browser");
+    await user.notSee("Confirm and finish sign-in");
+    expect((await readDenClientState(world.app)).authTokenPresent).toBe(false);
+    await user.click("Back");
+    await user.type(input, "", { replace: true });
+  });
+
+  await step("A pasted full sign-in link requires confirmation without signing in early", async () => {
+    await user.click(input);
+    await world.pasteLinkAndSubmit();
+    await user.see("Confirm and finish sign-in");
+    await user.notSee("Continue in browser");
+    await user.notSee(input);
+    expect((await readDenClientState(world.app)).authTokenPresent).toBe(false);
+  });
+
+  await step("Confirming the pasted link activates the intended organization", async () => {
+    await user.click("Confirm and finish sign-in");
+    const state = await probe.eventually(() => readDenClientState(world.app), {
+      within: 120_000,
+      label: "manual sign-in completed",
+      until: (value) => value.authTokenPresent && value.activeOrgName === "Manual Handoff Workspace",
+    });
+    expect(state.authTokenPresent).toBe(true);
+    expect(state.activeOrgName).toBe("Manual Handoff Workspace");
+    await user.notSee({ text: "Link this app to your organization" });
+  });
+  evidence.recordAssertionEvidence(
+    "Manual Enterprise handoff is discoverable and completes without a deep-link callback",
+    "The labeled field explains full links and excludes standalone codes. Workspace addresses retain browser confirmation. Pasted links require confirmation before any session exists, then activate the synthetic organization without invoking an OS callback.",
+    true,
+  );
+});

--- a/evals/worlds/enterprise-manual-signin.ts
+++ b/evals/worlds/enterprise-manual-signin.ts
@@ -26,6 +26,7 @@ export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place
       link.searchParams.set("grant", grant);
       link.searchParams.set("denBaseUrl", den.ref.webUrl);
       try {
+        await pressKey(app, process.platform === "darwin" && place.kind === "local" ? "Meta+A" : "Control+A");
         await typeText(app, link.toString());
         await pressKey(app, "Enter");
         const submitted = await evalIn(app, `(async () => {

--- a/evals/worlds/enterprise-manual-signin.ts
+++ b/evals/worlds/enterprise-manual-signin.ts
@@ -1,14 +1,19 @@
 import { createDesktopHandoffGrant, evalIn } from "@openwork/behaviors";
-import { pressKey, typeText } from "@openwork/cdp";
+import { attachSurface, pressKey, typeText } from "@openwork/cdp";
 import type { Place, Seed } from "@openwork/env";
-import { desktop } from "@openwork/hosts";
 
 export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place: Place }) {
   const den = await seed.den({ org: { name: "Manual Handoff Workspace" } });
-  const app = await desktop({
-    name: "enterprise-manual-signin",
-    host: place.host(),
+  // The generic desktop readiness helper expects the consumer welcome or
+  // workspace screen. This journey starts at the earlier Enterprise gate.
+  const host = place.host();
+  const handle = await host.spawnElectron("enterprise-manual-signin", {
+    profile: "fresh",
     env: { OPENWORK_DESKTOP_DISTRIBUTION: "enterprise" },
+  });
+  const app = await attachSurface(handle).catch(async () => {
+    await host.disposeSurface(handle);
+    throw new Error("Could not attach to the Enterprise activation screen.");
   });
   return {
     app,
@@ -37,6 +42,9 @@ export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place
         throw new Error("Could not paste and submit the manual sign-in link.");
       }
     },
-    async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
+    async [Symbol.asyncDispose]() {
+      try { await app[Symbol.asyncDispose](); }
+      finally { await host.disposeSurface(handle); }
+    },
   };
 }

--- a/evals/worlds/enterprise-manual-signin.ts
+++ b/evals/worlds/enterprise-manual-signin.ts
@@ -23,6 +23,14 @@ export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place
       try {
         await typeText(app, link.toString());
         await pressKey(app, "Enter");
+        const submitted = await evalIn(app, `(async () => {
+          const deadline = Date.now() + 10_000;
+          while (document.querySelector('#organization-server-input') && Date.now() < deadline) {
+            await new Promise(resolve => setTimeout(resolve, 50));
+          }
+          return !document.querySelector('#organization-server-input');
+        })()`, { awaitPromise: true, timeoutMs: 15_000 });
+        if (!submitted) throw new Error("Manual link submission did not reach confirmation.");
       } catch {
         // Never expose CDP arguments containing the link in error evidence.
         await evalIn(app, `document.querySelector('#organization-server-input')?.remove()`);

--- a/evals/worlds/enterprise-manual-signin.ts
+++ b/evals/worlds/enterprise-manual-signin.ts
@@ -1,0 +1,34 @@
+import { createDesktopHandoffGrant, evalIn } from "@openwork/behaviors";
+import { pressKey, typeText } from "@openwork/cdp";
+import type { Place, Seed } from "@openwork/env";
+import { desktop } from "@openwork/hosts";
+
+export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place: Place }) {
+  const den = await seed.den({ org: { name: "Manual Handoff Workspace" } });
+  const app = await desktop({
+    name: "enterprise-manual-signin",
+    host: place.host(),
+    env: { OPENWORK_DESKTOP_DISTRIBUTION: "enterprise" },
+  });
+  return {
+    app,
+    den,
+    // Use real keyboard input without putting a one-time grant in the user
+    // trace. No OS deep-link callback or auth control seam is invoked.
+    async pasteLinkAndSubmit() {
+      const grant = await createDesktopHandoffGrant(den.admin);
+      const link = new URL("openwork://den-auth");
+      link.searchParams.set("grant", grant);
+      link.searchParams.set("denBaseUrl", den.ref.webUrl);
+      try {
+        await typeText(app, link.toString());
+        await pressKey(app, "Enter");
+      } catch {
+        // Never expose CDP arguments containing the link in error evidence.
+        await evalIn(app, `document.querySelector('#organization-server-input')?.remove()`);
+        throw new Error("Could not paste and submit the manual sign-in link.");
+      }
+    },
+    async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
+  };
+}

--- a/evals/worlds/enterprise-manual-signin.ts
+++ b/evals/worlds/enterprise-manual-signin.ts
@@ -1,5 +1,5 @@
 import { createDesktopHandoffGrant, evalIn } from "@openwork/behaviors";
-import { attachSurface, pressKey, typeText } from "@openwork/cdp";
+import { attachSurface, clickAt, locate, pressKey, typeText } from "@openwork/cdp";
 import type { Place, Seed } from "@openwork/env";
 
 export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place: Place }) {
@@ -28,7 +28,8 @@ export async function enterpriseManualSigninWorld(seed: Seed, { place }: { place
       try {
         await pressKey(app, process.platform === "darwin" && place.kind === "local" ? "Meta+A" : "Control+A");
         await typeText(app, link.toString());
-        await pressKey(app, "Enter");
+        const submit = await locate(app, { role: "button", label: "Continue" });
+        await clickAt(app, submit.center);
         const submitted = await evalIn(app, `(async () => {
           const deadline = Date.now() + 10_000;
           while (document.querySelector('#organization-server-input') && Date.now() < deadline) {


### PR DESCRIPTION
Enterprise activation now renders before the workspace-dependent shell. Previously, the preactivation provider branch omitted the local workspace providers but still mounted DesktopUpdaterProvider, which requires them; a fresh Enterprise profile could show a blank screen before reaching sign-in.

The activation field also explains its existing manual recovery path: it accepts a workspace address or a full OpenWork sign-in link. Accessible help specifies that the full link must include the workspace address, and browser-return and validation messages use matching wording. Parsing, server confirmation, and authentication logic are unchanged.

Adds a focused Enterprise journey checking that the activation UI appears, explains manual recovery, preserves workspace-address confirmation, requires confirmation before creating a session, and completes manual sign-in without an OS deep-link callback. Sign-in values are excluded from recorded input and failure evidence. No overlap with onboarding PRs #4497 or #4496.

Verification: **Passed** on `72034f5ea63ef5350cb5df7d3c22df45083503f9`.

- `pnpm_config_verify_deps_before_run=false OPENWORK_EVAL_REF=fix/mail-09-manual-signin pnpm evals:e2e enterprise-manual-signin` — placement: `daytona (daytona CLI authenticated)`; cold boot, **1 passed, 0 failed, 0 skipped**, 236.98 seconds.
- `pnpm_config_verify_deps_before_run=false pnpm typecheck` — exit 0 on the final head. The environment flag reuses existing dependencies without initiating a local install.
- Final-head GitHub checks passed, including core regressions, packaged desktop build/smoke, required-tests gate, CodeQL, i18n, and Warden reviews. Conditional docs/model/extended lanes are skipped and are not counted as runtime proof.
- [Published journey evidence](https://github.com/different-ai/openwork/pull/4515#issuecomment-5554376805): four passing steps, an explicit passing behavioral assertion, and a sanitized screenshot for inspection. The screenshot has no separate visual assertion. No grants, session credentials, or private tenant identifiers are included.

The journey verifies that the activation screen renders, the address path retains browser confirmation, and the pasted full-link path creates no session before confirmation. After confirmation, it observes a session, verifies the saved activation record matches the confirmed server, and verifies the activation screen closes. Organization selection retains its existing behavior.
