### PR TITLE
test(dashboards): run the tile argument-error journey on Daytona

### DIFF
--- a/evals/packages/env/src/desktop-app.ts
+++ b/evals/packages/env/src/desktop-app.ts
@@ -16,6 +16,8 @@ interface SharedAppOptions {
   host?: Host;
   model?: string;
   workspacePath?: string;
+  /** Arrange a previously activated private-Den installation; does not test activation. */
+  enterpriseActivated?: boolean;
   /** Reuse this caller-owned local Electron profile root instead of creating one. */
   profileDir?: string;
   /** Eval-only delay before the desktop starts its embedded OpenWork server. */
@@ -154,6 +156,9 @@ export async function app(options: AppOptions): Promise<App> {
         bootstrap: {
           baseUrl: options.den.ref.webUrl,
           requireSignin: false,
+          ...(options.enterpriseActivated ? { enterpriseActivation: {
+            activatedAt: new Date().toISOString(), denBaseUrl: options.den.ref.apiUrl,
+          } } : {}),
         },
         env: Object.keys(env).length > 0 ? env : undefined,
       });
@@ -209,6 +214,9 @@ export async function app(options: AppOptions): Promise<App> {
       bootstrap: {
         baseUrl: options.den.ref.webUrl,
         requireSignin: false,
+        ...(options.enterpriseActivated ? { enterpriseActivation: {
+          activatedAt: new Date().toISOString(), denBaseUrl: options.den.ref.apiUrl,
+        } } : {}),
       },
       env: Object.keys(env).length > 0 ? env : undefined,
     });

--- a/evals/packages/env/src/seed.ts
+++ b/evals/packages/env/src/seed.ts
@@ -13,6 +13,8 @@ export interface SeedDesktopOptions {
   signIn?: false;
   model?: string;
   workspacePath?: string;
+  /** Arrange a previously activated private-Den installation; does not test activation. */
+  enterpriseActivated?: boolean;
   profileDir?: string;
   name?: string;
 }

--- a/evals/packages/hosts/src/desktop.ts
+++ b/evals/packages/hosts/src/desktop.ts
@@ -47,6 +47,8 @@ export interface DesktopOptions {
     baseUrl: string;
     apiBaseUrl?: string;
     requireSignin?: boolean;
+    /** Seed an installation already activated against its private Den. */
+    enterpriseActivation?: { activatedAt: string; denBaseUrl: string };
   };
   env?: Record<string, string>;
   /** Root package script used for a source Electron launch. */

--- a/evals/packages/hosts/src/types.ts
+++ b/evals/packages/hosts/src/types.ts
@@ -10,6 +10,8 @@ export interface ElectronSurfaceOptions {
     baseUrl: string;
     apiBaseUrl?: string;
     requireSignin?: boolean;
+    /** Seed an installation already activated against its private Den. */
+    enterpriseActivation?: { activatedAt: string; denBaseUrl: string };
   };
   env?: Record<string, string>;
   /** Root package script used for a source Electron launch. Setting this bypasses OPENWORK_EVAL_ELECTRON_BINARY. */

--- a/evals/packages/labs/src/index.ts
+++ b/evals/packages/labs/src/index.ts
@@ -8,3 +8,4 @@ export * from "./mock-mcp.ts";
 export * from "./not-implemented.ts";
 export * from "./release-feed.ts";
 export * from "./mock-planetscale.ts";
+export * from "./mock-atlassian.ts";

--- a/evals/packages/labs/src/mock-atlassian.ts
+++ b/evals/packages/labs/src/mock-atlassian.ts
@@ -1,0 +1,32 @@
+import type { MockMcpTool } from "./mock-mcp.ts";
+
+export const confluenceResourceUri = "ui://atlassian/confluence-page/view.html";
+export const jiraResourceUri = "ui://atlassian/jql-search/view.html";
+export const confluenceTileTitle = "Confluence page";
+export const jiraTileTitle = "Jira queue";
+export const pastedConfluenceJson = `{"pageId": "1122334455"}`;
+export const pastedJqlJson = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
+export const expectedJql = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
+
+const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
+
+
+/** Provider-shaped MCP Apps: a real RPC rejection for missing input, a successful control otherwise. */
+export const atlassianAppTools: MockMcpTool[] = [
+  { name: "getConfluencePage", title: "Get Confluence page", argument: "pageId", resourceUri: confluenceResourceUri },
+  { name: "searchJiraIssuesUsingJql", title: "Search Jira issues using JQL", argument: "jql", resourceUri: jiraResourceUri },
+].map(({ name, title, argument, resourceUri }) => ({
+  name,
+  title,
+  description: title,
+  inputSchema: {
+    type: "object",
+    properties: { cloudId: { type: "string" }, [argument]: { type: "string" } },
+    required: ["cloudId", argument],
+  },
+  annotations: { readOnlyHint: true, destructiveHint: false },
+  _meta: { ui: { resourceUri, visibility: ["model", "app"] } },
+  appHtml: APP_HTML,
+  validateRequiredArguments: true,
+  result: { content: [{ type: "text", text: `ok:${name}` }] },
+}));

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -82,6 +82,13 @@ export interface MockMcpTool {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  title?: string;
+  annotations?: { readOnlyHint: boolean; destructiveHint: boolean };
+  _meta?: { ui: { resourceUri: string; visibility?: string[] } };
+  /** Serve the HTML bound to this tool's _meta.ui.resourceUri. */
+  appHtml?: string;
+  /** Reject absent required input keys with JSON-RPC invalid params. */
+  validateRequiredArguments?: boolean;
   /** Hold the response while the real engine exposes its running tool state. */
   delayMs?: number;
   result: { content: { type: "text"; text: string }[]; isError?: boolean };

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -431,6 +431,7 @@ export class SeedChannel implements Seed {
             model: options.model,
             workspacePath: options.workspacePath,
             profileDir: options.profileDir,
+            enterpriseActivated: options.enterpriseActivated,
           }));
         }
         return this.#runtime.stack.use(await startApp({
