### PR TITLE
ci: detect missing CodeQL results after configuration changes

### DIFF
--- a/.github/workflows/codeql-result-coverage.yml
+++ b/.github/workflows/codeql-result-coverage.yml
@@ -1,0 +1,35 @@
+name: CodeQL Result Coverage
+
+on:
+  schedule:
+    - cron: "43 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+  security-events: read
+
+concurrency:
+  group: codeql-result-coverage
+  cancel-in-progress: false
+
+jobs:
+  coverage:
+    if: github.repository == 'different-ai/openwork'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+      - name: Test coverage classification
+        run: node --test scripts/ci/check-codeql-results.test.mjs
+      - name: Verify uploaded results for open pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/check-codeql-results.mjs

--- a/docs/codeql-results.md
+++ b/docs/codeql-results.md
@@ -1,0 +1,57 @@
+# Missing CodeQL results despite successful jobs
+
+OpenWork uses GitHub's CodeQL **default setup**, not a checked-in analysis workflow.
+GitHub can add a language automatically when repository contents change. Existing
+PRs may have successful scans from before that change and still lack the newly
+required result. The code-scanning merge rule checks uploaded analyses, not just
+whether an Actions job is green.
+
+On September 5, 2026, PR #4517 had Actions and JavaScript/TypeScript results for
+3427828, but Python was added to default setup after that scan. GitHub consequently
+reported one missing result for the PR head or its merge commit e322949.
+
+## Detect
+
+The daily `CodeQL Result Coverage` workflow checks open same-repository PRs
+against the current default-setup languages. It reports missing successful uploads
+at the current head or merge commit and fails with a PR-specific summary. It does
+not execute PR code, change settings, close PRs, or bypass scanning. Active scans
+are reported as pending. Forks are excluded because default setup does not scan them.
+
+Run the same read-only audit locally with an authenticated GitHub CLI:
+
+```sh
+node scripts/ci/check-codeql-results.mjs 4517
+node scripts/ci/check-codeql-results.mjs
+```
+
+API failures fail the audit; they are not interpreted as zero required results.
+This verifies coverage, not absence of vulnerabilities. The existing CodeQL rule
+continues to enforce alert thresholds. If switching to advanced setup, update this
+audit to use that workflow's categories; it intentionally fails when default setup
+is disabled.
+
+## Recover
+
+Inspect the failed scan first if one exists. For an old successful default-setup
+scan missing a newly enabled language, generate a new push event on the PR branch:
+
+```sh
+git status --short
+git commit --allow-empty -m 'ci: refresh CodeQL after configuration change'
+git push
+```
+
+Verify you are on the intended PR branch before committing. This changes the head
+SHA, so refresh any evidence that requires the exact head. Re-run the audit once
+CodeQL finishes and confirm every configured language has an uploaded result.
+A normal upcoming commit also triggers a fresh scan.
+
+GitHub rejected re-running the old generated workflow and manual dispatch for this
+incident; closing/reopening the PR did not generate a new CodeQL run. Do not use
+those as the recovery procedure, remove a language, or weaken the merge rule.
+After changing default setup, run the repository-wide audit to find older PRs
+that also need a fresh scan.
+
+References: [Default setup behavior](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types)
+and [editing default setup](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/edit-default-setup).

--- a/docs/codeql-results.md
+++ b/docs/codeql-results.md
@@ -12,7 +12,7 @@ reported one missing result for the PR head or its merge commit e322949.
 
 ## Detect
 
-The daily `CodeQL Result Coverage` workflow checks open same-repository PRs
+The daily `CodeQL Result Coverage` workflow checks open same-repository PRs targeting the default branch
 against successful language uploads at the newest scanned default-branch commit. It reports missing successful uploads
 at the current head or merge commit and fails with a PR-specific summary. It does
 not execute PR code, change settings, close PRs, or bypass scanning. Active scans

