### PR TITLE
fix(calendar): validate desktop event read arguments

### DIFF
--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -6,6 +6,7 @@ import { chmod, mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/p
 import { isIP, type LookupFunction } from "node:net";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { openworkServerConfigPath } from "@openwork/paths";
+import { z } from "zod";
 import {
   Agent,
   fetch as undiciFetch,
@@ -95,9 +96,9 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
     inputSchema: {
       type: "object",
       properties: {
-        timeMin: { type: "string", description: "Inclusive ISO datetime lower bound." },
-        timeMax: { type: "string", description: "Exclusive ISO datetime upper bound." },
-        maxResults: { type: "number", description: "Maximum events to return." },
+        timeMin: { type: "string", format: "date-time", description: "Exclusive lower bound for event end times. RFC 3339 with Z or a UTC offset, e.g. 2026-09-01T09:00:00+02:00." },
+        timeMax: { type: "string", format: "date-time", description: "Exclusive upper bound for event start times. RFC 3339 with Z or a UTC offset; must be later than timeMin." },
+        maxResults: { type: "integer", description: "Maximum events to return. Defaults to 10; clamped to 1–50." },
       },
       required: ["timeMin", "timeMax"],
       additionalProperties: false,
@@ -1424,11 +1425,20 @@ async function googleWorkspaceDownloadAttachment(config: ServerConfig, args: Rec
   };
 }
 
+const calendarReadTimestamp = z.string().trim().datetime({ offset: true, message: "Use an RFC 3339 datetime with Z or a UTC offset." });
+const calendarReadArgs = z.object({
+  timeMin: calendarReadTimestamp,
+  timeMax: calendarReadTimestamp,
+  maxResults: z.number().int().default(10),
+}).refine((args) => Date.parse(args.timeMax) > Date.parse(args.timeMin), {
+  path: ["timeMax"], message: "timeMax must be later than timeMin.",
+});
+
 async function googleWorkspaceListEvents(config: ServerConfig, args: Record<string, unknown>) {
-  const timeMin = readStringField(args, "timeMin");
-  const timeMax = readStringField(args, "timeMax");
-  if (!timeMin || !timeMax) throw new ApiError(400, "invalid_payload", "timeMin and timeMax are required");
-  const maxResults = Math.min(Math.max(Number(args.maxResults ?? 10), 1), 50);
+  const parsed = calendarReadArgs.safeParse(args);
+  if (!parsed.success) throw new ApiError(400, "invalid_payload", parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(" "));
+  const { timeMin, timeMax } = parsed.data;
+  const maxResults = Math.min(Math.max(parsed.data.maxResults, 1), 50);
   const { accessToken } = await googleWorkspaceAccessToken(config);
   const url = new URL("https://www.googleapis.com/calendar/v3/calendars/primary/events");
   url.searchParams.set("timeMin", timeMin);

--- a/evals/packages/labs/src/calendar-read-preload.ts
+++ b/evals/packages/labs/src/calendar-read-preload.ts
@@ -1,0 +1,33 @@
+// Provider witness loaded only by the desktop Calendar boundary spec.
+// No real provider request may escape this process.
+import { createServer } from "node:http";
+
+const requests: Array<Record<string, string>> = [];
+const witness = createServer((_request, response) => {
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(requests));
+});
+witness.listen(0, "127.0.0.1", () => {
+  const address = witness.address();
+  if (address && typeof address !== "string") console.log(`Calendar witness: http://127.0.0.1:${address.port}`);
+});
+witness.unref();
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = Object.assign(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+  const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+  if (url.hostname === "127.0.0.1" || url.hostname === "localhost") return originalFetch(input, init);
+  if (url.origin !== "https://www.googleapis.com" || url.pathname !== "/calendar/v3/calendars/primary/events") {
+    throw new Error("Unexpected external request in Calendar witness");
+  }
+  if ((init?.method ?? "GET") !== "GET" || new Headers(init?.headers).get("authorization") !== "Bearer calendar-fixture-token") {
+    throw new Error("Calendar witness requires a read with the synthetic account token");
+  }
+  const query = Object.fromEntries(url.searchParams);
+  requests.push(query);
+  if (!/^\d+$/.test(query.maxResults) || !Number.isFinite(Date.parse(query.timeMin)) || !Number.isFinite(Date.parse(query.timeMax)) || Date.parse(query.timeMax) <= Date.parse(query.timeMin)) {
+    return Response.json({ error: { message: "Bad Request" } }, { status: 400 });
+  }
+  if (query.maxResults === "13") return Response.json({ error: { message: "Synthetic provider rejection" } }, { status: 400 });
+  return Response.json({ items: [{ id: "synthetic-event", summary: "Fixture meeting" }] });
+}, originalFetch);

--- a/evals/specs/desktop-calendar-read.test.ts
+++ b/evals/specs/desktop-calendar-read.test.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect } from "vitest";
+import { eventually, needs, test } from "@openwork/testkit";
+import { stopChild } from "../worlds/openwork-server-cli.ts";
+
+// New boundary journey: the local extension's Calendar read, separate from Den's
+// hosted Google capabilities. All Calendar traffic is intercepted by the witness.
+test("desktop Calendar reads validate arguments before provider access and preserve valid requests", async ({ evidence, place }) => {
+  needs({ commands: ["bun"] });
+  console.log(`placement: ${place.kind} (PR lane resolved by testkit)`);
+  const root = await mkdtemp(join(tmpdir(), "calendar-read-"));
+  const repo = resolve(import.meta.dirname, "../..");
+  const config = join(root, "server.json");
+  const vault = join(root, "extensions", "google-workspace", "oauth.dev-plaintext.json");
+  await mkdir(join(root, "extensions", "google-workspace"), { recursive: true });
+  await writeFile(config, "{}");
+  await writeFile(vault, JSON.stringify({ version: 2, activeAccountId: "fixture-account", accounts: [{
+    account: { email: "calendar@example.test", name: "Calendar fixture", sub: "fixture-account", picture: null },
+    scopes: ["openid", "https://www.googleapis.com/auth/calendar.readonly"],
+    token: { accessToken: "calendar-fixture-token", refreshToken: "fixture-refresh", expiresAt: Date.now() + 3_600_000 },
+    connectedAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+  }] }));
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !/^(OPENWORK_|OPENCODE|GOOGLE_|SENTRY_)/.test(key)));
+  const child = spawn("bun", ["--conditions=development", "--preload", join(repo, "evals/packages/labs/src/calendar-read-preload.ts"), "src/cli.ts",
+    "--host", "127.0.0.1", "--port", "0", "--token", "calendar-client", "--host-token", "calendar-host", "--config", config,
+  ], { cwd: join(repo, "apps/server"), env: { ...inherited, OPENWORK_SERVER_CONFIG: config, OPENWORK_DATA_DIR: join(root, "data"),
+    XDG_CONFIG_HOME: join(root, "config"), XDG_DATA_HOME: join(root, "data"), XDG_CACHE_HOME: join(root, "cache"),
+    OPENWORK_DEV_MODE: "1", OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT: "1",
+  }, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += String(chunk); });
+  child.stderr.on("data", (chunk) => { output += String(chunk); });
+  try {
+    const base = await eventually(() => {
+      if (child.exitCode !== null) throw new Error(output);
+      return output.match(/OpenWork server listening on (http:\/\/127\.0\.0\.1:\d+)/)?.[1];
+    }, { within: 60_000, intervalMs: 100 });
+    const witness = output.match(/Calendar witness: (http:\/\/127\.0\.0\.1:\d+)/)?.[1];
+    if (!witness) throw new Error("Calendar witness did not start");
+    const requests = async () => (await fetch(witness)).json();
+    const actionsResponse = await fetch(`${base}/experimental/extensions/actions?extensionId=google-workspace`, { headers: { authorization: "Bearer calendar-client" } });
+    expect(actionsResponse.status).toBe(200);
+    expect(await actionsResponse.json()).toMatchObject({ actions: expect.arrayContaining([expect.objectContaining({
+      action: "calendar_list_events", inputSchema: expect.objectContaining({ properties: expect.objectContaining({
+        timeMin: expect.objectContaining({ format: "date-time", description: expect.stringContaining("UTC offset") }),
+        timeMax: expect.objectContaining({ format: "date-time", description: expect.stringContaining("later than timeMin") }),
+        maxResults: expect.objectContaining({ type: "integer" }),
+      }) }),
+    })]) });
+    const call = async (args: Record<string, unknown>) => {
+      const response = await fetch(`${base}/experimental/extensions/call`, { method: "POST", headers: { authorization: "Bearer calendar-client", "content-type": "application/json" },
+        body: JSON.stringify({ extensionId: "google-workspace", action: "calendar_list_events", args }), signal: AbortSignal.timeout(10_000) });
+      return { status: response.status, body: await response.json() };
+    };
+    const valid = { timeMin: "2026-09-01T09:00:00+02:00", timeMax: "2026-09-01T10:00:00+02:00" };
+    const invalid = [
+      { ...valid, maxResults: 2.5 }, { ...valid, maxResults: "many" },
+      { ...valid, timeMin: "2026-09-01T09:00:00" }, { ...valid, timeMin: "2026-09-01" },
+      { ...valid, timeMin: "2026-02-30T09:00:00Z" }, { ...valid, timeMax: valid.timeMin },
+      { ...valid, timeMax: "2026-09-01T06:00:00Z" },
+    ];
+    for (const args of invalid) {
+      const result = await call(args);
+      expect(result.status, JSON.stringify({ result, providerRequests: await requests() })).toBe(400);
+      expect(JSON.stringify(result.body)).toContain("invalid_payload");
+    }
+    expect(await requests()).toEqual([]);
+    evidence.recordAssertionEvidence("Invalid Calendar arguments stop before provider access", "Discovery advertises integer page sizes and offset timestamps. Seven invalid date, range and page-size requests return 400 invalid_payload; the provider witness receives zero requests.", true);
+
+    for (const args of [valid, { ...valid, maxResults: 50 }, { timeMin: "2026-09-01T07:00:00Z", timeMax: "2026-09-01T08:00:00Z", maxResults: 1 }]) {
+      expect(await call(args)).toMatchObject({ status: 200, body: { ok: true, result: { items: [{ id: "synthetic-event" }] } } });
+    }
+    expect(await requests()).toEqual([
+      { ...valid, maxResults: "10", singleEvents: "true", orderBy: "startTime" },
+      { ...valid, maxResults: "50", singleEvents: "true", orderBy: "startTime" },
+      { timeMin: "2026-09-01T07:00:00Z", timeMax: "2026-09-01T08:00:00Z", maxResults: "1", singleEvents: "true", orderBy: "startTime" },
+    ]);
+    evidence.recordAssertionEvidence("Valid offset and UTC reads preserve Calendar semantics", "Three reads return the synthetic event; exact queries retain offsets, the default and boundary page sizes, singleEvents=true and orderBy=startTime.", true);
+    const providerError = await call({ ...valid, maxResults: 13 });
+    expect(providerError.status).toBe(500);
+    expect(providerError.body).toEqual({ code: "internal_error", message: "Unexpected server error" });
+    expect(await requests()).toHaveLength(4);
+    evidence.recordAssertionEvidence("Unrelated provider errors remain visible", "A valid request reaches the provider once; its synthetic 400 rejection remains an error and is not converted to empty success.", true);
+  } finally {
+    await stopChild(child);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/evals/specs/desktop-calendar-read.test.ts
+++ b/evals/specs/desktop-calendar-read.test.ts
@@ -6,11 +6,9 @@ import { expect } from "vitest";
 import { eventually, needs, test } from "@openwork/testkit";
 import { stopChild } from "../worlds/openwork-server-cli.ts";
 
-// New boundary journey: the local extension's Calendar read, separate from Den's
-// hosted Google capabilities. All Calendar traffic is intercepted by the witness.
-test("desktop Calendar reads validate arguments before provider access and preserve valid requests", async ({ evidence, place }) => {
+// Both checks use the real local extension boundary with synthetic provider traffic.
+async function calendarServer() {
   needs({ commands: ["bun"] });
-  console.log(`placement: ${place.kind} (PR lane resolved by testkit)`);
   const root = await mkdtemp(join(tmpdir(), "calendar-read-"));
   const repo = resolve(import.meta.dirname, "../..");
   const config = join(root, "server.json");
@@ -40,52 +38,84 @@ test("desktop Calendar reads validate arguments before provider access and prese
     }, { within: 60_000, intervalMs: 100 });
     const witness = output.match(/Calendar witness: (http:\/\/127\.0\.0\.1:\d+)/)?.[1];
     if (!witness) throw new Error("Calendar witness did not start");
-    const requests = async () => (await fetch(witness)).json();
-    const actionsResponse = await fetch(`${base}/experimental/extensions/actions?extensionId=google-workspace`, { headers: { authorization: "Bearer calendar-client" } });
-    expect(actionsResponse.status).toBe(200);
-    expect(await actionsResponse.json()).toMatchObject({ actions: expect.arrayContaining([expect.objectContaining({
-      action: "calendar_list_events", inputSchema: expect.objectContaining({ properties: expect.objectContaining({
-        timeMin: expect.objectContaining({ format: "date-time", description: expect.stringContaining("UTC offset") }),
-        timeMax: expect.objectContaining({ format: "date-time", description: expect.stringContaining("later than timeMin") }),
-        maxResults: expect.objectContaining({ type: "integer" }),
-      }) }),
-    })]) });
+    const requests = async () => (await fetch(witness, { signal: AbortSignal.timeout(10_000) })).json();
     const call = async (args: Record<string, unknown>) => {
       const response = await fetch(`${base}/experimental/extensions/call`, { method: "POST", headers: { authorization: "Bearer calendar-client", "content-type": "application/json" },
         body: JSON.stringify({ extensionId: "google-workspace", action: "calendar_list_events", args }), signal: AbortSignal.timeout(10_000) });
       return { status: response.status, body: await response.json() };
     };
-    const valid = { timeMin: "2026-09-01T09:00:00+02:00", timeMax: "2026-09-01T10:00:00+02:00" };
-    const invalid = [
-      { ...valid, maxResults: 2.5 }, { ...valid, maxResults: "many" },
-      { ...valid, timeMin: "2026-09-01T09:00:00" }, { ...valid, timeMin: "2026-09-01" },
-      { ...valid, timeMin: "2026-02-30T09:00:00Z" }, { ...valid, timeMax: valid.timeMin },
-      { ...valid, timeMax: "2026-09-01T06:00:00Z" },
-    ];
-    for (const args of invalid) {
-      const result = await call(args);
-      expect(result.status, JSON.stringify({ result, providerRequests: await requests() })).toBe(400);
-      expect(JSON.stringify(result.body)).toContain("invalid_payload");
-    }
-    expect(await requests()).toEqual([]);
-    evidence.recordAssertionEvidence("Invalid Calendar arguments stop before provider access", "Discovery advertises integer page sizes and offset timestamps. Seven invalid date, range and page-size requests return 400 invalid_payload; the provider witness receives zero requests.", true);
-
-    for (const args of [valid, { ...valid, maxResults: 50 }, { timeMin: "2026-09-01T07:00:00Z", timeMax: "2026-09-01T08:00:00Z", maxResults: 1 }]) {
-      expect(await call(args)).toMatchObject({ status: 200, body: { ok: true, result: { items: [{ id: "synthetic-event" }] } } });
-    }
-    expect(await requests()).toEqual([
-      { ...valid, maxResults: "10", singleEvents: "true", orderBy: "startTime" },
-      { ...valid, maxResults: "50", singleEvents: "true", orderBy: "startTime" },
-      { timeMin: "2026-09-01T07:00:00Z", timeMax: "2026-09-01T08:00:00Z", maxResults: "1", singleEvents: "true", orderBy: "startTime" },
-    ]);
-    evidence.recordAssertionEvidence("Valid offset and UTC reads preserve Calendar semantics", "Three reads return the synthetic event; exact queries retain offsets, the default and boundary page sizes, singleEvents=true and orderBy=startTime.", true);
-    const providerError = await call({ ...valid, maxResults: 13 });
-    expect(providerError.status).toBe(500);
-    expect(providerError.body).toEqual({ code: "internal_error", message: "Unexpected server error" });
-    expect(await requests()).toHaveLength(4);
-    evidence.recordAssertionEvidence("Unrelated provider errors remain visible", "A valid request reaches the provider once; its synthetic 400 rejection remains an error and is not converted to empty success.", true);
-  } finally {
+    return { base, requests, call, [Symbol.asyncDispose]: async () => {
+      await stopChild(child);
+      await rm(root, { recursive: true, force: true });
+    } };
+  } catch (error) {
     await stopChild(child);
     await rm(root, { recursive: true, force: true });
+    throw error;
   }
+}
+
+// Keep the valid compatibility corpus separately selectable for clean-dev comparison.
+test("desktop Calendar valid compatibility corpus preserves dates and page sizes", async ({ evidence, place }) => {
+  console.log(`placement: ${place.kind} (PR lane resolved by testkit)`);
+  await using calendar = await calendarServer();
+  const utc = { timeMin: "2026-09-01T07:00:00Z", timeMax: "2026-09-01T08:00:00Z" };
+  const cases = [
+    { label: "UTC default", args: utc, expected: { ...utc, maxResults: "10" } },
+    { label: "positive offset", args: { timeMin: "2026-09-01T09:00:00+05:30", timeMax: "2026-09-01T10:00:00+05:30" }, expected: { timeMin: "2026-09-01T09:00:00+05:30", timeMax: "2026-09-01T10:00:00+05:30", maxResults: "10" } },
+    { label: "negative offset", args: { timeMin: "2026-09-01T09:00:00-07:00", timeMax: "2026-09-01T10:00:00-07:00" }, expected: { timeMin: "2026-09-01T09:00:00-07:00", timeMax: "2026-09-01T10:00:00-07:00", maxResults: "10" } },
+    { label: "UTC milliseconds", args: { timeMin: "2026-09-01T07:00:00.123Z", timeMax: "2026-09-01T08:00:00.456Z" }, expected: { timeMin: "2026-09-01T07:00:00.123Z", timeMax: "2026-09-01T08:00:00.456Z", maxResults: "10" } },
+    { label: "offset fractional seconds", args: { timeMin: "2026-09-01T09:00:00.123456+05:30", timeMax: "2026-09-01T10:00:00.654321+05:30" }, expected: { timeMin: "2026-09-01T09:00:00.123456+05:30", timeMax: "2026-09-01T10:00:00.654321+05:30", maxResults: "10" } },
+    { label: "surrounding whitespace", args: { timeMin: " 2026-09-01T07:00:00Z ", timeMax: " 2026-09-01T08:00:00Z " }, expected: { ...utc, maxResults: "10" } },
+    ...[
+      { label: "minimum", value: 1, expected: "1" },
+      { label: "explicit default", value: 10, expected: "10" },
+      { label: "maximum", value: 50, expected: "50" },
+      { label: "zero clamps upward", value: 0, expected: "1" },
+      { label: "negative clamps upward", value: -1, expected: "1" },
+      { label: "above maximum clamps downward", value: 51, expected: "50" },
+    ].map(({ label, value, expected }) => ({ label, args: { ...utc, maxResults: value }, expected: { ...utc, maxResults: expected } })),
+  ];
+  for (const entry of cases) {
+    expect(await calendar.call(entry.args), entry.label).toMatchObject({ status: 200, body: { ok: true, result: { items: [{ id: "synthetic-event" }] } } });
+  }
+  expect(await calendar.requests()).toEqual(cases.map(({ expected }) => ({ ...expected, singleEvents: "true", orderBy: "startTime" })));
+  evidence.recordAssertionEvidence("Valid Calendar compatibility corpus", "12 successful reads preserve UTC, positive and negative offsets, millisecond and six-digit fractions, whitespace trimming, omitted/explicit defaults, integer bounds and clamping. The provider witnesses exactly 12 ordered requests with exact time bounds, integer page sizes, singleEvents=true and orderBy=startTime.", true);
+});
+
+test("desktop Calendar reads validate arguments before provider access and preserve provider failures", async ({ evidence, place }) => {
+  console.log(`placement: ${place.kind} (PR lane resolved by testkit)`);
+  await using calendar = await calendarServer();
+  const { base, requests, call } = calendar;
+  const actionsResponse = await fetch(`${base}/experimental/extensions/actions?extensionId=google-workspace`, { headers: { authorization: "Bearer calendar-client" } });
+  expect(actionsResponse.status).toBe(200);
+  expect(await actionsResponse.json()).toMatchObject({ actions: expect.arrayContaining([expect.objectContaining({
+    action: "calendar_list_events", inputSchema: expect.objectContaining({ properties: expect.objectContaining({
+      timeMin: expect.objectContaining({ format: "date-time", description: expect.stringContaining("UTC offset") }),
+      timeMax: expect.objectContaining({ format: "date-time", description: expect.stringContaining("later than timeMin") }),
+      maxResults: expect.objectContaining({ type: "integer" }),
+    }) }),
+  })]) });
+  const valid = { timeMin: "2026-09-01T09:00:00+02:00", timeMax: "2026-09-01T10:00:00+02:00" };
+  const invalid = [
+    { ...valid, maxResults: 2.5 }, { ...valid, maxResults: "many" },
+    // Strings and null were formerly coerced but are outside the advertised numeric schema.
+    { ...valid, maxResults: "10" }, { ...valid, maxResults: null },
+    { ...valid, timeMin: "2026-09-01T09:00:00" }, { ...valid, timeMin: "2026-09-01" },
+    { ...valid, timeMin: "2026-02-30T09:00:00Z" }, { ...valid, timeMax: valid.timeMin },
+    { ...valid, timeMax: "2026-09-01T06:00:00Z" },
+  ];
+  for (const args of invalid) {
+    const result = await call(args);
+    expect(result.status, JSON.stringify({ result, providerRequests: await requests() })).toBe(400);
+    expect(JSON.stringify(result.body)).toContain("invalid_payload");
+  }
+  expect(await requests()).toEqual([]);
+  evidence.recordAssertionEvidence("Invalid Calendar arguments stop before provider access", "Discovery advertises integer page sizes and offset timestamps. Nine invalid date, range and page-size requests return 400 invalid_payload; the provider witness receives zero requests.", true);
+
+  const providerError = await call({ ...valid, maxResults: 13 });
+  expect(providerError.status).toBe(500);
+  expect(providerError.body).toEqual({ code: "internal_error", message: "Unexpected server error" });
+  expect(await requests()).toHaveLength(1);
+  evidence.recordAssertionEvidence("Unrelated provider errors remain visible", "A valid request reaches the provider once; its synthetic 400 rejection remains an error and is not converted to empty success.", true);
 });


### PR DESCRIPTION
A desktop `calendar_list_events` request with `maxResults: 2.5` passed the advertised number schema and reached Google unchanged, then surfaced as an internal server error. Validate integer page sizes, offset-aware timestamps, and increasing time ranges before accessing the account or provider. Discovery describes the constraints and Calendar's bound semantics. The follow-up adds compatibility coverage only; it changes no production code.

Related investigation: DESKTOP-APP-2P. This independently reproduces an input-contract flaw; it does **not** establish which arguments caused those production events. The event and trace lack request arguments and a diagnostic provider reason. Neither #3895's hosted agenda work nor #4377's hosted validation changes this desktop path. No production calendar was read or mutated by the proof.

Verification on `9c6d77622b176739d08eb46db4d58a589a556da9`:

- `pnpm --config.verify-deps-before-run=false evals:pr specs/desktop-calendar-read.test.ts`: **Passed**, 2 passed / 0 failed / 0 skipped. `placement: local (PR lane resolved by testkit)`. Each test cold-boots the real standalone server with a synthetic provider witness.
- Valid compatibility corpus: 12 successful reads, exactly 12 provider requests. UTC, positive/negative offsets, millisecond/six-digit fractions, whitespace trimming, omitted/explicit defaults, page sizes 1/50, and clamping from -1/0/51. Exact query assertions also preserve `singleEvents=true` and `orderBy=startTime`.
- Same valid corpus against fresh clean dev `aadaff1530fc5a80a7fff8671a5c3266aa62d989`, with only identical test fixtures overlaid: `pnpm --config.verify-deps-before-run=false evals:pr specs/desktop-calendar-read.test.ts -t 'valid compatibility corpus'` → 1 passed / 0 failed / 1 filtered-out test reported skipped. The selected compatibility check passed all 12 cases; this is not a claim that the full validation suite passes on dev. Tracked product source was unchanged.
- Fixed validation test: discovery constraints, nine invalid requests with zero provider calls, and an unrelated valid request whose provider rejection remains a failure.

Compatibility boundary: numeric strings such as `"10"` and `null` were previously coerced to 10, but are outside the advertised numeric schema. They now intentionally return 400 `invalid_payload`; both rejections are tested. This PR does not claim to preserve every formerly coerced value. Provider acceptance of minute-only/lowercase/compact-offset timestamps, huge integer values, malformed requests while disconnected, and actual model retry behavior remain untested.

Original fix verification: unchanged product code at `85a5dfccb` forwarded `maxResults=2.5` and returned HTTP 500; fixed code rejects before provider access. Existing Google Workspace suite: 33 passed / 0 failed; server typecheck passed. Broad boundary/channel ratchets failed identically on a separate clean original-base control and did not report this spec; no baselines changed.

The dependency-check option only avoids reinstalling already linked local dependencies on a disk-constrained machine. Monitor Calendar success and `invalid_payload` rates alongside Sentry: new input errors bypass exception capture, so fewer Sentry events alone do not establish recovered reads.
