### PR TITLE
Fix partial workspace catalogs when child folders are inaccessible

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -309,6 +309,8 @@ export type OpenworkWorkspaceCatalogEntry = {
 };
 
 export type OpenworkWorkspaceCatalog = {
+  incomplete?: boolean;
+  skippedDirectories?: string[];
   items: OpenworkWorkspaceCatalogEntry[];
   total: number;
   truncated: boolean;

--- a/apps/app/src/react-app/domains/session/artifacts/workspace-file-tree.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/workspace-file-tree.tsx
@@ -160,6 +160,9 @@ export function WorkspaceFileTree({ client, workspaceId, workspaceName, selected
           style={{ ["--trees-fg-override" as string]: "var(--foreground)" }}
         />
       )}
+      {query.data?.incomplete ? (
+        <p role="status" className="border-t border-border px-2 py-1 text-[10px] text-muted-foreground">Some folders could not be read. Check their permissions and refresh.</p>
+      ) : null}
       {query.data?.truncated ? (
         <p className="border-t border-border px-2 py-1 text-[10px] text-muted-foreground">Showing the first 10,000 entries</p>
       ) : null}

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -469,6 +469,9 @@ async function listWorkspaceCatalogEntries(workspaceRoot: string, excludeHeavyDi
         skippedDirectories.push(relative(rootResolved, dirPath).replace(/\\/g, "/"));
         return [];
       }
+      if (dirPath === rootResolved && error instanceof Error && "code" in error && error.code === "ENOENT") {
+        throw new ApiError(404, "workspace_not_found", "The workspace folder no longer exists.");
+      }
       throw error;
     });
     entries.sort((a, b) => a.name.localeCompare(b.name));

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -455,12 +455,22 @@ function normalizeResolvedRelativePath(input: string): string {
   return parts.join("/");
 }
 
