### PR TITLE
Fix retry handling for cloud session engine startup

### DIFF
--- a/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/remote-session-capabilities.ts
@@ -448,6 +448,19 @@ function threadErrorStatus(error: unknown): number | null {
 
 function threadErrorResult(action: RemoteSessionAction, sessionId: string | null, error: unknown): RemoteSessionToolResult {
   const status = threadErrorStatus(error)
+  // The worker binds HTTP before its managed engine finishes starting. Only
+  // retry creation when the session endpoint itself rejected the request;
+  // a later prompt failure may already have created a session.
+  if (action === "create" && status === 400 && isRecord(error)
+    && error.code === "opencode_unconfigured" && typeof error.path === "string"
+    && error.path.endsWith("/opencode/session")) {
+    return errorResult({
+      error: "cloud_runtime_waking",
+      message: "Your OpenWork Cloud workspace is reachable, but its engine is not ready yet. Retry the same call in about 30 seconds; no session was created.",
+      retryable: true,
+      retryAfterMs: 30_000,
+    })
+  }
   if (status === 404 && sessionId) {
     return errorResult({
       error: "unknown_session",

--- a/ee/apps/den-api/test/remote-session-capabilities.test.ts
+++ b/ee/apps/den-api/test/remote-session-capabilities.test.ts
@@ -337,6 +337,30 @@ test("a missing session maps to unknown_session", async () => {
   expect(body.retryable).toBe(false)
 })
 
+test("engine startup retries only a rejected create, not a partially created session", async () => {
+  for (const path of ["/workspace/ws_1/opencode/session", "/workspace/ws_1/opencode/session/ses_created/prompt_async"]) {
+    const result = await executeRemoteSessionCapability(
+      executeInput("create", { prompt: "Say hi" }),
+      readyDeps({
+        createThread: async () => {
+          throw new HeadlessThreadError({
+            code: "opencode_unconfigured",
+            message: "OpenCode base URL is missing for this workspace",
+            method: "POST",
+            path,
+            status: 400,
+          })
+        },
+      }),
+    )
+    const canRetry = path.endsWith("/opencode/session")
+    expect(result.isError).toBe(true)
+    expect(payload(result).error).toBe(canRetry ? "cloud_runtime_waking" : "remote_session_request_failed")
+    expect(payload(result).retryable).toBe(canRetry)
+    expect(payload(result).retryAfterMs).toBe(canRetry ? 30_000 : undefined)
+  }
+})
+
 test("a waking runtime is reported as retryable without touching the client", async () => {
   const result = await executeRemoteSessionCapability(
     executeInput("create", {}),

--- a/ee/apps/den-api/test/remote-session-capability-wire.test.ts
+++ b/ee/apps/den-api/test/remote-session-capability-wire.test.ts
@@ -54,6 +54,7 @@ const witness = {
   requests: [] as WitnessRequest[],
   sessions: new Map<string, WitnessSession>(),
   nextSessionId: 1,
+  engineReady: false,
 };
 
 function readBody(request: IncomingMessage): Promise<unknown> {
@@ -110,6 +111,7 @@ async function handle(request: IncomingMessage, response: ServerResponse) {
 
   const prefix = `/workspace/${WORKSPACE_ID}/opencode/session`;
   if (method === "POST" && path === prefix) {
+    if (!witness.engineReady) return json(response, 400, { code: "opencode_unconfigured", message: "OpenCode base URL is missing for this workspace" });
     const title = typeof body === "object" && body !== null && typeof (body as Record<string, unknown>).title === "string"
       ? String((body as Record<string, unknown>).title)
       : "Untitled";
@@ -214,6 +216,12 @@ test("remote-session capabilities drive a real openwork-server wire with scoped 
   const matches = searchRemoteSessionCapabilities("send a chat to my cloud web session", 10);
   expect(matches.map((match) => match.name)).toContain("remote-session:send");
   expect(matches.every((match) => match.invocation?.argumentsField === "body")).toBe(true);
+  const waking = await executeRemoteSessionCapability(input("create", { title: "Witness handoff", prompt: "start working" }), deps);
+  expect(waking.isError).toBe(true);
+  expect(payload(waking)).toMatchObject({ error: "cloud_runtime_waking", retryable: true, retryAfterMs: 30_000 });
+  expect(witness.sessions.size).toBe(0);
+  expect(witness.requests.some((request) => request.path.includes("/prompt_async"))).toBe(false);
+  witness.engineReady = true;
   const created = await executeRemoteSessionCapability(
     input("create", { title: "Witness handoff", prompt: "start working" }),
     deps,
@@ -224,6 +232,8 @@ test("remote-session capabilities drive a real openwork-server wire with scoped 
   expect(sessionId.startsWith("ses_witness_")).toBe(true);
   expect(createdBody.workspaceId).toBe(WORKSPACE_ID);
   expect(createdBody.started).toBe(true);
+  expect(witness.sessions.size).toBe(1);
+  expect(witness.sessions.get(sessionId)?.prompts).toEqual(["start working"]);
 
   const createRequest = witness.requests.find(
     (request) => request.method === "POST" && request.path === `/workspace/${WORKSPACE_ID}/opencode/session`,

--- a/evals/packages/labs/src/mock-cloud-runtime.ts
+++ b/evals/packages/labs/src/mock-cloud-runtime.ts
@@ -26,6 +26,7 @@ export async function startCloudRuntimeWitness() {
   const sessions: Array<{ id: string; sandboxId: string; title: string; prompts: string[] }> = [];
   const unexpected: string[] = [];
   let healthy = false;
+  let sessionError: { code: string; message: string } | null = null;
   let url = "";
 
   function sandboxDto(sandbox: typeof sandboxes[number]) {
@@ -66,6 +67,7 @@ export async function startCloudRuntimeWitness() {
       if (route === "/health") return json(response, healthy ? 200 : 503, { ready: healthy });
       if (route === "/workspaces") return json(response, 200, { activeId: "workspace_witness", items: [] });
       if (method === "POST" && route === "/workspace/workspace_witness/opencode/session") {
+        if (sessionError) return json(response, 400, sessionError);
         const input = await body(request);
         const session = { id: `ses_witness_${sessions.length + 1}`, sandboxId, title: String(input.title), prompts: [] };
         sessions.push(session);
@@ -99,6 +101,7 @@ export async function startCloudRuntimeWitness() {
   return {
     url, sandboxes, sessions, unexpected,
     ready() { healthy = true; },
+    sessionFailure(error: { code: string; message: string } | null) { sessionError = error; },
     async [Symbol.asyncDispose]() {
       server.closeAllConnections();
       await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));

--- a/evals/specs/remote-session-first-use.test.ts
+++ b/evals/specs/remote-session-first-use.test.ts
@@ -111,12 +111,26 @@ test("first cloud task provisions once over MCP, preserves access boundaries, an
 
   witness.ready();
   await eventually(async () => (await workers()).map((entry) => record(entry).status), { within: 60_000, label: "real provisioner records ready after witness health", until: (statuses) => statuses.length === 1 && statuses[0] === "healthy" });
+  // The worker's HTTP listener can be healthy before its engine has a URL.
+  witness.sessionFailure({ code: "opencode_unconfigured", message: "OpenCode base URL is missing for this workspace" });
+  const starting = await call(writeToken, "create", task);
+  expect(starting.result.isError).toBe(true);
+  expect(starting.payload).toMatchObject({ error: "cloud_runtime_waking", retryable: true, retryAfterMs: 30_000 });
+  expect(starting.payload.sessionId).toBeUndefined();
+  expect(witness.sessions).toHaveLength(0);
+  expect(witness.sandboxes).toHaveLength(1);
+  witness.sessionFailure({ code: "invalid_payload", message: "Invalid session payload" });
+  const invalid = await call(writeToken, "create", task);
+  expect(invalid.payload).toMatchObject({ error: "remote_session_request_failed", retryable: false });
+  expect(witness.sessions).toHaveLength(0);
+  witness.sessionFailure(null);
   const created = await call(writeToken, "create", task);
   expect(created.result.isError).toBeUndefined();
   expect(created.payload).toMatchObject({ target: "cloud", started: true, workerId: record(startedWorkers[0]).id });
   expect(witness.sessions).toHaveLength(1);
   expect(witness.sessions[0]?.prompts).toEqual([task.prompt]);
   expect(witness.sandboxes).toHaveLength(1);
+  evidence.recordAssertionEvidence("Engine startup is retryable without duplicate sessions or reprovisioning", "A healthy worker whose session endpoint lacked its engine URL returned a 30-second retry; an unrelated 400 stayed non-retryable. Retrying after engine readiness created exactly one session and submitted the prompt once on the existing sandbox.", true);
   const browser = await denFetch(den.admin, "/v1/cloud/instance", { headers: { authorization: `Bearer ${den.admin.token}` } });
   expect(browser.response.status, browser.text).toBe(200);
   expect(record(browser.body).status).toBe("ready");


### PR DESCRIPTION
Cloud workers can accept HTTP requests before their managed engine is ready. A cloud task created during that window currently returns a non-retryable “OpenCode base URL is missing” error.

Return `cloud_runtime_waking` with a 30-second retry for `opencode_unconfigured` from the session creation endpoint. Other errors and failures after a session has already been created retain their existing behavior, avoiding duplicate sessions on retry. Extend the existing HTTP witness and first-use journey with startup recovery assertions.

Validation on commit `7b49bb8ea`:
- `pnpm --dir ee/apps/den-api exec bun test --conditions development test/remote-session-capabilities.test.ts` — 21 passed, 0 failed.
- `pnpm --dir ee/apps/den-api exec bun test --conditions development test/remote-session-capability-wire.test.ts` — 2 passed, 0 failed; startup rejection followed by retry creates one session and sends the prompt once.
- `pnpm evals:pr specs/remote-session-first-use.test.ts` — failed during local database setup with “Connection lost: The server closed the connection.” No journey assertions ran. The spec explicitly requires local placement; no placement line was printed before failure.

Overall verification is **Incomplete** until the full first-use journey passes with working local MySQL and Redis and its evidence is published. The focused and HTTP tests pass; the full journey remains blocked by local infrastructure.
