### PR TITLE
fix(app): restore automatic thread title updates

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -9,6 +9,7 @@ import type {
   SessionStatus,
   TextPart,
   ToolPart,
+  UnknownError,
 } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, createDesktopFetch, type FieldsResult } from "./opencode";
@@ -55,6 +56,7 @@ type PromptParameters = SessionParameters & {
 
 type SessionCreateParameters = DirectoryParameters & {
   model?: ModelBinding;
+  title?: string;
 };
 
 type SessionUpdateParameters = SessionParameters & {
@@ -94,6 +96,7 @@ export type V2MappedMessage = {
       created: number;
       completed?: number;
     };
+    error?: UnknownError;
   };
   parts: Part[];
 };
@@ -182,7 +185,7 @@ function readTimestamp(value: Record<string, unknown>): number {
   return readNumber(value, "timestamp") ?? Date.now();
 }
 
-function mapV2Session(value: unknown, directory: string | undefined): Session | null {
+function mapV2Session(value: unknown, directory: string | undefined, eventCreated?: number): Session | null {
   const data = responseData(value);
   if (!isRecord(data)) return null;
   const source = readRecord(data, "info") ?? data;
@@ -190,7 +193,7 @@ function mapV2Session(value: unknown, directory: string | undefined): Session | 
   if (!id) return null;
   const time = readRecord(source, "time");
   const location = readRecord(source, "location");
-  const created = readNumber(time, "created") ?? readNumber(source, "created") ?? 0;
+  const created = readNumber(time, "created") ?? readNumber(source, "created") ?? eventCreated ?? 0;
   const updated = readNumber(time, "updated") ?? readNumber(source, "updated") ?? created;
   const archived = readNumber(time, "archived");
   const parentID = readString(source, "parentID");
@@ -199,7 +202,8 @@ function mapV2Session(value: unknown, directory: string | undefined): Session | 
     slug: readString(source, "slug") ?? id,
     projectID: readString(source, "projectID") ?? "v2",
     directory: readString(source, "directory") ?? readString(location, "directory") ?? directory ?? "",
-    title: readString(source, "title") ?? "Untitled session",
+    // Keep native untitled sessions eligible for compatibility title recovery.
+    title: readString(source, "title") || `New session - ${new Date(created).toISOString()}`,
     version: readString(source, "version") ?? "v2",
     time: {
       created,
@@ -359,15 +363,20 @@ function mapV2Message(value: unknown, sessionID: string): V2MappedMessage | null
   const completed = readNumber(time, "completed");
   const resolvedSessionID = readString(value, "sessionID") ?? sessionID;
   const parts = mapV2MessageParts(value, id, resolvedSessionID, created);
+  const role = messageRole(value);
+  const error = readRecord(value, "error");
   return {
     info: {
       id,
       sessionID: resolvedSessionID,
-      role: messageRole(value),
+      role,
       time: {
         created,
         ...(completed === undefined ? {} : { completed }),
       },
+      ...(role === "assistant" && error
+        ? { error: { name: "UnknownError", data: { message: errorMessage(error) } } }
+        : {}),
     },
     parts,
   };
@@ -903,13 +912,23 @@ export function translateV2Event(
     return sessionID ? [{ type: "session.idle", properties: { sessionID } }] : null;
   }
 
-  if (type === "session.created" || type === "session.renamed") {
-    const info = mapV2Session(properties, readString(readRecord(value, "location") ?? {}, "directory"));
+  if (type === "session.created") {
+    const info = mapV2Session(
+      properties,
+      readString(readRecord(value, "location") ?? {}, "directory"),
+      readNumber(value, "created"),
+    );
     if (!info) return null;
     return [{
-      type: type === "session.created" ? "session.created" : "session.updated",
+      type: "session.created",
       properties: { info },
     }];
+  }
+
+  if (type === "session.renamed") {
+    const title = readString(properties, "title");
+    if (!sessionID || title === undefined) return null;
+    return [{ type: "session.updated", properties: { info: { id: sessionID, title } } }];
   }
 
   if (type === "session.deleted") {
@@ -1271,6 +1290,7 @@ export function createClientV2(
     const location = parameters.directory ?? directory;
     const result = await request("POST", "/api/session", {
       ...(model ? { model } : {}),
+      ...(parameters.title === undefined ? {} : { title: parameters.title }),
       ...(location ? { location: { directory: location } } : {}),
     }, options?.signal);
     if (!result.response.ok) return failedResult(result);

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -800,6 +800,8 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "session.updated") {
     const update = getSessionUpdatedInfo(event);
     if (!update) return;
+    // Sidebar metadata updates must not depend on transcript tracking.
+    for (const listener of entry.sessionUpdatedListeners.keys()) listener(update);
     const title = typeof update.info.title === "string" ? update.info.title : "";
     if (title && !isGeneratedSessionTitle(title)) entry.titleRecovery?.resolve(update.sessionId);
     if (!isTrackedSession(entry, update.sessionId)) return;
@@ -815,7 +817,6 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
         return { ...current, session: { ...current.session, revert } };
       },
     );
-    for (const listener of entry.sessionUpdatedListeners.keys()) listener(update);
     return;
   }
 

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -151,6 +151,51 @@ function jsonResponse(value: unknown, status = 200): Response {
 }
 
 describe("OpenCode v2 event translation", () => {
+  test("uses the created envelope timestamp for an untitled session", () => {
+    const created = 1_788_548_737_221;
+    const event = {
+      type: "session.created",
+      created,
+      location: { directory: "/workspace" },
+      data: { sessionID: "ses_new" },
+    };
+
+    expect(translateV2Event(event, createV2EventTranslationState())).toEqual([{
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_new",
+          slug: "ses_new",
+          projectID: "v2",
+          directory: "/workspace",
+          title: `New session - ${new Date(created).toISOString()}`,
+          version: "v2",
+          time: { created, updated: created },
+        },
+      },
+    }]);
+    expect(event.data).toEqual({ sessionID: "ses_new" });
+  });
+
+  test.each(["Named session", "Untitled session", ""])("translates rename %j as a title-only patch", (title) => {
+    expect(translateV2Event({
+      type: "session.renamed",
+      created: 1_788_548_737_260,
+      location: { directory: "/workspace" },
+      data: { sessionID: "ses_named", title },
+    }, createV2EventTranslationState())).toEqual([{
+      type: "session.updated",
+      properties: { info: { id: "ses_named", title } },
+    }]);
+  });
+
+  test("does not turn an incomplete rename into a generated title", () => {
+    expect(translateV2Event({
+      type: "session.renamed",
+      data: { sessionID: "ses_named" },
+    }, createV2EventTranslationState())).toBeNull();
+  });
+
   test("uses one stable text part id from start through the cumulative end update", () => {
     const state = createV2EventTranslationState();
 
@@ -462,6 +507,109 @@ describe("OpenCode v2 event translation", () => {
 });
 
 describe("OpenCode v2 client compatibility", () => {
+  test("maps only missing and empty native titles to stable read-time placeholders", async () => {
+    const originalFetch = globalThis.fetch;
+    const created = 1_788_548_737_221;
+    const time = { created, updated: created + 100 };
+    const sessions = [
+      { id: "ses_missing", created },
+      { id: "ses_empty", title: "", time },
+      { id: "ses_literal", title: "Untitled session", time },
+      { id: "ses_named", title: "Named session", time },
+    ];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.method === "GET" && request.url.endsWith("/api/session")) {
+        return jsonResponse({ data: sessions });
+      }
+      const session = sessions.find((item) => request.url.endsWith(`/api/session/${item.id}`));
+      if (request.method === "GET" && session) return jsonResponse({ data: session });
+      throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+    };
+
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.list();
+      const placeholder = `New session - ${new Date(created).toISOString()}`;
+      expect(result.data?.map((session) => session.title)).toEqual([
+        placeholder, placeholder, "Untitled session", "Named session",
+      ]);
+      for (const session of result.data ?? []) {
+        const fetched = await client.session.get({ sessionID: session.id });
+        expect(fetched.data).toEqual(session);
+      }
+      expect(result.data?.[1]?.time).toEqual(time);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each([undefined, "", "Named session", "Untitled session"])("forwards only the provided title %j when creating a session", async (title) => {
+    const originalFetch = globalThis.fetch;
+    const bodies: unknown[] = [];
+    const created = 1_788_548_737_221;
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.method === "POST" && request.url.endsWith("/api/session")) {
+        bodies.push(await request.json());
+        return jsonResponse({ data: { id: "ses_new", title, created } });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+    };
+
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.create({ title });
+      expect(bodies).toEqual([{
+        location: { directory: "/workspace" },
+        ...(title === undefined ? {} : { title }),
+      }]);
+      expect(result.data?.title).toBe(title || `New session - ${new Date(created).toISOString()}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("retains native assistant errors even when a failed turn has text and a completion time", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.method === "GET" && request.url.endsWith("/api/session/ses_failed/message")) {
+        return jsonResponse({ data: [{
+          id: "msg_failed",
+          type: "assistant",
+          time: { created: 10, completed: 20 },
+          content: [{ type: "text", text: "Partial response" }],
+          error: { type: "unknown", message: "provider unavailable" },
+        }] });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+    };
+
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.messages({ sessionID: "ses_failed" });
+      expect(result.data).toEqual([{
+        info: {
+          id: "msg_failed",
+          sessionID: "ses_failed",
+          role: "assistant",
+          time: { created: 10, completed: 20 },
+          error: { name: "UnknownError", data: { message: "provider unavailable" } },
+        },
+        parts: [{
+          id: "msg_failed:0",
+          messageID: "msg_failed",
+          sessionID: "ses_failed",
+          type: "text",
+          text: "Partial response",
+        }],
+      }]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("maps active v2 sessions to busy compatibility statuses", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async (input, init) => {

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { Part, Session } from "@opencode-ai/sdk/v2/client";
 import type { UIMessage } from "ai";
 
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import {
   __applySessionSyncEventForTest,
   __createWorkspaceSessionSyncForTest,
+  snapshotKey,
   trackWorkspaceSessionSync,
   transcriptKey,
 } from "../src/react-app/domains/session/sync/session-sync";
@@ -326,12 +328,14 @@ describe("tool part mapper", () => {
       time: { created: 1, updated: 1 },
     };
     const createdIds: string[] = [];
+    const updates: { sessionId: string; info: Record<string, unknown> }[] = [];
     const deletedIds: string[] = [];
     const syncInput = {
       workspaceId: "workspace-a",
       baseUrl: "http://127.0.0.1:1234",
       openworkToken: "token",
       onSessionCreated: (session: Session) => createdIds.push(session.id),
+      onSessionUpdated: (update: { sessionId: string; info: Record<string, unknown> }) => updates.push(update),
       onSessionDeleted: (sessionId: string) => deletedIds.push(sessionId),
     };
     const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
@@ -341,6 +345,34 @@ describe("tool part mapper", () => {
         type: "session.created",
         properties: { sessionID: created.id, info: created },
       });
+
+      const queryClient = getReactQueryClient();
+      const snapshot: OpenworkSessionSnapshot = {
+        session: created,
+        messages: [],
+        todos: [],
+        status: { type: "idle" },
+      };
+      const otherSnapshot = { ...snapshot, session: { ...created, id: "session-other", title: "Other session" } };
+      queryClient.setQueryData(snapshotKey(syncInput.workspaceId, created.id), snapshot);
+      queryClient.setQueryData(snapshotKey(syncInput.workspaceId, "session-other"), otherSnapshot);
+      const cachedQueries = queryClient.getQueriesData({});
+      const renamed = { ...created, title: "Renamed in the background" };
+      __applySessionSyncEventForTest(syncInput, {
+        type: "session.updated",
+        properties: { sessionID: created.id, info: renamed },
+      });
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.updated",
+        properties: { info: { id: "msg-background", role: "assistant", sessionID: created.id } },
+      });
+
+      expect(updates).toEqual([{ sessionId: created.id, info: renamed }]);
+      expect(queryClient.getQueriesData({})).toEqual(cachedQueries);
+      expect(queryClient.getQueryData(snapshotKey(syncInput.workspaceId, created.id))).toBe(snapshot);
+      expect(queryClient.getQueryData(snapshotKey(syncInput.workspaceId, "session-other"))).toBe(otherSnapshot);
+      expect(queryClient.getQueryData(transcriptKey(syncInput.workspaceId, created.id))).toBeUndefined();
+
       __applySessionSyncEventForTest(syncInput, {
         type: "session.deleted",
         properties: { sessionID: created.id, info: created },

--- a/evals/specs/opencode-v2-chat-routing.e2e.test.ts
+++ b/evals/specs/opencode-v2-chat-routing.e2e.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { clickButton, createAndSelectWorkspace, evalIn, go, waitFor } from "@openwork/behaviors";
+import { clickButton, control, createAndSelectWorkspace, evalIn, go, renameSessionAndWait, waitFor } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
 import { desktop } from "@openwork/hosts";
 import { needs, resolveEvalEngine, test } from "@openwork/testkit";
@@ -19,6 +19,8 @@ const modelIdV1 = "witness-model-v1";
 const modelIdV2 = "witness-model-v2";
 const modelNameV1 = "Witness Model V1";
 const modelNameV2 = "Witness Model V2";
+const generatedTitle = "A friendly greeting";
+const manualTitle = "My chosen thread name";
 
 interface EngineV2PreviewStatus {
   enabled: boolean;
@@ -42,6 +44,7 @@ interface WitnessRequest {
   model: string;
   stream: boolean;
   nonce: string;
+  titleRequest: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -322,6 +325,17 @@ async function waitForChatSurface(app: Surface, sessionId: string, workspaceId: 
   })()`, { timeoutMs: 10_000, label: "v2 session surface after workspace switch" });
 }
 
+async function expectSessionTitle(app: Surface, sessionId: string, workspaceId: string, expected: string): Promise<void> {
+  const selector = `[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"] [data-session-title-text]`;
+  await waitFor(app, `(document.querySelector(${JSON.stringify(selector)})?.textContent ?? "").trim() === ${JSON.stringify(expected)}`, {
+    timeoutMs: 45_000,
+    label: `sidebar title becomes ${expected}`,
+  });
+  const result = await serverFetchJson(app, `/workspace/${encodeURIComponent(workspaceId)}/opencode2/api/session/${encodeURIComponent(sessionId)}`);
+  expect(result.status).toBe(200);
+  expect(result.json).toMatchObject({ data: { id: sessionId, title: expected } });
+}
+
 async function waitForWitnessRequest(
   requests: WitnessRequest[],
   predicate: (request: WitnessRequest) => boolean,
@@ -350,7 +364,7 @@ async function sendAndWaitForNonce(
   await clickButton(app, "Run task", { timeoutMs: 30_000 });
   const request = await waitForWitnessRequest(
     requests,
-    (candidate) => candidate.stream && candidate.at >= sentAt && candidate.at >= notBefore
+    (candidate) => candidate.stream && !candidate.titleRequest && candidate.at >= sentAt && candidate.at >= notBefore
       && candidate.auth === auth && candidate.model === model,
     `${round} streamed witness request`,
   );
@@ -407,8 +421,10 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
       }
       const model = isRecord(body) && typeof body.model === "string" ? body.model : "";
       const stream = isRecord(body) && body.stream === true;
-      const nonce = "OPENWORK-V2-ROUTING-NONCE";
-      witnessRequests.push({ at: Date.now(), auth, model, stream, nonce });
+      // Title generation is tool-free in both engines and can also stream.
+      const titleRequest = isRecord(body) && (!Array.isArray(body.tools) || body.tools.length === 0);
+      const nonce = titleRequest ? generatedTitle : `OPENWORK-V2-ROUTING-NONCE-${witnessRequests.length + 1}`;
+      witnessRequests.push({ at: Date.now(), auth, model, stream, nonce, titleRequest });
       const id = `chatcmpl-opencode-v2-routing-${witnessRequests.length}`;
       if (!stream) {
         response.writeHead(200, { "content-type": "application/json" });
@@ -417,7 +433,7 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
           object: "chat.completion",
           created: Math.floor(Date.now() / 1_000),
           model,
-          choices: [{ index: 0, message: { role: "assistant", content: "Witness title" }, finish_reason: "stop" }],
+          choices: [{ index: 0, message: { role: "assistant", content: nonce }, finish_reason: "stop" }],
         }));
         return;
       }
@@ -604,6 +620,10 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
     // New task uses the selected workspace's currently swapped client. This
     // avoids sending a v2 prompt to the pre-toggle v1 session id.
     const v2SessionId = await createNewSessionThroughSidebar(app);
+    await waitFor(app, `(document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${v2SessionId}"] [data-session-title-text]`)})?.textContent ?? "").trim() === "New session"`, {
+      timeoutMs: 15_000,
+      label: "an unnamed v2 session is displayed as a new session, not a finished title",
+    });
     await selectModel(app, modelNameV2);
     const r2 = await sendAndWaitForNonce(
       app,
@@ -621,6 +641,7 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
     expect(r2.request.at).toBeGreaterThanOrEqual(routedOnAt);
     expect(r2.request.auth).toBe(`Bearer ${keyV2}`);
     expect(r2.request.model).toBe(modelIdV2);
+    await expectSessionTitle(app, v2SessionId, workspaceId, generatedTitle);
     evidence.recordAssertionEvidence(
       "R2 routed chat creates and streams through v2 without touching v1",
       `The provider mirrored in ${mirrorLatencyMs}ms and its catalog warmed in ${catalogLatencyMs}ms without restarting pid ${pid0}; the v2 transcript streamed ${r2.request.nonce} from ${modelIdV2} with Bearer ${keyV2} in ${r2.latencyMs}ms; v2 sessions grew ${v2BeforeR2}→${v2AfterR2}, while v1 stayed frozen at ${v1BeforeR2}.`,
@@ -638,6 +659,32 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
       timeoutMs: 10_000,
       label: "v2 session remains in the sidebar after switching workspaces",
     });
+    await expectSessionTitle(app, v2SessionId, workspaceId, generatedTitle);
+    evidence.recordAssertionEvidence(
+      "an unnamed v2 thread gains a title and keeps it after workspace refetch",
+      "The sidebar initially showed New session, then the tool-free title response rather than the chat response; the native session API and the same sidebar row retained that title after leaving and reopening the thread.",
+      true,
+    );
+
+    const namedSessionId = await createNewSessionThroughSidebar(app);
+    const renameApp = app;
+    await renameSessionAndWait((action, args) => control(renameApp, action, args), namedSessionId, manualTitle);
+    await selectModel(app, modelNameV2);
+    const titleRequestsBefore = witnessRequests.filter((request) => request.titleRequest).length;
+    await sendAndWaitForNonce(app, witnessRequests, "hello from my named thread", `Bearer ${keyV2}`, modelIdV2, routedOnAt, "Named v2");
+    await expectSessionTitle(app, namedSessionId, workspaceId, manualTitle);
+    await clickSessionRow(app, v2SessionId, workspaceId);
+    await waitForChatSurface(app, v2SessionId, workspaceId);
+    await expectSessionTitle(app, v2SessionId, workspaceId, generatedTitle);
+    await clickSessionRow(app, namedSessionId, workspaceId);
+    await waitForChatSurface(app, namedSessionId, workspaceId);
+    await expectSessionTitle(app, namedSessionId, workspaceId, manualTitle);
+    expect(witnessRequests.filter((request) => request.titleRequest)).toHaveLength(titleRequestsBefore);
+    evidence.recordAssertionEvidence(
+      "a manually named v2 thread is not automatically renamed on its first turn",
+      "A completed first reply and reopening preserved the chosen name in the sidebar and native session API, made no title request, and left the other thread's generated title unchanged.",
+      true,
+    );
 
     const statusAfterR2 = await readStatus(app);
     expect(statusAfterR2.running).toBe(true);


### PR DESCRIPTION
## Summary
Threads using the v2 preview can stay unnamed because an absent native title becomes `Untitled session`, which the existing recovery path mistakes for a completed title. Native rename patches also pass through the full-session mapper, overwriting timestamps and other metadata. Separately, untracked-thread updates cancel title recovery without reaching the sidebar.

- Normalize missing v2 titles to the existing read-time placeholder so bounded title recovery remains active; preserve actual names, including literal `Untitled session`.
- Translate rename events as title-only patches and use the creation event timestamp for newly created sessions.
- Deliver background session metadata independently of transcript tracking.
- Forward explicit creation titles and retain failed assistant-message errors so unsuccessful turns are not classified as title-only failures.
- Extend the existing routing journey with initial placeholder, generated title, reopen persistence, and manual-name protection assertions. No new test files.

Native title inference and provider configuration are unchanged. This fixes confirmed OpenWork integration defects; it does not establish a provider-side explanation for every missing title.

## Verification — Incomplete
Head: `8010922007a2d5ab865cbc9dd191606b6152fbc2`, rebased on `94649b44ae8f64dd549a88b46a0bc7c9466b881d`.

Passed:
- `bun test --isolate apps/app/tests/opencode-v2-adapter.test.ts apps/app/tests/session-title-recovery.test.ts apps/app/tests/session-sync-tool-parts.test.ts` — exit 0, 43 passed, 0 failed.
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `git diff --check` — passed.

Blocked / missing:
- `OPENWORK_EVAL_REF=8010922007a2d5ab865cbc9dd191606b6152fbc2 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e opencode-v2-chat-routing` selected `placement: daytona (daytona CLI authenticated)` and checked out the exact head, but the invocation timed out during desktop startup before any title assertion. No passing end-to-end verdict is claimed.
- An earlier unpinned attempt failed during Daytona setup with a TLS handshake timeout and did not test the candidate.
- This existing routing spec requires a local witness for its round-trip assertions and currently skips them on Daytona. A reachable witness and a completed exact-head run are still required for title journey proof. No local run was substituted.
- `pnpm --dir evals typecheck` — exit 2. The reported TypeScript failure signatures reproduce on a clean detached control at the original base `46ba486a4` (including `agent-context-cloud-probe.ts` TS1294, missing database exports and `bun:sqlite` declarations). Those broader failures are not repaired here.

No merge, release, or deployment is included.