### PR TITLE
fix(mcp): read string commands from opencode.json and pass environment on first connect

### DIFF
--- a/apps/app/src/app/mcp.ts
+++ b/apps/app/src/app/mcp.ts
@@ -73,6 +73,25 @@ export async function removeMcpFromConfig(
   }
 }
 
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((part): part is string => typeof part === "string") : [];
+}
+
+/**
+ * Accept both command shapes users paste into opencode.json: OpenCode's
+ * `command: ["python3", "server.py"]` and the Claude Desktop / Cursor style
+ * `command: "python3", args: ["server.py"]`. Every reader downstream sees one
+ * array, so a string command no longer blanks the Settings page.
+ */
+function normalizeMcpServerConfig(value: object): McpServerConfig | null {
+  const config = value as McpServerConfig & { args?: unknown };
+  if (config.type !== "remote" && config.type !== "local") return null;
+  const rawCommand: unknown = config.command;
+  if (typeof rawCommand !== "string") return config;
+  const executable = rawCommand.trim();
+  return { ...config, command: executable ? [executable, ...stringList(config.args)] : undefined };
+}
+
 export function parseMcpServersFromContent(content: string): McpServerEntry[] {
   if (!content.trim()) return [];
 
@@ -89,10 +108,8 @@ export function parseMcpServersFromContent(content: string): McpServerEntry[] {
         return [];
       }
 
-      const config = value as McpServerConfig;
-      if (config.type !== "remote" && config.type !== "local") {
-        return [];
-      }
+      const config = normalizeMcpServerConfig(value);
+      if (!config) return [];
 
       return [{ name, config, source: "config.project" as const }];
     });

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -987,6 +987,11 @@ export function createConnectionsStore(options: {
                 type: "local" as const,
                 command: (mcpEntryConfig["command"] as string[]) ?? entry.command!,
                 enabled: true,
+                // The hot-add call is what spawns the process on first connect;
+                // the file write above only matters on a later engine start.
+                ...(mcpEntryConfig["environment"]
+                  ? { environment: mcpEntryConfig["environment"] as Record<string, string> }
+                  : {}),
               };
 
         unwrap(

--- a/apps/app/tests/mcp-oauth-status-synchronization.test.ts
+++ b/apps/app/tests/mcp-oauth-status-synchronization.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { getMcpIdentityKey } from "../src/app/mcp";
+import { getMcpIdentityKey, parseMcpServersFromContent } from "../src/app/mcp";
 import type { McpServerEntry, McpStatusMap } from "../src/app/types";
 import {
   createMcpStatusSynchronizer,
@@ -142,5 +142,41 @@ describe("MCP OAuth status synchronization", () => {
       [entry.name]: { status: "disconnected" },
     }, [entry])).toEqual({});
     expect(sync.project(sync.beginRefresh(workspace), {}, [entry])).toEqual({});
+  });
+});
+
+describe("local MCP entries from opencode.json", () => {
+  test("a Claude-style string command with args is read as one command list", () => {
+    const entries = parseMcpServersFromContent(JSON.stringify({
+      mcp: {
+        docs: { type: "local", command: "python3", args: ["server.py", "--port", "8080"], enabled: true },
+      },
+    }));
+
+    expect(entries).toEqual([{
+      name: "docs",
+      source: "config.project",
+      config: { type: "local", command: ["python3", "server.py", "--port", "8080"], args: ["server.py", "--port", "8080"], enabled: true },
+    }]);
+  });
+
+  test("an OpenCode command list and remote entries pass through unchanged", () => {
+    const entries = parseMcpServersFromContent(JSON.stringify({
+      mcp: {
+        files: { type: "local", command: ["npx", "-y", "@modelcontextprotocol/server-filesystem"] },
+        api: { type: "remote", url: "https://mcp.example.test", headers: { Authorization: "Bearer x" } },
+        broken: { type: "sse", url: "https://ignored.example.test" },
+      },
+    }));
+
+    expect(entries.map((entry) => [entry.name, entry.config.command ?? entry.config.url])).toEqual([
+      ["files", ["npx", "-y", "@modelcontextprotocol/server-filesystem"]],
+      ["api", "https://mcp.example.test"],
+    ]);
+  });
+
+  test("an empty string command is dropped rather than spawned", () => {
+    const [entry] = parseMcpServersFromContent(JSON.stringify({ mcp: { blank: { type: "local", command: "  " } } }));
+    expect(entry?.config.command).toBeUndefined();
   });
 });