-async function listWorkspaceCatalogEntries(workspaceRoot: string, excludeHeavyDirectories = false): Promise<FileSessionCatalogEntry[]> {
+async function listWorkspaceCatalogEntries(workspaceRoot: string, excludeHeavyDirectories = false) {
   const rootResolved = resolve(workspaceRoot);
   const items: FileSessionCatalogEntry[] = [];
+  const skippedDirectories: string[] = [];
 
   const walk = async (dirPath: string) => {
-    const entries = await readdir(dirPath, { withFileTypes: true });
+    const entries = await readdir(dirPath, { withFileTypes: true }).catch((error: unknown) => {
+      if (error instanceof Error && "code" in error && (error.code === "EACCES" || error.code === "EPERM")) {
+        if (dirPath === rootResolved) {
+          throw new ApiError(403, "workspace_permission_denied", "OpenWork does not have permission to list this workspace folder.");
+        }
+        skippedDirectories.push(relative(rootResolved, dirPath).replace(/\\/g, "/"));
+        return [];
+      }
+      throw error;
+    });
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
@@ -496,12 +506,10 @@ async function listWorkspaceCatalogEntries(workspaceRoot: string, excludeHeavyDi
     }
   };
 
-  if (await exists(rootResolved)) {
-    await walk(rootResolved);
-  }
+  await walk(rootResolved);
 
   items.sort((a, b) => a.path.localeCompare(b.path));
-  return items;
+  return { items, skippedDirectories };
 }
 
 
@@ -726,7 +734,7 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
     const limit = parseCatalogLimit(ctx.url.searchParams.get("limit"));
     const excludeHeavyDirectories = ctx.url.searchParams.get("excludeHeavyDirectories") === "true";
 
-    const entries = await listWorkspaceCatalogEntries(workspace.path, excludeHeavyDirectories);
+    const { items: entries, skippedDirectories } = await listWorkspaceCatalogEntries(workspace.path, excludeHeavyDirectories);
     const filtered = entries.filter((entry) => {
       if (!includeDirs && entry.kind === "dir") return false;
       if (!matchesCatalogFilter(entry.path, prefix)) return false;
@@ -745,6 +753,8 @@ export function registerFileRoutes(options: RegisterFileRoutesOptions): void {
       generatedAt: Date.now(),
       cursor: events.cursor,
       total: filtered.length,
+      incomplete: skippedDirectories.length > 0,
+      skippedDirectories,
       truncated,
       nextAfter,
       items,

--- a/evals/specs/artifact-code-browser.e2e.test.ts
+++ b/evals/specs/artifact-code-browser.e2e.test.ts
@@ -1,4 +1,5 @@
-import { spec } from "@openwork/testkit";
+import { expect } from "vitest";
+import { eventually, spec } from "@openwork/testkit";
 import { artifactCodeBrowserWorld } from "../worlds/first-run.ts";
 
 const test = spec.world(artifactCodeBrowserWorld);
@@ -13,7 +14,12 @@ test("artifact editor renders code with Pierre and browses workspace files", asy
     await user.press("Tab");
     await user.press("Enter");
     await user.see("Select tab: openwork-artifact-proof.ts", { timeoutMs: 30_000 });
-    await user.see({ text: /export const artifactEditor = true/ }, { timeoutMs: 30_000 });
+    // Pierre renders code inside a shadow root, outside the generic text locator.
+    const code = await eventually(() => world.visibleArtifactCode(), {
+      within: 30_000,
+      until: (value) => typeof value === "string" && value.includes("export const artifactEditor = true"),
+    });
+    expect(code).toContain("export const artifactEditor = true");
     await user.looks([
       "The artifact panel visibly shows a workspace file tree beside a syntax-highlighted TypeScript code viewer",
       "The code viewer visibly contains the TypeScript declaration export const artifactEditor = true",

--- a/evals/specs/artifact-code-browser.e2e.test.ts
+++ b/evals/specs/artifact-code-browser.e2e.test.ts
@@ -3,7 +3,7 @@ import { artifactCodeBrowserWorld } from "../worlds/first-run.ts";
 
 const test = spec.world(artifactCodeBrowserWorld);
 
-test("artifact editor renders code with Pierre and browses workspace files", async ({ user, step }) => {
+test("artifact editor renders code with Pierre and browses workspace files", async ({ world, user, step, evidence }) => {
   await user.click("Select tab: overflow-tab-12.md");
   await user.see({ placeholder: "Search files" }, { timeoutMs: 30_000 });
 
@@ -19,6 +19,22 @@ test("artifact editor renders code with Pierre and browses workspace files", asy
       "The code viewer visibly contains the TypeScript declaration export const artifactEditor = true",
       "No error dialog, blank artifact surface, or crash message is visible",
     ]);
+  });
+
+  await step("Restricted folders show an honest notice while readable files remain usable", async () => {
+    await world.setCatalogFolderRestricted(true);
+    try {
+      await user.click("Refresh workspace files");
+      await user.see({ text: "Some folders could not be read. Check their permissions and refresh." });
+      await user.see("Select tab: openwork-artifact-proof.ts");
+      await user.notSee({ text: "Could not load workspace files." });
+      evidence.recordAssertionEvidence("The file browser reports a permission gap without replacing readable files with an error", "After restricting a synthetic sibling folder and refreshing, the permissions notice and readable artifact tab remained visible, with no catalog load error.", true);
+    } finally {
+      await world.setCatalogFolderRestricted(false);
+    }
+    await user.click("Refresh workspace files");
+    await user.notSee({ text: "Some folders could not be read. Check their permissions and refresh." });
+    evidence.recordAssertionEvidence("The partial-catalog notice clears after restoring permissions", "Restoring the synthetic folder's permissions and using the refresh button removed the notice.", true);
   });
 
   await step("Selecting JSON replaces the active code artifact", async () => {

--- a/evals/specs/workspace-file-catalog.test.ts
+++ b/evals/specs/workspace-file-catalog.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect } from "vitest";
@@ -78,6 +78,85 @@ test("workspace catalog preserves readable siblings and reports permission gaps"
   } finally {
     await chmod(workspace, 0o700);
     await chmod(restricted, 0o700);
+    await stopChild(booted.child);
+    await rm(scratch, { recursive: true, force: true });
+  }
+});
+
+
+test("healthy workspace catalog preserves symlink boundaries, pagination, and directory exclusions", async ({ evidence }) => {
+  const scratch = await mkdtemp(join(tmpdir(), "openwork-catalog-compatibility-"));
+  const workspace = join(scratch, "workspace");
+  const outside = join(scratch, "outside");
+  const home = join(scratch, "home");
+  const pageNames = ["001.txt", "002.txt", "003.txt", "004.txt", "005.txt"];
+  for (const path of [outside, home, join(workspace, "pages"), join(workspace, ".git"), join(workspace, "node_modules"), join(workspace, "nested", "node_modules")]) {
+    await mkdir(path, { recursive: true });
+  }
+  await writeFile(join(outside, "outside-only.txt"), "synthetic external fixture");
+  for (const name of pageNames) await writeFile(join(workspace, "pages", name), name);
+  for (const path of [".git/internal.txt", "node_modules/dependency.txt", "nested/node_modules/dependency.txt", "nested/visible.txt"]) {
+    await writeFile(join(workspace, path), "synthetic fixture");
+  }
+  await symlink(outside, join(workspace, "external-link"), "dir");
+  await symlink(workspace, join(workspace, "cycle-link"), "dir");
+  await symlink(join(outside, "outside-only.txt"), join(workspace, "external-file-link"), "file");
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+  const headers = { authorization: "Bearer catalog-compatibility-token", "content-type": "application/json" };
+  const booted = bootServer({ ...inherited, HOME: home, XDG_CONFIG_HOME: join(home, ".config"), XDG_DATA_HOME: join(home, ".local/share"), OPENWORK_MANAGE_OPENCODE: "0" }, "catalog-compatibility-token", workspace, () => {});
+  try {
+    const base = await booted.listening;
+    const request = (path: string, body?: unknown) => fetch(`${base}${path}`, { headers, method: body === undefined ? "GET" : "POST", body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(10_000) });
+    const workspaces: unknown = await (await request("/workspaces")).json();
+    if (!isRecord(workspaces) || !Array.isArray(workspaces.items) || !isRecord(workspaces.items[0]) || typeof workspaces.items[0].id !== "string") throw new Error("Missing workspace");
+    const created: unknown = await (await request(`/workspace/${workspaces.items[0].id}/files/sessions`, { write: false })).json();
+    if (!isRecord(created) || !isRecord(created.session) || typeof created.session.id !== "string") throw new Error("Missing file session");
+    const sessionId = created.session.id;
+    const catalog = async (query: string) => {
+      const response = await request(`/files/sessions/${sessionId}/catalog/snapshot?${query}`);
+      expect(response.status).toBe(200);
+      const value: unknown = await response.json();
+      if (!isRecord(value) || !Array.isArray(value.items)) throw new Error("Missing catalog");
+      return { ...value, paths: value.items.filter(isRecord).map((item) => item.path), nextAfter: value.nextAfter, truncated: value.truncated, total: value.total };
+    };
+    const all = await catalog("excludeHeavyDirectories=false");
+    expect(all.paths).toContain("pages/001.txt");
+    expect(all.paths).not.toContain("external-link");
+    expect(all.paths).not.toContain("cycle-link");
+    expect(all.paths).not.toContain("external-file-link");
+    expect(all.paths.some((path) => typeof path === "string" && /outside-only|external-link\/|cycle-link\//.test(path))).toBe(false);
+    evidence.recordAssertionEvidence("Stable external and cyclic symlinks are excluded from the catalog", "The real HTTP snapshot completed within its deadline, included ordinary files, and excluded external-directory, external-file, and cyclic links and their target entries.", true);
+
+    const excluded = await catalog("excludeHeavyDirectories=true");
+    for (const path of [".git", ".git/internal.txt", "node_modules", "node_modules/dependency.txt", "nested/node_modules", "nested/node_modules/dependency.txt"]) {
+      expect(all.paths).toContain(path);
+      expect(excluded.paths).not.toContain(path);
+    }
+    expect(excluded.paths).toContain("nested/visible.txt");
+    expect(excluded).not.toMatchObject({ incomplete: true });
+    evidence.recordAssertionEvidence("Heavy directory exclusion is opt-in and applies at nested levels", "Both root and nested dependency directories and .git were present when inclusion was requested, absent when exclusion was requested, and the ordinary sibling remained visible.", true);
+
+    const received: unknown[] = [];
+    let after = "";
+    for (let page = 0; page < 3; page += 1) {
+      const result = await catalog(`prefix=pages&includeDirs=false&limit=2${after ? `&after=${encodeURIComponent(after)}` : ""}`);
+      expect(result.total).toBe(5 - page * 2);
+      expect(result.paths).toEqual(pageNames.slice(page * 2, page * 2 + 2).map((name) => `pages/${name}`));
+      expect(result.truncated).toBe(page < 2);
+      received.push(...result.paths);
+      if (page < 2) {
+        expect(result.nextAfter).toBe(result.paths.at(-1));
+        if (typeof result.nextAfter !== "string") throw new Error("Missing continuation cursor");
+        after = result.nextAfter;
+      } else expect(result.nextAfter).toBeUndefined();
+    }
+    expect(received).toEqual(pageNames.map((name) => `pages/${name}`));
+    expect(new Set(received).size).toBe(5);
+    const exhausted = await catalog(`prefix=pages&includeDirs=false&limit=2&after=${encodeURIComponent("pages/005.txt")}`);
+    expect(exhausted).toMatchObject({ paths: [], total: 0, truncated: false });
+    expect(exhausted.nextAfter).toBeUndefined();
+    evidence.recordAssertionEvidence("Numbered filenames paginate without omission or duplication", "Five files were returned exactly once across three HTTP pages (2, 2, 1); continuation cursors, remaining totals, terminal truncation, and an exhausted page were asserted.", true);
+  } finally {
     await stopChild(booted.child);
     await rm(scratch, { recursive: true, force: true });
   }

--- a/evals/specs/workspace-file-catalog.test.ts
+++ b/evals/specs/workspace-file-catalog.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect } from "vitest";
@@ -64,6 +64,17 @@ test("workspace catalog preserves readable siblings and reports permission gaps"
     expect(denied.status).toBe(403);
     expect(await denied.json()).toMatchObject({ code: "workspace_permission_denied" });
     evidence.recordAssertionEvidence("An unreadable workspace root returns a meaningful error", "Real root permission denial returned HTTP 403 workspace_permission_denied, never an empty successful catalog.", true);
+    await chmod(workspace, 0o700);
+    const moved = join(scratch, "moved-workspace");
+    await rename(workspace, moved);
+    try {
+      const missing = await request(catalogPath);
+      expect(missing.status).toBe(404);
+      expect(await missing.json()).toMatchObject({ code: "workspace_not_found" });
+      evidence.recordAssertionEvidence("A missing workspace folder returns a meaningful error", "Moving the workspace root after session creation returned HTTP 404 workspace_not_found instead of a server error or an empty successful catalog.", true);
+    } finally {
+      await rename(moved, workspace);
+    }
   } finally {
     await chmod(workspace, 0o700);
     await chmod(restricted, 0o700);

--- a/evals/specs/workspace-file-catalog.test.ts
+++ b/evals/specs/workspace-file-catalog.test.ts
@@ -1,0 +1,73 @@
+import { chmod, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { test } from "@openwork/testkit";
+import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
+
+// The file-session catalog is a public server journey used by the file browser
+// and sync clients. Exercise real OS permissions and HTTP, without mocking fs.
+test("workspace catalog preserves readable siblings and reports permission gaps", async ({ evidence }) => {
+  const scratch = await mkdtemp(join(tmpdir(), "openwork-catalog-permissions-"));
+  const workspace = join(scratch, "workspace");
+  const restricted = join(workspace, "a-restricted");
+  await mkdir(restricted, { recursive: true });
+  await mkdir(join(workspace, "z-readable"));
+  await writeFile(join(restricted, "private.txt"), "synthetic restricted fixture");
+  await writeFile(join(workspace, "z-readable", "report.txt"), "synthetic readable fixture");
+  const home = join(scratch, "home");
+  await mkdir(home);
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+  const headers = { authorization: "Bearer catalog-test-token", "content-type": "application/json" };
+  const booted = bootServer({ ...inherited, HOME: home, XDG_CONFIG_HOME: join(home, ".config"), XDG_DATA_HOME: join(home, ".local/share"), OPENWORK_MANAGE_OPENCODE: "0" }, "catalog-test-token", workspace, () => {});
+  try {
+    const base = await booted.listening;
+    const request = (path: string, body?: unknown) => fetch(`${base}${path}`, { headers, method: body === undefined ? "GET" : "POST", body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(10_000) });
+    const workspaces: unknown = await (await request("/workspaces")).json();
+    if (!isRecord(workspaces) || !Array.isArray(workspaces.items) || !isRecord(workspaces.items[0]) || typeof workspaces.items[0].id !== "string") throw new Error("Missing workspace");
+    const workspaceId = workspaces.items[0].id;
+    const created: unknown = await (await request(`/workspace/${workspaceId}/files/sessions`, { write: false })).json();
+    if (!isRecord(created) || !isRecord(created.session) || typeof created.session.id !== "string") throw new Error("Missing file session");
+    const catalogPath = `/files/sessions/${created.session.id}/catalog/snapshot`;
+    const catalog = async (query = "") => {
+      const response = await request(`${catalogPath}${query}`);
+      expect(response.status).toBe(200);
+      const value: unknown = await response.json();
+      if (!isRecord(value) || !Array.isArray(value.items)) throw new Error("Missing catalog");
+      return { ...value, paths: value.items.filter(isRecord).map((item) => item.path) };
+    };
+    await chmod(restricted, 0);
+    // Fail loudly under root or on an OS that does not enforce POSIX modes.
+    await expect(readdir(restricted)).rejects.toMatchObject({ code: "EACCES" });
+    const partial = await catalog();
+    expect(partial.paths).toContain("z-readable/report.txt");
+    expect(partial.paths).not.toContain("a-restricted/private.txt");
+    expect(partial).toMatchObject({ incomplete: true, skippedDirectories: ["a-restricted"], truncated: false });
+    const filtered = await catalog("?prefix=z-readable&includeDirs=false&limit=1");
+    expect(filtered.paths).toEqual(["z-readable/report.txt"]);
+    expect(filtered).toMatchObject({ incomplete: true, truncated: false, total: 1 });
+    const content = await request(`/workspace/${workspaceId}/files/content?path=z-readable%2Freport.txt`);
+    expect(content.status).toBe(200);
+    expect(await content.json()).toMatchObject({ content: "synthetic readable fixture" });
+    evidence.recordAssertionEvidence("Denied child folders do not hide readable sibling files", "Real chmod denial was observed; catalog and file read returned HTTP 200 for the readable sibling, excluded restricted contents, and explicitly reported incomplete=true with the relative skipped directory. Prefix and limit filtering retained the permission warning.", true);
+
+    await chmod(restricted, 0o700);
+    const complete = await catalog();
+    expect(complete.paths).toContain("a-restricted/private.txt");
+    expect(complete.paths).toContain("z-readable/report.txt");
+    expect(complete).toMatchObject({ incomplete: false, skippedDirectories: [] });
+    evidence.recordAssertionEvidence("Refreshing after permission restoration returns a complete catalog", "The same session's next HTTP snapshot included both files and cleared incomplete and skippedDirectories.", true);
+
+    await chmod(workspace, 0);
+    await expect(readdir(workspace)).rejects.toMatchObject({ code: "EACCES" });
+    const denied = await request(catalogPath);
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({ code: "workspace_permission_denied" });
+    evidence.recordAssertionEvidence("An unreadable workspace root returns a meaningful error", "Real root permission denial returned HTTP 403 workspace_permission_denied, never an empty successful catalog.", true);
+  } finally {
+    await chmod(workspace, 0o700);
+    await chmod(restricted, 0o700);
+    await stopChild(booted.child);
+    await rm(scratch, { recursive: true, force: true });
+  }
+});

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { app as startApp, server as startServer } from "@openwork/env";
@@ -155,6 +155,7 @@ export async function artifactCodeBrowserWorld(seed: Seed) {
       },
     );
     const responses = await Promise.all([
+      write("restricted/hidden-proof.ts", "export const restricted = true;"),
       write("src/openwork-artifact-proof.ts", "export const artifactEditor = true;\\n"),
       write("config/openwork-artifact-settings.json", "{\\"artifactEditor\\":true}\\n"),
     ]);
@@ -171,7 +172,19 @@ export async function artifactCodeBrowserWorld(seed: Seed) {
   // TODO(primitive): seed artifact tabs through a first-class artifact fixture.
   const tabs = await seed.evalIn(base.app, `window.__openworkControl.execute("eval.artifact_tabs.seed_overflow", { count: 12 })`, { awaitPromise: true });
   if (!isRecord(tabs) || tabs.ok !== true) throw new Error(`Could not seed artifact tabs: ${JSON.stringify(tabs)}`);
-  return base;
+  return {
+    ...base,
+    async setCatalogFolderRestricted(restricted: boolean) {
+      const path = join(base.workspacePath, "restricted");
+      const mode = restricted ? "000" : "700";
+      const sandbox = base.app.handle.sandboxId;
+      if (sandbox) {
+        await checkedExec(defaultDaytonaExec, remoteCommand(sandbox, `chmod ${mode} ${shellQuote(path)}`), "set synthetic catalog folder permissions");
+      } else {
+        await chmod(path, restricted ? 0 : 0o700);
+      }
+    },
+  };
 }
 
 export async function skillsLocalWorld(seed: Seed) {

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -174,6 +174,17 @@ export async function artifactCodeBrowserWorld(seed: Seed) {
   if (!isRecord(tabs) || tabs.ok !== true) throw new Error(`Could not seed artifact tabs: ${JSON.stringify(tabs)}`);
   return {
     ...base,
+    async visibleArtifactCode() {
+      return seed.evalIn(base.app, `(() => {
+        const root = document.querySelector("[data-artifact-code-view]");
+        if (!root || root.getBoundingClientRect().height === 0) return "";
+        const text = (node) => [...node.childNodes].map((child) =>
+          child.nodeType === Node.TEXT_NODE ? child.textContent :
+          child instanceof Element ? text(child.shadowRoot || child) : ""
+        ).join("");
+        return text(root);
+      })()`);
+    },
     async setCatalogFolderRestricted(restricted: boolean) {
       const path = join(base.workspacePath, "restricted");
       const mode = restricted ? "000" : "700";


### PR DESCRIPTION
A denied child directory currently makes the entire file-session catalog return HTTP 500 (DESKTOP-APP-25). This preserves readable siblings, reports `incomplete` with relative `skippedDirectories`, and shows a permissions notice in the file browser. Refreshing after permission restoration clears the notice and includes the restored files.

Only EACCES/EPERM directory reads are skipped. An unreadable workspace root returns `403 workspace_permission_denied`; a missing root returns `404 workspace_not_found`. Other filesystem errors still propagate. No OS permissions are bypassed.

Verification on `c446f9c7da2f8f106edf515cf57f72955326e4da` — **Passed**:
- `pnpm evals:pr specs/workspace-file-catalog.test.ts`: 2 passed, 0 failed, 0 skipped. Real HTTP and OS permissions prove readable siblings, honest partial results, filtering, restoration, root denial, and missing-root handling. Original catalog code reproduced HTTP 500 with the same restricted-folder scenario. Additional real HTTP checks cover stable external/cyclic symlink exclusion, directory exclusion toggles, and numbered filenames across three pages with no omissions or duplicates.
- `OPENWORK_EVAL_REF=c446f9c7da2f8f106edf515cf57f72955326e4da pnpm evals:e2e artifact-code-browser`: `placement: daytona (daytona CLI authenticated)`; 1 passed, 0 failed, 0 skipped. The existing desktop journey proves the notice appears and clears, readable content remains available, and TypeScript/JSON browsing works. Six screenshot checks passed by direct manual Codex image inspection, recorded with screenshot hashes and the explicit model label `manual-codex-image-inspection`; none pending.
- All three test runs are published together in the test-evidence comment. Server and app typechecks passed; final-commit CI is green.

The existing journey's generic text locator could not read Pierre's shadow-root content, reproduced on clean `dev`; its assertion now reads rendered code through the browser boundary. The new server spec passes the boundary classifier. Full boundary-ratchet violations also reproduce on clean `dev`; no baseline edits. Locally, the artifact regression suite reports 31 pass/0 fail followed by a Bun SIGTRAP, also reproduced on clean `dev`; that local process exit is not claimed successful. CI core regressions and the packaged desktop build pass.

All fixtures are synthetic. DESKTOP-APP-17 (Windows mkdir with no stack) is not claimed fixed. The prior startup permission fix (#3829) does not cover catalog traversal; Unicode downloads were already fixed by merged #4416.


Collateral comparison: the selected healthy compatibility test also passes on clean dev `aadaff153` (1 passed, 1 intentionally filtered/skipped). A separate mixed-case pagination probe fails identically on dev and the PR (second-page total 2 rather than 3); this inherited limitation is documented separately and is not claimed fixed. No product code changed in this collateral-validation update.
