### PR TITLE
Fix v2 session creation and first-message visibility

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -705,6 +705,33 @@ export function translateV2Event(
   const properties = eventProperties(value);
   const sessionID = readSessionID(properties);
 
+  if (type === "session.inbox.enqueued") {
+    const messageID = readString(properties, "inboxID");
+    const item = readRecord(properties, "item");
+    const payload = readRecord(item, "payload");
+    if (!sessionID || !messageID || readString(item, "type") !== "user" || !payload) return null;
+    // The inbox ID becomes the persisted user-message ID on delivery. Using
+    // it here lets the live row reconcile with history without duplicating it.
+    const message = mapV2Message({
+      ...payload,
+      id: messageID,
+      type: "user",
+      time: { created: readNumber(value, "created") ?? readTimestamp(properties) },
+    }, sessionID);
+    if (!message) return null;
+    return [
+      { type: "message.updated", properties: { info: message.info } },
+      ...message.parts.map((part): OpencodeEvent => ({ type: "message.part.updated", properties: { part } })),
+    ];
+  }
+
+  if (type === "session.inbox.cancelled") {
+    const messageID = readString(properties, "inboxID");
+    return sessionID && messageID
+      ? [{ type: "message.removed", properties: { sessionID, messageID } }]
+      : null;
+  }
+
   if (type === "session.execution.started") {
     if (!sessionID) return null;
     return [{ type: "session.status", properties: { sessionID, status: { type: "busy" } } }];

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1629,7 +1629,7 @@ function WorkspaceSidebarGroup({
                     e.stopPropagation();
                     ctx.onCreateTaskInWorkspace(workspace.id);
                   }}
-                  aria-label={t("session.new_task")}
+                  aria-label={`${t("session.new_task")} · ${workspaceLabel(workspace)}`}
                   title={t("session.new_task")}
                 >
                   <Plus className="size-4" />

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -7,7 +7,7 @@ import type { Session } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { createClientV2 } from "@/app/lib/opencode-v2-adapter";
-import type { OpenworkWorkspaceInfo } from "@/app/lib/openwork-server";
+import { OpenworkServerError, type OpenworkWorkspaceInfo } from "@/app/lib/openwork-server";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import type { WorkspaceInfo } from "@/app/lib/desktop-types";
 import type { WorkspaceSessionGroup } from "@/app/types";
@@ -53,6 +53,19 @@ export const v2RouteSessionList: RouteSessionListTransport = async ({ endpoint, 
   createClientV2(`${endpoint.mountedBaseUrl}/opencode2`, undefined, {
     token: endpoint.token,
   }).session.list({ limit });
+
+/** Resolve the owning server's engine even when this workspace isn't selected. */
+export async function createRouteSession(endpoint: ResolvedWorkspaceEndpoint, directory?: string): Promise<Session> {
+  const status = await endpoint.client.getEngineV2PreviewStatus().catch((error: unknown) => {
+    // Servers predating the preview endpoint still create sessions through v1.
+    if (error instanceof OpenworkServerError && error.status === 404) return null;
+    throw error;
+  });
+  const client = status?.enabled && status.chatRouting
+    ? createClientV2(`${endpoint.mountedBaseUrl}/opencode2`, directory, { token: endpoint.token })
+    : createClient(endpoint.opencodeBaseUrl, directory, { token: endpoint.token, mode: "openwork" });
+  return unwrap(await client.session.create({ directory }));
+}
 
 export async function listRouteSessions(
   endpoint: ResolvedWorkspaceEndpoint,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -77,6 +77,7 @@ import {
   describeTaskCreateFailure,
   describeTaskCreateRetry,
   describeWorkspaceCreateError,
+  createRouteSession,
   downloadWorkspaceJson,
   folderNameFromPath,
   getSessionStatus,
@@ -2087,13 +2088,6 @@ export function SessionRoute() {
     if (!endpoint || !endpoint.token) {
       return null;
     }
-    const workspaceClient = workspaceId === selectedWorkspaceId && opencodeClient
-      ? opencodeClient
-      : createClient(
-          endpoint.opencodeBaseUrl,
-          workspace.path?.trim() || undefined,
-          { token: endpoint.token, mode: "openwork" },
-        );
     const toastId = taskCreateUnavailableToastId(workspaceId);
     const attempts = TASK_CREATE_RETRY_DELAYS_MS.length + 1;
     try {
@@ -2103,9 +2097,7 @@ export function SessionRoute() {
       // and used to surface as a dead-end "unavailable" toast that only Cmd+R
       // seemed to fix. Retry transient failures with a visible countdown first.
       const session = await withTransientEngineRetry({
-        load: async () => unwrap(
-          await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
-        ),
+        load: () => createRouteSession(endpoint, workspace.path?.trim() || undefined),
         retryDelaysMs: TASK_CREATE_RETRY_DELAYS_MS,
         onRetry: (attempt) => {
           const notice = describeTaskCreateRetry({ developerMode, attempt, attempts });
@@ -2197,7 +2189,7 @@ export function SessionRoute() {
       }
       return null;
     }
-  }, [applyLastUsedModelToSession, developerMode, endpointForWorkspace, loading, navigateToWorkspaceSession, opencodeClient, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
+  }, [applyLastUsedModelToSession, developerMode, endpointForWorkspace, loading, navigateToWorkspaceSession, refreshCloudProviderSync, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, workspaces]);
 
   const handleCreateTaskInWorkspace = useCallback((workspaceId: string): Promise<string | null> => {
     const { focusedPane, secondary } = useWorkbenchStore.getState();
@@ -3372,17 +3364,8 @@ export function SessionRoute() {
             if (!workspace) return;
             const endpoint = endpointForWorkspace(workspace);
             if (!endpoint?.token) return;
-            const workspaceClient = workspaceId === selectedWorkspaceId && opencodeClient
-              ? opencodeClient
-              : createClient(
-              endpoint.opencodeBaseUrl,
-              workspace.path?.trim() || undefined,
-              { token: endpoint.token, mode: "openwork" },
-            );
             try {
-              const session = unwrap(
-                await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
-              );
+              const session = await createRouteSession(endpoint, workspace.path?.trim() || undefined);
               if (workspaceId === selectedWorkspaceId) {
                 void refreshCloudProviderSync("new_chat");
               }

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -151,6 +151,39 @@ function jsonResponse(value: unknown, status = 200): Response {
 }
 
 describe("OpenCode v2 event translation", () => {
+  test("renders an admitted user message before execution using its persisted identity", () => {
+    const state = createV2EventTranslationState();
+    const admitted = {
+      type: "session.inbox.enqueued",
+      created: 1_788_657_600_000,
+      location: { directory: "/workspace" },
+      data: {
+        sessionID: "ses_upgrade",
+        inboxID: "msg_user",
+        item: { type: "user", payload: { text: "hi" }, delivery: "steer" },
+      },
+    };
+    const expected = [
+      { type: "message.updated", properties: { info: {
+        id: "msg_user", sessionID: "ses_upgrade", role: "user", time: { created: admitted.created },
+      } } },
+      { type: "message.part.updated", properties: { part: {
+        id: "msg_user:0", messageID: "msg_user", sessionID: "ses_upgrade", type: "text", text: "hi",
+      } } },
+    ];
+    expect(translateV2Event(admitted, state)).toEqual(expected);
+    // A replay must update the same message and part, not create another row.
+    expect(translateV2Event(admitted, state)).toEqual(expected);
+    expect(translateV2Event({
+      type: "session.inbox.cancelled", data: { sessionID: "ses_upgrade", inboxID: "msg_user" },
+    }, state)).toEqual([
+      { type: "message.removed", properties: { sessionID: "ses_upgrade", messageID: "msg_user" } },
+    ]);
+    expect(translateV2Event({ ...admitted, data: {
+      ...admitted.data, item: { type: "synthetic", payload: { text: "Internal instructions" }, delivery: "steer" },
+    } }, state)).toBeNull();
+  });
+
   test("uses the created envelope timestamp for an untitled session", () => {
     const created = 1_788_548_737_221;
     const event = {

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   classifyRouteSessionReadError,
+  createRouteSession,
   mergeRouteWorkspaces,
   readRouteSessionsWithRetry,
   refreshRouteWorkspaceListState,
@@ -21,6 +22,65 @@ import {
   workspaceExtensionsRoute,
   workspaceSettingsRoute,
 } from "../src/react-app/shell/workspace-routes";
+import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
+
+describe("workspace session creation", () => {
+  for (const engine of ["v1", "v2", "legacy"]) {
+    test(`creates through the owning server's ${engine} engine`, async () => {
+      const originalFetch = globalThis.fetch;
+      const requests: string[] = [];
+      globalThis.fetch = async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const path = new URL(request.url).pathname;
+        requests.push(`${request.method} ${path}`);
+        if (path === "/experimental/engine-v2-preview/status") {
+          return Response.json({
+            enabled: engine === "v2", running: engine === "v2", chatRouting: engine === "v2",
+            mirroredProviderIds: [], skippedProviderIds: [], catalogModelIds: [],
+          }, {
+            status: engine === "legacy" ? 404 : 200,
+          });
+        }
+        expect(request.headers.get("Authorization")).toBe("Bearer fixture-token");
+        if (engine === "v2") expect(await request.json()).toMatchObject({ location: { directory: "/existing" } });
+        return Response.json({ id: "ses_created", title: "New session", time: { created: 1, updated: 1 } });
+      };
+      try {
+        const endpoint = resolveWorkspaceEndpoint({ id: "ws_existing", workspaceType: "local" }, {
+          baseUrl: "http://owner.test", token: "fixture-token",
+        });
+        if (!endpoint) throw new Error("Workspace endpoint missing");
+        expect((await createRouteSession(endpoint, "/existing")).id).toBe("ses_created");
+        expect(requests).toEqual([
+          "GET /experimental/engine-v2-preview/status",
+          `POST /workspace/ws_existing/${engine === "v2" ? "opencode2/api/session" : "opencode/session"}`,
+        ]);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+
+  test("a failed routing read cannot silently create a v1 session", async () => {
+    const originalFetch = globalThis.fetch;
+    const methods: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      methods.push(request.method);
+      return Response.json({ message: "Routing unavailable" }, { status: 503 });
+    };
+    try {
+      const endpoint = resolveWorkspaceEndpoint({ id: "ws_existing", workspaceType: "local" }, {
+        baseUrl: "http://owner.test", token: "fixture-token",
+      });
+      if (!endpoint) throw new Error("Workspace endpoint missing");
+      await expect(createRouteSession(endpoint, "/existing")).rejects.toThrow();
+      expect(methods).toEqual(["GET"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
 
 describe("workspace surface routes", () => {
   test("keeps Extensions outside Settings and preserves deep links", () => {

--- a/evals/packages/testkit/src/transcript-observer.ts
+++ b/evals/packages/testkit/src/transcript-observer.ts
@@ -25,6 +25,13 @@ export async function observeTranscript(probe: Probe, entries: readonly { role: 
     window[key] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
   }`, { args: [key, JSON.stringify(entries)] });
   return {
+    read() {
+      return probe.eval(`(key) => {
+        const observer = window[key];
+        if (!observer) throw new Error("Transcript observer was lost before verification");
+        return observer.state;
+      }`, { args: [key] });
+    },
     async finish() {
       const result = await probe.eval(`(key) => {
         const observer = window[key];

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "vitest";
+import { go } from "@openwork/behaviors";
+import { observeTranscript, spec } from "@openwork/testkit";
+import { workspaceEngineUpgrade } from "../worlds/chat.ts";
+
+// This journey crosses the engine boundary with an existing workspace. Fresh
+// engine chat journeys cannot witness ownership after an upgrade.
+const test = spec.world(workspaceEngineUpgrade, { timeout: 420_000 });
+const reply = "Hello. Your upgrade conversation is working.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+test("existing workspaces create usable sessions after changing chat engines", async ({ world, user, probe, step }) => {
+  expect((await probe.desktopApi("/experimental/engine-v2-preview/status")).body).toMatchObject({ chatRouting: false });
+  await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
+  await user.see({ text: "OpenCode v2 (preview)" }, { timeoutMs: 30_000 });
+  await user.click({ text: "OpenCode v2 (preview)" });
+  await probe.eventually(() => probe.desktopApi("/experimental/engine-v2-preview/status"), {
+    within: 120_000, label: "v2 configured and running",
+    until: (response) => isRecord(response.body) && response.body.running === true && response.body.chatRouting === true,
+  });
+  await go(world.app, `/workspace/${world.primary.workspaceId}/session`);
+  await user.reload();
+  await user.see("composer", { timeoutMs: 60_000 });
+
+  await step("create a new chat in the selected existing workspace", async () => {
+    await user.click({ role: "button", label: "New session" });
+    await probe.eventually(() => probe.hash(), { within: 30_000,
+      label: "new session route", until: (hash) => hash.includes("/session/ses_") });
+    await user.see("composer", { timeoutMs: 30_000 });
+    // Observe the real engine stream without changing requests or responses.
+    await probe.eval(`async (workspaceId) => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 120000);
+      const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port")
+        + "/workspace/" + workspaceId + "/opencode2/api/event", {
+        headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") },
+        signal: controller.signal,
+      });
+      if (!response.ok || !response.body) throw new Error("Event witness unavailable: " + response.status);
+      const events = [];
+      window.__upgradeEventWitness = { events, stop() { clearTimeout(timer); controller.abort(); } };
+      void (async () => {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        try {
+          while (true) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            buffer += decoder.decode(chunk.value, { stream: true });
+            const lines = buffer.split(/\\r?\\n/); buffer = lines.pop() ?? "";
+            for (const line of lines) {
+              if (!line.startsWith("data:")) continue;
+              let event = JSON.parse(line.slice(5).trim());
+              if (typeof event === "string") event = JSON.parse(event);
+              if (!event.type) continue;
+              events.push(/message|prompt/.test(event.type) ? event : { type: event.type });
+            }
+          }
+        } catch (error) { if (!controller.signal.aborted) events.push({ error: String(error) }); }
+      })();
+      return true;
+    }`, { args: [world.primary.workspaceId], awaitPromise: true });
+    await user.type("composer", "hi");
+    await using transcript = await observeTranscript(probe, [
+      { role: "user", text: "hi" }, { role: "assistant", text: reply },
+    ]);
+    await user.click("Run task");
+    await expect.soft(user.see({ text: "hi" }, { timeoutMs: 2_000 })).resolves.toBeUndefined();
+    await user.screenshot();
+    await user.see({ text: reply }, { timeoutMs: 90_000 });
+    await user.see("Run task", { timeoutMs: 30_000 });
+    await user.screenshot();
+    console.info("[workspace upgrade] native events", JSON.stringify(await probe.eval(`(() => {
+      const witness = window.__upgradeEventWitness; witness.stop(); return witness.events;
+    })()`)));
+    // Soft assertion lets the same run witness sidebar creation as well.
+    expect.soft(await transcript.finish()).toMatchObject({ seen: [true, true], violations: [], stopped: false });
+  });
+
+  await step("a sidebar new session belongs to the engine that will open it", async () => {
+    if (!world.otherName) throw new Error("Existing workspace name missing");
+    await user.hover({ role: "button", label: world.otherName });
+    // The first New session is global; the revealed workspace plus follows it.
+    await user.click({ role: "button", label: "New session", nth: 1 });
+    const route = await probe.eventually(() => probe.hash(), { within: 30_000,
+      label: "other workspace new session route",
+      until: (hash) => hash.includes(`/workspace/${world.other.workspaceId}/session/ses_`),
+    });
+    const sessionId = route.split("/session/")[1]?.split(/[?#/]/)[0];
+    if (!sessionId) throw new Error("Created session route omitted its ID");
+    const prefix = `/workspace/${world.other.workspaceId}`;
+    const v2 = await probe.desktopApi(`${prefix}/opencode2/api/session/${sessionId}`);
+    const v1 = await probe.desktopApi(`${prefix}/opencode/session/${sessionId}`);
+    console.info("[workspace upgrade] created-session ownership", JSON.stringify({ sessionId, v1: v1.status, v2: v2.status }));
+    await user.screenshot();
+    expect.soft(v2.status).toBe(200);
+    expect.soft(v1.status).toBe(404);
+    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
+  });
+});

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -1,15 +1,34 @@
 import { expect } from "vitest";
 import { go } from "@openwork/behaviors";
-import { observeTranscript, spec } from "@openwork/testkit";
+import { observeTranscript, spec, type Probe, type User } from "@openwork/testkit";
 import { workspaceEngineUpgrade } from "../worlds/chat.ts";
 
-// This journey crosses the engine boundary with an existing workspace. Fresh
-// engine chat journeys cannot witness ownership after an upgrade.
+// Fresh-engine chat journeys cannot witness ownership after an upgrade.
 const test = spec.world(workspaceEngineUpgrade, { timeout: 420_000 });
 const reply = "Hello. Your upgrade conversation is working.";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function greet(user: User, probe: Probe) {
+  await using transcript = await observeTranscript(probe, [
+    { role: "user", text: "hi" }, { role: "assistant", text: reply },
+  ]);
+  await user.type("composer", "hi");
+  await user.click("Run task");
+  // Observe the user row itself: text left in the composer cannot satisfy this.
+  await probe.eventually(() => transcript.read(), {
+    within: 2_000, label: "sent hi visible in the user transcript",
+    until: (state) => isRecord(state) && Array.isArray(state.seen) && state.seen[0] === true,
+  });
+  await user.screenshot();
+  await user.see({ text: reply }, { timeoutMs: 90_000 });
+  await user.see("Run task", { timeoutMs: 30_000 });
+  expect(await transcript.finish()).toMatchObject({ seen: [true, true], violations: [], stopped: false });
+  await user.reload();
+  await user.see({ text: /^hi$/ }, { timeoutMs: 30_000 });
+  await user.see({ text: reply });
 }
 
 test("existing workspaces create usable sessions after changing chat engines", async ({ world, user, probe, step }) => {
@@ -25,72 +44,18 @@ test("existing workspaces create usable sessions after changing chat engines", a
   await user.reload();
   await user.see("composer", { timeoutMs: 60_000 });
 
-  const failures: string[] = [];
-  let continuity: unknown;
-  await step("create a new chat in the selected existing workspace", async () => {
+  await step("a new chat in the selected existing workspace keeps the first message visible", async () => {
     await user.click({ role: "button", label: "New session" });
     await probe.eventually(() => probe.hash(), { within: 30_000,
       label: "new session route", until: (hash) => hash.includes("/session/ses_") });
     await user.see("composer", { timeoutMs: 30_000 });
-    // Observe the real engine stream without changing requests or responses.
-    await probe.eval(`async (workspaceId) => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 120000);
-      const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port")
-        + "/workspace/" + workspaceId + "/opencode2/api/event", {
-        headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") },
-        signal: controller.signal,
-      });
-      if (!response.ok || !response.body) throw new Error("Event witness unavailable: " + response.status);
-      const events = [];
-      window.__upgradeEventWitness = { events, stop() { clearTimeout(timer); controller.abort(); } };
-      void (async () => {
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-        try {
-          while (true) {
-            const chunk = await reader.read();
-            if (chunk.done) break;
-            buffer += decoder.decode(chunk.value, { stream: true });
-            const lines = buffer.split(/\\r?\\n/); buffer = lines.pop() ?? "";
-            for (const line of lines) {
-              if (!line.startsWith("data:")) continue;
-              let event = JSON.parse(line.slice(5).trim());
-              if (typeof event === "string") event = JSON.parse(event);
-              if (!event.type) continue;
-              events.push(/message|prompt|inbox/.test(event.type) ? event : { type: event.type });
-            }
-          }
-        } catch (error) { if (!controller.signal.aborted) events.push({ error: String(error) }); }
-      })();
-      return true;
-    }`, { args: [world.primary.workspaceId], awaitPromise: true });
-    await user.type("composer", "hi");
-    await using transcript = await observeTranscript(probe, [
-      { role: "user", text: "hi" }, { role: "assistant", text: reply },
-    ]);
-    await user.click("Run task");
-    try {
-      await user.see({ text: /^hi$/ }, { timeoutMs: 2_000 });
-    } catch (error) {
-      failures.push(error instanceof Error ? error.message : String(error));
-    }
-    await user.screenshot();
-    await user.see({ text: reply }, { timeoutMs: 90_000 });
-    await user.see("Run task", { timeoutMs: 30_000 });
-    await user.screenshot();
-    console.info("[workspace upgrade] native events", JSON.stringify(await probe.eval(`(() => {
-      const witness = window.__upgradeEventWitness; witness.stop(); return witness.events;
-    })()`)));
-    continuity = await transcript.finish();
+    await greet(user, probe);
   });
 
-  await step("a sidebar new session belongs to the engine that will open it", async () => {
+  await step("a sidebar new session opens and runs in the configured engine", async () => {
     if (!world.otherName) throw new Error("Existing workspace name missing");
     await user.hover({ role: "button", label: world.otherName });
-    // The global button and primary-workspace plus precede this workspace.
-    await user.click({ role: "button", label: "New session", nth: 2 });
+    await user.click({ role: "button", label: `New session · ${world.otherName}` });
     const route = await probe.eventually(() => probe.hash(), { within: 30_000,
       label: "other workspace new session route",
       until: (hash) => hash.includes(`/workspace/${world.other.workspaceId}/session/ses_`),
@@ -98,19 +63,28 @@ test("existing workspaces create usable sessions after changing chat engines", a
     const sessionId = route.split("/session/")[1]?.split(/[?#/]/)[0];
     if (!sessionId) throw new Error("Created session route omitted its ID");
     const prefix = `/workspace/${world.other.workspaceId}`;
-    const v2 = await probe.desktopApi(`${prefix}/opencode2/api/session/${sessionId}`);
-    const v1 = await probe.desktopApi(`${prefix}/opencode/session/${sessionId}`);
-    console.info("[workspace upgrade] created-session ownership", JSON.stringify({ sessionId, v1: v1.status, v2: v2.status }));
-    await user.screenshot();
-    if (v2.status !== 200 || v1.status !== 404) {
-      failures.push(`Created session belongs to the wrong engine: v1=${v1.status}, v2=${v2.status}`);
-    }
-    try {
-      await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
-    } catch (error) {
-      failures.push(error instanceof Error ? error.message : String(error));
-    }
+    expect((await probe.desktopApi(`${prefix}/opencode2/api/session/${sessionId}`)).status).toBe(200);
+    expect((await probe.desktopApi(`${prefix}/opencode/session/${sessionId}`)).status).toBe(404);
+    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
+    await greet(user, probe);
   });
-  expect(continuity).toMatchObject({ seen: [true, true], violations: [], stopped: false });
-  expect(failures).toEqual([]);
+
+  await step("switching back preserves v1 history and v1 can still create and run a chat", async () => {
+    await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
+    await user.click({ text: "OpenCode v1 (default)" });
+    await probe.eventually(() => probe.desktopApi("/experimental/engine-v2-preview/status"), {
+      within: 60_000, label: "v1 routing restored",
+      until: (response) => isRecord(response.body) && response.body.enabled === false && response.body.chatRouting === false,
+    });
+    await go(world.app, `/workspace/${world.primary.workspaceId}/session/${world.original.sessionId}`);
+    await user.see({ text: world.original.title }, { timeoutMs: 30_000 });
+    expect((await probe.desktopApi(`/workspace/${world.other.workspaceId}/opencode/session/${world.otherOriginal.sessionId}`)).status).toBe(200);
+    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
+    await user.click({ role: "button", label: "New session" });
+    await probe.eventually(() => probe.hash(), { within: 30_000,
+      label: "new v1 session route",
+      until: (hash) => hash.includes("/session/ses_") && !hash.includes(world.original.sessionId),
+    });
+    await greet(user, probe);
+  });
 });

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -25,6 +25,8 @@ test("existing workspaces create usable sessions after changing chat engines", a
   await user.reload();
   await user.see("composer", { timeoutMs: 60_000 });
 
+  const failures: string[] = [];
+  let continuity: unknown;
   await step("create a new chat in the selected existing workspace", async () => {
     await user.click({ role: "button", label: "New session" });
     await probe.eventually(() => probe.hash(), { within: 30_000,
@@ -69,7 +71,11 @@ test("existing workspaces create usable sessions after changing chat engines", a
       { role: "user", text: "hi" }, { role: "assistant", text: reply },
     ]);
     await user.click("Run task");
-    await expect.soft(user.see({ text: "hi" }, { timeoutMs: 2_000 })).resolves.toBeUndefined();
+    try {
+      await user.see({ text: /^hi$/ }, { timeoutMs: 2_000 });
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
     await user.screenshot();
     await user.see({ text: reply }, { timeoutMs: 90_000 });
     await user.see("Run task", { timeoutMs: 30_000 });
@@ -77,8 +83,7 @@ test("existing workspaces create usable sessions after changing chat engines", a
     console.info("[workspace upgrade] native events", JSON.stringify(await probe.eval(`(() => {
       const witness = window.__upgradeEventWitness; witness.stop(); return witness.events;
     })()`)));
-    // Soft assertion lets the same run witness sidebar creation as well.
-    expect.soft(await transcript.finish()).toMatchObject({ seen: [true, true], violations: [], stopped: false });
+    continuity = await transcript.finish();
   });
 
   await step("a sidebar new session belongs to the engine that will open it", async () => {
@@ -97,8 +102,15 @@ test("existing workspaces create usable sessions after changing chat engines", a
     const v1 = await probe.desktopApi(`${prefix}/opencode/session/${sessionId}`);
     console.info("[workspace upgrade] created-session ownership", JSON.stringify({ sessionId, v1: v1.status, v2: v2.status }));
     await user.screenshot();
-    expect.soft(v2.status).toBe(200);
-    expect.soft(v1.status).toBe(404);
-    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
+    if (v2.status !== 200 || v1.status !== 404) {
+      failures.push(`Created session belongs to the wrong engine: v1=${v1.status}, v2=${v2.status}`);
+    }
+    try {
+      await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
   });
+  expect(continuity).toMatchObject({ seen: [true, true], violations: [], stopped: false });
+  expect(failures).toEqual([]);
 });

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -59,7 +59,7 @@ test("existing workspaces create usable sessions after changing chat engines", a
               let event = JSON.parse(line.slice(5).trim());
               if (typeof event === "string") event = JSON.parse(event);
               if (!event.type) continue;
-              events.push(/message|prompt/.test(event.type) ? event : { type: event.type });
+              events.push(/message|prompt|inbox/.test(event.type) ? event : { type: event.type });
             }
           }
         } catch (error) { if (!controller.signal.aborted) events.push({ error: String(error) }); }
@@ -89,8 +89,8 @@ test("existing workspaces create usable sessions after changing chat engines", a
   await step("a sidebar new session belongs to the engine that will open it", async () => {
     if (!world.otherName) throw new Error("Existing workspace name missing");
     await user.hover({ role: "button", label: world.otherName });
-    // The first New session is global; the revealed workspace plus follows it.
-    await user.click({ role: "button", label: "New session", nth: 1 });
+    // The global button and primary-workspace plus precede this workspace.
+    await user.click({ role: "button", label: "New session", nth: 2 });
     const route = await probe.eventually(() => probe.hash(), { within: 30_000,
       label: "other workspace new session route",
       until: (hash) => hash.includes(`/workspace/${world.other.workspaceId}/session/ses_`),

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -35,7 +35,7 @@ test("the per-workspace New task plus stays clickable over a long truncated work
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
   const expandedBefore = await probe.eval(`document.querySelector('[data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
-  await user.click({ role: "button", label: "New task", nth: 1 });
+  await user.click({ role: "button", label: `New session · ${workspaceName}` });
   await probe.eventually(() => agent.list(), {
     within: 60_000,
     label: "session created by workspace New task",

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1372,3 +1372,35 @@ export async function visualization(seed: Seed) {
     },
   };
 }
+
+
+/** A persisted workspace and conversation created before opting into the other engine. */
+export async function workspaceEngineUpgrade(seed: Seed) {
+  const providerId = "workspace-upgrade-mock";
+  const modelId = "workspace-upgrade-model";
+  const mock = seed.mock({ agentWorkloads: [{
+    promptMarker: "hi",
+    finalReply: "Hello. Your upgrade conversation is working.",
+    finalReplyChunkSize: 3,
+    finalReplyDelayMs: 750,
+    steps: [],
+  }] });
+  const den = await seed.den({ mocks: { agent: mock } });
+  const primaryPath = seed.tmpPath("upgrade-primary");
+  const otherPath = seed.tmpPath("upgrade-existing");
+  const app = await seed.desktop({ den, as: "admin", workspacePath: primaryPath, model: `${providerId}/${modelId}` });
+  const primary = await seed.workspace(app, primaryPath);
+  const provider = { provider: { [providerId]: {
+    npm: "@ai-sdk/openai-compatible", name: "Upgrade mock",
+    options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-upgrade-fixture" },
+    models: { [modelId]: { name: "Upgrade model" } },
+  } } };
+  await configureProvider(seed, app, primary.workspaceId, providerId, modelId, provider);
+  const original = await seedSessionRetry(seed, app, { title: "Before engine upgrade" });
+  const other = await seed.workspace(app, otherPath, { create: true });
+  await configureProvider(seed, app, other.workspaceId, providerId, modelId, provider);
+  const otherOriginal = await seedSessionRetry(seed, app, { title: "Existing workspace history" });
+  return { app, den, primary, other, original, otherOriginal, providerId, modelId,
+    otherName: otherPath.split("/").at(-1),
+  };
+}


### PR DESCRIPTION
After enabling v2, creating a chat from another existing workspace could create it in v1 while the chat screen read from v2, causing `SessionNotFoundError`. Separately, the v2 adapter ignored incoming-message events, so “hi” stayed absent while the answer streamed and appeared only when completed history was fetched.

Session creation now resolves the owning server’s configured engine, including when the workspace is not selected. Older servers without the preview endpoint retain v1; other routing failures stop creation. The v2 adapter translates incoming user messages with the engine’s persistent message ID and removes cancelled inputs. Workspace create buttons expose their workspace in the accessible name.

The new upgrade journey seeds two v1 workspaces and sessions, selects v2 through Settings, reloads, creates and runs chats through the global and workspace buttons, then returns to v1 and verifies retained sessions and a fresh v1 chat. It observes user rows directly within two seconds of sending, checks continuity throughout streaming, and verifies the conversation after reload. The existing workspace-plus journey uses the contextual accessible name.

[Historical failing run and screenshots](https://github.com/different-ai/openwork/pull/4545#issuecomment-5556183415) reproduce both failures on the alpha.2737 chat implementation. The other workspace’s created ID returned v1=200 and v2=404; the pinned beta-19086 emitted the ignored incoming user event before the reply. These tests use real desktop/engine processes in Daytona with synthetic workspaces and controlled model replies. They do not use real provider inference or a user's existing profile.

Validation on final head `50d97678cb1de819eefc4ca710c5ded42ea0b260`:

- `pnpm evals:e2e workspace-engine-upgrade --daytona`: passed, 310.02s. Starts on v1, changes to v2 through Settings, then returns to v1.
- `OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e streamed-markdown-answer --daytona`: passed unchanged, 251.13s. Sent text and answer blocks never disappear or duplicate; reload retains the rendered document.
- `pnpm evals:e2e workspace-new-task-hit-target --daytona`: passed on v1, 127.34s.
- Each runtime run used `OPENWORK_EVAL_REF=fix/v2-workspace-upgrade`: 1 passed, 0 failed, 0 skipped. All three have published sections in the test-evidence comment.
- `pnpm exec bun test apps/app/tests/opencode-v2-adapter.test.ts apps/app/tests/workspace-routes.test.ts`: 49 passed, 0 failed.
- The eval typecheck reports the same 323 error signatures on a clean current-dev control and this branch, with no new errors. It is not a passing repository typecheck.

This change does not migrate conversation history or establish complete v2 feature parity.
