### PR TITLE
fix(privacy): redact credentials in feedback and diagnostics

### DIFF
--- a/apps/app/src/app/lib/diagnostic-sanitizer.ts
+++ b/apps/app/src/app/lib/diagnostic-sanitizer.ts
@@ -1,48 +1,8 @@
-const REDACTED = "[REDACTED]";
-
-const SENSITIVE_KEYS = new Set([
-  "authorization",
-  "token",
-  "secret",
-  "password",
-  "cookie",
-  "api_key",
-  "api-key",
-  "apikey",
-  "client_secret",
-]);
+import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "@openwork/types/diagnostic-sanitizer";
+export { sanitizeDiagnosticString, sanitizeDiagnosticValue, sanitizeDiagnosticRecord } from "@openwork/types/diagnostic-sanitizer";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isSensitiveKey(key: string): boolean {
-  return SENSITIVE_KEYS.has(key.trim().toLowerCase());
-}
-
-export function sanitizeDiagnosticString(value: string): string {
-  return value
-    .replace(/Bearer\s+[A-Za-z0-9._~+\/-]+=*/gi, `Bearer ${REDACTED}`)
-    .replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, REDACTED)
-    .replace(/\bow[thc]_[A-Za-z0-9_-]+\b/g, REDACTED);
-}
-
-export function sanitizeDiagnosticValue(value: unknown): unknown {
-  if (typeof value === "string") return sanitizeDiagnosticString(value);
-  if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
-  if (Array.isArray(value)) return value.map((item) => sanitizeDiagnosticValue(item));
-  if (!isRecord(value)) return String(value);
-
-  const sanitized: Record<string, unknown> = {};
-  for (const [key, nested] of Object.entries(value)) {
-    sanitized[key] = isSensitiveKey(key) ? REDACTED : sanitizeDiagnosticValue(nested);
-  }
-  return sanitized;
-}
-
-export function sanitizeDiagnosticRecord(value: Record<string, unknown>): Record<string, unknown> {
-  const sanitized = sanitizeDiagnosticValue(value);
-  return isRecord(sanitized) ? sanitized : {};
 }
 
 function isSafeCloudTokenMetadataKey(key: string): boolean {

--- a/apps/app/src/app/lib/diagnostics-bundle.ts
+++ b/apps/app/src/app/lib/diagnostics-bundle.ts
@@ -9,7 +9,8 @@ import {
   type OpenworkServerInfo,
 } from "./desktop";
 import { readPerfLogs, type PerfLogRecord } from "./perf-log";
-import { sanitizeCloudMcpHealthDiagnostic } from "./diagnostic-sanitizer";
+import { isSensitiveKey } from "@openwork/types/diagnostic-sanitizer";
+import { sanitizeDiagnosticValue, sanitizeCloudMcpHealthDiagnostic } from "./diagnostic-sanitizer";
 import {
   readOpenworkServerSettings,
   type OpenworkServerSettings,
@@ -73,7 +74,7 @@ function pickExecution(execution: OpencodeExecutionSnapshot | null): Diagnostics
     cwd: execution.cwd,
     env: execution.env.map((entry) => ({
       name: entry.name,
-      value: entry.value,
+      value: isSensitiveKey(entry.name) || entry.redacted ? "[REDACTED]" : entry.value,
       redacted: entry.redacted,
     })),
   };
@@ -187,7 +188,7 @@ export function composeDiagnosticsBundleJson(input: DiagnosticsBundleInputs): st
       recent: input.developerLogs,
     },
   };
