### PR TITLE
evals: reject missing observations and disappearing response text

### DIFF
--- a/evals/packages/behaviors/src/index.ts
+++ b/evals/packages/behaviors/src/index.ts
@@ -13,3 +13,5 @@ export * from "./sessions.ts";
 export * from "./workflows.ts";
 
 export * from "./live-openai.ts";
+
+export { observeText, textProgressFailures } from "./text-observation.ts";

--- a/evals/packages/behaviors/src/text-observation.ts
+++ b/evals/packages/behaviors/src/text-observation.ts
@@ -1,0 +1,58 @@
+import { callFunctionOnSurface } from "@openwork/cdp";
+import type { Surface } from "@openwork/cdp";
+
+/** Record changes, including empty frames, without modifying the renderer's fetch or event handlers. */
+export async function observeText(surface: Surface, selector: string, options: { ignoreExistingMessages?: boolean } = {}) {
+  const key = `text-observation-${crypto.randomUUID()}`;
+  await callFunctionOnSurface(surface, `(key, selector, ignoreExisting) => {
+    const previous = new Set(ignoreExisting ? [...document.querySelectorAll(selector)].map(node => node.closest('[data-message-id]')?.getAttribute('data-message-id')) : []);
+    const state = { samples: [], frames: 0, expired: false, overflow: false };
+    let frame;
+    const sample = () => {
+      const text = [...document.querySelectorAll(selector)]
+        .filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== 'hidden')
+        .filter(node => !previous.has(node.closest('[data-message-id]')?.getAttribute('data-message-id')))
+        .map(node => (node.innerText ?? node.textContent ?? '').trim()).join('\\n');
+      state.frames++;
+      if (state.samples.at(-1) !== text) {
+        if (state.samples.length < 2048) state.samples.push(text);
+        else state.overflow = true;
+      }
+      frame = requestAnimationFrame(sample);
+    };
+    sample();
+    const timer = setTimeout(() => { cancelAnimationFrame(frame); state.expired = true; }, 180000);
+    window[key] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
+  }`, [key, selector, options.ignoreExistingMessages === true]);
+  return {
+    async finish(): Promise<string[]> {
+      const value = await callFunctionOnSurface(surface, `(key) => {
+        const observer = window[key];
+        if (!observer) throw new Error('Text observation was lost');
+        observer.stop(); delete window[key]; return observer.state;
+      }`, [key]);
+      if (!value || typeof value !== "object" || !("samples" in value) || !Array.isArray(value.samples)
+        || !value.samples.every((item): item is string => typeof item === "string")
+        || !("frames" in value) || typeof value.frames !== "number" || value.frames < 2
+        || !("expired" in value) || value.expired !== false || !("overflow" in value) || value.overflow !== false)
+        throw new Error("Text observation was incomplete or malformed");
+      return value.samples;
+    },
+    async [Symbol.asyncDispose]() {
+      await callFunctionOnSurface(surface, `(key) => { window[key]?.stop(); delete window[key]; }`, [key]);
+    },
+  };
+}
+
+/** Once text appears, every subsequent frame must extend it toward the independent expected answer. */
+export function textProgressFailures(samples: readonly string[], expected: string): string[] {
+  const failures: string[] = [];
+  let previous = "";
+  for (const text of samples) {
+    if (!expected.startsWith(text)) failures.push(`Unexpected answer: ${JSON.stringify(text)}`);
+    if (!text.startsWith(previous)) failures.push(`Text disappeared or shrank: ${JSON.stringify(previous)} -> ${JSON.stringify(text)}`);
+    previous = text;
+  }
+  if (!expected || previous !== expected) failures.push("The complete expected answer was not observed");
+  return failures;
+}

