### PR TITLE
fix(automations): retry failed desktop registration promptly

### DIFF
--- a/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
+++ b/apps/app/src/react-app/domains/automations/automation-runner-bridge.tsx
@@ -110,6 +110,7 @@ export function AutomationRunnerBridge() {
           })
         } catch (error) {
           if (isCurrent()) console.warn("[automation-runner] registration failed", error)
+          throw error
         }
       },
     })

--- a/apps/app/src/react-app/domains/automations/automation-runner-connect-coordinator.ts
+++ b/apps/app/src/react-app/domains/automations/automation-runner-connect-coordinator.ts
@@ -19,6 +19,7 @@ export function createAutomationRunnerConnectCoordinator(
   let running: Promise<void> | undefined
   let cancelRefresh: (() => void) | undefined
   let rejectionAttempt = 0
+  let failureAttempt = 0
   const schedule = options.schedule ?? defaultSchedule
 
   const clearRefresh = () => {
@@ -35,23 +36,29 @@ export function createAutomationRunnerConnectCoordinator(
     const drain = async () => {
       while (!disposed) {
         const connectRevision = revision
-        await options.connect(() => !disposed && revision === connectRevision)
+        try {
+          await options.connect(() => !disposed && revision === connectRevision)
+        } catch (error) {
+          if (disposed || connectRevision !== revision) continue
+          throw error
+        }
         if (connectRevision === revision) return
       }
     }
     const task = drain()
     running = task
-    const settle = () => {
+    const settle = (failed: boolean) => {
       if (running !== task) return
       running = undefined
+      failureAttempt = failed ? failureAttempt + 1 : 0
       if (!disposed && !cancelRefresh) {
         cancelRefresh = schedule(() => {
           cancelRefresh = undefined
           void request().catch(() => undefined)
-        }, options.refreshMs)
+        }, failed ? Math.min(30_000, 1_000 * (2 ** Math.min(failureAttempt - 1, 5))) : options.refreshMs)
       }
     }
-    void task.then(settle, settle)
+    void task.then(() => settle(false), () => settle(true))
     return task
   }
 

--- a/apps/app/tests/automation-runner-connect-coordinator.test.ts
+++ b/apps/app/tests/automation-runner-connect-coordinator.test.ts
@@ -52,7 +52,7 @@ describe("Automation runner connect lifecycle", () => {
     expect(timers.activeCount()).toBe(0)
   })
 
-  test("a failed immediate remint leaves one periodic retry", async () => {
+  test("a failed immediate remint retries promptly then resumes the normal refresh", async () => {
     const timers = scheduler()
     const configured: number[] = []
     let connects = 0
@@ -71,11 +71,13 @@ describe("Automation runner connect lifecycle", () => {
     await Promise.resolve()
     expect(configured).toEqual([1])
     expect(timers.activeCount()).toBe(1)
+    expect(timers.entries.find((entry) => entry.active)?.delayMs).toBe(1_000)
 
     timers.fireActive()
     await Promise.resolve()
     await Promise.resolve()
     expect(configured).toEqual([1, 3])
+    expect(timers.entries.find((entry) => entry.active)?.delayMs).toBe(300_000)
     expect(timers.activeCount()).toBe(1)
     coordinator.dispose()
   })
@@ -171,4 +173,50 @@ describe("Automation runner connect lifecycle", () => {
     expect(timers.entries.filter((entry) => entry.active).map((entry) => entry.delayMs)).toEqual([500])
     coordinator.dispose()
   })
+})
+
+
+test("registration outages back off to thirty seconds and disposal cancels recovery", async () => {
+  const timers = scheduler()
+  const coordinator = createAutomationRunnerConnectCoordinator({
+    refreshMs: 1_800_000,
+    schedule: timers.schedule,
+    connect: async () => { throw new Error("temporarily unavailable") },
+  })
+  await expect(coordinator.request()).rejects.toThrow("temporarily unavailable")
+  for (const delayMs of [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000]) {
+    expect(timers.activeCount()).toBe(1)
+    expect(timers.entries.find((entry) => entry.active)?.delayMs).toBe(delayMs)
+    timers.fireActive()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+  coordinator.dispose()
+  expect(timers.activeCount()).toBe(0)
+})
+
+test("a failed stale registration immediately drains newer settings", async () => {
+  const timers = scheduler()
+  const first = deferred()
+  let attempts = 0
+  const coordinator = createAutomationRunnerConnectCoordinator({
+    refreshMs: 1_800_000,
+    schedule: timers.schedule,
+    connect: async () => {
+      attempts += 1
+      if (attempts === 1) {
+        await first.promise
+        throw new Error("old account unavailable")
+      }
+    },
+  })
+  const pending = coordinator.request()
+  void coordinator.request()
+  first.resolve()
+  await pending
+  expect(attempts).toBe(2)
+  expect(timers.activeCount()).toBe(1)
+  expect(timers.entries.find((entry) => entry.active)?.delayMs).toBe(1_800_000)
+  coordinator.dispose()
 })

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -8,6 +8,7 @@ test("desktop registration recovers from a transient Den outage without another 
   needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] })
   await using den = await server({
     place,
+    env: { DEN_AUTOMATIONS_ENABLED: "true" },
     org: { name: "Synthetic registration recovery", admin: { name: "Test Admin" } },
   })
   await using proxy = await faultProxy(den.ref, {

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -44,8 +44,12 @@ test("desktop registration recovers from a transient Den outage without another 
 })
 
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 function record(value: unknown): Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected response object")
+  if (!isRecord(value)) throw new Error("Expected response object")
   return value
 }
 

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest"
-import { evalIn } from "@openwork/behaviors"
+import { denFetch, evalIn } from "@openwork/behaviors"
 import { app, eventually, faultProxy, needs, server, test } from "@openwork/testkit"
 
 // Registration is independent of local engine health. A transient mint failure
@@ -39,6 +39,74 @@ test("desktop registration recovers from a transient Den outage without another 
   evidence.recordAssertionEvidence(
     "Registration recovers without another online event",
     "Two injected HTTP 503 registration failures were followed by one successful registration within 35 seconds after a single online event.",
+    true,
+  )
+})
+
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Expected response object")
+  return value
+}
+
+// Exercise the real Den dispatch boundary with a synthetic Windows runner;
+// no model provider or private desktop profile participates in this witness.
+test("a queued manual run completes once after a synthetic Windows runner registers", { timeout: 180_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] })
+  await using den = await server({ place, org: { name: "Synthetic dispatch recovery" } })
+  const headers = { authorization: `Bearer ${den.admin.token}` }
+  const request = async (path: string, method = "GET", body?: unknown, token?: string) => {
+    const result = await denFetch(den.admin, path, {
+      method,
+      headers: token ? { authorization: `Bearer ${token}` } : headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+    expect(result.response.ok, `HTTP ${result.response.status} from ${path}`).toBe(true)
+    return record(result.body)
+  }
+  const before = await request("/v1/automation-runners/presence")
+  expect(before.connected).toBe(false)
+  const created = await request("/v1/automations", "POST", {
+    name: "Synthetic recovery dispatch",
+    instructions: "Produce the synthetic recovery receipt.",
+    schedule: { kind: "daily", timezone: "UTC", hour: 23, minute: 59 },
+    model: { providerId: "opencode", modelId: "big-pickle", variant: null },
+  })
+  const automationId = record(created.automation).id
+  expect(typeof automationId).toBe("string")
+  const queued = await request(`/v1/automations/${automationId}/run`, "POST")
+  const runId = record(queued.run).id
+  expect(typeof runId).toBe("string")
+  const register = async (runnerId: string) => {
+    const minted = await request("/v1/automation-runners/token", "POST", {
+      runnerId, protocolVersion: 1, supportedExecutionTargets: ["desktop"],
+      capabilities: [], appVersion: "0.0.0-test", platform: "win32", concurrency: 1,
+    })
+    if (typeof minted.token !== "string") throw new Error("Runner token missing")
+    return minted.token
+  }
+  const token = await register("synthetic-recovery-runner")
+  const competing = await register("synthetic-competing-runner")
+  const work = await request("/v1/automation-runner/work", "GET", undefined, token)
+  expect(work.items).toEqual([{ runId, executionTarget: "desktop" }])
+  expect((await request("/v1/automation-runners/presence")).connected).toBe(true)
+  const claimed = await request(`/v1/automation-runs/${runId}/claim`, "POST", undefined, token)
+  expect(record(claimed.assignment).attempt).toBe(1)
+  expect((await request(`/v1/automation-runs/${runId}/claim`, "POST", undefined, competing)).assignment).toBeNull()
+  const completed = await request(`/v1/automation-runs/${runId}/complete`, "POST", {
+    attempt: 1, status: "succeeded", sessionId: "synthetic-session", workspaceId: "synthetic-workspace",
+    resultSummary: "Synthetic recovery completed.",
+    usage: { inputTokens: 0, outputTokens: 0, costMicros: 0 }, error: null,
+  }, token)
+  expect(record(completed.run).status).toBe("succeeded")
+  expect((await request(`/v1/automation-runs/${runId}/claim`, "POST", undefined, token)).assignment).toBeNull()
+  expect((await request("/v1/automation-runner/work", "GET", undefined, token)).items).toEqual([])
+  const receipt = record((await request(`/v1/automation-runs/${runId}`)).run)
+  expect(receipt.status).toBe("succeeded")
+  expect(receipt.attemptCount).toBe(1)
+  evidence.recordAssertionEvidence(
+    "A recovered manual dispatch completes once",
+    "A run queued with no desktop present was discovered and completed by a synthetic Windows runner. A competing runner could not claim it, and completion left no claimable work or second attempt.",
     true,
   )
 })

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "vitest"
+import { evalIn } from "@openwork/behaviors"
+import { app, eventually, faultProxy, needs, server, test } from "@openwork/testkit"
+
+// Registration is independent of local engine health. A transient mint failure
+// after reconnect must retry without another online event or a 30-minute wait.
+test("desktop registration recovers from a transient Den outage without another reconnect", { timeout: 420_000 }, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] })
+  await using den = await server({
+    place,
+    org: { name: "Synthetic registration recovery", admin: { name: "Test Admin" } },
+  })
+  await using proxy = await faultProxy(den.ref, {
+    place,
+    sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
+  })
+  await using desktop = await app({ den: { ...den, ref: proxy.ref }, as: "admin", place })
+  const registrationPath = "/api/den/v1/automation-runners/token"
+  await eventually(async () => (await proxy.requestLog()).some((request) =>
+    request.path === registrationPath && request.status === 200), {
+    within: 60_000,
+    label: "initial desktop registration",
+  })
+
+  const start = (await proxy.requestLog()).length
+  await proxy.faults.status(registrationPath, 503, { times: 2 })
+  await evalIn(desktop, `window.dispatchEvent(new Event("online"))`)
+  await eventually(async () => {
+    const requests = (await proxy.requestLog()).slice(start)
+      .filter((request) => request.path === registrationPath)
+    return requests.filter((request) => request.faulted && request.status === 503).length === 2
+      && requests.some((request) => !request.faulted && request.status === 200)
+  }, { within: 35_000, label: "automatic registration retry after two transient failures" })
+
+  const attempts = (await proxy.requestLog()).slice(start)
+    .filter((request) => request.path === registrationPath)
+  expect(attempts.filter((request) => request.faulted)).toHaveLength(2)
+  expect(attempts.filter((request) => request.status === 200)).toHaveLength(1)
+  evidence.recordAssertionEvidence(
+    "Registration recovers without another online event",
+    "Two injected HTTP 503 registration failures were followed by one successful registration within 35 seconds after a single online event.",
+    true,
+  )
+})

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -15,6 +15,11 @@ test("desktop registration recovers from a transient Den outage without another 
     place,
     sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
   })
