### PR TITLE
fix(den-web): recover skill saves through reauthentication

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/skill-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/skill-data.tsx
@@ -113,25 +113,31 @@ export function useSkill(pluginId: string, skillId: string) {
 
 export function useCreateSkill(pluginId: string) {
   const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (draft: SkillDraft): Promise<DenSkill> => {
-      const { response, payload } = await requestJson(
-        "/v1/config-objects",
-        {
-          method: "POST",
-          body: JSON.stringify(createSkillPayload(pluginId, draft)),
-        },
-        15000,
-      );
-      if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to create skill (${response.status}).`);
-      }
-      const skill = parseSkillResponse(payload);
-      if (!skill) {
-        throw new Error("Skill create response was incomplete.");
-      }
-      return skill;
+      const result: { skill?: DenSkill } = {};
+      await runReauthableAction("create-skill", async () => {
+        const { response, payload } = await requestJson(
+          "/v1/config-objects",
+          {
+            method: "POST",
+            body: JSON.stringify(createSkillPayload(pluginId, draft)),
+          },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to create skill (${response.status}).`);
+        }
+        const skill = parseSkillResponse(payload);
+        if (!skill) {
+          throw new Error("Skill create response was incomplete.");
+        }
+        result.skill = skill;
+      });
+      if (!result.skill) throw new Error("Skill save response was incomplete.");
+      return result.skill;
     },
     onSuccess: async () => {
       await Promise.all([
@@ -144,28 +150,34 @@ export function useCreateSkill(pluginId: string) {
 
 export function useUpdateSkill(pluginId: string) {
   const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
 
   return useMutation({
     mutationFn: async (input: { skillId: string; draft: SkillDraft }): Promise<DenSkill> => {
-      const { response, payload } = await requestJson(
-        `/v1/config-objects/${encodeURIComponent(input.skillId)}/versions`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            input: { rawSourceText: skillSourceFromDraft(input.draft) },
-            reason: "Updated from Den Web",
-          }),
-        },
-        15000,
-      );
-      if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to save skill (${response.status}).`);
-      }
-      const skill = parseSkillResponse(payload);
-      if (!skill) {
-        throw new Error("Skill update response was incomplete.");
-      }
-      return skill;
+      const result: { skill?: DenSkill } = {};
+      await runReauthableAction("update-skill", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/config-objects/${encodeURIComponent(input.skillId)}/versions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              input: { rawSourceText: skillSourceFromDraft(input.draft) },
+              reason: "Updated from Den Web",
+            }),
+          },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to save skill (${response.status}).`);
+        }
+        const skill = parseSkillResponse(payload);
+        if (!skill) {
+          throw new Error("Skill update response was incomplete.");
+        }
+        result.skill = skill;
+      });
+      if (!result.skill) throw new Error("Skill save response was incomplete.");
+      return result.skill;
     },
     onSuccess: async () => {
       await Promise.all([

--- a/ee/apps/den-web/app/(den)/dashboard/_components/skill-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/skill-editor-screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { ArrowLeft, FileText } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
@@ -15,6 +15,7 @@ const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; skillId?: string }) {
   const router = useRouter();
+  const submittingRef = useRef(false);
   const { orgSlug } = useOrgDashboard();
   const skillQuery = useSkill(pluginId, skillId ?? "");
   const createSkill = useCreateSkill(pluginId);
@@ -38,6 +39,7 @@ export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; ski
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (submittingRef.current) return;
     const draft = { name: name.trim(), description: description.trim(), body: body.trim() };
     if (!SKILL_NAME_PATTERN.test(draft.name) || draft.name.length > 64) {
       setValidationError("Name must use lowercase letters, numbers, and single hyphens only.");
@@ -53,6 +55,7 @@ export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; ski
     }
 
     setValidationError(null);
+    submittingRef.current = true;
     try {
       const saved = skillId
         ? await updateSkill.mutateAsync({ skillId, draft })
@@ -60,6 +63,8 @@ export function SkillEditorScreen({ pluginId, skillId }: { pluginId: string; ski
       router.push(getPluginSkillRoute(orgSlug, pluginId, saved.id));
     } catch {
       // React Query exposes the request error in the form below.
+    } finally {
+      submittingRef.current = false;
     }
   }
 

--- a/evals/specs/skill-editor-reauth.e2e.test.ts
+++ b/evals/specs/skill-editor-reauth.e2e.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { skillEditorReauth } from "../worlds/skill-editor-reauth.ts";
+
+const test = spec.world(skillEditorReauth, { timeout: 420_000 });
+const draft = "Keep these synthetic unsaved instructions.";
+
+test("skill edits survive blocked reauthentication and save once after verification", async ({ world, user, probe, evidence }) => {
+  await user.see({ text: "Edit synthetic-recovery" }, { timeoutMs: 90_000 });
+  await user.type({ placeholder: "# Instructions\\n\\nDescribe the complete workflow..." }, draft, { replace: true });
+  await world.expire();
+  await user.click("Save changes");
+  await user.see("Continue with Google", { timeoutMs: 20_000 });
+  await user.click("Continue with Google");
+  await user.see({ text: "OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again." });
+  await world.duplicateSubmit();
+  expect(await world.snapshot()).toEqual({ attempts: 1, writes: 0, verified: false, popupAttempts: 1, body: draft });
+  await user.screenshot();
+  evidence.recordAssertionEvidence("Blocked popup offers recovery, preserves the draft, and does not retry or duplicate the save", "Dialog offers allow-popups guidance; draft retained; one rejected attempt and zero writes", true);
+
+  await user.click("Close security check");
+  expect(await world.snapshot()).toEqual({ attempts: 1, writes: 0, verified: false, popupAttempts: 1, body: draft });
+  await user.click("Save changes");
+  await user.see("Verify password", { timeoutMs: 20_000 });
+  await user.type({ label: "Password" }, world.den.admin.password, { replace: true });
+  await user.click("Verify password");
+  await user.see({ text: "Complete skill body" }, { timeoutMs: 30_000 });
+  await user.see({ text: draft });
+  const snapshot = await world.snapshot();
+  expect(snapshot).toMatchObject({ attempts: 3, writes: 1, verified: true });
+  const persisted = await probe.api(world.den.admin, `/v1/config-objects/${world.skillId}`);
+  expect(JSON.stringify(persisted.body)).toContain(draft);
+  evidence.recordAssertionEvidence("After cancel and explicit retry, password verification resumes the saved draft exactly once", "Two rejected attempts, one successful write; persisted skill contains the edited body", true);
+  await user.screenshot();
+});

--- a/evals/worlds/skill-editor-reauth.ts
+++ b/evals/worlds/skill-editor-reauth.ts
@@ -1,0 +1,63 @@
+import type { Seed } from "@openwork/env";
+import { isRecord } from "./library.ts";
+
+function itemId(body: unknown): string {
+  if (!isRecord(body) || !isRecord(body.item) || typeof body.item.id !== "string") {
+    throw new Error("Synthetic skill setup returned no item ID");
+  }
+  return body.item.id;
+}
+
+export async function skillEditorReauth(seed: Seed) {
+  const den = await seed.den({ org: { name: "Skill recovery lab" } });
+  const plugin = await seed.api(den.admin, "/v1/plugins", {
+    method: "POST", body: JSON.stringify({ name: "Recovery plugin", orgWide: true }),
+  });
+  const pluginId = itemId(plugin.body);
+  const created = await seed.api(den.admin, "/v1/config-objects", {
+    method: "POST",
+    body: JSON.stringify({ type: "skill", sourceMode: "cloud", pluginIds: [pluginId], input: {
+      rawSourceText: "---\nname: synthetic-recovery\ndescription: Synthetic recovery instructions\n---\n\nOriginal instructions.",
+    } }),
+  });
+  const skillId = itemId(created.body);
+  const web = await seed.web({ den, signedInAs: den.admin,
+    startPath: `/dashboard/plugins/${pluginId}/skills/${skillId}/edit`, headless: true });
+  return {
+    den, web, skillId,
+    // Transport fault: only skill writes receive a deterministic step-up response.
+    // Successful writes and password verification still reach the real Den API.
+    async expire() {
+      await seed.evalIn(web, `(() => {
+        const originalFetch = window.fetch.bind(window);
+        window.__skillRecovery = { attempts: 0, writes: 0, verified: false, popupAttempts: 0 };
+        window.open = () => { window.__skillRecovery.popupAttempts++; return null; };
+        window.fetch = async (...args) => {
+          const path = new URL(typeof args[0] === 'string' ? args[0] : args[0].url, location.origin).pathname;
+          const state = window.__skillRecovery;
+          if (path.endsWith('/versions') && args[1]?.method === 'POST') {
+            state.attempts++;
+            if (!state.verified) return new Response(JSON.stringify({ error: 'reauth', reason: 'fresh_auth_required', message: 'Confirm your identity to continue.' }), { status: 403 });
+            const response = await originalFetch(...args);
+            if (response.ok) state.writes++;
+            return response;
+          }
+          const response = await originalFetch(...args);
+          if (path.endsWith('/api/auth/sign-in/email') && response.ok) state.verified = true;
+          if (path.endsWith('/v1/me') && response.ok) {
+            const payload = await response.clone().json();
+            payload.user.authProviders = ['email', 'google'];
+            return new Response(JSON.stringify(payload), { status: response.status, headers: response.headers });
+          }
+          return response;
+        };
+      })()`);
+    },
+    async snapshot() {
+      return seed.evalIn(web, `({ ...window.__skillRecovery, body: document.querySelector('textarea')?.value })`);
+    },
+    async duplicateSubmit() {
+      await seed.evalIn(web, `document.querySelector('textarea').closest('form').requestSubmit()`);
+    },
+  };
+}


### PR DESCRIPTION
Skill creation and edits could display a reauthentication error repeatedly without opening the security check: both mutations bypassed the existing queued-action handler. Route them through that handler so verification resumes the pending mutation, cancellation retains the form, and blocked popups use the existing recovery guidance. Guard duplicate form submissions while verification is pending.

Verification on `bba8fd10e00df0090a82d388559d94d833ba453f`:
- `pnpm evals:e2e skill-editor-reauth.e2e.test.ts --daytona` — `placement: daytona (--daytona)`; **Passed: 1 passed, 0 failed, 0 skipped**. [Completed run and downloadable evidence](https://github.com/different-ai/openwork/actions/runs/33982840649). The sticky test-evidence comment contains the assertion witnesses and screenshots.
- The synthetic browser journey injects a reauthentication-required transport response, exercises blocked-popup recovery and cancellation, retains the draft, rejects a duplicate submit, then verifies the password against the real Den API and observes exactly one persisted save. It does not exercise a live external identity provider.
- `bun test ee/apps/den-web/tests/skill-crud-ui.test.ts` — 6 passed; changed components also bundle successfully.
- Both repository-wide spec guards exit 1 on the branch and clean `origin/dev` (`85a5dfccb4d74732593628ab4cc8912f8b88283d`) with byte-identical failures in unrelated specs. The new journey is not flagged.

Local dependency setup was stopped for shared disk pressure. Runtime proof and deferred-evidence judging completed in CI; the already-judged final-head artifacts were published with the repository evidence publisher. Screenshots illustrate the machine-checked assertions and carry no separate visual claims. Only synthetic data is used.
