### PR TITLE
ci: schedule atomic handoff coverage on its required local topology

### DIFF
--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -231,22 +231,74 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+  local-handoff:
+    # The profile-permission fault and restart must run beside Electron.
+    # Keep this one journey scheduled even though it cannot use Daytona.
+    if: >-
+      github.repository == 'different-ai/openwork' &&
+      (github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.only == '' || contains('cross-server-handoff-atomic-commit.e2e.test.ts', inputs.only))))
+    name: E2E local (cross-server-handoff-atomic-commit.e2e.test.ts)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-tests
+      - name: Prepare local Den and Electron
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y xvfb x11-utils libgtk-3-0 libnss3 libasound2t64 libgbm1
+          pnpm --filter @openwork/types build
+          pnpm --filter @openwork-ee/den-db build
+          pnpm --filter @openwork/email build
+          pnpm dev:den:mysql
+      - name: Run local handoff journey
+        run: |
+          set -euo pipefail
+          # Permission failures must be real; root would bypass the fault.
+          test "$(id -u)" -ne 0
+          xvfb-run -a pnpm evals:e2e cross-server-handoff-atomic-commit.e2e.test.ts --local 2>&1 | tee /tmp/local-handoff-e2e.log
+      - name: Upload local handoff evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: local-handoff-e2e
+          path: |
+            evals/results/test-runs/
+            /tmp/local-handoff-e2e.log
+          retention-days: 14
+          if-no-files-found: warn
+
   verdict:
     needs:
       - plan
       - e2e
-    if: always() && needs.plan.outputs.enabled == 'true'
+      - local-handoff
+    if: always() && (needs.plan.outputs.enabled == 'true' || needs.local-handoff.result != 'skipped')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Report Daytona E2E verdict
         env:
           E2E_RESULT: ${{ needs.e2e.result }}
+          LOCAL_HANDOFF_RESULT: ${{ needs.local-handoff.result }}
           EVENT_NAME: ${{ github.event_name }}
           HAS_TESTS: ${{ needs.plan.outputs.has_tests }}
         run: |
           set -euo pipefail
 
+          echo "Local handoff E2E result: **$LOCAL_HANDOFF_RESULT**." >> "$GITHUB_STEP_SUMMARY"
+          if [ "$LOCAL_HANDOFF_RESULT" != "success" ] && [ "$LOCAL_HANDOFF_RESULT" != "skipped" ]; then
+            exit 1
+          fi
+          # A manual filter can select only the local journey.
+          if [ "$HAS_TESTS" != "true" ] && [ "$LOCAL_HANDOFF_RESULT" = "success" ]; then
+            exit 0
+          fi
           if [ "$EVENT_NAME" = "workflow_run" ] && [ "$HAS_TESTS" != "true" ]; then
             echo "Warden suggestion: add or update an evals/specs/<feature>.e2e.test.ts test for this PR." >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -38,6 +38,24 @@ export async function evalIn(
   });
 }
 
+/** Quit through Chromium before disposing a surface. Process-group signals
+ * are cleanup, not a user quit: they can lose pending localStorage writes.
+ * Matches the graceful restart used by the updater-channel journey. */
+export async function quitDesktop(app: Surface): Promise<void> {
+  await app.client.send("Browser.close").catch((error: unknown) => {
+    if (!/CDP websocket (?:failed|closed)/i.test(messageText(error))) throw error;
+  });
+  const deadline = Date.now() + DEFAULT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const stopped = await fetch(`${app.handle.cdpUrl.replace(/\/$/, "")}/json/version`, {
+      signal: AbortSignal.timeout(1_000),
+    }).then(() => false, () => true);
+    if (stopped) return;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error("Desktop did not quit within 30000ms.");
+}
+
 async function timeoutError(app: Surface, message: string): Promise<Error> {
   return new Error(`${message} On screen: ${await dumpScreenState(app)}.`);
 }

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -1,4 +1,4 @@
-export { control, createDesktopHandoffGrant, evalIn, signInDesktopAs } from "@openwork/behaviors";
+export { control, createDesktopHandoffGrant, evalIn, quitDesktop, signInDesktopAs } from "@openwork/behaviors";
 export { requestDenLoopback } from "@openwork/labs";
 export { desktop as relaunchDesktop, electronProfilePaths } from "@openwork/hosts";
 export type { DesktopHandle } from "@openwork/hosts";

