### PR TITLE
Report desktop task activity to OpenWork Models analytics

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -90,7 +90,9 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
-    "zustand": "^5.0.12"
+    "zustand": "^5.0.12",
+    "@openwork-ee/telemetry-contracts": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "20.12.0",

--- a/apps/app/src/app/lib/models-task-analytics.ts
+++ b/apps/app/src/app/lib/models-task-analytics.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import { modelsAnalyticsEventSchema, modelsAnalyticsSettingsSchema, type ModelsAnalyticsEvent } from "@openwork-ee/telemetry-contracts";
+import { readDenSettings, resolveDenBaseUrls } from "./den";
+import { desktopFetchViaMain } from "./desktop";
+import { isDesktopRuntime } from "./runtime-env";
+
+const messageSchema = z.object({
+  id: z.string(), sessionID: z.string(), parentID: z.string(), role: z.literal("assistant"),
+  providerID: z.literal("openwork"), summary: z.boolean().optional(), finish: z.string().optional(),
+  time: z.object({ created: z.number(), completed: z.number().optional() }),
+  error: z.object({ name: z.string() }).optional(),
+});
+const toolSchema = z.object({
+  id: z.string(), sessionID: z.string(), messageID: z.string(), callID: z.string(), type: z.literal("tool"), tool: z.string(),
+  state: z.object({
+    status: z.enum(["completed", "error"]),
+    time: z.object({ start: z.number(), end: z.number() }),
+    // Pick only capability identifiers. Tool arguments/results never leave the device.
+    input: z.object({ name: z.string().optional() }),
+    metadata: z.object({ skillVersion: z.string().optional(), mcp: z.string().optional() }).optional(),
+  }),
+});
+type Task = { sessionId: string; taskId: string; startedAt: number };
+type Pending = { event: ModelsAnalyticsEvent; expiresAt: number };
+
+let identity = "";
+let allowedUntil = 0;
+let allowed = false;
+let checking: Promise<boolean> | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let flushing = false;
+let lastCheckedTask = "";
+const tasks = new Map<string, Task>();
+const messages = new Map<string, Task>();
+let pending: Pending[] = [];
+
+function context() {
+  const settings = readDenSettings();
+  if (!settings.authToken || !settings.activeOrgId) return null;
+  const base = resolveDenBaseUrls(settings).apiBaseUrl;
+  return { identity: JSON.stringify([base, settings.activeOrgId, settings.authToken]), base, token: settings.authToken, orgId: settings.activeOrgId };
+}
+
+async function request(ctx: NonNullable<ReturnType<typeof context>>, path: string, init?: RequestInit) {
+  const url = `${ctx.base}/v1/inference/analytics/${path}`;
+  const fetcher = isDesktopRuntime() ? desktopFetchViaMain : globalThis.fetch;
+  return fetcher(url, { ...init, signal: AbortSignal.timeout(5_000), headers: {
+    "Content-Type": "application/json", Authorization: `Bearer ${ctx.token}`, "x-openwork-org-id": ctx.orgId,
+  } });
+}
+
+function schedule() {
+  if (timer || !pending.length) return;
+  timer = setTimeout(() => { timer = null; void flush(); }, 5_000);
+}
+
+async function flush() {
+  if (flushing) return;
+  const ctx = context();
+  if (!ctx || ctx.identity !== identity) { pending = []; return; }
+  flushing = true;
+  const batch = pending.splice(0, 50).filter((item) => item.expiresAt > Date.now());
+  try {
+    if (!batch.length) return;
+    const response = await request(ctx, "events", { method: "POST", body: JSON.stringify({ events: batch.map((item) => item.event) }) });
+    if (ctx.identity !== identity) return;
+    if (response.status === 204 || response.status === 403 || response.status === 401) {
+      pending = []; allowed = false; allowedUntil = 0; return;
+    }
+    const parsed = z.object({ acceptedIds: z.array(z.string()) }).safeParse(await response.json());
+    if (response.ok && parsed.success) pending.push(...batch.filter((item) => !parsed.data.acceptedIds.includes(item.event.id)));
+    else if (response.status >= 500) pending.push(...batch);
+  } catch { if (ctx.identity === identity) pending.push(...batch); }
+  finally { flushing = false; pending = pending.slice(-500); schedule(); }
+}
+
+function enqueue(event: ModelsAnalyticsEvent) {
+  if (!modelsAnalyticsEventSchema.safeParse(event).success) return;
+  if (pending.some((item) => item.event.id === event.id)) return;
+  pending.push({ event, expiresAt: Date.now() + 120_000 });
+  pending = pending.slice(-500);
+  schedule();
+}
+
+async function observe(workspaceId: string, event: { type: string; properties?: unknown }) {
+  const ctx = context();
+  const nextIdentity = ctx?.identity ?? "";
+  if (identity !== nextIdentity) {
+    identity = nextIdentity; allowedUntil = 0; allowed = false; checking = null;
+    tasks.clear(); messages.clear(); pending = [];
+    lastCheckedTask = "";
+  }
+  if (!ctx) return;
+  if (!allowed && event.type === "message.updated") {
+    const info = z.object({ info: messageSchema }).safeParse(event.properties);
+    if (info.success && lastCheckedTask !== info.data.info.parentID) {
+      lastCheckedTask = info.data.info.parentID;
+      allowedUntil = 0;
+    }
+  }
+  if (Date.now() >= allowedUntil) {
+    checking ??= request(ctx, "settings").then(async (response) => {
+      const parsed = modelsAnalyticsSettingsSchema.safeParse(await response.json());
+      if (identity !== ctx.identity) return false;
+      allowed = response.ok && parsed.success && parsed.data.enabled;
+      allowedUntil = Date.now() + 30_000;
+      return allowed;
+    }).catch(() => {
+      if (identity === ctx.identity) { allowed = false; allowedUntil = Date.now() + 30_000; }
+      return false;
+    }).finally(() => { if (identity === ctx.identity) checking = null; });
+    if (!await checking) return;
+  }
+  if (!allowed || identity !== ctx.identity) return;
+  const props = z.object({ info: z.unknown().optional(), part: z.unknown().optional() }).safeParse(event.properties);
+  if (!props.success) return;
+  if (event.type === "message.updated") {
+    const parsed = messageSchema.safeParse(props.data.info);
+    if (!parsed.success || parsed.data.summary) return;
+    const info = parsed.data;
+    const taskKey = `${workspaceId}:${info.sessionID}:${info.parentID}`;
+    const task = tasks.get(taskKey) ?? { sessionId: info.sessionID, taskId: info.parentID, startedAt: info.time.created };
+    if (!tasks.has(taskKey)) {
+      tasks.set(taskKey, task);
+      enqueue({ id: `${task.taskId}:started`, type: "task.started", timestamp: new Date(task.startedAt).toISOString(), sessionId: task.sessionId, taskId: task.taskId });
+    }
+    messages.set(`${workspaceId}:${info.id}`, task);
+    if (info.time.completed && (info.error || info.finish && info.finish !== "tool-calls")) {
+      const status = info.error?.name === "MessageAbortedError" ? "cancelled" : info.error ? "failed" : "completed";
+      enqueue({ id: `${task.taskId}:${status}`, type: `task.${status}`, status, sessionId: task.sessionId, taskId: task.taskId,
+        timestamp: new Date(info.time.completed).toISOString(), durationMs: Math.max(0, info.time.completed - task.startedAt) });
+    }
+    if (tasks.size > 500) tasks.delete(tasks.keys().next().value!);
+    if (messages.size > 2_000) messages.delete(messages.keys().next().value!);
+  }
+  if (event.type === "message.part.updated") {
+    const parsed = toolSchema.safeParse(props.data.part);
+    if (!parsed.success) return;
+    const part = parsed.data;
+    const task = messages.get(`${workspaceId}:${part.messageID}`);
+    if (!task || task.sessionId !== part.sessionID) return;
+    const name = part.state.input.name;
+    const cloudSkill = part.tool === "openwork-cloud_execute_capability" && name?.startsWith("plugin:");
+    const skill = part.state.status === "completed" && (part.tool === "skill" || cloudSkill) ? name : undefined;
+    enqueue({ id: part.id, callId: part.callID, type: skill ? "skill.loaded" : "tool.executed",
+      timestamp: new Date(part.state.time.end).toISOString(), sessionId: task.sessionId, taskId: task.taskId,
+      tool: part.tool, ...(skill ? { skill, skillVersion: part.state.metadata?.skillVersion } : {}),
+      mcp: part.tool.startsWith("openwork-cloud_") ? "openwork-cloud" : part.state.metadata?.mcp,
+      durationMs: Math.max(0, part.state.time.end - part.state.time.start), status: part.state.status === "completed" ? "completed" : "failed",
+    });
+  }
+}
+
+/** Optional, bounded reporting from live runtime events. Never blocks chat. */
+export function observeModelsTaskEvent(workspaceId: string, event: { type: string; properties?: unknown }) {
+  if (event.type !== "message.updated" && event.type !== "message.part.updated") return;
+  void observe(workspaceId, event).catch(() => {});
+}