--- a/docs/codeql-results.md
+++ b/docs/codeql-results.md
@@ -13,7 +13,7 @@ reported one missing result for the PR head or its merge commit e322949.
 ## Detect
 
 The daily `CodeQL Result Coverage` workflow checks open same-repository PRs
-against the current default-setup languages. It reports missing successful uploads
+against successful language uploads at the newest scanned default-branch commit. It reports missing successful uploads
 at the current head or merge commit and fails with a PR-specific summary. It does
 not execute PR code, change settings, close PRs, or bypass scanning. Active scans
 are reported as pending. Forks are excluded because default setup does not scan them.
@@ -25,11 +25,14 @@ node scripts/ci/check-codeql-results.mjs 4517
 node scripts/ci/check-codeql-results.mjs
 ```
 
-API failures fail the audit; they are not interpreted as zero required results.
+API failures and missing baselines fail the audit; they are not interpreted as zero required results.
+The monitor uses baseline uploads because reading default-setup settings requires
+Administration permission, which the workflow token does not have. Newly enabled
+languages become expected once their baseline uploads succeed. Results are read
+from the latest 100 baseline analyses; old PR history is paginated in full.
 This verifies coverage, not absence of vulnerabilities. The existing CodeQL rule
 continues to enforce alert thresholds. If switching to advanced setup, update this
-audit to use that workflow's categories; it intentionally fails when default setup
-is disabled.
+audit to use that workflow's categories; it expects the default-setup analysis key.
 
 ## Recover
 

--- a/scripts/ci/check-codeql-results.mjs
+++ b/scripts/ci/check-codeql-results.mjs
@@ -21,18 +21,26 @@ function api(path, paginate = false) {
 async function main() {
   const repo = process.env.GITHUB_REPOSITORY ?? "different-ai/openwork";
   const prefix = `repos/${repo}`;
-  const setup = api(`${prefix}/code-scanning/default-setup`);
-  if (setup.state !== "configured") throw new Error("This audit requires CodeQL default setup; review it when migrating to advanced setup.");
+  // Reading default-setup settings needs Administration permission, unavailable
+  // to GITHUB_TOKEN. Use the successful baseline uploads that PRs must match.
+  const repository = api(prefix);
+  const baseline = api(`${prefix}/code-scanning/analyses?ref=${encodeURIComponent(`refs/heads/${repository.default_branch}`)}&tool_name=CodeQL&per_page=100`);
+  const latest = baseline.find((analysis) => !analysis.error && analysis.analysis_key === "dynamic/github-code-scanning/codeql:upload");
+  if (!latest) throw new Error("No successful default-setup baseline found; inspect CodeQL on the default branch.");
+  const languages = [...new Set(baseline.filter((analysis) =>
+    analysis.commit_sha === latest.commit_sha && !analysis.error &&
+    analysis.analysis_key === "dynamic/github-code-scanning/codeql:upload"
+  ).map((analysis) => analysis.category.replace(/^\/language:/, "")))];
   const number = process.argv[2];
   if (number && !/^\d+$/.test(number)) throw new Error("Usage: node scripts/ci/check-codeql-results.mjs [PR number]");
   const pulls = number ? [api(`${prefix}/pulls/${number}`)] : api(`${prefix}/pulls?state=open&per_page=100`, true);
-  const lines = ["# CodeQL result coverage", "", `Configured languages: ${[...new Set(setup.languages)].join(", ")}`, ""];
+  const lines = ["# CodeQL result coverage", "", `Default-branch baseline languages: ${languages.join(", ")}`, ""];
   let failures = 0;
   for (const pull of pulls) {
     if (pull.state !== "open" || pull.head.repo?.full_name !== repo) continue;
     const refs = [`refs/pull/${pull.number}/head`, `refs/pull/${pull.number}/merge`];
     const analyses = refs.flatMap((ref) => api(`${prefix}/code-scanning/analyses?ref=${encodeURIComponent(ref)}&tool_name=CodeQL&per_page=100`, true));
-    const missing = missingLanguages(setup.languages, analyses, [pull.head.sha, pull.merge_commit_sha].filter(Boolean));
+    const missing = missingLanguages(languages, analyses, [pull.head.sha, pull.merge_commit_sha].filter(Boolean));
     // Only query workflow state when coverage is incomplete.
     const runs = missing.length ? api(`${prefix}/actions/runs?head_sha=${pull.head.sha}&per_page=100`, true) : [];
     const active = runs.flatMap((page) => page.workflow_runs).some((run) =>

--- a/scripts/ci/check-codeql-results.mjs
+++ b/scripts/ci/check-codeql-results.mjs
@@ -37,7 +37,7 @@ async function main() {
   const lines = ["# CodeQL result coverage", "", `Default-branch baseline languages: ${languages.join(", ")}`, ""];
   let failures = 0;
   for (const pull of pulls) {
-    if (pull.state !== "open" || pull.head.repo?.full_name !== repo) continue;
+    if (pull.state !== "open" || pull.head.repo?.full_name !== repo || pull.base.ref !== repository.default_branch) continue;
     const refs = [`refs/pull/${pull.number}/head`, `refs/pull/${pull.number}/merge`];
     const analyses = refs.flatMap((ref) => api(`${prefix}/code-scanning/analyses?ref=${encodeURIComponent(ref)}&tool_name=CodeQL&per_page=100`, true));
     const missing = missingLanguages(languages, analyses, [pull.head.sha, pull.merge_commit_sha].filter(Boolean));

--- a/scripts/ci/check-codeql-results.mjs
+++ b/scripts/ci/check-codeql-results.mjs
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export function missingLanguages(languages, analyses, shas) {
+  const canonical = (language) => ["javascript", "typescript"].includes(language) ? "javascript-typescript" : language;
+  const expected = [...new Set(languages.map(canonical))];
+  const uploaded = new Set(analyses.filter((analysis) =>
+    shas.includes(analysis.commit_sha) && analysis.tool.name === "CodeQL" && !analysis.error
+  ).map((analysis) => analysis.category));
+  return expected.filter((language) => !uploaded.has(`/language:${language}`));
+}
+
+function api(path, paginate = false) {
+  const args = ["api", path];
+  if (paginate) args.push("--paginate", "--slurp");
+  const value = JSON.parse(execFileSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }));
+  return paginate ? value.flat() : value;
+}
+
+async function main() {
+  const repo = process.env.GITHUB_REPOSITORY ?? "different-ai/openwork";
+  const prefix = `repos/${repo}`;
+  const setup = api(`${prefix}/code-scanning/default-setup`);
+  if (setup.state !== "configured") throw new Error("This audit requires CodeQL default setup; review it when migrating to advanced setup.");
+  const number = process.argv[2];
+  if (number && !/^\d+$/.test(number)) throw new Error("Usage: node scripts/ci/check-codeql-results.mjs [PR number]");
+  const pulls = number ? [api(`${prefix}/pulls/${number}`)] : api(`${prefix}/pulls?state=open&per_page=100`, true);
+  const lines = ["# CodeQL result coverage", "", `Configured languages: ${[...new Set(setup.languages)].join(", ")}`, ""];
+  let failures = 0;
+  for (const pull of pulls) {
+    if (pull.state !== "open" || pull.head.repo?.full_name !== repo) continue;
+    const refs = [`refs/pull/${pull.number}/head`, `refs/pull/${pull.number}/merge`];
+    const analyses = refs.flatMap((ref) => api(`${prefix}/code-scanning/analyses?ref=${encodeURIComponent(ref)}&tool_name=CodeQL&per_page=100`, true));
+    const missing = missingLanguages(setup.languages, analyses, [pull.head.sha, pull.merge_commit_sha].filter(Boolean));
+    // Only query workflow state when coverage is incomplete.
+    const runs = missing.length ? api(`${prefix}/actions/runs?head_sha=${pull.head.sha}&per_page=100`, true) : [];
+    const active = runs.flatMap((page) => page.workflow_runs).some((run) =>
+      run.path === "dynamic/github-code-scanning/codeql" && run.status !== "completed"
+    );
+    if (!missing.length) {
+      lines.push(`- #${pull.number} (${pull.head.sha.slice(0, 7)}): all language results uploaded.`);
+    } else if (active) {
+      lines.push(`- #${pull.number}: scan in progress; pending ${missing.join(", ")}.`);
+    } else {
+      failures++;
+      lines.push(`- #${pull.number} (${pull.head.sha.slice(0, 7)}): **missing ${missing.join(", ")}**. See docs/codeql-results.md for recovery.`);
+    }
+  }
+  lines.push("", "Coverage only: existing security alerts and merge requirements still apply.");
+  const report = `${lines.join("\n")}\n`;
+  console.log(report);
+  if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
+  process.exitCode = failures ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => { console.error(error.message); process.exitCode = 1; });
+}