@@ -440,6 +441,7 @@ export class SeedChannel implements Seed {
           model: options.model,
           workspacePath: options.workspacePath,
           profileDir: options.profileDir,
+          enterpriseActivated: options.enterpriseActivated,
         }));
       }
       if (options.as) throw new Error("seed.desktop({ as }) requires a Den.");

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -75,6 +75,7 @@ test(
     expect(jqlTile.opaque).toBe(false);
     expect(confluenceTile.text).toContain("rejected the tool arguments");
     expect(jqlTile.text).toContain("rejected the tool arguments");
+    await user.screenshot();
 
     // The witness saw both launches with the pasted arguments byte-identical
     // and no cloudId — the provider rejection is the only failure in the chain.

--- a/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
+++ b/evals/specs/dashboard-atlassian-tile-error.e2e.test.ts
@@ -22,13 +22,8 @@ import type { DashboardTileFacts } from "../worlds/dashboard-launch-input.ts";
  * fetch stubs — and asserts the member now sees the provider's own rejection
  * naming `cloudId` on the tile, never the generic 500 text. The witness proves
  * the pasted launch arguments arrived byte-identically.
- *
- * The witness is an inline loopback MCP server, so Den must run in the same
- * place — the same local-placement constraint remote-mcp-apps declares.
+ * The testkit places the witness beside Den, including on Daytona.
  */
-
-const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1"
-  && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
 
 const test = spec.world(atlassianDashboardTiles, { timeout: 480_000 });
 
@@ -37,7 +32,7 @@ function requireTile(value: DashboardTileFacts | null, label: string): Dashboard
   return value;
 }
 
