### PR TITLE
test: enforce chat transcript continuity on v1 and v2

### DIFF
--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -129,6 +129,11 @@ jobs:
           fi
 
           tests="$(echo "$eligible_tests" | jq -c --arg event "$EVENT_NAME" --arg only "$only_filter" --argjson matched "$matched_tests" 'map(select(if $event == "workflow_run" then (. as $test | ($matched | index($test)) != null) else ($only == "" or contains($only)) end))')"
+          # The chat contract must also run when its implementation changes.
+          if [ "$EVENT_NAME" = "workflow_run" ] && git diff --name-only "$BASE_SHA...$HEAD_SHA" | grep -E '^(apps/app/src/app/lib/opencode-v2-adapter|apps/app/src/react-app/domains/session/|apps/app/src/components/chat/|evals/worlds/chat|evals/packages/testkit/src/transcript-observer)' >/dev/null; then
+            tests="$(echo "$tests" | jq -c '. + ["streamed-markdown-answer.e2e.test.ts"] | unique')"
+          fi
+          tests="$(echo "$tests" | jq -c '[.[] | . as $spec | (if . == "streamed-markdown-answer.e2e.test.ts" then ["v1", "v2"] else ["v1"] end)[] | {spec: $spec, engine: .}]')"
           count="$(echo "$tests" | jq 'length')"
           has_tests=false
           if [ "$count" -gt 0 ]; then
@@ -137,18 +142,20 @@ jobs:
           echo "tests=$tests" >> "$GITHUB_OUTPUT"
           echo "has_tests=$has_tests" >> "$GITHUB_OUTPUT"
           echo "### Daytona E2E plan: $count spec(s)" >> "$GITHUB_STEP_SUMMARY"
-          echo "$tests" | jq -r '.[] | "- `\(.)`"' >> "$GITHUB_STEP_SUMMARY"
+          echo "$tests" | jq -r '.[] | "- `\(.spec)` · \(.engine)"' >> "$GITHUB_STEP_SUMMARY"
 
   e2e:
     needs: plan
     if: needs.plan.outputs.enabled == 'true' && needs.plan.outputs.has_tests == 'true'