+  // Keep the advertised API origin on the fault proxy. Otherwise desktop
+  // handoff follows Den's runtime config directly to the upstream API.
+  await proxy.faults.status("/api/runtime-config", 200, {
+    times: 100, body: { denApiUrl: proxy.ref.apiUrl },
+  })
   await using desktop = await app({ den: { ...den, ref: proxy.ref }, as: "admin", place })
   const isRegistration = (path: string) => path.split("?")[0].endsWith("/v1/automation-runners/token")
   const initial = await eventually(async () => {

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -20,36 +20,44 @@ test("desktop registration recovers from a transient Den outage without another 
   await proxy.faults.status("/api/runtime-config", 200, {
     times: 100, body: { denApiUrl: proxy.ref.apiUrl },
   })
+  const registrationPath = "/api/den/v1/automation-runners/token"
+  await proxy.faults.status(registrationPath, 503, { times: 100 })
   await using desktop = await app({ den: { ...den, ref: proxy.ref }, as: "admin", place })
-  const isRegistration = (path: string) => path.split("?")[0].endsWith("/v1/automation-runners/token")
-  const initial = await eventually(async () => {
-    const requests = await proxy.requestLog()
-    return {
-      registration: requests.find((request) => isRegistration(request.path) && request.status === 200),
-      diagnostics: requests.filter((request) => isRegistration(request.path) || request.path.endsWith("/v1/me/desktop-config"))
-        .map(({ method, path, status }) => ({ method, path: path.split("?")[0], status })),
-    }
-  }, { within: 60_000, label: "initial desktop registration", until: (value) => Boolean(value.registration) })
-  if (!initial.registration) throw new Error("Initial registration missing")
-  const registrationPath = initial.registration.path.split("?")[0]
+  const presence = async () => {
+    const result = await denFetch(den.admin, "/v1/automation-runners/presence", {
+      headers: { authorization: `Bearer ${den.admin.token}` },
+    })
+    expect(result.response.status).toBe(200)
+    return record(result.body).connected
+  }
+  await eventually(async () => (await proxy.requestLog()).some((request) =>
+    request.path === registrationPath && request.faulted && request.status === 503), {
+    within: 60_000, label: "registration outage reached by the desktop",
+  })
+  expect(await presence()).toBe(false)
 
-  const start = (await proxy.requestLog()).length
+  await proxy.faults.clear()
+  await proxy.faults.status("/api/runtime-config", 200, {
+    times: 100, body: { denApiUrl: proxy.ref.apiUrl },
+  })
   await proxy.faults.status(registrationPath, 503, { times: 2 })
+  const start = (await proxy.requestLog()).length
   await evalIn(desktop, `window.dispatchEvent(new Event("online"))`)
   await eventually(async () => {
     const requests = (await proxy.requestLog()).slice(start)
       .filter((request) => request.path === registrationPath)
     return requests.filter((request) => request.faulted && request.status === 503).length === 2
-      && requests.some((request) => !request.faulted && request.status === 200)
-  }, { within: 35_000, label: "automatic registration retry after two transient failures" })
+      && requests.some((request) => !request.faulted)
+      && await presence() === true
+  }, { within: 35_000, label: "Den observes a registered desktop after two transient failures" })
 
   const attempts = (await proxy.requestLog()).slice(start)
     .filter((request) => request.path === registrationPath)
   expect(attempts.filter((request) => request.faulted)).toHaveLength(2)
-  expect(attempts.filter((request) => request.status === 200)).toHaveLength(1)
+  expect(attempts.filter((request) => !request.faulted)).toHaveLength(1)
   evidence.recordAssertionEvidence(
     "Registration recovers without another online event",
-    "Two injected HTTP 503 registration failures were followed by one successful registration within 35 seconds after a single online event.",
+    "Den reported no desktop during the injected startup registration outage. After a single online event and two further HTTP 503s, the desktop retried and Den reported it connected within 35 seconds.",
     true,
   )
 })

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -40,24 +40,24 @@ test("desktop registration recovers from a transient Den outage without another 
   await proxy.faults.status("/api/runtime-config", 200, {
     times: 100, body: { denApiUrl: proxy.ref.apiUrl },
   })
-  await proxy.faults.status(registrationPath, 503, { times: 2 })
+  await proxy.faults.status(registrationPath, 503, { times: 1 })
   const start = (await proxy.requestLog()).length
   await evalIn(desktop, `window.dispatchEvent(new Event("online"))`)
   await eventually(async () => {
     const requests = (await proxy.requestLog()).slice(start)
       .filter((request) => request.path === registrationPath)
-    return requests.filter((request) => request.faulted && request.status === 503).length === 2
+    return requests.filter((request) => request.faulted && request.status === 503).length === 1
       && requests.some((request) => !request.faulted)
       && await presence() === true
-  }, { within: 35_000, label: "Den observes a registered desktop after two transient failures" })
+  }, { within: 35_000, label: "Den observes a registered desktop after a transient failure" })
 
   const attempts = (await proxy.requestLog()).slice(start)
     .filter((request) => request.path === registrationPath)
