### PR TITLE
fix(release): ship launchable openwork-server and AUR binaries

### DIFF
--- a/.github/workflows/aur-validate.yml
+++ b/.github/workflows/aur-validate.yml
@@ -388,6 +388,12 @@ jobs:
             exit 1
           fi
 
+          if [ ! -x /usr/bin/openwork ]; then
+            echo "/usr/bin/openwork is missing or points at a non-executable target" >&2
+            ls -l /usr/bin/openwork >&2 || true
+            exit 1
+          fi
+
           launch_bin=""
           for candidate in \
             "$(command -v openwork 2>/dev/null || true)" \

--- a/.github/workflows/aur-validate.yml
+++ b/.github/workflows/aur-validate.yml
@@ -377,7 +377,7 @@ jobs:
           pkg_file=$(ls -1 openwork-*.pkg.tar.* | head -n 1)
           pacman -U --noconfirm "$pkg_file"
 
-      - name: Smoke launch
+      - name: Validate installed launcher
         shell: bash
         run: |
           set -euo pipefail
@@ -394,25 +394,8 @@ jobs:
             exit 1
           fi
 
-          launch_bin=""
-          for candidate in \
-            "$(command -v openwork 2>/dev/null || true)" \
-            /usr/bin/openwork \
-            /opt/openwork/openwork \
-            /opt/openwork/openwork-desktop \
-            /opt/openwork/opencode
-          do
-            if [ -n "$candidate" ] && [ -x "$candidate" ]; then
-              launch_bin="$candidate"
-              break
-            fi
-          done
-
-          if [ -n "$launch_bin" ]; then
-            xvfb-run -a bash -lc '"$1" --help >/tmp/openwork-help.txt 2>&1 || "$1" --version >/tmp/openwork-version.txt 2>&1 || true' -- "$launch_bin"
-          else
-            echo "No runnable desktop binary found; install sanity check passed." 
-          fi
+          test "$(readlink -f /usr/bin/openwork)" = /opt/openwork/openwork
+          echo "Installed launcher resolves to the expected executable. Desktop startup is not validated by this check." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish to AUR
         if: env.PUSH_TO_AUR == 'true'

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1204,6 +1204,13 @@ jobs:
           name: openwork-server-npm-${{ env.RELEASE_VERSION }}
           path: ${{ runner.temp }}/openwork-server-npm
 
+      - name: Restore executable bits lost in the artifact round-trip
+        run: |
+          set -euo pipefail
+          chmod 755 "$RUNNER_TEMP/openwork-server-npm/bin/openwork-server.mjs" \
+            "$RUNNER_TEMP/openwork-server-npm/dist/bin/openwork-server"
+          test -x "$RUNNER_TEMP/openwork-server-npm/dist/bin/openwork-server"
+
       - name: Publish openwork-server
         run: npm publish "$RUNNER_TEMP/openwork-server-npm" --access public --provenance
 

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -1211,8 +1211,24 @@ jobs:
             "$RUNNER_TEMP/openwork-server-npm/dist/bin/openwork-server"
           test -x "$RUNNER_TEMP/openwork-server-npm/dist/bin/openwork-server"
 
+      - name: Pack and verify executable permissions
+        id: npm-pack
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/openwork-server-npm"
+          npm pack --json --pack-destination "$RUNNER_TEMP" > "$RUNNER_TEMP/npm-pack.json"
+          filename="$(node -p 'require(process.env.RUNNER_TEMP + "/npm-pack.json")[0].filename')"
+          tarball="$RUNNER_TEMP/$filename"
+          unpacked="$(mktemp -d)"
+          tar -xzf "$tarball" -C "$unpacked"
+          test -x "$unpacked/package/bin/openwork-server.mjs"
+          test -x "$unpacked/package/dist/bin/openwork-server"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
       - name: Publish openwork-server