-  return scrubKnownSecretValues(JSON.stringify(bundle, null, 2), collectSecretValues(input));
+  return scrubKnownSecretValues(JSON.stringify(sanitizeDiagnosticValue(bundle), null, 2), collectSecretValues(input));
 }
 
 async function readAppInfo(desktopRuntime: boolean) {

--- a/apps/app/src/app/lib/feedback.ts
+++ b/apps/app/src/app/lib/feedback.ts
@@ -1,3 +1,5 @@
+import { sanitizeDiagnosticString } from "@openwork/types/diagnostic-sanitizer";
+
 const ENV_FEEDBACK_URL = String(import.meta.env.VITE_OPENWORK_FEEDBACK_URL ?? "").trim();
 const ENV_APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
 
@@ -85,7 +87,7 @@ export function buildFeedbackUrl(options: FeedbackUrlOptions): string {
   const osContext = parseClientOsContext();
 
   url.searchParams.set("source", "openwork-app");
-  url.searchParams.set("entrypoint", options.entrypoint);
+  url.searchParams.set("entrypoint", sanitizeDiagnosticString(options.entrypoint));
 
   const entries = {
     deployment: options.deployment?.trim() ?? "",
@@ -99,7 +101,7 @@ export function buildFeedbackUrl(options: FeedbackUrlOptions): string {
 
   for (const [key, value] of Object.entries(entries)) {
     if (value) {
-      url.searchParams.set(key, value);
+      url.searchParams.set(key, sanitizeDiagnosticString(value));
     }
   }
 

--- a/apps/app/tests/diagnostics-bundle.test.ts
+++ b/apps/app/tests/diagnostics-bundle.test.ts
@@ -78,12 +78,18 @@ describe("diagnostics bundle", () => {
       pid: 222,
       lastStdout: null,
       lastStderr: `engine leaked ${opencodeSecret}`,
-      execution: null,
+      execution: {
+        command: "opencode", args: ["serve", "--api-key", "synthetic-argument"],
+        cwd: "/tmp/synthetic-workspace",
+        env: [{ name: "OPENAI_API_KEY", value: "synthetic-environment-value", redacted: false }],
+      },
     };
 
     const json = composeDiagnosticsBundleJson(input);
     const parsed = JSON.parse(json);
 
+    expect(json).not.toContain("synthetic-argument");
+    expect(json).not.toContain("synthetic-environment-value");
     expect(json).toContain('"tokenPresent": true');
     expect(parsed.openworkServer.settings.tokenPresent).toBe(true);
     expect(parsed.openworkServer.host.lastStderr).toContain("[redacted]");
@@ -145,5 +151,52 @@ describe("diagnostics bundle", () => {
     expect(json).not.toContain("owt_mcp_synthetic_secret");
     expect(json).not.toContain("owt_den_synthetic_secret");
     expect(json).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+  });
+});
+
+test("redacts pasted credentials and nested diagnostic fields while retaining context", () => {
+  const input = baseInputs();
+  input.cloudMcpHealth = {
+    phase: "engine_failed",
+    nested: {
+      accessToken: "synthetic-access",
+      refresh_token: "synthetic-refresh",
+      apiKey: "synthetic-key",
+      "set-cookie": "synthetic-cookie",
+    },
+    error: "request failed Bearer synthetic-bearer-123",
+  };
+  input.context = { openworkServerUrl: "https://example.invalid/?access_token=synthetic-query&status=failed" };
+  const json = composeDiagnosticsBundleJson(input);
+  for (const secret of ["synthetic-access", "synthetic-refresh", "synthetic-key", "synthetic-cookie", "synthetic-bearer", "synthetic-query"]) {
+    expect(json).not.toContain(secret);
+  }
+  expect(json).toContain("engine_failed");
+  expect(json).toContain("status=failed");
+});
+
+test("shared sanitizer handles freeform credentials before truncation without removing useful metadata", async () => {
+  const { sanitizeDiagnosticString, sanitizeDiagnosticRecord } = await import("../src/app/lib/diagnostic-sanitizer");
+  const examples = [
+    "Bearer synthetic-bearer",
+    "Cookie: session=synthetic-cookie; other=synthetic-other",
+    "OPENAI_API_KEY=synthetic-environment",
+    "sk-proj-synthetic-api-credential",
+    "xoxb-synthetic-oauth-credential",
+    "ya29.synthetic-oauth-credential",
+    "github_pat_synthetic-credential",
+    'please inspect api_key="synthetic-key with spaces"',
+    '{"refreshToken":"synthetic-refresh","status":"failed"}',
+    "--client-secret synthetic-cli",
+    "https://synthetic-user:synthetic-password@example.invalid",
+  ];
+  for (const example of examples) {
+    const redacted = sanitizeDiagnosticString(example);
+    expect(redacted).not.toContain("synthetic");
+    expect(redacted).toContain("[REDACTED]");
+    expect(sanitizeDiagnosticString(redacted)).toBe(redacted);
+  }
+  expect(sanitizeDiagnosticRecord({ appVersion: "1.2.3", statusCode: 401, tokenPresent: true })).toEqual({
+    appVersion: "1.2.3", statusCode: 401, tokenPresent: true,
   });
 });

--- a/ee/apps/landing/app/api/app-feedback/route.ts
+++ b/ee/apps/landing/app/api/app-feedback/route.ts
@@ -1,3 +1,4 @@
+import { sanitizeDiagnosticString } from "@openwork/types/diagnostic-sanitizer";
 import { buildResponseHeaders, jsonResponse, rateLimitFormRequest, validateAntiSpamFields, validateTrustedOrigin, verifyFormBotProtection } from "../_lib/security";
 import { EmailSendError, sendEmail, type FeedbackEmailProps } from "@openwork/email";
 
@@ -26,7 +27,7 @@ type FeedbackPayload = {
 const DEFAULT_INTERNAL_FEEDBACK_EMAIL = "team@openworklabs.com";
 
 function sanitizeValue(value: unknown, maxLength = 240) {
-  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+  return typeof value === "string" ? sanitizeDiagnosticString(value.trim()).slice(0, maxLength) : "";
 }
 
 function sanitizeContext(input: FeedbackContext | undefined) {
@@ -106,8 +107,8 @@ export async function POST(request: Request) {
   }
 
   const message = sanitizeValue(payload.message, 5000);
-  const name = sanitizeValue(payload.name, 120);
-  const email = sanitizeValue(payload.email, 240);
+  const name = typeof payload.name === "string" ? payload.name.trim().slice(0, 120) : "";
+  const email = typeof payload.email === "string" ? payload.email.trim().slice(0, 240) : "";
   const mode = sanitizeValue(payload.mode, 40) === "contact" ? "contact" : "feedback";
 
   if (!name) {

--- a/ee/apps/landing/components/app-feedback-form.tsx
+++ b/ee/apps/landing/components/app-feedback-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlertCircle, CheckCircle2, Copy, Mail, MessageSquareText, Send } from "lucide-react";
+import { sanitizeDiagnosticString, sanitizeDiagnosticRecord } from "@openwork/types/diagnostic-sanitizer";
 import { useMemo, useState } from "react";
 
 export type AppFeedbackPrefill = {
@@ -107,11 +108,11 @@ export function AppFeedbackForm(props: Props) {
         body: JSON.stringify({
           name: trimmedName,
           email: trimmedEmail,
-          message: trimmed,
+          message: sanitizeDiagnosticString(trimmed),
           website,
           startedAt,
           mode,
-          context: props.prefill,
+          context: sanitizeDiagnosticRecord(props.prefill),
         }),
       });
 

--- a/ee/apps/landing/next.config.js
+++ b/ee/apps/landing/next.config.js
@@ -5,7 +5,7 @@ const mintlifyOrigin = "https://differentai.mintlify.dev";
 
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ["@openwork/email", "@openwork/ui"],
+  transpilePackages: ["@openwork/email", "@openwork/ui", "@openwork/types"],
   // Lets evals build/serve a production instance beside next dev without clobbering .next.
   distDir: process.env.LANDING_DIST_DIR || ".next",
   // Bake VERCEL_ENV at build time so the PostHog gates (app/layout.tsx and

--- a/ee/apps/landing/package.json
+++ b/ee/apps/landing/package.json
@@ -18,7 +18,8 @@
     "lucide-react": "^0.577.0",
     "next": "15.5.21",
     "react": "catalog:react18",
-    "react-dom": "catalog:react18"
+    "react-dom": "catalog:react18",
+    "@openwork/types": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "^1.3.6",

--- a/evals/specs/feedback-privacy.test.ts
+++ b/evals/specs/feedback-privacy.test.ts
@@ -1,0 +1,98 @@
+import { createServer } from "node:net";
+import { expect } from "vitest";
+import { chrome } from "@openwork/hosts";
+import { evaluateOnSurface, typeText } from "@openwork/cdp";
+import { eventually, needs, test } from "@openwork/testkit";
+
+test("feedback removes credentials before submission and email delivery", async ({ evidence }) => {
+  needs({ env: ["OPENWORK_EVAL_LANDING_URL", "OPENWORK_EVAL_FEEDBACK_SMTP_PORT"] });
+  const origin = process.env.OPENWORK_EVAL_LANDING_URL;
+  const messages: string[] = [];
+  const smtp = createServer((socket) => {
+    socket.write("220 localhost synthetic witness\r\n");
+    let buffer = "";
+    let data = false;
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString();
+      while (buffer.includes("\r\n")) {
+        if (data) {
+          const end = buffer.indexOf("\r\n.\r\n");
+          if (end < 0) return;
+          messages.push(buffer.slice(0, end));
+          buffer = buffer.slice(end + 5);
+          data = false;
+          socket.write("250 accepted\r\n");
+          continue;
+        }
+        const end = buffer.indexOf("\r\n");
+        const line = buffer.slice(0, end);
+        buffer = buffer.slice(end + 2);
+        if (line.startsWith("DATA")) { data = true; socket.write("354 send data\r\n"); }
+        else if (line.startsWith("QUIT")) socket.end("221 bye\r\n");
+        else socket.write("250 OK\r\n");
+      }
+    });
+  });
+  await new Promise<void>((resolve) => smtp.listen(Number(process.env.OPENWORK_EVAL_FEEDBACK_SMTP_PORT), "127.0.0.1", resolve));
+  try {
+    await using browser = await chrome({ startUrl: `${origin}/feedback`, headless: true });
+    await eventually(() => evaluateOnSurface(browser, 'Boolean(document.querySelector("textarea"))'), {
+      within: 60_000, until: (ready) => ready === true,
+    });
+    await eventually(() => evaluateOnSurface(browser, 'document.readyState'), {
+      within: 30_000, until: (state) => state === "complete",
+    });
+    // Allow client hydration and respect the real form's minimum submission age.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    for (const [selector, value] of [
+      ['input[autocomplete="name"]', "Synthetic Reporter"],
+      ['input[type="email"]', "reporter@example.invalid"],
+      ["textarea", "Connection failed Bearer synthetic-browser-secret sk-proj-synthetic-api-secret"],
+    ]) {
+      await evaluateOnSurface(browser, `document.querySelector(${JSON.stringify(selector)}).focus()`);
+      await typeText(browser, value);
+    }
+    await evaluateOnSurface(browser, `(() => {
+      const original = window.fetch;
+      window.fetch = async (...args) => {
+        if (String(args[0]).includes("/api/app-feedback")) window.__feedbackPayload = JSON.parse(args[1].body);
+        return original(...args);
+      };
+    })()`);
+    // Respect the real form's minimum submission age.
+    await new Promise((resolve) => setTimeout(resolve, 1600));
+    await evaluateOnSurface(browser, 'document.querySelector("form").requestSubmit()');
+    const payload = await eventually(() => evaluateOnSurface(browser, "window.__feedbackPayload"), {
+      within: 15_000, until: (value) => Boolean(value),
+    });
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("synthetic-browser-secret");
+    expect(serialized).not.toContain("synthetic-api-secret");
+    expect(serialized).toContain("Connection failed");
+    expect(serialized).toContain("reporter@example.invalid");
+    evidence.recordAssertionEvidence("Browser redacts pasted credentials before HTTP transmission", "Synthetic bearer and API credentials absent; failure context and intentional contact preserved", true);
+    await eventually(() => messages.length, { within: 30_000, until: (count) => count === 1 });
+    const response = await fetch(`${origin}/api/app-feedback`, {
+      method: "POST",
+      headers: { origin: String(origin), "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Synthetic Reporter", email: "reporter@example.invalid", website: "",
+        startedAt: Date.now() - 2000,
+        message: 'Connection failed {"refresh_token":"synthetic-direct-secret"} Bearer synthetic-direct-bearer',
+        context: { appVersion: "1.2.3", platform: "api_key=synthetic-context-secret" },
+      }),
+    });
+    expect(response.status).toBe(200);
+    await eventually(() => messages.length, { within: 30_000, until: (count) => count === 2 });
+    const delivered = messages.join("\n");
+    for (const secret of ["synthetic-browser-secret", "synthetic-api-secret", "synthetic-direct-secret", "synthetic-direct-bearer", "synthetic-context-secret"]) {
+      expect(delivered).not.toContain(secret);
+    }
+    expect(delivered).toContain("Connection failed");
+    expect(delivered).toContain("reporter@example.invalid");
+    expect(delivered).toContain("1.2.3");
+    evidence.recordAssertionEvidence("Email boundary redacts direct submissions and diagnostic context", "Two synthetic emails captured locally; secrets absent and useful context/contact retained", true);
+  } finally {
+    await new Promise<void>((resolve, reject) => smtp.close((error) => error ? reject(error) : resolve()));
+  }
+});

