### PR TITLE
fix(mcp): preserve OAuth callback response issuers

### DIFF
--- a/apps/server/src/local-managed-mcp.ts
+++ b/apps/server/src/local-managed-mcp.ts
@@ -1156,6 +1156,7 @@ export async function completeLocalManagedMcpAuthorization(
   config: ServerConfig,
   state: string,
   code: string,
+  responseIssuer?: string,
 ): Promise<{ connection: LocalManagedMcpPublicConnection; workspaceId: string }> {
   const payload = await verifyAuthorizationState(config, state);
   const diagnostics: EnterpriseMcpDiagnosticEvent[] = [];
@@ -1166,6 +1167,7 @@ export async function completeLocalManagedMcpAuthorization(
       redirectUri: payload.redirectUri,
       code,
       authorizationId: state,
+      responseIssuer,
     });
     await verifyTools(config, payload.workspaceId, payload.name, payload.redirectUri, diagnostics);
     await writeManagedRuntimeEntry(config, payload.workspaceId, payload.name, true);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3683,7 +3683,7 @@ function createRoutes(
     const state = ctx.url.searchParams.get("state") ?? "";
     const code = ctx.url.searchParams.get("code") ?? "";
     if (!state || !code) throw new ApiError(400, "managed_mcp_oauth_callback_invalid", "OAuth callback is missing code or state");
-    const { connection, workspaceId } = await completeLocalManagedMcpAuthorization(config, state, code);
+    const { connection, workspaceId } = await completeLocalManagedMcpAuthorization(config, state, code, ctx.url.searchParams.get("iss") ?? undefined);
     const workspace = config.workspaces.find((item) => item.id === workspaceId);
     if (workspace) {
       await syncRuntimeMcpToOpencodeEngine(config, workspace, [connection.name], undefined, engineMcpServerState).catch(() => undefined);

--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -274,6 +274,7 @@ export async function completeExternalMcpAuth(
   member?: ExternalMcpMemberContext,
   diagnosticReferenceId?: string,
   signedState?: string,
+  responseIssuer?: string,
 ): Promise<void> {
   if (!signedState) throw new Error("The enterprise MCP OAuth callback requires its signed state transaction.")
   await runEnterpriseMcpOperation({
@@ -284,6 +285,7 @@ export async function completeExternalMcpAuth(
       redirectUri,
       code,
       authorizationId: signedState,
+      responseIssuer,
     }),
   })
 }

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -1379,6 +1379,7 @@ async function handleExternalMcpOAuthCallback(input: {
   const completeAuthorization = statePayload.version === 2
     ? completeExternalMcpAuth
     : completeLegacyExternalMcpAuth
+  let validatedResponseIssuer: string | undefined
   if (statePayload.version === 2) {
     const responseIssuer = url.searchParams.has("iss")
       ? (url.searchParams.get("iss") ?? "")
@@ -1398,6 +1399,9 @@ async function handleExternalMcpOAuthCallback(input: {
               ? "pinned-transaction"
               : "response-issuer",
       })
+      // Preserve the isolated-callback defense for providers whose unadvertised
+      // issuer was explicitly ignored; otherwise pass the validated value to the SDK.
+      validatedResponseIssuer = validation.ignoredResponseIssuer === undefined ? responseIssuer : undefined
       if (validation.ignoredResponseIssuer !== undefined) {
         logger.warn("external_mcp_connect_callback_untrusted_issuer_ignored", {
           connection_id: connection.id,
@@ -1475,6 +1479,7 @@ async function handleExternalMcpOAuthCallback(input: {
       member,
       input.requestId,
       state,
+      validatedResponseIssuer,
     )
   } catch (error) {
     try {

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -87,7 +87,7 @@ export interface StartMockMcpOptions {
   publicUrl?: string;
   /** Advertised OAuth/resource origin when the mock sits behind a proxy; defaults to the mock's own URL. */
   issuer?: string;
-  /** Advertise RFC 9207 and include the issuer in authorization responses. */
+  /** Set RFC 9207 metadata explicitly; undefined omits it. Only true includes response iss. */
   authorizationResponseIssuerSupported?: boolean;
   profileId?: EnterpriseMcpProfileId;
   fault?: string;
@@ -318,7 +318,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
         PORT: String(port),
         ISSUER: options.issuer ?? url,
         AUTO_APPROVE: "1",
-        ...(options.authorizationResponseIssuerSupported ? { MOCK_AUTHORIZATION_RESPONSE_ISSUER: "1" } : {}),
+        ...(options.authorizationResponseIssuerSupported === undefined ? {} : { MOCK_AUTHORIZATION_RESPONSE_ISSUER: options.authorizationResponseIssuerSupported ? "1" : "0" }),
         ...(options.allowUnauthenticatedMcp ? { MOCK_ALLOW_UNAUTHENTICATED_MCP: "1" } : {}),
         ...(options.extraToolCount ? { MOCK_EXTRA_TOOL_COUNT: String(options.extraToolCount) } : {}),
         ...(options.appToolName ? { MOCK_APP_TOOL_NAME: options.appToolName } : {}),

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -87,6 +87,8 @@ export interface StartMockMcpOptions {
   publicUrl?: string;
   /** Advertised OAuth/resource origin when the mock sits behind a proxy; defaults to the mock's own URL. */
   issuer?: string;
+  /** Advertise RFC 9207 and include the issuer in authorization responses. */
+  authorizationResponseIssuerSupported?: boolean;
   profileId?: EnterpriseMcpProfileId;
   fault?: string;
   oauthClientSecret?: string;
@@ -316,6 +318,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
         PORT: String(port),
         ISSUER: options.issuer ?? url,
         AUTO_APPROVE: "1",
+        ...(options.authorizationResponseIssuerSupported ? { MOCK_AUTHORIZATION_RESPONSE_ISSUER: "1" } : {}),
         ...(options.allowUnauthenticatedMcp ? { MOCK_ALLOW_UNAUTHENTICATED_MCP: "1" } : {}),
         ...(options.extraToolCount ? { MOCK_EXTRA_TOOL_COUNT: String(options.extraToolCount) } : {}),
         ...(options.appToolName ? { MOCK_APP_TOOL_NAME: options.appToolName } : {}),

--- a/evals/specs/mcp-oauth-response-issuer.test.ts
+++ b/evals/specs/mcp-oauth-response-issuer.test.ts
@@ -6,118 +6,149 @@ import { denFetch } from "@openwork/behaviors";
 import { mcpMock, needs, server, test } from "@openwork/testkit";
 import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
 
-// This callback journey was missing from the boundary lane: previous coverage
-// used providers that never advertised RFC 9207 response issuer support.
-test("local MCP sign-in preserves the response issuer and rejects mix-ups before exchanging a code", { timeout: 120_000 }, async ({ place, evidence }) => {
-  needs({ commands: ["bun"] });
-  const root = await mkdtemp(join(tmpdir(), "openwork-oauth-issuer-"));
-  const workspace = join(root, "workspace");
-  await mkdir(workspace);
-  const { handle: provider } = await mcpMock({ authorizationResponseIssuerSupported: true }).boot(place);
-  const token = "synthetic-local-oauth-client";
-  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
-  const server = bootServer({
-    ...inherited,
-    XDG_CONFIG_HOME: join(root, "config"),
-    OPENWORK_RUNTIME_DB: join(root, "runtime.sqlite"),
-    OPENWORK_ALLOW_PRIVATE_MCP_URLS: "1",
-    OPENWORK_ENCRYPTION_KEY: "synthetic-oauth-vault-key",
-  }, token, workspace, () => {});
-  try {
-    const base = await server.listening;
-    const request = (path: string, body?: unknown) => fetch(`${base}${path}`, {
-      method: body === undefined ? "GET" : "POST",
-      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-      signal: AbortSignal.timeout(20_000),
+for (const issuerSupport of [true, false, undefined]) {
+  const metadataLabel = issuerSupport === undefined ? "absent" : String(issuerSupport);
+
+  // This callback journey was missing from the boundary lane: previous coverage
+  // used providers that never advertised RFC 9207 response issuer support.
+  test(`local OAuth (issuer support ${metadataLabel}) validates callbacks and preserves usable credentials`, { timeout: 120_000 }, async ({ place, evidence }) => {
+    needs({ commands: ["bun"] });
+    const root = await mkdtemp(join(tmpdir(), "openwork-oauth-issuer-"));
+    const workspace = join(root, "workspace");
+    await mkdir(workspace);
+    const { handle: provider } = await mcpMock({ authorizationResponseIssuerSupported: issuerSupport }).boot(place);
+    const metadata: unknown = await (await fetch(`${provider.url}/.well-known/oauth-authorization-server`, { signal: AbortSignal.timeout(15_000) })).json();
+    expect(metadata).toHaveProperty("issuer", provider.url);
+    if (!isRecord(metadata)) throw new Error("Provider metadata missing");
+    expect(metadata.authorization_response_iss_parameter_supported).toBe(issuerSupport);
+    const token = "synthetic-local-oauth-client";
+    const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+    const server = bootServer({
+      ...inherited,
+      XDG_CONFIG_HOME: join(root, "config"),
+      OPENWORK_RUNTIME_DB: join(root, "runtime.sqlite"),
+      OPENWORK_ALLOW_PRIVATE_MCP_URLS: "1",
+      OPENWORK_ENCRYPTION_KEY: "synthetic-oauth-vault-key",
+    }, token, workspace, () => {});
+    try {
+      const base = await server.listening;
+      const request = (path: string, body?: unknown) => fetch(`${base}${path}`, {
+        method: body === undefined ? "GET" : "POST",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(20_000),
+      });
+      const workspaces: unknown = await (await request("/workspaces")).json();
+      if (!isRecord(workspaces) || !Array.isArray(workspaces.items) || !isRecord(workspaces.items[0]) || typeof workspaces.items[0].id !== "string") throw new Error("Workspace missing");
+      const path = `/workspace/${workspaces.items[0].id}/mcp`;
+      const tokenRequests = async () => (await provider.requests()).filter((entry) => entry.path === "/token").length;
+      for (const mode of issuerSupport === true ? ["mismatch", "missing", "empty", "state", "valid"] : ["state", "valid"]) {
+        const name = `issuer-${mode}`;
+        const added = await request(`${path}/managed`, { name, url: provider.mcpUrl });
+        const result: unknown = await added.json();
+        expect(added.status, JSON.stringify(result)).toBe(201);
+        if (!isRecord(result) || typeof result.authorizeUrl !== "string") throw new Error("Authorization URL missing");
+        const authorize = new URL(result.authorizeUrl);
+        expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
+        expect(authorize.searchParams.get("code_challenge")).toBeTruthy();
+        const redirect = await fetch(authorize, { redirect: "manual" });
+        expect(redirect.status).toBe(302);
+        const callback = new URL(redirect.headers.get("location")!);
+        expect(callback.searchParams.get("iss")).toBe(issuerSupport === true ? provider.url : null);
+        if (mode === "mismatch") callback.searchParams.set("iss", "https://other-issuer.example.test");
+        if (mode === "missing") callback.searchParams.delete("iss");
+        if (mode === "empty") callback.searchParams.set("iss", "");
+        if (mode === "state") callback.searchParams.set("state", "invalid-state");
+        const before = await tokenRequests();
+        const completed = await fetch(callback, { signal: AbortSignal.timeout(20_000) });
+        const html = await completed.text();
+        const connection: unknown = await (await request(`${path}/${name}/managed`)).json();
+        if (mode !== "valid") {
+          expect(completed.ok, html).toBe(false);
+          expect(await tokenRequests()).toBe(before);
+          expect(connection).not.toMatchObject({ status: "connected" });
+          evidence.recordAssertionEvidence(`Reject ${mode} callback before token exchange`, `HTTP ${completed.status}; zero token requests; connection is not connected.`, true);
+        } else {
+          expect(completed.status, html).toBe(200);
+          expect(html).toContain("Connected");
+          expect(connection).toMatchObject({ status: "connected" });
+          expect(await tokenRequests()).toBe(before + 1);
+          evidence.recordAssertionEvidence(`Sign-in supports ${metadataLabel} issuer-support metadata with PKCE`, "Verified advertised metadata and callback issuer presence; provider required S256 and accepted exactly one code exchange; callback and server report connected.", true);
+          const replay = await fetch(callback, { signal: AbortSignal.timeout(20_000) });
+          expect(replay.ok).toBe(false);
+          expect(await tokenRequests()).toBe(before + 1);
+          // Replay currently marks the local status reconnect_required on both dev
+          // and this fix. Assert credential usability separately from that inherited defect.
+          const reused = await request(`${path}/${name}/managed/connect`, {});
+          expect(reused.status).toBe(200);
+          expect(await reused.json()).toMatchObject({ status: "connected" });
+          expect(await tokenRequests()).toBe(before + 1);
+          evidence.recordAssertionEvidence("Replay preserves usable credentials", "Replay rejected without another token exchange; connecting again reused persisted credentials and passed authenticated tool discovery without OAuth.", true);
+        }
+      }
+    } finally {
+      await stopChild(server.child);
+      await provider.stop();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test(`Den OAuth (issuer support ${metadataLabel}) validates callbacks and preserves usable credentials`, { timeout: 300_000 }, async ({ place, evidence }) => {
+    needs({ commands: ["bun"] });
+    await using den = await server({
+      place, web: false,
+      mocks: { connector: mcpMock({ authorizationResponseIssuerSupported: issuerSupport }) },
+      org: { name: `OAuth Issuer ${Date.now()}`, members: {} },
     });
-    const workspaces: unknown = await (await request("/workspaces")).json();
-    if (!isRecord(workspaces) || !Array.isArray(workspaces.items) || !isRecord(workspaces.items[0]) || typeof workspaces.items[0].id !== "string") throw new Error("Workspace missing");
-    const path = `/workspace/${workspaces.items[0].id}/mcp`;
-    const tokenRequests = async () => (await provider.requests()).filter((entry) => entry.path === "/token").length;
-    for (const mode of ["mismatch", "missing", "empty", "state", "valid"]) {
-      const name = `issuer-${mode}`;
-      const added = await request(`${path}/managed`, { name, url: provider.mcpUrl });
-      const result: unknown = await added.json();
-      expect(added.status, JSON.stringify(result)).toBe(201);
-      if (!isRecord(result) || typeof result.authorizeUrl !== "string") throw new Error("Authorization URL missing");
-      const authorize = new URL(result.authorizeUrl);
-      expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
-      expect(authorize.searchParams.get("code_challenge")).toBeTruthy();
-      const redirect = await fetch(authorize, { redirect: "manual" });
+    const provider = den.mocks.connector;
+    const metadata: unknown = await (await fetch(`${provider.url}/.well-known/oauth-authorization-server`, { signal: AbortSignal.timeout(15_000) })).json();
+    if (!isRecord(metadata)) throw new Error("Provider metadata missing");
+    expect(metadata.authorization_response_iss_parameter_supported).toBe(issuerSupport);
+    const headers = { authorization: `Bearer ${den.admin.token}` };
+    for (const mode of issuerSupport === true ? ["mismatch", "valid"] : ["valid"]) {
+      const created = await denFetch(den.admin, "/v1/mcp-connections", {
+        method: "POST", headers,
+        body: JSON.stringify({ name: `Issuer ${mode}`, url: provider.mcpUrl, authType: "oauth", credentialMode: "shared", access: { orgWide: true } }),
+      });
+      expect(created.response.status, created.text).toBe(200);
+      if (!isRecord(created.body) || typeof created.body.id !== "string") throw new Error("Connection id missing");
+      const id = created.body.id;
+      const started = await denFetch(den.admin, `/v1/mcp-connections/${id}/connect/start`, { headers });
+      expect(started.response.status, started.text).toBe(200);
+      if (!isRecord(started.body) || typeof started.body.authorizeUrl !== "string") throw new Error("Authorization URL missing");
+      const redirect = await fetch(started.body.authorizeUrl, { redirect: "manual" });
       expect(redirect.status).toBe(302);
       const callback = new URL(redirect.headers.get("location")!);
-      expect(callback.searchParams.get("iss")).toBe(provider.url);
+      expect(callback.searchParams.get("iss")).toBe(issuerSupport === true ? provider.url : null);
       if (mode === "mismatch") callback.searchParams.set("iss", "https://other-issuer.example.test");
-      if (mode === "missing") callback.searchParams.delete("iss");
-      if (mode === "empty") callback.searchParams.set("iss", "");
-      if (mode === "state") callback.searchParams.set("state", "invalid-state");
-      const before = await tokenRequests();
-      const completed = await fetch(callback, { signal: AbortSignal.timeout(20_000) });
+      const before = (await provider.requests()).filter((entry) => entry.path === "/token").length;
+      const completed = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
       const html = await completed.text();
-      const connection: unknown = await (await request(`${path}/${name}/managed`)).json();
-      if (mode !== "valid") {
-        expect(completed.ok, html).toBe(false);
-        expect(await tokenRequests()).toBe(before);
-        expect(connection).not.toMatchObject({ status: "connected" });
-        evidence.recordAssertionEvidence(`Reject ${mode} callback before token exchange`, `HTTP ${completed.status}; zero token requests; connection is not connected.`, true);
-      } else {
-        expect(completed.status, html).toBe(200);
-        expect(html).toContain("Connected");
-        expect(connection).toMatchObject({ status: "connected" });
-        expect(await tokenRequests()).toBe(before + 1);
-        evidence.recordAssertionEvidence("Valid issuer completes sign-in with PKCE", "Provider required S256 and accepted exactly one code exchange; callback returned Connected and the server reports connected.", true);
-        const replay = await fetch(callback, { signal: AbortSignal.timeout(20_000) });
-        expect(replay.ok).toBe(false);
-        expect(await tokenRequests()).toBe(before + 1);
-        evidence.recordAssertionEvidence("A consumed authorization cannot be replayed", "Replay rejected without a second token exchange.", true);
+      expect(completed.status, html).toBe(mode === "valid" ? 200 : 400);
+      expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(before + (mode === "valid" ? 1 : 0));
+      const listed = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers });
+      expect(listed.response.status).toBe(200);
+      if (!isRecord(listed.body) || !Array.isArray(listed.body.connections)) throw new Error("Connections missing");
+      const connection = listed.body.connections.find((entry) => isRecord(entry) && entry.id === id);
+      expect(connection).toMatchObject({ connected: mode === "valid" });
+      evidence.recordAssertionEvidence(
+        `Den ${mode === "valid" ? `completes sign-in with ${metadataLabel} issuer-support metadata` : "rejects a mismatched issuer before exchange"}`,
+        `Callback returned HTTP ${completed.status}; provider observed ${mode === "valid" ? "exactly one" : "zero"} token requests.`, true,
+      );
+      if (mode === "valid") {
+        const replay = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+        expect(replay.status).toBe(400);
+        expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(before + 1);
+        const afterReplay = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers });
+        expect(afterReplay.response.status).toBe(200);
+        if (!isRecord(afterReplay.body) || !Array.isArray(afterReplay.body.connections)) throw new Error("Connections missing after replay");
+        expect(afterReplay.body.connections.find((entry) => isRecord(entry) && entry.id === id)).toMatchObject({ connected: true });
+        const reused = await denFetch(den.admin, `/v1/mcp-connections/${id}/connect/start`, { headers });
+        expect(reused.response.status, reused.text).toBe(200);
+        expect(reused.body).toMatchObject({ status: "connected", authorizeUrl: null });
+        expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(before + 1);
+        evidence.recordAssertionEvidence("Den replay preserves usable credentials", "Replay rejected; a subsequent connection check reused saved credentials and remained connected without another token exchange.", true);
       }
     }
-  } finally {
-    await stopChild(server.child);
-    await provider.stop();
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
-test("Den forwards a valid response issuer and rejects a mismatch before the token endpoint", { timeout: 300_000 }, async ({ place, evidence }) => {
-  needs({ commands: ["bun"] });
-  await using den = await server({
-    place, web: false,
-    mocks: { connector: mcpMock({ authorizationResponseIssuerSupported: true }) },
-    org: { name: `OAuth Issuer ${Date.now()}`, members: {} },
   });
-  const provider = den.mocks.connector;
-  const headers = { authorization: `Bearer ${den.admin.token}` };
-  for (const mode of ["mismatch", "valid"]) {
-    const created = await denFetch(den.admin, "/v1/mcp-connections", {
-      method: "POST", headers,
-      body: JSON.stringify({ name: `Issuer ${mode}`, url: provider.mcpUrl, authType: "oauth", credentialMode: "shared", access: { orgWide: true } }),
-    });
-    expect(created.response.status, created.text).toBe(200);
-    if (!isRecord(created.body) || typeof created.body.id !== "string") throw new Error("Connection id missing");
-    const id = created.body.id;
-    const started = await denFetch(den.admin, `/v1/mcp-connections/${id}/connect/start`, { headers });
-    expect(started.response.status, started.text).toBe(200);
-    if (!isRecord(started.body) || typeof started.body.authorizeUrl !== "string") throw new Error("Authorization URL missing");
-    const redirect = await fetch(started.body.authorizeUrl, { redirect: "manual" });
-    expect(redirect.status).toBe(302);
-    const callback = new URL(redirect.headers.get("location")!);
-    expect(callback.searchParams.get("iss")).toBe(provider.url);
-    if (mode === "mismatch") callback.searchParams.set("iss", "https://other-issuer.example.test");
-    const before = (await provider.requests()).filter((entry) => entry.path === "/token").length;
-    const completed = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
-    const html = await completed.text();
-    expect(completed.status, html).toBe(mode === "valid" ? 200 : 400);
-    expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(before + (mode === "valid" ? 1 : 0));
-    const listed = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers });
-    expect(listed.response.status).toBe(200);
-    if (!isRecord(listed.body) || !Array.isArray(listed.body.connections)) throw new Error("Connections missing");
-    const connection = listed.body.connections.find((entry) => isRecord(entry) && entry.id === id);
-    expect(connection).toMatchObject({ connected: mode === "valid" });
-    evidence.recordAssertionEvidence(
-      `Den ${mode === "valid" ? "completes sign-in with the valid issuer" : "rejects a mismatched issuer before exchange"}`,
-      `Callback returned HTTP ${completed.status}; provider observed ${mode === "valid" ? "exactly one" : "zero"} token requests.`, true,
-    );
-  }
-});
+}

--- a/evals/specs/mcp-oauth-response-issuer.test.ts
+++ b/evals/specs/mcp-oauth-response-issuer.test.ts
@@ -1,0 +1,123 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { mcpMock, needs, server, test } from "@openwork/testkit";
+import { bootServer, isRecord, stopChild } from "../worlds/openwork-server-cli.ts";
+
+// This callback journey was missing from the boundary lane: previous coverage
+// used providers that never advertised RFC 9207 response issuer support.
+test("local MCP sign-in preserves the response issuer and rejects mix-ups before exchanging a code", { timeout: 120_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"] });
+  const root = await mkdtemp(join(tmpdir(), "openwork-oauth-issuer-"));
+  const workspace = join(root, "workspace");
+  await mkdir(workspace);
+  const { handle: provider } = await mcpMock({ authorizationResponseIssuerSupported: true }).boot(place);
+  const token = "synthetic-local-oauth-client";
+  const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("OPENWORK_") && !key.startsWith("OPENCODE")));
+  const server = bootServer({
+    ...inherited,
+    XDG_CONFIG_HOME: join(root, "config"),
+    OPENWORK_RUNTIME_DB: join(root, "runtime.sqlite"),
+    OPENWORK_ALLOW_PRIVATE_MCP_URLS: "1",
+    OPENWORK_ENCRYPTION_KEY: "synthetic-oauth-vault-key",
+  }, token, workspace, () => {});
+  try {
+    const base = await server.listening;
+    const request = (path: string, body?: unknown) => fetch(`${base}${path}`, {
+      method: body === undefined ? "GET" : "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(20_000),
+    });
+    const workspaces: unknown = await (await request("/workspaces")).json();
+    if (!isRecord(workspaces) || !Array.isArray(workspaces.items) || !isRecord(workspaces.items[0]) || typeof workspaces.items[0].id !== "string") throw new Error("Workspace missing");
+    const path = `/workspace/${workspaces.items[0].id}/mcp`;
+    const tokenRequests = async () => (await provider.requests()).filter((entry) => entry.path === "/token").length;
+    for (const mode of ["mismatch", "missing", "empty", "state", "valid"]) {
+      const name = `issuer-${mode}`;
+      const added = await request(`${path}/managed`, { name, url: provider.mcpUrl });
+      const result: unknown = await added.json();
+      expect(added.status, JSON.stringify(result)).toBe(201);
+      if (!isRecord(result) || typeof result.authorizeUrl !== "string") throw new Error("Authorization URL missing");
+      const authorize = new URL(result.authorizeUrl);
+      expect(authorize.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(authorize.searchParams.get("code_challenge")).toBeTruthy();
+      const redirect = await fetch(authorize, { redirect: "manual" });
+      expect(redirect.status).toBe(302);
+      const callback = new URL(redirect.headers.get("location")!);
+      expect(callback.searchParams.get("iss")).toBe(provider.url);
+      if (mode === "mismatch") callback.searchParams.set("iss", "https://other-issuer.example.test");
+      if (mode === "missing") callback.searchParams.delete("iss");
+      if (mode === "empty") callback.searchParams.set("iss", "");
+      if (mode === "state") callback.searchParams.set("state", "invalid-state");
+      const before = await tokenRequests();
+      const completed = await fetch(callback, { signal: AbortSignal.timeout(20_000) });
+      const html = await completed.text();
+      const connection: unknown = await (await request(`${path}/${name}/managed`)).json();
+      if (mode !== "valid") {
+        expect(completed.ok, html).toBe(false);
+        expect(await tokenRequests()).toBe(before);
+        expect(connection).not.toMatchObject({ status: "connected" });
+        evidence.recordAssertionEvidence(`Reject ${mode} callback before token exchange`, `HTTP ${completed.status}; zero token requests; connection is not connected.`, true);
+      } else {
+        expect(completed.status, html).toBe(200);
+        expect(html).toContain("Connected");
+        expect(connection).toMatchObject({ status: "connected" });
+        expect(await tokenRequests()).toBe(before + 1);
+        evidence.recordAssertionEvidence("Valid issuer completes sign-in with PKCE", "Provider required S256 and accepted exactly one code exchange; callback returned Connected and the server reports connected.", true);
+        const replay = await fetch(callback, { signal: AbortSignal.timeout(20_000) });
+        expect(replay.ok).toBe(false);
+        expect(await tokenRequests()).toBe(before + 1);
+        evidence.recordAssertionEvidence("A consumed authorization cannot be replayed", "Replay rejected without a second token exchange.", true);
+      }
+    }
+  } finally {
+    await stopChild(server.child);
+    await provider.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Den forwards a valid response issuer and rejects a mismatch before the token endpoint", { timeout: 300_000 }, async ({ place, evidence }) => {
+  needs({ commands: ["bun"] });
+  await using den = await server({
+    place, web: false,
+    mocks: { connector: mcpMock({ authorizationResponseIssuerSupported: true }) },
+    org: { name: `OAuth Issuer ${Date.now()}`, members: {} },
+  });
+  const provider = den.mocks.connector;
+  const headers = { authorization: `Bearer ${den.admin.token}` };
+  for (const mode of ["mismatch", "valid"]) {
+    const created = await denFetch(den.admin, "/v1/mcp-connections", {
+      method: "POST", headers,
+      body: JSON.stringify({ name: `Issuer ${mode}`, url: provider.mcpUrl, authType: "oauth", credentialMode: "shared", access: { orgWide: true } }),
+    });
+    expect(created.response.status, created.text).toBe(200);
+    if (!isRecord(created.body) || typeof created.body.id !== "string") throw new Error("Connection id missing");
+    const id = created.body.id;
+    const started = await denFetch(den.admin, `/v1/mcp-connections/${id}/connect/start`, { headers });
+    expect(started.response.status, started.text).toBe(200);
+    if (!isRecord(started.body) || typeof started.body.authorizeUrl !== "string") throw new Error("Authorization URL missing");
+    const redirect = await fetch(started.body.authorizeUrl, { redirect: "manual" });
+    expect(redirect.status).toBe(302);
+    const callback = new URL(redirect.headers.get("location")!);
+    expect(callback.searchParams.get("iss")).toBe(provider.url);
+    if (mode === "mismatch") callback.searchParams.set("iss", "https://other-issuer.example.test");
+    const before = (await provider.requests()).filter((entry) => entry.path === "/token").length;
+    const completed = await fetch(callback, { redirect: "manual", signal: AbortSignal.timeout(30_000) });
+    const html = await completed.text();
+    expect(completed.status, html).toBe(mode === "valid" ? 200 : 400);
+    expect((await provider.requests()).filter((entry) => entry.path === "/token").length).toBe(before + (mode === "valid" ? 1 : 0));
+    const listed = await denFetch(den.admin, "/v1/mcp-connections?scope=manageable", { headers });
+    expect(listed.response.status).toBe(200);
+    if (!isRecord(listed.body) || !Array.isArray(listed.body.connections)) throw new Error("Connections missing");
+    const connection = listed.body.connections.find((entry) => isRecord(entry) && entry.id === id);
+    expect(connection).toMatchObject({ connected: mode === "valid" });
+    evidence.recordAssertionEvidence(
+      `Den ${mode === "valid" ? "completes sign-in with the valid issuer" : "rejects a mismatched issuer before exchange"}`,
+      `Callback returned HTTP ${completed.status}; provider observed ${mode === "valid" ? "exactly one" : "zero"} token requests.`, true,
+    );
+  }
+});

--- a/packages/enterprise-mcp-client/src/contracts.ts
+++ b/packages/enterprise-mcp-client/src/contracts.ts
@@ -236,6 +236,8 @@ export type EnterpriseMcpCompleteAuthorizationInput = {
   connection: EnterpriseMcpConnection
   redirectUri: string
   code: string
+  /** The decoded iss parameter from the authorization response, when present. */
+  responseIssuer?: string
   /** The exact signed state returned by the provider callback. */
   authorizationId: string
 }

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -540,7 +540,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
           let exchangedTokens = false
           let operationFailed = false
           try {
-            await session.transport.finishAuth(code)
+            await session.transport.finishAuth(code, input.responseIssuer)
             exchangedTokens = true
             await connectWithProtocolNegotiation({
               session,

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -418,7 +418,7 @@ function protectedResourceMetadata() {
 function authorizationServerMetadata() {
   return {
     issuer,
-    ...(process.env.MOCK_AUTHORIZATION_RESPONSE_ISSUER === "1" ? { authorization_response_iss_parameter_supported: true } : {}),
+    ...(process.env.MOCK_AUTHORIZATION_RESPONSE_ISSUER === undefined ? {} : { authorization_response_iss_parameter_supported: process.env.MOCK_AUTHORIZATION_RESPONSE_ISSUER === "1" }),
     authorization_endpoint: `${issuer}/authorize`,
     token_endpoint: `${issuer}/token`,
     ...(disableDcr ? {} : { registration_endpoint: `${issuer}/register` }),

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -418,6 +418,7 @@ function protectedResourceMetadata() {
 function authorizationServerMetadata() {
   return {
     issuer,
+    ...(process.env.MOCK_AUTHORIZATION_RESPONSE_ISSUER === "1" ? { authorization_response_iss_parameter_supported: true } : {}),
     authorization_endpoint: `${issuer}/authorize`,
     token_endpoint: `${issuer}/token`,
     ...(disableDcr ? {} : { registration_endpoint: `${issuer}/register` }),
@@ -513,6 +514,7 @@ function redirectWithCode(res, params) {
 
   const callback = new URL(redirectUri);
   callback.searchParams.set("code", code);
+  if (process.env.MOCK_AUTHORIZATION_RESPONSE_ISSUER === "1") callback.searchParams.set("iss", issuer);
   const state = params.get("state");
   if (state) callback.searchParams.set("state", state);
 


### PR DESCRIPTION
OAuth providers that require the RFC 9207 `iss` parameter failed after consent because OpenWork discarded that parameter before calling the MCP SDK. Forward the decoded response issuer through the local-server and Den callbacks to `finishAuth(code, issuer)`, retaining SDK issuer validation, signed state, PKCE, and Den's existing isolated-callback defense.

Addresses Sentry DESKTOP-APP-1Z. This does not claim to fix the separate Slack authorization report (#4158) or concurrent token-refresh issues.

Verification:
- Added the missing callback boundary journey, `evals/specs/mcp-oauth-response-issuer.test.ts`, using synthetic OAuth/MCP providers and real local-server and Den HTTP routes. A valid issuer completes sign-in; mismatched, missing, and empty issuers and tampered state cause no token exchange; consumed callbacks cannot exchange again. Den also proves successful connection and mismatch rejection.
- Final-head proof: six boundary journeys pass with zero skips, covering true/false/absent issuer-support metadata on local-server and Den. Replay cannot exchange a code again; saved credentials remain usable without another OAuth exchange. Den also remains connected immediately after replay.
- Clean current dev (`aadaff1530fc5a80a7fff8671a5c3266aa62d989`) passes the four optional-metadata cases and reproduces the original two required-issuer failures. Local replay temporarily changes status to reconnect_required on both dev and this fix; this inherited defect is documented separately and is not claimed fixed.
- 85 enterprise MCP-client tests pass; enterprise MCP-client and Den typechecks pass.
- Repository-wide boundary/channel ratchets have identical unrelated failures on this branch and a clean `origin/dev` control at `85a5dfccb4d74732593628ab4cc8912f8b88283d`; this spec introduces no violations.

Exact-head assertion evidence and reproduction commands are published in the test-evidence comment. No production payloads or customer data are included.

Current commit: `b5ef77c44d1b595165bb296aba5892f82562fb20`. Fresh six-journey evidence and the separate compatibility audit are posted below. This follow-up changes only the existing test and synthetic fixtures.

Final-commit CI completed: **28 successful checks, 6 conditional skips, 1 neutral; zero failed or pending**.