-        run: npm publish "$RUNNER_TEMP/openwork-server-npm" --access public --provenance
+        env:
+          NPM_TARBALL: ${{ steps.npm-pack.outputs.tarball }}
+        run: npm publish "$NPM_TARBALL" --access public --provenance
 
   publish-daytona-snapshot:
     name: Build + Push Daytona Snapshot

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -40,7 +40,8 @@ package() {
   cp -a "${bundle_dir}/." "${pkgdir}/opt/openwork/"
 
   install -d "${pkgdir}/usr/bin"
-  ln -s /opt/openwork/@openworkdesktop "${pkgdir}/usr/bin/openwork"
+  test -x "${pkgdir}/opt/openwork/openwork"
+  ln -s /opt/openwork/openwork "${pkgdir}/usr/bin/openwork"
 
   install -Dm644 "${pkgdir}/opt/openwork/resources/app-dist/openwork-logo-square.svg" \
     "${pkgdir}/usr/share/icons/hicolor/scalable/apps/openwork.svg"


### PR DESCRIPTION
## Problem

Installed launchers can fail before the application starts:

- `openwork-server` loses the compiled executable's permission bits across the release artifact upload/download boundary, causing EACCES (#4001).
- The AUR package links `/usr/bin/openwork` to `/opt/openwork/@openworkdesktop`, although the bundle executable is `/opt/openwork/openwork`.

## Changes

- Restore executable permissions after downloading the npm package, pack it, extract the resulting tarball, and assert that both the shim and payload are executable. Publish that exact verified tarball, not a newly packed directory.
- Correct the AUR launcher target and reject a bundle whose launcher is not executable.
- Assert that the installed AUR command resolves to the expected executable. Remove the fallback launch loop that ignored crashes; the check now explicitly reports that it validates the installed launcher, not desktop startup.

## Verification

Candidate: `bf45ff765cda4843dc5047dcdfd5c63ff0da845d`, based on `8f6d4649d1391773b625d68de12a6b24e06a62d0` (`dev`). Both commits have verified signatures.

Focused local packaging checks, exit 0 on this candidate:

- Executed the workflow's restore and pack/verify shell blocks against a package containing the real repository shim and a deterministic shell payload, both initially mode 0644. The uncorrected package failed the executable assertion. The corrected tarball installed into an isolated npm prefix with lifecycle scripts disabled, and the installed shim successfully executed the fixture payload.
- Executed `PKGBUILD`'s `package()` for x86_64 and aarch64 bundle fixtures. Both produced the exact intended symlink; both rejected a non-executable payload. This was a macOS fixture check with icon destination parents pre-created for BSD install compatibility, not Arch makepkg or Electron execution.
- Both changed workflows parse as YAML; `bash -n packaging/aur/PKGBUILD` and `git diff --check` pass.

The regression assertions live directly in the packaging workflows. Local fixture checks are diagnostic packaging evidence, not a compiled-server or desktop startup journey.

## Verdict: Incomplete

- Deferred: exact-head Arch makepkg/install validation, compiled Linux server startup, full desktop startup, and validation of the eventual published release. No tag, publication, merge, release, or deployment was performed.
- Historical AUR run [34016032368](https://github.com/different-ai/openwork/actions/runs/34016032368) passed the launcher assertion on the previous head against v0.18.42. It is not exact-head proof, and its ignored launch crash did not establish startup success.
- Local `pnpm warden:check` exited 1: both applicable skills (`diff-security-review`, `confidentiality-review`) failed authentication before analysis. Expected scope was the three changed files; neither skill completed. HEAD and origin/dev were unchanged before and after the attempt. This is Incomplete, not a no-findings clearance.
- GitHub [Warden run 34419621444](https://github.com/different-ai/openwork/actions/runs/34419621444) completed successfully on this exact head. Both applicable skills completed with zero findings and zero annotations. The other two skills were not applicable to these paths. [Clearance run 34419670792](https://github.com/different-ai/openwork/actions/runs/34419670792) published a clear analysis summary but explicitly withheld approval: `PR #4554 touches review machinery; human review required`. Both changed workflow paths match its `.github/` guard. No approving review exists; independent review is required. Review configuration and policies are unchanged.
