### PR TITLE
Fix browser views covering OpenWork

### DIFF
--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -255,6 +255,23 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     };
   }
 
+  // Read the actual native hierarchy, not the registry's intended surfacing.
+  // A tab can be logically background while its native view covers the app.
+  function browserNativeViews() {
+    const mainWindow = window();
+    const children = mainWindow?.contentView.children ?? [];
+    const appIndex = children.indexOf(mainWindow?.webContentsView);
+    return [...browserTabs.values()].map(({ tabId, view }) => {
+      const index = children.indexOf(view);
+      return {
+        tabId,
+        attached: index !== -1,
+        aboveApp: index !== -1 && index > appIndex,
+        bounds: view.getBounds(),
+      };
+    });
+  }
+
   function browserTabUrl(tab) {
     const url = tab?.view?.webContents?.getURL?.();
     return typeof url === "string" && url && url !== "about:blank" ? url : null;
@@ -619,9 +636,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   // A tab whose conversation is not on screen must still behave like a real
   // page for the agent driving it: lay out at a real viewport, accept typing as
   // a focused page, and paint so CDP screenshots work. Chromium only paints a
-  // page it considers visible, so the view keeps a one-pixel presence in the
-  // window corner (under the rounded-corner mask) while a DevTools session of
-  // ours emulates a full viewport and focus. Both are undone when the tab
+  // page it considers visible, so the view keeps a one-pixel presence behind
+  // the app renderer while a DevTools session of ours emulates a full viewport
+  // and focus. Never put this presence above the app: emulation must not make
+  // a background page intercept the user's window. Both are undone when the tab
   // returns to the screen. This is the headless-browser recipe applied to a
   // headful window.
   function enterBackgroundMode(tab) {
@@ -631,10 +649,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     tab.background = true;
     const mainWindow = window();
     if (mainWindow && !mainWindow.isDestroyed()) {
-      if (!mainWindow.contentView.children.includes(tab.view)) {
-        mainWindow.contentView.addChildView(tab.view);
-      }
       tab.view.setBounds({ ...BACKGROUND_TAB_PRESENCE_BOUNDS });
+      // addChildView also reorders an already attached foreground view.
+      mainWindow.contentView.addChildView(tab.view, 0);
     }
     const cdp = webContents.debugger;
     runDetachedTask("emulate background browser tab", async () => {
@@ -759,15 +776,15 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   function attachActiveBrowserView() {
     const mainWindow = window();
     if (!mainWindow || !browserViewVisible) return;
+    if (!lastBrowserBounds || lastBrowserBounds.width <= 0 || lastBrowserBounds.height <= 0) return;
     const tab = getBrowserTab();
     if (!tab) return;
     exitBackgroundMode(tab);
     detachIdleBrowserViews(tab.view);
+    // Size before attaching so a restored view never flashes at stale bounds.
+    tab.view.setBounds(scaleRendererBounds(lastBrowserBounds));
     if (!mainWindow.contentView.children.includes(tab.view)) {
       mainWindow.contentView.addChildView(tab.view);
-    }
-    if (lastBrowserBounds && lastBrowserBounds.width > 0 && lastBrowserBounds.height > 0) {
-      tab.view.setBounds(scaleRendererBounds(lastBrowserBounds));
     }
   }
 
@@ -935,7 +952,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         view.setBounds(scaleRendererBounds(bounds));
       }
     });
-    ipcMain.handle("openwork:browser:state", () => browserStatePayload());
+    ipcMain.handle("openwork:browser:state", () => ({ ...browserStatePayload(), nativeViews: browserNativeViews() }));
     ipcMain.handle("openwork:browser:createTab", (_event, url, sessionId) => {
       const target = typeof url === "string" && url.trim() ? url : BROWSER_NEW_TAB_URL;
       const ownerSessionId = sessionId === undefined ? registry.visibleSessionId() : normalizeSessionId(sessionId);

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -4,9 +4,9 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, WebContentsView, clipboard, session, shell } from "electron";
+import { app, BrowserWindow, WebContentsView, clipboard, session, shell } from "electron";
 import {
-  BACKGROUND_TAB_PRESENCE_BOUNDS,
+  BACKGROUND_TAB_VIEWPORT,
   backgroundTabEmulationCommands,
   createBrowserTabRegistry,
   foregroundTabEmulationCommands,
@@ -33,6 +33,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   const browserTabs = new Map();
   const registry = createBrowserTabRegistry();
   let browserViewVisible = false;
+  let backgroundWindow = null;
   // Last browser panel bounds reported by the renderer, in renderer CSS pixels.
   // Converted to window device-independent pixels at every setBounds call.
   let lastBrowserBounds = null;
@@ -622,32 +623,46 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   }
 
   function detachBrowserView(view) {
-    const mainWindow = window();
-    if (!mainWindow || !view) return;
-    try {
-      if (mainWindow.contentView.children.includes(view)) {
-        mainWindow.contentView.removeChildView(view);
+    if (!view) return;
+    for (const host of [window(), backgroundWindow]) {
+      try {
+        if (host && !host.isDestroyed() && host.contentView.children.includes(view)) {
+          host.contentView.removeChildView(view);
+        }
+      } catch {
+        // already removed
       }
-    } catch {
-      // already removed
     }
+  }
+
+  function backgroundBrowserWindow() {
+    if (!backgroundWindow || backgroundWindow.isDestroyed()) {
+      backgroundWindow = new BrowserWindow({
+        ...BACKGROUND_TAB_VIEWPORT,
+        show: false,
+        paintWhenInitiallyHidden: true,
+        focusable: false,
+        skipTaskbar: true,
+        webPreferences: { backgroundThrottling: false, sandbox: true },
+      });
+    }
+    return backgroundWindow;
   }
 
   // A tab whose conversation is not on screen must still behave like a real
   // page for the agent driving it: lay out at a real viewport, accept typing as
-  // a focused page, and paint so CDP screenshots work. Keep the native view
-  // detached while a DevTools session of ours emulates a full viewport and
-  // focus. Every child of BrowserWindow.contentView paints above the app;
-  // neither child ordering nor one-pixel bounds can isolate it. Both are undone when the tab
-  // returns to the screen. This is the headless-browser recipe applied to a
-  // headful window.
+  // a focused page, and paint so CDP screenshots work. Park it in a never-shown
+  // window: detached views stop painting, and every child of the main window's
+  // contentView paints above OpenWork, regardless of its child index or bounds.
+  // Moving the same view preserves the document and CDP target.
   function enterBackgroundMode(tab) {
     if (!tab || tab.background) return;
     const webContents = tab.view.webContents;
     if (webContents.isDestroyed()) return;
     tab.background = true;
     detachBrowserView(tab.view);
-    tab.view.setBounds({ ...BACKGROUND_TAB_PRESENCE_BOUNDS });
+    tab.view.setBounds({ x: 0, y: 0, ...BACKGROUND_TAB_VIEWPORT });
+    backgroundBrowserWindow().contentView.addChildView(tab.view);
     const cdp = webContents.debugger;
     runDetachedTask("emulate background browser tab", async () => {
       if (webContents.isDestroyed() || !tab.background) return;
@@ -907,6 +922,8 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     }
     browserTabs.clear();
     registry.clear();
+    if (backgroundWindow && !backgroundWindow.isDestroyed()) backgroundWindow.destroy();
+    backgroundWindow = null;
     lastBrowserBounds = null;
     sendBrowserState();
   }

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -260,13 +260,13 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
   function browserNativeViews() {
     const mainWindow = window();
     const children = mainWindow?.contentView.children ?? [];
-    const appIndex = children.indexOf(mainWindow?.webContentsView);
     return [...browserTabs.values()].map(({ tabId, view }) => {
       const index = children.indexOf(view);
       return {
         tabId,
         attached: index !== -1,
-        aboveApp: index !== -1 && index > appIndex,
+        // BrowserWindow's primary renderer is below the entire contentView.
+        aboveApp: index !== -1,
         bounds: view.getBounds(),
       };
     });
@@ -635,11 +635,10 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
 
   // A tab whose conversation is not on screen must still behave like a real
   // page for the agent driving it: lay out at a real viewport, accept typing as
-  // a focused page, and paint so CDP screenshots work. Chromium only paints a
-  // page it considers visible, so the view keeps a one-pixel presence behind
-  // the app renderer while a DevTools session of ours emulates a full viewport
-  // and focus. Never put this presence above the app: emulation must not make
-  // a background page intercept the user's window. Both are undone when the tab
+  // a focused page, and paint so CDP screenshots work. Keep the native view
+  // detached while a DevTools session of ours emulates a full viewport and
+  // focus. Every child of BrowserWindow.contentView paints above the app;
+  // neither child ordering nor one-pixel bounds can isolate it. Both are undone when the tab
   // returns to the screen. This is the headless-browser recipe applied to a
   // headful window.
   function enterBackgroundMode(tab) {
@@ -647,12 +646,8 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
     const webContents = tab.view.webContents;
     if (webContents.isDestroyed()) return;
     tab.background = true;
-    const mainWindow = window();
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      tab.view.setBounds({ ...BACKGROUND_TAB_PRESENCE_BOUNDS });
-      // addChildView also reorders an already attached foreground view.
-      mainWindow.contentView.addChildView(tab.view, 0);
-    }
+    detachBrowserView(tab.view);
+    tab.view.setBounds({ ...BACKGROUND_TAB_PRESENCE_BOUNDS });
     const cdp = webContents.debugger;
     runDetachedTask("emulate background browser tab", async () => {
       if (webContents.isDestroyed() || !tab.background) return;

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -66,12 +66,19 @@ const RESET_SEQUENCE = [
 ];
 
 function createPanel() {
-  const children = [];
+  const appView = {};
+  const children = [appView];
   const sent = [];
   const mainWindow = {
+    webContentsView: appView,
     contentView: {
       children,
-      addChildView(view) { children.push(view); },
+      addChildView(view, index) {
+        const previous = children.indexOf(view);
+        if (previous !== -1) children.splice(previous, 1);
+        children.splice(index ?? children.length, 0, view);
+        assert.ok(view.getBounds().width > 0 && view.getBounds().height > 0, "size a view before attaching it");
+      },
       removeChildView(view) { children.splice(children.indexOf(view), 1); },
     },
     webContents: { getZoomFactor: () => 1, isDestroyed: () => false, send(channel, payload) { sent.push({ channel, payload }); } },
@@ -86,10 +93,10 @@ function createPanel() {
   const invoke = (channel, ...args) => handlers.get(channel)(null, ...args);
   // The on-screen tab is the attached view with real panel bounds; background
   // presences are attached too, but only ever one pixel large.
-  const onScreen = () => children.find((view) => view.getBounds().width > 1) ?? null;
+  const onScreen = () => children.slice(children.indexOf(appView) + 1).find((view) => view.getBounds().width > 1) ?? null;
   const commands = (view) => view.webContents.debugger.commands;
   const messages = (channel) => sent.filter((entry) => entry.channel === channel).map((entry) => entry.payload);
-  return { invoke, onScreen, commands, children, messages };
+  return { invoke, onScreen, commands, children, messages, appView };
 }
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
@@ -176,7 +183,7 @@ const FOREGROUND_SEQUENCE = [
 ];
 
 test("a tab opened for a background conversation loads silently and leaves the visible conversation's tab on screen", async () => {
-  const { invoke, onScreen, commands, children, messages } = createPanel();
+  const { invoke, onScreen, commands, children, messages, appView } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const visibleView = onScreen();
@@ -188,7 +195,8 @@ test("a tab opened for a background conversation loads silently and leaves the v
 
   const state = invoke("openwork:browser:state");
   const backgroundTab = state.tabs.find((tab) => tab.id === tabId);
-  const backgroundView = children.find((view) => view !== visibleView);
+  const backgroundView = children.find((view) => view !== visibleView && view !== appView);
+  assert.deepEqual(children, [backgroundView, appView, visibleView], "background content stays below the app renderer");
   assert.equal(onScreen(), visibleView, "the visible conversation keeps its tab on screen");
   assert.equal(state.activeTabId, state.tabs.find((tab) => tab.ownerSessionId === "A").id);
   assert.equal(backgroundTab.ownerSessionId, "B");
@@ -198,15 +206,22 @@ test("a tab opened for a background conversation loads silently and leaves the v
   assert.equal(backgroundView.webContents.debugger.isAttached(), true, "our emulation session stays open while unseen");
   assert.deepEqual(commands(visibleView), [], "the visible tab is untouched");
   assert.deepEqual(messages("openwork:browser:panel-opened"), [], "no panel pops for a silent tab until it navigates");
+
+  // Even an unexpectedly large background surface must not intercept the app.
+  backgroundView.setBounds({ x: 0, y: 0, width: 1280, height: 800 });
+  invoke("openwork:browser:hide");
+  assert.deepEqual(children, [backgroundView, appView]);
+  assert.equal(onScreen(), null);
+  assert.ok(invoke("openwork:browser:state").nativeViews.every((view) => !view.aboveApp));
 });
 
 test("navigating a background conversation's tab reports its owner instead of taking the screen", async () => {
-  const { invoke, onScreen, children, messages } = createPanel();
+  const { invoke, onScreen, children, messages, appView } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const visibleView = onScreen();
   invoke("openwork:browser:createTab", "https://b.example", "B");
-  const backgroundView = children.find((view) => view !== visibleView);
+  const backgroundView = children.find((view) => view !== visibleView && view !== appView);
   await flush();
 
   backgroundView.webContents.emit("did-start-navigation", "https://b.example/next", false, true);
@@ -217,12 +232,12 @@ test("navigating a background conversation's tab reports its owner instead of ta
 });
 
 test("switching to the background conversation swaps its tab on screen and restores a normal viewport", async () => {
-  const { invoke, onScreen, commands, children } = createPanel();
+  const { invoke, onScreen, commands, children, appView } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const aView = onScreen();
   invoke("openwork:browser:createTab", "https://b.example", "B");
-  const bView = children.find((view) => view !== aView);
+  const bView = children.find((view) => view !== aView && view !== appView);
   await flush();
   commands(aView).length = 0;
   commands(bView).length = 0;
@@ -231,6 +246,7 @@ test("switching to the background conversation swaps its tab on screen and resto
   await flush();
 
   assert.equal(onScreen(), bView, "B's tab takes the screen");
+  assert.deepEqual(children, [aView, appView, bView], "the previous foreground view moves below the app renderer");
   assert.deepEqual(bView.getBounds(), PANEL_BOUNDS);
   assert.deepEqual(commands(bView), FOREGROUND_SEQUENCE, "B's emulation is undone before it is shown");
   assert.equal(bView.webContents.debugger.isAttached(), false, "our session is released for the user-driven reset path");

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -10,8 +10,10 @@ export const app = { on() {} };
 export const clipboard = { writeText() {} };
 export const session = { fromPartition() { return {}; } };
 export const shell = { openExternal() { return Promise.resolve(); } };
+export const createdViews = [];
 export class WebContentsView {
   constructor() {
+    createdViews.push(this);
     const listeners = new Map();
     let attached = false;
     this.bounds = { x: 0, y: 0, width: 0, height: 0 };
@@ -58,6 +60,7 @@ export function load(url, context, next) {
 
 register(`data:text/javascript,${encodeURIComponent(hooks)}`);
 const { createBrowserPanel } = await import("./browser-panel.mjs");
+const { createdViews } = await import("electron");
 
 const PANEL_BOUNDS = { x: 800, y: 40, width: 400, height: 900 };
 const RESET_SEQUENCE = [
@@ -66,11 +69,10 @@ const RESET_SEQUENCE = [
 ];
 
 function createPanel() {
-  const appView = {};
-  const children = [appView];
+  const children = [];
+  const firstView = createdViews.length;
   const sent = [];
   const mainWindow = {
-    webContentsView: appView,
     contentView: {
       children,
       addChildView(view, index) {
@@ -91,12 +93,12 @@ function createPanel() {
   };
   createBrowserPanel({ getWindow: () => mainWindow, remoteDebugPort: 0, onDeepLink: () => {} }).registerIpc(ipcMain);
   const invoke = (channel, ...args) => handlers.get(channel)(null, ...args);
-  // The on-screen tab is the attached view with real panel bounds; background
-  // presences are attached too, but only ever one pixel large.
-  const onScreen = () => children.slice(children.indexOf(appView) + 1).find((view) => view.getBounds().width > 1) ?? null;
+  // Electron paints every child above the BrowserWindow's primary renderer.
+  const onScreen = () => children.find((view) => view.getBounds().width > 1) ?? null;
+  const views = () => createdViews.slice(firstView);
   const commands = (view) => view.webContents.debugger.commands;
   const messages = (channel) => sent.filter((entry) => entry.channel === channel).map((entry) => entry.payload);
-  return { invoke, onScreen, commands, children, messages, appView };
+  return { invoke, onScreen, commands, children, messages, views };
 }
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
@@ -183,7 +185,7 @@ const FOREGROUND_SEQUENCE = [
 ];
 
 test("a tab opened for a background conversation loads silently and leaves the visible conversation's tab on screen", async () => {
-  const { invoke, onScreen, commands, children, messages, appView } = createPanel();
+  const { invoke, onScreen, commands, children, messages, views } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const visibleView = onScreen();
@@ -195,13 +197,13 @@ test("a tab opened for a background conversation loads silently and leaves the v
 
   const state = invoke("openwork:browser:state");
   const backgroundTab = state.tabs.find((tab) => tab.id === tabId);
-  const backgroundView = children.find((view) => view !== visibleView && view !== appView);
-  assert.deepEqual(children, [backgroundView, appView, visibleView], "background content stays below the app renderer");
+  const backgroundView = views().find((view) => view !== visibleView);
+  assert.deepEqual(children, [visibleView], "background content stays detached from the window");
   assert.equal(onScreen(), visibleView, "the visible conversation keeps its tab on screen");
   assert.equal(state.activeTabId, state.tabs.find((tab) => tab.ownerSessionId === "A").id);
   assert.equal(backgroundTab.ownerSessionId, "B");
   assert.equal(state.activeTabIdByOwner.B, tabId, "the tab is B's active tab, ready for when B is opened");
-  assert.deepEqual(backgroundView.getBounds(), { x: 0, y: 0, width: 1, height: 1 }, "a one-pixel presence keeps the page painting");
+  assert.deepEqual(backgroundView.getBounds(), { x: 0, y: 0, width: 1, height: 1 });
   assert.deepEqual(commands(backgroundView), BACKGROUND_SEQUENCE, "the page lays out and focuses like a visible one");
   assert.equal(backgroundView.webContents.debugger.isAttached(), true, "our emulation session stays open while unseen");
   assert.deepEqual(commands(visibleView), [], "the visible tab is untouched");
@@ -210,18 +212,18 @@ test("a tab opened for a background conversation loads silently and leaves the v
   // Even an unexpectedly large background surface must not intercept the app.
   backgroundView.setBounds({ x: 0, y: 0, width: 1280, height: 800 });
   invoke("openwork:browser:hide");
-  assert.deepEqual(children, [backgroundView, appView]);
+  assert.deepEqual(children, []);
   assert.equal(onScreen(), null);
   assert.ok(invoke("openwork:browser:state").nativeViews.every((view) => !view.aboveApp));
 });
 
 test("navigating a background conversation's tab reports its owner instead of taking the screen", async () => {
-  const { invoke, onScreen, children, messages, appView } = createPanel();
+  const { invoke, onScreen, messages, views } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const visibleView = onScreen();
   invoke("openwork:browser:createTab", "https://b.example", "B");
-  const backgroundView = children.find((view) => view !== visibleView && view !== appView);
+  const backgroundView = views().find((view) => view !== visibleView);
   await flush();
 
   backgroundView.webContents.emit("did-start-navigation", "https://b.example/next", false, true);
@@ -232,12 +234,12 @@ test("navigating a background conversation's tab reports its owner instead of ta
 });
 
 test("switching to the background conversation swaps its tab on screen and restores a normal viewport", async () => {
-  const { invoke, onScreen, commands, children, appView } = createPanel();
+  const { invoke, onScreen, commands, children, views } = createPanel();
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const aView = onScreen();
   invoke("openwork:browser:createTab", "https://b.example", "B");
-  const bView = children.find((view) => view !== aView && view !== appView);
+  const bView = views().find((view) => view !== aView);
   await flush();
   commands(aView).length = 0;
   commands(bView).length = 0;
@@ -246,7 +248,7 @@ test("switching to the background conversation swaps its tab on screen and resto
   await flush();
 
   assert.equal(onScreen(), bView, "B's tab takes the screen");
-  assert.deepEqual(children, [aView, appView, bView], "the previous foreground view moves below the app renderer");
+  assert.deepEqual(children, [bView], "the previous foreground view detaches from the window");
   assert.deepEqual(bView.getBounds(), PANEL_BOUNDS);
   assert.deepEqual(commands(bView), FOREGROUND_SEQUENCE, "B's emulation is undone before it is shown");
   assert.equal(bView.webContents.debugger.isAttached(), false, "our session is released for the user-driven reset path");

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -11,6 +11,20 @@ export const clipboard = { writeText() {} };
 export const session = { fromPartition() { return {}; } };
 export const shell = { openExternal() { return Promise.resolve(); } };
 export const createdViews = [];
+export class BrowserWindow {
+  constructor(options) {
+    if (options.show !== false || options.focusable !== false) throw new Error("background host must never show or focus");
+    const children = [];
+    this.contentView = {
+      children,
+      addChildView(view) { children.push(view); },
+      removeChildView(view) { children.splice(children.indexOf(view), 1); },
+    };
+    this.destroyed = false;
+  }
+  isDestroyed() { return this.destroyed; }
+  destroy() { this.destroyed = true; }
+}
 export class WebContentsView {
   constructor() {
     createdViews.push(this);
@@ -203,7 +217,7 @@ test("a tab opened for a background conversation loads silently and leaves the v
   assert.equal(state.activeTabId, state.tabs.find((tab) => tab.ownerSessionId === "A").id);
   assert.equal(backgroundTab.ownerSessionId, "B");
   assert.equal(state.activeTabIdByOwner.B, tabId, "the tab is B's active tab, ready for when B is opened");
-  assert.deepEqual(backgroundView.getBounds(), { x: 0, y: 0, width: 1, height: 1 });
+  assert.deepEqual(backgroundView.getBounds(), { x: 0, y: 0, width: 1280, height: 800 });
   assert.deepEqual(commands(backgroundView), BACKGROUND_SEQUENCE, "the page lays out and focuses like a visible one");
   assert.equal(backgroundView.webContents.debugger.isAttached(), true, "our emulation session stays open while unseen");
   assert.deepEqual(commands(visibleView), [], "the visible tab is untouched");
@@ -253,7 +267,7 @@ test("switching to the background conversation swaps its tab on screen and resto
   assert.deepEqual(commands(bView), FOREGROUND_SEQUENCE, "B's emulation is undone before it is shown");
   assert.equal(bView.webContents.debugger.isAttached(), false, "our session is released for the user-driven reset path");
   assert.deepEqual(commands(aView), BACKGROUND_SEQUENCE, "A's tab now keeps painting in the background");
-  assert.deepEqual(aView.getBounds(), { x: 0, y: 0, width: 1, height: 1 });
+  assert.deepEqual(aView.getBounds(), { x: 0, y: 0, width: 1280, height: 800 });
   const state = invoke("openwork:browser:state");
   assert.equal(state.visibleSessionId, "B");
   assert.equal(state.activeTabId, state.activeTabIdByOwner.B);

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -74,6 +74,7 @@ export function load(url, context, next) {
 
 register(`data:text/javascript,${encodeURIComponent(hooks)}`);
 const { createBrowserPanel } = await import("./browser-panel.mjs");
+// @ts-expect-error The registered test-only Electron stub exports its view inventory.
 const { createdViews } = await import("electron");
 
 const PANEL_BOUNDS = { x: 800, y: 40, width: 400, height: 900 };

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -37,7 +37,7 @@ test("a background conversation's agent browses silently and its page is waiting
     expect(state.activeTabId).toBe(readingTab.tabId);
     expect(state.tabs.find((tab) => tab.id === opened.tabId)?.ownerSessionId).toBe(researching.sessionId);
     expect(state.nativeViews.find((view) => view.tabId === opened.tabId)).toMatchObject({
-      attached: true,
+      attached: false,
       aboveApp: false,
       bounds: { x: 0, y: 0, width: 1, height: 1 },
     });
@@ -71,7 +71,7 @@ test("a background conversation's agent browses silently and its page is waiting
       label: "no native browser view covers OpenWork after the panel closes",
     });
     expect(hidden.nativeViews.find((view) => view.tabId === readingTab.tabId)?.attached).toBe(false);
-    expect(hidden.nativeViews.find((view) => view.tabId === researchTab.tabId)).toMatchObject({ attached: true, aboveApp: false });
+    expect(hidden.nativeViews.find((view) => view.tabId === researchTab.tabId)).toMatchObject({ attached: false, aboveApp: false });
     expect(await world.clickAndType(researchTab, "ok")).toEqual({ clicks: 2, value: "okok" });
     const screenshot = await world.screenshotSize(researchTab);
     expect(screenshot.width).toBeGreaterThanOrEqual(BACKGROUND_TAB_VIEWPORT.width);
@@ -99,7 +99,7 @@ test("a background conversation's agent browses silently and its page is waiting
     const native = await world.readBrowserState();
     expect(native.nativeViews.find((view) => view.tabId === researchTab.tabId)).toMatchObject({ attached: true, aboveApp: true });
     expect(native.nativeViews.find((view) => view.tabId === readingTab.tabId)).toMatchObject({
-      attached: true,
+      attached: false,
       aboveApp: false,
       bounds: { x: 0, y: 0, width: 1, height: 1 },
     });

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -36,6 +36,11 @@ test("a background conversation's agent browses silently and its page is waiting
     expect(state.visibleSessionId).toBe(reading.sessionId);
     expect(state.activeTabId).toBe(readingTab.tabId);
     expect(state.tabs.find((tab) => tab.id === opened.tabId)?.ownerSessionId).toBe(researching.sessionId);
+    expect(state.nativeViews.find((view) => view.tabId === opened.tabId)).toMatchObject({
+      attached: true,
+      aboveApp: false,
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+    });
     await user.see(tabButton(readingTab.name));
     await user.notSee(tabButton(opened.name));
     expect(await world.readViewport(readingTab)).toEqual(panelViewport);
@@ -58,6 +63,23 @@ test("a background conversation's agent browses silently and its page is waiting
     expect(screenshot.height).toBeGreaterThanOrEqual(BACKGROUND_TAB_VIEWPORT.height);
   });
 
+  await step("Closing the panel leaves no browser surface above OpenWork while background browsing continues", async () => {
+    await user.click({ role: "button", label: "Close side panel" });
+    const hidden = await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: (state) => state.nativeViews.every((view) => !view.aboveApp),
+      label: "no native browser view covers OpenWork after the panel closes",
+    });
+    expect(hidden.nativeViews.find((view) => view.tabId === readingTab.tabId)?.attached).toBe(false);
+    expect(hidden.nativeViews.find((view) => view.tabId === researchTab.tabId)).toMatchObject({ attached: true, aboveApp: false });
+    expect(await world.clickAndType(researchTab, "ok")).toEqual({ clicks: 2, value: "okok" });
+    const screenshot = await world.screenshotSize(researchTab);
+    expect(screenshot.width).toBeGreaterThanOrEqual(BACKGROUND_TAB_VIEWPORT.width);
+    expect(screenshot.height).toBeGreaterThanOrEqual(BACKGROUND_TAB_VIEWPORT.height);
+    await user.click({ role: "button", label: "Open side panel" });
+    await user.see(tabButton(readingTab.name));
+  });
+
   await step("Switching to the background conversation shows its page at the panel's size", async () => {
     await user.click(conversation(researching.title));
     const state = await eventually(() => world.readBrowserState(), {
@@ -74,6 +96,13 @@ test("a background conversation's agent browses silently and its page is waiting
       label: "the shown tab lays out for the panel again",
     });
     expect(restored).toEqual(panelViewport);
+    const native = await world.readBrowserState();
+    expect(native.nativeViews.find((view) => view.tabId === researchTab.tabId)).toMatchObject({ attached: true, aboveApp: true });
+    expect(native.nativeViews.find((view) => view.tabId === readingTab.tabId)).toMatchObject({
+      attached: true,
+      aboveApp: false,
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+    });
   });
 
   await step("Returning to the first conversation brings back only its own tab", async () => {

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -39,7 +39,7 @@ test("a background conversation's agent browses silently and its page is waiting
     expect(state.nativeViews.find((view) => view.tabId === opened.tabId)).toMatchObject({
       attached: false,
       aboveApp: false,
-      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      bounds: { x: 0, y: 0, ...BACKGROUND_TAB_VIEWPORT },
     });
     await user.see(tabButton(readingTab.name));
     await user.notSee(tabButton(opened.name));
@@ -101,7 +101,7 @@ test("a background conversation's agent browses silently and its page is waiting
     expect(native.nativeViews.find((view) => view.tabId === readingTab.tabId)).toMatchObject({
       attached: false,
       aboveApp: false,
-      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      bounds: { x: 0, y: 0, ...BACKGROUND_TAB_VIEWPORT },
     });
   });
 

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -30,6 +30,12 @@ export interface BrowserState {
   activeTabId: string | null;
   visibleSessionId: string | null;
   tabs: BrowserTabState[];
+  nativeViews: Array<{
+    tabId: string;
+    attached: boolean;
+    aboveApp: boolean;
+    bounds: Viewport & { x: number; y: number };
+  }>;
 }
 
 export interface OpenedTab extends BuiltinBrowserTab {
@@ -56,9 +62,22 @@ function pngSize(png: Buffer): Viewport {
 
 function parseBrowserState(value: unknown): BrowserState {
   if (!isRecord(value) || !Array.isArray(value.tabs)) throw new Error("The desktop bridge did not report browser state.");
+  if (!Array.isArray(value.nativeViews)) throw new Error("The desktop bridge did not report native browser views.");
   return {
     activeTabId: typeof value.activeTabId === "string" ? value.activeTabId : null,
     visibleSessionId: typeof value.visibleSessionId === "string" ? value.visibleSessionId : null,
+    nativeViews: value.nativeViews.map((view) => {
+      if (!isRecord(view) || typeof view.attached !== "boolean" || typeof view.aboveApp !== "boolean"
+        || !isRecord(view.bounds) || typeof view.bounds.x !== "number" || typeof view.bounds.y !== "number") {
+        throw new Error("The desktop bridge reported malformed native browser view state.");
+      }
+      return {
+        tabId: stringField(view.tabId),
+        attached: view.attached,
+        aboveApp: view.aboveApp,
+        bounds: { ...parseViewport(view.bounds), x: view.bounds.x, y: view.bounds.y },
+      };
+    }),
     tabs: value.tabs.map((tab) => {
       if (!isRecord(tab)) throw new Error("Browser state listed a malformed tab.");
       return {

--- a/packages/browser-tabs/index.d.ts
+++ b/packages/browser-tabs/index.d.ts
@@ -39,6 +39,8 @@ export type BrowserStatePayload = {
   /** The conversation whose tabs may take the screen. */
   visibleSessionId?: string | null;
   tabs?: BrowserPanelTab[];
+  /** Actual native hierarchy and bounds, included by getState (not state events). */
+  nativeViews?: Array<{ tabId: string; attached: boolean; aboveApp: boolean; bounds: Bounds }>;
 };
 
 export type BrowserPanelOwnerPayload = {

--- a/packages/browser-tabs/index.mjs
+++ b/packages/browser-tabs/index.mjs
@@ -16,8 +16,8 @@ export const BACKGROUND_TAB_VIEWPORT = Object.freeze({ width: 1280, height: 800 
 
 /**
  * Bounds of the on-window presence that keeps a background tab's compositor
- * producing frames. One device pixel in the window's top-left corner sits under
- * the rounded corner mask on macOS and Windows 11, so it is never seen.
+ * producing frames. Keep this presence behind the app's native renderer;
+ * one-pixel bounds alone are not a visibility or input-isolation boundary.
  */
 export const BACKGROUND_TAB_PRESENCE_BOUNDS = Object.freeze({ x: 0, y: 0, width: 1, height: 1 });
 

--- a/packages/browser-tabs/index.mjs
+++ b/packages/browser-tabs/index.mjs
@@ -15,9 +15,8 @@ export const SHARED_OWNER_KEY = "*";
 export const BACKGROUND_TAB_VIEWPORT = Object.freeze({ width: 1280, height: 800 });
 
 /**
- * Bounds of the on-window presence that keeps a background tab's compositor
- * producing frames. Keep this presence behind the app's native renderer;
- * one-pixel bounds alone are not a visibility or input-isolation boundary.
+ * Parking bounds for detached background tabs. These bounds must never be
+ * used as a visibility boundary: attached native views paint above the app.
  */
 export const BACKGROUND_TAB_PRESENCE_BOUNDS = Object.freeze({ x: 0, y: 0, width: 1, height: 1 });
 


### PR DESCRIPTION
## Summary

The per-conversation browser change (#4434) kept background WebContentsViews attached to the main window at one-pixel bounds. Electron paints every child of BrowserWindow.contentView above the main renderer; child order cannot put those pages behind OpenWork.

- Park background pages in a separate never-shown, non-focusable window, preserving their existing WebContents and CDP targets.
- Keep background viewport, typing, and screenshot support without attaching those pages over OpenWork.
- Size foreground pages before attachment and require positive panel bounds.
- Destroy the hidden host with browser-panel teardown.
- Extend the existing browser ownership journey to inspect native attachment while browsing, closing the panel, and switching conversations.

Conversation ownership, persistent browser sessions, and foreground tab behavior stay unchanged. No release or deployment is included.

## Verification — Passed

Exact head: `2ed6eb27856cccf4a7709494576f83b132e8b4f4`.

- `OPENWORK_EVAL_REF=2ed6eb27856cccf4a7709494576f83b132e8b4f4 pnpm evals:e2e browser-tabs-owned-by-thread`: exit 0; **1 passed / 0 failed / 0 skipped**. Cold-booted real Electron. Printed placement: `placement: daytona (daytona CLI authenticated)`.
- Published exact-head test evidence in the sticky comment: background native isolation, viewport, typing, screenshots, panel closure/reopening, and conversation switching all passed.
- `pnpm --filter @openwork/desktop typecheck:electron`: exit 0.
- `node --test apps/desktop/electron/browser-panel.test.mjs`: exit 0; **9 passed / 0 failed / 0 skipped**. Supplemental mocked wiring checks, not runtime proof.
- `git diff --check`: exit 0.

Earlier candidates failed real-app verification: child reordering did not isolate the view, and complete detachment stopped screenshot painting. The hidden-host implementation replaces both; neither failed approach is the final behavior. The test-only TypeScript import error was also corrected.

Deferred: native macOS/Windows-specific verification, renderer-crash cleanup, and rapid emulation-transition serialization. These are not claimed by the Linux Electron journey.