--- a/apps/app/src/app/lib/models-task-analytics.ts
+++ b/apps/app/src/app/lib/models-task-analytics.ts
@@ -21,11 +21,12 @@ const toolSchema = z.object({
   }),
 });
 type Task = { sessionId: string; taskId: string; startedAt: number };
-type Pending = { event: ModelsAnalyticsEvent; expiresAt: number };
+type Pending = { event: ModelsAnalyticsEvent; expiresAt: number; consentedAt: string };
 
 let identity = "";
 let allowedUntil = 0;
 let allowed = false;
+let consentedAt: string | null = null;
 let checking: Promise<boolean> | null = null;
 let timer: ReturnType<typeof setTimeout> | null = null;
 let flushing = false;
@@ -62,22 +63,34 @@ async function flush() {
   const batch = pending.splice(0, 50).filter((item) => item.expiresAt > Date.now());
   try {
     if (!batch.length) return;
-    const response = await request(ctx, "events", { method: "POST", body: JSON.stringify({ events: batch.map((item) => item.event) }) });
+    // Recheck consent at the upload boundary. A cached allowance must not send
+    // metadata after opt-out, or backfill it into a later consent period.
+    const settingsResponse = await request(ctx, "settings");
+    const settings = modelsAnalyticsSettingsSchema.safeParse(await settingsResponse.json());
+    if (ctx.identity !== identity) return;
+    allowed = settingsResponse.ok && settings.success && settings.data.enabled;
+    consentedAt = allowed && settings.success ? settings.data.consentedAt : null;
+    allowedUntil = Date.now() + 30_000;
+    if (!allowed || !consentedAt) { pending = []; return; }
+    const consented = batch.filter((item) => item.consentedAt === consentedAt);
+    if (!consented.length) return;
+    const response = await request(ctx, "events", { method: "POST", body: JSON.stringify({ events: consented.map((item) => item.event) }) });
     if (ctx.identity !== identity) return;
     if (response.status === 204 || response.status === 403 || response.status === 401) {
       pending = []; allowed = false; allowedUntil = 0; return;
     }
     const parsed = z.object({ acceptedIds: z.array(z.string()) }).safeParse(await response.json());
-    if (response.ok && parsed.success) pending.push(...batch.filter((item) => !parsed.data.acceptedIds.includes(item.event.id)));
-    else if (response.status >= 500) pending.push(...batch);
+    if (response.ok && parsed.success) pending.push(...consented.filter((item) => !parsed.data.acceptedIds.includes(item.event.id)));
+    else if (response.status >= 500) pending.push(...consented);
   } catch { if (ctx.identity === identity) pending.push(...batch); }
   finally { flushing = false; pending = pending.slice(-500); schedule(); }
 }
 
 function enqueue(event: ModelsAnalyticsEvent) {
+  if (!consentedAt) return;
   if (!modelsAnalyticsEventSchema.safeParse(event).success) return;
   if (pending.some((item) => item.event.id === event.id)) return;
-  pending.push({ event, expiresAt: Date.now() + 120_000 });
+  pending.push({ event, expiresAt: Date.now() + 120_000, consentedAt });
   pending = pending.slice(-500);
   schedule();
 }
