### PR TITLE
fix(app): keep mention instructions out of user messages

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -98,6 +98,7 @@ export type ComposerPart =
   | { type: "text"; text: string }
   | { type: "agent"; name: string }
   | { type: "skill"; name: string }
+  | { type: "connect-skill"; slug: string; name: string; marketplace: string; capability: string }
   | { type: "file"; path: string; label?: string }
   /** A macOS app targeted via Computer Use (composer "@App" mention). */
   | { type: "app"; name: string }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -53,7 +53,7 @@ import { isComputerTarget } from "./composer/computer-mentions";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
-import { connectSkillPrompt, parseConnectSkillToken } from "./composer/connect-skill-token";
+import { parseConnectSkillToken } from "./composer/connect-skill-token";
 import { createPastedTextChip, resolvePastedTextPlaceholders } from "./composer/pasted-text";
 import {
   canAdmitNextQueuedItem,
@@ -1739,7 +1739,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       const connectSkill = parseConnectSkillToken(segment);
       if (connectSkill) {
-        return [{ type: "text", text: connectSkillPrompt(connectSkill) } satisfies ComposerDraft["parts"][number]];
+        return [{ type: "connect-skill", ...connectSkill } satisfies ComposerDraft["parts"][number]];
       }
       const skillMatch = segment.match(/^\[skill (.+)\]$/);
       if (skillMatch?.[1]) {
@@ -1763,13 +1763,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
     resolved = resolved.replace(/\[attachment [^\]]+\]/g, "");
     resolved = resolved.replace(/\[connect-skill [^\]]+\]/g, (match) => {
       const token = parseConnectSkillToken(match);
-      return token ? connectSkillPrompt(token) : match;
+      return token ? `/${token.slug}` : match;
     });
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
     for (const value of Object.keys(mentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
     }
-    const slashCommand = parseSlashCommandInvocation(resolved);
+    // A selected Connect skill is a mention, even though its label starts with /.
+    const slashCommand = text.trimStart().startsWith("[connect-skill ") ? null : parseSlashCommandInvocation(resolved);
     return {
       mode: "prompt",
       parts,

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -33,8 +33,7 @@ import { addOpencodeCacheHint, safeStringify } from "../../../../app/utils";
 import { clearSessionDraft, LOCAL_SESSION_DRAFT_SCOPE, saveSessionDraft } from "./draft-store";
 import { firstLineLocalFileParts, isReadInlineablePath } from "./prompt-file-parts";
 import { composerAttachmentToFilePart } from "./attachment-file-part";
-import { computerMentionInstruction } from "../surface/composer/computer-mentions";
-import { appMentionInstruction } from "../surface/composer/app-mentions";
+import { mentionPromptParts } from "./mention-parts";
 
 type SessionModelConfig = {
   applyPendingSessionChoice: (sessionId: string) => void;
@@ -163,12 +162,10 @@ export function createSessionActionsStore(options: {
         parts.push({ type: "agent", name: part.name } as AgentPartInput);
         continue;
       }
-      if (part.type === "computer") {
-        parts.push({ type: "text", text: computerMentionInstruction(part.target), synthetic: true });
-        continue;
-      }
-      if (part.type === "app") {
-        parts.push({ type: "text", text: appMentionInstruction(part.name) } as TextPartInput);
+      if (part.type === "computer" || part.type === "app" || part.type === "skill" || part.type === "connect-skill") {
+        // The resolved user text already contains the visible mention label.
+        const [, instruction] = mentionPromptParts(part);
+        parts.push(instruction);
         continue;
       }
       if (part.type === "file") {

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -495,7 +495,8 @@ export function createSessionActionsStore(options: {
     const c = options.client();
     if (!c) return;
 
-    const compactShortcut = /^\/compact(?:\s+.*)?$/i.test(content);
+    const compactShortcut = !resolvedDraft.text.trimStart().startsWith("[connect-skill ")
+      && /^\/compact(?:\s+.*)?$/i.test(content);
     const compactCommand = resolvedDraft.command?.name === "compact" || compactShortcut;
     const commandName = compactCommand ? "compact" : (resolvedDraft.command?.name ?? null);
     if (compactCommand && !options.selectedSessionId()) {

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -15,9 +15,8 @@ import {
   joinWorkspaceRelativePath,
   toFileUrl,
 } from "./prompt-file-parts";
-import { computerMentionInstruction } from "../surface/composer/computer-mentions";
-import { appMentionInstruction } from "../surface/composer/app-mentions";
-import { connectSkillPrompt, parseConnectSkillToken } from "../surface/composer/connect-skill-token";
+import { mentionPromptParts } from "./mention-parts";
+import { parseConnectSkillToken } from "../surface/composer/connect-skill-token";
 import { decodeComposerMentionValue } from "../surface/composer/mention-encoding";
 
 // All workspace-scoped server URLs/clients/tokens come from
@@ -96,12 +95,12 @@ export async function draftToParts(
       }
       const connectSkill = parseConnectSkillToken(segment);
       if (connectSkill) {
-        parts.push({ type: "text", text: connectSkillPrompt(connectSkill) });
+        parts.push(...mentionPromptParts({ type: "connect-skill", ...connectSkill }));
         continue;
       }
       const skillMatch = segment.match(/^\[skill (.+)\]$/);
       if (skillMatch?.[1]) {
-        parts.push({ type: "text", text: `Load [skill ${skillMatch[1]}] and follow its instructions.` });
+        parts.push(...mentionPromptParts({ type: "skill", name: skillMatch[1] }));
         continue;
       }
       if (segment.startsWith("@")) {
@@ -117,13 +116,8 @@ export async function draftToParts(
           parts.push({ type: "agent", name: mentionPart.name });
           continue;
         }
-        if (mentionPart?.type === "computer") {
-          parts.push({ type: "text", text: `@${mentionPart.target}` });
-          parts.push({ type: "text", text: computerMentionInstruction(mentionPart.target), synthetic: true });
-          continue;
-        }
-        if (mentionPart?.type === "app") {
-          parts.push({ type: "text", text: appMentionInstruction(mentionPart.name) });
+        if (mentionPart?.type === "computer" || mentionPart?.type === "app") {
+          parts.push(...mentionPromptParts(mentionPart));
           continue;
         }
         if (mentionPart?.type === "file") {
@@ -161,17 +155,8 @@ export async function draftToParts(
         parts.push({ type: "agent", name: part.name });
         continue;
       }
-      if (part.type === "skill") {
-        parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
-        continue;
-      }
-      if (part.type === "computer") {
-        parts.push({ type: "text", text: `@${part.target}` });
-        parts.push({ type: "text", text: computerMentionInstruction(part.target), synthetic: true });
-        continue;
-      }
-      if (part.type === "app") {
-        parts.push({ type: "text", text: appMentionInstruction(part.name) });
+      if (part.type === "skill" || part.type === "connect-skill" || part.type === "computer" || part.type === "app") {
+        parts.push(...mentionPromptParts(part));
         continue;
       }
       if (part.type === "file") {

--- a/apps/app/src/react-app/domains/session/sync/mention-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/mention-parts.ts
@@ -1,0 +1,26 @@
+import type { TextPartInput } from "@opencode-ai/sdk/v2/client";
+import type { ComposerPart } from "@/app/types";
+import { appMentionInstruction } from "../surface/composer/app-mentions";
+import { computerMentionInstruction } from "../surface/composer/computer-mentions";
+import { connectSkillPrompt } from "../surface/composer/connect-skill-token";
+
+type InstructionMention = Extract<ComposerPart, { type: "computer" | "app" | "skill" | "connect-skill" }>;
+
+/** Keep generated instructions out of user text in every send path. */
+export function mentionPromptParts(part: InstructionMention): [TextPartInput, TextPartInput & { synthetic: true }] {
+  const { label, instruction } = mentionContent(part);
+  return [{ type: "text", text: label }, { type: "text", text: instruction, synthetic: true }];
+}
+
+function mentionContent(part: InstructionMention): { label: string; instruction: string } {
+  switch (part.type) {
+    case "computer":
+      return { label: `@${part.target}`, instruction: computerMentionInstruction(part.target) };
+    case "app":
+      return { label: `@${part.name}`, instruction: appMentionInstruction(part.name) };
+    case "skill":
+      return { label: `[skill ${part.name}]`, instruction: `Load [skill ${part.name}] and follow its instructions.` };
+    case "connect-skill":
+      return { label: `/${part.slug}`, instruction: connectSkillPrompt(part) };
+  }
+}

--- a/apps/app/tests/prompt-file-parts.test.ts
+++ b/apps/app/tests/prompt-file-parts.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { ComposerPart } from "../src/app/types";
+import { encodeConnectSkillToken } from "../src/react-app/domains/session/surface/composer/connect-skill-token";
 import { draftToParts } from "../src/react-app/domains/session/sync/draft-parts";
 import { firstLineLocalFileParts, isReadInlineablePath } from "../src/react-app/domains/session/sync/prompt-file-parts";
 import {
@@ -237,6 +239,32 @@ describe("computer task mentions", () => {
         expect(parts.filter((part) => part.type === "text" && !part.synthetic)
           .map((part) => part.type === "text" ? part.text : "").join(""))
           .toBe(`@${target} Summarize notes for person@${target} `);
+      }
+    });
+  }
+});
+
+
+describe("generated mention instructions", () => {
+  const connected = { type: "connect-skill", slug: "summarize", name: "Summarize", marketplace: "Team tools", capability: "skill:summarize" } satisfies ComposerPart;
+  const cases: { part: ComposerPart; token: string; label: string; instruction: string }[] = [
+    { part: { type: "app", name: "Notes" }, token: "@Notes", label: "@Notes", instruction: "computer-use tools" },
+    { part: { type: "skill", name: "summarize" }, token: "[skill summarize]", label: "[skill summarize]", instruction: "follow its instructions" },
+    { part: connected, token: encodeConnectSkillToken(connected), label: "/summarize", instruction: "skill:summarize" },
+  ];
+  for (const { part, token, label, instruction } of cases) {
+    test(`${part.type} preserves its label and hides instructions in both send branches`, async () => {
+      for (const attachmentToken of ["", "[attachment removed]"]) {
+        const parts = await draftToParts({
+          mode: "prompt", text: `${token} Please summarize. ${attachmentToken}`,
+          parts: [part, { type: "text", text: " Please summarize. " }], attachments: [],
+        }, "/workspace", "ses_mentions", null);
+        expect(parts.filter((part) => part.type === "text" && !part.synthetic)
+          .map((part) => part.type === "text" ? part.text : "").join(""))
+          .toBe(`${label} Please summarize. `);
+        expect(parts.filter((part) => part.type === "text" && part.synthetic)).toEqual([
+          { type: "text", synthetic: true, text: expect.stringContaining(instruction) },
+        ]);
       }
     });
   }

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -18,6 +18,11 @@ test("computer mentions steer tasks through Connect and Automations names the co
     await user.type("composer", "COMPUTER-CLOUD-TASK Summarize the project notes.");
     await user.press("Enter");
     await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
+    await user.see({ text: /^@cloud COMPUTER-CLOUD-TASK Summarize the project notes\.$/ });
+    await user.notSee({ text: /The user selected @cloud|Use OpenWork Connect search_capabilities/ });
+    await user.reload();
+    await user.see({ text: /^@cloud COMPUTER-CLOUD-TASK Summarize the project notes\.$/ });
+    await user.notSee({ text: /The user selected @cloud|Use OpenWork Connect search_capabilities/ });
   });
 
   await step("typing desktop directly works without selecting the menu", async () => {

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -38,7 +38,7 @@ test("computer mentions steer tasks through Connect and Automations names the co
 
   await step("skill mentions keep generated instructions out of the user message", async () => {
     for (const { token, visible, hidden } of [
-      { token: "[skill summarize]", visible: "[skill summarize] COMPUTER-PLAIN-TASK Summarize notes.", hidden: /Load \[skill summarize\] and follow its instructions/ },
+      { token: "[skill summarize]", visible: "summarize COMPUTER-PLAIN-TASK Summarize notes.", hidden: /Load \[skill summarize\] and follow its instructions/ },
       { token: "[connect-skill summarize|Summarize|Team tools|skill:summarize]", visible: "/summarize COMPUTER-PLAIN-TASK Summarize notes.", hidden: /skill:summarize/ },
     ]) {
       await user.click({ role: "button", label: "New task" });

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -36,12 +36,31 @@ test("computer mentions steer tasks through Connect and Automations names the co
     await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
   });
 
+  await step("skill mentions keep generated instructions out of the user message", async () => {
+    for (const { token, visible, hidden } of [
+      { token: "[skill summarize]", visible: "[skill summarize] COMPUTER-PLAIN-TASK Summarize notes.", hidden: /Load \[skill summarize\] and follow its instructions/ },
+      { token: "[connect-skill summarize|Summarize|Team tools|skill:summarize]", visible: "/summarize COMPUTER-PLAIN-TASK Summarize notes.", hidden: /skill:summarize/ },
+    ]) {
+      await user.click({ role: "button", label: "New task" });
+      await user.type("composer", `${token} COMPUTER-PLAIN-TASK Summarize notes.`);
+      await user.press("Enter");
+      await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
+      await user.see({ text: visible });
+      await user.notSee({ text: hidden });
+      await user.reload();
+      await user.see({ text: visible });
+      await user.notSee({ text: hidden });
+    }
+  });
+
   await step("computer handoffs reach Connect, while ordinary text makes no tool call", async () => {
     const messages = await world.submittedParts();
     expect(messages).toEqual([
       { visible: "@cloud COMPUTER-CLOUD-TASK Summarize the project notes.", routing: [expect.stringContaining('target "cloud"')] },
       { visible: "@desktop COMPUTER-DESKTOP-TASK Summarize my local project notes.", routing: [expect.stringContaining('target "desktop"')] },
       { visible: "COMPUTER-PLAIN-TASK Explain the address person@cloud and the word desktop.", routing: [] },
+      { visible: "[skill summarize] COMPUTER-PLAIN-TASK Summarize notes.", routing: [expect.stringContaining("Load [skill summarize] and follow its instructions.")] },
+      { visible: "/summarize COMPUTER-PLAIN-TASK Summarize notes.", routing: [expect.stringContaining("skill:summarize")] },
     ]);
     const calls = await probe.toolCalls(world.den.mocks.agent);
     expect(calls.map(({ name, args }) => ({ name, args }))).toEqual([

--- a/evals/specs/computer-task-mentions.e2e.test.ts
+++ b/evals/specs/computer-task-mentions.e2e.test.ts
@@ -23,14 +23,15 @@ test("computer mentions steer tasks through Connect and Automations names the co
     await user.reload();
     await user.see({ text: /^@cloud COMPUTER-CLOUD-TASK Summarize the project notes\.$/ });
     await user.notSee({ text: /The user selected @cloud|Use OpenWork Connect search_capabilities/ });
+    evidence.recordAssertionEvidence("Cloud mention stays compact after reload", "The user sees the exact @cloud task text before and after reload; generated routing instructions are absent in both views.", true);
   });
 
   await step("typing desktop directly works without selecting the menu", async () => {
-    await user.click({ role: "button", label: "New task" });
+    await user.click({ role: "button", label: "New session" });
     await user.type("composer", "@desktop COMPUTER-DESKTOP-TASK Summarize my local project notes.");
     await user.press("Enter");
     await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
-    await user.click({ role: "button", label: "New task" });
+    await user.click({ role: "button", label: "New session" });
     await user.type("composer", "COMPUTER-PLAIN-TASK Explain the address person@cloud and the word desktop.");
     await user.press("Enter");
     await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
@@ -41,7 +42,7 @@ test("computer mentions steer tasks through Connect and Automations names the co
       { token: "[skill summarize]", visible: "summarize COMPUTER-PLAIN-TASK Summarize notes.", hidden: /Load \[skill summarize\] and follow its instructions/ },
       { token: "[connect-skill summarize|Summarize|Team tools|skill:summarize]", visible: "/summarize COMPUTER-PLAIN-TASK Summarize notes.", hidden: /skill:summarize/ },
     ]) {
-      await user.click({ role: "button", label: "New task" });
+      await user.click({ role: "button", label: "New session" });
       await user.type("composer", `${token} COMPUTER-PLAIN-TASK Summarize notes.`);
       await user.press("Enter");
       await user.see({ text: "Received computer task.", nth: 0 }, { timeoutMs: 90_000 });
@@ -51,6 +52,7 @@ test("computer mentions steer tasks through Connect and Automations names the co
       await user.see({ text: visible });
       await user.notSee({ text: hidden });
     }
+    evidence.recordAssertionEvidence("Skill labels survive reload without instruction expansion", "Both local and Connect skill labels remain visible before and after reload, with generated instructions absent from chat.", true);
   });
 
   await step("computer handoffs reach Connect, while ordinary text makes no tool call", async () => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1319,7 +1319,7 @@ export async function computerMentions(seed: Seed) {
         messages.sort((a, b) => a.info.time.created - b.info.time.created);
         return messages.filter((message) => message.info.role === "user").map((message) => ({
           visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join("").trim(),
-          routing: message.parts.filter((part) => part.type === "text" && part.synthetic && part.text.includes("remote-session:create")).map((part) => part.text),
+          routing: message.parts.filter((part) => part.type === "text" && part.synthetic).map((part) => part.text),
         }));
       }`, { args: [workspace.workspaceId], awaitPromise: true });
     },


### PR DESCRIPTION
Mention expansion must preserve what the user typed in the conversation. App and skill instructions could become visible message text, while computer mentions already used hidden text parts.

Add a shared, typed mention builder that always returns a visible label plus a synthetic instruction. Use it in both send paths, and keep Connect skills structured until submission so their instructions never enter the resolved user text. Preserve their slash labels without treating them as native commands.

Validation:
- Focused prompt tests: 21 passed, 0 failed, including computer, app, local skill, and Connect skill mentions with and without attachment parsing.
- App typecheck: passed.
- `OPENWORK_EVAL_REF=fix/mention-display pnpm evals:e2e computer-task-mentions`: **Passed**, 1 passed / 0 failed / 0 skipped. Placement: `daytona (daytona CLI authenticated)`. Checks cloud and skill labels before and after reload, desktop routing, ordinary text, and hidden instructions at the engine boundary.
- Evidence for final head `bfe0ed06107146c4cd5f860450761462d267d51a` is published in the PR’s test-evidence comment. The earlier run caught a test selector mismatch (`New task` vs `New session`); the corrected journey passes.
