### PR TITLE
Fix command palette session creation with v2 enabled

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -45,6 +45,7 @@ import { useModelPicker } from "@/react-app/domains/session/modals/use-model-pic
 import {
   type RouteWorkspace,
   type RouteSession,
+  createRouteSession,
   describeRouteError,
   downloadWorkspaceJson,
   getSessionStatus,
@@ -1146,19 +1147,17 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     [sessionsByWorkspaceId, selectedWorkspaceId, workspaces],
   );
   const handleCreatePaletteSession = useCallback(async () => {
-    if (!opencodeClient || !selectedWorkspaceId) {
+    if (!selectedWorkspaceEndpoint?.token || !selectedWorkspaceId) {
       navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session");
       return;
     }
     try {
-      const session = unwrap(
-        await opencodeClient.session.create({ directory: selectedWorkspaceRoot || undefined }),
-      );
+      const session = await createRouteSession(selectedWorkspaceEndpoint, selectedWorkspaceRoot || undefined);
       navigate(workspaceSessionRoute(selectedWorkspaceId, session.id));
     } catch (error) {
       toast.error(describeRouteError(error));
     }
-  }, [navigate, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot]);
+  }, [navigate, selectedWorkspaceEndpoint, selectedWorkspaceId, selectedWorkspaceRoot]);
   // Settings refreshes provider auth whenever the picker opens (the session
   // route does not need this; its provider state is kept fresh elsewhere).
   useEffect(() => {

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -4,7 +4,7 @@ import { observeTranscript, spec, type Probe, type User } from "@openwork/testki
 import { workspaceEngineUpgrade } from "../worlds/chat.ts";
 
 // Fresh-engine chat journeys cannot witness ownership after an upgrade.
-const test = spec.world(workspaceEngineUpgrade, { timeout: 420_000 });
+const test = spec.world(workspaceEngineUpgrade, { timeout: 600_000 });
 const reply = "Hello. Your upgrade conversation is working.";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -32,6 +32,25 @@ async function greet(user: User, probe: Probe) {
 }
 
 test("existing workspaces create usable sessions after changing chat engines", async ({ world, user, probe, step }) => {
+  const macPlatform = await probe.eval(`/Mac|iPhone|iPad|iPod/.test(navigator.platform)`);
+  const paletteShortcut = macPlatform ? "Meta+K" : "Control+K";
+  const createPaletteChat = async () => {
+    const previousRoute = await probe.hash();
+    const paletteInput = { placeholder: "Search actions, settings, and sessions…" };
+    await user.press(paletteShortcut);
+    await user.see(paletteInput);
+    await user.type(paletteInput, "New session", { replace: true });
+    await user.click({ role: "option", label: /^New session\b/ });
+    await probe.eventually(() => probe.hash(), {
+      within: 30_000, label: "palette opens a new chat in the selected workspace",
+      until: (hash) => hash !== previousRoute && hash.includes(`/workspace/${world.primary.workspaceId}/session/ses_`),
+    });
+    await user.notSee(paletteInput);
+    await user.see("Run task", { timeoutMs: 30_000 });
+    await user.notSee({ text: /SessionNotFoundError|Session not found|Session could not be loaded/ });
+    await greet(user, probe);
+  };
+
   expect((await probe.desktopApi("/experimental/engine-v2-preview/status")).body).toMatchObject({ chatRouting: false });
   await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
   await user.see({ text: "OpenCode v2 (preview)" }, { timeoutMs: 30_000 });
@@ -40,6 +59,7 @@ test("existing workspaces create usable sessions after changing chat engines", a
     within: 120_000, label: "v2 configured and running",
     until: (response) => isRecord(response.body) && response.body.running === true && response.body.chatRouting === true,
   });
+  await step("the Settings command palette creates a usable chat after enabling v2", createPaletteChat);
   await go(world.app, `/workspace/${world.primary.workspaceId}/session`);
   await user.reload();
   await user.see("composer", { timeoutMs: 60_000 });
@@ -51,6 +71,8 @@ test("existing workspaces create usable sessions after changing chat engines", a
     await user.see("composer", { timeoutMs: 30_000 });
     await greet(user, probe);
   });
+
+  await step("the chat command palette creates another usable v2 chat", createPaletteChat);
 
   await step("a sidebar new session opens and runs in the configured engine", async () => {
     if (!world.otherName) throw new Error("Existing workspace name missing");
@@ -87,4 +109,9 @@ test("existing workspaces create usable sessions after changing chat engines", a
     });
     await greet(user, probe);
   });
+
+  await step("the chat command palette still creates a usable chat after returning to v1", createPaletteChat);
+  await go(world.app, `/workspace/${world.primary.workspaceId}/settings/advanced`);
+  await user.see({ text: "OpenCode v1 (default)" }, { timeoutMs: 30_000 });
+  await step("the Settings command palette still creates a usable v1 chat", createPaletteChat);
 });

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -65,9 +65,10 @@ test("existing workspaces create usable sessions after changing chat engines", a
   await user.see("composer", { timeoutMs: 60_000 });
 
   await step("a new chat in the selected existing workspace keeps the first message visible", async () => {
+    const previousRoute = await probe.hash();
     await user.click({ role: "button", label: "New session" });
     await probe.eventually(() => probe.hash(), { within: 30_000,
-      label: "new session route", until: (hash) => hash.includes("/session/ses_") });
+      label: "new session route", until: (hash) => hash !== previousRoute && hash.includes("/session/ses_") });
     await user.see("composer", { timeoutMs: 30_000 });
     await greet(user, probe);
   });


### PR DESCRIPTION
Command Palette → New session from Settings created a v1 session while v2 chat routing was enabled. Opening it in the v2 chat view produced an unusable chat. Settings now uses the existing engine-aware `createRouteSession` helper, matching chat and sidebar creation. V1 and older servers retain their existing creation path.

The existing workspace-upgrade journey now opens the actual keyboard palette from both Settings and chat on v2 and again after returning to v1. Each new conversation must accept “hi,” keep it visible during streaming, return a reply, and retain both messages after reload. Existing sidebar creation and pre-upgrade v1 history checks remain covered. History reloads are checked within the engine that created the session; cross-engine history migration is not part of this preview or this PR. No new spec files or CI filename exceptions.

Runtime verdict: **Passed** on final head `1ba9a97fbcee0ff75ff5051a3604da6c575f7718`: 1 cold Daytona journey, all 7 steps passed in 346.211 seconds, 0 failures and 0 skips. [Published evidence](https://github.com/different-ai/openwork/pull/4549#issuecomment-5557220177). Seven screenshots support the observable assertions; no separate visual judgments were requested.

- Historical reproduction: the test-only change failed after sending “hi” through Settings → palette → New session ([trace](https://github.com/different-ai/openwork/pull/4549#issuecomment-5557190238)).
- App typecheck passes. CI is green; Warden security and desktop/server checks are clear. The history-migration review comment was resolved with an explanation of the separate engine stores.
- Route/palette unit selection: 30 pass, 2 failures reproduced identically on clean base `8f33e1403768`. Both are stale expectations in `command-palette-settings.test.ts` about Advanced settings entries/search ranking; the engine-routing cases all pass.
- Final runtime command: `OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e workspace-engine-upgrade --daytona`. Placement: `daytona (--daytona)`. Uses a deterministic model with the real desktop, Den, and both engines.