-  expect(attempts.filter((request) => request.faulted)).toHaveLength(2)
+  expect(attempts.filter((request) => request.faulted)).toHaveLength(1)
   expect(attempts.filter((request) => !request.faulted)).toHaveLength(1)
   evidence.recordAssertionEvidence(
     "Registration recovers without another online event",
-    "Den reported no desktop during the injected startup registration outage. After a single online event and two further HTTP 503s, the desktop retried and Den reported it connected within 35 seconds.",
+    "Den reported no desktop during the injected startup registration outage. After a single online event and one further HTTP 503, the desktop retried and Den reported it connected within 35 seconds.",
     true,
   )
 })

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -15,12 +15,17 @@ test("desktop registration recovers from a transient Den outage without another 
     sandbox: den.placement?.kind === "daytona" ? den.placement.sandboxId : undefined,
   })
   await using desktop = await app({ den: { ...den, ref: proxy.ref }, as: "admin", place })
-  const registrationPath = "/api/den/v1/automation-runners/token"
-  await eventually(async () => (await proxy.requestLog()).some((request) =>
-    request.path === registrationPath && request.status === 200), {
-    within: 60_000,
-    label: "initial desktop registration",
-  })
+  const isRegistration = (path: string) => path.split("?")[0].endsWith("/v1/automation-runners/token")
+  const initial = await eventually(async () => {
+    const requests = await proxy.requestLog()
+    return {
+      registration: requests.find((request) => isRegistration(request.path) && request.status === 200),
+      diagnostics: requests.filter((request) => isRegistration(request.path) || request.path.endsWith("/v1/me/desktop-config"))
+        .map(({ method, path, status }) => ({ method, path: path.split("?")[0], status })),
+    }
+  }, { within: 60_000, label: "initial desktop registration", until: (value) => Boolean(value.registration) })
+  if (!initial.registration) throw new Error("Initial registration missing")
+  const registrationPath = initial.registration.path.split("?")[0]
 
   const start = (await proxy.requestLog()).length
   await proxy.faults.status(registrationPath, 503, { times: 2 })