-    name: E2E (${{ matrix.spec }})
+    name: E2E (${{ matrix.spec }}, ${{ matrix.engine }})
     environment: ${{ github.event_name == 'workflow_run' && 'pr-slow-specs' || 'scheduled-e2e-regression' }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        spec: ${{ fromJSON(needs.plan.outputs.tests) }}
+        include: ${{ fromJSON(needs.plan.outputs.tests) }}
+    env:
+      OPENWORK_EVAL_ENGINE: ${{ matrix.engine }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -129,10 +129,6 @@ jobs:
           fi
 
           tests="$(echo "$eligible_tests" | jq -c --arg event "$EVENT_NAME" --arg only "$only_filter" --argjson matched "$matched_tests" 'map(select(if $event == "workflow_run" then (. as $test | ($matched | index($test)) != null) else ($only == "" or contains($only)) end))')"
-          # The chat contract must also run when its implementation changes.
-          if [ "$EVENT_NAME" = "workflow_run" ] && git diff --name-only "$BASE_SHA...$HEAD_SHA" | grep -E '^(apps/app/src/app/lib/opencode-v2-adapter|apps/app/src/react-app/domains/session/|apps/app/src/components/chat/|evals/worlds/chat|evals/packages/testkit/src/transcript-observer)' >/dev/null; then
-            tests="$(echo "$tests" | jq -c '. + ["streamed-markdown-answer.e2e.test.ts"] | unique')"
-          fi
           tests="$(echo "$tests" | jq -c '[.[] | . as $spec | (if . == "streamed-markdown-answer.e2e.test.ts" then ["v1", "v2"] else ["v1"] end)[] | {spec: $spec, engine: .}]')"
           count="$(echo "$tests" | jq 'length')"
           has_tests=false

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -129,7 +129,6 @@ jobs:
           fi
 
           tests="$(echo "$eligible_tests" | jq -c --arg event "$EVENT_NAME" --arg only "$only_filter" --argjson matched "$matched_tests" 'map(select(if $event == "workflow_run" then (. as $test | ($matched | index($test)) != null) else ($only == "" or contains($only)) end))')"
-          tests="$(echo "$tests" | jq -c '[.[] | . as $spec | (if . == "streamed-markdown-answer.e2e.test.ts" then ["v1", "v2"] else ["v1"] end)[] | {spec: $spec, engine: .}]')"
           count="$(echo "$tests" | jq 'length')"
           has_tests=false
           if [ "$count" -gt 0 ]; then
@@ -138,20 +137,18 @@ jobs:
           echo "tests=$tests" >> "$GITHUB_OUTPUT"
           echo "has_tests=$has_tests" >> "$GITHUB_OUTPUT"
           echo "### Daytona E2E plan: $count spec(s)" >> "$GITHUB_STEP_SUMMARY"
-          echo "$tests" | jq -r '.[] | "- `\(.spec)` · \(.engine)"' >> "$GITHUB_STEP_SUMMARY"
+          echo "$tests" | jq -r '.[] | "- `\(.)`"' >> "$GITHUB_STEP_SUMMARY"
 
   e2e:
     needs: plan
     if: needs.plan.outputs.enabled == 'true' && needs.plan.outputs.has_tests == 'true'
-    name: E2E (${{ matrix.spec }}, ${{ matrix.engine }})
+    name: E2E (${{ matrix.spec }})
     environment: ${{ github.event_name == 'workflow_run' && 'pr-slow-specs' || 'scheduled-e2e-regression' }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        include: ${{ fromJSON(needs.plan.outputs.tests) }}
-    env:
-      OPENWORK_EVAL_ENGINE: ${{ matrix.engine }}
+        spec: ${{ fromJSON(needs.plan.outputs.tests) }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -36,6 +36,8 @@ export interface MockAgentWorkload {
   finalReply: string;
   /** Stream the final reply as consecutive content deltas of this many characters instead of one. */
   finalReplyChunkSize?: number;
+  /** Hold the final response before sending headers, to exercise loading transitions. */
+  finalReplyDelayMs?: number;
   /** Tool calls the agent makes before its final reply; empty answers directly. */
   steps: MockAgentToolStep[];
 }

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -14,3 +14,5 @@ export * from "./link.ts";
 export * from "./self-host.ts";
 export * from "./spec/index.ts";
 export * from "./state.ts";
+
+export { observeTranscript } from "./transcript-observer.ts";

--- a/evals/packages/testkit/src/transcript-observer.ts
+++ b/evals/packages/testkit/src/transcript-observer.ts
@@ -3,8 +3,8 @@ import type { Probe } from "./spec/types.ts";
 /** Observe rendered transcript text across frames, including gaps between eventual assertions. */
 export async function observeTranscript(probe: Probe, entries: readonly { role: "user" | "assistant"; text: string }[]) {
   const key = `transcript-observer-${crypto.randomUUID()}`;
-  await probe.eval(`(() => {
-    const entries = ${JSON.stringify(entries)};
+  await probe.eval(`(key, entriesJson) => {
+    const entries = JSON.parse(entriesJson);
     const state = { frames: 0, seen: entries.map(() => false), violations: [], stopped: false };
     let frame;
     const started = performance.now();
@@ -22,19 +22,19 @@ export async function observeTranscript(probe: Probe, entries: readonly { role: 
     };
     frame = requestAnimationFrame(sample);
     const timer = setTimeout(() => { cancelAnimationFrame(frame); state.stopped = true; }, 180000);
-    window[${JSON.stringify(key)}] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
-  })()`);
+    window[key] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
+  }`, { args: [key, JSON.stringify(entries)] });
   return {
     async finish() {
-      const result = await probe.eval(`(() => {
-        const observer = window[${JSON.stringify(key)}];
+      const result = await probe.eval(`(key) => {
+        const observer = window[key];
         if (!observer) throw new Error("Transcript observer was lost before verification");
-        observer.stop(); delete window[${JSON.stringify(key)}]; return observer.state;
-      })()`);
+        observer.stop(); delete window[key]; return observer.state;
+      }`, { args: [key] });
       return result;
     },
     async [Symbol.asyncDispose]() {
-      await probe.eval(`(() => { window[${JSON.stringify(key)}]?.stop(); delete window[${JSON.stringify(key)}]; })()`);
+      await probe.eval(`(key) => { window[key]?.stop(); delete window[key]; }`, { args: [key] });
     },
   };
 }

--- a/evals/packages/testkit/src/transcript-observer.ts
+++ b/evals/packages/testkit/src/transcript-observer.ts
@@ -1,0 +1,40 @@
+import type { Probe } from "./spec/types.ts";
+
+/** Observe rendered transcript text across frames, including gaps between eventual assertions. */
+export async function observeTranscript(probe: Probe, entries: readonly { role: "user" | "assistant"; text: string }[]) {
+  const key = `transcript-observer-${crypto.randomUUID()}`;
+  await probe.eval(`(() => {
+    const entries = ${JSON.stringify(entries)};
+    const state = { frames: 0, seen: entries.map(() => false), violations: [], stopped: false };
+    let frame;
+    const started = performance.now();
+    const sample = () => {
+      state.frames++;
+      entries.forEach((entry, index) => {
+        const nodes = [...document.querySelectorAll('[data-message-role="' + entry.role + '"]')]
+          .filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== "hidden");
+        const count = nodes.reduce((sum, node) => sum + ((node.innerText ?? "").split(entry.text).length - 1), 0);
+        if (count > 0) state.seen[index] = true;
+        if (state.seen[index] && count !== 1 && state.violations.length < 30)
+          state.violations.push({ index, count, atMs: Math.round(performance.now() - started) });
+      });
+      frame = requestAnimationFrame(sample);
+    };
+    frame = requestAnimationFrame(sample);
+    const timer = setTimeout(() => { cancelAnimationFrame(frame); state.stopped = true; }, 180000);
+    window[${JSON.stringify(key)}] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
+  })()`);
+  return {
+    async finish() {
+      const result = await probe.eval(`(() => {
+        const observer = window[${JSON.stringify(key)}];
+        if (!observer) throw new Error("Transcript observer was lost before verification");
+        observer.stop(); delete window[${JSON.stringify(key)}]; return observer.state;
+      })()`);
+      return result;
+    },
+    async [Symbol.asyncDispose]() {
+      await probe.eval(`(() => { window[${JSON.stringify(key)}]?.stop(); delete window[${JSON.stringify(key)}]; })()`);
+    },
+  };
+}

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { spec } from "@openwork/testkit";
+import { observeTranscript, spec } from "@openwork/testkit";
 import { streamedMarkdown, streamedMarkdownMarker } from "../worlds/chat.ts";
 
 const test = spec.world(streamedMarkdown, { timeout: 300_000 });
@@ -28,9 +28,13 @@ function expectSettledDocument(visibleText: string) {
 }
 
 test("a streaming answer renders as markdown block by block and settles to the same document", async ({ user, probe, step }) => {
+  await using transcript = await observeTranscript(probe, [
+    { role: "user", text: prompt },
+    ...blockSentinels.map((text): { role: "assistant"; text: string } => ({ role: "assistant", text })),
+  ]);
   await user.type("composer", prompt);
   await user.click("Run task");
-  await user.see({ text: prompt }, { timeoutMs: 30_000 });
+  await user.see({ text: prompt }, { timeoutMs: 2_000 });
 
   await step("finished blocks render as markdown while later blocks are still arriving", async () => {
     await user.see({ text: headingText }, { timeoutMs: 90_000 });
@@ -47,10 +51,20 @@ test("a streaming answer renders as markdown block by block and settles to the s
     await user.notSee({ text: /Something went wrong/ });
   });
 
+  await step("sent text and streamed blocks never disappear or duplicate", async () => {
+    expect(await transcript.finish()).toMatchObject({
+      seen: [true, ...blockSentinels.map(() => true)],
+      violations: [],
+      stopped: false,
+      frames: expect.any(Number),
+    });
+  });
+
   await step("history renders the same document after a reload", async () => {
     await user.reload();
     await user.see({ text: closingText }, { timeoutMs: 120_000 });
     expectSettledDocument(await probe.text());
+    await user.see({ text: prompt });
     await user.see({ text: headingText });
   });
 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { join, resolve } from "node:path";
 import { evalIn } from "@openwork/behaviors";
-import type { Seed } from "@openwork/env";
+import { resolveEvalEngine, type Seed } from "@openwork/env";
 import type { MockAgentWorkload } from "@openwork/labs";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -561,6 +561,7 @@ export async function streamedMarkdown(seed: Seed) {
       promptMarker: streamedMarkdownMarker,
       finalReply: streamedMarkdownAnswer,
       finalReplyChunkSize: 8,
+      finalReplyDelayMs: 1500,
       steps: [],
     }],
   });
@@ -577,6 +578,26 @@ export async function streamedMarkdown(seed: Seed) {
       },
     },
   });
