### PR TITLE
docs(mcp): explain required OAuth resources and cover rejection paths

### DIFF
--- a/docs/mcp-client-oauth.md
+++ b/docs/mcp-client-oauth.md
@@ -1,0 +1,60 @@
+# Connect a third-party MCP client with OAuth
+
+Configure the client with your deployment's `/mcp/agent` endpoint. Public OAuth
+access tokens are intended for this endpoint. Use the deployed URL, including
+any reverse-proxy prefix; do not substitute the web dashboard URL.
+
+## Discovery and setup
+
+1. Send an unauthenticated request to the MCP endpoint. On `401`, follow the
+   `resource_metadata` URL in `WWW-Authenticate`. For a synthetic endpoint
+   `https://api.example.com/mcp/agent`, the discovery URL is
+   `https://api.example.com/.well-known/oauth-protected-resource/mcp/agent`.
+2. Read the metadata's `resource` and `authorization_servers`. Discover OAuth
+   endpoints from the advertised authorization server; its origin may differ
+   from the MCP endpoint's origin. Do not use the metadata URL or issuer URL as
+   the resource value.
+3. Register or configure the client using the discovered registration endpoint
+   and the client's actual callback URI. Use authorization code flow with PKCE
+   (`S256`). Keep callback validation, state verification, and consent enabled.
+4. Send exactly one `resource` parameter containing the discovered resource in
+   the authorization URL query **and** in the form-encoded token request body.
+   Supplying it only during registration or only in the browser URL is insufficient.
+   For the synthetic endpoint above, the encoded parameter is
+   `resource=https%3A%2F%2Fapi.example.com%2Fmcp%2Fagent`.
+5. Send the access token as an Authorization Bearer header to the MCP endpoint.
+   Clients should also send the resource on refresh requests. Den's existing
+   refresh compatibility path can infer its singleton audience when omitted;
+   this does not make omission valid for the initial authorization or code exchange.
+
+These steps follow the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#resource-parameter-implementation)
+and [RFC 9728 discovery](https://www.rfc-editor.org/rfc/rfc9728.html).
+
+## `invalid_target`: “must include the protected resource”
+
+This response means an MCP OAuth request omitted `resource`. Confirm that the
+client sends the field at both stages above. Some generic OAuth clients support
+extra authorization parameters but cannot include extra token-body parameters.
+If your client cannot send both, update it or use a client that implements MCP
+resource indicators. Changing scopes or registering the client again does not
+supply this missing field.
+
+An unknown resource or multiple resource parameters also return `invalid_target`.
+Use the single discovered value; do not add arbitrary audiences or disable
+validation. [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html#section-2)
+defines this error for missing, unknown, malformed, or otherwise invalid resources.
+
+For a support report, record only the failing stage, HTTP status, error code,
+and whether the parameter was present. Do not share full authorization URLs,
+cookies, authorization codes, tokens, client secrets, or tenant identifiers.
+
+## Regression evidence
+
+The existing `mcp-auth-rate-limit-recovery` journey follows the challenge to the
+protected-resource metadata, rejects missing, unknown, and repeated resources
+at authorization and code exchange, then exchanges the same code with the
+advertised resource and uses the token on MCP. Run:
+
+```sh
+pnpm evals:e2e mcp-auth-rate-limit-recovery
+```

--- a/ee/apps/den-api/src/mcp/README.md
+++ b/ee/apps/den-api/src/mcp/README.md
@@ -2,6 +2,9 @@
 
 The MCP catalog is generated from `openapi.json`, then filtered by `policy.ts` before tools are registered.
 
+For third-party client setup and `invalid_target` troubleshooting, see
+[Connect a third-party MCP client with OAuth](../../../../../docs/mcp-client-oauth.md).
+
 ## Allowed Tags
 
 Every tagged Den API product surface is allowed unless it is listed under blocked tags or blocked operation IDs:

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -58,8 +58,28 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
   expect(registration.status).toBe(201);
   const clientId = stringField(await registration.json(), "client_id");
   const verifier = randomBytes(32).toString("base64url");
-  const resource = `${den.ref.apiUrl}/mcp/agent`;
+  const challenge = await request("/mcp/agent");
+  expect(challenge.status).toBe(401);
+  const metadataUrl = challenge.headers.get("www-authenticate")?.match(/resource_metadata="([^"]+)"/)?.[1];
+  expect(metadataUrl).toBe(`${den.ref.apiUrl}/.well-known/oauth-protected-resource/mcp/agent`);
+  await challenge.arrayBuffer();
+  if (!metadataUrl) throw new Error("Missing protected-resource discovery URL");
+  const discovery = await request(new URL(metadataUrl).pathname);
+  expect(discovery.status).toBe(200);
+  const metadata: unknown = await discovery.json();
+  const resource = stringField(metadata, "resource");
+  expect(resource).toBe(`${den.ref.apiUrl}/mcp/agent`);
+  expect(metadata).toMatchObject({ authorization_servers: [`${den.ref.apiUrl}/api/auth`], bearer_methods_supported: ["header"] });
   const authorize = new URLSearchParams({ client_id: clientId, response_type: "code", redirect_uri: redirectUri, scope, resource, code_challenge: createHash("sha256").update(verifier).digest("base64url"), code_challenge_method: "S256", prompt: "consent" });
+  for (const resources of [[], ["https://unrelated.example/mcp"], [resource, resource]]) {
+    const rejectedQuery = new URLSearchParams(authorize);
+    rejectedQuery.delete("resource");
+    for (const value of resources) rejectedQuery.append("resource", value);
+    const rejected = await request(`/api/auth/oauth2/authorize?${rejectedQuery}`, { headers: { cookie } });
+    expect(rejected.status).toBe(400);
+    expect(rejected.headers.has("location")).toBe(false);
+    expect(await rejected.json()).toMatchObject({ error: "invalid_target" });
+  }
   const authorization = await request(`/api/auth/oauth2/authorize?${authorize}`, { headers: { cookie } });
   expect(authorization.status).toBe(302);
   const consentLocation = authorization.headers.get("location");
@@ -73,6 +93,21 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
   const callback = new URL(stringField(await consent.json(), "url"));
   const code = callback.searchParams.get("code");
   if (!code) throw new Error("Missing authorization code");
+  for (const resources of [[], ["https://unrelated.example/mcp"], [resource, resource]]) {
+    const rejectedBody = new URLSearchParams({ grant_type: "authorization_code", client_id: clientId, code, code_verifier: verifier, redirect_uri: redirectUri });
+    for (const value of resources) rejectedBody.append("resource", value);
+    const rejected = await request("/api/auth/oauth2/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: rejectedBody,
+    });
+    expect(rejected.status).toBe(400);
+    expect(rejected.headers.get("cache-control")).toBe("no-store");
+    const error: unknown = await rejected.json();
+    expect(error).toMatchObject({ error: "invalid_target" });
+    expect(error).not.toHaveProperty("access_token");
+    expect(error).not.toHaveProperty("refresh_token");
+  }
   const exchange = await request("/api/auth/oauth2/token", {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -81,6 +116,11 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
   expect(exchange.status).toBe(200);
   const token = stringField(await exchange.json(), "access_token");
   expect(token.split(".")).toHaveLength(3);
+  evidence.recordAssertionEvidence(
+    "Protected-resource discovery supports a synthetic OAuth client without accepting invalid resources",
+    "The unauthenticated challenge led to agent metadata. Missing, unknown, and repeated resources returned invalid_target at authorization and code exchange; no redirect or token was issued. The same code then exchanged successfully with the discovered resource.",
+    true,
+  );
 
   // This also proves the server is running with production rate limits enabled.
   const burstStarted = Date.now();

--- a/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
+++ b/evals/specs/mcp-auth-rate-limit-recovery.e2e.test.ts
@@ -69,7 +69,7 @@ test("MCP requests keep valid credentials after the public auth rate limit is ex
   const metadata: unknown = await discovery.json();
   const resource = stringField(metadata, "resource");
   expect(resource).toBe(`${den.ref.apiUrl}/mcp/agent`);
-  expect(metadata).toMatchObject({ authorization_servers: [`${den.ref.apiUrl}/api/auth`], bearer_methods_supported: ["header"] });
+  expect(metadata).toMatchObject({ authorization_servers: [`${origin}/api/auth`], bearer_methods_supported: ["header"] });
   const authorize = new URLSearchParams({ client_id: clientId, response_type: "code", redirect_uri: redirectUri, scope, resource, code_challenge: createHash("sha256").update(verifier).digest("base64url"), code_challenge_method: "S256", prompt: "consent" });
   for (const resources of [[], ["https://unrelated.example/mcp"], [resource, resource]]) {
     const rejectedQuery = new URLSearchParams(authorize);


### PR DESCRIPTION
## Problem and change

An MCP client that omits `resource` receives `invalid_target`, but the gateway documentation did not explain how to resolve it. Add discovery and setup guidance covering the authorization query and token body, including clients that cannot send both. Existing audience and resource checks remain unchanged.

Extend the existing OAuth journey to follow protected-resource discovery and reject missing, unknown, and repeated resources at authorization and code exchange. Then exchange the same code with the advertised resource and exercise authenticated MCP. All examples are synthetic.

## Protocol and prior work

Existing resource-registry and refresh compatibility fixes already cover their respective server behavior; this change addresses the remaining guidance and boundary-coverage gap. MCP requires resource indicators in authorization and token requests; RFC 8707 permits `invalid_target` for a missing resource. Primary protocol sources and setup details are linked in `docs/mcp-client-oauth.md`.

## Verification

**Journey verdict: Passed** on `083d49e6f79b6edaeaad397e8b9f85e19a774206`. Final-head CI completed with no failed or pending checks: the required test gate, core/build tests, SDK check, review/security gates, and all image builds passed. Conditional workflow skips are not counted as runtime proof.

- Command: `pnpm evals:e2e mcp-auth-rate-limit-recovery.e2e.test.ts --daytona`
- Placement: `placement: daytona (--daytona)`
- Exit 0: **1 passed, 0 failed, 0 skipped**; both assertion-evidence sections passed, none pending.
- [Completed final-head run and downloadable test-run artifacts](https://github.com/different-ai/openwork/actions/runs/33983058476)
- [Published assertion evidence](https://github.com/different-ai/openwork/pull/4516#issuecomment-5553796270)

The first run failed because a new test assertion assumed the OAuth issuer shared the API origin. The remote deployment correctly advertises a separate auth origin; the final assertion checks that configured origin. The final cold-boot run above includes that correction.

Local dependency setup was stopped for disk pressure before tests began. Only this task's partial installation was removed. Evidence was produced remotely and published through the repository publisher after inspecting its sanitized preview; no pending visual judgments existed.

Separately, `node evals/scripts/spec-boundary-ratchet.mjs` and `node evals/scripts/spec-channel-ratchet.mjs` both exit 1 with byte-identical output on the final head and clean `origin/dev` at `85a5dfccb4d74732593628ab4cc8912f8b88283d`. First failures: a product-source import in `bench-opencode-engines.test.ts`, and a stale baseline in `active-session-workspace-storm.e2e.test.ts`, respectively. The changed journey introduces no ratchet violations. These pre-existing standalone-check failures are not represented as passing tests.