--- a/evals/specs/library-mcp-servers-from-config.e2e.test.ts
+++ b/evals/specs/library-mcp-servers-from-config.e2e.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "vitest";
+import { spec } from "@openwork/testkit";
+import { emptySession } from "../worlds/desktop.ts";
+
+const test = spec.world(emptySession);
+
+// People paste MCP servers into opencode.json from Claude Desktop or Cursor,
+// where the shape is `command: "python3", args: [...]`. OpenWork must list that
+// server beside its own `command: [...]` shape instead of blanking Settings.
+const handWrittenConfig = {
+  $schema: "https://opencode.ai/config.json",
+  mcp: {
+    "docs-helper": { type: "local", command: "python3", args: ["-m", "http.server", "8321"], enabled: false },
+    "files-helper": { type: "local", command: ["npx", "-y", "@modelcontextprotocol/server-filesystem"], enabled: false },
+    "remote-helper": { type: "remote", url: "https://mcp.example.test/sse", enabled: false },
+  },
+};
+
+test("the Library lists MCP servers written by hand into opencode.json, whichever command shape they use", async ({ world, seed, user, agent, probe, step, evidence }) => {
+  await step("a person writes three servers into the workspace's opencode.json", async () => {
+    const written = await seed.evalIn(world.app, `async (workspacePath, content) => {
+      const result = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("writeOpencodeConfig", "project", workspacePath, content);
+      return result ?? { ok: false, stderr: "desktop bridge unavailable" };
+    }`, { args: [world.workspacePath, `${JSON.stringify(handWrittenConfig, null, 2)}\n`], awaitPromise: true });
+    expect(written).toMatchObject({ ok: true });
+  });
+
+  await step("Settings opens and the Library lists every server", async () => {
+    await agent.run("route.extensions.skills");
+    await user.see({ text: "Library" });
+    await user.click({ role: "button", label: "MCPs" });
+    await user.see({ text: "docs-helper" });
+    await user.see({ text: "files-helper" });
+    await user.see({ text: "remote-helper" });
+    await user.screenshot();
+  });
+
+  await step("Settings stayed a working page rather than a blank document", async () => {
+    const body = await probe.text();
+    expect(body).toContain("docs-helper");
+    expect(body).toContain("files-helper");
+    expect(body.length).toBeGreaterThan(200);
+    evidence.recordAssertionEvidence(
+      "A Claude-style string command no longer blanks Settings",
+      "With docs-helper written as command: \"python3\", args: [...] beside an array-command server and a remote server, Settings rendered and the MCPs filter listed all three names.",
+      true,
+    );
+  });
+
+  await step("expanding the string-command server shows its command line", async () => {
+    await user.click({ text: "docs-helper" });
+    await user.click({ text: "Technical details" });
+    await user.see({ text: "python3 -m http.server 8321" });
+    await user.notSee({ text: "python3,-m" });
+    await user.screenshot();
+    evidence.recordAssertionEvidence(
+      "String command and args are read as one command list",
+      "Technical details showed \"python3 -m http.server 8321\" for the hand-written entry, proving the parser folded command and args into one list rather than treating the string as an array.",
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Two ways a local MCP breaks the first time someone uses it:

1. **Blank Settings page on a valid-looking config.** People copy servers from Claude Desktop or Cursor, where the shape is `command: "python3", args: ["server.py"]`. OpenWork read `command` as if it were already an array, so the Settings route threw inside render and the whole page went white (#3372, #2908). The user cannot even reach the list to fix or remove the entry.
2. **"MCP error -32000: Connection closed" on first connect.** When OpenWork connects a local server without the OpenWork server path, the hot-add call that actually spawns the process carried the command but not its resolved environment. The file on disk was correct, so the same server connected fine after a restart, which made the failure look intermittent.

## Change

- `apps/app/src/app/mcp.ts`: `parseMcpServersFromContent` normalizes a string `command` plus optional `args` into one command list. Array commands and remote entries pass through unchanged; an empty string command is dropped rather than spawned. Every downstream reader (Settings, the connections store, the MCP view) sees one shape.
- `apps/app/src/react-app/domains/connections/store.ts`: the local hot-add config forwards `environment` the same way the remote branch already forwards `headers` and `oauth`.

## Verification

- `pnpm --filter @openwork/app typecheck` — passed.
- `bun test --isolate tests/mcp-oauth-status-synchronization.test.ts` (apps/app) — 14 passed, 0 failed (3 new: string command with args becomes one list; array and remote entries unchanged and unknown types dropped; empty string command dropped).

## Verdict: Incomplete

No `evals/specs` journey seeds a workspace `opencode.json` with a local MCP and opens Settings → Connections, so the blank-page recovery is proven at the parser boundary only. Missing: an app journey that seeds a string-command entry and asserts the Settings page lists it. Manual repro: add `"docs": { "type": "local", "command": "python3", "args": ["-m", "http.server"] }` under `mcp` in a workspace's `opencode.json`, open Settings → Connections, and confirm the page renders with the entry listed.