+  const engine = resolveEvalEngine();
+  const ready = await seed.evalIn(app, `async (workspaceId, engine, providerId, modelId) => {
+    const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
+    const headers = { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") };
+    const deadline = Date.now() + 60000;
+    while (Date.now() < deadline) {
+      const status = await (await fetch(base + "/experimental/engine-v2-preview/status", { headers })).json();
+      if (engine === "v1" && !status.chatRouting) return true;
+      if (engine === "v2" && status.running && status.chatRouting) {
+        const response = await fetch(base + "/workspace/" + workspaceId + "/opencode2/api/model", { headers });
+        if (response.ok) {
+          const catalog = JSON.stringify(await response.json());
+          if (catalog.includes(providerId) && catalog.includes(modelId)) return true;
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+    return false;
+  }`, { args: [workspace.workspaceId, engine, providerId, modelId], awaitPromise: true, timeoutMs: 65000 });
+  if (ready !== true) throw new Error(`Selected ${engine} engine was not ready for the streaming journey`);
   const session = await seedSessionRetry(seed, app);
   return { app, den, workspace, session };
 }

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -202,7 +202,10 @@ function validateAgentWorkloads(value) {
       }
       return { tool: step.tool.trim(), arguments: structuredClone(step.arguments), argumentsFrom: step.argumentsFrom };
     });