--- a/evals/specs/feedback-privacy.test.ts
+++ b/evals/specs/feedback-privacy.test.ts
@@ -56,7 +56,11 @@ test("feedback removes credentials before submission and email delivery", async 
       const original = window.fetch;
       window.fetch = async (...args) => {
         if (String(args[0]).includes("/api/app-feedback")) window.__feedbackPayload = JSON.parse(args[1].body);
-        return original(...args);
+        const response = await original(...args);
+        if (String(args[0]).includes("/api/app-feedback")) {
+          window.__feedbackResponse = { status: response.status, body: await response.clone().json() };
+        }
+        return response;
       };
     })()`);
     // Respect the real form's minimum submission age.
@@ -71,6 +75,10 @@ test("feedback removes credentials before submission and email delivery", async 
     expect(serialized).toContain("Connection failed");
     expect(serialized).toContain("reporter@example.invalid");
     evidence.recordAssertionEvidence("Browser redacts pasted credentials before HTTP transmission", "Synthetic bearer and API credentials absent; failure context and intentional contact preserved", true);
+    const submission = await eventually(() => evaluateOnSurface(browser, "window.__feedbackResponse"), {
+      within: 30_000, until: (value) => Boolean(value),
+    });
+    expect(submission).toEqual({ status: 200, body: { ok: true } });
     await eventually(() => messages.length, { within: 30_000, until: (count) => count === 1 });
     const response = await fetch(`${origin}/api/app-feedback`, {
       method: "POST",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -108,6 +108,11 @@
       "types": "./src/url.ts",
       "development": "./src/url.ts",
       "default": "./src/url.ts"
+    },
+    "./diagnostic-sanitizer": {
+      "types": "./src/diagnostic-sanitizer.ts",
+      "development": "./src/diagnostic-sanitizer.ts",
+      "default": "./src/diagnostic-sanitizer.ts"
     }
   },
   "files": [

--- a/packages/types/src/diagnostic-sanitizer.ts
+++ b/packages/types/src/diagnostic-sanitizer.ts
@@ -1,0 +1,50 @@
+const REDACTED = "[REDACTED]";
+
+// Credential detection is deliberately bounded; this is not general PII detection.
+const SENSITIVE_KEY = /^(?:authorization|proxyauthorization|cookie|setcookie|password|passwd|secret|clientsecret|token|accesstoken|refreshtoken|idtoken|apikey|xapikey|credential|credentials|privatekey|sessiontoken|clienttoken|ownertoken|hosttoken)$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isSensitiveKey(key: string): boolean {
+  const normalized = key.replace(/[-_\s]/g, "");
+  return SENSITIVE_KEY.test(normalized) || /(?:apiKey|accessToken|refreshToken|clientSecret|password|privateKey)$/i.test(normalized);
+}
+
+export function sanitizeDiagnosticString(value: string): string {
+  return value
+    .replace(/^(\s*(?:authorization|proxy-authorization|cookie|set-cookie)\s*:\s*)[^\r\n]+/gim, `$1${REDACTED}`)
+    .replace(/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*/gi, (match) => `${match.split(/\s/)[0]} ${REDACTED}`)
+    .replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g, REDACTED)
+    .replace(/\b(?:ow[thc]_|sk-(?:proj-|ant-)?|gh[pousr]_|github_pat_|xox[a-z]-|xoxe-(?:\d-)?|ya29\.|AIza)[A-Za-z0-9_.-]+/g, REDACTED)
+    // JSON, environment assignments, CLI flags and URL query credentials.
+    .replace(/(["']?)\b((?:[\w-]*(?:token|secret|password|api[_-]?key|private[_-]?key)|authorization|proxy[_-]?authorization|cookie|set[_-]?cookie|passwd|credentials?))\1(\s*[:=]\s*)(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s&,;)}\]]+)/gi,
+      (match, quote: string, key: string, separator: string) =>
+        isSensitiveKey(key.replace(/^--/, "")) ? `${quote}${key}${quote}${separator}"${REDACTED}"` : match)
+    .replace(/(--[\w-]+)\s+("[^"]*"|'[^']*'|[^\s]+)/g,
+      (match, key: string) => isSensitiveKey(key) ? `${key} ${REDACTED}` : match)
+    .replace(/(https?:\/\/)[^\s/@]+:[^\s/@]+@/gi, `$1${REDACTED}@`);
+}
+
+export function sanitizeDiagnosticValue(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeDiagnosticString(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+  if (Array.isArray(value)) return value.map((item, index) => {
+    const previous = value[index - 1];
+    return typeof previous === "string" && previous.startsWith("--") && isSensitiveKey(previous)
+      ? REDACTED : sanitizeDiagnosticValue(item);
+  });
+  if (!isRecord(value)) return String(value);
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    sanitized[key] = isSensitiveKey(key) ? REDACTED : sanitizeDiagnosticValue(nested);
+  }
+  return sanitized;
+}
+
+export function sanitizeDiagnosticRecord(value: Record<string, unknown>): Record<string, unknown> {
+  const sanitized = sanitizeDiagnosticValue(value);
+  return isRecord(sanitized) ? sanitized : {};
+}

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup"
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    "diagnostic-sanitizer": "src/diagnostic-sanitizer.ts",
     "agent-context-diagnostics": "src/agent-context-diagnostics.ts",
     "openwork-affordance": "src/openwork-affordance.ts",
     "openwork-context": "src/openwork-context.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,9 @@ importers:
       '@openwork/email':
         specifier: workspace:*
         version: link:../../../packages/email
+      '@openwork/types':
+        specifier: workspace:*
+        version: link:../../../packages/types
       '@openwork/ui':
         specifier: workspace:*
         version: link:../../../packages/ui


### PR DESCRIPTION
## Change
Feedback notes and diagnostic context could include pasted credentials. Reuse the desktop diagnostic sanitizer as a shared utility, redact feedback in the browser before HTTP transmission and again before email delivery, and sanitize the complete generated diagnostic bundle. Intentional name and reply-email fields remain separate.

Covers common bearer/basic, API and OAuth token formats, sensitive nested fields, credential assignments, CLI arguments, and URL credentials. This is bounded credential redaction, not exhaustive PII detection.

## Verification
Final head: 7453a351c0d5003b5419a46fb8f4f5f1481cb7af.

- [Published journey evidence](https://github.com/different-ai/openwork/pull/4526#issuecomment-5553804489): **Passed**, 1 journey, 2 recorded assertion groups, no skips. Browser HTTP payload and two locally captured SMTP messages exclude synthetic credentials while retaining context and intentional contact fields.
- Diagnostic regressions: `bun test apps/app/tests/diagnostics-bundle.test.ts apps/app/tests/cloud-mcp-diagnostics.test.ts` — exit 0, 11 passed, 0 failed.
- Shared types: `node evals/node_modules/typescript/bin/tsc --noEmit -p packages/types/tsconfig.json` — exit 0.
- Local PR lane, restarted landing server on final head; this lane emitted no placement line. Executed the underlying runner from `evals`: `node node_modules/vitest/vitest.mjs run --config vitest.config.ts --project pr --maxWorkers=1 --minWorkers=1 specs/feedback-privacy.test.ts` — exit 0, 1 passed, 0 failed/skipped.
- Both `node evals/scripts/spec-boundary-ratchet.mjs` and `node evals/scripts/spec-channel-ratchet.mjs` exit 1 on this branch and clean `origin/dev` at 85a5dfccb4d74732593628ab4cc8912f8b88283d, with byte-identical output. First failures are existing `bench-opencode-engines.test.ts` product-source imports and stale `active-session-workspace-storm.e2e.test.ts` baseline counts. The new journey is not among reported violations.
- Final-head GitHub checks completed: 28 successful, 0 failed/pending, 6 conditional skips, 1 neutral review check. `gh pr checks --watch --fail-fast` exited 0; GitHub reports merge state CLEAN. Skipped/neutral checks are not counted as runtime proof; the targeted journey has no skips.

Journey reproduction: run a local landing development server with `LANDING_FORM_ALLOWED_ORIGINS` matching its URL, `SMTP_HOST=127.0.0.1`, a free `SMTP_PORT`, and synthetic `EMAIL_FROM` / `OPENWORK_FEEDBACK_EMAIL` addresses under `example.invalid`. Clear external email provider configuration. Set `OPENWORK_EVAL_LANDING_URL` and `OPENWORK_EVAL_FEEDBACK_SMTP_PORT` to those same values, then run `pnpm evals:pr specs/feedback-privacy.test.ts --maxWorkers=1 --minWorkers=1`. The test owns the synthetic SMTP receiver. Local dependency reuse avoided downloads after disk pressure; temporary source-resolution links were not committed.

No source messages, real credentials, real accounts, or external mail delivery were used.