--- a/evals/scripts/list-daytona-raw-desktop-tests.mjs
+++ b/evals/scripts/list-daytona-raw-desktop-tests.mjs
@@ -6,6 +6,14 @@ const files = (await readdir(specs))
   .sort();
 
 for (const file of files) {
+  // This journey uses app(), but chmods its local Electron profile and
+  // restarts it against two independent local Den servers. Keep its full
+  // rollback/recovery proof runnable with evals:e2e <slug> --local; selecting
+  // it for Daytona only produces an Incomplete skip, never product evidence.
+  if (file === "cross-server-handoff-atomic-commit.e2e.test.ts") {
+    console.log(file);
+    continue;
+  }
   const source = await readFile(new URL(file, specs), "utf8");
   if (/import\s*\{[^}]*\bdesktop\b[^}]*\}\s*from\s*["']@openwork\/hosts["']/s.test(source)) {
     console.log(file);

--- a/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
+++ b/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
@@ -12,6 +12,7 @@ import {
   eventually,
   localMysqlIsRunning,
   needs,
+  quitDesktop,
   readDenClientState,
   relaunchDesktop,
   server,
@@ -250,6 +251,9 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(
       // port would otherwise rotate the origin that scopes localStorage.
       const rendererPort = desktop.handle.meta?.vitePort;
       if (!rendererPort) throw new Error("The first launch did not record its renderer port.");
+      // Exercise a user quit, allowing Chromium to persist renderer storage,
+      // before disposing the dev processes. stop() alone sends SIGINT.
+      await quitDesktop(desktop);
       await desktop.stop();
       desktop = null;
       // The dev server auto-increments a busy port instead of failing, which


### PR DESCRIPTION
The scheduled Daytona matrix selected a journey that requires local Electron, two independent Den servers, and a filesystem permission fault. The [original job](https://github.com/different-ai/openwork/actions/runs/33983213474/job/101352075291) skipped its only test and correctly returned **Incomplete**, exit 2. No handoff assertion ran.

Run this valid recovery journey as one named local job on the existing twice-daily schedule, with the repository runtime setup, MySQL/Redis, and Xvfb. Manual runs honor the existing `only` filter. The job preserves the eval CLI exit code, always uploads evidence, and participates in the aggregate verdict. The Daytona selector excludes exactly this journey, leaving every other spec's eligibility unchanged.

The first actual local CI run exposed a brittle restart setup: the test sent SIGINT to the dev process tree immediately after writing renderer storage. It passed enrollment, rollback, recovery, and replay assertions, then restarted signed out. The journey now uses Chromium's graceful quit before disposing the dev processes, following the existing updater restart behavior. All assertions remain intact. This proves ordinary user quit/relaunch; it does not claim abrupt-crash durability. Product code is unchanged.

The underlying atomic transaction already landed in #4054 (`3e425fa53`) and its test registration in #4375. Both were present in the original revision `85a5dfccb`; the spec and selector were unchanged on the investigated dev `f6f93bdb3`. Verdict: CI placement defect plus brittle shutdown setup, not evidence of a new atomic-handoff product regression.

## Proof

**Passed** on final head `1812bff157972ab279cfb742175d6e9df498f963`: [branch workflow](https://github.com/different-ai/openwork/actions/runs/34017856116), [published assertion evidence](https://github.com/different-ai/openwork/pull/4559#issuecomment-5557612063).

`pnpm evals:e2e cross-server-handoff-atomic-commit.e2e.test.ts --local` under Xvfb printed `placement: local (--local)`, **1 passed / 0 failed / 0 skipped**, exit 0. Verified the checkout SHA and downloaded test-run SHA against the PR head. The artifact contains five passed assertion checkpoints, no failures or pending judgments:

1. Initial enrollment to A.
2. Bootstrap-write failure leaves A active and publishes no success.
3. A fresh grant commits B.
4. A consumed grant cannot be replayed or disturb B.
5. Ordinary quit/relaunch restores the complete B enrollment.

The aggregate workflow also passed. The [preceding run](https://github.com/different-ai/openwork/actions/runs/34017290240) at `4cb6ac74a` failed the unchanged restart assertion, and its aggregate verdict correctly failed. Its downloadable artifact retains the four passed checkpoints and restart timeout for comparison.

This coverage is worth keeping: a normal single-server sign-in does not exercise rollback after persistence failure, fresh-link recovery, or restoration across restart. No new journey files, removed assertions, longer timeouts, or seeded restart credentials were added.

## Other checks and limitations

- Selector comparison passed: exactly this filename was excluded; the complete source test and other eligibility (including the Atlassian tile journey) remain.
- `actionlint -ignore 'label "blacksmith' .github/workflows/daytona-e2e.yml` passed; only custom runner label validation was suppressed.
- `pnpm --dir evals run typecheck:spec-layer` passed.
- Global channel/boundary ratchets fail with byte-identical output on a clean `f6f93bdb3` control. Layer lint under Node 24.15.0 reports the same 19 errors on branch and control, outside changed files. These broader checks remain red; this journey adds zero raw channel escapes.
- Local-machine reproduction with `--daytona` matched the original **0/0/1 Incomplete**, exit 2. Local `--local` failed during MySQL setup (`Connection lost: The server closed the connection.`), before any assertion. Docker also did not answer within 10 seconds; shared services were not restarted. Isolated CI supplied the completed proof.
- Proof uses the real app's state and persistence assertions, with five recorded expectations; it contains no screenshots or vision observations. Abrupt-crash durability and PR-triggered automatic local execution are outside this change. Scheduled/manual execution is provided by the named job.

Reproduce locally: install both workspaces, build `@openwork/types`, `@openwork-ee/den-db`, and `@openwork/email`, run `pnpm dev:den:mysql`, then the local command above (`xvfb-run -a` on headless Linux).

Shared files: `.github/workflows/daytona-e2e.yml`, `evals/scripts/list-daytona-raw-desktop-tests.mjs`, `evals/packages/behaviors/src/desktop.ts`, and the testkit export. The existing handoff spec calls the graceful-quit helper. Other failure investigations remain independent.
