### PR TITLE
feat(den): use full-width onboarding with an explicit finish action

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/setup-frame.module.css
+++ b/ee/apps/den-web/app/(den)/_components/setup-frame.module.css
@@ -3,10 +3,11 @@
   --dls-hover: #f5f5f5; --dls-accent: #171717;
   min-height: 100dvh; background: #fcfcfc; color: #171717; padding: 28px clamp(20px, 5vw, 80px) 20px;
 }
-.top { max-width: 1240px; margin: auto; display: flex; align-items: center; justify-content: space-between; gap: 32px; }
+.top, .grid { max-width: 1130px; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.12fr); gap: clamp(40px, 7vw, 100px); }
+.top { margin: auto; align-items: center; }
 .brand { display: flex; align-items: center; gap: 10px; font-size: 18px; font-weight: 600; letter-spacing: -.6px; white-space: nowrap; }
 .cloud { color: #818181; font-weight: 400; }
-.progress { width: min(100%, 470px); min-width: 0; }
+.progress { width: 100%; min-width: 0; }
 .progressSummary { display: none; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 12px; font-size: 14px; line-height: 1.4; }
 .progressSummary > span:first-child { color: #171717; font-weight: 500; }
 .progressSummary > span:last-child { color: #777; font-size: 12px; font-variant-numeric: tabular-nums; }
@@ -17,7 +18,7 @@
 .steps [aria-current] .progressSegment { background: #171717; }
 .done { color: #686868; }
 .done .progressSegment { background: #a6a6a6; }
-.grid { max-width: 1130px; margin: clamp(48px, 8vh, 90px) auto 60px; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.12fr); align-items: start; gap: clamp(40px, 7vw, 100px); }
+.grid { margin: clamp(48px, 8vh, 90px) auto 60px; align-items: start; }
 .story { min-width: 0; padding-top: 15px; }
 .eyebrow { margin: 0 0 22px; font-size: 9px; font-weight: 600; letter-spacing: .19em; color: #787878; }
 .intro h1 { margin: 0; font-size: clamp(42px, 4.5vw, 62px); line-height: 1.04; letter-spacing: -.064em; font-weight: 500; max-width: 440px; text-wrap: balance; }
@@ -111,9 +112,10 @@
 .gatewayContext small { display: block; margin-top: 3px; font-size: 7px; line-height: 1.6; color: #999; }
 .preview figcaption { font-size: 10px; line-height: 1.7; color: #777; margin-top: 12px; }
 .storyNote { max-width: 330px; font-size: 11px; line-height: 1.8; color: #888; margin: 19px 0 0; }
-.footer { display: flex; justify-content: space-between; gap: 20px; max-width: 1240px; margin: auto; padding-top: 18px; border-top: 1px solid #e9e9e9; color: #888; font-size: 10px; }
+.footer { display: flex; justify-content: space-between; gap: 20px; max-width: 1130px; margin: auto; padding-top: 18px; border-top: 1px solid #e9e9e9; color: #888; font-size: 10px; }
 .embedded { min-height: auto; border-radius: 18px; padding: 30px clamp(18px, 3vw, 42px); }
-.embedded .grid { gap: 35px; margin: 48px auto; grid-template-columns: minmax(0, .85fr) minmax(0, 1.15fr); }
+.embedded .top, .embedded .grid { gap: 35px; grid-template-columns: minmax(0, .85fr) minmax(0, 1.15fr); }
+.embedded .grid { margin: 48px auto; }
 .embedded .intro h1 { font-size: clamp(36px, 3.6vw, 50px); }
 .embedded .cloud { display: none; }
 @keyframes enter { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
@@ -121,12 +123,12 @@
   .embedded .grid { grid-template-columns: 1fr; margin-top: 28px; gap: 26px; }
   .embedded .story { display: grid; grid-template-columns: 1fr; }
   .embedded .preview, .embedded .customPreview, .embedded .storyNote { display: none; }
-  .embedded .top { flex-direction: column; align-items: stretch; gap: 22px; }
+  .embedded .top { grid-template-columns: 1fr; align-items: stretch; gap: 22px; }
   .embedded .progress { width: 100%; }
 }
 @media (max-width: 760px) {
   .frame, .embedded { padding: 22px 20px; }
-  .top { align-items: stretch; flex-direction: column; gap: 23px; }
+  .top { align-items: stretch; grid-template-columns: 1fr; gap: 23px; }
   .brand { font-size: 17px; }
   .progress { width: 100%; }
   .progressSummary { display: flex; }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -143,7 +143,6 @@ export function MarketplaceOnboardingScreen({
   return (
     <SetupFrame
       step="ready"
-      embedded
       title="Put your tools to work."
       description={`Start a chat. Build dashboards, run workflows, and use ${orgName}’s tools—with the model you choose.`}
     >
@@ -229,12 +228,15 @@ export function MarketplaceOnboardingScreen({
           <p className="mt-1 text-[13px]">OpenWork’s MCP gateway brings shared tools into compatible AI apps. Each person uses their own connected accounts and team permissions.</p>
           <Link href={getYourConnectionsRoute(orgSlug)} className="mt-3 inline-block font-medium text-neutral-900 underline-offset-4 hover:underline">Connect your accounts →</Link>
         </div>
-        <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--dls-border)] pt-5 text-sm">
-          <span className="text-[var(--dls-text-secondary)]">Keep setting up at your own pace.</span>
-          <Link href={getOrgDashboardRoute(orgSlug)} className="rounded-sm font-medium text-[var(--dls-text-primary)] underline-offset-4 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--dls-text-primary)]">
-            Go to dashboard →
+        <section aria-labelledby="setup-finish-heading" className="grid gap-4 border-t border-[var(--dls-border)] pt-7" data-testid="onboarding-finish">
+          <div>
+            <h2 id="setup-finish-heading" className="text-base font-semibold tracking-tight text-[var(--dls-text-primary)]">Your workspace is ready</h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--dls-text-secondary)]">Finish setup to open your dashboard. You can download the app, connect accounts, and choose models whenever you’re ready.</p>
+          </div>
+          <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-neutral-950 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-neutral-800">
+            Finish setup<ArrowRight className="size-4" aria-hidden />
           </Link>
-        </footer>
+        </section>
       </div>
     </SetupFrame>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/onboarding-teammates-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/onboarding-teammates-screen.tsx
@@ -30,7 +30,7 @@ export function OnboardingTeammatesScreen() {
   const { orgId, orgSlug, orgContext, orgError } = useOrgDashboard();
   const { user } = useDenFlow();
   if (!orgId || !orgContext || orgContext.organization.id !== orgId || !user) {
-    return <SetupFrame step="people" title="Bring your people." description={description} embedded>
+    return <SetupFrame step="people" title="Bring your people." description={description}>
       <p role={orgError ? "alert" : "status"} className="text-sm text-neutral-500">{orgError ?? "Getting your workspace ready…"}</p>
     </SetupFrame>;
   }
@@ -165,7 +165,7 @@ function TeammatesForm({ orgId, orgSlug, organizationName, selfEmail, selfName, 
     <div className="mt-7 border-t border-neutral-100 pt-5 text-sm leading-6 text-neutral-500">A shared place for tools, connections, and the way your team works.</div>
   </div>;
 
-  return <SetupFrame step="people" title="Bring your people." description={description} aside={preview} embedded>
+  return <SetupFrame step="people" title="Bring your people." description={description} aside={preview}>
     <div data-testid="onboarding-teammates" aria-busy={sending}>
       {canInvite ? <form noValidate onSubmit={(event) => { event.preventDefault(); void sendInvitations(); }}>
         <div className="mb-5 flex items-center justify-between gap-3">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/onboarding-tools-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/onboarding-tools-screen.tsx
@@ -20,7 +20,7 @@ export function OnboardingToolsScreen() {
   const { orgId, orgContext, orgError } = useOrgDashboard();
   const { user } = useDenFlow();
   if (!orgId || !orgContext || orgContext.organization.id !== orgId || !user) {
-    return <SetupFrame step="tools" title="Give your team a head start." description={description} embedded>
+    return <SetupFrame step="tools" title="Give your team a head start." description={description}>
       <p role={orgError ? "alert" : "status"} className="text-sm text-neutral-500">{orgError ?? "Getting your workspace ready…"}</p>
     </SetupFrame>;
   }
@@ -104,7 +104,7 @@ function ToolsForm() {
     router.push(getMarketplaceOnboardingRoute(orgSlug));
   }
 
-  return <SetupFrame step="tools" title="Give your team a head start." description={description} panelVisual={<OnboardingTexture />} embedded>
+  return <SetupFrame step="tools" title="Give your team a head start." description={description} panelVisual={<OnboardingTexture />}>
     <div className="mb-5">
       <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-400">Optional · Team tools</p>
       <h2 className="mt-2 text-xl font-semibold tracking-[-0.03em] text-neutral-950">What do you work with?</h2>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -38,6 +38,7 @@ import {
   getOrgDashboardRoute,
   getOrgSettingsRoute,
   getMarketplacesRoute,
+  getMarketplaceOnboardingRoute,
   getPluginsRoute,
   getSsoRoute,
   getScimRoute,
@@ -296,6 +297,8 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
 
 export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const onboardingRoute = getMarketplaceOnboardingRoute();
+  const isOnboarding = pathname === onboardingRoute || pathname.startsWith(`${onboardingRoute}/`);
   const { user, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const {
     activeOrg,
@@ -332,6 +335,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
+      if (isOnboarding) return;
       if (
         event.key.toLowerCase() !== "k"
         || (!event.metaKey && !event.ctrlKey)
@@ -346,7 +350,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [isOnboarding]);
 
   useEffect(() => {
     if (commandPaletteWasOpenRef.current && !commandPaletteOpen) {
@@ -391,6 +395,16 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         onPick={switchOrganization}
         onSignOut={() => void signOut()}
       />
+    );
+  }
+
+  // Setup owns the full page until the user leaves for their dashboard.
+  if (isOnboarding) {
+    return (
+      <>
+        <WorkspaceFavicon metadata={orgContext?.organization.metadata} />
+        <main data-testid="den-onboarding-shell">{children}</main>
+      </>
     );
   }
 

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -14,11 +14,18 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.notSee({ role: "button", label: "Open menu" });
     expect(await probe.eval(`(() => {
       const frame = document.querySelector('[data-testid="setup-frame"]');
+      const frameBounds = frame?.getBoundingClientRect();
+      const footer = frame?.querySelector('footer')?.getBoundingClientRect();
       const story = frame?.querySelector('aside')?.getBoundingClientRect();
       const panel = frame?.querySelector('aside')?.nextElementSibling?.getBoundingClientRect();
       const brand = frame?.querySelector('header > div')?.getBoundingClientRect();
       const progress = frame?.querySelector('nav[aria-label="Setup progress"]')?.getBoundingClientRect();
-      return Boolean(story && panel && brand && progress
+      return Boolean(frameBounds && footer && story && panel && brand && progress
+        && Math.abs(frameBounds.left) < 2
+        && Math.abs(frameBounds.right - document.documentElement.clientWidth) < 2
+        && Math.abs(panel.right - story.left - 1130) < 2
+        && Math.abs(footer.left - story.left) < 2
+        && Math.abs(footer.right - panel.right) < 2
         && story.right <= panel.left && Math.abs(story.top - panel.top) < 2
         && Math.abs(brand.left - story.left) < 2
         && Math.abs(progress.left - panel.left) < 2
@@ -184,7 +191,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
     expect(await connectionsFor(personalId)).toEqual([]);
     expect(await invitationsFor(personalId)).toEqual([]);
-    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready have separate desktop panes with the logo aligned to the story and the stepper aligned to both panel edges, without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
+    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready fill the viewport with a 1130px desktop content area and matching footer edges, with the logo aligned to the story and the stepper aligned to both panel edges, without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
   });
 
   let flexibleId = "";

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -160,12 +160,26 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
   });
 
   await step("finish opens the dashboard without requiring an installation or provider", async () => {
-    await user.see({ text: "Your workspace is ready" });
-    await user.notSee({ testId: "den-org-sidebar" });
-    await user.click({ role: "link", label: "Finish setup" });
-    await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
-    await user.notSee({ testId: "den-onboarding-shell" });
-    expect(await world.pathname()).toBe("/dashboard");
+    for (const shortcut of ["Control+k", "Meta+k"]) {
+      if (shortcut === "Meta+k") {
+        await user.navigate(new URL("/dashboard/onboarding", world.den.ref.webUrl).toString());
+      }
+      await user.see({ text: "Your workspace is ready" });
+      await user.notSee({ testId: "den-org-sidebar" });
+      await user.press(shortcut);
+      await user.notSee({ testId: "den-command-palette" });
+      await user.click({ role: "link", label: "Finish setup" });
+      await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
+      await user.notSee({ testId: "den-onboarding-shell" });
+      expect(await world.pathname()).toBe("/dashboard");
+      // Assert before reload: navigation must not reveal a queued shortcut.
+      await user.notSee({ testId: "den-command-palette" });
+      await user.press(shortcut);
+      await user.see({ testId: "den-command-palette" });
+      await user.press("Escape");
+      await user.notSee({ testId: "den-command-palette" });
+      evidence.recordAssertionEvidence(`${shortcut} is suppressed during onboarding and restored on the dashboard`, "Pressing the shortcut during setup leaves the palette closed both before and after Finish setup, without reloading; pressing it on the dashboard opens the palette, and Escape closes it.", true);
+    }
     await user.reload();
     await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
     expect(await connectionsFor(personalId)).toEqual([]);

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -154,7 +154,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
   });
 
   await step("finish opens the dashboard without requiring an installation or provider", async () => {
-    await user.see({ role: "heading", label: "Your workspace is ready" });
+    await user.see({ text: "Your workspace is ready" });
     await user.notSee({ testId: "den-org-sidebar" });
     await user.click({ role: "link", label: "Finish setup" });
     await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -16,7 +16,13 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
       const frame = document.querySelector('[data-testid="setup-frame"]');
       const story = frame?.querySelector('aside')?.getBoundingClientRect();
       const panel = frame?.querySelector('aside')?.nextElementSibling?.getBoundingClientRect();
-      return Boolean(story && panel && story.right <= panel.left && Math.abs(story.top - panel.top) < 2);
+      const brand = frame?.querySelector('header > div')?.getBoundingClientRect();
+      const progress = frame?.querySelector('nav[aria-label="Setup progress"]')?.getBoundingClientRect();
+      return Boolean(story && panel && brand && progress
+        && story.right <= panel.left && Math.abs(story.top - panel.top) < 2
+        && Math.abs(brand.left - story.left) < 2
+        && Math.abs(progress.left - panel.left) < 2
+        && Math.abs(progress.right - panel.right) < 2);
     })()`)).toBe(true);
     expect(await probe.eval("document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
   };
@@ -164,7 +170,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
     expect(await connectionsFor(personalId)).toEqual([]);
     expect(await invitationsFor(personalId)).toEqual([]);
-    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready have separate desktop panes without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
+    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready have separate desktop panes with the logo aligned to the story and the stepper aligned to both panel edges, without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
   });
 
   let flexibleId = "";

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -373,7 +373,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.see({ role: "button", label: "Open menu" }, { timeoutMs: 30_000 });
     await mobileUser.notSee({ testId: "den-onboarding-shell" });
     await mobileUser.click({ role: "button", label: "Open menu" });
-    await mobileUser.see({ testId: "den-org-sidebar" });
+    await mobileUser.see({ testId: "den-org-sidebar", nth: 1 });
     evidence.recordAssertionEvidence("Mobile onboarding finishes without downloading and reveals working dashboard navigation", "Tools and Ready omit the menu; Finish setup restores it and opening the menu reveals the sidebar.", true);
     await mobileUser.navigate(new URL("/dashboard/onboarding", world.den.ref.webUrl).toString());
     await mobileUser.see({ role: "button", label: "Email me the download link" }, { timeoutMs: 90_000 });

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -8,6 +8,18 @@ const test = spec.world(signupWorkspace, { timeout: 600_000 });
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 test("signup distinguishes joining, personal work, and restricted team setup without changing another organization", async ({ world, user, probe, seed, evidence, step }) => {
+  const expectFocusedSetup = async () => {
+    await user.see({ testId: "den-onboarding-shell" });
+    await user.notSee({ testId: "den-org-sidebar" });
+    await user.notSee({ role: "button", label: "Open menu" });
+    expect(await probe.eval(`(() => {
+      const frame = document.querySelector('[data-testid="setup-frame"]');
+      const story = frame?.querySelector('aside')?.getBoundingClientRect();
+      const panel = frame?.querySelector('aside')?.nextElementSibling?.getBoundingClientRect();
+      return Boolean(story && panel && story.right <= panel.left && Math.abs(story.top - panel.top) < 2);
+    })()`)).toBe(true);
+    expect(await probe.eval("document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
+  };
   const orgs = async () => {
     const result = await probe.api(world.den.admin, "/v1/me/orgs");
     expect(result.response.ok).toBe(true);
@@ -91,6 +103,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.type({ role: "textbox", label: "Organization name" }, "Personal work");
     await user.click({ role: "button", label: "Continue" });
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     const memberships = await orgs();
     expect(memberships).toHaveLength(1);
     const personal = memberships.find((entry) => entry.name === "Personal work");
@@ -106,10 +119,12 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     if (typeof defaultPolicy?.id !== "string") throw new Error("Expected default desktop policy id");
     await user.navigate(new URL(`/dashboard/desktop-policies/${encodeURIComponent(defaultPolicy.id)}?setup=restricted`, world.den.ref.webUrl).toString());
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await world.pathname()).toMatch(/\/onboarding\/people$/);
     expect(await policyFor(personalId)).toEqual(personalPolicy);
     await user.reload();
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await policyFor(personalId)).toEqual(personalPolicy);
     evidence.recordAssertionEvidence("Opening a legacy Restricted setup link never changes an existing flexible policy", "The personal workspace kept its complete original desktop policy after opening the legacy URL and reloading; navigation only resumed optional People onboarding.", true);
     expect(await invitationsFor(personalId)).toEqual([]);
@@ -117,11 +132,13 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.type({ role: "textbox", label: "Teammate email 1" }, "unsent@openwork.test");
     await user.click({ role: "button", label: "Do this later" });
     await user.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     const connectionsBeforeSkip = await connectionsFor(personalId);
     expect(connectionsBeforeSkip).toEqual([]);
     await user.click({ role: "checkbox", label: "Add Notion" });
     await user.click({ role: "button", label: "Do this later" });
     await user.see({ testId: "marketplace-onboarding" }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await connectionsFor(personalId)).toEqual(connectionsBeforeSkip);
     evidence.recordAssertionEvidence("Skipping optional tools does not save even a selected connection", "Notion was selected, then Do this later continued to Ready; the personal organization's connection inventory stayed empty.", true);
     await user.click({ text: "Other platforms and versions" });
@@ -136,6 +153,20 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     evidence.recordAssertionEvidence("Personal setup preserves desktop defaults and explicit skip never submits a typed invitation", JSON.stringify({ memberships: memberships.length, personalPolicy, invitations: [], emailsUnchanged: true }), true);
   });
 
+  await step("finish opens the dashboard without requiring an installation or provider", async () => {
+    await user.see({ role: "heading", label: "Your workspace is ready" });
+    await user.notSee({ testId: "den-org-sidebar" });
+    await user.click({ role: "link", label: "Finish setup" });
+    await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
+    await user.notSee({ testId: "den-onboarding-shell" });
+    expect(await world.pathname()).toBe("/dashboard");
+    await user.reload();
+    await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
+    expect(await connectionsFor(personalId)).toEqual([]);
+    expect(await invitationsFor(personalId)).toEqual([]);
+    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready have separate desktop panes without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
+  });
+
   let flexibleId = "";
   await step("a flexible team keeps existing defaults without opening policy setup", async () => {
     await user.navigate(new URL("/organization", world.den.ref.webUrl).toString());
@@ -145,6 +176,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.click({ text: "Flexible" });
     await user.click({ role: "button", label: "Continue" });
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     await user.notSee({ text: "Review your team’s desktop access" });
     const memberships = await orgs();
     expect(memberships).toHaveLength(2);
@@ -206,6 +238,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.looks(["The optional people setup shows two completed invitations and a clear Continue action within the same neutral onboarding frame"]);
     await user.click({ role: "button", label: "Continue" });
     await user.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     evidence.recordAssertionEvidence("Partial invitation failure preserves the unsuccessful address and retries it without resending successful invitations or granting admin access", JSON.stringify({ invitations, recipientCounts: [1, 1], personalInvitations: 0 }), true);
   });
 
@@ -230,10 +263,12 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.looks(["The optional Tools screen shows Notion and Linear added for the team while explaining that each person still signs in to their own account, with a clear Continue action. Its product example is a chat with inline team tools and a persistent composer"]);
     await user.reload();
     await user.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await connectionsFor(flexibleId)).toEqual(added);
     await user.see({ text: "Already added" });
     await user.click({ role: "button", label: "Continue" });
     await user.see({ testId: "marketplace-onboarding" }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await connectionsFor(flexibleId)).toEqual(added);
     evidence.recordAssertionEvidence("Selected tools become organization-wide configuration without authorizing member accounts or creating duplicates on reload", JSON.stringify({ added, personalConnections: [], sameConnectionsAfterReload: true }), true);
   });
@@ -251,6 +286,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.looks(["Team setup uses subdued neutral cards with Restricted selected, without heavy black card outlines, and explains that restrictions apply on Continue"]);
     await user.click({ role: "button", label: "Continue" });
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await world.pathname()).toMatch(/\/onboarding\/people$/);
     await user.notSee({ text: "Review your team’s desktop access" });
     await user.notSee({ role: "button", label: "Save changes" });
@@ -263,6 +299,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     expect(saved.showWelcomePage).toBe(true);
     await user.reload();
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await world.pathname()).toMatch(/\/onboarding\/people$/);
     expect(await policyFor(team.id)).toEqual(saved);
     const policies = await probe.api(world.den.admin, "/v1/desktop-policies", { headers: { "x-openwork-org-id": team.id } });
@@ -272,6 +309,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     if (typeof defaultPolicy?.id !== "string") throw new Error("Expected default desktop policy id");
     await user.navigate(new URL(`/dashboard/desktop-policies/${encodeURIComponent(defaultPolicy.id)}?setup=restricted`, world.den.ref.webUrl).toString());
     await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await world.pathname()).toMatch(/\/onboarding\/people$/);
     await user.notSee({ text: "Review your team’s desktop access" });
     await user.notSee({ role: "button", label: "Save changes" });
@@ -282,9 +320,11 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     expect(await invitationsFor(team.id)).toEqual([]);
     await user.click({ role: "button", label: "Do this later" });
     await user.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await connectionsFor(team.id)).toEqual([]);
     await user.click({ role: "button", label: "Do this later" });
     await user.see({ testId: "marketplace-onboarding" }, { timeoutMs: 90_000 });
+    await expectFocusedSetup();
     expect(await connectionsFor(team.id)).toEqual([]);
     expect(await connectionsFor(personalId)).toEqual([]);
     expect(await invitationsFor(team.id)).toEqual([]);
@@ -310,6 +350,8 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     const toolsBefore = await connectionsFor(flexibleId);
     await mobileUser.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
     await mobileUser.see({ text: "Already added" });
+    await mobileUser.notSee({ role: "button", label: "Open menu" });
+    await mobileUser.notSee({ testId: "den-org-sidebar" });
     expect(await probe.eval(mobile, "document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
     await mobileUser.press("Control+Home");
     await mobileUser.looks(["The top of the narrow Tools screen shows legible setup progress and the Give your team a head start heading without horizontal clipping"]);
@@ -326,6 +368,15 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.looks(["The mobile OpenWork Desktop card shows its complete heading, OpenWork mark, explanatory copy, and Email me the download link button in a restrained neutral card"]);
     await mobileUser.hover({ role: "link", label: "Try OpenWork Web" });
     await mobileUser.looks(["The mobile OpenWork Web card shows its complete heading, OpenWork mark, access-and-plans explanation, and Try OpenWork Web link without horizontal clipping"]);
+    await mobileUser.notSee({ role: "button", label: "Open menu" });
+    await mobileUser.click({ role: "link", label: "Finish setup" });
+    await mobileUser.see({ role: "button", label: "Open menu" }, { timeoutMs: 30_000 });
+    await mobileUser.notSee({ testId: "den-onboarding-shell" });
+    await mobileUser.click({ role: "button", label: "Open menu" });
+    await mobileUser.see({ testId: "den-org-sidebar" });
+    evidence.recordAssertionEvidence("Mobile onboarding finishes without downloading and reveals working dashboard navigation", "Tools and Ready omit the menu; Finish setup restores it and opening the menu reveals the sidebar.", true);
+    await mobileUser.navigate(new URL("/dashboard/onboarding", world.den.ref.webUrl).toString());
+    await mobileUser.see({ role: "button", label: "Email me the download link" }, { timeoutMs: 90_000 });
     const before = await downloadEmails();
     await mobileUser.click({ role: "button", label: "Email me the download link" });
     await mobileUser.see({ role: "button", label: "Download link sent" }, { timeoutMs: 30_000 });


### PR DESCRIPTION
## Summary
Den onboarding now fills the page with its existing two-pane setup layout. The logo aligns with the left content pane, and the stepper spans the right panel edges; the footer shares the same overall width. People, Tools, and Get to work hide dashboard navigation, including the mobile menu and command palette shortcut. A new “Your workspace is ready” section ends with a primary “Finish setup” link that opens the dashboard and restores navigation.

## Why
Keep users focused until the guided flow ends. Downloading the app is optional and does not prove installation or configuration is complete; users can finish without downloads, invitations, connected accounts, or model setup. This follows the completion message and destination pattern in https://www.patternfly.org/components/wizard/design-guidelines/.

## Scope
Reuse the existing responsive SetupFrame at full width, preserve organization access checks, and extend the existing signup journey with viewport-filling frame, 1130px desktop content width, aligned footer bounds, hidden navigation, finish/reload, mobile menu assertions, and independent Ctrl+K/Cmd+K checks that verify no queued palette appears after finishing and both shortcuts work on the dashboard.

## Testing
- Passed: `pnpm exec bun test ee/apps/den-web/tests/onboarding-page.test.ts ee/apps/den-web/tests/org-dashboard-shell-layout.test.ts` — 7 passed, 0 failed.
- Passed: `OPENWORK_EVAL_REF=0690175a349fef8faee9bb10af93161be3b3f572 pnpm evals:e2e signup-workspace-intent` — 1 passed, 0 failed, 0 skipped; exit 0.
- Placement: `daytona (daytona CLI authenticated)`. Fresh Den and browser environments checked out the exact PR head. Den production build succeeded.

## Evidence
The test-evidence comment contains the completed signup journey, desktop and mobile navigation assertions, and captured screenshots.

## Manual verification
1. Create a workspace and continue through People and Tools. On desktop, the introduction and form appear in separate panes; dashboard navigation stays hidden. On mobile, content stacks without horizontal scrolling and there is no menu button.
2. On Get to work, leave downloads and model setup untouched. Select Finish setup at the bottom.
3. Confirm the dashboard opens with desktop navigation or the mobile menu. Reload and confirm it remains usable.

## Risk and rollback
Layout and navigation only; no persistence or API changes. Revert this commit to restore embedded onboarding and its former dashboard link.
