### PR TITLE
Unify session status indicators on the left

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -161,9 +161,10 @@ import { SessionTitle } from "./session-title";
 const OUTCOME_DOT_UNREAD = "#2FBE54";
 const OUTCOME_DOT_NEEDS_ACTION = "#E8933A";
 
-interface SessionLoadingIndicatorProps {
+interface SessionStatusIndicatorProps {
   status?: string;
   isActiveWork: boolean;
+  isUnread: boolean;
 }
 
 function ShowMoreSessionsButton({
@@ -187,32 +188,23 @@ function ShowMoreSessionsButton({
   );
 }
 
-/** Glyph-lane activity only — never used for unread / completion. */
-function SessionLoadingIndicator({ status, isActiveWork }: SessionLoadingIndicatorProps) {
-  if (!isActiveWork) return <SidebarGlyphSlot />;
-
-  const title = isSessionActivityStatus(status) && status !== "idle"
-    ? getSessionActivityStatusLabel(status)
-    : t("workspace_list.session_streaming");
-
+/** Activity and outcomes share the fixed glyph slot before the session title. */
+function SessionStatusIndicator({ status, isActiveWork, isUnread }: SessionStatusIndicatorProps) {
   return (
     <SidebarGlyphSlot>
-      <SessionDotMatrixLoader label={title} />
+      {isActiveWork ? (
+        <SessionDotMatrixLoader label={isSessionActivityStatus(status) && status !== "idle"
+          ? getSessionActivityStatusLabel(status)
+          : t("workspace_list.session_streaming")} />
+      ) : (
+        <SessionOutcomeIndicator status={status} isUnread={isUnread} />
+      )}
     </SidebarGlyphSlot>
   );
 }
 
-interface SessionOutcomeIndicatorProps {
-  className?: string;
-  status?: string;
-  isActiveWork: boolean;
-  isUnread: boolean;
-}
-
-/** Right-edge outcome: orange = needs you, green = unread result, none = read/idle. */
-function SessionOutcomeIndicator({ className, status, isActiveWork, isUnread }: SessionOutcomeIndicatorProps) {
-  if (isActiveWork) return null;
-
+/** Orange = needs you, green = unread result, none = read/idle. */
+function SessionOutcomeIndicator({ status, isUnread }: { status?: string; isUnread: boolean }) {
   if (isNeedsAttentionSessionStatus(status)) {
     const title = isSessionActivityStatus(status)
       ? getSessionActivityStatusLabel(status)
@@ -220,7 +212,7 @@ function SessionOutcomeIndicator({ className, status, isActiveWork, isUnread }: 
     return (
       <span
         data-session-attention-indicator
-        className={cn("size-2 shrink-0 rounded-full", className)}
+        className="size-2 shrink-0 rounded-full"
         style={{ backgroundColor: OUTCOME_DOT_NEEDS_ACTION }}
         title={title}
         aria-label={title}
@@ -233,7 +225,7 @@ function SessionOutcomeIndicator({ className, status, isActiveWork, isUnread }: 
   return (
     <span
       data-session-attention-indicator
-      className={cn("size-2 shrink-0 rounded-full", className)}
+      className="size-2 shrink-0 rounded-full"
       style={{ backgroundColor: OUTCOME_DOT_UNREAD }}
       title={t("workspace_list.session_unread")}
       aria-label={t("workspace_list.session_unread")}
@@ -2337,17 +2329,11 @@ function SessionMenuItem({
   // Pinned/archived rows identify their workspace via the tooltip title
   // only — no workspace color dot in these sections.
   const leading = (
-    <SessionLoadingIndicator status={sessionActivityStatus} isActiveWork={resolvedActiveWork} />
+    <SessionStatusIndicator status={sessionActivityStatus} isActiveWork={resolvedActiveWork} isUnread={isUnread} />
   );
 
   const trailing = (
     <>
-      <SessionOutcomeIndicator
-        className="absolute right-3 top-1/2 -translate-y-1/2 opacity-100 group-hover/menu-sub-item:opacity-0 max-lg:opacity-0 pointer-coarse:opacity-0 pointer-events-none select-none"
-        status={sessionActivityStatus}
-        isActiveWork={resolvedActiveWork}
-        isUnread={isUnread}
-      />
       <SessionHoverQuickActions
         sessionId={session.id}
         isPinned={isPinned}

--- a/evals/specs/live-tool-visible-after-session-switch.e2e.test.ts
+++ b/evals/specs/live-tool-visible-after-session-switch.e2e.test.ts
@@ -207,6 +207,27 @@ async function approvePendingPermission(appSurface: App, workspaceId: string, se
   return statuses.length;
 }
 
+async function expectLeftSessionIndicator(appSurface: App, sessionId: string, kind: "loading" | "attention"): Promise<void> {
+  const fact = await eventually(() => evalIn(appSurface, `(() => {
+    const row = document.querySelector('[data-sidebar-session-id="' + CSS.escape(${JSON.stringify(sessionId)}) + '"]');
+    const title = row?.querySelector("[data-session-title-slot]");
+    const indicators = row?.querySelectorAll("[data-session-loading-indicator], [data-session-attention-indicator]");
+    const indicator = row?.querySelector(${JSON.stringify(`[data-session-${kind}-indicator]`)});
+    if (!(title instanceof HTMLElement) || !(indicator instanceof HTMLElement)) return false;
+    const box = indicator.getBoundingClientRect();
+    const style = getComputedStyle(indicator);
+    return indicators?.length === 1 && box.width > 0 && box.height > 0
+      && box.right <= title.getBoundingClientRect().left
+      && style.visibility === "visible" && style.opacity === "1";
+  })()`), {
+    within: 15_000,
+    intervalMs: 250,
+    label: `exactly one visible ${kind} indicator before the session title`,
+    until: (value) => value === true,
+  });
+  expect(fact).toBe(true);
+}
+
 async function readVisibleTool(
   appSurface: App,
   sessionId: string,
@@ -338,6 +359,7 @@ test.skipIf(!runnable)(
       },
     );
     expect(visibleBeforeSwitch.visible).toBe(true);
+    await expectLeftSessionIndicator(desktopApp, chatA, "loading");
 
     await clickSessionRow(desktopApp, workspaceB.workspaceId, chatB);
     const absentFromChatB = await readVisibleTool(desktopApp, chatB, runningTool.callId);
@@ -386,6 +408,7 @@ test.skipIf(!runnable)(
     );
     await screenshot(desktopApp);
 
+    await clickSessionRow(desktopApp, workspaceB.workspaceId, chatB);
     const completed = await eventually(
       () => readSessionFacts(desktopApp, workspaceA.workspaceId, chatA),
       {
@@ -398,6 +421,14 @@ test.skipIf(!runnable)(
       },
     );
     expect(completed.text).toContain(completionMarker);
+    await expectLeftSessionIndicator(desktopApp, chatA, "attention");
+    evidence.recordAssertionEvidence(
+      "Session activity and unread completion use the same left indicator slot",
+      "During the run and after completion in another chat, exactly one visible indicator was positioned before chat A's title; no second status indicator remained on the right.",
+      true,
+    );
+    await screenshot(desktopApp);
+    await clickSessionRow(desktopApp, workspaceA.workspaceId, chatA);
     const visibleAfterCompletion = await eventually(
       () => readVisibleTool(desktopApp, chatA, laterTool.callId),
       {


### PR DESCRIPTION
Session activity appeared to the left of titles, while needs-attention and unread dots appeared on the right and disappeared on hover. Render all session statuses in the existing fixed left slot, keeping titles aligned and status visible alongside the row actions.

Verification:
- `pnpm typecheck` — passed.
- `OPENWORK_EVAL_REF=2623165edb188bd187146dd4585a9073d37e8e30 pnpm evals:e2e live-tool-visible-after-session-switch` — Passed; 1 passed, 0 failed, 0 skipped. Placement: `daytona (daytona CLI authenticated)`.
- Extended the existing session-switch journey to assert exactly one visible indicator before the title during a tool run and after completion in another chat.
- `git diff HEAD^ --check` — passed.
- Supplemental `pnpm --dir evals exec tsc -p . --noEmit` did not pass: it reports errors across the eval workspace, including missing JSX configuration for email templates and missing DOM types in shared clients. No diagnostics reference the modified journey. These diagnostics were not checked against a clean control.