-test.skipIf(!localPlacement)(
+test(
   "a dashboard tile launched with the reported Atlassian JSON names the missing required argument",
   async ({ world, user, probe, evidence }) => {
     await probe.eventually(() => world.openDashboard(), {
@@ -50,7 +45,7 @@ test.skipIf(!localPlacement)(
     });
 
     // Launch both tiles exactly as the member does: press Run.
-    world.receivedCalls.length = 0;
+    const launchedAt = new Date().toISOString();
     await user.click({ role: "button", label: `Run ${confluenceTileTitle}` });
     await user.click({ role: "button", label: `Run ${jiraTileTitle}` });
 
@@ -83,7 +78,8 @@ test.skipIf(!localPlacement)(
 
     // The witness saw both launches with the pasted arguments byte-identical
     // and no cloudId — the provider rejection is the only failure in the chain.
-    const witnessedByTool = new Map(world.receivedCalls.map((call) => [call.name, call.args]));
+    const calls = await world.witness.toolCalls({ sinceIso: launchedAt, atLeast: 2 });
+    const witnessedByTool = new Map(calls.map((call) => [call.name, call.args]));
     expect(witnessedByTool.get("getConfluencePage")).toEqual({ pageId: "1122334455" });
     expect(witnessedByTool.get("searchJiraIssuesUsingJql")).toEqual({ jql: expectedJql });
 

--- a/evals/worlds/dashboard-launch-input.ts
+++ b/evals/worlds/dashboard-launch-input.ts
@@ -1,7 +1,12 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { Den, Seed } from "@openwork/env";
 import { evalIn as rawEvalIn } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
+
+import {
+  atlassianAppTools, confluenceResourceUri, jiraResourceUri,
+  confluenceTileTitle, jiraTileTitle, pastedConfluenceJson, pastedJqlJson,
+} from "@openwork/labs";
+export { confluenceTileTitle, jiraTileTitle, expectedJql } from "@openwork/labs";
 
 /**
  * A managed Dashboard whose two tiles launch an Atlassian-shaped MCP with
@@ -13,18 +18,6 @@ import type { DenSession } from "@openwork/behaviors";
  * Payloads are anonymized, structure-identical stand-ins for the reported
  * ones (a Confluence page id and a JQL string with escaped quotes).
  */
-
-export const confluenceResourceUri = "ui://atlassian/confluence-page/view.html";
-export const jiraResourceUri = "ui://atlassian/jql-search/view.html";
-export const confluenceTileTitle = "Confluence page";
-export const jiraTileTitle = "Jira queue";
-export const pastedConfluenceJson = `{"pageId": "1122334455"}`;
-export const pastedJqlJson = `{ "jql": "project = HELPDESK AND status NOT IN (\\"Closed\\", \\"Resolved\\", \\"Duplicate\\", \\"Declined\\", \\"Spam\\") AND assignee = currentUser() ORDER BY updated ASC" }`;
-export const expectedJql = 'project = HELPDESK AND status NOT IN ("Closed", "Resolved", "Duplicate", "Declined", "Spam") AND assignee = currentUser() ORDER BY updated ASC';
-
-const APP_HTML = "<!doctype html><html><head></head><body>Atlassian</body></html>";
-
-export type WitnessCall = { name: string; args: Record<string, unknown> };
 
 /** What one dashboard tile shows the member after a launch attempt. */
 export interface DashboardTileFacts {
@@ -59,171 +52,6 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value;
 }
 
-function readBody(request: IncomingMessage): Promise<string> {
-  request.setEncoding("utf8");
-  return new Promise((resolve, reject) => {
-    let body = "";
-    request.on("data", (chunk: string) => {
-      body += chunk;
-    });
-    request.on("end", () => resolve(body));
-    request.on("error", reject);
-  });
-}
-
-function sendJson(response: ServerResponse, status: number, body: unknown): void {
-  response.writeHead(status, { "cache-control": "no-store", "content-type": "application/json" });
-  response.end(JSON.stringify(body));
-}
-
-async function listen(server: Server): Promise<string> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") throw new Error("The Atlassian witness did not bind a TCP port.");
-  return `http://127.0.0.1:${address.port}`;
-}
-
-async function closeServer(server: Server): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-    server.closeAllConnections();
-  });
-}
-
-function withDispose<T extends object>(value: T, dispose: () => Promise<void>): T & AsyncDisposable {
-  return Object.assign(value, { [Symbol.asyncDispose]: dispose });
-}
-
-export function atlassianWitnessRpc(
-  message: Record<string, unknown>,
-  receivedCalls: WitnessCall[],
-): Record<string, unknown> | null {
-  if (message.method === "initialize") {
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: "2025-06-18",
-        capabilities: {
-          tools: { listChanged: false },
-          resources: { listChanged: false, subscribe: false },
-          extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
-        },
-        serverInfo: { name: "atlassian-remote-mcp-witness", version: "1.0.0" },
-      },
-    };
-  }
-  if (message.id === undefined) return null;
-  if (message.method === "tools/list") {
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        tools: [
-          {
-            name: "getConfluencePage",
-            title: "Get Confluence page",
-            description: "Get a Confluence page by id.",
-            inputSchema: {
-              type: "object",
-              properties: { cloudId: { type: "string" }, pageId: { type: "string" } },
-              required: ["cloudId", "pageId"],
-            },
-            annotations: { readOnlyHint: true, destructiveHint: false },
-            _meta: { ui: { resourceUri: confluenceResourceUri, visibility: ["model", "app"] } },
-          },
-          {
-            name: "searchJiraIssuesUsingJql",
-            title: "Search Jira issues using JQL",
-            description: "Search Jira issues with a JQL query.",
-            inputSchema: {
-              type: "object",
-              properties: { cloudId: { type: "string" }, jql: { type: "string" } },
-              required: ["cloudId", "jql"],
-            },
-            annotations: { readOnlyHint: true, destructiveHint: false },
-            _meta: { ui: { resourceUri: jiraResourceUri, visibility: ["model", "app"] } },
-          },
-        ],
-      },
-    };
-  }
-  if (message.method === "resources/read") {
-    const params = isRecord(message.params) ? message.params : {};
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        contents: [{
-          uri: params.uri,
-          mimeType: "text/html;profile=mcp-app",
-          text: APP_HTML,
-          _meta: {
-            ui: {
-              csp: { connectDomains: [], resourceDomains: [], frameDomains: [], baseUriDomains: [] },
-              prefersBorder: true,
-            },
-          },
-        }],
-      },
-    };
-  }
-  if (message.method === "tools/call") {
-    const params = isRecord(message.params) ? message.params : {};
-    const name = typeof params.name === "string" ? params.name : "";
-    const args = isRecord(params.arguments) ? params.arguments : {};
-    receivedCalls.push({ name, args });
-    if (typeof args.cloudId !== "string" || !args.cloudId) {
-      return {
-        jsonrpc: "2.0",
-        id: message.id,
-        error: {
-          code: -32602,
-          message: `Invalid arguments for tool ${name}: [{"code":"invalid_type","expected":"string","received":"undefined","path":["cloudId"],"message":"Required"}]`,
-        },
-      };
-    }
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { content: [{ type: "text", text: `ok:${name}` }], structuredContent: { ok: true } },
-    };
-  }
-  return { jsonrpc: "2.0", id: message.id, result: {} };
-}
-
-/** A loopback MCP server shaped like the Atlassian remote MCP. */
-export function createAtlassianWitness(receivedCalls: WitnessCall[]): Server {
-  return createServer((request, response) => {
-    void (async () => {
-      if (request.method !== "POST") {
-        sendJson(response, 405, { error: "method_not_allowed" });
-        return;
-      }
-      const raw = await readBody(request);
-      const parsed: unknown = raw.trim() ? JSON.parse(raw) : {};
-      const messages = Array.isArray(parsed) ? parsed : [parsed];
-      const replies = messages.flatMap((entry) => {
-        if (!isRecord(entry)) return [];
-        const reply = atlassianWitnessRpc(entry, receivedCalls);
-        return reply ? [reply] : [];
-      });
-      if (replies.length === 0) {
-        response.writeHead(202);
-        response.end();
-        return;
-      }
-      sendJson(response, 200, Array.isArray(parsed) ? replies : replies[0]);
-    })().catch((error: unknown) => {
-      if (!response.headersSent) sendJson(response, 500, { error: String(error) });
-      else response.destroy(error instanceof Error ? error : undefined);
-    });
-  });
-}
-
 async function activeOrganizationId(seed: Seed, session: DenSession): Promise<string> {
   const result = await seed.api(session, "/v1/me/orgs");
   const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs.filter(isRecord) : [];
@@ -250,182 +78,175 @@ async function mintMcpTokens(seed: Seed, den: Den, organizationId: string): Prom
 }
 
 export async function atlassianDashboardTiles(seed: Seed) {
-  const receivedCalls: WitnessCall[] = [];
-  const witness = createAtlassianWitness(receivedCalls);
-  const witnessUrl = `${await listen(witness)}/mcp`;
-  try {
-    const den = await seed.den({
-      env: { DEN_DASHBOARDS_ENABLED: "true" },
-      org: { name: `Dashboard launch input ${Date.now()}`, admin: { name: "Avery" } },
-    });
-    const organizationId = await activeOrganizationId(seed, den.admin);
-    const orgHeaders = { "x-openwork-org-id": organizationId };
-    const connection = await seed.orgConnection(den.admin, {
-      name: "Atlassian (One org account)",
-      url: witnessUrl,
-      authType: "none",
-      credentialMode: "shared",
-      access: { orgWide: true },
-    });
+  const den = await seed.den({
+    env: { DEN_DASHBOARDS_ENABLED: "true" },
+    mocks: { atlassian: seed.mock({ allowUnauthenticatedMcp: true, tools: atlassianAppTools }) },
+    org: { name: `Dashboard launch input ${Date.now()}`, admin: { name: "Avery" } },
+  });
+  const organizationId = await activeOrganizationId(seed, den.admin);
+  const orgHeaders = { "x-openwork-org-id": organizationId };
+  const connection = await seed.orgConnection(den.admin, {
+    name: "Atlassian (One org account)",
+    url: den.mocks.atlassian.mcpUrl,
+    authType: "none",
+    credentialMode: "shared",
+    access: { orgWide: true },
+  });
 
-    const appsResult = await seed.api(den.admin, `/v1/mcp-connections/${connection.id}/mcp-apps`, { headers: orgHeaders });
-    if (appsResult.response.status !== 200) {
-      throw new Error(`Listing connection MCP Apps failed: HTTP ${appsResult.response.status} ${appsResult.text.slice(0, 500)}`);
-    }
-    const apps = isRecord(appsResult.body) && Array.isArray(appsResult.body.apps) ? appsResult.body.apps.filter(isRecord) : [];
-    const confluenceApp = requireRecord(apps.find((entry) => entry.toolName === "getConfluencePage"), "Confluence app entry");
-    const jqlApp = requireRecord(apps.find((entry) => entry.toolName === "searchJiraIssuesUsingJql"), "JQL app entry");
+  const appsResult = await seed.api(den.admin, `/v1/mcp-connections/${connection.id}/mcp-apps`, { headers: orgHeaders });
+  if (appsResult.response.status !== 200) {
+    throw new Error(`Listing connection MCP Apps failed: HTTP ${appsResult.response.status} ${appsResult.text.slice(0, 500)}`);
+  }
+  const apps = isRecord(appsResult.body) && Array.isArray(appsResult.body.apps) ? appsResult.body.apps.filter(isRecord) : [];
+  const confluenceApp = requireRecord(apps.find((entry) => entry.toolName === "getConfluencePage"), "Confluence app entry");
+  const jqlApp = requireRecord(apps.find((entry) => entry.toolName === "searchJiraIssuesUsingJql"), "JQL app entry");
 
-    // Mirror the add-app dialog: bare JSON.parse of the pasted text.
-    const confluenceArguments = requireRecord(JSON.parse(pastedConfluenceJson), "Confluence launch input");
-    const jqlArguments = requireRecord(JSON.parse(pastedJqlJson), "JQL launch input");
-    const createResult = await seed.api(den.admin, "/v1/dashboards", {
+  // Mirror the add-app dialog: bare JSON.parse of the pasted text.
+  const confluenceArguments = requireRecord(JSON.parse(pastedConfluenceJson), "Confluence launch input");
+  const jqlArguments = requireRecord(JSON.parse(pastedJqlJson), "JQL launch input");
+  const createResult = await seed.api(den.admin, "/v1/dashboards", {
+    method: "POST",
+    headers: orgHeaders,
+    body: JSON.stringify({
+      name: "Atlassian board",
+      elements: [
+        {
+          serverName: String(confluenceApp.serverName ?? ""),
+          connectionId: connection.id,
+          toolName: "getConfluencePage",
+          projectedToolName: String(confluenceApp.projectedToolName ?? ""),
+          resourceUri: confluenceResourceUri,
+          title: confluenceTileTitle,
+          launchArguments: confluenceArguments,
+        },
+        {
+          serverName: String(jqlApp.serverName ?? ""),
+          connectionId: connection.id,
+          toolName: "searchJiraIssuesUsingJql",
+          projectedToolName: String(jqlApp.projectedToolName ?? ""),
+          resourceUri: jiraResourceUri,
+          title: jiraTileTitle,
+          launchArguments: jqlArguments,
+        },
+      ],
+    }),
+  });
+  if (createResult.response.status !== 201) {
+    throw new Error(`Creating the dashboard failed: HTTP ${createResult.response.status} ${createResult.text.slice(0, 500)}`);
+  }
+  const dashboardId = String(requireRecord(requireRecord(createResult.body, "dashboard response").item, "dashboard item").id ?? "");
+  const grantResult = await seed.api(den.admin, `/v1/dashboards/${dashboardId}/access`, {
+    method: "POST",
+    headers: orgHeaders,
+    body: JSON.stringify({ orgWide: true, role: "viewer" }),
+  });
+  if (grantResult.response.status !== 201) {
+    throw new Error(`Granting the dashboard failed: HTTP ${grantResult.response.status} ${grantResult.text.slice(0, 500)}`);
+  }
+
+  const { mcpToken, appHostToken } = await mintMcpTokens(seed, den, organizationId);
+  const app = await seed.desktop({ den, as: "admin" });
+  const workspace = await seed.workspace(app, seed.tmpPath("dashboard-launch-input"));
+  // The signed-in harness Desktop does not run the production Cloud
+  // provisioning loop, so hand it the same Connect MCP configuration the
+  // product writes: the central Cloud MCP entry plus the private App-host
+  // authorization. This is the documented reconcile surface, not a stub.
+  // TODO(primitive): seed.connectMcp
+  const reconciled = await rawEvalIn(app, `(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return "missing local server credentials";
+    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
       method: "POST",
-      headers: orgHeaders,
+      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
       body: JSON.stringify({
-        name: "Atlassian board",
-        elements: [
-          {
-            serverName: String(confluenceApp.serverName ?? ""),
-            connectionId: connection.id,
-            toolName: "getConfluencePage",
-            projectedToolName: String(confluenceApp.projectedToolName ?? ""),
-            resourceUri: confluenceResourceUri,
-            title: confluenceTileTitle,
-            launchArguments: confluenceArguments,
-          },
-          {
-            serverName: String(jqlApp.serverName ?? ""),
-            connectionId: connection.id,
-            toolName: "searchJiraIssuesUsingJql",
-            projectedToolName: String(jqlApp.projectedToolName ?? ""),
-            resourceUri: jiraResourceUri,
-            title: jiraTileTitle,
-            launchArguments: jqlArguments,
-          },
-        ],
+        config: {
+          type: "remote",
+          url: ${JSON.stringify(`${den.ref.apiUrl}/mcp/agent`)},
+          enabled: true,
+          headers: { Authorization: ${JSON.stringify(`Bearer ${mcpToken}`)} },
+          oauth: false,
+        },
+        appHostAuthorization: ${JSON.stringify(`Bearer ${appHostToken}`)},
+        trigger: "dashboard-launch-input-world",
       }),
     });
-    if (createResult.response.status !== 201) {
-      throw new Error(`Creating the dashboard failed: HTTP ${createResult.response.status} ${createResult.text.slice(0, 500)}`);
-    }
-    const dashboardId = String(requireRecord(requireRecord(createResult.body, "dashboard response").item, "dashboard item").id ?? "");
-    const grantResult = await seed.api(den.admin, `/v1/dashboards/${dashboardId}/access`, {
-      method: "POST",
-      headers: orgHeaders,
-      body: JSON.stringify({ orgWide: true, role: "viewer" }),
-    });
-    if (grantResult.response.status !== 201) {
-      throw new Error(`Granting the dashboard failed: HTTP ${grantResult.response.status} ${grantResult.text.slice(0, 500)}`);
-    }
+    const text = await response.text();
+    return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
+  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  if (reconciled !== "ok") throw new Error(`Reconciling Connect MCP for the desktop failed: ${String(reconciled)}`);
 
-    const { mcpToken, appHostToken } = await mintMcpTokens(seed, den, organizationId);
-    const app = await seed.desktop({ den, as: "admin" });
-    const workspace = await seed.workspace(app, seed.tmpPath("dashboard-launch-input"));
-    // The signed-in harness Desktop does not run the production Cloud
-    // provisioning loop, so hand it the same Connect MCP configuration the
-    // product writes: the central Cloud MCP entry plus the private App-host
-    // authorization. This is the documented reconcile surface, not a stub.
-    // TODO(primitive): seed.connectMcp
-    const reconciled = await rawEvalIn(app, `(async () => {
-      const port = localStorage.getItem("openwork.server.port");
-      const token = localStorage.getItem("openwork.server.token");
-      if (!port || !token) return "missing local server credentials";
-      const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
-        method: "POST",
-        headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          config: {
-            type: "remote",
-            url: ${JSON.stringify(`${den.ref.apiUrl}/mcp/agent`)},
-            enabled: true,
-            headers: { Authorization: ${JSON.stringify(`Bearer ${mcpToken}`)} },
-            oauth: false,
-          },
-          appHostAuthorization: ${JSON.stringify(`Bearer ${appHostToken}`)},
-          trigger: "dashboard-launch-input-world",
-        }),
-      });
-      const text = await response.text();
-      return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
-    })()`, { awaitPromise: true, timeoutMs: 120_000 });
-    if (reconciled !== "ok") throw new Error(`Reconciling Connect MCP for the desktop failed: ${String(reconciled)}`);
-
-    const section = `[data-granted-dashboard="${dashboardId}"]`;
-    return withDispose({
-      app,
-      dashboardId,
-      connectionId: connection.id,
-      receivedCalls,
-      /**
-       * Opens the Dashboard from the sidebar navigation, which renders only
-       * after Desktop reads dashboardEnabled from /v1/me/desktop-config.
-       * Returns whether the navigation was clicked yet; opens a collapsed
-       * sidebar on the way.
-       */
-      // TODO(primitive): user.click({ role: "button", text: "Dashboard" }) should locate the sidebar rail entry and open a collapsed sidebar.
-      async openDashboard(): Promise<boolean> {
-        const opened = await rawEvalIn(app, `(() => {
-          const button = [...document.querySelectorAll("button")]
-            .find((entry) => entry.textContent?.trim() === "Dashboard");
-          if (button instanceof HTMLButtonElement && !button.disabled) {
-            button.click();
-            // In a narrow harness window the sidebar is an overlay that covers
-            // the tile grid; collapse it so tiles are hit-testable.
-            const toggle = [...document.querySelectorAll("button")]
-              .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
-            if (toggle instanceof HTMLButtonElement) toggle.click();
-            return true;
-          }
-          const sidebarOpen = [...document.querySelectorAll("button")]
-            .some((entry) => entry.textContent?.includes("Search sessions"));
-          if (!sidebarOpen) {
-            const toggle = [...document.querySelectorAll("button")]
-              .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
-            if (toggle instanceof HTMLButtonElement) toggle.click();
-          }
-          return false;
-        })()`);
-        return opened === true;
-      },
-      /** True once both granted tiles render with their Run buttons. */
-      // TODO(primitive): probe.dashboardTiles should expose granted tiles and their launch controls.
-      async tilesReady(): Promise<boolean> {
-        const ready = await rawEvalIn(app, `(() => {
-          const section = document.querySelector(${JSON.stringify(section)});
-          return section instanceof HTMLElement
-            && section.innerText.includes(${JSON.stringify(confluenceTileTitle)})
-            && section.innerText.includes(${JSON.stringify(jiraTileTitle)})
-            && Boolean(section.querySelector('button[aria-label="Run ${confluenceTileTitle}"]'))
-            && Boolean(section.querySelector('button[aria-label="Run ${jiraTileTitle}"]'));
-        })()`);
-        return ready === true;
-      },
-      /** The member-visible state of both tiles. */
-      // TODO(primitive): probe.dashboardTiles
-      async tiles(): Promise<DashboardTilesFacts> {
-        const value = await rawEvalIn(app, `(() => {
-          const section = document.querySelector(${JSON.stringify(section)});
-          if (!(section instanceof HTMLElement)) return null;
-          const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
-          const read = (title) => {
-            const tile = tiles.find((entry) => entry.textContent?.includes(title));
-            if (!(tile instanceof HTMLElement)) return null;
-            return {
-              text: tile.innerText.replace(/\\s+/g, " ").trim(),
-              badgeFailed: tile.innerText.includes("Refresh failed"),
-              opaque: tile.innerText.includes("Unexpected server error"),
-              namesCloudId: tile.innerText.includes("cloudId"),
-            };
+  const section = `[data-granted-dashboard="${dashboardId}"]`;
+  return {
+    app,
+    dashboardId,
+    connectionId: connection.id,
+    witness: den.mocks.atlassian,
+    /**
+     * Opens the Dashboard from the sidebar navigation, which renders only
+     * after Desktop reads dashboardEnabled from /v1/me/desktop-config.
+     * Returns whether the navigation was clicked yet; opens a collapsed
+     * sidebar on the way.
+     */
+    // TODO(primitive): user.click({ role: "button", text: "Dashboard" }) should locate the sidebar rail entry and open a collapsed sidebar.
+    async openDashboard(): Promise<boolean> {
+      const opened = await rawEvalIn(app, `(() => {
+        const button = [...document.querySelectorAll("button")]
+          .find((entry) => entry.textContent?.trim() === "Dashboard");
+        if (button instanceof HTMLButtonElement && !button.disabled) {
+          button.click();
+          // In a narrow harness window the sidebar is an overlay that covers
+          // the tile grid; collapse it so tiles are hit-testable.
+          const toggle = [...document.querySelectorAll("button")]
+            .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
+          if (toggle instanceof HTMLButtonElement) toggle.click();
+          return true;
+        }
+        const sidebarOpen = [...document.querySelectorAll("button")]
+          .some((entry) => entry.textContent?.includes("Search sessions"));
+        if (!sidebarOpen) {
+          const toggle = [...document.querySelectorAll("button")]
+            .find((entry) => (entry.getAttribute("aria-label") ?? entry.textContent ?? "").trim() === "Toggle Sidebar");
+          if (toggle instanceof HTMLButtonElement) toggle.click();
+        }
+        return false;
+      })()`);
+      return opened === true;
+    },
+    /** True once both granted tiles render with their Run buttons. */
+    // TODO(primitive): probe.dashboardTiles should expose granted tiles and their launch controls.
+    async tilesReady(): Promise<boolean> {
+      const ready = await rawEvalIn(app, `(() => {
+        const section = document.querySelector(${JSON.stringify(section)});
+        return section instanceof HTMLElement
+          && section.innerText.includes(${JSON.stringify(confluenceTileTitle)})
+          && section.innerText.includes(${JSON.stringify(jiraTileTitle)})
+          && Boolean(section.querySelector('button[aria-label="Run ${confluenceTileTitle}"]'))
+          && Boolean(section.querySelector('button[aria-label="Run ${jiraTileTitle}"]'));
+      })()`);
+      return ready === true;
+    },
+    /** The member-visible state of both tiles. */
+    // TODO(primitive): probe.dashboardTiles
+    async tiles(): Promise<DashboardTilesFacts> {
+      const value = await rawEvalIn(app, `(() => {
+        const section = document.querySelector(${JSON.stringify(section)});
+        if (!(section instanceof HTMLElement)) return null;
+        const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
+        const read = (title) => {
+          const tile = tiles.find((entry) => entry.textContent?.includes(title));
+          if (!(tile instanceof HTMLElement)) return null;
+          return {
+            text: tile.innerText.replace(/\\s+/g, " ").trim(),
+            badgeFailed: tile.innerText.includes("Refresh failed"),
+            opaque: tile.innerText.includes("Unexpected server error"),
+            namesCloudId: tile.innerText.includes("cloudId"),
           };
-          return { confluence: read(${JSON.stringify(confluenceTileTitle)}), jql: read(${JSON.stringify(jiraTileTitle)}) };
-        })()`);
-        const facts = isRecord(value) ? value : {};
-        return { confluence: parseTileFacts(facts.confluence), jql: parseTileFacts(facts.jql) };
-      },
-    }, () => closeServer(witness));
-  } catch (error) {
-    await closeServer(witness);
-    throw error;
-  }
+        };
+        return { confluence: read(${JSON.stringify(confluenceTileTitle)}), jql: read(${JSON.stringify(jiraTileTitle)}) };
+      })()`);
+      const facts = isRecord(value) ? value : {};
+      return { confluence: parseTileFacts(facts.confluence), jql: parseTileFacts(facts.jql) };
+    },
+  };
 }

--- a/evals/worlds/dashboard-launch-input.ts
+++ b/evals/worlds/dashboard-launch-input.ts
@@ -145,7 +145,10 @@ export async function atlassianDashboardTiles(seed: Seed) {
   }
 
   const { mcpToken, appHostToken } = await mintMcpTokens(seed, den, organizationId);
-  const app = await seed.desktop({ den, as: "admin" });
+  // The private test Den must be the installation's activated origin before
+  // the real App host will accept its credentials. Local dev loopback alone
+  // hid this prerequisite; seeding it leaves the product trust checks intact.
+  const app = await seed.desktop({ den, as: "admin", enterpriseActivated: true });
   const workspace = await seed.workspace(app, seed.tmpPath("dashboard-launch-input"));
   // The signed-in harness Desktop does not run the production Cloud
   // provisioning loop, so hand it the same Connect MCP configuration the

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -705,7 +705,13 @@ function tokenFingerprint(req) {
 
 function mcpResult(message) {
   if (configuredTools.length && message.method === "tools/list") {
-    return { tools: configuredTools.map(({ result, delayMs, ...tool }) => tool) };
+    return { tools: configuredTools.map(({ result, delayMs, appHtml, validateRequiredArguments, ...tool }) => tool) };
+  }
+  if (message.method === "resources/read") {
+    const tool = configuredTools.find((candidate) => candidate._meta?.ui?.resourceUri === message.params?.uri);
+    if (tool?.appHtml !== undefined) {
+      return { contents: [{ uri: message.params.uri, mimeType: "text/html;profile=mcp-app", text: tool.appHtml }] };
+    }
   }
   if (message.method === "tools/call") {
     const tool = configuredTools.find((candidate) => candidate.name === message.params?.name);
@@ -715,7 +721,13 @@ function mcpResult(message) {
     case "initialize":
       return {
         protocolVersion: "2025-06-18",
-        capabilities: { tools: {} },
+        capabilities: {
+          tools: {},
+          ...(configuredTools.some((tool) => tool.appHtml !== undefined) ? {
+            resources: {},
+            extensions: { "io.modelcontextprotocol/ui": { mimeTypes: ["text/html;profile=mcp-app"] } },
+          } : {}),
+        },
         serverInfo: { name: "mock-oauth-mcp", version: "1.0.0" },
       };
     case "tools/list":
@@ -852,6 +864,22 @@ function mcpResult(message) {
 }
 
 function mcpResponse(message) {
+  if (message.method === "tools/call") {
+    const tool = configuredTools.find((candidate) => candidate.name === message.params?.name);
+    if (tool?.validateRequiredArguments) {
+      const missing = (tool.inputSchema.required ?? []).filter((key) => message.params?.arguments?.[key] === undefined);
+      if (missing.length) {
+        return {
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: -32602,
+            message: `Invalid arguments for tool ${tool.name}: ${JSON.stringify(missing.map((key) => ({ path: [key], message: "Required" })))}`,
+          },
+        };
+      }
+    }
+  }
   // This fixture speaks legacy MCP. Give modern clients the explicit fallback
   // signal instead of a successful but malformed discovery response.
   if (message.method === "server/discover") {

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -131,6 +131,41 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     { name: "execute_capability", args: { target: "desktop" } },
   ]);
 
+  const appTool = {
+    name: "get_page",
+    title: "Get page",
+    inputSchema: { type: "object", properties: { cloudId: { type: "string" } }, required: ["cloudId"] },
+    _meta: { ui: { resourceUri: "ui://mock/page" } },
+    appHtml: "<!doctype html><html><body>Page</body></html>",
+    validateRequiredArguments: true,
+    result: { content: [{ type: "text", text: "page loaded" }] },
+  };
+  const appConfigured = await fetch(`${origin}/admin/tools`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tools: [appTool] }),
+  });
+  assert.equal(appConfigured.status, 200);
+  const appCatalog = await rpc("tools/list", {});
+  assert.equal(appCatalog.result.tools[0]._meta.ui.resourceUri, "ui://mock/page");
+  assert.equal("appHtml" in appCatalog.result.tools[0], false);
+  assert.equal("validateRequiredArguments" in appCatalog.result.tools[0], false);
+  const appInitialized = await rpc("initialize", {});
+  assert.deepEqual(appInitialized.result.capabilities.resources, {});
+  const resource = await rpc("resources/read", { uri: "ui://mock/page" });
+  assert.equal(resource.result.contents[0].text, appTool.appHtml);
+  assert.equal(resource.result.contents[0].mimeType, "text/html;profile=mcp-app");
+  const rejected = await rpc("tools/call", { name: "get_page", arguments: {} });
+  assert.equal(rejected.error.code, -32602);
+  assert.match(rejected.error.message, /cloudId/);
+  assert.equal("result" in rejected, false);
+  const recovered = await rpc("tools/call", { name: "get_page", arguments: { cloudId: "workspace" } });
+  assert.equal(recovered.result.content[0].text, "page loaded");
+  assert.equal("error" in recovered, false);
+  const appLog = await (await fetch(`${origin}/requests`)).json();
+  assert.deepEqual(appLog.requests.flatMap((entry) => entry.toolCalls ?? [])
+    .filter((call) => call.name === "get_page").map((call) => call.args), [{}, { cloudId: "workspace" }]);
+
   const workload = await fetch(`${origin}/admin/agent-workloads`, {
     method: "POST",
     headers: { "content-type": "application/json" },


### PR DESCRIPTION
The scheduled dashboard tile-error job never exercised its assertions: its loopback-only provider forced a Daytona skip (0 passed, 0 failed, 1 skipped; `incomplete`, exit 2). The clean dev control reproduces that result. This is a test placement/setup defect, not a newly demonstrated product regression. The missing-argument product fix from #4385 was already in the failed run.

Move the existing Atlassian-shaped witness into the supported Den mock lifecycle so it runs beside Den on either placement. Keep both real desktop Run actions, per-tile missing-argument/failed-refresh checks, absence of the generic server error, and exact saved JSON/JQL witness checks. Capture the visible tile errors as evidence. Mock required-key validation and MCP App HTML are opt-in; existing mock behavior stays unchanged.

The world explicitly seeds an installation already activated against the test Den's exact API origin. Its former local-only setup relied on development loopback trust; a remote Den correctly needs activation before the App host accepts private credentials. The new `enterpriseActivated` fixture is opt-in and writes the existing bootstrap shape. No production trust or auth code changes. Activation itself is outside this journey.

Coverage remains separate from `dashboard-duplicate-capability-tiles`, which covers authoring and duplicate launch inputs, and `remote-mcp-apps`, which covers general MCP App use. The earlier boundary-only Atlassian test was retired in #4402; this visible dashboard journey is worth preserving.

## Verification

Original job: https://github.com/different-ai/openwork/actions/runs/33983213474/job/101352075454

- Clean control `f6f93bdb3`: `pnpm --config.verify-deps-before-run=false evals:e2e dashboard-atlassian-tile-error --daytona` → `placement: daytona (--daytona)`, **0 passed / 0 failed / 1 skipped**, exit 2, **Incomplete**. Dependencies were shared read-only with the isolated checkout; product/spec sources were unmodified.
- Final head: `f90728b8a8e640f6d2f1183f2779afa1e3ac84c7`.
- `infisical run --silent -- env OPENWORK_EVAL_REF=f90728b8a8e640f6d2f1183f2779afa1e3ac84c7 pnpm evals:e2e dashboard-atlassian-tile-error --daytona`: **1 passed / 0 failed / 0 skipped**, exit 0, **Passed**; `placement: daytona (--daytona)`. Cold-boot Den and desktop both verified with `git rev-parse HEAD` at that full SHA. Assertions confirm both visible errors name `cloudId`, neither is the generic server error, and both saved inputs reach the provider intact. Source run: `2026-09-06T06-58-15-563Z-a-dashboard-tile-launched-with-the-reported-atlassian-json-names-the-missing-req`.
- `infisical run --silent -- env OPENWORK_EVAL_REF=f90728b8a8e640f6d2f1183f2779afa1e3ac84c7 pnpm evals:e2e dashboard-duplicate-capability-tiles --daytona`: **1 passed / 0 failed / 0 skipped**, exit 0, **Passed**; `placement: daytona (--daytona)`. Existing authoring/default-fixture consumer confirms two distinct inputs coexist and an identical third input is refused. Source run: `2026-09-06T07-03-01-873Z-an-organization-dashboard-holds-two-tiles-of-the-same-mcp-app-capability-with-di`.
- [Published assertion evidence and screenshots](https://github.com/different-ai/openwork/pull/4562#issuecomment-5557643445). Screenshots are illustrative, without vision expectations; the recorded UI/API/provider assertions determine both passing verdicts.
- `pnpm --dir evals exec tsc --noEmit -p tsconfig.primitives.json`: passed.
- Existing Daytona/local host setup checks: **26 passed / 0 failed / 0 skipped**.
- Existing mock labs checks (including native Responses header enforcement): **4 passed / 0 failed / 0 skipped**.
- Mock server checks extended with resource loading, missing-key rejection and corrected-input success: **1 passed / 0 failed / 0 skipped**.
- Broad boundary ratchet and dependency-layer checks fail identically on clean dev: unrelated bench/v2 spec debt and 19 existing dependency violations respectively. No new violations. Dependency-layer check used Node 24 because the host's Node 25 is unsupported.

An intermediate migrated run reached and clicked both tiles but failed on the missing activation prerequisite; its screen reported `The originating Connect MCP server is not available to this workspace.` That run is not passing evidence. Initial missing workspace dependencies and abbreviated-ref provisioning attempts also produced no journey proof.
