### PR TITLE
fix(automations): wait for engine warm-up and deliver providers before a Cloud run

### DIFF
--- a/ee/apps/den-api/src/automations/cloud-agent-executor.ts
+++ b/ee/apps/den-api/src/automations/cloud-agent-executor.ts
@@ -11,11 +11,13 @@ import {
   OPENWORK_WEB_ACCESS_REQUIRED_CODE,
   OPENWORK_WEB_ACCESS_REQUIRED_MESSAGE,
 } from "../openwork-web-runtime-access.js"
+import { materializeCloudWorkerProviders } from "../llm/cloud-provider-materialization.js"
+import { appLogger } from "../observability/logger.js"
 import { resolveCloudRuntimeAccess, type CloudWorkerAccess } from "../workers/worker-access.js"
 import { cloudHostingAvailable } from "../capability-sources/cloud-hosting.js"
 import { CLOUD_INSTANCE_BACKEND } from "../workers/cloud-constants.js"
 import { wakeCloudWorker } from "../workers/cloud-lifecycle.js"
-import { fetchPreviewNoRedirect, previewFetch } from "../workers/preview-fetch.js"
+import { fetchPreviewNoRedirect, previewFetch, type FetchLike } from "../workers/preview-fetch.js"
 import { resolveAutomationModelAccess } from "./authority.js"
 
 const WORKER_READY_TIMEOUT_MS = 120_000
@@ -23,6 +25,16 @@ const WORKER_READY_POLL_MS = 1_000
 const WORKER_REQUEST_TIMEOUT_MS = 15_000
 const ABORT_SETTLE_TIMEOUT_MS = 15_000
 const RESULT_SUMMARY_LIMIT = 20_000
+// A woken sandbox answers /health as soon as openwork-server binds, before its
+// managed OpenCode engine has spawned. Until then the Cloud MCP health probe
+// reports opencode_unconfigured. Cloud Chat rides this window out because a
+// person takes seconds to type; an Automation sends its first request at once,
+// so it needs an explicit bounded wait instead of a terminal failure.
+const ENGINE_WARMUP_TIMEOUT_MS = 60_000
+const ENGINE_WARMUP_POLL_MS = 2_000
+const ENGINE_WARMUP_FAILURE_CODE = "opencode_unconfigured"
+
+const logger = appLogger.child({ component: "cloud_agent_executor" })
 
 type OwnerScope = { organizationId: string; ownerMemberId: string }
 type AgentAction = Extract<AutomationAction, { kind: "agent" }>
@@ -295,13 +307,41 @@ export function cloudAgentRuntimeUnavailableResult(input: {
   }
 }
 
