### PR TITLE
Restore underlying tool details for v2 Code Mode

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -237,6 +237,11 @@ function compatibleToolName(tool: string): string {
   return tool === "shell" ? "bash" : tool;
 }
 
+function toolPartMetadata(tool: string): Pick<ToolPart, "metadata"> {
+  // Adapter provenance stays separate from metadata returned by the tool.
+  return tool === "execute" ? { metadata: { openworkV2CodeMode: true } } : {};
+}
+
 function toolOutput(value: unknown, result?: unknown): string {
   if (Array.isArray(value)) {
     const text = value.flatMap((item) => {
@@ -281,6 +286,7 @@ function mapV2ToolPart(
     type: "tool",
     callID,
     tool,
+    ...toolPartMetadata(sourceTool),
   };
 
   if (status === "pending") {
@@ -595,6 +601,7 @@ function pendingToolPart(stream: ToolStream): ToolPart {
     type: "tool",
     callID: stream.callID,
     tool: stream.tool,
+    ...toolPartMetadata(stream.tool),
     state: {
       status: "pending",
       input: stream.input,
@@ -611,6 +618,7 @@ function runningToolPart(stream: ToolStream, start: number): ToolPart {
     type: "tool",
     callID: stream.callID,
     tool: stream.tool,
+    ...toolPartMetadata(stream.tool),
     state: {
       status: "running",
       input: stream.input,
@@ -633,6 +641,7 @@ function completedToolPart(
     type: "tool",
     callID: stream.callID,
     tool: stream.tool,
+    ...toolPartMetadata(stream.tool),
     state: {
       status: "completed",
       input: stream.input,
@@ -656,6 +665,7 @@ function failedToolPart(
     type: "tool",
     callID: stream.callID,
     tool: stream.tool,
+    ...toolPartMetadata(stream.tool),
     state: {
       status: "error",
       input: stream.input,

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -26,6 +26,8 @@ type CapabilityCallLineProps = ChatToolReconnectCallbacks & {
   part: DynamicToolUIPart
   className?: string
   connector?: ConnectorToolIdentity | null
+  resultUnavailable?: boolean
+  statusUnknown?: boolean
 }
 
 function ConnectorMark({ connector }: { connector: ConnectorToolIdentity }) {
@@ -102,7 +104,7 @@ function failureInstruction(part: DynamicToolUIPart, reconnectName: string | nul
   return "The call failed. Full error is under Technical details."
 }
 
-function TechnicalDetailsPanel({ part }: { part: DynamicToolUIPart }) {
+export function TechnicalDetailsPanel({ part, resultUnavailable = false }: { part: DynamicToolUIPart; resultUnavailable?: boolean }) {
   return (
     <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
       <div className="font-mono text-[11px] text-muted-foreground">
@@ -117,6 +119,9 @@ function TechnicalDetailsPanel({ part }: { part: DynamicToolUIPart }) {
         <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
           {formatTechnicalValue(part.output)}
         </pre>
+      ) : null}
+      {resultUnavailable ? (
+        <p>The engine did not provide an individual result for this action. See the execution details.</p>
       ) : null}
       {part.state === "output-error" && part.errorText ? (
         <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
@@ -141,15 +146,17 @@ export function CapabilityCallLine({
   part,
   className,
   connector,
+  resultUnavailable = false,
+  statusUnknown = false,
   onReconnect,
   onReopenAuthorization,
   onRetry,
 }: CapabilityCallLineProps) {
   const [open, setOpen] = useState(false)
   const [detailsOpen, setDetailsOpen] = useState(false)
-  const inFlight = isToolPartInFlight(part)
+  const inFlight = !statusUnknown && isToolPartInFlight(part)
   const isFailed = part.state === "output-error"
-  const duration = trackToolCallDuration(part)
+  const duration = statusUnknown ? null : trackToolCallDuration(part)
   const { reconnectAction, reconnectState, reconnectError, reconnectPresentation, handleReconnect } =
     useChatToolReconnect(part, { onReconnect, onReopenAuthorization, onRetry })
   const ReconnectIcon = reconnectState === "opening"
@@ -260,7 +267,7 @@ export function CapabilityCallLine({
   }
 
   const sentence = getCapabilityCallSentence(part)
-  const line = inFlight ? sentence.present : sentence.past
+  const line = statusUnknown ? `${sentence.present} — status unavailable` : inFlight ? sentence.present : sentence.past
   return (
     <Collapsible data-capability-call={part.toolName} open={open} onOpenChange={setOpen} className={className}>
       <div className="flex min-w-0 items-center gap-2">
@@ -282,7 +289,7 @@ export function CapabilityCallLine({
         </CollapsibleTrigger>
       </div>
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
-        <TechnicalDetailsPanel part={part} />
+        <TechnicalDetailsPanel part={part} resultUnavailable={resultUnavailable} />
       </CollapsibleContent>
     </Collapsible>
   )

--- a/apps/app/src/components/chat/code-mode-tool.tsx
+++ b/apps/app/src/components/chat/code-mode-tool.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import type { DynamicToolUIPart } from "ai";
+import { ChevronRight } from "lucide-react";
+import { CapabilityCallLine, TechnicalDetailsPanel } from "./capability-call-line";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import type { CurrentToolLifecycle } from "@/lib/current-tool-lifecycle";
+import { isToolPartInFlight } from "@/lib/tool-activity";
+import { cn } from "@/lib/utils";
+import { resolveConnectorToolIdentity, type ConnectorToolIdentity } from "@/react-app/domains/connections/connector-tool-identity";
+
+export function CodeModeTool({ part, calls, lifecycle, connectors }: {
+  part: DynamicToolUIPart;
+  calls: DynamicToolUIPart[];
+  lifecycle: CurrentToolLifecycle | null;
+  connectors: ConnectorToolIdentity[];
+}) {
+  const [open, setOpen] = useState(true);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const inFlight = isToolPartInFlight(part);
+  const failed = part.state === "output-error" || calls.some(call => call.state === "output-error");
+  const status = inFlight
+    ? lifecycle === "waiting" ? "Waiting for your action" : lifecycle === "running" ? "Running" : "Status unavailable"
+    : failed ? "Completed with errors" : "Completed";
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} data-code-mode-call={part.toolCallId}>
+      <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground">
+        <ChevronRight aria-hidden="true" className={cn("size-3 transition-transform", open && "rotate-90")} />
+        <span>{calls.length ? "Tool activity" : "Task step"}</span>
+        <span className={cn("text-xs", failed && "text-destructive")}>{status}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-2 border-l border-border pl-3">
+        {calls.map(call => (
+          <CapabilityCallLine
+            key={call.toolCallId}
+            part={call}
+            connector={resolveConnectorToolIdentity(call, connectors)}
+            resultUnavailable={call.state === "output-available"}
+            statusUnknown={isToolPartInFlight(call) && (!inFlight || lifecycle !== "running")}
+          />
+        ))}
+        <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
+          <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground">
+            <ChevronRight aria-hidden="true" className={cn("size-3 transition-transform", detailsOpen && "rotate-90")} />
+            Execution details
+          </CollapsibleTrigger>
+          <CollapsibleContent><TechnicalDetailsPanel part={part} /></CollapsibleContent>
+        </Collapsible>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -85,6 +85,8 @@ import {
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
 import { CapabilityCallLine } from "@/components/chat/capability-call-line"
+import { CodeModeTool } from "@/components/chat/code-mode-tool"
+import { codeModeToolCalls } from "@/lib/code-mode-tools"
 import { hasPreservedMcpAppResult, McpAppFrame } from "@/components/chat/mcp-app-frame"
 import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { SubagentRunLine } from "@/components/chat/subagent-run-line"
@@ -181,6 +183,11 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
   const { connectorIdentities, onMcpReconnect, onMcpReopenAuthorization, onMcpRetry } = useMessageList()
   const resolveLifecycle = useCurrentToolLifecycleResolver()
   const lifecycle = resolveLifecycle(part.toolCallId, isToolPartInFlight(part))
+
+  if (part.type === "dynamic-tool") {
+    const calls = codeModeToolCalls(part)
+    if (calls) return <CodeModeTool part={part} calls={calls} lifecycle={lifecycle} connectors={connectorIdentities} />
+  }
 
   if (lifecycle === "waiting") {
     return (

--- a/apps/app/src/lib/code-mode-tools.ts
+++ b/apps/app/src/lib/code-mode-tools.ts
@@ -1,0 +1,27 @@
+import type { DynamicToolUIPart } from "ai";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Project recorded calls, never infer execution by parsing the generated code. */
+export function codeModeToolCalls(part: DynamicToolUIPart): DynamicToolUIPart[] | null {
+  const codeMode = part.callProviderMetadata?.openwork?.codeMode;
+  if (!isRecord(codeMode) || !Array.isArray(codeMode.calls)) return null;
+  return codeMode.calls.flatMap((call, ordinal): DynamicToolUIPart[] => {
+    if (!isRecord(call) || typeof call.tool !== "string" || !call.tool.trim()) return [];
+    const base = {
+      // v2 reports calls in their invocation order, including repeated/parallel calls.
+      toolCallId: `${part.toolCallId}:call:${ordinal}`,
+      toolName: call.tool.replaceAll(".", "_"),
+      input: call.input,
+    };
+    if (call.status === "running") return [{ ...base, type: "dynamic-tool", state: "input-streaming" }];
+    if (call.status === "completed") return [{ ...base, type: "dynamic-tool", state: "output-available", output: undefined }];
+    if (call.status === "error") return [{
+      ...base, type: "dynamic-tool", state: "output-error",
+      errorText: "The tool call failed. The engine did not provide an individual error; see the execution details.",
+    }];
+    return [];
+  });
+}

--- a/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/parse-tool-parts.ts
@@ -82,6 +82,11 @@ function toolCallProviderMetadata(part: ToolPart): ProviderMetadata {
   const openwork = {
     ...(mcpResult ? { mcpResult } : {}),
     ...(childSessionId ? { childSessionId } : {}),
+    ...(part.metadata?.openworkV2CodeMode === true ? {
+      codeMode: {
+        calls: Array.isArray(stateMetadata.toolCalls) && isJsonValue(stateMetadata.toolCalls) ? stateMetadata.toolCalls : [],
+      },
+    } : {}),
   };
   return {
     opencode: { partId: part.id },
@@ -134,6 +139,14 @@ export function parseDynamicToolUIPart(part: ToolPart): DynamicToolUIPart | null
   }
 
   if (part.state.status === "completed") {
+    if (part.metadata?.openworkV2CodeMode === true && part.state.metadata.error === true) {
+      return {
+        type: "dynamic-tool", toolName: part.tool, toolCallId: part.callID,
+        state: "output-error", input: part.state.input,
+        errorText: normalizeErrorText(part.state.output).display,
+        callProviderMetadata: toolCallProviderMetadata(part),
+      };
+    }
     return {
       type: "dynamic-tool",
       toolName: part.tool,

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -5,6 +5,8 @@ import {
   createV2EventTranslationState,
   translateV2Event,
 } from "../src/app/lib/opencode-v2-adapter";
+import { parseDynamicToolUIPart } from "../src/react-app/domains/session/sync/parse-tool-parts";
+import { codeModeToolCalls } from "../src/lib/code-mode-tools";
 
 const capturedPermissionAsked = {
   id: "evt_permission_asked",
@@ -540,6 +542,50 @@ describe("OpenCode v2 event translation", () => {
 });
 
 describe("OpenCode v2 client compatibility", () => {
+  test("Code Mode keeps the same child identities through progress, replay, and saved history", async () => {
+    const state = createV2EventTranslationState();
+    const data = { sessionID: "ses_code", assistantMessageID: "msg_code", id: "execute-code" };
+    const toolCalls = [
+      { tool: "openwork-cloud.search_capabilities", status: "completed", input: { query: "Slack" } },
+      { tool: "openwork-cloud.execute_capability", status: "running", input: { name: "mcp:connection:list_channels" } },
+    ];
+    translateV2Event({ type: "session.tool.input.started", data: { ...data, name: "execute" } }, state);
+    translateV2Event({ type: "session.tool.called", data: { ...data, input: { code: "recorded code" } } }, state);
+    const progress = { type: "session.tool.progress", data: { ...data, metadata: { toolCalls } } };
+    const expected = [{ type: "message.part.updated", properties: { part: {
+      id: "execute-code", callID: "execute-code", tool: "execute", metadata: { openworkV2CodeMode: true },
+      state: { status: "running", metadata: { toolCalls } },
+    } } }];
+    expect(translateV2Event(progress, state)).toMatchObject(expected);
+    expect(translateV2Event(progress, state)).toMatchObject(expected);
+    const completedCalls = toolCalls.map(call => ({ ...call, status: "completed" }));
+    expect(translateV2Event({ type: "session.tool.success", data: {
+      ...data, metadata: { toolCalls: completedCalls }, content: [{ type: "text", text: "Combined result" }],
+    } }, state)).toMatchObject([{ properties: { part: { id: "execute-code", state: {
+      output: "Combined result", metadata: { toolCalls: completedCalls },
+    } } } }]);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => jsonResponse({ data: [{
+      id: "msg_code", type: "assistant", time: { created: 1, completed: 2 },
+      content: [{ id: "execute-code", type: "tool", name: "execute", time: { created: 1, completed: 2 }, state: {
+        status: "completed", input: { code: "recorded code" }, metadata: { toolCalls: completedCalls },
+        content: [{ type: "text", text: "Combined result" }],
+      } }],
+    }] });
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.messages({ sessionID: "ses_code" });
+      const saved = result.data?.[0]?.parts[0];
+      if (saved?.type !== "tool") throw new Error("Missing saved execute part");
+      const ui = parseDynamicToolUIPart(saved);
+      if (!ui) throw new Error("Missing execute UI part");
+      expect(codeModeToolCalls(ui)?.map(call => [call.toolCallId, call.toolName, call.state])).toEqual([
+        ["execute-code:call:0", "openwork-cloud_search_capabilities", "output-available"],
+        ["execute-code:call:1", "openwork-cloud_execute_capability", "output-available"],
+      ]);
+      expect(ui).toMatchObject({ output: "Combined result" });
+    } finally { globalThis.fetch = originalFetch; }
+  });
   test("maps only missing and empty native titles to stable read-time placeholders", async () => {
     const originalFetch = globalThis.fetch;
     const created = 1_788_548_737_221;

--- a/apps/app/tests/session-sync-tool-parts.test.ts
+++ b/apps/app/tests/session-sync-tool-parts.test.ts
@@ -16,6 +16,7 @@ import {
   parseStructuredOutputUIPart,
 } from "../src/react-app/domains/session/sync/parse-tool-parts";
 import { parseOpenWorkSessionCreateResult } from "../src/components/tools/openwork-session-create";
+import { codeModeToolCalls } from "../src/lib/code-mode-tools";
 
 afterEach(() => {
   getReactQueryClient().clear();
@@ -88,6 +89,52 @@ function writeToolPart(
 }
 
 describe("tool part mapper", () => {
+  test("v1 execute tools keep their existing representation even with code or toolCalls metadata", () => {
+    const part = writeToolPart("completed", { code: 'tools["openwork-cloud"].search_capabilities({})' }, { tool: "execute" });
+    if (part.state.status !== "completed") throw new Error("Expected completed fixture");
+    part.state.metadata = { toolCalls: [{ tool: "openwork-cloud.search_capabilities", status: "completed" }] };
+    const mapped = parseDynamicToolUIPart(part);
+    if (!mapped) throw new Error("Missing v1 tool");
+    expect(codeModeToolCalls(mapped)).toBeNull();
+    expect(mapped).toMatchObject({ toolName: "execute", state: "output-available", output: "ok" });
+  });
+
+  test("Code Mode uses recorded invocation positions for repeated calls and preserves partial failures", () => {
+    const part = writeToolPart("completed", { code: "recorded code" }, { tool: "execute" });
+    if (part.state.status !== "completed") throw new Error("Expected completed fixture");
+    part.metadata = { openworkV2CodeMode: true };
+    part.state.metadata = { toolCalls: [
+      { tool: "openwork-cloud.search_capabilities", status: "completed", input: { query: "Slack" } },
+      null,
+      { tool: "openwork-cloud.search_capabilities", status: "running", input: { query: "Calendar" } },
+      { tool: "openwork-cloud.execute_capability", status: "error", input: { name: "mcp:connection:list_channels" } },
+      { tool: "unexpected", status: "unrecognized" },
+    ] };
+    const mapped = parseDynamicToolUIPart(part);
+    if (!mapped) throw new Error("Missing Code Mode tool");
+    const calls = codeModeToolCalls(mapped);
+    expect(calls?.map(call => [call.toolCallId, call.toolName, call.state])).toEqual([
+      ["call-write:call:0", "openwork-cloud_search_capabilities", "output-available"],
+      ["call-write:call:2", "openwork-cloud_search_capabilities", "input-streaming"],
+      ["call-write:call:3", "openwork-cloud_execute_capability", "output-error"],
+    ]);
+    expect(calls?.[0]?.input).toEqual({ query: "Slack" });
+    expect(calls?.[0]).toHaveProperty("output", undefined);
+    expect(codeModeToolCalls({ ...mapped, toolCallId: "other-parent" })?.[0]?.toolCallId).toBe("other-parent:call:0");
+    expect(mapped).toMatchObject({ state: "output-available", output: "ok" });
+  });
+
+  test("a v2 completed wrapper with an error retains the actual execution error", () => {
+    const part = writeToolPart("completed", { code: "throw new Error()" }, { tool: "execute" });
+    if (part.state.status !== "completed") throw new Error("Expected completed fixture");
+    part.metadata = { openworkV2CodeMode: true };
+    part.state.metadata = { error: true, toolCalls: [] };
+    part.state.output = "History lookup failed.";
+    const mapped = parseDynamicToolUIPart(part);
+    expect(mapped).toMatchObject({ state: "output-error", errorText: "History lookup failed." });
+    if (!mapped) throw new Error("Missing Code Mode tool");
+    expect(codeModeToolCalls(mapped)).toEqual([]);
+  });
   test("defers in-progress tools with empty input", () => {
     // shouldDeferInProgressTool left with the legacy message list (#2016);
     // the deferral behavior itself is still pinned here via the parser and

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -82,7 +82,9 @@ export interface MockMcpTool {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
-  result: { content: { type: "text"; text: string }[] };
+  /** Hold the response while the real engine exposes its running tool state. */
+  delayMs?: number;
+  result: { content: { type: "text"; text: string }[]; isError?: boolean };
 }
 
 export interface StartMockMcpOptions {

--- a/evals/specs/connector-tool-call-branding.e2e.test.ts
+++ b/evals/specs/connector-tool-call-branding.e2e.test.ts
@@ -52,6 +52,7 @@ test("connector-backed tool calls show first-class branding and human-readable l
     await user.see({ text: /^Reading history$/ }, { timeoutMs: 30_000 });
     await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 60_000 });
     await user.see("Run task");
+    await user.see({ text: "The history lookup failed." });
     await user.notSee({ role: "button", label: "Read history. Show technical details" });
     await user.notSee({ role: "button", label: /^Ran(?:\s|\.|[0-9]|$)/ });
     expect(await world.den.mocks.connector.toolCalls({ name: "read_history", sinceIso, atLeast: 1 }))
@@ -59,6 +60,7 @@ test("connector-backed tool calls show first-class branding and human-readable l
     await user.screenshot();
     await user.reload();
     await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 30_000 });
+    await user.see({ text: "The history lookup failed." });
     await user.notSee({ role: "button", label: "Read history. Show technical details" });
     await user.notSee({ role: "button", label: /^Ran(?:\s|\.|[0-9]|$)/ });
   });

--- a/evals/specs/connector-tool-call-branding.e2e.test.ts
+++ b/evals/specs/connector-tool-call-branding.e2e.test.ts
@@ -19,7 +19,8 @@ test("connector-backed tool calls show first-class branding and human-readable l
   await step("the completed connector action exposes its arguments and survives reload", async () => {
     await user.see({ text: world.proof }, { timeoutMs: 60_000 });
     await user.see("Run task");
-    expect(await world.den.mocks.connector.toolCalls({ name: "list_channels", sinceIso, atLeast: 1 })).toHaveLength(1);
+    expect(await world.den.mocks.connector.toolCalls({ name: "list_channels", sinceIso, atLeast: 1 }))
+      .toMatchObject([{ name: "list_channels", args: { limit: 3 } }]);
     // TODO(primitive): probe.connectorBranding
     const inspect = () => probe.eval(`(() => {
       const rows = [...document.querySelectorAll('[data-capability-call]')];
@@ -34,11 +35,15 @@ test("connector-backed tool calls show first-class branding and human-readable l
     expect(branded).toMatchObject({ count: 1, connector: "Slack", imageLoaded: true });
     await user.click({ role: "button", label: "Listed channels. Show technical details" });
     await user.see({ text: /mcp:.*:list_channels/ });
+    await user.see({ text: /"limit":\s*3/ });
     await user.screenshot();
     await user.reload();
     await user.see({ text: /^Listed channels$/ }, { timeoutMs: 30_000 });
     expect(await inspect()).toMatchObject({ count: 1, connector: "Slack" });
     await user.notSee({ text: /openwork-cloud_execute_capability/ });
+    await user.click({ role: "button", label: "Listed channels. Show technical details" });
+    await user.see({ text: /"limit":\s*3/ });
+    await user.click({ role: "button", label: "Listed channels. Hide technical details" });
   });
 
   await step("a failed connector action stays identifiable and is not shown as successful", async () => {
@@ -49,7 +54,8 @@ test("connector-backed tool calls show first-class branding and human-readable l
     await user.see("Run task");
     await user.notSee({ role: "button", label: "Read history. Show technical details" });
     await user.notSee({ role: "button", label: /^Ran(?:\s|\.|[0-9]|$)/ });
-    expect(await world.den.mocks.connector.toolCalls({ name: "read_history", sinceIso, atLeast: 1 })).toHaveLength(1);
+    expect(await world.den.mocks.connector.toolCalls({ name: "read_history", sinceIso, atLeast: 1 }))
+      .toMatchObject([{ name: "read_history", args: { limit: 3 } }]);
     await user.screenshot();
     await user.reload();
     await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 30_000 });

--- a/evals/specs/connector-tool-call-branding.e2e.test.ts
+++ b/evals/specs/connector-tool-call-branding.e2e.test.ts
@@ -2,24 +2,54 @@ import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { connectorBranding, isRecord } from "../worlds/library.ts";
 
-const test = spec.world(connectorBranding);
+const test = spec.world(connectorBranding, { timeout: 420_000 });
 
-test("connector-backed tool calls show first-class branding and human-readable labels", async ({ user, probe }) => {
-  await user.see({ text: /Fetched Google Workspace Calendar Events/ }, { timeoutMs: 30_000 });
-  await user.notSee({ text: /openwork-cloud_execute_capability/ });
-  // TODO(primitive): probe.connectorBranding
-  const rendered = await probe.eval(`(() => {
-    const mark = document.querySelector('[data-connector-name="Google Workspace"]');
-    const row = mark?.closest('[data-capability-call]');
-    const image = mark?.querySelector('img');
-    return {
-      connector: mark?.getAttribute('data-connector-name') ?? null,
-      imageLoaded: image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0,
-      text: row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, ' ').trim() : '',
-      rawNameVisible: document.body.innerText.includes('openwork-cloud_execute_capability'),
-    };
-  })()`);
-  expect(rendered).toMatchObject({ connector: "Google Workspace", imageLoaded: true, rawNameVisible: false });
-  if (!isRecord(rendered) || typeof rendered.text !== "string") throw new Error("The connector row was not readable.");
-  expect(rendered.text).toContain("Fetched Google Workspace Calendar Events");
+test("connector-backed tool calls show first-class branding and human-readable labels", async ({ world, user, probe, step }) => {
+  const sinceIso = new Date().toISOString();
+  await user.type("composer", world.prompt);
+  await user.click("Run task");
+
+  await step("the real search and connector action are readable while the tool runs", async () => {
+    await user.see({ text: /Searched your connections for.*Slack list_channels/ }, { timeoutMs: 60_000 });
+    await user.see({ text: /^Listing channels$/ }, { timeoutMs: 30_000 });
+    await user.notSee({ text: /openwork-cloud_execute_capability/ });
+    await user.screenshot();
+  });
+
+  await step("the completed connector action exposes its arguments and survives reload", async () => {
+    await user.see({ text: world.proof }, { timeoutMs: 60_000 });
+    await user.see("Run task");
+    expect(await world.den.mocks.connector.toolCalls({ name: "list_channels", sinceIso, atLeast: 1 })).toHaveLength(1);
+    // TODO(primitive): probe.connectorBranding
+    const inspect = () => probe.eval(`(() => {
+      const rows = [...document.querySelectorAll('[data-capability-call]')];
+      const matching = rows.filter(row => row.textContent.includes('Listed channels'));
+      const mark = matching[0]?.querySelector('[data-connector-name="Slack"]');
+      const image = mark?.querySelector('img');
+      return { count: matching.length, connector: mark?.getAttribute('data-connector-name'),
+        imageLoaded: image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 };
+    })()`);
+    const branded = await probe.eventually(inspect, { within: 15_000, label: "Slack tool icon and one completed row",
+      until: (value) => isRecord(value) && value.imageLoaded === true });
+    expect(branded).toMatchObject({ count: 1, connector: "Slack", imageLoaded: true });
+    await user.click({ role: "button", label: "Listed channels. Show technical details" });
+    await user.see({ text: /mcp:.*:list_channels/ });
+    await user.screenshot();
+    await user.reload();
+    await user.see({ text: /^Listed channels$/ }, { timeoutMs: 30_000 });
+    expect(await inspect()).toMatchObject({ count: 1, connector: "Slack" });
+    await user.notSee({ text: /openwork-cloud_execute_capability/ });
+  });
+
+  await step("a failed connector action stays identifiable and is not shown as successful", async () => {
+    await user.type("composer", world.failurePrompt);
+    await user.click("Run task");
+    await user.see({ text: /^Reading history$/ }, { timeoutMs: 30_000 });
+    await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 60_000 });
+    await user.see("Run task");
+    expect(await world.den.mocks.connector.toolCalls({ name: "read_history", sinceIso, atLeast: 1 })).toHaveLength(1);
+    await user.screenshot();
+    await user.reload();
+    await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 30_000 });
+  });
 });

--- a/evals/specs/connector-tool-call-branding.e2e.test.ts
+++ b/evals/specs/connector-tool-call-branding.e2e.test.ts
@@ -47,9 +47,13 @@ test("connector-backed tool calls show first-class branding and human-readable l
     await user.see({ text: /^Reading history$/ }, { timeoutMs: 30_000 });
     await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 60_000 });
     await user.see("Run task");
+    await user.notSee({ role: "button", label: "Read history. Show technical details" });
+    await user.notSee({ role: "button", label: /^Ran(?:\s|\.|[0-9]|$)/ });
     expect(await world.den.mocks.connector.toolCalls({ name: "read_history", sinceIso, atLeast: 1 })).toHaveLength(1);
     await user.screenshot();
     await user.reload();
     await user.see({ role: "button", label: /Read history failed/ }, { timeoutMs: 30_000 });
+    await user.notSee({ role: "button", label: "Read history. Show technical details" });
+    await user.notSee({ role: "button", label: /^Ran(?:\s|\.|[0-9]|$)/ });
   });
 });

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -1,13 +1,14 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { app as startApp, faultProxy as startFaultProxy, SkipError } from "@openwork/env";
+import { app as startApp, faultProxy as startFaultProxy, resolveEvalEngine, SkipError } from "@openwork/env";
 import type { Den, MockHandle, Seed } from "@openwork/env";
 import { denFetch, evalIn as rawEvalIn } from "@openwork/behaviors";
 import type { DenFetchResult, DenSession } from "@openwork/behaviors";
 import { allocateFreePort } from "@openwork/cdp";
 import { startMockMcp } from "@openwork/labs";
 import { captureExternalBrowserUrls, electronProfilePaths } from "@openwork/hosts";
+import { configureProvider } from "./chat.ts";
 
 export const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -315,15 +316,59 @@ export async function preseededConnect(seed: Seed) {
 }
 
 export async function connectorBranding(seed: Seed) {
-  const app = await seed.desktop({ name: "connector-tool-call-branding" });
-  await seed.workspace(app, seed.tmpPath("connector-tool-call-branding"));
-  await seed.session(app);
-  // TODO(primitive): seed.connectorToolCall
-  await seed.evalIn(app, `window.__openworkControl.execute("eval.connector_tool_call.seed")`, {
-    awaitPromise: true,
-    timeoutMs: 60_000,
+  const engine = resolveEvalEngine();
+  const proof = `Channel list ${crypto.randomUUID()}`;
+  const prompt = "List my Slack channels.";
+  const failurePrompt = "Read my Slack history.";
+  const search = (name: string) => ({ query: `Slack ${name}`, type: "mcp", limit: 1 });
+  const steps = (name: string) => engine === "v2" ? [{
+    tool: "execute",
+    arguments: { code: `
+      const found = await tools["openwork-cloud"].search_capabilities(${JSON.stringify(search(name))});
+      const result = typeof found === "string" ? JSON.parse(found) : found;
+      const catalog = result.matches ? result : JSON.parse(result.content[0].text);
+      return await tools["openwork-cloud"].execute_capability({ name: catalog.matches[0].name });
+    ` },
+  }] : [
+    { tool: "search_capabilities", arguments: search(name) },
+    { tool: "execute_capability", arguments: {}, argumentsFrom: "capability-search" },
+  ];
+  const den = await seed.den({
+    org: { name: "Connector tool display", admin: { name: "Connector Admin" } },
+    mocks: { connector: seed.mock({
+      allowUnauthenticatedMcp: true,
+      tools: [
+        { name: "list_channels", description: "List Slack channels", inputSchema: { type: "object", properties: {} },
+          delayMs: 4_000, result: { content: [{ type: "text", text: proof }] } },
+        { name: "read_history", description: "Read Slack history", inputSchema: { type: "object", properties: {} },
+          delayMs: 4_000, result: { isError: true, content: [{ type: "text", text: "History lookup failed." }] } },
+      ],
+    }) },
   });
-  return { app };
+  await seed.orgConnection(den.admin, {
+    name: "Slack", url: den.mocks.connector.mcpUrl, authType: "none", credentialMode: "shared", access: { orgWide: true },
+  });
+  const workloads = await fetch(`${den.mocks.connector.url}/admin/agent-workloads`, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ workloads: [
+      { promptMarker: prompt, latestUserTurn: true, finalReply: "Listed the channels.", finalReplyFrom: "last-tool-text", steps: steps("list_channels") },
+      { promptMarker: failurePrompt, latestUserTurn: true, finalReply: "The history lookup failed.", steps: steps("read_history") },
+    ] }),
+  });
+  if (!workloads.ok) throw new Error("Could not arrange connector model turns.");
+  const providerId = "connector-display";
+  const modelId = "connector-display-model";
+  const app = await seed.desktop({ den, as: "admin", model: `${providerId}/${modelId}` });
+  const workspace = await seed.workspace(app, seed.tmpPath("connector-tool-call-branding"));
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    provider: { [providerId]: {
+      npm: "@ai-sdk/openai-compatible", name: "Connector display model",
+      options: { baseURL: `${den.mocks.connector.url}/v1`, apiKey: "sk-connector-display-fixture" },
+      models: { [modelId]: { name: "Connector display model" } },
+    } },
+  });
+  await seed.session(app);
+  return { app, den, prompt, failurePrompt, proof };
 }
 
 export async function connectorsQuickAdd(seed: Seed) {

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -318,8 +318,10 @@ export async function preseededConnect(seed: Seed) {
 export async function connectorBranding(seed: Seed) {
   const engine = resolveEvalEngine();
   const proof = `Channel list ${crypto.randomUUID()}`;
-  const prompt = "List my Slack channels.";
-  const failurePrompt = "Read my Slack history.";
+  const prompt = "List three of my Slack channels.";
+  const failurePrompt = "Read the three latest items in my Slack history.";
+  const toolArguments = { limit: 3 };
+  const inputSchema = { type: "object", properties: { limit: { type: "integer" } }, required: ["limit"] };
   const search = (name: string) => ({ query: `Slack ${name}`, type: "mcp", limit: 1 });
   const steps = (name: string) => engine === "v2" ? [{
     tool: "execute",
@@ -327,20 +329,20 @@ export async function connectorBranding(seed: Seed) {
       const found = await tools["openwork-cloud"].search_capabilities(${JSON.stringify(search(name))});
       const result = typeof found === "string" ? JSON.parse(found) : found;
       const catalog = result.matches ? result : JSON.parse(result.content[0].text);
-      return await tools["openwork-cloud"].execute_capability({ name: catalog.matches[0].name, body: {} });
+      return await tools["openwork-cloud"].execute_capability({ name: catalog.matches[0].name, body: ${JSON.stringify(toolArguments)} });
     ` },
   }] : [
     { tool: "search_capabilities", arguments: search(name) },
-    { tool: "execute_capability", arguments: { body: {} }, argumentsFrom: "capability-search" },
+    { tool: "execute_capability", arguments: { body: toolArguments }, argumentsFrom: "capability-search" },
   ];
   const den = await seed.den({
     org: { name: "Connector tool display", admin: { name: "Connector Admin" } },
     mocks: { connector: seed.mock({
       allowUnauthenticatedMcp: true,
       tools: [
-        { name: "list_channels", description: "List Slack channels", inputSchema: { type: "object", properties: {} },
+        { name: "list_channels", description: "List Slack channels", inputSchema,
           delayMs: 4_000, result: { content: [{ type: "text", text: proof }] } },
-        { name: "read_history", description: "Read Slack history", inputSchema: { type: "object", properties: {} },
+        { name: "read_history", description: "Read Slack history", inputSchema,
           delayMs: 4_000, result: { isError: true, content: [{ type: "text", text: "History lookup failed." }] } },
       ],
     }) },

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -327,11 +327,11 @@ export async function connectorBranding(seed: Seed) {
       const found = await tools["openwork-cloud"].search_capabilities(${JSON.stringify(search(name))});
       const result = typeof found === "string" ? JSON.parse(found) : found;
       const catalog = result.matches ? result : JSON.parse(result.content[0].text);
-      return await tools["openwork-cloud"].execute_capability({ name: catalog.matches[0].name });
+      return await tools["openwork-cloud"].execute_capability({ name: catalog.matches[0].name, body: {} });
     ` },
   }] : [
     { tool: "search_capabilities", arguments: search(name) },
-    { tool: "execute_capability", arguments: {}, argumentsFrom: "capability-search" },
+    { tool: "execute_capability", arguments: { body: {} }, argumentsFrom: "capability-search" },
   ];
   const den = await seed.den({
     org: { name: "Connector tool display", admin: { name: "Connector Admin" } },

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -705,7 +705,7 @@ function tokenFingerprint(req) {
 
 function mcpResult(message) {
   if (configuredTools.length && message.method === "tools/list") {
-    return { tools: configuredTools.map(({ result, ...tool }) => tool) };
+    return { tools: configuredTools.map(({ result, delayMs, ...tool }) => tool) };
   }
   if (message.method === "tools/call") {
     const tool = configuredTools.find((candidate) => candidate.name === message.params?.name);
@@ -916,6 +916,9 @@ async function handleMcp(req, res, entry) {
       args: message.params.arguments ?? message.params.args ?? {},
       tokenId: entry.tokenId,
     }));
+  const responseDelay = Math.max(0, ...entry.toolNames.map((name) =>
+    configuredTools.find((tool) => tool.name === name)?.delayMs ?? 0));
+  if (responseDelay > 0) await new Promise((resolve) => setTimeout(resolve, responseDelay));
   const responses = messages.flatMap((message) => {
     if (!message || typeof message !== "object" || message.id === undefined) return [];
     return [mcpResponse(message)];
@@ -952,7 +955,8 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/admin/tools" && req.method === "POST") {
       const body = await readJson(req);
-      if (!Array.isArray(body?.tools) || body.tools.some((tool) => !tool || typeof tool.name !== "string" || !tool.inputSchema || !tool.result)) {
+      if (!Array.isArray(body?.tools) || body.tools.some((tool) => !tool || typeof tool.name !== "string" || !tool.inputSchema || !tool.result
+        || (tool.delayMs !== undefined && (!Number.isFinite(tool.delayMs) || tool.delayMs < 0 || tool.delayMs > 30_000)))) {
         json(res, 400, { error: "tools must have a name, inputSchema, and result" });
         return;
       }

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -392,7 +392,7 @@ async function handleAgentCompletion(req, res, entry) {
     return;
   }
   const toolArguments = step.argumentsFrom === "computer-mention" ? computerMentionArguments(messages)
-    : step.argumentsFrom === "capability-search" ? capabilitySearchArguments(scopedMessages) : step.arguments;
+    : step.argumentsFrom === "capability-search" ? { ...step.arguments, ...capabilitySearchArguments(scopedMessages) } : step.arguments;
   const callId = `call_${workload.promptMarker.replace(/[^a-zA-Z0-9_-]/g, "_")}_${completedTools + 1}`;
   entry.agentCompletion = {
     ...baseRequest,

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -166,7 +166,7 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     body: JSON.stringify({ workloads: [{ promptMarker: "Find the assigned skill", finalReply: "unused fixture reply",
       finalReplyFrom: "last-tool-text", steps: [
         { tool: "search_capabilities", arguments: { query: "Assigned skill" } },
-        { tool: "execute_capability", arguments: {}, argumentsFrom: "capability-search" },
+        { tool: "execute_capability", arguments: { body: { limit: 3 } }, argumentsFrom: "capability-search" },
       ],
     }] }),
   });
@@ -186,7 +186,7 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     const result = await modelRequest([JSON.stringify({ matches: [{ name }] })]);
     assert.equal(result.status, 200);
     const call = result.frames.flatMap(frame => frame.choices[0].delta.tool_calls ?? [])[0];
-    assert.deepEqual(JSON.parse(call.function.arguments), { name });
+    assert.deepEqual(JSON.parse(call.function.arguments), { name, body: { limit: 3 } });
   }
   const missing = await modelRequest([JSON.stringify({ matches: [] })]);
   assert.equal(missing.status, 500);


### PR DESCRIPTION
V2 runs connector work inside Code Mode, but chat rendered only a generic “Ran” row. Preserve the recorded child calls through the v2 adapter and show readable search/action labels, connector identity, arguments, and failures in an expandable activity group. Generated code and the combined result remain under Execution details. V1 keeps its existing rendering path, including ordinary tools named execute.

The existing branding journey now sends normal chat requests through the real desktop, engine, OpenWork gateway, and synthetic MCP instead of injecting a transcript. Identical assertions on v1 and v2 check live activity, one connector invocation, the connector result reaching chat, a loaded connector icon, `limit: 3` reaching the connector and appearing in details before and after reload, and the failed action plus final assistant reply surviving reload without a successful-looking duplicate. The model is deterministic.

V2 currently exposes child names, inputs, and statuses, but no individual results or error messages. Details explain that limit rather than inventing results; child IDs use the parent call ID and invocation ordinal.

Validation on `1c3705a0a34ae13c201ace9c141c511833c2da53`:

- Cold Daytona journey, v2: **passed**, 272.68s, 1 test, zero skips.
- Cold Daytona journey, v1: **passed**, 272.85s, 1 test, zero skips.
- Adapter/parser unit tests: **44 passed**, 0 failed.
- Mock MCP server suite: **1 passed**, 0 failed.
- Evals typecheck: **325 errors**, matching clean control `da4694ea3a208a7dfda74739a1ace30456bbd596`; no new diagnostic signatures.
- Screenshots support the UI and connector-witness assertions; they have no separate vision judgments.

```sh
OPENWORK_EVAL_REF=fix/v2-tool-call-display OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e connector-tool-call-branding --daytona
OPENWORK_EVAL_REF=fix/v2-tool-call-display OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e connector-tool-call-branding --daytona
pnpm exec bun test apps/app/tests/session-sync-tool-parts.test.ts apps/app/tests/opencode-v2-adapter.test.ts
pnpm exec node --test scripts/mock-oauth-mcp-server.test.mjs
pnpm --dir evals typecheck
```

[Historical unfixed v2 reproduction](https://github.com/different-ai/openwork/pull/4548#issuecomment-5556702772): the real tool completed, but the UI showed only “Ran4.5s” and failed the search-label assertion.

[Final v1 and v2 evidence and screenshots](https://github.com/different-ai/openwork/pull/4548#issuecomment-5557150977). CI and Warden are green; all review comments are resolved.
