### PR TITLE
fix(den): confirm the initial administrator password

### DIFF
--- a/ee/apps/den-web/app/(den)/setup/page.tsx
+++ b/ee/apps/den-web/app/(den)/setup/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowRight, CheckCircle2 } from "lucide-react";
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { AUTH_TOKEN_STORAGE_KEY, getErrorMessage, getToken, requestJson } from "../_lib/den-flow";
 
 type SetupStatus = "loading" | "available" | "complete" | "unavailable";
@@ -24,6 +24,9 @@ export default function SetupPage() {
   const [setupCode, setSetupCode] = useState("");
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordMismatch, setPasswordMismatch] = useState(false);
+  const confirmationInput = useRef<HTMLInputElement>(null);
   const [grant, setGrant] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -73,8 +76,14 @@ export default function SetupPage() {
 
   async function submitAccount(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setBusy(true);
     setError(null);
+    if (password !== confirmPassword) {
+      setPasswordMismatch(true);
+      confirmationInput.current?.focus();
+      return;
+    }
+    setPasswordMismatch(false);
+    setBusy(true);
     try {
       const { response, payload } = await requestJson("/api/auth/sign-up/email", {
         method: "POST",
@@ -200,9 +209,36 @@ export default function SetupPage() {
                 autoComplete="new-password"
                 className="den-input"
                 value={password}
-                onChange={(event) => setPassword(event.currentTarget.value)}
+                onChange={(event) => {
+                  setPassword(event.currentTarget.value);
+                  setPasswordMismatch(false);
+                }}
                 required
               />
+            </div>
+            <div className="grid gap-2">
+              <label className="den-label" htmlFor="setup-confirm-password">Confirm password</label>
+              <input
+                ref={confirmationInput}
+                id="setup-confirm-password"
+                name="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                className="den-input"
+                value={confirmPassword}
+                onChange={(event) => {
+                  setConfirmPassword(event.currentTarget.value);
+                  setPasswordMismatch(false);
+                }}
+                aria-invalid={passwordMismatch}
+                aria-describedby={passwordMismatch ? "setup-password-mismatch" : undefined}
+                required
+              />
+              {passwordMismatch ? (
+                <p id="setup-password-mismatch" className="m-0 text-sm font-medium text-rose-600" role="alert">
+                  Passwords do not match. Enter the same password in both fields.
+                </p>
+              ) : null}
             </div>
             {error ? <p className="m-0 text-sm font-medium text-rose-600" role="alert">{error}</p> : null}
             <button type="submit" className="den-button-primary" disabled={busy}>

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -684,6 +684,7 @@ export async function server(options: ServerOptions): Promise<Den> {
       ref: base.ref,
       reuse: preparedSandbox,
       bootstrapAdminEmail: bootstrapAdmin.email,
+      seed: options.provision !== false,
       env: denEnv,
       log: (line) => console.error(`[openwork/testkit] ${line}`),
     });

--- a/evals/packages/hosts/src/provision.ts
+++ b/evals/packages/hosts/src/provision.ts
@@ -50,6 +50,8 @@ export interface DenSandboxOptions {
   reuse?: string;
   repoRoot?: string;
   bootstrapAdminEmail?: string;
+  /** Disable demo accounts for first-account setup journeys. Defaults to true. */
+  seed?: boolean;
   /** Extra Den environment for a freshly provisioned sandbox; a reused Den is already running and cannot take it. */
   env?: Record<string, string>;
   log?: (line: string) => void;
@@ -500,12 +502,12 @@ export function encodeDenExtraEnv(env: Record<string, string>): string {
   return Buffer.from(lines.join("\n"), "utf8").toString("base64");
 }
 
-function runDenProvisionScript(ref: string, repoRoot: string, bootstrapAdminEmail: string | undefined, extraEnv: Record<string, string> | undefined, log: (line: string) => void, urlsFile: string): Promise<LocalProcessResult> {
+function runDenProvisionScript(ref: string, repoRoot: string, bootstrapAdminEmail: string | undefined, extraEnv: Record<string, string> | undefined, log: (line: string) => void, urlsFile: string, seed: boolean): Promise<LocalProcessResult> {
   return new Promise((resolve, reject) => {
     const env: NodeJS.ProcessEnv = { ...process.env, OPENWORK_DEN_URLS_FILE: urlsFile };
     if (bootstrapAdminEmail) env.DEN_BOOTSTRAP_ADMIN_EMAILS = bootstrapAdminEmail;
     if (extraEnv && Object.keys(extraEnv).length > 0) env.OPENWORK_DEN_EXTRA_ENV_B64 = encodeDenExtraEnv(extraEnv);
-    const child = spawn("bash", [".devcontainer/test-server-on-daytona.sh", ref, "--seed", "--name", serverSandboxName()], {
+    const child = spawn("bash", [".devcontainer/test-server-on-daytona.sh", ref, ...(seed ? ["--seed"] : []), "--name", serverSandboxName()], {
       cwd: repoRoot,
       env,
       stdio: ["ignore", "pipe", "pipe"],
@@ -677,6 +679,7 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
         options.env,
         log,
         urlsFile,
+        options.seed !== false,
       ));
       if (result.code !== 0) {
         throw new Error(`Den provisioning script gate failed with exit ${result.code}. Output tail:\n${textTail(result.output)}`);
@@ -698,7 +701,9 @@ export async function provisionDenSandbox(options: DenSandboxOptions & Provision
     }
   }
 
-  await timedStep(log, "Den seeded-org proof", () => proveDenSeed(apiUrl, webUrl, sandbox, Boolean(reused)));
+  if (options.seed !== false) {
+    await timedStep(log, "Den seeded-org proof", () => proveDenSeed(apiUrl, webUrl, sandbox, Boolean(reused)));
+  }
   return { sandbox, apiUrl, webUrl, created: !reused };
 }
 

--- a/evals/specs/initial-admin-setup.e2e.test.ts
+++ b/evals/specs/initial-admin-setup.e2e.test.ts
@@ -1,0 +1,40 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { initialAdminSetup } from "../worlds/initial-admin-setup.ts";
+
+// No existing journey covers the private deployment's first-account form.
+const test = spec.world(initialAdminSetup, { timeout: 420_000 });
+
+test("initial administrator creation requires matching passwords before closing setup", async ({ world, user, probe, evidence }) => {
+  const password = "Synthetic-owner-password-47!";
+  await user.see({ label: "Administrator email" }, { timeoutMs: 90_000 });
+  await user.type({ label: "Administrator email" }, world.email);
+  await user.type({ label: "One-time setup code" }, world.setupCode);
+  await user.click({ role: "button", label: "Continue" });
+  await user.see({ label: "Confirm password" });
+  await user.type({ label: "Name" }, "Example Owner");
+  await user.type({ label: "Password" }, password);
+
+  await user.click({ role: "button", label: "Create administrator" });
+  expect(await world.confirmationState()).toMatchObject({ required: true, missing: true });
+  expect(await world.status()).toMatchObject({ status: "available" });
+  evidence.recordAssertionEvidence("Empty confirmation cannot create the first account", "Native required validation rejects empty confirmation; server setup remains available.", true);
+
+  await user.type({ label: "Confirm password" }, `${password}typo`);
+  await user.click({ role: "button", label: "Create administrator" });
+  await user.see({ text: "Passwords do not match. Enter the same password in both fields." });
+  expect(await world.confirmationState()).toMatchObject({ invalid: "true", focused: true, role: "alert", error: "Passwords do not match. Enter the same password in both fields." });
+  expect(await world.status()).toMatchObject({ status: "available" });
+  expect(await world.signIn(password)).toBe(401);
+  evidence.recordAssertionEvidence("A mismatch is announced and creates no owner", "Confirmation is focused, marked invalid, and associated with the alert. Setup remains available and sign-in fails.", true);
+  await user.screenshot();
+
+  await user.type({ label: "Confirm password" }, password, { replace: true });
+  await user.notSee({ text: "Passwords do not match. Enter the same password in both fields." });
+  expect(await world.confirmationState()).toMatchObject({ invalid: "false" });
+  await user.click({ role: "button", label: "Create administrator" });
+  await probe.eventually(() => world.status(), { within: 30_000, label: "setup closes after account creation", until: (value) => typeof value === "object" && value !== null && "status" in value && value.status === "complete" });
+  expect(await world.signIn(password)).toBe(200);
+  expect(await world.signIn(`${password}typo`)).toBe(401);
+  evidence.recordAssertionEvidence("Correcting confirmation creates the owner with the intended password", "Setup becomes complete, the intended password signs in, and the mistyped password is rejected.", true);
+});

--- a/evals/specs/initial-admin-setup.e2e.test.ts
+++ b/evals/specs/initial-admin-setup.e2e.test.ts
@@ -7,20 +7,20 @@ const test = spec.world(initialAdminSetup, { timeout: 420_000 });
 
 test("initial administrator creation requires matching passwords before closing setup", async ({ world, user, probe, evidence }) => {
   const password = "Synthetic-owner-password-47!";
-  await user.see({ label: "Administrator email" }, { timeoutMs: 90_000 });
-  await user.type({ label: "Administrator email" }, world.email);
-  await user.type({ label: "One-time setup code" }, world.setupCode);
+  await user.see({ label: /^Administrator email$/i }, { timeoutMs: 90_000 });
+  await user.type({ label: /^Administrator email$/i }, world.email);
+  await user.type({ label: /^One-time setup code$/i }, world.setupCode);
   await user.click({ role: "button", label: "Continue" });
-  await user.see({ label: "Confirm password" });
-  await user.type({ label: "Name" }, "Example Owner");
-  await user.type({ label: "Password" }, password);
+  await user.see({ label: /^Confirm password$/i });
+  await user.type({ label: /^Name$/i }, "Example Owner");
+  await user.type({ label: /^Password$/i }, password);
 
   await user.click({ role: "button", label: "Create administrator" });
   expect(await world.confirmationState()).toMatchObject({ required: true, missing: true });
   expect(await world.status()).toMatchObject({ status: "available" });
   evidence.recordAssertionEvidence("Empty confirmation cannot create the first account", "Native required validation rejects empty confirmation; server setup remains available.", true);
 
-  await user.type({ label: "Confirm password" }, `${password}typo`);
+  await user.type({ label: /^Confirm password$/i }, `${password}typo`);
   await user.click({ role: "button", label: "Create administrator" });
   await user.see({ text: "Passwords do not match. Enter the same password in both fields." });
   expect(await world.confirmationState()).toMatchObject({ invalid: "true", focused: true, role: "alert", error: "Passwords do not match. Enter the same password in both fields." });
@@ -29,7 +29,7 @@ test("initial administrator creation requires matching passwords before closing 
   evidence.recordAssertionEvidence("A mismatch is announced and creates no owner", "Confirmation is focused, marked invalid, and associated with the alert. Setup remains available and sign-in fails.", true);
   await user.screenshot();
 
-  await user.type({ label: "Confirm password" }, password, { replace: true });
+  await user.type({ label: /^Confirm password$/i }, password, { replace: true });
   await user.notSee({ text: "Passwords do not match. Enter the same password in both fields." });
   expect(await world.confirmationState()).toMatchObject({ invalid: "false" });
   await user.click({ role: "button", label: "Create administrator" });

--- a/evals/worlds/initial-admin-setup.ts
+++ b/evals/worlds/initial-admin-setup.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto";
+import type { Seed } from "@openwork/env";
+
+export async function initialAdminSetup(seed: Seed) {
+  const email = "owner@example.test";
+  const setupCode = randomUUID();
+  const den = await seed.den({
+    provision: false,
+    env: {
+      DEN_ORG_MODE: "single_org",
+      DEN_SINGLE_ORG_NAME: "Example workspace",
+      DEN_SINGLE_ORG_SLUG: "example-workspace",
+      DEN_SINGLE_ORG_OWNER_EMAILS: email,
+      DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: "false",
+      DEN_INITIAL_ADMIN_BOOTSTRAP_CODE: setupCode,
+    },
+  });
+  const web = await seed.web({ den, startPath: "/setup", headless: true });
+  return {
+    den, web, email, setupCode,
+    async status(): Promise<unknown> {
+      const response = await fetch(`${den.ref.apiUrl}/v1/auth/bootstrap/status`, { signal: AbortSignal.timeout(10_000) });
+      if (!response.ok) throw new Error(`Setup status failed: ${response.status}`);
+      return response.json();
+    },
+    // TODO(primitive): expose native validity, error association, and focus through probe.
+    async confirmationState() {
+      return seed.evalIn(web, `(() => {
+        const input = document.getElementById("setup-confirm-password");
+        const error = document.getElementById(input?.getAttribute("aria-describedby"));
+        return {
+          required: input?.required,
+          missing: input?.validity.valueMissing,
+          invalid: input?.getAttribute("aria-invalid"),
+          focused: document.activeElement === input,
+          error: error?.textContent.trim(),
+          role: error?.getAttribute("role"),
+        };
+      })()`);
+    },
+    async signIn(password: string) {
+      const response = await fetch(`${den.ref.apiUrl}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: den.ref.webUrl },
+        body: JSON.stringify({ email, password }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      return response.status;
+    },
+  };
+}


### PR DESCRIPTION
A typo in the first administrator's password can close private-deployment setup before email recovery is configured. `/setup` now requires password confirmation before sending account creation. A mismatch focuses confirmation and displays an associated alert; editing clears it. Authentication and bootstrap authorization are unchanged.

The private setup journey verifies empty and mismatched confirmation leave setup available with no usable account, then checks matching values create the owner and only the intended password signs in. The test infrastructure now honors `provision: false` on Daytona without seeding a demo account; other journeys retain default seeding.

Verification on `d0562a3370116bf81821d65fc39993d640842524`:
- `pnpm evals:e2e initial-admin-setup --daytona`: **Passed**, exit 0; 1 passed, 0 failed, 0 skipped. Placement: `daytona (--daytona)`. [Completed run](https://github.com/different-ai/openwork/actions/runs/33983365484).
- Three assertion groups and the mismatch screenshot are published in the sticky test-evidence comment. The screenshot illustrates the assertions; it is not a separate visual claim. All examples are synthetic, and setup-code trace text was redacted before publication without changing results.
- `git diff --check`: passed. Local dependency preparation was stopped when the shared machine ran out of disk space; verification ran remotely.
- Repository-wide spec boundary and channel ratchets each exit 1 with identical output on the branch and fresh `origin/dev` (`85a5dfccb4d74732593628ab4cc8912f8b88283d`). Their existing failures do not name this journey.