@@ -86,7 +99,7 @@ async function observe(workspaceId: string, event: { type: string; properties?: 
   const ctx = context();
   const nextIdentity = ctx?.identity ?? "";
   if (identity !== nextIdentity) {
-    identity = nextIdentity; allowedUntil = 0; allowed = false; checking = null;
+    identity = nextIdentity; allowedUntil = 0; allowed = false; consentedAt = null; checking = null;
     tasks.clear(); messages.clear(); pending = [];
     lastCheckedTask = "";
   }
@@ -103,6 +116,7 @@ async function observe(workspaceId: string, event: { type: string; properties?: 
       const parsed = modelsAnalyticsSettingsSchema.safeParse(await response.json());
       if (identity !== ctx.identity) return false;
       allowed = response.ok && parsed.success && parsed.data.enabled;
+      consentedAt = allowed && parsed.success ? parsed.data.consentedAt : null;
       allowedUntil = Date.now() + 30_000;
       return allowed;
     }).catch(() => {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -5,6 +5,7 @@ import type { FilePart, Part, PermissionRequest, PermissionV2Request, QuestionRe
 import { getReactQueryClient } from "../../../infra/query-client";
 import { captureAnalyticsEvent, takeTaskRunStart } from "@/app/lib/analytics";
 import { trackTaskCompleted, trackTaskFailed } from "@/app/lib/den-telemetry";
+import { observeModelsTaskEvent } from "@/app/lib/models-task-analytics";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { perfNow, recordPerfLog } from "@/app/lib/perf-log";
@@ -788,6 +789,7 @@ function upsertPart(messages: UIMessage[], messageId: string, partId: string, ne
 }
 
 function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent) {
+  observeModelsTaskEvent(workspaceId, event);
   const queryClient = getReactQueryClient();
   const input = entry.input;
 

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -898,6 +898,11 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
   const engineMcpStatusClient = readEngineMcpStatusClient(factoryInput);
   const engineMcpStatusDirectory = factoryContext.directory ?? factoryContext.worktree;
   return {
+  "chat.headers": async (input: { sessionID: string; model: { providerID: string }; message: { id: string } }, output: { headers: Record<string, string> }) => {
+    if (input.model.providerID !== "openwork") return;
+    output.headers["x-openwork-session-id"] = input.sessionID;
+    output.headers["x-openwork-task-id"] = input.message.id;
+  },
   "tool.execute.after": async (_input: unknown, output: unknown) => {
     // OpenCode 1.17.x keeps the text projection of an MCP result but drops
     // structuredContent and result _meta before persisting the completed tool

--- a/docs/features/models-task-analytics/README.md
+++ b/docs/features/models-task-analytics/README.md
@@ -1,8 +1,8 @@
 # OpenWork Models task analytics
 
-This is the Den-first rollout. Land and deploy the API and migration before the
-desktop follow-up in #4563. Keep the rollout capability off until both phases are
-ready. This phase does not change any published desktop contract.
+The API and migration land first in #4567. This desktop follow-up uses that
+existing API after its deployment is verified. The organization rollout capability
+remains off by default, and analytics still requires explicit admin consent.
 
 Task analytics is included with a paid OpenWork Models subscription. An internal
 organization capability, `modelsAnalytics`, controls rollout and defaults to off.
@@ -75,10 +75,12 @@ settings route keeps analytics off and leaves chat running; failed checks are ca
 to avoid retrying on every streamed update.
 
 `pnpm evals:e2e models-analytics-upgrade` runs a continuous subscriber journey with
-an isolated Den database, real inference HTTP service and browser. Its
+an isolated Den database, real inference HTTP service, browser and desktop. Its
 upstream and Langfuse witnesses use synthetic credentials. The journey starts
 with an existing paid account before the analytics tables exist, applies the real
 migration, and checks the same model key, consent UI, accounting, tenant/member
-isolation, export, downgrade and workspace deletion. The desktop follow-up extends
-the same journey with live task/skill/tool reporting and continued conversation. It does not make a real
+isolation, export, downgrade, workspace deletion and continued conversation.
+An independently observed HTTP link first returns 404 for analytics settings,
+proving the newer desktop still chats without uploading task events. Restoring
+the endpoint then exercises live task/skill/tool reporting in the same conversation. It does not make a real
 Stripe purchase or call a paid model provider.

--- a/evals/specs/models-analytics-upgrade.e2e.test.ts
+++ b/evals/specs/models-analytics-upgrade.e2e.test.ts
@@ -1,6 +1,6 @@
 import { spec } from "@openwork/testkit";
 import { expect } from "vitest";
-import { denFetch } from "@openwork/behaviors";
+import { denFetch, sendComposerMessage, waitForAssistantReply, selectModel } from "@openwork/behaviors";
 import { modelsAnalyticsWorld } from "../worlds/models-analytics.ts";
 
 const test = spec.world(modelsAnalyticsWorld, { timeout: 900_000, needs: {} });
@@ -10,7 +10,7 @@ function record(value: unknown): Record<string, unknown> {
 }
 function list(value: unknown): Record<string, unknown>[] { return Array.isArray(value) ? value.map(record) : []; }
 
-test("an existing Models subscriber can upgrade Den and opt into analytics without losing Models", { timeout: 1_800_000 }, async ({ world, user, probe, evidence }) => {
+test("an existing Models subscriber can decline, enable and disable task analytics without losing Models", { timeout: 1_800_000 }, async ({ world, user, probe, evidence }) => {
   {
   const api = (path: string, init?: RequestInit, session = world.den.admin) => denFetch(session, path, {
     ...init, headers: { authorization: `Bearer ${session.token}`, "x-openwork-org-id": world.orgId, "content-type": "application/json" },
@@ -177,10 +177,71 @@ test("an existing Models subscriber can upgrade Den and opt into analytics witho
   evidence.recordAssertionEvidence("Turning off task analytics stops export while Models keeps responding", "New Models request returned 200 after disable; no extra spans arrived across a full export interval", true);
   evidence.recordAssertionEvidence("Opt-out finishes only after an already-authorized export has finished", "The Langfuse witness held an export response; the UI could not confirm opt-out until the response was released, then no later export arrived", true);
   }
-  const removed = await denFetch(world.den.admin, "/v1/org", { method: "DELETE", headers: {
-    authorization: `Bearer ${world.den.admin.token}`, "x-openwork-org-id": world.orgId,
-  } });
-  expect(removed.response.status).toBe(200);
+  {
+  const webUser = user.on(world.web);
+  const api = (path: string, init?: RequestInit) => denFetch(world.den.admin, path, { ...init,
+    headers: { authorization: `Bearer ${world.den.admin.token}`, "x-openwork-org-id": world.orgId, "content-type": "application/json" },
+  });
+  await world.rollout(true);
+  expect((await api("/v1/inference/analytics/settings", { method: "PATCH", body: JSON.stringify({ enabled: false }) })).response.ok).toBe(true);
+  const { app, session, analyticsTransport, upgradeDenApi } = await world.desktop();
+  await selectModel(app, "z-ai/glm-5.2", { provider: "OpenWork Models" });
+  let replies = 0;
+  async function send(prompt: string) {
+    await sendComposerMessage(app, prompt);
+    const reply = await probe.eventually(() => waitForAssistantReply(app, { timeoutMs: 30_000 }), {
+      within: 60_000, label: "a new assistant reply", until: (reply) => reply.assistantMessageCount > replies && reply.text.includes("Models are working."),
+    });
+    replies = reply.assistantMessageCount;
+    await user.on(app).see({ role: "button", label: "Run task" }, { timeoutMs: 60_000 });
+    await user.on(app).notSee({ testId: "session-error-card" });
+  }
+  const activity = async () => list(record((await api(`/v1/inference/analytics/activity?sessionId=${session.sessionId}`)).body).events);
+  await send("Summarize the plan before enabling task analytics.");
+  const legacyRequests = await probe.eventually(() => analyticsTransport.requestLog(), {
+    within: 30_000, label: "the desktop encounters an unavailable analytics endpoint",
+    until: (requests) => requests.some((request) => request.path.endsWith("/inference/analytics/settings") && request.status === 404 && request.faulted),
+  });
+  expect(legacyRequests.some((request) => request.method === "POST" && request.path.endsWith("/inference/analytics/events"))).toBe(false);
+  evidence.recordAssertionEvidence("A newer desktop keeps Models working when Den has no analytics endpoint", "The real desktop received an injected HTTP 404 for analytics settings, still produced the assistant reply, and never attempted to upload task events", true);
+  await upgradeDenApi();
+  await webUser.reload();
+  await webUser.see({ role: "button", label: "Enable task analytics" }, { timeoutMs: 60_000 });
+  await webUser.click({ role: "button", label: "Enable task analytics" });
+  await webUser.see({ role: "tab", label: "Activity" });
+  expect(await activity()).toEqual([]);
+  await send("Continue the same conversation after enabling task analytics.");
+  await user.on(app).screenshot();
+  const events = await probe.eventually(activity, { within: 90_000, label: "live task correlated with its model call", until: (events) => events.some((event) => event.type === "model.call") && events.some((event) => typeof event.type === "string" && ["task.completed", "task.failed", "task.cancelled"].includes(event.type)) });
+  expect(events.filter((event) => event.type === "task.completed")).toHaveLength(1);
+  expect(new Set(events.map((event) => event.taskId)).size).toBe(1);
+  expect(events.filter((event) => event.type === "task.started")).toHaveLength(1);
+  expect(JSON.stringify(events)).not.toContain("Continue the same conversation");
+  await selectModel(app, "minimax/minimax-m3", { provider: "OpenWork Models" });
+  await send("Continue with another OpenWork model.");
+  const switched = await probe.eventually(activity, { within: 90_000, label: "model switch keeps the conversation's task history", until: (events) => events.filter((event) => event.type === "task.completed").length === 2 });
+  expect(new Set(switched.filter((event) => event.type === "model.call").map((event) => event.model))).toEqual(new Set(["z-ai/glm-5.2", "minimax/minimax-m3"]));
+  await user.on(app).see({ text: "Summarize the plan before enabling task analytics." });
+  await user.on(app).screenshot();
+  evidence.recordAssertionEvidence("Real desktop tasks correlate with inference usage after opt-in without replacing the conversation or collecting earlier prompts", "The same conversation produced new replies before and after opt-in; runtime task start/completion joined the model call by task ID; two models and two tasks retained; prompt text absent", true);
+  await send("Load the analytics fixture skill, find its file, and report whether Models are working.");
+  const withSkill = await probe.eventually(activity, { within: 90_000, label: "native skill and tool activity reaches Models analytics", until: (rows) => rows.some((row) => row.type === "skill.loaded" && row.skill === "analytics-fixture") && rows.some((row) => row.type === "tool.executed" && row.tool === "glob") && rows.filter((row) => row.type === "task.completed").length === 3 });
+  expect(withSkill.find((row) => row.skill === "analytics-fixture")).toMatchObject({ type: "skill.loaded", tool: "skill", status: "completed" });
+  evidence.recordAssertionEvidence("A real desktop skill invocation produces task analytics", "The model invoked the native skill tool; OpenCode loaded the arranged skill and the resulting skill.loaded event reached the API without a handcrafted ingestion event", true);
+  expect(withSkill.find((row) => row.tool === "glob")).toMatchObject({ type: "tool.executed", status: "completed", taskId: withSkill.find((row) => row.skill === "analytics-fixture")?.taskId });
+  evidence.recordAssertionEvidence("A real desktop file search produces tool activity within the same task", "The model invoked the native glob tool; its completed tool.executed event reached analytics with the skill invocation's task ID, without a handcrafted ingestion event", true);
+  await webUser.click({ role: "button", label: "Turn off analytics" });
+  await webUser.see({ role: "button", label: "Enable task analytics" });
+  await send("Keep working after turning off task analytics.");
+  const providerCalls = list(record(await fetch(`${world.witnessUrl}/fixture/requests`).then((response) => response.json())).calls);
+  expect(providerCalls.at(-1)).toMatchObject({ model: "minimax/minimax-m3", authenticated: true, kind: "success" });
+  await webUser.click({ role: "button", label: "Enable task analytics" });
+  await webUser.see({ role: "tab", label: "Activity" });
+  expect(await activity()).toHaveLength(withSkill.length);
+  await user.on(app).see({ text: "Keep working after turning off task analytics." });
+  evidence.recordAssertionEvidence("Turning analytics off leaves the existing desktop conversation and selected model usable", "A new assistant reply arrived after disable; after re-enabling, the disabled-period task was absent and the earlier conversation was still visible", true);
+  expect((await api("/v1/org", { method: "DELETE" })).response.status).toBe(200);
   await world.verifyErasure();
   evidence.recordAssertionEvidence("Deleting a workspace erases its task analytics and stored export credentials", "Workspace deletion returned 200; an independent data-store witness found no retained history or analytics configuration", true);
+  }
 });

--- a/evals/specs/models-analytics-upgrade.e2e.test.ts
+++ b/evals/specs/models-analytics-upgrade.e2e.test.ts
@@ -198,7 +198,7 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   }
   const activity = async () => list(record((await api(`/v1/inference/analytics/activity?sessionId=${session.sessionId}`)).body).events);
   await send("Summarize the plan before enabling task analytics.");
-  const legacyRequests = await probe.eventually(() => analyticsTransport.requestLog(), {
+  const legacyRequests = await probe.eventually(async () => (await analyticsTransport.admin.requests()).requests, {
     within: 30_000, label: "the desktop encounters an unavailable analytics endpoint",
     until: (requests) => requests.some((request) => request.path.endsWith("/inference/analytics/settings") && request.status === 404 && request.faulted),
   });
@@ -237,9 +237,12 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   expect(providerCalls.at(-1)).toMatchObject({ model: "minimax/minimax-m3", authenticated: true, kind: "success" });
   await webUser.click({ role: "button", label: "Enable task analytics" });
   await webUser.see({ role: "tab", label: "Activity" });
+  // Observe beyond background reporting and the cached settings interval so a
+  // delayed upload cannot make the disabled-period task appear after this check.
+  await new Promise((resolve) => setTimeout(resolve, 40_000));
   expect(await activity()).toHaveLength(withSkill.length);
   await user.on(app).see({ text: "Keep working after turning off task analytics." });
-  evidence.recordAssertionEvidence("Turning analytics off leaves the existing desktop conversation and selected model usable", "A new assistant reply arrived after disable; after re-enabling, the disabled-period task was absent and the earlier conversation was still visible", true);
+  evidence.recordAssertionEvidence("Turning analytics off leaves the existing desktop conversation and selected model usable", "A new assistant reply arrived from the same selected model after disable; after re-enabling and observing 40 seconds of background reporting, the disabled-period task was absent and the earlier conversation was still visible", true);
   expect((await api("/v1/org", { method: "DELETE" })).response.status).toBe(200);
   await world.verifyErasure();
   evidence.recordAssertionEvidence("Deleting a workspace erases its task analytics and stored export credentials", "Workspace deletion returned 200; an independent data-store witness found no retained history or analytics configuration", true);

--- a/evals/specs/models-analytics-upgrade.e2e.test.ts
+++ b/evals/specs/models-analytics-upgrade.e2e.test.ts
@@ -232,6 +232,7 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   evidence.recordAssertionEvidence("A real desktop file search produces tool activity within the same task", "The model invoked the native glob tool; its completed tool.executed event reached analytics with the skill invocation's task ID, without a handcrafted ingestion event", true);
   await webUser.click({ role: "button", label: "Turn off analytics" });
   await webUser.see({ role: "button", label: "Enable task analytics" });
+  await analyticsTransport.admin.phase("analytics-disabled");
   await send("Keep working after turning off task analytics.");
   const providerCalls = list(record(await fetch(`${world.witnessUrl}/fixture/requests`).then((response) => response.json())).calls);
   expect(providerCalls.at(-1)).toMatchObject({ model: "minimax/minimax-m3", authenticated: true, kind: "success" });
@@ -241,8 +242,10 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   // delayed upload cannot make the disabled-period task appear after this check.
   await new Promise((resolve) => setTimeout(resolve, 40_000));
   expect(await activity()).toHaveLength(withSkill.length);
+  const afterOptOut = (await analyticsTransport.admin.requests()).requests.filter((request) => request.phase === "analytics-disabled");
+  expect(afterOptOut.some((request) => request.method === "POST" && request.path.endsWith("/inference/analytics/events"))).toBe(false);
   await user.on(app).see({ text: "Keep working after turning off task analytics." });
-  evidence.recordAssertionEvidence("Turning analytics off leaves the existing desktop conversation and selected model usable", "A new assistant reply arrived from the same selected model after disable; after re-enabling and observing 40 seconds of background reporting, the disabled-period task was absent and the earlier conversation was still visible", true);
+  evidence.recordAssertionEvidence("Turning analytics off leaves the existing desktop conversation and selected model usable", "A new assistant reply arrived from the same selected model after disable; the independent HTTP witness observed no task-event uploads across opt-out, re-enable and 40 seconds of background reporting, the disabled-period task was absent, and the earlier conversation was still visible", true);
   expect((await api("/v1/org", { method: "DELETE" })).response.status).toBe(200);
   await world.verifyErasure();
   evidence.recordAssertionEvidence("Deleting a workspace erases its task analytics and stored export credentials", "Workspace deletion returned 200; an independent data-store witness found no retained history or analytics configuration", true);

--- a/evals/worlds/models-analytics.ts
+++ b/evals/worlds/models-analytics.ts
@@ -96,15 +96,22 @@ export async function modelsAnalyticsWorld(seed: Seed) {
       return other;
     },
     async desktop() {
-      const analyticsTransport = await seed.faultProxy(den);
+      // Shape the API directly: the web /api/den route redirects to another
+      // origin, which would strip bearer credentials before reaching Den.
+      const analyticsTransport = await seed.denLink({ ...den, ref: { ...den.ref, webUrl: den.ref.apiUrl } }, remote ? { sandboxId: remote } : {});
+      const desktopDen = { apiUrl: analyticsTransport.ref.webUrl, webUrl: analyticsTransport.ref.webUrl };
+      const runtimeConfig = object(await fetch(`${den.ref.webUrl}/api/runtime-config`, { signal: AbortSignal.timeout(5_000) }).then((response) => response.json()));
       const upgradeDenApi = async () => {
-        await analyticsTransport.faults.clear();
         // API discovery must keep the desktop on the independently observed link.
-        await analyticsTransport.faults.status("/api/runtime-config", 200, { times: 10_000, body: { denApiUrl: analyticsTransport.ref.apiUrl } });
+        await analyticsTransport.admin.rules([{ kind: "status", pathPrefix: "/api/runtime-config", statusCode: 200, times: 10_000, body: { ...runtimeConfig, denApiUrl: desktopDen.apiUrl } }]);
       };
-      await upgradeDenApi();
-      await analyticsTransport.faults.status("/api/den/v1/inference/analytics", 404, { times: 10_000, body: { error: "not_found" } });
-      const app = await seed.desktop({ den: { ...den, ref: analyticsTransport.ref }, as: "admin", model: "openwork/z-ai/glm-5.2" });
+      await analyticsTransport.admin.rules([
+        { kind: "status", pathPrefix: "/api/runtime-config", statusCode: 200, times: 10_000, body: { ...runtimeConfig, denApiUrl: desktopDen.apiUrl } },
+        { kind: "status", pathPrefix: "/v1/inference/analytics", statusCode: 404, times: 10_000, body: { error: "not_found" } },
+      ]);
+      const modelsAccess = await fetch(`${desktopDen.apiUrl}/v1/inference`, { headers: { authorization: `Bearer ${den.admin.token}`, "x-openwork-org-id": orgId }, signal: AbortSignal.timeout(10_000) });
+      if (!modelsAccess.ok) throw new Error(`Observed Den link cannot access the existing Models subscription: HTTP ${modelsAccess.status}`);
+      const app = await seed.desktop({ den: { ...den, ref: desktopDen }, as: "admin", model: "openwork/z-ai/glm-5.2" });
       const workspacePath = seed.tmpPath("models-analytics-upgrade");
       const skillPath = join(workspacePath, ".opencode/skills/analytics-fixture");
       const skill = "---\nname: analytics-fixture\ndescription: A harmless skill for the Models analytics upgrade journey.\n---\n\nReport that Models are working. No files or external services are needed.\n";

--- a/evals/worlds/models-analytics.ts
+++ b/evals/worlds/models-analytics.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { allocateFreePort } from "@openwork/cdp";
 import { provisionOrg } from "@openwork/behaviors";
 import { createDaytonaHost, defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
@@ -92,6 +94,33 @@ export async function modelsAnalyticsWorld(seed: Seed) {
       const analytics = await seed.api(other.admin, "/v1/inference/analytics/settings", { method: "PATCH", headers: scoped, body: JSON.stringify({ enabled: true, consentVersion: 1 }) });
       if (!analytics.response.ok) throw new Error("Second subscriber analytics setup failed");
       return other;
+    },
+    async desktop() {
+      const analyticsTransport = await seed.faultProxy(den);
+      const upgradeDenApi = async () => {
+        await analyticsTransport.faults.clear();
+        // API discovery must keep the desktop on the independently observed link.
+        await analyticsTransport.faults.status("/api/runtime-config", 200, { times: 10_000, body: { denApiUrl: analyticsTransport.ref.apiUrl } });
+      };
+      await upgradeDenApi();
+      await analyticsTransport.faults.status("/api/den/v1/inference/analytics", 404, { times: 10_000, body: { error: "not_found" } });
+      const app = await seed.desktop({ den: { ...den, ref: analyticsTransport.ref }, as: "admin", model: "openwork/z-ai/glm-5.2" });
+      const workspacePath = seed.tmpPath("models-analytics-upgrade");
+      const skillPath = join(workspacePath, ".opencode/skills/analytics-fixture");
+      const skill = "---\nname: analytics-fixture\ndescription: A harmless skill for the Models analytics upgrade journey.\n---\n\nReport that Models are working. No files or external services are needed.\n";
+      if (app.handle.sandboxId) {
+        const script = `mkdir -p ${quote(skillPath)}\nprintf %s ${Buffer.from(skill).toString("base64")} | base64 -d > ${quote(join(skillPath, "SKILL.md"))}\nprintf %s eyJwZXJtaXNzaW9uIjp7InNraWxsIjoiYWxsb3cifX0= | base64 -d > ${quote(join(workspacePath, "opencode.json"))}`;
+        const encoded = Buffer.from(script).toString("base64");
+        const result = await execInSandbox(defaultDaytonaExec, app.handle.sandboxId, `printf %s ${encoded} | base64 -d | bash`, { timeoutMs: 15_000, context: "Seed native analytics skill" });
+        if (result.code !== 0) throw new Error("Native skill arrangement failed");
+      } else {
+        await mkdir(skillPath, { recursive: true });
+        await writeFile(join(skillPath, "SKILL.md"), skill);
+        await writeFile(join(workspacePath, "opencode.json"), JSON.stringify({ permission: { skill: "allow" } }));
+      }
+      await seed.workspace(app, workspacePath, { create: true });
+      const session = await seed.session(app, { title: "Existing Models conversation" });
+      return { app, session, analyticsTransport, upgradeDenApi };
     },
     async rollout(enabled: boolean) {
       const result = await seed.api(den.admin, `/v1/admin/organizations/${orgId}/capabilities`, { method: "PUT", body: JSON.stringify({ capabilities: { modelsAnalytics: enabled } }) });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.18.15
         version: 1.18.18
+      '@openwork-ee/telemetry-contracts':
+        specifier: workspace:*
+        version: link:../../ee/packages/telemetry-contracts
       '@openwork/browser-tabs':
         specifier: workspace:*
         version: link:../../packages/browser-tabs
@@ -282,6 +285,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))


### PR DESCRIPTION
Report live task, skill and tool activity after a workspace admin opts into OpenWork Models analytics. Existing paid Models access, model selection, credentials and conversations continue working. The Den API and migration landed and deployed first in #4567.

### Behavior

- Report bounded metadata from real OpenCode events and correlate it with existing model requests. Prompt/response, tool argument/result and file contents are excluded.
- Keep analytics disabled when its API is missing or unavailable. Reporting never blocks the conversation.
- Recheck consent before each upload and discard events queued under an earlier consent period.
- Require the existing rollout, paid subscription and explicit admin-consent gates. The organization capability defaults to off.

### Verification

The final commit `6cbf4d371dd61c1383c408afa900263646c3bf15` passed the cold Daytona subscriber journey: **18 observable assertions, 1 journey passed, 0 failures, 0 skips**. [Published evidence](https://github.com/different-ai/openwork/pull/4563#issuecomment-5561272294).

```sh
infisical run --silent -- env OPENWORK_EVAL_REF=6cbf4d371dd61c1383c408afa900263646c3bf15 pnpm evals:e2e models-analytics-upgrade
pnpm --filter @openwork/app exec tsc --noEmit
```

The journey verifies the real migration with an existing paid account, key/subscription continuity, consent UI, isolation, consumption, export revocation and deletion. The same desktop conversation works with a missing analytics endpoint, after opt-in, through model switching, and after opt-out. Native skill and file-search invocations produce correlated activity. An independent HTTP witness confirms no task-event uploads through opt-out, re-enable and a further 40-second observation window.

The provider and billing fixtures are synthetic; this does not make a Stripe purchase or call a paid model provider. The backend phase also passed [13 upgrade assertions and all 45 inference regression tests](https://github.com/different-ai/openwork/pull/4567#issuecomment-5561080498). App typecheck and CI passed; a broader evals typecheck previously failed and is not claimed as passing.

### Rollout and rollback

#4567 merged at `493ed4c1682fa64657ee525fb4e8c0da0d5fd1a7`. Before this desktop follow-up, production `/health` reported `commit 493ed4c`, `/ready` returned HTTP 200, the analytics settings route changed from 404 to 401 without authentication, and [the migration succeeded](https://github.com/different-ai/openwork/actions/runs/34050248831).

After organization rollout, paid Models includes analytics and admins explicitly opt in through **Unlock custom insights**. Disabling the capability stops analytics without changing Models routing, credentials or subscription billing.