--- a/scripts/ci/check-codeql-results.test.mjs
+++ b/scripts/ci/check-codeql-results.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { missingLanguages } from "./check-codeql-results.mjs";
+
+const result = (language, overrides = {}) => ({
+  category: `/language:${language}`, commit_sha: "head", tool: { name: "CodeQL" }, error: "", ...overrides,
+});
+
+test("a green two-language scan is incomplete after Python is enabled", () => {
+  assert.deepEqual(missingLanguages(["actions", "javascript", "typescript", "javascript-typescript", "python"],
+    [result("actions"), result("javascript-typescript")], ["head", "merge"]), ["python"]);
+});
+
+test("accepts current head and merge results and deduplicates language aliases", () => {
+  assert.deepEqual(missingLanguages(["javascript", "typescript", "python"],
+    [result("javascript-typescript"), result("python", { commit_sha: "merge" })], ["head", "merge"]), []);
+});
+
+test("old commits, failed uploads, and other tools cannot satisfy coverage", () => {
+  assert.deepEqual(missingLanguages(["python"], [
+    result("python", { commit_sha: "old" }),
+    result("python", { error: "extraction failed" }),
+    result("python", { tool: { name: "another scanner" } }),
+  ], ["head", "merge"]), ["python"]);
+});


### PR DESCRIPTION
## Problem

