### PR TITLE
evals: prove Connect skill use through the signed-in desktop

### DIFF
--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -24,7 +24,7 @@ export interface MockToolCall {
 
 export interface MockAgentToolStep {
   /** Derive the handoff from the actual model input instead of fixture arguments. */
-  argumentsFrom?: "computer-mention";
+  argumentsFrom?: "computer-mention" | "capability-search";
   tool: string;
   arguments: Record<string, unknown>;
 }
@@ -34,6 +34,8 @@ export interface MockAgentWorkload {
   latestUserTurn?: boolean;
   promptMarker: string;
   finalReply: string;
+  /** Return text actually delivered by the engine after its last tool invocation. */
+  finalReplyFrom?: "last-tool-text";
   /** Stream the final reply as consecutive content deltas of this many characters instead of one. */
   finalReplyChunkSize?: number;
   /** Hold the final response before sending headers, to exercise loading transitions. */

--- a/evals/specs/connect-readiness-preseeded.e2e.test.ts
+++ b/evals/specs/connect-readiness-preseeded.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "vitest";
+import { readAvailableModels, selectModel } from "@openwork/behaviors";
 import { spec } from "@openwork/testkit";
 import {
   cloudHealthExpression,
@@ -10,15 +11,15 @@ import {
   toolJson,
 } from "../worlds/library.ts";
 
-const test = spec.world(preseededConnect, { timeout: 360_000 });
+const test = spec.world(preseededConnect, { timeout: 600_000 });
 
-test("bundled engine connects to preseeded organization skills and connections", async ({ world, user, seed, probe, step }) => {
+test("bundled engine connects to preseeded organization skills and connections", async ({ world, user, agent, seed, probe, step, evidence }) => {
   await user.click("Library");
   await user.see({ text: "Library" });
   const signedOut = await probe.connectState(world.app);
   expect(signedOut).toMatchObject({ status: "missing", connectEnabled: false });
   expect(signedOut).not.toMatchObject({ status: "available" });
-  await user.looks(["The OpenWork desktop is visible", "No crash or error dialog is visible"]);
+  await user.screenshot();
 
   await seed.signIn(world.app, world.member, "admin");
   const signedIn = await probe.eventually(
@@ -104,15 +105,38 @@ test("bundled engine connects to preseeded organization skills and connections",
   });
   if (!connectionMatch) throw new Error(`Connect did not discover ${world.connectionName}.`);
   const connectionStatus = isRecord(connectionMatch.connectionStatus) ? connectionMatch.connectionStatus : null;
-  const readiness = connectionStatus?.state === "needs_connection" && connectionStatus.actor === "member"
-    ? "needs_signin"
-    : connectionStatus?.actor === "organization_admin" ? "needs_admin_setup" : "ready";
-  expect(["ready", "needs_signin", "needs_admin_setup"]).toContain(readiness);
+  expect(connectionStatus).toMatchObject({
+    state: "needs_connection", actor: "member", credentialMode: "per_member",
+    connectionId: world.connection.id, connectionName: world.connectionName,
+    action: { type: "connect", surface: "openwork_your_connections" },
+  });
+  evidence.recordAssertionEvidence("An unconnected member-owned connection requires member sign-in",
+    JSON.stringify(connectionStatus), true);
 
   await user.click("Library");
   await user.see({ text: world.connectionName }, { timeoutMs: 60_000 });
-  await user.looks([
-    `A Library view lists an organization connection card named '${world.connectionName}'`,
-    "No crash or error dialog is visible",
-  ]);
+  await user.screenshot();
+
+  await step("the signed-in desktop agent discovers and reads the skill", async () => {
+    expect(world.prompt).not.toContain(world.pluginId);
+    expect(world.prompt).not.toContain(world.proofPhrase);
+    await agent.createSession();
+    await probe.eventually(() => readAvailableModels(world.app), {
+      within: 120_000, label: "the published model reaches the signed-in desktop",
+      until: models => models.some(model => model.name === world.modelId && model.selectable),
+    });
+    await selectModel(world.app, world.modelId, { provider: world.providerName });
+    await agent.send(world.prompt);
+    await user.see({ text: world.proofPhrase }, { timeoutMs: 120_000 });
+    const calls = await world.den.mocks.connector.agentRequests({ promptMarker: world.prompt });
+    const tools = calls.filter(call => call.kind === "tool");
+    expect(tools).toHaveLength(2);
+    expect(tools[0]?.toolName).toMatch(/search_capabilities$/);
+    expect(tools[1]?.toolName).toMatch(/execute_capability$/);
+    expect(tools[1]?.arguments.name).toMatch(new RegExp(`^plugin:${world.pluginId}:`));
+    expect(calls.some(call => call.kind === "final" && call.completedTools === 2)).toBe(true);
+    evidence.recordAssertionEvidence("The desktop agent uses the assigned organization skill",
+      "The model was offered search and execute, resolved the capability from its search result, and displayed the unique phrase returned by skill execution.", true);
+    await user.screenshot();
+  });
 });

--- a/evals/specs/connect-readiness-preseeded.e2e.test.ts
+++ b/evals/specs/connect-readiness-preseeded.e2e.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { readAvailableModels, selectModel } from "@openwork/behaviors";
-import { spec } from "@openwork/testkit";
+import { observeTranscript, spec } from "@openwork/testkit";
 import {
   cloudHealthExpression,
   isRecord,
@@ -126,8 +126,11 @@ test("bundled engine connects to preseeded organization skills and connections",
       until: models => models.some(model => model.name === world.modelId && model.selectable),
     });
     await selectModel(world.app, world.modelId, { provider: world.providerName });
+    await using transcript = await observeTranscript(probe, [{ role: "assistant", text: world.proofPhrase }]);
     await agent.send(world.prompt);
-    await user.see({ text: world.proofPhrase }, { timeoutMs: 120_000 });
+    await user.see({ text: new RegExp(world.proofPhrase) }, { timeoutMs: 120_000 });
+    await user.see("Run task", { timeoutMs: 60_000 });
+    expect(await transcript.finish()).toMatchObject({ seen: [true], stopped: false });
     const calls = await world.den.mocks.connector.agentRequests({ promptMarker: world.prompt });
     const tools = calls.filter(call => call.kind === "tool");
     expect(tools).toHaveLength(2);

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -242,11 +242,23 @@ export async function connectStateProvenance(seed: Seed) {
 export async function preseededConnect(seed: Seed) {
   const stamp = Date.now();
   const skillName = `preseeded-connect-proof-${stamp}`;
-  const connectionName = `PR3806 conn ${String(stamp).slice(-6)}`;
-  const rawSourceText = `---\nname: ${skillName}\ndescription: Proves preseeded Connect skill discovery.\n---\n\nReturn the preseeded Connect proof phrase.`;
+  const connectionName = `Preseeded connection ${String(stamp).slice(-6)}`;
+  const proofPhrase = `Connect skill proof ${crypto.randomUUID()}`;
+  const prompt = `Find and read the organization skill named ${skillName}.`;
+  const providerName = "Connect discovery model";
+  const modelId = "connect-discovery-model";
+  const rawSourceText = `---\nname: ${skillName}\ndescription: Proves preseeded Connect skill discovery.\n---\n\nReturn this exact phrase: ${proofPhrase}.`;
   const den = await seed.den({
     org: { name: `Preseeded Connect ${stamp}`, admin: { name: "Connect Admin" } },
-    mocks: { connector: seed.mock() },
+    mocks: { connector: seed.mock({ agentWorkloads: [{
+      promptMarker: prompt,
+      finalReply: "The skill was read.",
+      finalReplyFrom: "last-tool-text",
+      steps: [
+        { tool: "search_capabilities", arguments: { query: skillName, limit: 1, type: "skills" } },
+        { tool: "execute_capability", arguments: {}, argumentsFrom: "capability-search" },
+      ],
+    }] }) },
   });
   const organizationId = await activeOrganizationId(seed, den.admin);
   const createdSkill = await seed.api(den.admin, "/v1/plugins", {
@@ -267,6 +279,19 @@ export async function preseededConnect(seed: Seed) {
     credentialMode: "per_member",
     access: { orgWide: true },
   });
+  const provider = await seed.api(den.admin, "/v1/llm-providers", {
+    method: "POST",
+    headers: { "x-openwork-org-id": organizationId },
+    body: JSON.stringify({
+      name: providerName, source: "custom", allMembers: true, memberIds: [], teamIds: [],
+      apiKey: "sk-openwork-connect-eval-only",
+      customConfig: { id: "connect-discovery", name: providerName, npm: "@ai-sdk/openai-compatible",
+        options: { baseURL: `${den.mocks.connector.url}/v1` }, env: ["CONNECT_EVAL_API_KEY"],
+        models: [{ id: modelId, name: modelId, tool_call: true, limit: { context: 128000, output: 8192 } }],
+      },
+    }),
+  });
+  if (provider.response.status !== 201) throw new Error(`Could not publish the Connect fixture model: HTTP ${provider.response.status}`);
   const mcpSession = await mintMcpSession(seed, den, organizationId);
   const app = await seed.desktop({ den, signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("preseeded-connect"));
@@ -275,7 +300,7 @@ export async function preseededConnect(seed: Seed) {
     args: [workspace.workspaceId],
   });
   return {
-    app,
+    app, den, prompt, proofPhrase, providerName, modelId,
     admin: den.admin,
     member: den.admin,
     mcpSession,

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -190,6 +190,9 @@ function validateAgentWorkloads(value) {
     if (workload.latestUserTurn !== undefined && typeof workload.latestUserTurn !== "boolean") {
       throw new Error(`agent workload ${promptMarker} latestUserTurn must be a boolean`);
     }
+    if (workload.finalReplyFrom !== undefined && workload.finalReplyFrom !== "last-tool-text") {
+      throw new Error(`agent workload ${promptMarker} has an unknown reply source`);
+    }
     const steps = workload.steps.map((step) => {
       if (!step || typeof step !== "object" || typeof step.tool !== "string" || !step.tool.trim()) {
         throw new Error(`agent workload ${promptMarker} has an invalid tool step`);
@@ -197,7 +200,7 @@ function validateAgentWorkloads(value) {
       if (!step.arguments || typeof step.arguments !== "object" || Array.isArray(step.arguments)) {
         throw new Error(`agent workload ${promptMarker} tool ${step.tool} needs object arguments`);
       }
-      if (step.argumentsFrom !== undefined && step.argumentsFrom !== "computer-mention") {
+      if (step.argumentsFrom !== undefined && !["computer-mention", "capability-search"].includes(step.argumentsFrom)) {
         throw new Error(`agent workload ${promptMarker} has an unknown argument source`);
       }
       return { tool: step.tool.trim(), arguments: structuredClone(step.arguments), argumentsFrom: step.argumentsFrom };
@@ -205,7 +208,7 @@ function validateAgentWorkloads(value) {
     const finalReplyDelayMs = workload.finalReplyDelayMs ?? 0;
     if (!Number.isInteger(finalReplyDelayMs) || finalReplyDelayMs < 0 || finalReplyDelayMs > 10000)
       throw new Error("finalReplyDelayMs must be between 0 and 10000");
-    return { promptMarker, finalReply, finalReplyChunkSize, finalReplyDelayMs, steps, latestUserTurn: workload.latestUserTurn === true };
+    return { promptMarker, finalReply, finalReplyFrom: workload.finalReplyFrom, finalReplyChunkSize, finalReplyDelayMs, steps, latestUserTurn: workload.latestUserTurn === true };
   });
 }
 
@@ -274,6 +277,24 @@ function computerMentionArguments(messages) {
     .replace(/\s+/g, " ").trim();
   if (!prompt) throw new Error("computer task has no prompt");
   return { name: "remote-session:create", body: { target, prompt } };
+}
+
+// Resolve execution from the result the engine actually returned to the model.
+function lastToolText(messages) {
+  const message = [...messages].reverse().find((message) => message?.role === "tool");
+  const text = agentContentText(message);
+  if (!text) throw new Error("the model received no tool result");
+  return text;
+}
+
+function capabilitySearchArguments(messages) {
+  let payload = JSON.parse(lastToolText(messages));
+  if (Array.isArray(payload.content)) payload = JSON.parse(agentContentText(payload));
+  const matches = payload.matches;
+  if (!Array.isArray(matches) || matches.length !== 1 || typeof matches[0]?.name !== "string") {
+    throw new Error("capability search did not return exactly one named match");
+  }
+  return { name: matches[0].name };
 }
 
 // Native OpenAI Responses witness for plain-text workloads. Unsupported tool
@@ -357,7 +378,7 @@ async function handleAgentCompletion(req, res, entry) {
     entry.agentCompletion = { ...baseRequest, kind: "final", promptMarker: workload.promptMarker, toolName: null, arguments: {} };
     agentStream(res, model, [
       agentChunk(model, { role: "assistant" }),
-      ...finalReplyChunks(workload).map((content) => agentChunk(model, { content })),
+      ...finalReplyChunks(workload.finalReplyFrom === "last-tool-text" ? { ...workload, finalReply: lastToolText(scopedMessages) } : workload).map((content) => agentChunk(model, { content })),
       agentChunk(model, {}, "stop"),
     ]);
     return;
@@ -369,7 +390,8 @@ async function handleAgentCompletion(req, res, entry) {
     json(res, 400, { error: { message: `tool ${step.tool} was not offered to the mock agent` } });
     return;
   }
-  const toolArguments = step.argumentsFrom === "computer-mention" ? computerMentionArguments(messages) : step.arguments;
+  const toolArguments = step.argumentsFrom === "computer-mention" ? computerMentionArguments(messages)
+    : step.argumentsFrom === "capability-search" ? capabilitySearchArguments(scopedMessages) : step.arguments;
   const callId = `call_${workload.promptMarker.replace(/[^a-zA-Z0-9_-]/g, "_")}_${completedTools + 1}`;
   entry.agentCompletion = {
     ...baseRequest,

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -161,6 +161,39 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     assert.deepEqual(JSON.parse(call.function.arguments), { name: "remote-session:create", body: { target, prompt: task } });
   }
 
+  const discoveryWorkload = await fetch(`${origin}/admin/agent-workloads`, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ workloads: [{ promptMarker: "Find the assigned skill", finalReply: "unused fixture reply",
+      finalReplyFrom: "last-tool-text", steps: [
+        { tool: "search_capabilities", arguments: { query: "Assigned skill" } },
+        { tool: "execute_capability", arguments: {}, argumentsFrom: "capability-search" },
+      ],
+    }] }),
+  });
+  assert.equal(discoveryWorkload.status, 200);
+  const modelRequest = async (toolResults) => {
+    const response = await fetch(`${origin}/v1/chat/completions`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "discovery-model", messages: [
+        { role: "user", content: "Find the assigned skill" },
+        ...toolResults.map(content => ({ role: "tool", content })),
+      ], tools: ["search_capabilities", "execute_capability"].map(name => ({ type: "function", function: { name } })) }),
+    });
+    const body = await response.text();
+    return { status: response.status, frames: body.split("\n").filter(line => line.startsWith("data: {")).map(line => JSON.parse(line.slice(6))) };
+  };
+  for (const name of ["plugin:first:skill", "plugin:second:skill"]) {
+    const result = await modelRequest([JSON.stringify({ matches: [{ name }] })]);
+    assert.equal(result.status, 200);
+    const call = result.frames.flatMap(frame => frame.choices[0].delta.tool_calls ?? [])[0];
+    assert.deepEqual(JSON.parse(call.function.arguments), { name });
+  }
+  const missing = await modelRequest([JSON.stringify({ matches: [] })]);
+  assert.equal(missing.status, 500);
+  const final = await modelRequest([JSON.stringify({ matches: [{ name: "plugin:first:skill" }] }), "unique text returned by the real tool"]);
+  assert.equal(final.status, 200);
+  assert.equal(final.frames.map(frame => frame.choices[0].delta.content ?? "").join(""), "unique text returned by the real tool");
+
   const failedResponse = await fetch(`${origin}/admin/agent-workloads`, {
     method: "POST",
     headers: { "content-type": "application/json" },


### PR DESCRIPTION
Connect readiness previously converted any response into one of three accepted labels, including treating unknown states as ready. Its skill-execution check used a separately minted gateway session, so it could pass while the desktop model lacked Cloud tools.

The existing journey now requires the seeded, unconnected per-member connection to report `needs_connection` owned by the member. It then sends a task through the signed-in desktop, using an organization-published fixture model. The mock model must receive search and execute tools, derive the capability name from the actual search result, and display a unique phrase returned by skill execution. Neither the prompt nor the scripted answer contains that phrase. The shared transcript observer verifies that the phrase appears in the assistant response. Existing direct gateway checks remain separate boundary coverage.

The shared mock gains result-derived execution arguments and replies. Its focused test verifies changing search results, rejecting missing matches, and forwarding the tool result. No product or CI behavior changes.

Validation on final commit 29788001e6720b47621ca5384d3c2f86f17b06f4:

- Daytona `connect-readiness-preseeded`: 1 passed, 0 failed, 0 skipped (244.00s), with the default v1 engine and a deterministic model fixture. The normal desktop sign-in flow supplied the Cloud tools; the model performed both calls and displayed the actual skill result.
- The existing mock unit test passed, including result-derived execution assertions.
- Eval typecheck matched the clean control's 311 error signatures. This is a baseline failure, not a passing typecheck.

Runtime verdict: Passed. Final-commit evidence and desktop screenshots are published in the test-evidence comment. Required CI and Warden review are green.
