### PR TITLE
feat: add lightweight Visualization mockups to chat

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -1,5 +1,6 @@
 "use memo";
 
+import { VisualizationTool } from "@/components/tools/visualization-tool"
 import * as React from "react"
 import {
   AlertTriangle,
@@ -211,6 +212,10 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
         </div>
       </div>
     )
+  }
+
+  if (part.type === "dynamic-tool" && part.toolName === "openwork_visualization") {
+    return <VisualizationTool part={part} />
   }
 
   if (isBashToolPart(part)) {

--- a/apps/app/src/components/tools/visualization-tool.tsx
+++ b/apps/app/src/components/tools/visualization-tool.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import { ImageIcon, Monitor, Smartphone } from "lucide-react";
+import {
+  visualizationSchema,
+  type Visualization,
+} from "@openwork/types/visualization";
+import type { AnyToolPart } from "@/lib/tool-aggregate";
+import { Button } from "@/components/ui/button";
+import { useMessageList } from "@/components/chat/message-list-provider";
+
+function MockBlock({
+  block,
+}: {
+  block: Visualization["sections"][number]["blocks"][number];
+}) {
+  switch (block.kind) {
+    case "metric":
+      return (
+        <div className="rounded-xl border bg-background p-4">
+          <div className="text-xs text-muted-foreground">{block.label}</div>
+          <div className="mt-2 text-2xl font-semibold tracking-tight">
+            {block.value ?? "—"}
+          </div>
+        </div>
+      );
+    case "field":
+      return (
+        <div className="space-y-2">
+          <div className="text-xs font-medium">{block.label}</div>
+          <div className="min-h-9 rounded-lg border bg-background px-3 py-2 text-sm text-muted-foreground">
+            {block.value ?? "Enter a value…"}
+          </div>
+        </div>
+      );
+    case "button":
+      return (
+        <div>
+          <span className="inline-flex min-h-9 items-center rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background">
+            {block.label}
+          </span>
+        </div>
+      );
+    case "list":
+      return (
+        <div className="rounded-xl border bg-background p-4">
+          <div className="mb-2 text-sm font-medium">{block.label}</div>
+          <ul className="divide-y">
+            {block.items?.map((item, index) => (
+              <li key={index} className="py-2 text-sm text-muted-foreground">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    case "image":
+      return (
+        <div className="flex min-h-32 flex-col items-center justify-center gap-2 rounded-xl border border-dashed bg-muted/40 p-4 text-xs text-muted-foreground">
+          <ImageIcon className="size-5" aria-hidden="true" />
+          {block.label}
+        </div>
+      );
+    case "text":
+      return (
+        <div>
+          <div className="text-sm font-medium">{block.label}</div>
+          {block.value && (
+            <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+              {block.value}
+            </p>
+          )}
+        </div>
+      );
+  }
+}
+
+export function VisualizationTool({ part }: { part: AnyToolPart }) {
+  const [mobile, setMobile] = useState(false);
+  const { setPrompt } = useMessageList();
+  if (part.state === "output-error")
+    return (
+      <div role="alert" className="text-sm text-destructive">
+        Couldn’t create this visualization. Ask to try again.
+      </div>
+    );
+  if (part.state === "output-denied")
+    return (
+      <div role="status" className="text-sm text-muted-foreground">
+        Visualization wasn’t approved.
+      </div>
+    );
+  if (part.state !== "output-available")
+    return (
+      <div role="status" className="text-sm text-muted-foreground">
+        Creating visualization…
+      </div>
+    );
+  let output: unknown = part.output;
+  if (typeof output === "string") {
+    try {
+      output = JSON.parse(output);
+    } catch {
+      output = null;
+    }
+  }
+  const parsed = visualizationSchema.safeParse(output);
+  if (!parsed.success)
+    return (
+      <div role="alert" className="text-sm text-muted-foreground">
+        This visualization couldn’t be displayed. Ask for a new version.
+      </div>
+    );
+  const design = parsed.data;
+  return (
+    <section
+      aria-label={`Visualization: ${design.title}, revision ${design.revision}`}
+      className="my-3 min-w-0 break-words overflow-hidden rounded-2xl border bg-background text-foreground"
+      data-testid="visualization-card"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+        <div>
+          <div className="text-sm font-medium">{design.title}</div>
+          <div className="text-xs text-muted-foreground">
+            Visualization · v{design.revision} · Mockup
+          </div>
+        </div>
+        <div className="flex gap-1" role="group" aria-label="Preview size">
+          <Button
+            variant={mobile ? "ghost" : "secondary"}
+            size="sm"
+            aria-label="Desktop preview"
+            aria-pressed={!mobile}
+            onClick={() => setMobile(false)}
+          >
+            <Monitor className="size-4" />
+          </Button>
+          <Button
+            variant={mobile ? "secondary" : "ghost"}
+            size="sm"
+            aria-label="Mobile preview"
+            aria-pressed={mobile}
+            onClick={() => setMobile(true)}
+          >
+            <Smartphone className="size-4" />
+          </Button>
+        </div>
+      </div>
+      <div className="bg-muted/30 p-3 sm:p-5">
+        <div
+          data-testid="visualization-preview"
+          data-viewport={mobile ? "mobile" : "desktop"}
+          className={`mx-auto overflow-hidden rounded-xl border bg-background shadow-sm ${mobile ? "max-w-[360px]" : "w-full"}`}
+        >
+          {design.navigation && (
+            <div className="flex flex-wrap gap-x-4 gap-y-2 border-b px-5 py-3 text-xs text-muted-foreground">
+              {design.navigation.map((label, index) => (
+                <span
+                  key={index}
+                  className={index === 0 ? "font-medium text-foreground" : ""}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="@container space-y-6 p-5">
+            {design.description && (
+              <p className="text-sm text-muted-foreground">
+                {design.description}
+              </p>
+            )}
+            {design.sections.map((section, index) => (
+              <section key={index} className="space-y-3">
+                <h3 className="text-base font-semibold tracking-tight">
+                  {section.title}
+                </h3>
+                <div
+                  className={`grid gap-3 [&>*]:min-w-0 ${mobile ? "grid-cols-1" : section.columns === "three" ? "grid-cols-1 @min-[480px]:grid-cols-3" : section.columns === "two" ? "grid-cols-1 @min-[480px]:grid-cols-2" : "grid-cols-1"}`}
+                >
+                  {section.blocks.map((block, blockIndex) => (
+                    <MockBlock key={blockIndex} block={block} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t px-4 py-3">
+        <p className="text-xs text-muted-foreground">
+          A design sketch. Controls are for illustration.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            setPrompt(
+              `Revise visualization "${design.title}" (id: ${design.id}, version ${design.revision}). Create version ${design.revision + 1} with these changes: `,
+            )
+          }
+        >
+          Request changes
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -756,11 +756,11 @@ describe("OpenWorkExtensionsPreview session tools", () => {
 });
 
 describe("OpenWorkExtensionsPreview semantic tool surface", () => {
-  test("exposes only the three semantic tools", async () => {
+  test("exposes semantic tools and the native visualization tool", async () => {
     const plugin = await OpenWorkExtensionsPreview();
     const tools = Object.keys(plugin.tool).sort();
 
-    expect(tools).toEqual(["openwork_context", "openwork_execute", "openwork_query"]);
+    expect(tools).toEqual(["openwork_context", "openwork_execute", "openwork_query", "openwork_visualization"]);
 
     const system = await transformedSystem(plugin);
     expect(system).not.toContain("## Default Skill: skill-creator");
@@ -770,8 +770,28 @@ describe("OpenWorkExtensionsPreview semantic tool surface", () => {
     expect(system).not.toContain("openwork_extension_");
     expect(system).not.toContain("openwork_browser_");
     expect(system).toContain("Use openwork_context");
+    expect(system).toContain("use openwork_visualization");
     expect(system).toContain("session.search");
     expect(system).toContain("browser.open_url");
+  });
+
+  test("renders a bounded visualization without calling a backend", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+    const design = {
+      id: "project-overview", title: "Project overview", revision: 1,
+      sections: [{ title: "Projects", columns: "two", blocks: [
+        { kind: "metric", label: "Active", value: "12" },
+        { kind: "text", label: "Note", value: "<script>alert(1)</script>" },
+      ] }],
+    };
+    expect(JSON.parse(await plugin.tool.openwork_visualization.execute(design))).toEqual(design);
+    expect(fake.requests).toHaveLength(0);
+    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: [] })).rejects.toThrow();
+    await expect(plugin.tool.openwork_visualization.execute({ ...design, revision: 0 })).rejects.toThrow();
+    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: Array(9).fill(design.sections[0]) })).rejects.toThrow();
+    await expect(plugin.tool.openwork_visualization.execute({ ...design, sections: [{ title: "Unsafe", blocks: [{ kind: "html", label: "Code" }] }] })).rejects.toThrow();
+    expect(fake.requests).toHaveLength(0);
   });
 
   test("proposes an Automation without creating anything or calling a backend", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -1,5 +1,6 @@
 import { realpath } from "node:fs/promises";
 import { z } from "zod";
+import { visualizationSchema } from "@openwork/types/visualization";
 import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import { automationProposalSchema } from "@openwork/types/automations";
 import {
@@ -118,6 +119,7 @@ const sessionMessageSchema = z.object({
 
 const OPENWORK_AGENT_SURFACE_INSTRUCTION =
   `## OpenWork app context
+For lightweight UI mockups, wireframes, and design iterations, use openwork_visualization to show a native OpenWork-styled sketch in the conversation. Keep the design id when revising, increment revision, and send the complete updated design. Mock controls are illustrative; use the normal app-building workflow when a working app is requested.
 Use openwork_context when the request depends on the current OpenWork screen, open tabs, split view, focused pane, sidebar, side panel, settings panel, or available app actions.
 Each affordance declares its effects and executor. Use openwork_query only for side-effect-free affordances whose executor is OpenWork. Use openwork_execute for OpenWork commands without activating the desktop window. If executor names another tool, call that exact tool instead.
 Reading another session does not require opening it. Prefer session.search then session.read for transcript questions; use session.create for new chats and a UI command only when the user asks to navigate.
@@ -938,6 +940,13 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
     );
   },
   tool: {
+    openwork_visualization: {
+      description: "Show a lightweight UI mockup inline in OpenWork using native OpenWork styling. Use for wireframes, screen layouts, and design iteration instead of ASCII UI. Provide a title, optional navigation, and sections of text, metrics, fields, buttons, lists, or image placeholders. These are mock controls, not a working app. For revisions, keep the same id and send the complete updated mockup with an increased revision; earlier versions remain in the conversation. No HTML, scripts, servers, or files needed.",
+      args: visualizationSchema.shape,
+      async execute(rawArgs: unknown) {
+        return JSON.stringify(visualizationSchema.parse(rawArgs));
+      },
+    },
     openwork_context: {
       description: "Read one semantic snapshot of OpenWork: current screen, retained conversation tabs, split view and focused pane, sidebar and side panel state, settings panel, provider contributions, remote skill guidance, and available affordances with explicit effects and executors.",
       args: {},

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -30,6 +30,8 @@ export interface MockAgentToolStep {
 }
 
 export interface MockAgentWorkload {
+  /** Chat Completions: match the latest user message and count only its tool rounds. */
+  latestUserTurn?: boolean;
   promptMarker: string;
   finalReply: string;
   /** Stream the final reply as consecutive content deltas of this many characters instead of one. */

--- a/evals/packages/labs/test/mock-mcp.test.ts
+++ b/evals/packages/labs/test/mock-mcp.test.ts
@@ -93,3 +93,39 @@ test("scripts and records deterministic OpenAI-compatible agent tool rounds", as
   assert.deepEqual(requests.map((request) => request.completedTools), [0, 1, 2]);
   assert.deepEqual(requests.map((request) => request.matchedMarkers), [[marker], [marker], [marker]]);
 });
+
+test("turn-scoped workloads isolate revisions from earlier markers and tool rounds", async () => {
+  await using mock = await startMockMcp({
+    port: await allocateFreePort(),
+    agentWorkloads: ["first sketch", "revise sketch"].map((promptMarker) => ({
+      latestUserTurn: true,
+      promptMarker,
+      finalReply: `${promptMarker} complete`,
+      steps: [{ tool: "write", arguments: { content: promptMarker } }],
+    })),
+  });
+  const history = [
+    { role: "user", content: "first sketch" },
+    { role: "tool", tool_call_id: "old", content: "old result" },
+    { role: "assistant", content: "first sketch complete" },
+    { role: "user", content: "revise sketch" },
+  ];
+  for (const completed of [false, true]) {
+    const response = await fetch(`${mock.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...completionBody("unused", 0),
+        messages: [...history, ...(completed ? [{ role: "tool", tool_call_id: "new", content: "new result" }] : [])],
+      }),
+    });
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.match(text, completed ? /revise sketch complete/ : /"name":"write"/);
+    assert.doesNotMatch(text, /first sketch complete/);
+  }
+  const requests = await mock.agentRequests({ promptMarker: "revise sketch" });
+  assert.deepEqual(requests.map((request) => request.kind), ["tool", "final"]);
+  assert.deepEqual(requests.map((request) => request.completedTools), [0, 1]);
+  assert.deepEqual(requests.map((request) => request.matchedMarkers), [["revise sketch"], ["revise sketch"]]);
+});

--- a/evals/specs/visualization.e2e.test.ts
+++ b/evals/specs/visualization.e2e.test.ts
@@ -18,7 +18,10 @@ test("a user previews and revises a lightweight design in conversation", async (
   });
   await user.click("Run task");
   try {
-    await user.see({ text: "Your first sketch is ready." }, { timeoutMs: 90_000 });
+    await user.see(
+      { text: "Your first sketch is ready." },
+      { timeoutMs: 90_000 },
+    );
   } finally {
     await user.screenshot();
   }
@@ -37,9 +40,9 @@ test("a user previews and revises a lightweight design in conversation", async (
         scripts: 0,
         executed: false,
       });
-      await user.notSee(
-        "This visualization couldn’t be displayed. Ask for a new version.",
-      );
+      await user.notSee({
+        text: "This visualization couldn’t be displayed. Ask for a new version.",
+      });
       await user.screenshot();
     },
   );
@@ -71,7 +74,10 @@ test("a user previews and revises a lightweight design in conversation", async (
       expect((await probe.composer()).userMessageCount).toBe(before);
       await user.type("composer", "Make it calmer", { replace: false });
       await user.click("Run task");
-      await user.see({ text: "Your revised sketch is ready." }, { timeoutMs: 90_000 });
+      await user.see(
+        { text: "Your revised sketch is ready." },
+        { timeoutMs: 90_000 },
+      );
       await user.see({ text: "Visualization · v2 · Mockup" });
       await user.see({ text: "Visualization · v1 · Mockup" });
       await user.see({ text: "A calmer overview" });

--- a/evals/specs/visualization.e2e.test.ts
+++ b/evals/specs/visualization.e2e.test.ts
@@ -1,0 +1,77 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { visualization } from "../worlds/chat.ts";
+
+const test = spec.world(visualization);
+
+test("a user previews and revises a lightweight design in conversation", async ({
+  world,
+  user,
+  probe,
+  step,
+}) => {
+  await user.type("composer", "Sketch a project overview");
+  await user.press("Enter");
+  await user.see("Your first sketch is ready.", { timeoutMs: 90_000 });
+  await step(
+    "the real visualization tool produces a safe inline mockup",
+    async () => {
+      await user.see("Visualization · v1 · Mockup");
+      await user.see("Active projects");
+      await user.see("Website refresh");
+      await user.see("Create project");
+      await user.see("Draft reviewed");
+      await user.see("Cover image");
+      expect(await world.preview()).toMatchObject({
+        viewport: "desktop",
+        cards: 1,
+        scripts: 0,
+        executed: false,
+      });
+      await user.notSee(
+        "This visualization couldn’t be displayed. Ask for a new version.",
+      );
+      await user.screenshot();
+    },
+  );
+  await step(
+    "preview controls resize the sketch without submitting a message",
+    async () => {
+      const before = (await probe.composer()).userMessageCount;
+      await user.click({ role: "button", label: "Mobile preview" });
+      expect(await world.preview()).toMatchObject({
+        viewport: "mobile",
+        width: expect.any(Number),
+      });
+      const mobile = await world.preview();
+      expect(mobile.width).toBeLessThanOrEqual(360);
+      expect((await probe.composer()).userMessageCount).toBe(before);
+      await user.screenshot();
+      await user.click({ role: "button", label: "Desktop preview" });
+      expect(await world.preview()).toMatchObject({ viewport: "desktop" });
+    },
+  );
+  await step(
+    "requesting changes drafts a revision and preserves the first sketch",
+    async () => {
+      const before = (await probe.composer()).userMessageCount;
+      await user.click({ role: "button", label: "Request changes" });
+      expect((await probe.composer()).draftText).toContain(
+        "id: project-overview, version 1",
+      );
+      expect((await probe.composer()).userMessageCount).toBe(before);
+      await user.type("composer", "Make it calmer", { replace: false });
+      await user.press("Enter");
+      await user.see("Your revised sketch is ready.", { timeoutMs: 90_000 });
+      await user.see("Visualization · v2 · Mockup");
+      await user.see("Visualization · v1 · Mockup");
+      await user.see("A calmer overview");
+      expect(await world.preview()).toMatchObject({
+        cards: 2,
+        scripts: 0,
+        executed: false,
+      });
+      await user.screenshot();
+    },
+  );
+});

--- a/evals/specs/visualization.e2e.test.ts
+++ b/evals/specs/visualization.e2e.test.ts
@@ -11,7 +11,7 @@ test("a user previews and revises a lightweight design in conversation", async (
   step,
 }) => {
   await user.type("composer", "Sketch a project overview");
-  await user.press("Enter");
+  await user.click("Run task");
   await user.see("Your first sketch is ready.", { timeoutMs: 90_000 });
   await step(
     "the real visualization tool produces a safe inline mockup",
@@ -61,7 +61,7 @@ test("a user previews and revises a lightweight design in conversation", async (
       );
       expect((await probe.composer()).userMessageCount).toBe(before);
       await user.type("composer", "Make it calmer", { replace: false });
-      await user.press("Enter");
+      await user.click("Run task");
       await user.see("Your revised sketch is ready.", { timeoutMs: 90_000 });
       await user.see("Visualization · v2 · Mockup");
       await user.see("Visualization · v1 · Mockup");

--- a/evals/specs/visualization.e2e.test.ts
+++ b/evals/specs/visualization.e2e.test.ts
@@ -18,19 +18,19 @@ test("a user previews and revises a lightweight design in conversation", async (
   });
   await user.click("Run task");
   try {
-    await user.see("Your first sketch is ready.", { timeoutMs: 90_000 });
+    await user.see({ text: "Your first sketch is ready." }, { timeoutMs: 90_000 });
   } finally {
     await user.screenshot();
   }
   await step(
     "the real visualization tool produces a safe inline mockup",
     async () => {
-      await user.see("Visualization · v1 · Mockup");
-      await user.see("Active projects");
-      await user.see("Website refresh");
-      await user.see("Create project");
-      await user.see("Draft reviewed");
-      await user.see("Cover image");
+      await user.see({ text: "Visualization · v1 · Mockup" });
+      await user.see({ text: "Active projects" });
+      await user.see({ text: "Website refresh" });
+      await user.see({ text: "Create project" });
+      await user.see({ text: "Draft reviewed" });
+      await user.see({ text: "Cover image" });
       expect(await world.preview()).toMatchObject({
         viewport: "desktop",
         cards: 1,
@@ -71,10 +71,10 @@ test("a user previews and revises a lightweight design in conversation", async (
       expect((await probe.composer()).userMessageCount).toBe(before);
       await user.type("composer", "Make it calmer", { replace: false });
       await user.click("Run task");
-      await user.see("Your revised sketch is ready.", { timeoutMs: 90_000 });
-      await user.see("Visualization · v2 · Mockup");
-      await user.see("Visualization · v1 · Mockup");
-      await user.see("A calmer overview");
+      await user.see({ text: "Your revised sketch is ready." }, { timeoutMs: 90_000 });
+      await user.see({ text: "Visualization · v2 · Mockup" });
+      await user.see({ text: "Visualization · v1 · Mockup" });
+      await user.see({ text: "A calmer overview" });
       expect(await world.preview()).toMatchObject({
         cards: 2,
         scripts: 0,

--- a/evals/specs/visualization.e2e.test.ts
+++ b/evals/specs/visualization.e2e.test.ts
@@ -11,8 +11,17 @@ test("a user previews and revises a lightweight design in conversation", async (
   step,
 }) => {
   await user.type("composer", "Sketch a project overview");
+  await probe.eventually(() => probe.composer(), {
+    within: 30_000,
+    label: "visualization request is ready to send",
+    until: (composer) => composer.runTaskEnabled,
+  });
   await user.click("Run task");
-  await user.see("Your first sketch is ready.", { timeoutMs: 90_000 });
+  try {
+    await user.see("Your first sketch is ready.", { timeoutMs: 90_000 });
+  } finally {
+    await user.screenshot();
+  }
   await step(
     "the real visualization tool produces a safe inline mockup",
     async () => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1300,8 +1300,8 @@ export async function visualization(seed: Seed) {
     ] }],
   };
   const mock = seed.mock({ agentWorkloads: [
-    { promptMarker: "Sketch a project overview", finalReply: "Your first sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: design }] },
-    { promptMarker: "Create version 2", finalReply: "Your revised sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: { ...design, revision: 2, description: "A calmer overview" } }] },
+    { latestUserTurn: true, promptMarker: "Sketch a project overview", finalReply: "Your first sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: design }] },
+    { latestUserTurn: true, promptMarker: "Create version 2", finalReply: "Your revised sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: { ...design, revision: 2, description: "A calmer overview" } }] },
   ] });
   const den = await seed.den({ mocks: { agent: mock } });
   const app = await seed.desktop({ name: "visualization", model: `${providerId}/${modelId}` });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1282,3 +1282,50 @@ export async function computerMentions(seed: Seed) {
     },
   };
 }
+
+/** A deterministic model calls the real built-in visualization tool. */
+export async function visualization(seed: Seed) {
+  const providerId = "visualization-mock";
+  const modelId = "visualization-model";
+  const design = {
+    id: "project-overview", title: "Project overview", revision: 1,
+    navigation: ["Overview", "Projects", "Settings"],
+    sections: [{ title: "Your workspace", columns: "two", blocks: [
+      { kind: "metric", label: "Active projects", value: "12" },
+      { kind: "field", label: "Project name", value: "Website refresh" },
+      { kind: "button", label: "Create project" },
+      { kind: "list", label: "Recent activity", items: ["Draft reviewed", "Mockup updated"] },
+      { kind: "image", label: "Cover image" },
+      { kind: "text", label: "Design note", value: "<script>window.mockupExecuted = true</script>" },
+    ] }],
+  };
+  const mock = seed.mock({ agentWorkloads: [
+    { promptMarker: "Sketch a project overview", finalReply: "Your first sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: design }] },
+    { promptMarker: "Create version 2", finalReply: "Your revised sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: { ...design, revision: 2, description: "A calmer overview" } }] },
+  ] });
+  const den = await seed.den({ mocks: { agent: mock } });
+  const app = await seed.desktop({ name: "visualization", den, as: "admin", model: `${providerId}/${modelId}` });
+  const workspace = await seed.workspace(app, seed.tmpPath("visualization"));
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    permission: { openwork_visualization: "allow" },
+    provider: { [providerId]: {
+      npm: "@ai-sdk/openai-compatible", name: "Visualization mock",
+      options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-visualization" },
+      models: { [modelId]: { name: "Visualization model", tool_call: true } },
+    } },
+  });
+  const session = await seedSessionRetry(seed, app);
+  return {
+    den, app, workspace, session,
+    preview: async () => {
+      const result = await evalIn(app, `(() => {
+      const preview = document.querySelector('[data-testid="visualization-preview"]');
+      return { viewport: preview?.getAttribute('data-viewport'), width: preview?.getBoundingClientRect().width,
+        scripts: preview?.querySelectorAll('script').length, executed: window.mockupExecuted === true,
+        cards: document.querySelectorAll('[data-testid="visualization-card"]').length };
+    })()`);
+      if (!isRecord(result) || typeof result.width !== "number") throw new Error("Visualization preview missing");
+      return { ...result, width: result.width };
+    },
+  };
+}

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1304,7 +1304,7 @@ export async function visualization(seed: Seed) {
     { promptMarker: "Create version 2", finalReply: "Your revised sketch is ready.", steps: [{ tool: "openwork_visualization", arguments: { ...design, revision: 2, description: "A calmer overview" } }] },
   ] });
   const den = await seed.den({ mocks: { agent: mock } });
-  const app = await seed.desktop({ name: "visualization", den, as: "admin", model: `${providerId}/${modelId}` });
+  const app = await seed.desktop({ name: "visualization", model: `${providerId}/${modelId}` });
   const workspace = await seed.workspace(app, seed.tmpPath("visualization"));
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
     permission: { openwork_visualization: "allow" },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -108,6 +108,11 @@
       "types": "./src/url.ts",
       "development": "./src/url.ts",
       "default": "./src/url.ts"
+    },
+    "./visualization": {
+      "types": "./src/visualization.ts",
+      "development": "./src/visualization.ts",
+      "default": "./src/visualization.ts"
     }
   },
   "files": [

--- a/packages/types/src/visualization.ts
+++ b/packages/types/src/visualization.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+// A bounded, declarative mockup: all content renders as text, never HTML or code.
+const text = z.string().trim().min(1).max(500);
+const blockSchema = z.object({
+  kind: z.enum(["text", "metric", "field", "button", "list", "image"]),
+  label: text,
+  value: z.string().max(2000).optional(),
+  items: z.array(text).max(12).optional(),
+});
+
+export const visualizationSchema = z.object({
+  id: z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]{1,80}$/)
+    .describe("Stable design id; reuse for revisions."),
+  title: text,
+  revision: z.number().int().min(1).max(9999),
+  description: z.string().max(1000).optional(),
+  navigation: z.array(text).max(8).optional(),
+  sections: z
+    .array(
+      z.object({
+        title: text,
+        columns: z.enum(["one", "two", "three"]).default("one"),
+        blocks: z.array(blockSchema).min(1).max(12),
+      }),
+    )
+    .min(1)
+    .max(8),
+});
+
+export type Visualization = z.infer<typeof visualizationSchema>;

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -187,6 +187,9 @@ function validateAgentWorkloads(value) {
     if (finalReplyChunkSize !== null && (!Number.isInteger(finalReplyChunkSize) || finalReplyChunkSize < 1)) {
       throw new Error(`agent workload ${promptMarker} finalReplyChunkSize must be a positive integer`);
     }
+    if (workload.latestUserTurn !== undefined && typeof workload.latestUserTurn !== "boolean") {
+      throw new Error(`agent workload ${promptMarker} latestUserTurn must be a boolean`);
+    }
     const steps = workload.steps.map((step) => {
       if (!step || typeof step !== "object" || typeof step.tool !== "string" || !step.tool.trim()) {
         throw new Error(`agent workload ${promptMarker} has an invalid tool step`);
@@ -199,7 +202,7 @@ function validateAgentWorkloads(value) {
       }
       return { tool: step.tool.trim(), arguments: structuredClone(step.arguments), argumentsFrom: step.argumentsFrom };
     });
-    return { promptMarker, finalReply, finalReplyChunkSize, steps };
+    return { promptMarker, finalReply, finalReplyChunkSize, steps, latestUserTurn: workload.latestUserTurn === true };
   });
 }
 
@@ -321,10 +324,14 @@ async function handleAgentCompletion(req, res, entry) {
   const model = typeof body.model === "string" ? body.model : "mock-agent-workload-model";
   const messages = Array.isArray(body.messages) ? body.messages : [];
   const conversationText = messages.map(agentContentText).join("\n");
-  const matchedMarkers = agentWorkloads
-    .filter((workload) => conversationText.includes(workload.promptMarker))
-    .map((workload) => workload.promptMarker);
-  const completedTools = messages.filter((message) => message && typeof message === "object" && message.role === "tool").length;
+  const latestUserIndex = messages.findLastIndex((message) => message?.role === "user");
+  const latestUserText = latestUserIndex < 0 ? "" : agentContentText(messages[latestUserIndex]);
+  const matched = agentWorkloads.filter((workload) =>
+    (workload.latestUserTurn ? latestUserText : conversationText).includes(workload.promptMarker));
+  const matchedMarkers = matched.map((workload) => workload.promptMarker);
+  const workload = matched[0];
+  const scopedMessages = workload?.latestUserTurn ? messages.slice(latestUserIndex + 1) : messages;
+  const completedTools = scopedMessages.filter((message) => message && typeof message === "object" && message.role === "tool").length;
   const baseRequest = { model, matchedMarkers, completedTools };
 
   if (!Array.isArray(body.tools) || body.tools.length === 0) {
@@ -341,7 +348,6 @@ async function handleAgentCompletion(req, res, entry) {
     json(res, 400, { error: { message: `expected one workload marker, found ${matchedMarkers.length}` } });
     return;
   }
-  const workload = agentWorkloads.find((candidate) => candidate.promptMarker === matchedMarkers[0]);
   if (!workload) throw new Error("matched agent workload disappeared");
   if (completedTools >= workload.steps.length) {
     entry.agentCompletion = { ...baseRequest, kind: "final", promptMarker: workload.promptMarker, toolName: null, arguments: {} };


### PR DESCRIPTION
Adds `openwork_visualization`, a built-in tool for lightweight UI sketches and design iteration directly in chat. Mockups use native OpenWork styling and a bounded schema for navigation, text, metrics, fields, buttons, lists, and image placeholders. They require no generated app, server, or executable HTML.

Users can switch between desktop and mobile previews and choose **Request changes** to draft a revision request in the composer. The design ID and version identify the sketch being revised; prior versions remain in the conversation. Mock controls are labeled as illustrative.

The journey uses the real tool in a local workspace, with a deterministic model. An opt-in turn-scoped mode in the existing model fixture lets it distinguish follow-up revisions from earlier prompts and tool results; existing fixtures retain their previous behavior.

Validation — **Passed** for the feature journey:
- [Published test evidence and screenshots](https://github.com/different-ai/openwork/pull/4517#issuecomment-5553901076): 1 journey passed, 0 failed, 0 skipped on head `0c2b1fa6d9dc57038344e1a25fab03a719fb0bab`. All three steps passed: safe inline rendering; preview resizing without sending; drafting and completing a revision while retaining both versions. Screenshots provide visual context; the verdict comes from the assertions.
- `pnpm typecheck` — passed.
- `pnpm --filter openwork-server exec bun test src/opencode-plugins/openwork-extensions-preview.test.ts src/opencode-plugins/system-prompt-composition.test.ts` — 29 passed, 0 failed.
- `pnpm --dir evals exec node --test packages/labs/test/mock-mcp.test.ts` — 3 passed, 0 failed.
- `pnpm evals:typecheck` — 310 errors, identical after normalizing paths to an independently installed clean control at base `85a5dfccb4d7`; no new diagnostics.

Reproduce: `OPENWORK_EVAL_REF=0c2b1fa6d9dc57038344e1a25fab03a719fb0bab OPENWORK_EVAL_DAYTONA_REF=0c2b1fa6d9dc57038344e1a25fab03a719fb0bab pnpm evals:e2e visualization`.
Placement: `daytona (daytona CLI authenticated)`.