-async function connectHealth(input: {
+export type CloudConnectDeps = {
+  fetchImpl: FetchLike
+  materializeProviders: typeof materializeCloudWorkerProviders
+  sleep: typeof abortableSleep
+  now: () => number
+}
+
+type CloudConnectResult = { ok: true } | { ok: false; code: "connect_access_unavailable" | "model_access_lost"; message: string }
+
+function engineWarmingUp(health: Record<string, unknown> | null): boolean {
+  const failure = isRecord(health?.firstFailure) ? health.firstFailure : null
+  return failure?.code === ENGINE_WARMUP_FAILURE_CODE
+}
+
+/**
+ * Bring the worker's Cloud MCP to a usable state for this run's model: wait
+ * for the managed engine to finish starting, deliver the organization's
+ * current provider credentials and catalog, then run the health probe (with
+ * one engine refresh) exactly as before.
+ */
+export async function connectHealth(input: {
+  organizationId: string
+  workerId: string
   baseUrl: string
   workspaceId: string
   access: CloudWorkerAccess
   action: AgentAction
   signal: AbortSignal
-}): Promise<{ ok: true } | { ok: false; code: "connect_access_unavailable" | "model_access_lost"; message: string }> {
+}, options: Partial<CloudConnectDeps> = {}): Promise<CloudConnectResult> {
+  const deps: CloudConnectDeps = {
+    fetchImpl: options.fetchImpl ?? previewFetch(),
+    materializeProviders: options.materializeProviders ?? materializeCloudWorkerProviders,
+    sleep: options.sleep ?? abortableSleep,
+    now: options.now ?? Date.now,
+  }
   const encodedWorkspace = encodeURIComponent(input.workspaceId)
   const query = new URLSearchParams({
     provider: input.action.model.providerId,
@@ -309,7 +349,7 @@ async function connectHealth(input: {
     probe: "true",
   })
   const request = async (method: "GET" | "POST", path: string, body?: unknown) => {
-    const response = await fetchPreviewNoRedirect(previewFetch(), `${input.baseUrl}${path}`, {
+    const response = await fetchPreviewNoRedirect(deps.fetchImpl, `${input.baseUrl}${path}`, {
       method,
       headers: {
         ...workerHeaders(input.access),
@@ -322,15 +362,44 @@ async function connectHealth(input: {
     const value: unknown = await response.json()
     return isRecord(value) ? value : null
   }
-  let value = await request("GET", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/health?${query}`)
-  let health = value
+  const healthPath = `/workspace/${encodedWorkspace}/mcp/openwork-cloud/health?${query}`
+
+  let health = await request("GET", healthPath)
+  const warmupDeadline = deps.now() + ENGINE_WARMUP_TIMEOUT_MS
+  while (engineWarmingUp(health) && deps.now() < warmupDeadline) {
+    await deps.sleep(ENGINE_WARMUP_POLL_MS, input.signal)
+    health = await request("GET", healthPath)
+  }
+
+  // Cloud Chat materializes providers on every gateway resolve; Automations
+  // are the only other producer of engine turns and must do the same, or a
+  // provider added or rotated after the worker was provisioned never reaches
+  // a worker that only runs Automations. Runs after the engine is up so the
+  // read phase cannot fail on the same warm-up window.
+  if (!engineWarmingUp(health)) {
+    try {
+      await deps.materializeProviders({
+        organizationId: normalizeDenTypeId("organization", input.organizationId),
+        workerId: normalizeDenTypeId("worker", input.workerId),
+        instanceUrl: input.baseUrl,
+        hostToken: input.access.hostToken,
+        clientToken: input.access.clientToken,
+      })
+    } catch (error) {
+      logger.warn("automation run provider materialization warning", {
+        worker_id: input.workerId,
+        message: error instanceof Error ? error.message : "provider_materialization_failed",
+      })
+    }
+  }
+
   if (health?.usable !== true || health.usableByCurrentModel !== true) {
-    value = await request("POST", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/engine-refresh`, {
+    const refreshed = await request("POST", `/workspace/${encodedWorkspace}/mcp/openwork-cloud/engine-refresh`, {
       provider: input.action.model.providerId,
       model: input.action.model.modelId,
       trigger: "automation_run",
     })
-    health = isRecord(value?.health) ? value.health : null
+    health = isRecord(refreshed?.health) ? refreshed.health : null
   }
   if (health?.usable === true && health.usableByCurrentModel === true) return { ok: true }
   if (health?.usable === true && health.usableByCurrentModel !== true) {
@@ -476,7 +545,15 @@ export async function executeCloudAgent(input: CloudAgentExecutorInput): Promise
     // Recovery keeps the receipt's workspace (the turn may already be running
     // there); otherwise the revision pin wins over the worker's active workspace.
     const workspaceId = previousReceipt?.workspaceId ?? input.workspaceId ?? runtime.workspaceId
-    const connect = await connectHealth({ ...runtime, workspaceId, action: input.action, signal })
+    const connect = await connectHealth({
+      organizationId: input.organizationId,
+      workerId: runtime.workerId,
+      baseUrl: runtime.baseUrl,
+      access: runtime.access,
+      workspaceId,
+      action: input.action,
+      signal,
+    })
     if (!connect.ok) {
       return { ok: false, status: "failed", code: connect.code, message: connect.message, retryable: false, needsAttention: true }
     }

--- a/ee/apps/den-api/test/cloud-agent-signed-preview-routing.test.ts
+++ b/ee/apps/den-api/test/cloud-agent-signed-preview-routing.test.ts
@@ -16,6 +16,7 @@ type ExecutorModule = typeof import("../src/automations/cloud-agent-executor.js"
 let resolveCloudAgentWorkspace: ExecutorModule["resolveCloudAgentWorkspace"]
 let cloudAgentRuntimeUnavailableResult: ExecutorModule["cloudAgentRuntimeUnavailableResult"]
 let resolveCloudAgentReadyWorker: ExecutorModule["resolveCloudAgentReadyWorker"]
+let connectHealth: ExecutorModule["connectHealth"]
 
 beforeAll(async () => {
   seedRequiredEnv()
@@ -23,6 +24,7 @@ beforeAll(async () => {
   resolveCloudAgentWorkspace = executor.resolveCloudAgentWorkspace
   cloudAgentRuntimeUnavailableResult = executor.cloudAgentRuntimeUnavailableResult
   resolveCloudAgentReadyWorker = executor.resolveCloudAgentReadyWorker
+  connectHealth = executor.connectHealth
 })
 
 test("an in-progress Cloud Automation wake preserves the single-attempt terminal baseline", () => {
@@ -119,4 +121,123 @@ test("Cloud Automations discover their workspace through the signed preview", as
     workspaceId: "workspace-automation",
   })
   expect(requested).toEqual(["https://automation.preview.example.test/workspaces"])
+})
+
+type HealthPayload = Record<string, unknown>
+
+function connectScenario(healthReplies: HealthPayload[]) {
+  const requests: Array<{ method: string; path: string }> = []
+  const materialized: string[] = []
+  let sleptMs = 0
+  let now = 0
+  const access: CloudWorkerAccess = {
+    workerId: createDenTypeId("worker"),
+    url: "https://automation.preview.example.test",
+    expiresAt: new Date("2026-09-05T12:00:00.000Z"),
+    clientToken: "client-token",
+    hostToken: "host-token",
+  }
+  let lastHealth: HealthPayload = {}
+  const fetchImpl = async (url: string, init: RequestInit) => {
+    const method = init.method ?? "GET"
+    const path = new URL(url).pathname
+    requests.push({ method, path })
+    // An engine refresh that changes nothing reports the same health again.
+    if (path.endsWith("/engine-refresh")) return Response.json({ health: lastHealth })
+    lastHealth = (healthReplies.length > 1 ? healthReplies.shift() : healthReplies[0]) ?? {}
+    return Response.json(lastHealth)
+  }
+  const run = (signal = new AbortController().signal) => connectHealth({
+    organizationId: createDenTypeId("organization"),
+    workerId: access.workerId,
+    baseUrl: access.url,
+    workspaceId: "workspace-automation",
+    access,
+    action: { kind: "agent", prompt: "Summarize today", model: { providerId: "openwork", modelId: "fast" } },
+    signal,
+  }, {
+    fetchImpl,
+    materializeProviders: async (input) => {
+      materialized.push(`${requests.length}:${input.instanceUrl}`)
+      return { ok: true, status: "cached", fingerprint: "fp", providers: 1 }
+    },
+    now: () => now,
+    sleep: async (ms, signal) => {
+      if (signal.aborted) throw signal.reason
+      sleptMs += ms
+      now += ms
+    },
+  })
+  return { run, requests, materialized, slept: () => sleptMs }
+}
+
+const warmingUp: HealthPayload = {
+  usable: false,
+  usableByCurrentModel: false,
+  firstFailure: { code: "opencode_unconfigured", message: "OpenCode base URL is missing for this workspace." },
+}
+const usable: HealthPayload = { usable: true, usableByCurrentModel: true }
+
+test("a Cloud Automation waits for the managed engine to finish starting instead of failing its first run", async () => {
+  const scenario = connectScenario([warmingUp, warmingUp, usable])
+
+  const result = await scenario.run()
+
+  expect(result).toEqual({ ok: true })
+  expect(scenario.requests.filter((request) => request.path.endsWith("/health"))).toHaveLength(3)
+  expect(scenario.requests.some((request) => request.path.endsWith("/engine-refresh"))).toBe(false)
+  expect(scenario.slept()).toBe(4_000)
+  // Providers are delivered only once the engine answers, after the third probe.
+  expect(scenario.materialized).toEqual(["3:https://automation.preview.example.test"])
+})
+
+test("a Cloud Automation delivers the organization's current providers before every run", async () => {
+  const scenario = connectScenario([usable])
+
+  const result = await scenario.run()
+
+  expect(result).toEqual({ ok: true })
+  expect(scenario.materialized).toHaveLength(1)
+  expect(scenario.slept()).toBe(0)
+})
+
+test("a Connect failure that is not engine warm-up still fails the run immediately", async () => {
+  const scenario = connectScenario([{
+    usable: false,
+    usableByCurrentModel: false,
+    firstFailure: { code: "connect_unauthorized", message: "OpenWork Connect rejected the worker token." },
+  }])
+
+  const result = await scenario.run()
+
+  expect(result).toEqual({
+    ok: false,
+    code: "connect_access_unavailable",
+    message: "OpenWork Connect rejected the worker token.",
+  })
+  expect(scenario.slept()).toBe(0)
+  expect(scenario.requests.map((request) => request.path.split("/").at(-1)?.split("?")[0])).toEqual(["health", "engine-refresh"])
+})
+
+test("an engine that never starts fails the run with its own message after the bounded wait", async () => {
+  const scenario = connectScenario([warmingUp])
+
+  const result = await scenario.run()
+
+  expect(result).toEqual({
+    ok: false,
+    code: "connect_access_unavailable",
+    message: "OpenCode base URL is missing for this workspace.",
+  })
+  expect(scenario.slept()).toBe(60_000)
+  expect(scenario.materialized).toEqual([])
+})
+
+test("cancelling a run during engine warm-up stops waiting", async () => {
+  const controller = new AbortController()
+  const scenario = connectScenario([warmingUp])
+  const pending = scenario.run(controller.signal)
+  controller.abort(new Error("cancelled"))
+
+  await expect(pending).rejects.toThrow("cancelled")
 })


### PR DESCRIPTION
## Problem

A Cloud Automation whose worker just woke from the idle stop fails its first run within seconds with `connect_access_unavailable` — "OpenCode base URL is missing for this workspace" — and is parked as needs-attention. The sandbox answers `/health` as soon as `openwork-server` binds, before its managed OpenCode engine has spawned (the same boot race #4344 fixed for the Cloud Chat gateway path). A person typing into Cloud Chat rides the window out; an Automation sends its first request immediately and loses every time.

Separately, Automations never delivered the organization's provider credentials and model catalog to the worker. Only the Cloud Chat gateway path did, so a provider added or rotated after the worker was provisioned never reached a worker that only runs Automations, and every run failed until the worker idled out and woke again.

## Change

`ee/apps/den-api/src/automations/cloud-agent-executor.ts` — in `connectHealth`, before the existing probe:

1. Wait through engine warm-up: while the health probe's `firstFailure.code` is `opencode_unconfigured`, poll every 2 s for up to 60 s. Cancellation and the run's own deadline interrupt the wait. Any other Connect failure still fails immediately.
2. Materialize the organization's providers on the worker (`materializeCloudWorkerProviders`, fingerprint-cached so a warm worker pays one DB read). Runs after the engine is up so its read phase cannot hit the same warm-up 400. Failures are logged and the probe still decides the outcome.
3. Run the health probe and one engine refresh exactly as before.

The function gains injectable `fetchImpl`, `materializeProviders`, `sleep`, and `now` for tests; production wiring is unchanged.

## Verification

- `pnpm run typecheck:automations` (ee/apps/den-api) — passed.
- `bun test --conditions development test/cloud-agent-signed-preview-routing.test.ts` — 9 passed, 0 failed (5 new: waits through warm-up then delivers providers once; delivers providers on a warm run; non-warm-up failure fails immediately with no wait; an engine that never starts fails with its own message after the bounded wait; cancellation during warm-up stops waiting).

## Verdict: Incomplete

No journey spec in `evals/specs` exercises a Cloud Automation run against a cold worker; this class of den-api executor behaviour was demoted to `ee/apps/den-api/test` in #4353, which is where the coverage above lives. Missing: an end-to-end run on a freshly woken sandbox observed through the Automation run history. Manual repro: create a Cloud Automation, wait for the worker's idle stop, run it now, and confirm the run completes instead of failing needs-attention within ~2 s.