-    return { promptMarker, finalReply, finalReplyChunkSize, steps, latestUserTurn: workload.latestUserTurn === true };
+    const finalReplyDelayMs = workload.finalReplyDelayMs ?? 0;
+    if (!Number.isInteger(finalReplyDelayMs) || finalReplyDelayMs < 0 || finalReplyDelayMs > 10000)
+      throw new Error("finalReplyDelayMs must be between 0 and 10000");
+    return { promptMarker, finalReply, finalReplyChunkSize, finalReplyDelayMs, steps, latestUserTurn: workload.latestUserTurn === true };
   });
 }
 
@@ -350,6 +353,7 @@ async function handleAgentCompletion(req, res, entry) {
   }
   if (!workload) throw new Error("matched agent workload disappeared");
   if (completedTools >= workload.steps.length) {
+    if (workload.finalReplyDelayMs) await new Promise(resolve => setTimeout(resolve, workload.finalReplyDelayMs));
     entry.agentCompletion = { ...baseRequest, kind: "final", promptMarker: workload.promptMarker, toolName: null, arguments: {} };
     agentStream(res, model, [
       agentChunk(model, { role: "assistant" }),


### PR DESCRIPTION
The streaming journey previously waited for the submitted message once and then checked the completed answer. A message could disappear during loading and reappear at completion without failing the test.

This extends that existing journey with a reusable rendered-frame transcript observer, a two-second first-message bound, delayed provider headers, and checks that observed user text and completed answer blocks never disappear or duplicate. Reload must retain the submitted message too. Both engine lanes use identical assertions; the world verifies the selected engine is ready. The same journey supports v1 and v2 through OPENWORK_EVAL_ENGINE. This PR makes no CI workflow changes. Mandatory suite selection and engine matrices need a general policy, outside this PR.

This PR changes test coverage only. No product fix is included. Runtime verdict is **Failed on v2**: after Send, the desktop shows Working and Stop but the submitted user text is absent for the full two-second assertion window. This reproduces the reported missing-message behavior. The user explicitly requested landing this coverage-only PR with the known regression documented. The product fix remains separate; assertions have not been weakened.

Validation:
- `node --check scripts/mock-oauth-mcp-server.mjs`: passed.
- `git diff --check`: passed.
- `OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_REF=test/chat-continuity-proof pnpm evals:e2e streamed-markdown-answer --daytona`: **Passed**, 1 passed / 0 failed / 0 skipped, 255.22s, on final commit `a70c68f05f3c195e45c69f4695bb5b65bd8c2845`. Both engine results are retained in the evidence comment.
- Same command with `OPENWORK_EVAL_ENGINE=v2`: **Failed**, 0 passed / 1 failed / 0 skipped, 229.30s, on `a70c68f05f3c195e45c69f4695bb5b65bd8c2845`. Published evidence shows the failed user-visible assertion.
- `pnpm evals:typecheck`: exits 2 with 311 errors, exactly matching untouched base `aadaff153` using the same installation steps and command; zero branch-only signatures. First error: TS1294 at `apps/server/src/agent-context-cloud-probe.ts:216`.
- CodeQL input-sanitization findings were addressed by passing structured CDP arguments and are marked fixed.

The observer checks rendered transcript content, not screenshots or private engine events. It samples animation frames; it does not claim to detect changes that never reach a rendered frame.

All six owned Daytona instances were cleaned up. The previous CI checks passed; the workflow-only removal triggers fresh checks; the v2 runtime contract still fails and is explicitly documented for follow-up.

Follow-up `be06f0cd0` removes only the hardcoded implementation-path selection block. The published Daytona results are from `a70c68f05`; test, fixture, and product code are unchanged by this removal. `git diff --check` passed. Runtime tests were not repeated for this selection-rule deletion.

Follow-up `41eb3e85c` removes the remaining filename-specific engine matrix and restores the workflow exactly to the base version. The final PR has zero changes under `.github/`. Published v1/v2 runtime evidence remains from `a70c68f05`; runtime test code is unchanged by these workflow reversions.
