### PR TITLE
fix(den): return reconnect guidance for rejected native Google refreshes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -78,13 +78,25 @@ jobs:
       matrix:
         variant: [head, dev-control]
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout PR head
+        if: matrix.variant == 'head' && github.event_name == 'pull_request'
+        uses: actions/checkout@v6
         with:
-          ref: ${{ matrix.variant == 'dev-control' && 'dev' || github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout event revision
+        if: matrix.variant == 'head' && github.event_name != 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+      - name: Checkout clean dev control
+        if: matrix.variant == 'dev-control'
+        uses: actions/checkout@v6
+        with:
+          ref: dev
       - name: Overlay only compatibility witnesses onto clean dev
         if: matrix.variant == 'dev-control' && github.event_name == 'pull_request'
         env:
-          PROOF_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          PROOF_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           git fetch origin "$PROOF_HEAD"
           git show "$PROOF_HEAD:evals/specs/native-google-refresh-recovery.test.ts" > evals/specs/native-google-refresh-recovery.test.ts

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -70,7 +70,8 @@ jobs:
 
   native-google-refresh:
     needs: classify-changes
-    if: needs.classify-changes.outputs.lane == 'full'
+    # PR-only: comparison witnesses must never execute in a default-branch cache context.
+    if: needs.classify-changes.outputs.lane == 'full' && github.event_name == 'pull_request'
     runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 15
     strategy:
@@ -83,11 +84,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Checkout event revision
-        if: matrix.variant == 'head' && github.event_name != 'pull_request'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
       - name: Checkout clean dev control
         if: matrix.variant == 'dev-control'
         uses: actions/checkout@v6
@@ -346,7 +342,9 @@ jobs:
 
           case "$LANE" in
             full)
-              [ "$CORE_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && [ "$GOOGLE_REFRESH_RESULT" = "success" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
+              GOOGLE_REFRESH_EXPECTED=skipped
+              if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then GOOGLE_REFRESH_EXPECTED=success; fi
+              [ "$CORE_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && [ "$GOOGLE_REFRESH_RESULT" = "$GOOGLE_REFRESH_EXPECTED" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
               ;;
             snapshot)
               [ "$SNAPSHOT_RESULT" = "success" ] && [ "$CORE_RESULT" = "skipped" ] && [ "$BUILD_RESULT" = "skipped" ] && [ "$GOOGLE_REFRESH_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -68,6 +68,34 @@ jobs:
       - name: Run core product regressions
         run: pnpm test:core
 
+  native-google-refresh:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.lane == 'full'
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: ./.github/actions/setup-tests
+      - name: Prepare native Google refresh boundary
+        run: |
+          pnpm --filter @openwork/types build
+          pnpm --filter @openwork-ee/den-db build
+          pnpm --filter @openwork/email build
+          pnpm dev:den:mysql
+      - name: Verify native Google refresh recovery
+        env:
+          OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH: '1'
+        run: pnpm evals:pr specs/native-google-refresh-recovery.test.ts
+      - name: Upload native Google refresh evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-google-refresh-${{ github.run_attempt }}
+          path: evals/results/test-runs/**
+          retention-days: 7
+
   openwork-tests-build:
     needs: classify-changes
     if: needs.classify-changes.outputs.lane == 'full'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -87,7 +87,15 @@ jobs:
       - name: Verify native Google refresh recovery
         env:
           OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH: '1'
-        run: pnpm evals:pr specs/native-google-refresh-recovery.test.ts
+        run: |
+          pnpm evals:pr specs/native-google-refresh-recovery.test.ts
+          node --input-type=module <<'NODE'
+          import { readdirSync, readFileSync } from "node:fs";
+          const root = "evals/results/test-runs";
+          const runs = readdirSync(root).filter(name => name.includes("native-google-refresh")).map(name =>
+            JSON.parse(readFileSync(`${root}/${name}/test-run.json`, "utf8")));
+          if (runs.length !== 1 || runs[0].outcome !== "passed") throw new Error("Native Google refresh proof must execute and pass; skips are not proof.");
+          NODE
       - name: Upload native Google refresh evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -284,7 +292,7 @@ jobs:
   # Single stable context for branch rulesets to require. Green only when
   # the lane selected by classification succeeds; always reports.
   openwork-tests-required:
-    needs: [classify-changes, openwork-tests-core, openwork-tests-build, validate-models-snapshot, validate-docs]
+    needs: [classify-changes, openwork-tests-core, openwork-tests-build, native-google-refresh, validate-models-snapshot, validate-docs]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -294,12 +302,14 @@ jobs:
           LANE: ${{ needs.classify-changes.outputs.lane }}
           CORE_RESULT: ${{ needs.openwork-tests-core.result }}
           BUILD_RESULT: ${{ needs.openwork-tests-build.result }}
+          GOOGLE_REFRESH_RESULT: ${{ needs.native-google-refresh.result }}
           SNAPSHOT_RESULT: ${{ needs.validate-models-snapshot.result }}
           DOCS_RESULT: ${{ needs.validate-docs.result }}
         run: |
           echo "classification: $CLASSIFY_RESULT ($LANE)"
           echo "core product regressions: $CORE_RESULT"
           echo "packaging and IPC contract: $BUILD_RESULT"
+          echo "native Google refresh: $GOOGLE_REFRESH_RESULT"
           echo "snapshot validation: $SNAPSHOT_RESULT"
           echo "docs validation: $DOCS_RESULT"
 
@@ -310,13 +320,13 @@ jobs:
 
           case "$LANE" in
             full)
-              [ "$CORE_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
+              [ "$CORE_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && [ "$GOOGLE_REFRESH_RESULT" = "success" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
               ;;
             snapshot)
-              [ "$SNAPSHOT_RESULT" = "success" ] && [ "$CORE_RESULT" = "skipped" ] && [ "$BUILD_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
+              [ "$SNAPSHOT_RESULT" = "success" ] && [ "$CORE_RESULT" = "skipped" ] && [ "$BUILD_RESULT" = "skipped" ] && [ "$GOOGLE_REFRESH_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
               ;;
             docs)
-              [ "$DOCS_RESULT" = "success" ] && [ "$CORE_RESULT" = "skipped" ] && [ "$BUILD_RESULT" = "skipped" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] || exit 1
+              [ "$DOCS_RESULT" = "success" ] && [ "$CORE_RESULT" = "skipped" ] && [ "$BUILD_RESULT" = "skipped" ] && [ "$GOOGLE_REFRESH_RESULT" = "skipped" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] || exit 1
               ;;
             *)
               echo "Changed-file classification returned an unexpected value; blocking merge." >&2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           ref: ${{ matrix.variant == 'dev-control' && 'dev' || github.event.pull_request.head.sha || github.sha }}
       - name: Overlay only compatibility witnesses onto clean dev
-        if: matrix.variant == 'dev-control'
+        if: matrix.variant == 'dev-control' && github.event_name == 'pull_request'
         env:
           PROOF_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -73,10 +73,23 @@ jobs:
     if: needs.classify-changes.outputs.lane == 'full'
     runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [head, dev-control]
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ matrix.variant == 'dev-control' && 'dev' || github.event.pull_request.head.sha || github.sha }}
+      - name: Overlay only compatibility witnesses onto clean dev
+        if: matrix.variant == 'dev-control'
+        env:
+          PROOF_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          git fetch origin "$PROOF_HEAD"
+          git show "$PROOF_HEAD:evals/specs/native-google-refresh-recovery.test.ts" > evals/specs/native-google-refresh-recovery.test.ts
+          git show "$PROOF_HEAD:evals/packages/labs/src/mock-google-server.ts" > evals/packages/labs/src/mock-google-server.ts
+          git rev-parse HEAD
       - uses: ./.github/actions/setup-tests
       - name: Prepare native Google refresh boundary
         run: |
@@ -87,6 +100,7 @@ jobs:
       - name: Verify native Google refresh recovery
         env:
           OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH: '1'
+          OPENWORK_EVAL_NATIVE_REFRESH_COMPATIBILITY_ONLY: ${{ matrix.variant == 'dev-control' && '1' || '0' }}
         run: |
           pnpm evals:pr specs/native-google-refresh-recovery.test.ts
           node --input-type=module <<'NODE'
@@ -100,7 +114,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: native-google-refresh-${{ github.run_attempt }}
+          name: native-google-refresh-${{ matrix.variant }}-${{ github.run_attempt }}
           path: evals/results/test-runs/**
           retention-days: 7
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -70,34 +70,13 @@ jobs:
 
   native-google-refresh:
     needs: classify-changes
-    # PR-only: comparison witnesses must never execute in a default-branch cache context.
-    if: needs.classify-changes.outputs.lane == 'full' && github.event_name == 'pull_request'
+    if: needs.classify-changes.outputs.lane == 'full'
     runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [head, dev-control]
     steps:
-      - name: Checkout PR head
-        if: matrix.variant == 'head' && github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Checkout clean dev control
-        if: matrix.variant == 'dev-control'
-        uses: actions/checkout@v6
-        with:
-          ref: dev
-      - name: Overlay only compatibility witnesses onto clean dev
-        if: matrix.variant == 'dev-control' && github.event_name == 'pull_request'
-        env:
-          PROOF_HEAD: ${{ github.event.pull_request.head.sha }}
-        run: |
-          git fetch origin "$PROOF_HEAD"
-          git show "$PROOF_HEAD:evals/specs/native-google-refresh-recovery.test.ts" > evals/specs/native-google-refresh-recovery.test.ts
-          git show "$PROOF_HEAD:evals/packages/labs/src/mock-google-server.ts" > evals/packages/labs/src/mock-google-server.ts
-          git rev-parse HEAD
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/setup-tests
       - name: Prepare native Google refresh boundary
         run: |
@@ -108,7 +87,6 @@ jobs:
       - name: Verify native Google refresh recovery
         env:
           OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH: '1'
-          OPENWORK_EVAL_NATIVE_REFRESH_COMPATIBILITY_ONLY: ${{ matrix.variant == 'dev-control' && '1' || '0' }}
         run: |
           pnpm evals:pr specs/native-google-refresh-recovery.test.ts
           node --input-type=module <<'NODE'
@@ -122,7 +100,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: native-google-refresh-${{ matrix.variant }}-${{ github.run_attempt }}
+          name: native-google-refresh-${{ github.run_attempt }}
           path: evals/results/test-runs/**
           retention-days: 7
 
@@ -342,9 +320,7 @@ jobs:
 
           case "$LANE" in
             full)
-              GOOGLE_REFRESH_EXPECTED=skipped
-              if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then GOOGLE_REFRESH_EXPECTED=success; fi
-              [ "$CORE_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && [ "$GOOGLE_REFRESH_RESULT" = "$GOOGLE_REFRESH_EXPECTED" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
+              [ "$CORE_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && [ "$GOOGLE_REFRESH_RESULT" = "success" ] && [ "$SNAPSHOT_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1
               ;;
             snapshot)
               [ "$SNAPSHOT_RESULT" = "success" ] && [ "$CORE_RESULT" = "skipped" ] && [ "$BUILD_RESULT" = "skipped" ] && [ "$GOOGLE_REFRESH_RESULT" = "skipped" ] && [ "$DOCS_RESULT" = "skipped" ] || exit 1

--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -488,7 +488,27 @@ export async function getValidAccessToken(input: {
     return { error: "client_not_configured" }
   }
 
-  const refreshed = await refreshTokens({ provider: input.provider, client, refreshToken: account.refreshToken })
+  let refreshed: TokenResponse
+  try {
+    refreshed = await refreshTokens({ provider: input.provider, client, refreshToken: account.refreshToken })
+  } catch (error) {
+    if (!(error instanceof OAuthTokenExchangeError) || error.code !== "oauth_invalid_grant") throw error
+
+    // A rejected old grant must not disconnect a newer refresh or reconnect.
+    // Leave persistence untouched: another worker may still be saving its grant.
+    const current = await getConnectedAccount({
+      organizationId: input.organizationId,
+      orgMembershipId: input.orgMembershipId,
+      providerId: input.credentialProviderId,
+    })
+    if (
+      current?.accessToken
+      && (!current.expiresAt || current.expiresAt.getTime() - TOKEN_EXPIRY_SAFETY_WINDOW_MS > Date.now())
+    ) {
+      return { accessToken: current.accessToken, account: current }
+    }
+    return { error: "not_connected" }
+  }
   const expiresAt = refreshed.expires_in ? new Date(Date.now() + refreshed.expires_in * 1000) : null
   const updated = await refreshConnectedAccountForActiveMember({
     organizationId: input.organizationId,

--- a/evals/packages/labs/src/mock-google-server.ts
+++ b/evals/packages/labs/src/mock-google-server.ts
@@ -24,6 +24,7 @@ interface Account {
 }
 
 interface RequestEntry {
+  tokenId?: string;
   method: string;
   path: string;
   url: string;
@@ -221,8 +222,10 @@ function accountForRequest(state: MockGoogleState, request: IncomingMessage): Ac
 }
 
 function recordRequest(state: MockGoogleState, request: IncomingMessage, url: URL): void {
+  const credential = bearerToken(request);
   state.requests.push({
     method: method(request),
+    ...(credential ? { tokenId: tokenId(credential) } : {}),
     path: url.pathname,
     url: `${url.pathname}${url.search}`,
     at: new Date().toISOString(),
@@ -670,6 +673,15 @@ async function handleRequest(state: MockGoogleState, request: IncomingMessage, r
   }
   if (requestMethod === "GET" && url.pathname === "/userinfo") {
     userinfo(state, request, response);
+    return;
+  }
+  // Minimal Graph-compatible mail boundary for the shared native OAuth journey.
+  if (requestMethod === "GET" && url.pathname === "/v1.0/me/messages") {
+    if (!accountForRequest(state, request)) {
+      sendJson(response, 401, { error: { code: "InvalidAuthenticationToken" } });
+      return;
+    }
+    sendJson(response, 200, { value: [] });
     return;
   }
   if (requestMethod === "GET" && url.pathname === "/gmail/v1/users/me/profile") {

--- a/evals/packages/labs/src/mock-google-server.ts
+++ b/evals/packages/labs/src/mock-google-server.ts
@@ -87,6 +87,11 @@ interface MockGoogleState {
   drafts: Map<string, RecordedDraft[]>;
   driveUploads: Map<string, RecordedDriveUpload[]>;
   keys: SigningKeys;
+  authorizationExpiresIn: number;
+  refreshError: string | null;
+  holdRefresh: boolean;
+  pendingRefreshes: Array<() => void>;
+  refreshAttempts: number;
 }
 
 const HTML_ENTITIES: Record<string, string> = {
@@ -369,6 +374,18 @@ async function token(state: MockGoogleState, request: IncomingMessage, response:
       sendJson(response, 400, { error: "invalid_grant" });
       return;
     }
+    state.refreshAttempts++;
+    const refreshError = state.refreshError;
+    if (state.holdRefresh) {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 10_000);
+        state.pendingRefreshes.push(() => { clearTimeout(timer); resolve(); });
+      });
+    }
+    if (refreshError) {
+      sendJson(response, refreshError === "invalid_grant" ? 400 : 503, { error: refreshError });
+      return;
+    }
     credential = refresh;
   } else {
     sendJson(response, 400, { error: "unsupported_grant_type" });
@@ -380,7 +397,7 @@ async function token(state: MockGoogleState, request: IncomingMessage, response:
     access_token: issued.accessToken,
     refresh_token: issued.refreshToken,
     token_type: "Bearer",
-    expires_in: 3600,
+    expires_in: grantType === "authorization_code" ? state.authorizationExpiresIn : 3600,
     scope: credential.scope,
     id_token: issued.idToken,
   });
@@ -611,6 +628,18 @@ async function handleRequest(state: MockGoogleState, request: IncomingMessage, r
     sendJson(response, 200, { requests: state.requests });
     return;
   }
+  if (url.pathname === "/__mock-google/refresh-control") {
+    if (requestMethod === "POST") {
+      const input = await jsonBody(request);
+      if (!isRecord(input)) { sendJson(response, 400, { error: "invalid_request" }); return; }
+      if (typeof input.authorizationExpiresIn === "number") state.authorizationExpiresIn = input.authorizationExpiresIn;
+      if (input.refreshError === null || input.refreshError === "invalid_grant" || input.refreshError === "temporarily_unavailable") state.refreshError = input.refreshError;
+      if (typeof input.holdRefresh === "boolean") state.holdRefresh = input.holdRefresh;
+      if (input.release === true) state.pendingRefreshes.splice(0).forEach(release => release());
+    }
+    sendJson(response, 200, { attempts: state.refreshAttempts, pending: state.pendingRefreshes.length });
+    return;
+  }
   if (requestMethod === "GET" && url.pathname === "/__mock-google/pending-authorizations") {
     sendJson(response, 200, pendingAuthorizations(state));
     return;
@@ -705,6 +734,11 @@ export async function startMockGoogleServer(options: MockGoogleServerOptions): P
     autoApprove: options.autoApprove,
     baseUrl: options.baseUrl ?? "http://127.0.0.1",
     requests: [],
+    authorizationExpiresIn: 3600,
+    refreshError: null,
+    holdRefresh: false,
+    pendingRefreshes: [],
+    refreshAttempts: 0,
     pending: new Map(),
     codes: new Map(),
     accessTokens: new Map(),

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { startMockGoogle } from "@openwork/labs";
+import { needs, server, test } from "@openwork/testkit";
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected object");
+  return value;
+}
+
+// Native-provider refresh and reconnect is separate from OpenWork's MCP OAuth grants.
+test("native Google refresh rejects revoked grants safely and preserves a concurrent reconnect", { timeout: 300_000 }, async ({ evidence, place }) => {
+  needs({ placement: "local", optIn: ["OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH"] });
+  await using google = await startMockGoogle({ accounts: ["mailbox@example.test"], port: 0 });
+  await using den = await server({ place, web: false, org: { members: {} }, env: {
+    DEN_GOOGLE_OAUTH_AUTHORIZE_URL: google.authorizeUrl,
+    DEN_GOOGLE_OAUTH_TOKEN_URL: google.tokenUrl,
+    DEN_GOOGLE_OAUTH_USERINFO_URL: google.userinfoUrl,
+    DEN_GOOGLE_API_BASE_URL: google.apiUrl,
+    SENTRY_DSN: "",
+  } });
+  const headers = { authorization: `Bearer ${den.admin.token}` };
+  const configured = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/client", {
+    method: "POST", headers, body: JSON.stringify({ clientId: "refresh-fixture", clientSecret: "synthetic-secret" }),
+  });
+  expect(configured.response.status, configured.text).toBe(200);
+  async function control(body?: Record<string, unknown>) {
+    const response = await fetch(`${google.apiUrl}/__mock-google/refresh-control`, body ? {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+    } : {});
+    expect(response.status).toBe(200);
+    return record(await response.json());
+  }
+  async function connect() {
+    const started = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/connect/start", { headers });
+    expect(started.response.status, started.text).toBe(200);
+    const url = record(started.body).authorizeUrl;
+    if (typeof url !== "string") throw new Error("Missing authorize URL");
+    expect(new URL(url).origin).toBe(new URL(google.apiUrl).origin);
+    const result = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    expect(result.status).toBe(200);
+    expect(await result.text()).toContain("Connection complete");
+  }
+  const read = () => denFetch(den.admin, "/v1/capabilities/google-workspace/gmail-messages", { headers });
+  await control({ authorizationExpiresIn: 1, refreshError: "invalid_grant" });
+  await connect();
+  const revoked = await read();
+  expect(revoked.response.status, revoked.text).toBe(409);
+  expect(revoked.body).toMatchObject({ error: "needs_connection" });
+  expect(record(revoked.body).message).toContain("Connect your Google account");
+  expect((await control()).attempts).toBe(1);
+  const requests = record(await (await fetch(`${google.apiUrl}/requests`)).json()).requests;
+  expect(Array.isArray(requests)).toBe(true);
+  expect(JSON.stringify(requests)).not.toContain("/gmail/v1/");
+  evidence.recordAssertionEvidence("Revoked native credentials return actionable reconnect without automatic retries or mailbox access", "A real Den Gmail request received 409 needs_connection and Connect guidance after one rejected provider refresh; no Gmail endpoint was called.", true);
+
+  await control({ refreshError: "temporarily_unavailable" });
+  const unavailable = await read();
+  expect(unavailable.response.status).toBe(500);
+  expect(unavailable.body).not.toMatchObject({ error: "needs_connection" });
+  await control({ refreshError: null });
+  const recovered = await read();
+  expect(recovered.response.status, recovered.text).toBe(200);
+  expect((await control()).attempts).toBe(3);
+  evidence.recordAssertionEvidence("Temporary provider failures preserve the grant for retry", "A provider outage remained a server failure, not a false reconnect response; the next request refreshed the same grant successfully without new authorization.", true);
+
+  await connect(); // Issue another short-lived access token.
+  await control({ refreshError: "invalid_grant", holdRefresh: true });
+  const lateRead = read();
+  try {
+    const deadline = Date.now() + 8_000;
+    while ((await control()).pending !== 1 && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 25));
+    expect((await control()).pending).toBe(1);
+    await control({ authorizationExpiresIn: 3600 });
+    await connect();
+  } finally {
+    await control({ holdRefresh: false, release: true });
+  }
+  const late = await lateRead;
+  expect(late.response.status, late.text).toBe(200);
+  expect((await read()).response.status).toBe(200);
+  expect((await control()).attempts).toBe(4);
+  evidence.recordAssertionEvidence("A stale refresh rejection cannot erase a newer reconnect", "Held an old grant's refresh at the provider, completed a new PKCE connection, then released invalid_grant. Both the waiting Gmail read and a later read succeeded without another refresh.", true);
+
+  await connect();
+  const disconnected = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/disconnect", { method: "POST", headers });
+  expect(disconnected.response.status, disconnected.text).toBe(200);
+  expect((await read()).response.status).toBe(409);
+  expect((await control()).attempts).toBe(4);
+  evidence.recordAssertionEvidence("Explicit disconnect remains disconnected", "After disconnect, Gmail returned needs_connection and did not refresh or recreate credentials.", true);
+});

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -8,11 +8,9 @@ function record(value: unknown): Record<string, unknown> {
   return value;
 }
 
-// The control executes only unchanged behavior against clean dev product code.
 // Google and Microsoft both use the real default resolver, never an injected token.
 test("native Google refresh and Microsoft compatibility preserve reconnect and disconnect boundaries", { timeout: 300_000 }, async ({ evidence, place }) => {
   needs({ placement: "local", optIn: ["OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH"] });
-  const compatibilityOnly = process.env.OPENWORK_EVAL_NATIVE_REFRESH_COMPATIBILITY_ONLY === "1";
   await using google = await startMockGoogle({ accounts: ["mailbox@example.test"], port: 0 });
   await using den = await server({ place, web: false, org: { members: {} }, env: {
     DEN_GOOGLE_OAUTH_AUTHORIZE_URL: google.authorizeUrl,
@@ -86,7 +84,7 @@ test("native Google refresh and Microsoft compatibility preserve reconnect and d
     }
     await control({ refreshError: null, holdRefresh: false });
 
-    if (!compatibilityOnly) {
+    {
       await control({ refreshError: "invalid_grant" });
       await connect();
       const before = Number((await control()).attempts);
@@ -135,9 +133,7 @@ test("native Google refresh and Microsoft compatibility preserve reconnect and d
     expect(concurrentTokens).toContain((await requests(providerPath)).at(-1)?.tokenId);
     proved("Concurrent successful refreshes retain a usable successor", "Two held successful refresh responses completed concurrently; both waiting reads succeeded. A later read succeeded without another refresh and used a credential fingerprint observed on the concurrent mailbox reads.");
 
-    // Run the success path on both clean dev and the PR. The rejection variant
-    // checks the new handler only; clean dev is known to throw on invalid_grant.
-    for (const refreshError of compatibilityOnly ? [null] : [null, "invalid_grant"]) {
+    for (const refreshError of [null, "invalid_grant"]) {
       await connect();
       await control({ refreshError, holdRefresh: true });
       const lateRead = read();

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -39,7 +39,16 @@ test("native Google refresh rejects revoked grants safely and preserves a concur
     expect(new URL(url).origin).toBe(new URL(google.apiUrl).origin);
     const result = await fetch(url, { signal: AbortSignal.timeout(15_000) });
     expect(result.status).toBe(200);
-    expect(await result.text()).toContain("Connection complete");
+    expect(await result.text()).toContain("Choose an account");
+    await google.chooseAccount("mailbox@example.test", { timeoutMs: 15_000 });
+    const status = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/status", { headers });
+    expect(status.response.status, status.text).toBe(200);
+    expect(status.body).toMatchObject({ connected: true });
+  }
+  async function waitForRefreshes(count: number) {
+    const deadline = Date.now() + 8_000;
+    while ((await control()).pending !== count && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 25));
+    expect((await control()).pending).toBe(count);
   }
   const read = () => denFetch(den.admin, "/v1/capabilities/google-workspace/gmail-messages", { headers });
   await control({ authorizationExpiresIn: 1, refreshError: "invalid_grant" });
@@ -64,13 +73,24 @@ test("native Google refresh rejects revoked grants safely and preserves a concur
   expect((await control()).attempts).toBe(3);
   evidence.recordAssertionEvidence("Temporary provider failures preserve the grant for retry", "A provider outage remained a server failure, not a false reconnect response; the next request refreshed the same grant successfully without new authorization.", true);
 
+  await connect();
+  await control({ holdRefresh: true });
+  const concurrent = Promise.all([read(), read()]);
+  try {
+    await waitForRefreshes(2);
+  } finally {
+    await control({ holdRefresh: false, release: true });
+  }
+  expect((await concurrent).map(result => result.response.status)).toEqual([200, 200]);
+  expect((await read()).response.status).toBe(200);
+  expect((await control()).attempts).toBe(5);
+  evidence.recordAssertionEvidence("Concurrent successful refreshes preserve a usable successor", "Two held refreshes completed concurrently; both Gmail requests and a later read succeeded with no additional refresh.", true);
+
   await connect(); // Issue another short-lived access token.
   await control({ refreshError: "invalid_grant", holdRefresh: true });
   const lateRead = read();
   try {
-    const deadline = Date.now() + 8_000;
-    while ((await control()).pending !== 1 && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 25));
-    expect((await control()).pending).toBe(1);
+    await waitForRefreshes(1);
     await control({ authorizationExpiresIn: 3600 });
     await connect();
   } finally {
@@ -79,13 +99,21 @@ test("native Google refresh rejects revoked grants safely and preserves a concur
   const late = await lateRead;
   expect(late.response.status, late.text).toBe(200);
   expect((await read()).response.status).toBe(200);
-  expect((await control()).attempts).toBe(4);
+  expect((await control()).attempts).toBe(6);
   evidence.recordAssertionEvidence("A stale refresh rejection cannot erase a newer reconnect", "Held an old grant's refresh at the provider, completed a new PKCE connection, then released invalid_grant. Both the waiting Gmail read and a later read succeeded without another refresh.", true);
 
+  await control({ authorizationExpiresIn: 1, holdRefresh: true });
   await connect();
-  const disconnected = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/disconnect", { method: "POST", headers });
-  expect(disconnected.response.status, disconnected.text).toBe(200);
+  const disconnectedRead = read();
+  try {
+    await waitForRefreshes(1);
+    const disconnected = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/disconnect", { method: "POST", headers });
+    expect(disconnected.response.status, disconnected.text).toBe(200);
+  } finally {
+    await control({ holdRefresh: false, release: true });
+  }
+  expect((await disconnectedRead).response.status).toBe(409);
   expect((await read()).response.status).toBe(409);
-  expect((await control()).attempts).toBe(4);
-  evidence.recordAssertionEvidence("Explicit disconnect remains disconnected", "After disconnect, Gmail returned needs_connection and did not refresh or recreate credentials.", true);
+  expect((await control()).attempts).toBe(7);
+  evidence.recordAssertionEvidence("Explicit disconnect wins over a stale refresh failure", "Disconnected while a rejected refresh was held. Both the held and subsequent Gmail reads returned needs_connection with no new refresh or recreated credentials.", true);
 });

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -21,7 +21,7 @@ test("native Google refresh rejects revoked grants safely and preserves a concur
   } });
   const headers = { authorization: `Bearer ${den.admin.token}` };
   const configured = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/client", {
-    method: "POST", headers, body: JSON.stringify({ clientId: "refresh-fixture", clientSecret: "synthetic-secret" }),
+    method: "POST", headers, body: JSON.stringify({ clientId: "refresh-fixture", clientSecret: "synthetic-secret", features: ["gmailRead"] }),
   });
   expect(configured.response.status, configured.text).toBe(200);
   async function control(body?: Record<string, unknown>) {

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -8,22 +8,23 @@ function record(value: unknown): Record<string, unknown> {
   return value;
 }
 
-// Native-provider refresh and reconnect is separate from OpenWork's MCP OAuth grants.
-test("native Google refresh rejects revoked grants safely and preserves a concurrent reconnect", { timeout: 300_000 }, async ({ evidence, place }) => {
+// The control executes only unchanged behavior against clean dev product code.
+// Google and Microsoft both use the real default resolver, never an injected token.
+test("native Google refresh and Microsoft compatibility preserve reconnect and disconnect boundaries", { timeout: 300_000 }, async ({ evidence, place }) => {
   needs({ placement: "local", optIn: ["OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH"] });
+  const compatibilityOnly = process.env.OPENWORK_EVAL_NATIVE_REFRESH_COMPATIBILITY_ONLY === "1";
   await using google = await startMockGoogle({ accounts: ["mailbox@example.test"], port: 0 });
   await using den = await server({ place, web: false, org: { members: {} }, env: {
     DEN_GOOGLE_OAUTH_AUTHORIZE_URL: google.authorizeUrl,
     DEN_GOOGLE_OAUTH_TOKEN_URL: google.tokenUrl,
     DEN_GOOGLE_OAUTH_USERINFO_URL: google.userinfoUrl,
     DEN_GOOGLE_API_BASE_URL: google.apiUrl,
+    DEN_MICROSOFT_OAUTH_AUTHORIZE_URL: google.authorizeUrl,
+    DEN_MICROSOFT_OAUTH_TOKEN_URL: google.tokenUrl,
+    DEN_MICROSOFT_GRAPH_BASE_URL: `${google.apiUrl}/v1.0`,
     SENTRY_DSN: "",
   } });
   const headers = { authorization: `Bearer ${den.admin.token}` };
-  const configured = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/client", {
-    method: "POST", headers, body: JSON.stringify({ clientId: "refresh-fixture", clientSecret: "synthetic-secret", features: ["gmailRead"] }),
-  });
-  expect(configured.response.status, configured.text).toBe(200);
   async function control(body?: Record<string, unknown>) {
     const response = await fetch(`${google.apiUrl}/__mock-google/refresh-control`, body ? {
       method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
@@ -31,89 +32,136 @@ test("native Google refresh rejects revoked grants safely and preserves a concur
     expect(response.status).toBe(200);
     return record(await response.json());
   }
-  async function connect() {
-    const started = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/connect/start", { headers });
-    expect(started.response.status, started.text).toBe(200);
-    const url = record(started.body).authorizeUrl;
-    if (typeof url !== "string") throw new Error("Missing authorize URL");
-    expect(new URL(url).origin).toBe(new URL(google.apiUrl).origin);
-    const result = await fetch(url, { signal: AbortSignal.timeout(15_000) });
-    expect(result.status).toBe(200);
-    expect(await result.text()).toContain("Choose an account");
-    await google.chooseAccount("mailbox@example.test", { timeoutMs: 15_000 });
-    const status = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/status", { headers });
-    expect(status.response.status, status.text).toBe(200);
-    expect(status.body).toMatchObject({ connected: true });
-  }
   async function waitForRefreshes(count: number) {
     const deadline = Date.now() + 8_000;
     while ((await control()).pending !== count && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 25));
     expect((await control()).pending).toBe(count);
   }
-  const read = () => denFetch(den.admin, "/v1/capabilities/google-workspace/gmail-messages", { headers });
-  await control({ authorizationExpiresIn: 1, refreshError: "invalid_grant" });
-  await connect();
-  const revoked = await read();
-  expect(revoked.response.status, revoked.text).toBe(409);
-  expect(revoked.body).toMatchObject({ error: "needs_connection" });
-  expect(record(revoked.body).message).toContain("Connect your Google account");
-  expect((await control()).attempts).toBe(1);
-  const requests = record(await (await fetch(`${google.apiUrl}/requests`)).json()).requests;
-  expect(Array.isArray(requests)).toBe(true);
-  expect(JSON.stringify(requests)).not.toContain("/gmail/v1/");
-  evidence.recordAssertionEvidence("Revoked native credentials return actionable reconnect without automatic retries or mailbox access", "A real Den Gmail request received 409 needs_connection and Connect guidance after one rejected provider refresh; no Gmail endpoint was called.", true);
-
-  await control({ refreshError: "temporarily_unavailable" });
-  const unavailable = await read();
-  expect(unavailable.response.status).toBe(500);
-  expect(unavailable.body).not.toMatchObject({ error: "needs_connection" });
-  await control({ refreshError: null });
-  const recovered = await read();
-  expect(recovered.response.status, recovered.text).toBe(200);
-  expect((await control()).attempts).toBe(3);
-  evidence.recordAssertionEvidence("Temporary provider failures preserve the grant for retry", "A provider outage remained a server failure, not a false reconnect response; the next request refreshed the same grant successfully without new authorization.", true);
-
-  await connect();
-  await control({ holdRefresh: true });
-  const concurrent = Promise.all([read(), read()]);
-  try {
-    await waitForRefreshes(2);
-  } finally {
-    await control({ holdRefresh: false, release: true });
+  async function requests(path: string) {
+    const body = record(await (await fetch(`${google.apiUrl}/requests`)).json());
+    if (!Array.isArray(body.requests)) throw new Error("Missing provider request witness");
+    return body.requests.map(record).filter(request => request.path === path);
   }
-  expect((await concurrent).map(result => result.response.status)).toEqual([200, 200]);
-  expect((await read()).response.status).toBe(200);
-  expect((await control()).attempts).toBe(5);
-  evidence.recordAssertionEvidence("Concurrent successful refreshes preserve a usable successor", "Two held refreshes completed concurrently; both Gmail requests and a later read succeeded with no additional refresh.", true);
 
-  await connect(); // Issue another short-lived access token.
-  await control({ refreshError: "invalid_grant", holdRefresh: true });
-  const lateRead = read();
-  try {
-    await waitForRefreshes(1);
-    await control({ authorizationExpiresIn: 3600 });
+  for (const providerId of ["google-workspace", "microsoft-365"]) {
+    const microsoft = providerId === "microsoft-365";
+    const apiPath = microsoft ? "mail-messages" : "gmail-messages";
+    const providerPath = microsoft ? "/v1.0/me/messages" : "/gmail/v1/users/me/messages";
+    const configuration = await denFetch(den.admin, `/v1/oauth-providers/${providerId}/client`, {
+      method: "POST", headers, body: JSON.stringify({
+        clientId: `refresh-fixture-${providerId}`, clientSecret: "synthetic-secret",
+        features: [microsoft ? "mailRead" : "gmailRead"],
+        ...(microsoft ? { tenantId: "example.onmicrosoft.com" } : {}),
+      }),
+    });
+    expect(configuration.response.status, configuration.text).toBe(200);
+    const read = () => denFetch(den.admin, `/v1/capabilities/${providerId}/${apiPath}`, { headers });
+    const status = () => denFetch(den.admin, `/v1/oauth-providers/${providerId}/status`, { headers });
+    async function disconnect() {
+      const result = await denFetch(den.admin, `/v1/oauth-providers/${providerId}/disconnect`, { method: "POST", headers });
+      expect(result.response.status, result.text).toBe(200);
+    }
+    async function connect(expiresIn = 1) {
+      await control({ authorizationExpiresIn: expiresIn });
+      const started = await denFetch(den.admin, `/v1/oauth-providers/${providerId}/connect/start`, { headers });
+      expect(started.response.status, started.text).toBe(200);
+      const url = record(started.body).authorizeUrl;
+      if (typeof url !== "string") throw new Error("Missing authorize URL");
+      expect(new URL(url).origin).toBe(new URL(google.apiUrl).origin);
+      const result = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+      expect(result.status).toBe(200);
+      if (microsoft) {
+        expect(await result.text()).toContain("Connection complete");
+      } else {
+        expect(await result.text()).toContain("Choose an account");
+        await google.chooseAccount("mailbox@example.test", { timeoutMs: 15_000 });
+      }
+      const connected = await status();
+      expect(connected.response.status, connected.text).toBe(200);
+      expect(connected.body).toMatchObject({ connected: true });
+    }
+    function proved(claim: string, detail: string) {
+      evidence.recordAssertionEvidence(`${providerId}: ${claim}`, detail, true);
+    }
+    await control({ refreshError: null, holdRefresh: false });
+
+    if (!compatibilityOnly) {
+      await control({ refreshError: "invalid_grant" });
+      await connect();
+      const before = Number((await control()).attempts);
+      const mailBefore = (await requests(providerPath)).length;
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        const rejected = await read();
+        expect(rejected.response.status, rejected.text).toBe(409);
+        expect(rejected.body).toMatchObject({ error: "needs_connection" });
+        expect(record(rejected.body).message).toContain(microsoft ? "Microsoft" : "Google");
+        expect((await control()).attempts).toBe(before + attempt);
+        expect((await status()).body).toMatchObject({ connected: true });
+      }
+      expect((await requests(providerPath)).length).toBe(mailBefore);
+      proved("Repeated revoked grants return 409 without mailbox access", "Three explicit reads made exactly three refresh attempts and no mailbox requests. Status continued to report connected: true: retained credentials are an existing UI-status limitation, not a claim of durable invalidation.");
+    }
+
     await connect();
-  } finally {
-    await control({ holdRefresh: false, release: true });
-  }
-  const late = await lateRead;
-  expect(late.response.status, late.text).toBe(200);
-  expect((await read()).response.status).toBe(200);
-  expect((await control()).attempts).toBe(6);
-  evidence.recordAssertionEvidence("A stale refresh rejection cannot erase a newer reconnect", "Held an old grant's refresh at the provider, completed a new PKCE connection, then released invalid_grant. Both the waiting Gmail read and a later read succeeded without another refresh.", true);
+    await control({ refreshError: "temporarily_unavailable" });
+    const unavailable = await read();
+    expect(unavailable.response.status, unavailable.text).toBe(microsoft ? 502 : 500);
+    expect(unavailable.body).not.toMatchObject({ error: "needs_connection" });
+    await control({ refreshError: null });
+    expect((await read()).response.status).toBe(200);
+    proved("Temporary failures preserve recovery", "Provider unavailability retained the existing error classification (Google 500; Microsoft 502). The next read refreshed successfully without another authorization.");
 
-  await control({ authorizationExpiresIn: 1, holdRefresh: true });
-  await connect();
-  const disconnectedRead = read();
-  try {
-    await waitForRefreshes(1);
-    const disconnected = await denFetch(den.admin, "/v1/oauth-providers/google-workspace/disconnect", { method: "POST", headers });
-    expect(disconnected.response.status, disconnected.text).toBe(200);
-  } finally {
-    await control({ holdRefresh: false, release: true });
+    await connect(3600);
+    const freshAttempts = (await control()).attempts;
+    expect((await read()).response.status).toBe(200);
+    expect((await read()).response.status).toBe(200);
+    expect((await control()).attempts).toBe(freshAttempts);
+    proved("Fresh credentials avoid token-endpoint work", "Two valid-token mail reads succeeded without any refresh attempt.");
+
+    await connect();
+    await control({ holdRefresh: true });
+    const concurrent = Promise.all([read(), read()]);
+    try { await waitForRefreshes(2); }
+    finally { await control({ holdRefresh: false, release: true }); }
+    expect((await concurrent).map(result => result.response.status)).toEqual([200, 200]);
+    expect((await read()).response.status).toBe(200);
+    proved("Concurrent successful refreshes retain a usable successor", "Two held successful refresh responses completed concurrently; both waiting reads and a later read succeeded.");
+
+    // Run the success path on both clean dev and the PR. The rejection variant
+    // checks the new handler only; clean dev is known to throw on invalid_grant.
+    for (const refreshError of compatibilityOnly ? [null] : [null, "invalid_grant"]) {
+      await connect();
+      await control({ refreshError, holdRefresh: true });
+      const lateRead = read();
+      let replacementToken: unknown;
+      try {
+        await waitForRefreshes(1);
+        await connect(3600);
+        expect((await read()).response.status).toBe(200);
+        replacementToken = (await requests(providerPath)).at(-1)?.tokenId;
+        expect(typeof replacementToken).toBe("string");
+      } finally { await control({ holdRefresh: false, release: true }); }
+      expect((await lateRead).response.status).toBe(200);
+      expect((await requests(providerPath)).at(-1)?.tokenId).toBe(replacementToken);
+      const attemptsAfter = (await control()).attempts;
+      expect((await read()).response.status).toBe(200);
+      expect((await requests(providerPath)).at(-1)?.tokenId).toBe(replacementToken);
+      expect((await control()).attempts).toBe(attemptsAfter);
+      proved(`${refreshError ?? "successful refresh"} cannot overwrite reconnect`, "A new authorization completed while the old refresh was held. The waiting read and a subsequent read used the exact replacement credential fingerprint, without another refresh.");
+
+      await connect();
+      await control({ holdRefresh: true });
+      const disconnectedRead = read();
+      const mailBefore = (await requests(providerPath)).length;
+      try { await waitForRefreshes(1); await disconnect(); }
+      finally { await control({ holdRefresh: false, release: true }); }
+      expect((await disconnectedRead).response.status).toBe(409);
+      expect((await status()).body).toMatchObject({ connected: false });
+      const attemptsAfterDisconnect = (await control()).attempts;
+      expect((await read()).response.status).toBe(409);
+      expect((await control()).attempts).toBe(attemptsAfterDisconnect);
+      expect((await requests(providerPath)).length).toBe(mailBefore);
+      proved(`Disconnect wins over ${refreshError ?? "successful refresh"}`, "Disconnect completed before the held token response. Both waiting and later reads required connection, status remained disconnected, and no mail call or additional refresh occurred.");
+    }
   }
-  expect((await disconnectedRead).response.status).toBe(409);
-  expect((await read()).response.status).toBe(409);
-  expect((await control()).attempts).toBe(7);
-  evidence.recordAssertionEvidence("Explicit disconnect wins over a stale refresh failure", "Disconnected while a rejected refresh was held. Both the held and subsequent Gmail reads returned needs_connection with no new refresh or recreated credentials.", true);
 });

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -19,8 +19,8 @@ test("native Google refresh and Microsoft compatibility preserve reconnect and d
     DEN_GOOGLE_OAUTH_TOKEN_URL: google.tokenUrl,
     DEN_GOOGLE_OAUTH_USERINFO_URL: google.userinfoUrl,
     DEN_GOOGLE_API_BASE_URL: google.apiUrl,
-    DEN_MICROSOFT_OAUTH_AUTHORIZE_URL: google.authorizeUrl,
-    DEN_MICROSOFT_OAUTH_TOKEN_URL: google.tokenUrl,
+    DEN_MICROSOFT_OAUTH_AUTHORIZE_URL: `${google.authorizeUrl}?tenant={tenantId}`,
+    DEN_MICROSOFT_OAUTH_TOKEN_URL: `${google.tokenUrl}?tenant={tenantId}`,
     DEN_MICROSOFT_GRAPH_BASE_URL: `${google.apiUrl}/v1.0`,
     SENTRY_DSN: "",
   } });
@@ -68,6 +68,7 @@ test("native Google refresh and Microsoft compatibility preserve reconnect and d
       const url = record(started.body).authorizeUrl;
       if (typeof url !== "string") throw new Error("Missing authorize URL");
       expect(new URL(url).origin).toBe(new URL(google.apiUrl).origin);
+      if (microsoft) expect(new URL(url).searchParams.get("tenant")).toBe("example.onmicrosoft.com");
       const result = await fetch(url, { signal: AbortSignal.timeout(15_000) });
       expect(result.status).toBe(200);
       if (microsoft) {

--- a/evals/specs/native-google-refresh-recovery.test.ts
+++ b/evals/specs/native-google-refresh-recovery.test.ts
@@ -121,12 +121,19 @@ test("native Google refresh and Microsoft compatibility preserve reconnect and d
 
     await connect();
     await control({ holdRefresh: true });
+    const concurrentMailBefore = (await requests(providerPath)).length;
     const concurrent = Promise.all([read(), read()]);
     try { await waitForRefreshes(2); }
     finally { await control({ holdRefresh: false, release: true }); }
     expect((await concurrent).map(result => result.response.status)).toEqual([200, 200]);
+    const concurrentAttempts = (await control()).attempts;
+    const concurrentTokens = (await requests(providerPath)).slice(concurrentMailBefore).map(request => request.tokenId);
+    expect(concurrentTokens).toHaveLength(2);
+    for (const token of concurrentTokens) expect(typeof token).toBe("string");
     expect((await read()).response.status).toBe(200);
-    proved("Concurrent successful refreshes retain a usable successor", "Two held successful refresh responses completed concurrently; both waiting reads and a later read succeeded.");
+    expect((await control()).attempts).toBe(concurrentAttempts);
+    expect(concurrentTokens).toContain((await requests(providerPath)).at(-1)?.tokenId);
+    proved("Concurrent successful refreshes retain a usable successor", "Two held successful refresh responses completed concurrently; both waiting reads succeeded. A later read succeeded without another refresh and used a credential fingerprint observed on the concurrent mailbox reads.");
 
     // Run the success path on both clean dev and the PR. The rejection variant
     // checks the new handler only; clean dev is known to throw on invalid_grant.


### PR DESCRIPTION
A native Google capability call with a rejected OAuth refresh grant returned `500 internal_server_error`. The shared resolver now returns the existing actionable `409 needs_connection` response, or reuses a newer valid credential if another refresh or reconnect has already saved one. Microsoft 365 also uses this resolver; its rejected-grant response changes from 502 to 409.

Only `oauth_invalid_grant` is handled as reconnect. Other token failures retain their existing behavior. The error path never clears credentials, so a stale rejection cannot erase a newer grant or invalidate another worker's pending persistence. There is no automatic retry inside the request. Explicit later requests still try the retained grant, and status still reports `connected: true` while an access token is stored; this existing status limitation is now asserted, not claimed fixed.

Related Sentry issue: DEN-API-12. The production-tagged `den-api.local` URL is used by internal MCP invocation and does not alone establish test traffic. The historical reason Google rejected the grant remains unknown. This native-provider path is distinct from #4441's OpenWork-issued MCP refresh grants.

Validation:
- Current candidate: `b7a646b03201a3aca6391c7f92dabe555096a62c`. **Passed: 1 test, 16 assertion groups, 0 failures, 0 skips, 0 pending judgments.** [Final-head proof job](https://github.com/different-ai/openwork/actions/runs/33996998460/job/101389180473); [matching-SHA evidence](https://github.com/different-ai/openwork/pull/4524#issuecomment-5555329013). The concurrency check verifies credential reuse without another refresh. The historical compatibility-only switch has been removed: rejected-grant cases always run.
- Command: `OPENWORK_EVAL_NATIVE_GOOGLE_REFRESH=1 pnpm evals:pr specs/native-google-refresh-recovery.test.ts`.
- The expanded journey drives the real Google and Microsoft default resolvers through HTTP with synthetic OAuth and mail endpoints. It covers three repeated rejected-grant requests without mailbox access; temporary provider failure followed by recovery; fresh-token reads without refresh; two concurrent successful refreshes; successful and rejected refreshes held across reconnect and disconnect. Credential fingerprints prove that late responses do not overwrite a completed reconnect.
- [Historical clean-dev control](https://github.com/different-ai/openwork/pull/4524#issuecomment-5555245920): product source `aadaff1530fc5a80a7fff8671a5c3266aa62d989`, 1 test and 10 unchanged-behavior assertion groups passed, zero skips. Only the test and synthetic fixture were overlaid; this historical control predates the additional concurrency persistence assertions and removal of the compatibility-only switch in the final candidate. The control deliberately excludes the new rejected-grant semantics.
- The earlier unchanged-product reproduction at `12563e7e897ce47d654e8e9c0db23906612cff88` returned 500 where 409 was required: [failing control job](https://github.com/different-ai/openwork/actions/runs/33983139501/job/101351847024).
- The permanent required job runs final-head proof only and rejects skipped outcomes. The temporary clean-dev comparison matrix was removed after recording its evidence; no security gate was weakened.
- New spec boundary classification passes. Existing repository-wide boundary/channel ratchet failures were identical on the original branch and clean dev control `85a5dfccb4d74732593628ab4cc8912f8b88283d`; no baseline was weakened.

Remaining gaps: strict provider refresh-token rotation, omitted refresh-token responses, tenant/client rotation or member removal during refresh, cross-member/connector isolation, desktop reconnect-card behavior, and latency/load measurements. Those behaviors are not claimed proven by this journey. All fixtures and published evidence are synthetic; no production payloads or credentials are used.