### PR DESCRIPTION
A transient desktop registration failure leaves the runner waiting for the normal 30-minute credential refresh. An awake desktop with a healthy local engine can therefore remain unavailable to Den longer than the manual or scheduled claim window.

Propagate registration failures to the existing coordinator and retry after 1, 2, 4, 8, 16, then at most 30 seconds. Success restores the normal refresh interval. Requests remain serialized; a failed stale attempt drains newer settings, and disposal cancels recovery.

Related work checked: #4322 addresses cloud engine warmup; #4143 addresses rejected runner credentials; #3239 addresses Windows workspace matching. Merged #3775, #3921 and #4254 cover occurrence recovery, credential retirement and runner request deadlines. This change addresses the remaining registration retry delay.

## Verification

Final head: `672f3d0eeaa35e6fc5bfc2860c5e236d741f05af`.

- `bun test apps/app/tests/automation-runner-connect-coordinator.test.ts`: 7 passed, 0 failed, 0 skipped. New assertions against the unchanged coordinator produce 4 passed and 3 failed, including expected 1000ms versus actual 1800000ms.
- `pnpm evals:e2e automation-registration-recovery --daytona`: placement `daytona (--daytona)`; **2 passed, 0 failed, 0 skipped**. A fresh desktop remains absent from Den during a registration outage, then registers within 35 seconds after one online event and a further injected 503. A separate real Den manual dispatch completes through a synthetic Windows runner; competing and post-completion claims cannot create a second execution attempt.
- Identical journey on isolated baseline `85a5dfccb` plus only the spec: **1 passed, 1 failed, 0 skipped**. Registration recovery times out after 35 seconds; unchanged manual dispatch behavior passes.
- [Published assertion evidence](https://github.com/different-ai/openwork/pull/4521#issuecomment-5554365733), [final-head journey run](https://github.com/different-ai/openwork/actions/runs/33987918955), [baseline control](https://github.com/different-ai/openwork/actions/runs/33987924543).

The app journey uses Linux Electron on Daytona; the dispatch witness registers a synthetic Windows runner. This is not a physical Windows certification or proof that every symptom in the report has the same cause. No external model provider participates. Local full-stack setup was stopped because the shared disk was nearly full; remote evidence above supplies the completed journey proof.

All scenarios use synthetic data. No report-specific identifiers or source messages were used. No deployment or merge is included.