--- a/evals/packages/behaviors/test/text-observation.test.ts
+++ b/evals/packages/behaviors/test/text-observation.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { textProgressFailures } from "../src/text-observation.ts";
+
+test("streaming proof permits loading before output and repeated frames", () => {
+  assert.deepEqual(textProgressFailures(["", "", "Hello", "Hello", "Hello world"], "Hello world"), []);
+});
+test("streaming proof rejects blank, shrinking, substituted, duplicate, and incomplete output", () => {
+  for (const samples of [
+    ["Hello", "", "Hello world"], ["Hello wor", "Hello", "Hello world"],
+    ["Other answer", "Hello world"], ["Hello world\nHello world"], [""], [], ["Hello"],
+  ]) assert.ok(textProgressFailures(samples, "Hello world").length > 0, JSON.stringify(samples));
+});
+
+import { runInNewContext } from "node:vm";
+import type { Surface } from "@openwork/cdp";
+import { observeText } from "../src/text-observation.ts";
+
+test("the browser observer retains an empty frame between visible text frames", async () => {
+  let text = "";
+  let frame: (() => void) | undefined;
+  const page = {
+    window: {},
+    document: { querySelectorAll: () => text ? [{ innerText: text, getClientRects: () => [{}], closest: () => null }] : [] },
+    getComputedStyle: () => ({ visibility: "visible" }),
+    requestAnimationFrame: (callback: () => void) => { frame = callback; return 1; },
+    cancelAnimationFrame: () => {}, setTimeout: () => 1, clearTimeout: () => {},
+  };
+  const surface: Surface = {
+    handle: { name: "text", kind: "electron", hostKind: "test", cdpUrl: "http://127.0.0.1:1" },
+    client: {
+      async send(method, params = {}) {
+        if (method === "Runtime.evaluate") return { result: { objectId: "page" } };
+        if (typeof params.functionDeclaration !== "string" || !Array.isArray(params.arguments)) throw new Error("Unexpected CDP invocation");
+        const fn: unknown = runInNewContext(`(${params.functionDeclaration})`, page);
+        if (typeof fn !== "function") throw new Error("Browser evaluation was not a function");
+        const args = params.arguments.map((arg: unknown) => arg && typeof arg === "object" && "value" in arg ? arg.value : undefined);
+        return { result: { value: fn(...args) } };
+      }, close() {},
+    },
+  };
+  await using observation = await observeText(surface, '[data-message-role="assistant"]');
+  for (const value of ["Hello", "", "Hello world"]) { text = value; frame?.(); }
+  const samples = await observation.finish();
+  assert.equal(JSON.stringify(samples), JSON.stringify(["", "Hello", "", "Hello world"]));
+  assert.ok(textProgressFailures(samples, "Hello world").length > 0);
+});

--- a/evals/packages/cdp/src/input.ts
+++ b/evals/packages/cdp/src/input.ts
@@ -131,6 +131,8 @@ function numberField(value: Record<string, unknown>, key: string): number | null
   return typeof value[key] === "number" && Number.isFinite(value[key]) ? value[key] : null;
 }
 
