### PR TITLE
fix(settings): make Apply changes in Environment restart the local server

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2199,6 +2199,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       runtime: "direct",
       workspacePaths,
       openworkRemoteAccess: openworkServerSnapshot.openworkServerSettings.remoteAccessEnabled === true,
+      // The user env file is read when the local server process spawns, so a
+      // healthy engine must be replaced, not reused, for new values to apply.
+      forceRestart: true,
     });
     const reconnected = await openworkServerStore.reconnectOpenworkServer();
     if (!reconnected) {


### PR DESCRIPTION
## Problem

Settings → Environment → **Apply changes** shows a confirm dialog that says "OpenWork will restart local agents so they can use the latest environment", then reports success — but nothing restarts. `engineStart` reuses the healthy running local server, and the user env file (`loadUserEnvFile`) is only read when that process spawns. A newly added variable never reaches the engine, and any `{env:VAR}` reference in a provider config resolves to nothing until the user quits and relaunches OpenWork. The banner then reads "Changes are active" while they are not.

## Change

`apps/app/src/react-app/shell/settings-route.tsx` — `handleApplyEnvironmentChanges` passes `forceRestart: true` to `engineStart`. `runtime.mjs` already honors that flag (`if (forceRestart === true) return { reuse: false, ... }`) and the existing active-task guard (`apply_blocked_active_tasks`) still prevents interrupting running work. Nothing else changes.

## Verification

- `pnpm --filter @openwork/app typecheck` — passed.
- Behaviour is a renderer → IPC option; the IPC handler forwards `options` unchanged (`main.mjs:1807-1811`) and the runtime's reuse decision is already unit-covered for `forceRestart`.

## Verdict: Incomplete

No `evals/specs` journey covers Settings → Environment → Apply changes. Missing: an app journey that adds a variable, applies, and asserts the local server generation changed and a `{env:VAR}` provider option resolves. Manual repro: add `FOO=bar` in Settings → Environment, click Apply changes, confirm, then check the local server PID (or `openwork-server` log start line) changed and a provider using `{env:FOO}` sees the value without relaunching.
