### PR TITLE
fix(billing): preserve cancellation status and effective dates

### DIFF
--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -46,6 +46,8 @@ function stripe() {
   if (!stripeClient) {
     stripeClient = new Stripe(env.stripe.secretKey, {
       apiVersion: STRIPE_API_VERSION as any,
+      ...(process.env.OPENWORK_DEV_MODE === "1" && process.env.OPENWORK_TEST_STRIPE_PORT
+        ? { host: "127.0.0.1", port: Number(process.env.OPENWORK_TEST_STRIPE_PORT), protocol: "http" as const } : {}),
     })
   }
   return stripeClient
@@ -503,8 +505,8 @@ export async function upsertOrgSubscriptionFromStripe(subscription: Stripe.Subsc
     stripe_price_id: priceId,
     stripe_subscription_item_id: item?.id ?? null,
     quantity,
-    current_period_start: fromUnixSeconds((subscription as Stripe.Subscription & { current_period_start?: number }).current_period_start),
-    current_period_end: fromUnixSeconds((subscription as Stripe.Subscription & { current_period_end?: number }).current_period_end),
+    current_period_start: fromUnixSeconds(item?.current_period_start),
+    current_period_end: fromUnixSeconds(item?.current_period_end),
     cancel_at_period_end: subscription.cancel_at_period_end,
     payment_failed: paymentFailed,
     canceled_at: fromUnixSeconds(subscription.canceled_at),
@@ -570,8 +572,8 @@ export async function refreshOrgSubscriptionFromStripe(stripeSubscriptionId: str
       stripe_price_id: priceId,
       stripe_subscription_item_id: item?.id ?? null,
       quantity,
-      current_period_start: fromUnixSeconds((subscription as Stripe.Subscription & { current_period_start?: number }).current_period_start),
-      current_period_end: fromUnixSeconds((subscription as Stripe.Subscription & { current_period_end?: number }).current_period_end),
+      current_period_start: fromUnixSeconds(item?.current_period_start),
+      current_period_end: fromUnixSeconds(item?.current_period_end),
       cancel_at_period_end: subscription.cancel_at_period_end,
       ...(existing?.type !== WEB_SUBSCRIPTION_TYPE ? { payment_failed: paymentFailed } : {}),
       canceled_at: fromUnixSeconds(subscription.canceled_at),
@@ -1241,6 +1243,8 @@ async function expireNonWebSubscriptionAfterPaymentFailure(
   row: NonNullable<Awaited<ReturnType<typeof findOrgSubscriptionByStripeId>>>,
   eventId: string,
 ) {
+  // A late failed invoice must not overwrite a completed cancellation.
+  if (row.status === "canceled") return
   await db
     .update(OrgSubscriptionTable)
     .set({ status: "expired", last_event_id: eventId, updated_at: new Date() })

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -349,6 +349,8 @@ export function BillingDashboardScreen() {
   const aiCancelling = stripeBilling?.subscription?.cancelAtPeriodEnd === true;
 
   const seatsActive = seatBilling?.hasActiveSubscription === true;
+  const seatsCancelling = seatsActive && seatBilling?.subscription?.cancelAtPeriodEnd === true;
+  const seatsEndDate = formatBillingDate(seatBilling?.subscription?.currentPeriodEnd ?? null);
   const freeSeatCount = seatBilling?.freeSeatCount ?? 0;
   const billableSeatCount = seatBilling?.billableSeatCount ?? 0;
   const seatChargeMinor = seatBilling ? seatBilling.unitAmount * billableSeatCount : 0;
@@ -700,11 +702,23 @@ export function BillingDashboardScreen() {
           action={
             !seatsConfigured
               ? <DenBadge tone="neutral">Not billed</DenBadge>
+              : seatsCancelling
+                ? <DenBadge tone="warning">Cancellation scheduled</DenBadge>
               : seatsActive
                 ? <DenBadge tone="success" icon={Check}>Active</DenBadge>
                 : <DenBadge tone="neutral">Included</DenBadge>
           }
         />
+
+        {seatsCancelling ? (
+          <DenNotice
+            tone="warning"
+            className="mt-5"
+            message={seatsEndDate
+              ? `Seat billing ends ${seatsEndDate}. Your subscription will not renew.`
+              : "Cancellation scheduled. Your subscription will not renew after the current paid period."}
+          />
+        ) : null}
 
         <DenNotice
           tone="neutral"

--- a/evals/packages/labs/src/index.ts
+++ b/evals/packages/labs/src/index.ts
@@ -7,3 +7,5 @@ export * from "./mock-cloud-runtime.ts";
 export * from "./mock-mcp.ts";
 export * from "./not-implemented.ts";
 export * from "./release-feed.ts";
+
+export { mockStripe } from "./mock-stripe.ts";

--- a/evals/packages/labs/src/mock-stripe.ts
+++ b/evals/packages/labs/src/mock-stripe.ts
@@ -1,0 +1,86 @@
+import { createServer } from "node:http";
+import { createHmac } from "node:crypto";
+
+const priceAmounts: Record<string, number> = { price_team: 1000, price_enterprise: 4000, price_sso: 30000 };
+type Subscription = {
+  id: string; object: string; customer: string; status: string; metadata: Record<string, string>;
+  latest_invoice: string; items: { data: { id: string; price: ReturnType<typeof price>; quantity: number; current_period_start: number; current_period_end: number }[] };
+  cancel_at_period_end: boolean;
+};
+function price(id: string) {
+  return { id, object: "price", active: true, type: "recurring", billing_scheme: "per_unit", transform_quantity: null,
+    unit_amount: priceAmounts[id], currency: "usd", recurring: { interval: "month", interval_count: 1, usage_type: "licensed" } };
+}
+
+export async function mockStripe() {
+  const disabledPrices = new Set<string>();
+  const customers = new Map<string, { id: string; metadata: Record<string, string> }>();
+  const subscriptions = new Map<string, Subscription>();
+  const sessions = new Map<string, { id: string; object: string; customer: string; metadata: Record<string, string>; mode: string; client_reference_id: string; status: string; url: string; subscription?: string; payment_status?: string; price: string; quantity: number }>();
+  const invoices = new Map<string, { id: string; status: string; parent: { type: string; subscription_details: { subscription: string } } }>();
+  const calls: { path: string; method: string; body: URLSearchParams }[] = [];
+  const list = (data: unknown[]) => ({ object: "list", data, has_more: false, url: "/v1/mock" });
+  const server = createServer(async (req, res) => {
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    const body = new URLSearchParams(raw);
+    const url = new URL(req.url ?? "/", "http://localhost");
+    calls.push({ path: url.pathname, method: req.method ?? "GET", body });
+    let result: unknown;
+    if (url.pathname.startsWith("/v1/prices/")) {
+      const id = url.pathname.split("/").at(-1) ?? "";
+      result = { ...price(id), active: !disabledPrices.has(id) };
+    }
+    else if (url.pathname === "/v1/customers/search") result = { ...list([...customers.values()].filter((c) => url.searchParams.get("query")?.includes(c.metadata.org_id))), object: "search_result" };
+    else if (url.pathname === "/v1/customers" && req.method === "POST") {
+      const customer = { id: `cus_${customers.size + 1}`, metadata: { org_id: body.get("metadata[org_id]") ?? "" } };
+      customers.set(customer.id, customer); result = customer;
+    } else if (url.pathname.startsWith("/v1/customers/")) result = customers.get(url.pathname.split("/").at(-1) ?? "");
+    else if (url.pathname === "/v1/customers") result = list([]);
+    else if (url.pathname === "/v1/subscriptions") result = list([...subscriptions.values()].filter((s) => s.customer === url.searchParams.get("customer")));
+    else if (url.pathname.startsWith("/v1/subscriptions/")) result = subscriptions.get(url.pathname.split("/").at(-1) ?? "");
+    else if (url.pathname.startsWith("/v1/invoices/")) result = invoices.get(url.pathname.split("/").at(-1) ?? "");
+    else if (url.pathname === "/v1/checkout/sessions" && req.method === "POST") {
+      const session = { id: `cs_${sessions.size + 1}`, object: "checkout.session", customer: body.get("customer") ?? "", mode: body.get("mode") ?? "", status: "open", url: `https://checkout.stripe.test/${sessions.size + 1}`,
+        metadata: { org_id: body.get("metadata[org_id]") ?? "", subscription_type: body.get("metadata[subscription_type]") ?? "" },
+        client_reference_id: body.get("client_reference_id") ?? "", price: body.get("line_items[0][price]") ?? "", quantity: Number(body.get("line_items[0][quantity]")) };
+      sessions.set(session.id, session); result = session;
+    } else if (url.pathname === "/v1/checkout/sessions") result = list([...sessions.values()].filter((s) => s.customer === url.searchParams.get("customer")).reverse());
+    else if (url.pathname.startsWith("/v1/checkout/sessions/")) {
+      const session = sessions.get(url.pathname.split("/")[4]);
+      if (url.pathname.endsWith("/line_items")) result = list(session ? [{ price: price(session.price), quantity: session.quantity, current_period_start: 1788220800, current_period_end: 1790812800 }] : []);
+      else if (url.pathname.endsWith("/expire") && session) { session.status = "expired"; result = session; }
+      else result = session;
+    } else if (url.pathname === "/v1/billing_portal/sessions") result = { id: "bps_mock", url: "https://billing.stripe.test/confirm" };
+    else if (url.pathname.startsWith("/v1/subscription_items/")) result = { id: url.pathname.split("/").at(-1), quantity: Number(body.get("quantity")) };
+    res.setHeader("content-type", "application/json");
+    if (result === undefined) { res.statusCode = 404; result = { error: { message: `Mock Stripe: unhandled ${req.method} ${url.pathname}` } }; }
+    res.end(JSON.stringify(result));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Mock Stripe did not bind");
+  let eventNumber = 0;
+  return {
+    port: address.port, calls, subscriptions, sessions, invoices, disabledPrices,
+    complete(sessionId: string, paid = true) {
+      const session = sessions.get(sessionId);
+      if (!session) throw new Error("Unknown checkout");
+      session.status = "complete"; session.payment_status = paid ? "paid" : "unpaid";
+      const id = `sub_${subscriptions.size + 1}`;
+      session.subscription = id;
+      const invoiceId = `in_${id}`;
+      invoices.set(invoiceId, { id: invoiceId, status: paid ? "paid" : "open", parent: { type: "subscription_details", subscription_details: { subscription: id } } });
+      subscriptions.set(id, { id, object: "subscription", customer: session.customer, status: "active", metadata: session.metadata,
+        latest_invoice: invoiceId, cancel_at_period_end: false, items: { data: [{ id: `si_${id}`, price: price(session.price), quantity: session.quantity, current_period_start: 1788220800, current_period_end: 1790812800 }] } });
+      return id;
+    },
+    async webhook(apiUrl: string, type: string, object: unknown, valid = true, eventId?: string) {
+      const payload = JSON.stringify({ id: eventId ?? `evt_${++eventNumber}`, object: "event", type, data: { object } });
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signature = createHmac("sha256", valid ? "whsec_plan_test" : "invalid").update(`${timestamp}.${payload}`).digest("hex");
+      return fetch(`${apiUrl}/v1/webhooks/stripe`, { method: "POST", headers: { "content-type": "application/json", "stripe-signature": `t=${timestamp},v1=${signature}` }, body: payload });
+    },
+    async [Symbol.asyncDispose]() { server.closeAllConnections(); await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())); },
+  };
+}

--- a/evals/specs/billing-cancellation.e2e.test.ts
+++ b/evals/specs/billing-cancellation.e2e.test.ts
@@ -3,6 +3,8 @@ import { billingCancellationWeb } from "../worlds/billing-cancellation.ts";
 
 const test = spec.world(billingCancellationWeb, { timeout: 420_000 });
 test("billing confirms scheduled seat and model cancellation with an effective date", async ({ world, user, evidence }) => {
+  await user.see({ role: "link", label: "Settings" }, { timeoutMs: 90_000 });
+  await user.click({ role: "link", label: "Settings" });
   await user.see({ role: "link", label: "Billing" }, { timeoutMs: 90_000 });
   await user.click({ role: "link", label: "Billing" });
   await user.see({ testId: "billing-seats-card" }, { timeoutMs: 90_000 });

--- a/evals/specs/billing-cancellation.e2e.test.ts
+++ b/evals/specs/billing-cancellation.e2e.test.ts
@@ -3,7 +3,8 @@ import { billingCancellationWeb } from "../worlds/billing-cancellation.ts";
 
 const test = spec.world(billingCancellationWeb, { timeout: 420_000 });
 test("billing confirms scheduled seat and model cancellation with an effective date", async ({ world, user, evidence }) => {
-  await user.click({ role: "link", label: "Billing" }, { timeoutMs: 90_000 });
+  await user.see({ role: "link", label: "Billing" }, { timeoutMs: 90_000 });
+  await user.click({ role: "link", label: "Billing" });
   await user.see({ testId: "billing-seats-card" }, { timeoutMs: 90_000 });
   await user.see({ text: "Cancellation scheduled" });
   await user.see({ text: `Seat billing ends ${world.effectiveDate}. Your subscription will not renew.` });

--- a/evals/specs/billing-cancellation.e2e.test.ts
+++ b/evals/specs/billing-cancellation.e2e.test.ts
@@ -3,10 +3,11 @@ import { billingCancellationWeb } from "../worlds/billing-cancellation.ts";
 
 const test = spec.world(billingCancellationWeb, { timeout: 420_000 });
 test("billing confirms scheduled seat and model cancellation with an effective date", async ({ world, user, evidence }) => {
+  await user.click({ role: "link", label: "Billing" }, { timeoutMs: 90_000 });
   await user.see({ testId: "billing-seats-card" }, { timeoutMs: 90_000 });
   await user.see({ text: "Cancellation scheduled" });
   await user.see({ text: `Seat billing ends ${world.effectiveDate}. Your subscription will not renew.` });
-  await user.see({ text: `access ends ${world.effectiveDate}` });
+  await user.see({ text: new RegExp(`access ends ${world.effectiveDate}`) });
   evidence.recordAssertionEvidence("Billing confirms the effective cancellation date for seats and models", "Seat card says cancellation scheduled and no renewal on October 1; model access ends on the same date", true);
   await user.screenshot();
 });

--- a/evals/specs/billing-cancellation.e2e.test.ts
+++ b/evals/specs/billing-cancellation.e2e.test.ts
@@ -1,0 +1,12 @@
+import { spec } from "@openwork/testkit";
+import { billingCancellationWeb } from "../worlds/billing-cancellation.ts";
+
+const test = spec.world(billingCancellationWeb, { timeout: 420_000 });
+test("billing confirms scheduled seat and model cancellation with an effective date", async ({ world, user, evidence }) => {
+  await user.see({ testId: "billing-seats-card" }, { timeoutMs: 90_000 });
+  await user.see({ text: "Cancellation scheduled" });
+  await user.see({ text: `Seat billing ends ${world.effectiveDate}. Your subscription will not renew.` });
+  await user.see({ text: `access ends ${world.effectiveDate}` });
+  evidence.recordAssertionEvidence("Billing confirms the effective cancellation date for seats and models", "Seat card says cancellation scheduled and no renewal on October 1; model access ends on the same date", true);
+  await user.screenshot();
+});

--- a/evals/specs/billing-cancellation.test.ts
+++ b/evals/specs/billing-cancellation.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "vitest";
+import { denFetch, provisionOrg } from "@openwork/behaviors";
+import { mockStripe } from "@openwork/labs";
+import { needs, server, test } from "@openwork/testkit";
+
+test("confirmed cancellation survives retries and stale events with its effective date", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs({ placement: "local", env: ["OPENWORK_EVAL_MYSQL_URL"] });
+  await using stripe = await mockStripe();
+  await using den = await server({ place, web: false, env: {
+    OPENWORK_TEST_STRIPE_PORT: String(stripe.port), STRIPE_SECRET_KEY: "sk_test_cancellation",
+    STRIPE_WEBHOOK_SECRET: "whsec_plan_test", STRIPE_INFERENCE_PRICE_ID: "price_team", STRIPE_SEAT_PRICE_ID: "price_team",
+  } });
+  const request = (path: string, method = "GET", body?: unknown) => denFetch(den.admin, path, {
+    headers: { authorization: `Bearer ${den.admin.token}` }, method,
+    body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(30_000),
+  });
+  const billing = async () => {
+    const result = await request("/v1/billing");
+    expect(result.response.status).toBe(200);
+    return result.body;
+  };
+  expect((await request("/v1/billing/stripe/checkout", "POST", { type: "inference" })).response.status).toBe(200);
+  const id = stripe.complete("cs_1");
+  const subscription = stripe.subscriptions.get(id)!;
+  const stale = structuredClone(subscription);
+  expect((await stripe.webhook(den.ref.apiUrl, "customer.subscription.created", subscription)).status).toBe(200);
+  expect(await billing()).toMatchObject({ billing: { stripe: { subscription: { status: "active", cancelAtPeriodEnd: false } } } });
+  subscription.cancel_at_period_end = true;
+  for (const payload of [subscription, subscription, stale]) {
+    expect((await stripe.webhook(den.ref.apiUrl, "customer.subscription.updated", payload, true, "evt_cancellation_retry")).status).toBe(200);
+    expect(await billing()).toMatchObject({ billing: { stripe: { subscription: {
+      status: "active", cancelAtPeriodEnd: true, currentPeriodStart: "2026-09-01T00:00:00.000Z", currentPeriodEnd: "2026-10-01T00:00:00.000Z",
+    } } } });
+  }
+  evidence.recordAssertionEvidence("Scheduled cancellation persists with its effective date", "Duplicate and stale signed events retain cancellation on October 1; access remains active during the paid period", true);
+  subscription.status = "canceled";
+  for (const type of ["customer.subscription.deleted", "customer.subscription.deleted", "customer.subscription.updated"]) {
+    expect((await stripe.webhook(den.ref.apiUrl, type, type.endsWith("updated") ? stale : subscription)).status).toBe(200);
+    expect(await billing()).toMatchObject({ billing: { stripe: { hasActiveSubscription: false, subscription: { status: "canceled", cancelAtPeriodEnd: true } } } });
+  }
+  expect((await stripe.webhook(den.ref.apiUrl, "invoice.payment_failed", stripe.invoices.get(subscription.latest_invoice))).status).toBe(200);
+  expect(await billing()).toMatchObject({ billing: { stripe: { hasActiveSubscription: false, subscription: { status: "canceled" } } } });
+  const other = await provisionOrg(den.ref, {});
+  const otherBilling = await denFetch(other.admin, "/v1/billing", { headers: { authorization: `Bearer ${other.admin.token}` } });
+  expect(otherBilling.body).toMatchObject({ billing: { stripe: { hasActiveSubscription: false, subscription: null } } });
+  expect(stripe.calls.filter((call) => call.path.startsWith("/v1/subscriptions/") && call.method !== "GET")).toEqual([]);
+  evidence.recordAssertionEvidence("Canceled subscriptions stay canceled without mutations or cross-organization effects", "Deleted-event retries and stale active updates do not restore access; unrelated organization has no subscription; reconciliation sends no subscription writes", true);
+});

--- a/evals/specs/billing-cancellation.test.ts
+++ b/evals/specs/billing-cancellation.test.ts
@@ -27,8 +27,8 @@ test("confirmed cancellation survives retries and stale events with its effectiv
   expect(await billing()).toMatchObject({ billing: { stripe: { subscription: { status: "active", cancelAtPeriodEnd: false } } } });
   subscription.cancel_at_period_end = true;
   for (const payload of [subscription, subscription, stale]) {
-    expect((await stripe.webhook(den.ref.apiUrl, "customer.subscription.updated", payload, true, "evt_cancellation_retry")).status).toBe(200);
-    expect(await billing()).toMatchObject({ billing: { stripe: { subscription: {
+    expect((await stripe.webhook(den.ref.apiUrl, "customer.subscription.updated", payload, true, payload === stale ? "evt_before_cancellation" : "evt_cancellation_retry")).status).toBe(200);
+    expect(await billing()).toMatchObject({ billing: { stripe: { hasActiveSubscription: true, subscription: {
       status: "active", cancelAtPeriodEnd: true, currentPeriodStart: "2026-09-01T00:00:00.000Z", currentPeriodEnd: "2026-10-01T00:00:00.000Z",
     } } } });
   }

--- a/evals/worlds/billing-cancellation.ts
+++ b/evals/worlds/billing-cancellation.ts
@@ -1,0 +1,32 @@
+import type { Seed } from "@openwork/env";
+import { mockStripe } from "@openwork/labs";
+
+export async function billingCancellationWeb(seed: Seed) {
+  const stripe = await mockStripe();
+  try {
+    const den = await seed.den({ env: {
+      OPENWORK_TEST_STRIPE_PORT: String(stripe.port), STRIPE_SECRET_KEY: "sk_test_cancellation",
+      STRIPE_WEBHOOK_SECRET: "whsec_plan_test", STRIPE_INFERENCE_PRICE_ID: "price_team", STRIPE_SEAT_PRICE_ID: "price_team",
+    } });
+    const checkout = await seed.api(den.admin, "/v1/billing/stripe/checkout", { method: "POST", body: JSON.stringify({ type: "inference" }) });
+    if (checkout.response.status !== 200) throw new Error(`Fixture checkout failed: ${checkout.response.status}`);
+    const subscription = stripe.subscriptions.get(stripe.complete("cs_1"))!;
+    subscription.cancel_at_period_end = true;
+    const seat = structuredClone(subscription);
+    seat.id = "sub_seats";
+    seat.metadata.subscription_type = "seat";
+    stripe.subscriptions.set(seat.id, seat);
+    for (const value of [subscription, seat]) {
+      const response = await stripe.webhook(den.ref.apiUrl, "customer.subscription.updated", value);
+      if (!response.ok) throw new Error(`Fixture webhook failed: ${response.status}`);
+    }
+    const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard/billing", headless: true,
+      viewport: { width: 1440, height: 1100 } });
+    const effectiveDate = await seed.evalIn(web, `new Date("2026-10-01T00:00:00.000Z").toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" })`);
+    if (typeof effectiveDate !== "string") throw new Error("Browser date formatting failed");
+    return { den, web, effectiveDate, async [Symbol.asyncDispose]() { await stripe[Symbol.asyncDispose](); } };
+  } catch (error) {
+    await stripe[Symbol.asyncDispose]();
+    throw error;
+  }
+}

--- a/evals/worlds/billing-cancellation.ts
+++ b/evals/worlds/billing-cancellation.ts
@@ -20,7 +20,7 @@ export async function billingCancellationWeb(seed: Seed) {
       const response = await stripe.webhook(den.ref.apiUrl, "customer.subscription.updated", value);
       if (!response.ok) throw new Error(`Fixture webhook failed: ${response.status}`);
     }
-    const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard/billing", headless: true,
+    const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard", headless: true,
       viewport: { width: 1440, height: 1100 } });
     const effectiveDate = await seed.evalIn(web, `new Date("2026-10-01T00:00:00.000Z").toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" })`);
     if (typeof effectiveDate !== "string") throw new Error("Browser date formatting failed");


### PR DESCRIPTION
Den could lose a cancellation’s effective date because it read [subscription-level billing periods removed by Stripe](https://docs.stripe.com/changelog/basil/2025-03-31/deprecate-subscription-current-period-start-and-end). Team seats kept displaying Active while scheduled to cancel, and a late failed-invoice webhook could replace a canceled status with expired.

Read the subscription item’s billing periods, show scheduled seat cancellation with the effective date and no-renewal confirmation, and preserve canceled status on late payment failures. Reconciliation continues to retrieve the current Stripe subscription, so stale event payloads cannot restore active status. This is separate from #4448’s self-serve plans and #2512’s payment retry behavior; the report does not establish incorrect real charges.

Verification on `e6ae3bb12487081dbf64feb4553a505a3ca73127`:
- API journey: `OPENWORK_EVAL_MYSQL_URL=mysql://root:password@127.0.0.1:3306 pnpm evals:pr specs/billing-cancellation.test.ts` — 1 passed, 0 skipped. Real Den with signed synthetic Stripe webhooks covers scheduled cancellation dates, duplicate delivery, stale active updates, completed cancellation, late failed invoices, isolation, and absence of subscription mutations.
- Browser journey: `OPENWORK_EVAL_MYSQL_URL=mysql://root:password@127.0.0.1:3306 pnpm evals:e2e billing-cancellation` — 1 passed, 0 skipped. Opens Settings → Billing and observes scheduled cancellation plus the effective date for seats and models. Sanitized screenshot and assertion evidence are published below.
- Dev control at `85a5dfccb4d74732593628ab4cc8912f8b88283d`, with only the new test fixtures/loopback transport hook, fails both journeys: the confirmation is absent and period dates are null. An early PR browser attempt returned 404; the final journey navigates through Settings and passes.
- Final-head GitHub checks: 27 successful, 1 informational neutral result, 6 conditional skips; none pending or failing. The explicit API and browser journeys above provide runtime proof without skips.
- The repository-wide spec-boundary ratchet fails identically on this head and clean dev `85a5dfccb4d74732593628ab4cc8912f8b88283d` in unrelated existing specs. Neither cancellation spec is flagged.

Runs execute inside an isolated Daytona sandbox with co-located Den and the synthetic Stripe service. The runner reports `placement: local (daytona CLI missing or not authenticated)` inside that sandbox. Local dependency installation was stopped due to host disk exhaustion. No production billing actions were taken.