+export class TargetNotFoundError extends Error {}
+
 export async function locate(surface: Surface, target: Target): Promise<Located> {
   const parsed = JSON.stringify(parseTarget(target));
   const value = await callFunctionOnSurface(surface, `(serialized) => {
@@ -263,7 +265,7 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
       ? value.candidates.filter((candidate): candidate is string => typeof candidate === "string").slice(0, 8)
       : [];
     const candidateDetail = candidates.length > 0 ? ` Visible button/link candidates: ${candidates.join(", ")}.` : "";
-    throw new Error(`Could not locate ${JSON.stringify(typeof target === "string" ? target : parseTarget(target))}.${candidateDetail}`);
+    throw new TargetNotFoundError(`Could not locate ${JSON.stringify(typeof target === "string" ? target : parseTarget(target))}.${candidateDetail}`);
   }
   if (!isRecord(value) || !isRecord(value.center) || !isRecord(value.rect)) {
     throw new Error(`Could not locate ${JSON.stringify(typeof target === "string" ? target : parseTarget(target))}.`);
@@ -387,4 +389,19 @@ export async function waitForLocated(
   }
   const detail = lastError instanceof Error ? ` ${lastError.message}` : "";
   throw new Error(`Timed out after ${timeoutMs}ms locating target.${detail}`);
+}
+
+/** Require every inspection in the interval to observe a missing or hidden target. */
+export async function assertAbsent(surface: Surface, target: Target, timeoutMs = 3000): Promise<void> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("Absence observation requires a positive duration");
+  const deadline = Date.now() + timeoutMs;
+  do {
+    try {
+      const found = await locate(surface, target);
+      if (found.visible) throw new Error(`Target remained visible: ${JSON.stringify(target)}`);
+    } catch (error) {
+      if (!(error instanceof TargetNotFoundError)) throw error;
+    }
+    await new Promise(resolve => setTimeout(resolve, Math.min(100, Math.max(0, deadline - Date.now()))));
+  } while (Date.now() < deadline);
 }

--- a/evals/packages/cdp/test/input.test.ts
+++ b/evals/packages/cdp/test/input.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { locate, mapKey, parseTarget, waitForLocated } from "../src/input.ts";
+import { assertAbsent, locate, TargetNotFoundError, mapKey, parseTarget, waitForLocated } from "../src/input.ts";
 import type { Surface } from "../src/surface.ts";
 
 function surfaceReturning(value: unknown): Surface {
@@ -87,4 +87,31 @@ test("waitForLocated identifies the element covering a visible target", async ()
     waitForLocated(surface, "Run task", { mustHitTest: true, timeoutMs: 10 }),
     /visible=true, hitTestOk=false\. Covered by div role="dialog" text="Blocking overlay"/,
   );
+});
+
+
+test("only a successful browser inspection can report a missing target", async () => {
+  await assert.rejects(locate(surfaceReturning({ notFound: true }), "Missing"), TargetNotFoundError);
+  await assert.rejects(locate(surfaceReturning(null), "Missing"), error =>
+    error instanceof Error && !(error instanceof TargetNotFoundError));
+  const disconnected = surfaceReturning(null);
+  disconnected.client.send = async () => { throw new Error("CDP disconnected"); };
+  await assert.rejects(locate(disconnected, "Missing"), /CDP disconnected/);
+});
+
+
+test("absence never turns disconnection or malformed browser results into a pass", async () => {
+  await assertAbsent(surfaceReturning({ notFound: true }), "Missing", 10);
+  await assert.rejects(assertAbsent(surfaceReturning(null), "Missing", 10), /Could not locate/);
+  await assert.rejects(assertAbsent(surfaceReturning({ center: {}, rect: {} }), "Missing", 10), /invalid located-element geometry/);
+  const disconnected = surfaceReturning(null);
+  disconnected.client.send = async () => { throw new Error("CDP disconnected"); };
+  await assert.rejects(assertAbsent(disconnected, "Missing", 10), /CDP disconnected/);
+  await assert.rejects(assertAbsent(surfaceReturning(null), "Missing", 0), /positive duration/);
+});
+
+test("absence distinguishes a hidden target from a visible target", async () => {
+  const target = { center: { x: 1, y: 1 }, rect: { x: 0, y: 0, width: 2, height: 2 }, tag: "div", name: "Error", visible: false, hitTestOk: false, editable: false, value: "", text: "Error", covering: null };
+  await assertAbsent(surfaceReturning(target), "Error", 10);
+  await assert.rejects(assertAbsent(surfaceReturning({ ...target, visible: true }), "Error", 10), /remained visible/);
 });

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -99,6 +99,8 @@ export interface StartMockMcpOptions {
   appToolName?: string;
   /** Script deterministic OpenAI-compatible agent turns through this mock. */
   agentWorkloads?: MockAgentWorkload[];
+  /** Verify native provider requests retain this private model header. */
+  agentRequiredHeader?: { name: string; value: string };
 }
 
 export type EnterpriseMcpProfileId =
@@ -348,7 +350,7 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
     const response = await fetch(`${url}/admin/agent-workloads`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ workloads: options.agentWorkloads }),
+      body: JSON.stringify({ workloads: options.agentWorkloads, requiredHeader: options.agentRequiredHeader }),
       signal: AbortSignal.timeout(15_000),
     });
     if (!response.ok) {

--- a/evals/packages/labs/test/mock-mcp.test.ts
+++ b/evals/packages/labs/test/mock-mcp.test.ts
@@ -129,3 +129,26 @@ test("turn-scoped workloads isolate revisions from earlier markers and tool roun
   assert.deepEqual(requests.map((request) => request.completedTools), [0, 1]);
   assert.deepEqual(requests.map((request) => request.matchedMarkers), [["revise sketch"], ["revise sketch"]]);
 });
+
+
+test("native Responses preserve the configured provider header", async () => {
+  await using mock = await startMockMcp({
+    port: await allocateFreePort(),
+    agentWorkloads: [{ promptMarker: "native-header-proof", finalReply: "The header reached the provider", steps: [] }],
+    agentRequiredHeader: { name: "x-private-model-setting", value: "fixture-only-value" },
+  });
+  const request = (header?: string) => fetch(`${mock.url}/v1/responses`, {
+    method: "POST", headers: { "content-type": "application/json", ...(header ? { "x-private-model-setting": header } : {}) },
+    body: JSON.stringify({ model: "native-fixture", input: "native-header-proof", stream: true }),
+  });
+  for (const header of [undefined, "wrong-value"]) {
+    const denied = await request(header);
+    assert.equal(denied.status, 401);
+    await denied.text();
+  }
+  const accepted = await request("fixture-only-value");
+  assert.equal(accepted.status, 200);
+  const events = (await accepted.text()).split("\n").filter(line => line.startsWith("data: ")).map(line => JSON.parse(line.slice(6)));
+  assert.ok(events.some(event => event.type === "response.completed"));
+  assert.equal(events.filter(event => event.type === "response.output_text.delta").map(event => event.delta).join(""), "The header reached the provider");
+});

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -17,6 +17,7 @@ import {
   evaluateOnSurface,
   hoverAt,
   locate,
+  assertAbsent,
   navigate,
   pressKey,
   reload,
@@ -586,8 +587,6 @@ export class SeedChannel implements Seed {
   }
 }
 
-class VisibleTargetError extends Error {}
-
 export class UserChannel implements User {
   readonly #runtime: SpecRuntime;
   readonly #surface: Surface | null;
@@ -681,17 +680,7 @@ export class UserChannel implements User {
   notSee(target: Target, options: { timeoutMs?: number } = {}): Promise<void> {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("user", "notSee", `notSee(${targetDetail(target)})`, surface, async () => {
-      const timeoutMs = options.timeoutMs ?? 3_000;
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        try {
-          const found = await locate(surface, target);
-          if (found.visible) throw new VisibleTargetError(`${targetDetail(target)} remained visible. On screen: ${await dumpScreenState(surface)}.`);
-        } catch (error) {
-          if (error instanceof VisibleTargetError) throw error;
-        }
-        await new Promise((resolve) => setTimeout(resolve, Math.min(100, Math.max(0, deadline - Date.now()))));
-      }
+      await assertAbsent(surface, target, options.timeoutMs ?? 3_000);
     });
   }
 

--- a/evals/specs/cloud-provider-sync-contract.e2e.test.ts
+++ b/evals/specs/cloud-provider-sync-contract.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect, onTestFinished } from "vitest";
-import { control, denFetch, evalIn, go, readAvailableModels, selectModel, sendComposerMessage, waitFor } from "@openwork/behaviors";
+import { observeText, textProgressFailures, control, denFetch, evalIn, go, readAvailableModels, selectModel, sendComposerMessage, waitFor } from "@openwork/behaviors";
 import type { DenSession, ModelFacts } from "@openwork/behaviors";
 import { screenshot, validate } from "@openwork/test-evidence";
 import { app, eventually, mcpMock, needs, server, sleep, test, unmetNeeds } from "@openwork/testkit";
@@ -581,27 +581,13 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
     "The selected catalog provider/model stayed unchanged through Settings, cloud refresh, native v2 mirroring and routing refresh; zero default writes, unavailable warnings or maximum-depth errors were observed.", true,
   );
   await selectModel(desktopApp, CUSTOM_MODEL_ID, { provider: CUSTOM_PROVIDER_NAME });
-  await evalIn(desktopApp, `(() => {
-    window.__responseFrames = [];
-    const record = () => {
-      for (const element of document.querySelectorAll('[data-message-role="assistant"] .prose')) {
-        const text = element.textContent.trim();
-        if (text && window.__responseFrames.at(-1) !== text) window.__responseFrames.push(text);
-      }
-    };
-    window.__responseObserver = new MutationObserver(record);
-    window.__responseObserver.observe(document.body, { subtree: true, childList: true, characterData: true });
-  })()`);
+  await using responseObservation = await observeText(desktopApp, '[data-message-role="assistant"] .prose');
   await sendComposerMessage(desktopApp, `Reply to the request marked ${promptMarker}.`);
   await waitFor(desktopApp, `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).some((row) => row.textContent.includes(${JSON.stringify(finalReply)}))`, { timeoutMs: 120_000, label: "native provider reply in the v2 transcript" });
   await sleep(2_000); // includes the streamed-to-persisted message reconciliation
-  const frames = await evalIn(desktopApp, `(() => {
-    window.__responseObserver.disconnect();
-    return window.__responseFrames;
-  })()`);
-  expect(Array.isArray(frames) && frames.length > 0).toBe(true);
-  expect(Array.isArray(frames) && frames.every((frame) => typeof frame === "string" && finalReply.startsWith(frame)), JSON.stringify(frames)).toBe(true);
-  evidence.recordAssertionEvidence("streamed assistant text does not flash a different answer before the saved response", "Every observed assistant text frame was a prefix of the independent witness reply, including two seconds after completion; no unrelated or substituted response appeared.", true);
+  const frames = await responseObservation.finish();
+  expect(textProgressFailures(frames, finalReply), JSON.stringify(frames)).toEqual([]);
+  evidence.recordAssertionEvidence("streamed assistant text does not flash a different answer before the saved response", "Observed frames included empty states and never shrank after text appeared; the independent expected reply completed without replacement, including two seconds after completion.", true);
   const nativeRequests = await den.mocks.agent.agentRequests({ promptMarker, atLeast: 1, timeoutMs: 10_000 });
   expect(nativeRequests.some((request) => request.model === CUSTOM_MODEL_ID && request.kind === "final")).toBe(true);
   expect(nativeRequests.some((request) => request.model !== CUSTOM_MODEL_ID || request.kind === "error")).toBe(false);
@@ -691,20 +677,7 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   // env-store rotation with the fixture organization's unchanged secret.
   await go(desktopApp, nativeSessionRoute);
   await waitFor(desktopApp, `Array.from(document.querySelectorAll('[data-message-role="assistant"] .prose')).some((row) => row.textContent.trim() === ${JSON.stringify(finalReply)})`, { timeoutMs: 30_000, label: "original reply restored before continuing the conversation" });
-  await evalIn(desktopApp, `(() => {
-    const priorMessages = new Set(Array.from(document.querySelectorAll('[data-message-role="assistant"]'), (row) => row.getAttribute("data-message-id")));
-    window.__rotationFrames = [];
-    window.__rotationObserver = new MutationObserver(() => {
-      for (const row of document.querySelectorAll('[data-message-role="assistant"]')) {
-        if (priorMessages.has(row.getAttribute("data-message-id"))) continue;
-        for (const element of row.querySelectorAll('.prose')) {
-          const text = element.textContent.trim();
-          if (text && window.__rotationFrames.at(-1) !== text) window.__rotationFrames.push(text);
-        }
-      }
-    });
-    window.__rotationObserver.observe(document.body, { subtree: true, childList: true, characterData: true });
-  })()`);
+  await using rotationObservation = await observeText(desktopApp, '[data-message-role="assistant"] .prose', { ignoreExistingMessages: true });
   const rotatedMarker = `${promptMarker}-rotated`;
   const rotatedReply = `ROTATED-REPLY-${Date.now()}`;
   const rotatedKey = "sk-openwork-sync-contract-rotated-eval-only";
@@ -730,9 +703,8 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   await sendComposerMessage(desktopApp, `Reply to the request marked ${rotatedMarker}.`);
   await waitFor(desktopApp, `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).some((row) => row.textContent.includes(${JSON.stringify(rotatedReply)}))`, { timeoutMs: 120_000, label: "reply after credential rotation" });
   await sleep(2_000);
-  const rotationFrames = await evalIn(desktopApp, `(() => { window.__rotationObserver.disconnect(); return window.__rotationFrames; })()`);
-  expect(Array.isArray(rotationFrames) && rotationFrames.length > 0).toBe(true);
-  expect(Array.isArray(rotationFrames) && rotationFrames.every((frame) => typeof frame === "string" && rotatedReply.startsWith(frame)), JSON.stringify(rotationFrames)).toBe(true);
+  const rotationFrames = await rotationObservation.finish();
+  expect(textProgressFailures(rotationFrames, rotatedReply), JSON.stringify(rotationFrames)).toEqual([]);
   expect(await evalIn(desktopApp, `document.querySelectorAll('[data-message-role="assistant"]').length >= 2 && Array.from(document.querySelectorAll('[data-message-role="assistant"] .prose')).some((row) => row.textContent.trim() === ${JSON.stringify(finalReply)})`)).toBe(true);
   evidence.recordAssertionEvidence("a second assistant response never substitutes the previous answer or overwrites it", "Every new response frame matched only the independent second reply; after completion the first answer remained intact in a separate assistant message.", true);
   const rotatedRequests = await den.mocks.agent.agentRequests({ promptMarker: rotatedMarker, sinceIso: rotatedAt, atLeast: 1 });

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -51,6 +51,7 @@ const refreshTokens = new Set();
 const requests = [];
 const drafts = [];
 let agentWorkloads = [];
+let agentRequiredHeader = null;
 let configuredTools = [];
 
 const gmailThreadId = "thread-q3-launch";
@@ -934,7 +935,14 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/admin/agent-workloads" && req.method === "POST") {
       const body = await readJson(req);
+      const requiredHeader = body?.requiredHeader;
+      if (requiredHeader !== undefined && (!requiredHeader || typeof requiredHeader.name !== "string"
+        || !requiredHeader.name.trim() || typeof requiredHeader.value !== "string" || !requiredHeader.value)) {
+        json(res, 400, { error: "requiredHeader needs a name and value" });
+        return;
+      }
       agentWorkloads = validateAgentWorkloads(body?.workloads);
+      agentRequiredHeader = requiredHeader ?? null;
       json(res, 200, { configured: agentWorkloads.length });
       return;
     }


### PR DESCRIPTION
Two observation gaps could let the evals pass while the app was broken: `user.notSee()` swallowed browser-inspection failures, and cloud-provider response observers dropped empty frames and accepted shrinking prefixes.

Absence now accepts only an observed hidden target or a typed target-not-found result. Transport failures and malformed results propagate. A shared rendered-text observer records empty states, checks its sampling health, and verifies monotonic progress to the complete expected answer. The existing provider-sync journey uses it for both initial output and output after credential rotation.

The native Responses fixture also referenced an undefined header setting and did not receive that setting from its boot options. The fixture now carries the setting through; checks verify missing/wrong headers fail while the expected header permits streaming. The original HTTP 500 was reproduced on the clean base before this repair.

Validation on final commit b5aa90d392436a53c1ae29c44bf2a169c1640e3d:

- 14 focused absence, rendered-text, and mock tests passed.
- Daytona `cloud-provider-sync-contract`: 1 passed, 0 failed, 0 skipped (582.41s). Proves native v2 inference, both response-continuity assertions, credential rotation in the same conversation, and return to v1.
- Daytona `den-command-palette`: 1 passed, 0 failed, 0 skipped (214.16s). Exercises the shared absence primitive through the existing UI journey.
- Eval typecheck reports 310 errors versus 311 on the clean base, with no new signatures; the fixture option repair removes one error. This is an existing baseline failure, not a passing typecheck.

Runtime verdict: Passed. Evidence for both final-commit journeys is published in the test-evidence comment. Required CI and Warden review are green.