CodeQL default setup added Python after #4517's successful Actions and JavaScript/TypeScript scan. The code-scanning rule therefore expected one more uploaded result, despite green jobs. GitHub rejected rerunning or dispatching the old dynamic workflow; reopening the PR did not trigger a scan. A fresh push triggered the current three-language configuration.

## Change

Add a daily, manually runnable read-only audit of actual CodeQL uploads for open same-repository PRs targeting the default branch, plus a local single-PR command and a recovery runbook. The audit compares the language results on the newest scanned default-branch commit against successful uploads at the current head or merge SHA, normalizes JavaScript/TypeScript aliases, reports running scans as pending, and fails with the PR and missing languages. API errors fail visibly. Existing scanning settings and merge rules remain enforced. Baseline uploads avoid requiring Administration permission (the default-setup settings endpoint requires it). New languages become expected once their baseline upload succeeds.

This detects configuration drift; recovery requires a fresh push by a branch owner. The scheduled workflow becomes active after merge. Forks are excluded because default setup does not scan them.

## Validation

- Three diagnostic regression tests pass, including the original missing-Python case, current head/merge acceptance, and rejection of stale/failed/other-tool results. The new test file covers the standalone diagnostic boundary.
- `actionlint .github/workflows/codeql-result-coverage.yml` passes.
- Live single-PR audit first identified pending results and now confirms all three uploads on #4517 at 0c2b1fa. CodeQL is green.
- No application runtime changes; UI journey testing is not relevant to this monitoring change.

The initial repository-wide live audit found 108 same-repository PRs missing one or more current languages, confirming the issue extends beyond #4517. The daily audit reports affected PRs; it does not push commits to other contributors' branches.
