### PR TITLE
fix(app): preserve v2 transcript events and prompt failures

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1,4 +1,5 @@
 import type {
+  FilePart,
   Model,
   Part,
   PermissionRequest,
@@ -6,6 +7,7 @@ import type {
   Provider,
   ProviderListResponse,
   QuestionRequest,
+  ReasoningPart,
   Session,
   SessionStatus,
   TextPart,
@@ -146,6 +148,7 @@ type TextStream = {
   partID: string;
   ordinal: number;
   text: string;
+  start: number;
 };
 
 type ToolStream = {
@@ -220,10 +223,6 @@ function readMessageID(value: Record<string, unknown>): string {
   return readString(value, "assistantMessageID") ?? readString(value, "messageID") ?? readString(value, "messageId") ?? "";
 }
 
-function readTimestamp(value: Record<string, unknown>): number {
-  return readNumber(value, "timestamp") ?? Date.now();
-}
-
 function mapV2Session(value: unknown, directory: string | undefined, eventCreated?: number): Session | null {
   const data = responseData(value);
   if (!isRecord(data)) return null;
@@ -261,19 +260,56 @@ function messageRole(value: Record<string, unknown>): V2MessageRole {
   return "assistant";
 }
 
-function parseToolInput(value: unknown): Record<string, unknown> {
-  if (isRecord(value)) return value;
+function parseToolInput(value: unknown, tool?: string): Record<string, unknown> {
+  if (isRecord(value)) {
+    return tool === "subagent" && typeof value.agent === "string"
+      ? { subagent_type: value.agent, ...value }
+      : value;
+  }
   if (typeof value !== "string" || value === "") return {};
   try {
     const parsed: unknown = JSON.parse(value);
-    return isRecord(parsed) ? parsed : {};
+    return isRecord(parsed) ? parseToolInput(parsed, tool) : {};
   } catch {
     return {};
   }
 }
 
 function compatibleToolName(tool: string): string {
-  return tool === "shell" ? "bash" : tool;
+  return tool === "shell" ? "bash" : tool === "subagent" ? "task" : tool;
+}
+
+function toolMetadata(tool: string, metadata: Record<string, unknown>): Record<string, unknown> {
+  return tool === "subagent" && typeof metadata.sessionID === "string"
+    ? { sessionId: metadata.sessionID, ...metadata }
+    : metadata;
+}
+
+function toolAttachments(
+  content: unknown,
+  callID: string,
+  messageID: string,
+  sessionID: string,
+): { attachments?: FilePart[] } {
+  if (!Array.isArray(content)) return {};
+  const attachments: FilePart[] = [];
+  for (const item of content) {
+    if (!isRecord(item) || item.type !== "file") continue;
+    const url = readString(item, "uri");
+    const mime = readString(item, "mime");
+    if (url === undefined || mime === undefined) continue;
+    const filename = readString(item, "name");
+    attachments.push({
+      id: `${callID}:file:${attachments.length}`,
+      messageID,
+      sessionID,
+      type: "file",
+      url,
+      mime,
+      ...(filename === undefined ? {} : { filename }),
+    });
+  }
+  return attachments.length > 0 ? { attachments } : {};
 }
 
 function toolPartMetadata(tool: string): Pick<ToolPart, "metadata"> {
@@ -311,13 +347,13 @@ function mapV2ToolPart(
   const status = readString(state, "status");
   if (!callID || !sourceTool || !state) return null;
   const tool = compatibleToolName(sourceTool);
-  const input = parseToolInput(state.input);
+  const input = parseToolInput(state.input, sourceTool);
   const time = readRecord(value, "time");
   const created = readNumber(time, "created") ?? messageCreated;
   const start = readNumber(time, "ran") ?? created;
   const end = readNumber(time, "completed") ?? start;
   const title = readString(state, "title") ?? tool;
-  const metadata = readRecord(state, "metadata") ?? {};
+  const metadata = toolMetadata(sourceTool, readRecord(state, "metadata") ?? {});
   const base: Omit<ToolPart, "state"> = {
     id: callID,
     messageID,
@@ -328,9 +364,9 @@ function mapV2ToolPart(
     ...toolPartMetadata(sourceTool),
   };
 
-  if (status === "pending") {
+  if (status === "pending" || status === "streaming") {
     const raw = typeof state.input === "string" ? state.input : "";
-    return { ...base, state: { status, input, raw } };
+    return { ...base, state: { status: "pending", input, raw } };
   }
   if (status === "running") {
     return { ...base, state: { status, input, title, metadata, time: { start } } };
@@ -342,6 +378,7 @@ function mapV2ToolPart(
         status,
         input,
         output: toolOutput(state.content, state.result),
+        ...toolAttachments(state.content, callID, messageID, sessionID),
         title,
         metadata,
         time: { start, end },
@@ -370,16 +407,27 @@ function mapV2MessageParts(
   messageCreated: number,
 ): Part[] {
   if (Array.isArray(value.content)) {
-    return value.content.flatMap<Part>((entry, ordinal) => {
+    const ordinals = { text: 0, reasoning: 0 };
+    return value.content.flatMap<Part>((entry) => {
       if (!isRecord(entry)) return [];
-      if (readString(entry, "type") === "text") {
+      const kind = readString(entry, "type");
+      if (kind === "text" || kind === "reasoning") {
+        const ordinal = ordinals[kind]++;
         const text = readString(entry, "text");
+        const time = readRecord(entry, "time");
+        const end = readNumber(time, "completed");
         return text === undefined ? [] : [{
-          id: `${messageID}:${ordinal}`,
+          id: textPartID(messageID, kind, ordinal),
           messageID,
           sessionID,
-          type: "text" as const,
           text,
+          ...(kind === "reasoning" ? {
+            type: kind,
+            time: {
+              start: readNumber(time, "created") ?? messageCreated,
+              ...(end === undefined ? {} : { end }),
+            },
+          } : { type: kind }),
         }];
       }
       if (readString(entry, "type") === "tool") {
@@ -590,25 +638,40 @@ function errorMessage(value: unknown): string {
   }
 }
 
-function streamKey(properties: Record<string, unknown>, sessionID: string, messageID: string): string {
-  const explicit = readString(properties, "textID") ?? readString(properties, "textId");
-  if (explicit) return explicit;
+function textPartID(messageID: string, kind: "text" | "reasoning", ordinal: number): string {
+  return kind === "text" ? `${messageID}:${ordinal}` : `${messageID}:reasoning:${ordinal}`;
+}
+
+function streamKey(
+  properties: Record<string, unknown>,
+  sessionID: string,
+  messageID: string,
+  kind: "text" | "reasoning",
+): string {
+  const explicit = readString(properties, `${kind}ID`) ?? readString(properties, `${kind}Id`);
+  if (explicit !== undefined) return JSON.stringify([sessionID, kind, "id", explicit]);
   const ordinal = readNumber(properties, "ordinal");
-  // v2 emits one text stream per (assistantMessageID, ordinal); keying on the
-  // event-provided ordinal keeps multi-part messages from merging into one part.
-  return ordinal === undefined ? `${sessionID}:${messageID}` : `${messageID}:${ordinal}`;
+  return JSON.stringify([sessionID, kind, messageID, ordinal]);
 }
 
 function resolveTextStream(
   properties: Record<string, unknown>,
   state: V2EventTranslationState,
+  kind: "text" | "reasoning",
 ): TextStream | null {
   const sessionID = readSessionID(properties);
   const messageID = readMessageID(properties);
-  const explicitKey = streamKey(properties, sessionID, messageID);
+  const hasMessageID = "assistantMessageID" in properties || "messageID" in properties || "messageId" in properties;
+  const explicitKey = streamKey(properties, sessionID, messageID, kind);
   const byExplicitKey = state.streams.get(explicitKey);
-  if (byExplicitKey) return byExplicitKey;
-  const latestKey = sessionID ? state.latestStreamKeyBySession.get(sessionID) : undefined;
+  if (byExplicitKey) {
+    if (hasMessageID && byExplicitKey.messageID !== messageID) return null;
+    if ("ordinal" in properties && byExplicitKey.ordinal !== properties.ordinal) return null;
+    return byExplicitKey;
+  }
+  // Only identity-free legacy fragments may use the latest stream of this kind.
+  if (hasMessageID || "ordinal" in properties || `${kind}ID` in properties || `${kind}Id` in properties) return null;
+  const latestKey = sessionID ? state.latestStreamKeyBySession.get(JSON.stringify([sessionID, kind])) : undefined;
   if (latestKey) return state.streams.get(latestKey) ?? null;
   return null;
 }
@@ -642,7 +705,7 @@ function pendingToolPart(stream: ToolStream): ToolPart {
     sessionID: stream.sessionID,
     type: "tool",
     callID: stream.callID,
-    tool: stream.tool,
+    tool: compatibleToolName(stream.tool),
     ...toolPartMetadata(stream.tool),
     state: {
       status: "pending",
@@ -659,13 +722,13 @@ function runningToolPart(stream: ToolStream, start: number): ToolPart {
     sessionID: stream.sessionID,
     type: "tool",
     callID: stream.callID,
-    tool: stream.tool,
+    tool: compatibleToolName(stream.tool),
     ...toolPartMetadata(stream.tool),
     state: {
       status: "running",
       input: stream.input,
-      title: stream.tool,
-      metadata: stream.metadata,
+      title: compatibleToolName(stream.tool),
+      metadata: toolMetadata(stream.tool, stream.metadata),
       time: { start },
     },
   };
@@ -682,14 +745,15 @@ function completedToolPart(
     sessionID: stream.sessionID,
     type: "tool",
     callID: stream.callID,
-    tool: stream.tool,
+    tool: compatibleToolName(stream.tool),
     ...toolPartMetadata(stream.tool),
     state: {
       status: "completed",
       input: stream.input,
       output: toolOutput(properties.content, properties.result),
-      title: stream.tool,
-      metadata: stream.metadata,
+      ...toolAttachments(properties.content, stream.callID, stream.messageID, stream.sessionID),
+      title: compatibleToolName(stream.tool),
+      metadata: toolMetadata(stream.tool, stream.metadata),
       time: { start: stream.start ?? end, end },
     },
   };
@@ -706,13 +770,13 @@ function failedToolPart(
     sessionID: stream.sessionID,
     type: "tool",
     callID: stream.callID,
-    tool: stream.tool,
+    tool: compatibleToolName(stream.tool),
     ...toolPartMetadata(stream.tool),
     state: {
       status: "error",
       input: stream.input,
       error: errorMessage(properties.error ?? properties.result),
-      metadata: stream.metadata,
+      metadata: toolMetadata(stream.tool, stream.metadata),
       time: { start: stream.start ?? end, end },
     },
   };
@@ -768,7 +832,7 @@ export function translateV2Event(
       ...payload,
       id: messageID,
       type: "user",
-      time: { created: readNumber(value, "created") ?? readTimestamp(properties) },
+      time: { created: readNumber(value, "created") ?? readNumber(properties, "timestamp") ?? Date.now() },
     }, sessionID);
     if (!message) return null;
     return [
@@ -789,31 +853,37 @@ export function translateV2Event(
     return [{ type: "session.status", properties: { sessionID, status: { type: "busy" } } }];
   }
 
-  if (type === "session.text.started" || type === "session.next.text.started") {
+  const kind = type.startsWith("session.reasoning.") || type.startsWith("session.next.reasoning.") ? "reasoning" : "text";
+  if (type === `session.${kind}.started` || type === `session.next.${kind}.started`) {
     const messageID = readMessageID(properties);
     if (!sessionID || !messageID) return null;
-    const key = streamKey(properties, sessionID, messageID);
-    const existing = state.streams.get(key);
+    const key = streamKey(properties, sessionID, messageID, kind);
+    const counterKey = JSON.stringify([sessionID, messageID, kind]);
+    const candidate = state.streams.get(key);
+    const existing = candidate?.messageID === messageID ? candidate : undefined;
     const ordinal = readNumber(properties, "ordinal")
       ?? existing?.ordinal
-      ?? state.nextOrdinalByMessage.get(messageID)
+      ?? state.nextOrdinalByMessage.get(counterKey)
       ?? 0;
     const stream = existing ?? {
       sessionID,
       messageID,
-      partID: `${messageID}:${ordinal}`,
+      partID: textPartID(messageID, kind, ordinal),
       ordinal,
       text: "",
+      start: toolEventTimestamp(value, properties),
     };
     state.streams.set(key, stream);
-    state.latestStreamKeyBySession.set(sessionID, key);
-    if (!existing) state.nextOrdinalByMessage.set(messageID, ordinal + 1);
-    const part: TextPart = {
+    state.latestStreamKeyBySession.set(JSON.stringify([sessionID, kind]), key);
+    if (!existing) {
+      state.nextOrdinalByMessage.set(counterKey, Math.max(state.nextOrdinalByMessage.get(counterKey) ?? 0, ordinal + 1));
+    }
+    const part: TextPart | ReasoningPart = {
       id: stream.partID,
       messageID,
       sessionID,
-      type: "text",
-      text: "",
+      text: stream.text,
+      ...(kind === "reasoning" ? { type: kind, time: { start: stream.start } } : { type: kind }),
     };
     return [
       {
@@ -823,7 +893,7 @@ export function translateV2Event(
             id: messageID,
             sessionID,
             role: "assistant",
-            time: { created: readTimestamp(properties) },
+            time: { created: stream.start },
           },
         },
       },
@@ -831,8 +901,8 @@ export function translateV2Event(
     ];
   }
 
-  if (type === "session.text.delta" || type === "session.next.text.delta") {
-    const stream = resolveTextStream(properties, state);
+  if (type === `session.${kind}.delta` || type === `session.next.${kind}.delta`) {
+    const stream = resolveTextStream(properties, state, kind);
     const delta = readString(properties, "delta");
     if (!stream || delta === undefined) return null;
     stream.text += delta;
@@ -848,17 +918,20 @@ export function translateV2Event(
     }];
   }
 
-  if (type === "session.text.ended" || type === "session.next.text.ended") {
-    const stream = resolveTextStream(properties, state);
+  if (type === `session.${kind}.ended` || type === `session.next.${kind}.ended`) {
+    const stream = resolveTextStream(properties, state, kind);
     if (!stream) return null;
     const fullText = readString(properties, "text");
     if (fullText !== undefined) stream.text = fullText;
-    const part: TextPart = {
+    const part: TextPart | ReasoningPart = {
       id: stream.partID,
       messageID: stream.messageID,
       sessionID: stream.sessionID,
-      type: "text",
       text: stream.text,
+      ...(kind === "reasoning" ? {
+        type: kind,
+        time: { start: stream.start, end: toolEventTimestamp(value, properties) },
+      } : { type: kind }),
     };
     return [{ type: "message.part.updated", properties: { part } }];
   }
@@ -868,7 +941,6 @@ export function translateV2Event(
     const callID = readToolCallID(properties);
     const sourceTool = readString(properties, "name") ?? readString(properties, "tool");
     if (!sessionID || !messageID || !callID || !sourceTool) return null;
-    const tool = compatibleToolName(sourceTool);
     const key = toolStreamKey(sessionID, callID);
     const existing = state.tools.get(key);
     const stream = existing ?? {
@@ -876,16 +948,12 @@ export function translateV2Event(
       messageID,
       partID: callID,
       callID,
-      tool,
+      tool: sourceTool,
       raw: "",
       input: {},
       metadata: {},
     };
     state.tools.set(key, stream);
-    if (!existing) {
-      const ordinal = state.nextOrdinalByMessage.get(messageID) ?? 0;
-      state.nextOrdinalByMessage.set(messageID, ordinal + 1);
-    }
     return [
       {
         type: "message.updated",
@@ -907,7 +975,7 @@ export function translateV2Event(
     const delta = readString(properties, "delta");
     if (!stream || delta === undefined) return null;
     stream.raw += delta;
-    stream.input = parseToolInput(stream.raw);
+    stream.input = parseToolInput(stream.raw, stream.tool);
     return [{ type: "message.part.updated", properties: { part: pendingToolPart(stream) } }];
   }
 
@@ -916,14 +984,14 @@ export function translateV2Event(
     const text = readString(properties, "text");
     if (!stream || text === undefined) return null;
     stream.raw = text;
-    stream.input = parseToolInput(text);
+    stream.input = parseToolInput(text, stream.tool);
     return [{ type: "message.part.updated", properties: { part: pendingToolPart(stream) } }];
   }
 
   if (type === "session.tool.called" || type === "session.next.tool.called") {
     const stream = resolveToolStream(properties, state);
     if (!stream) return null;
-    stream.input = parseToolInput(properties.input);
+    stream.input = parseToolInput(properties.input, stream.tool);
     stream.start = toolEventTimestamp(value, properties);
     return [{
       type: "message.part.updated",
@@ -1078,85 +1146,6 @@ async function* translateV2Events(
   }
 }
 
-type InjectedEventQueue = {
-  events: OpencodeEvent[];
-  push: (event: OpencodeEvent) => void;
-  wait: () => Promise<void>;
-  close: () => void;
-};
-
-function createInjectedEventQueue(): InjectedEventQueue {
-  const events: OpencodeEvent[] = [];
-  let wake: (() => void) | undefined;
-  let closed = false;
-  return {
-    events,
-    push: (event) => {
-      if (closed) return;
-      events.push(event);
-      wake?.();
-      wake = undefined;
-    },
-    wait: () => {
-      if (events.length > 0 || closed) return Promise.resolve();
-      return new Promise<void>((resolve) => {
-        wake = resolve;
-      });
-    },
-    close: () => {
-      closed = true;
-      wake?.();
-      wake = undefined;
-    },
-  };
-}
-
-type MergedEventResult =
-  | { source: IteratorResult<OpencodeEvent> }
-  | { injected: true };
-
-async function waitForSource(
-  source: Promise<IteratorResult<OpencodeEvent>>,
-): Promise<MergedEventResult> {
-  return { source: await source };
-}
-
-async function waitForInjected(queue: InjectedEventQueue): Promise<MergedEventResult> {
-  await queue.wait();
-  return { injected: true };
-}
-
-async function* mergeV2Events(
-  response: Response,
-  signal: AbortSignal | undefined,
-  queue: InjectedEventQueue,
-  close: () => void,
-  directory?: string,
-): AsyncGenerator<OpencodeEvent> {
-  const source = translateV2Events(response, signal, directory);
-  let sourceNext = source.next();
-  try {
-    while (!signal?.aborted) {
-      const injected = queue.events.shift();
-      if (injected) {
-        yield injected;
-        continue;
-      }
-      const result = await Promise.race([
-        waitForSource(sourceNext),
-        waitForInjected(queue),
-      ]);
-      if ("injected" in result) continue;
-      if (result.source.done) return;
-      yield result.source.value;
-      sourceNext = source.next();
-    }
-  } finally {
-    close();
-    void source.return(undefined);
-  }
-}
-
 function createWebFetch(auth: { token?: string }): typeof globalThis.fetch {
   return (input, init) => {
     const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
@@ -1231,13 +1220,8 @@ export function createClientV2(
   const baseUrl = opencode2BaseUrl.replace(/\/+$/, "");
   const fetchImpl = createV2Fetch(auth);
   const compatibilityClient = createClient(baseUrl, directory, { mode: "openwork", token: auth.token });
-  const injectedEventListeners = new Set<(event: OpencodeEvent) => void>();
   const permissionSessionByRequestID = new Map<string, string>();
   const questionFormsByID = new Map<string, NonNullable<ReturnType<typeof mapV2Question>>>();
-
-  const emitInjectedEvent = (event: OpencodeEvent) => {
-    for (const listener of injectedEventListeners) listener(event);
-  };
 
   const request = async (
     method: string,
@@ -1515,34 +1499,13 @@ export function createClientV2(
         .filter((part) => part.type === "text" && typeof part.text === "string")
         .map((part) => typeof part.text === "string" ? part.text : "")
         .join("");
-      const promptPath = `/api/session/${encodeURIComponent(parameters.sessionID)}/prompt`;
-      const promptBody = { text };
-      const promptResult = request(
+      const promptResult = await request(
         "POST",
-        promptPath,
-        promptBody,
+        `/api/session/${encodeURIComponent(parameters.sessionID)}/prompt`,
+        { text },
         options?.signal,
       );
-      void promptResult.then(
-        (result) => {
-          if (result.response.ok) return;
-          emitInjectedEvent(sessionErrorEvent(parameters.sessionID, result.payload));
-        },
-        (error: unknown) => {
-          emitInjectedEvent(sessionErrorEvent(parameters.sessionID, error));
-        },
-      );
-      const headers = new Headers({ "Content-Type": "application/json" });
-      if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
-      return successfulResult({
-        payload: null,
-        request: new Request(`${baseUrl}${promptPath}`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(promptBody),
-        }),
-        response: new Response(null, { status: 202 }),
-      }, {});
+      return promptResult.response.ok ? successfulResult(promptResult, {}) : failedResult(promptResult);
     },
     abort: async (
       parameters: SessionParameters,
@@ -1702,14 +1665,8 @@ export function createClientV2(
           Object.assign(error, { status: response.status, response });
           throw error;
         }
-        const queue = createInjectedEventQueue();
-        const listener = (event: OpencodeEvent) => queue.push(event);
-        injectedEventListeners.add(listener);
         return {
-          stream: mergeV2Events(response, options?.signal, queue, () => {
-            injectedEventListeners.delete(listener);
-            queue.close();
-          }, directory),
+          stream: translateV2Events(response, options?.signal, directory),
         };
       },
     },

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -490,6 +490,87 @@ describe("OpenCode v2 event translation", () => {
     ]);
   });
 
+  test.each(["text", "reasoning"])("isolates %s streams by session, message, kind, and ordinal", (kind) => {
+    const state = createV2EventTranslationState();
+    for (const sessionID of ["ses_one", "ses_two"]) {
+      for (const assistantMessageID of ["msg_one", "msg_two"]) {
+        for (const streamKind of ["text", "reasoning"]) {
+          translateV2Event({
+            type: `session.${streamKind}.started`, created: 10,
+            data: { sessionID, assistantMessageID, ordinal: 0 },
+          }, state);
+        }
+      }
+    }
+    const identity = { sessionID: "ses_one", assistantMessageID: "msg_one", ordinal: 0 };
+    const id = kind === "text" ? "msg_one:0" : "msg_one:reasoning:0";
+    expect(translateV2Event({
+      type: `session.${kind}.delta`, data: { ...identity, delta: "only this part" },
+    }, state)).toEqual([{
+      type: "message.part.delta",
+      properties: { sessionID: "ses_one", messageID: "msg_one", partID: id, field: "text", delta: "only this part" },
+    }]);
+    for (const unmatched of [
+      { ...identity, assistantMessageID: "msg_missing" },
+      { ...identity, ordinal: 9 },
+      { ...identity, sessionID: "ses_missing" },
+      { sessionID: "ses_one", [`${kind}ID`]: "missing" },
+      { sessionID: "ses_one", [`${kind}Id`]: "missing" },
+      { sessionID: "ses_one", assistantMessageID: "msg_one" },
+      { sessionID: "ses_one", assistantMessageID: "" },
+      { sessionID: "ses_one", messageID: null },
+    ]) {
+      expect(translateV2Event({ type: `session.${kind}.delta`, data: { ...unmatched, delta: "WRONG" } }, state)).toBeNull();
+      expect(translateV2Event({ type: `session.${kind}.ended`, data: { ...unmatched, text: "WRONG" } }, state)).toBeNull();
+    }
+    for (const sessionID of ["ses_one", "ses_two"]) {
+      for (const assistantMessageID of ["msg_one", "msg_two"]) {
+        for (const streamKind of ["text", "reasoning"]) {
+          expect(translateV2Event({
+            type: `session.${streamKind}.ended`, created: 20,
+            data: { sessionID, assistantMessageID, ordinal: 0 },
+          }, state)).toMatchObject([{
+            properties: { part: {
+              sessionID, messageID: assistantMessageID, type: streamKind,
+              text: sessionID === "ses_one" && assistantMessageID === "msg_one" && streamKind === kind ? "only this part" : "",
+            } },
+          }]);
+        }
+      }
+    }
+  });
+
+  test("keeps legacy aliases and kind-local counters without letting tools consume text ordinals", () => {
+    const state = createV2EventTranslationState();
+    const identity = { sessionID: "ses_legacy", assistantMessageID: "msg_legacy" };
+    translateV2Event({ type: "session.tool.input.started", data: { ...identity, id: "call_first", name: "shell" } }, state);
+    for (const ordinal of [0, 1]) {
+      for (const kind of ["reasoning", "text"]) {
+        const id = `msg_legacy:${kind === "reasoning" ? "reasoning:" : ""}${ordinal}`;
+        const started = {
+          type: `session.next.${kind}.started`, created: 10,
+          data: { ...identity, [`${kind}ID`]: `shared_${ordinal}` },
+        };
+        expect(translateV2Event(started, state)?.[1]).toMatchObject({ properties: { part: { id, text: "" } } });
+        translateV2Event({ type: `session.next.${kind}.delta`, data: { sessionID: identity.sessionID, delta: "legacy" } }, state);
+        // Replayed starts must not reset accumulated text or advance the counter.
+        expect(translateV2Event(started, state)?.[1]).toMatchObject({ properties: { part: { id, text: "legacy" } } });
+        expect(translateV2Event({
+          type: `session.next.${kind}.ended`, created: 20,
+          data: { sessionID: identity.sessionID, [`${kind}ID`]: `shared_${ordinal}` },
+        }, state)).toMatchObject([{ properties: { part: { id, text: "legacy" } } }]);
+        expect(translateV2Event({
+          type: `session.next.${kind}.delta`,
+          data: { ...identity, assistantMessageID: "msg_other", [`${kind}ID`]: `shared_${ordinal}`, delta: "WRONG" },
+        }, state)).toBeNull();
+        expect(translateV2Event({
+          type: `session.next.${kind}.delta`,
+          data: { ...identity, ordinal: 9, [`${kind}ID`]: `shared_${ordinal}`, delta: "WRONG" },
+        }, state)).toBeNull();
+      }
+    }
+  });
+
   test("emits an error before terminal idle events for failed execution", () => {
     const state = createV2EventTranslationState();
     expect(translateV2Event({
@@ -603,6 +684,174 @@ describe("OpenCode v2 client compatibility", () => {
       expect(ui).toMatchObject({ output: "Combined result" });
     } finally { globalThis.fetch = originalFetch; }
   });
+  test("hydrates mixed native content with the same text and reasoning IDs as streaming", async () => {
+    const originalFetch = globalThis.fetch;
+    // beta19086 schema: each kind has its own ordinal; reasoning time is optional.
+    const message = {
+      id: "msg_mixed", type: "assistant", time: { created: 5, completed: 90 },
+      error: { type: "unknown", message: "partial turn failed" },
+      content: [
+        { type: "reasoning", text: "First thought", time: { created: 10, completed: 20 } },
+        { ...capturedV2ToolMessage.content[1] },
+        { type: "text", text: "First answer" },
+        { type: "reasoning", text: "Second thought", time: { created: 40, completed: 50 } },
+        { type: "text", text: "Second answer" },
+        { type: "reasoning", text: "Unfinished thought" },
+      ],
+    };
+    globalThis.fetch = async () => jsonResponse({ data: [message] });
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.messages({ sessionID: "ses_mixed" });
+      const parts = result.data?.[0]?.parts;
+      expect(parts?.map((part) => part.id)).toEqual([
+        "msg_mixed:reasoning:0", "call_captured_shell", "msg_mixed:0",
+        "msg_mixed:reasoning:1", "msg_mixed:1", "msg_mixed:reasoning:2",
+      ]);
+      expect(result.data?.[0]?.info.error).toEqual({ name: "UnknownError", data: { message: "partial turn failed" } });
+      expect(parts?.[5]).toEqual({
+        id: "msg_mixed:reasoning:2", sessionID: "ses_mixed", messageID: "msg_mixed",
+        type: "reasoning", text: "Unfinished thought", time: { start: 5 },
+      });
+      const state = createV2EventTranslationState();
+      const identity = { sessionID: "ses_mixed", assistantMessageID: "msg_mixed" };
+      translateV2Event({ type: "session.tool.input.started", data: { ...identity, id: "call_captured_shell", name: "shell" } }, state);
+      for (const [kind, ordinal, text, start, end, index] of [
+        ["reasoning", 0, "First thought", 10, 20, 0],
+        ["text", 0, "First answer", 30, 35, 2],
+        ["reasoning", 1, "Second thought", 40, 50, 3],
+        ["text", 1, "Second answer", 60, 70, 4],
+      ] as const) {
+        const data = { ...identity, ordinal };
+        const started = translateV2Event({ type: `session.${kind}.started`, created: start, data }, state);
+        expect(started?.[0]).toMatchObject({ properties: { info: { time: { created: start } } } });
+        expect(started?.[1]).toMatchObject({ properties: { part: { id: parts?.[index]?.id, type: kind, text: "" } } });
+        translateV2Event({ type: `session.${kind}.delta`, data: { ...data, delta: "partial" } }, state);
+        const ended = { type: `session.${kind}.ended`, created: end, data: { ...data, text } };
+        expect(translateV2Event(ended, state)).toEqual([{ type: "message.part.updated", properties: { part: parts?.[index] } }]);
+        expect(translateV2Event(ended, state)).toEqual([{ type: "message.part.updated", properties: { part: parts?.[index] } }]);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("maps native file results to stable per-call attachments in live and hydrated completed tools", async () => {
+    const originalFetch = globalThis.fetch;
+    const content = [
+      { type: "text", text: "Created files" },
+      { type: "file", uri: "file:///workspace/report.pdf", mime: "application/pdf", name: "report.pdf" },
+      { type: "text", text: "Two outputs" },
+      { type: "file", uri: "data:image/png;base64,AA==", mime: "image/png" },
+    ];
+    const tools = ["call_one", "call_two"].map((id) => ({
+      type: "tool", id, name: "export_report",
+      state: { status: "completed", input: {}, content, metadata: { files: 2 } },
+      time: { created: 10, ran: 20, completed: 30 },
+    }));
+    globalThis.fetch = async () => jsonResponse({ data: [{ id: "msg_files", type: "assistant", time: { created: 5 }, content: tools }] });
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.messages({ sessionID: "ses_files" });
+      const state = createV2EventTranslationState();
+      for (const [index, tool] of tools.entries()) {
+        const identity = { sessionID: "ses_files", assistantMessageID: "msg_files", id: tool.id };
+        translateV2Event({ type: "session.tool.input.started", created: 10, data: { ...identity, name: tool.name } }, state);
+        translateV2Event({ type: "session.tool.called", created: 20, data: { ...identity, input: {}, executed: false } }, state);
+        const completed = translateV2Event({
+          type: "session.tool.success", created: 30, data: { ...identity, content, metadata: { files: 2 }, executed: false },
+        }, state);
+        expect(completed).toEqual([{ type: "message.part.updated", properties: { part: result.data?.[0]?.parts[index] } }]);
+        expect(result.data?.[0]?.parts[index]).toMatchObject({ state: {
+          output: "Created files\nTwo outputs",
+          attachments: [
+            { id: `${tool.id}:file:0`, sessionID: "ses_files", messageID: "msg_files", type: "file", url: content[1]?.uri, mime: "application/pdf", filename: "report.pdf" },
+            { id: `${tool.id}:file:1`, sessionID: "ses_files", messageID: "msg_files", type: "file", url: content[3]?.uri, mime: "image/png" },
+          ],
+        } });
+        // Repeated completion retains IDs, including identical URIs on distinct calls.
+        expect(translateV2Event({
+          type: "session.tool.success", created: 30, data: { ...identity, content },
+        }, state)).toEqual(completed);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each(["subagent", "task", "custom_subagent"])("normalizes only native subagent fields, not %s lookalikes", async (name) => {
+    const originalFetch = globalThis.fetch;
+    const input = { agent: "explore", prompt: "Inspect workspace", description: "Workspace inspection", extra: { keep: true } };
+    const metadata = { sessionID: "ses_child", status: "working", extra: ["keep"] };
+    const expectedInput = name === "subagent" ? { ...input, subagent_type: "explore" } : input;
+    const expectedMetadata = name === "subagent" ? { ...metadata, sessionId: "ses_child" } : metadata;
+    const expectedTool = name === "subagent" ? "task" : name;
+    const error = { type: "unknown", message: "child failed" };
+    const content = [{ type: "text", text: "Child result" }];
+    const states = [
+      { status: "streaming", input: JSON.stringify(input) },
+      { status: "running", input, metadata },
+      { status: "completed", input, metadata, content },
+      { status: "error", input, metadata, error },
+    ];
+    globalThis.fetch = async () => jsonResponse({ data: states.map((state) => ({
+      id: "msg_parent", type: "assistant", time: { created: 5 },
+      content: [{ type: "tool", id: "call_child", name, state, time: { created: 10, ran: 20, completed: 30 } }],
+    })) });
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.messages({ sessionID: "ses_parent" });
+      for (const [index, message] of (result.data ?? []).entries()) {
+        expect(message.parts[0]).toMatchObject({
+          tool: expectedTool, state: { input: expectedInput, ...(index > 0 ? { metadata: expectedMetadata } : {}) },
+        });
+      }
+      const state = createV2EventTranslationState();
+      const identity = { sessionID: "ses_parent", assistantMessageID: "msg_parent", id: "call_child" };
+      translateV2Event({ type: "session.tool.input.started", created: 10, data: { ...identity, name } }, state);
+      for (const type of ["session.tool.input.delta", "session.tool.input.ended"]) {
+        expect(translateV2Event({ type, data: { ...identity, delta: JSON.stringify(input), text: JSON.stringify(input) } }, state))
+          .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[0]?.parts[0] } }]);
+      }
+      expect(translateV2Event({ type: "session.tool.called", created: 20, data: { ...identity, input, executed: false } }, state))
+        .toMatchObject([{ properties: { part: { tool: expectedTool, state: { input: expectedInput, status: "running" } } } }]);
+      expect(translateV2Event({ type: "session.tool.progress", created: 25, data: { ...identity, metadata } }, state))
+        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[1]?.parts[0] } }]);
+      expect(translateV2Event({ type: "session.tool.success", created: 30, data: { ...identity, metadata, content, executed: false } }, state))
+        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[2]?.parts[0] } }]);
+      expect(translateV2Event({ type: "session.tool.failed", created: 30, data: { ...identity, metadata, error, executed: false } }, state))
+        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[3]?.parts[0] } }]);
+      expect(result.data?.[3]?.parts[0]).toMatchObject({ state: { error: "child failed" } });
+      expect(input).not.toHaveProperty("subagent_type");
+      expect(metadata).not.toHaveProperty("sessionId");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("preserves existing compatibility fields on native subagent inputs and metadata", async () => {
+    const originalFetch = globalThis.fetch;
+    const input = { agent: "explore", subagent_type: "manual", custom: { agent: "unchanged" } };
+    const metadata = { sessionID: "ses_native", sessionId: "ses_manual", custom: { sessionID: "unchanged" } };
+    globalThis.fetch = async () => jsonResponse({ data: [{
+      id: "msg_parent", type: "assistant", time: { created: 10 },
+      content: [{ type: "tool", id: "call_child", name: "subagent", time: { created: 10, ran: 20 }, state: { status: "running", input, metadata } }],
+    }] });
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.messages({ sessionID: "ses_parent" });
+      expect(result.data?.[0]?.parts[0]).toMatchObject({ tool: "task", state: { input, metadata } });
+      const state = createV2EventTranslationState();
+      const identity = { sessionID: "ses_parent", assistantMessageID: "msg_parent", id: "call_child" };
+      translateV2Event({ type: "session.tool.input.started", created: 10, data: { ...identity, name: "subagent" } }, state);
+      translateV2Event({ type: "session.tool.called", created: 20, data: { ...identity, input, executed: false } }, state);
+      expect(translateV2Event({ type: "session.tool.progress", data: { ...identity, metadata } }, state))
+        .toEqual([{ type: "message.part.updated", properties: { part: result.data?.[0]?.parts[0] } }]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("maps only missing and empty native titles to stable read-time placeholders", async () => {
     const originalFetch = globalThis.fetch;
     const created = 1_788_548_737_221;
@@ -778,33 +1027,41 @@ describe("OpenCode v2 client compatibility", () => {
     }
   });
 
-  test("returns from promptAsync before a delayed prompt response", async () => {
+  test("waits for native prompt admission and returns its actual response without waiting for execution", async () => {
     const originalFetch = globalThis.fetch;
-    let promptSettled: Promise<void> = Promise.resolve();
+    const admission = Promise.withResolvers<Response>();
+    const dispatched = Promise.withResolvers<Request>();
+    const response = new Response(null, { status: 204, headers: { "X-Admission": "accepted" } });
     globalThis.fetch = async (input, init) => {
       const request = input instanceof Request ? input : new Request(input, init);
       if (request.url.endsWith("/model")) return jsonResponse({ data: {} });
       if (request.url.endsWith("/prompt")) {
-        promptSettled = delay(2_000);
-        await promptSettled;
-        return jsonResponse({ data: {} });
+        dispatched.resolve(request);
+        return admission.promise;
       }
       throw new Error(`Unexpected request: ${request.method} ${request.url}`);
     };
 
     try {
       const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
-      const startedAt = performance.now();
-      const result = await client.session.promptAsync({
+      let settled = false;
+      const pending = client.session.promptAsync({
         sessionID: "ses_prompt",
         model: { providerID: "witness", modelID: "model" },
         parts: [{ type: "text", text: "hello" }],
-      });
-
-      expect(performance.now() - startedAt).toBeLessThan(100);
-      expect(result.response.status).toBe(202);
-      await promptSettled;
+      }).finally(() => { settled = true; });
+      const request = await dispatched.promise;
+      await delay(10);
+      expect(settled).toBe(false);
+      expect(await request.clone().json()).toEqual({ text: "hello" });
+      admission.resolve(response);
+      const result = await pending;
+      expect(result.error).toBeUndefined();
+      expect(result.response).toBe(response);
+      expect(result.response.status).toBe(204);
+      expect(result.request.url).toBe(request.url);
     } finally {
+      admission.resolve(response);
       globalThis.fetch = originalFetch;
     }
   });
@@ -831,50 +1088,119 @@ describe("OpenCode v2 client compatibility", () => {
     }
   });
 
-  test("emits session.error when the dispatched prompt fails", async () => {
+  test.each([400, 409, 500])("returns native prompt admission failure %i to a separate send client", async (status) => {
     const originalFetch = globalThis.fetch;
-    let eventController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const error = { name: "SessionPromptFailed", error: { message: "admission rejected", detail: { retryable: false } } };
+    const response = jsonResponse(error, status);
     globalThis.fetch = async (input, init) => {
       const request = input instanceof Request ? input : new Request(input, init);
       if (request.url.endsWith("/api/event")) {
-        return new Response(new ReadableStream<Uint8Array>({
-          start: (controller) => {
-            eventController = controller;
-          },
-        }), { headers: { "Content-Type": "text/event-stream" } });
+        return new Response("", { headers: { "Content-Type": "text/event-stream" } });
       }
       if (request.url.endsWith("/model")) return jsonResponse({ data: {} });
       if (request.url.endsWith("/prompt")) {
-        await delay(10);
-        return jsonResponse({ error: { message: "provider unavailable" } }, 500);
+        return response;
       }
       throw new Error(`Unexpected request: ${request.method} ${request.url}`);
     };
 
     try {
+      const eventClient = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const subscription = await eventClient.event.subscribe();
       const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
-      const subscription = await client.event.subscribe();
-      const nextEvent = subscription.stream.next();
       const result = await client.session.promptAsync({
         sessionID: "ses_failure",
         model: { providerID: "witness", modelID: "model" },
         parts: [{ type: "text", text: "hello" }],
       });
-      expect(result.response.status).toBe(202);
-
-      expect(await nextEvent).toEqual({
-        done: false,
-        value: {
-          type: "session.error",
-          properties: {
-            sessionID: "ses_failure",
-            error: { name: "UnknownError", data: { message: "provider unavailable" } },
-          },
-        },
-      });
-      eventController?.close();
-      await subscription.stream.return(undefined);
+      expect(result.response).toBe(response);
+      expect(result.error).toEqual(error);
+      expect(result.data).toBeUndefined();
+      expect(result.request.url).toEndWith("/api/session/ses_failure/prompt");
+      expect(await subscription.stream.next()).toEqual({ done: true, value: undefined });
     } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each(["model", "prompt"])("propagates network rejection from %s without fabricating success", async (endpoint) => {
+    const originalFetch = globalThis.fetch;
+    const failure = new TypeError("network unavailable");
+    const paths: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      paths.push(new URL(request.url).pathname);
+      if (request.url.endsWith(`/${endpoint}`)) throw failure;
+      return jsonResponse({ data: {} });
+    };
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      await expect(client.session.promptAsync({
+        sessionID: "ses_failure",
+        model: { providerID: "witness", modelID: "model" },
+        parts: [{ type: "text", text: "hello" }],
+      })).rejects.toBe(failure);
+      expect(paths).toHaveLength(endpoint === "model" ? 1 : 2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("preserves model admission failure and does not dispatch a prompt", async () => {
+    const originalFetch = globalThis.fetch;
+    const error = { name: "ModelNotFound", data: { modelID: "missing" } };
+    const response = jsonResponse(error, 404);
+    const paths: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      paths.push(new URL(request.url).pathname);
+      return response;
+    };
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const result = await client.session.promptAsync({
+        sessionID: "ses_failure",
+        model: { providerID: "witness", modelID: "missing" },
+        parts: [{ type: "text", text: "hello" }],
+      });
+      expect(result.response).toBe(response);
+      expect(result.error).toEqual(error);
+      expect(result.data).toBeUndefined();
+      expect(paths).toEqual(["/opencode2/api/session/ses_failure/model"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each(["model", "prompt"])("propagates abort while waiting for %s admission", async (endpoint) => {
+    const originalFetch = globalThis.fetch;
+    const controller = new AbortController();
+    const dispatched = Promise.withResolvers<Request>();
+    const paths: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      paths.push(new URL(request.url).pathname);
+      if (!request.url.endsWith(`/${endpoint}`)) return jsonResponse({ data: {} });
+      dispatched.resolve(request);
+      return new Promise<Response>((_resolve, reject) => {
+        request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
+      });
+    };
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      const pending = client.session.promptAsync({
+        sessionID: "ses_abort",
+        model: { providerID: "witness", modelID: "model" },
+        parts: [{ type: "text", text: "hello" }],
+      }, { signal: controller.signal });
+      const request = await dispatched.promise;
+      const failure = new DOMException("Cancelled admission", "AbortError");
+      controller.abort(failure);
+      await expect(pending).rejects.toBe(failure);
+      expect(request.signal.aborted).toBe(true);
+      expect(paths).toHaveLength(endpoint === "model" ? 1 : 2);
+    } finally {
+      controller.abort();
       globalThis.fetch = originalFetch;
     }
   });
@@ -1051,7 +1377,7 @@ describe("v2 question forms", () => {
       const client = createClientV2("http://owner.test/opencode2", "/workspace", {});
       const parameters = { sessionID: "ses_side", model: { providerID: "mock", modelID: "model" },
         system: "Main conversation reference: ses_main", parts: [{ type: "text", text: "What is happening?" }] };
-      expect((await client.session.promptAsync(parameters)).response.status).toBe(202);
+      expect((await client.session.promptAsync(parameters)).response.status).toBe(204);
       expect(requests.map((item) => item.method)).toEqual(["POST", "PUT", "POST"]);
       expect(requests[1]).toMatchObject({ path: "/opencode2/api/session/ses_side/instructions/entries/openwork-context", body: { value: parameters.system } });
       expect(requests[2]?.body).toEqual({ text: "What is happening?" });

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -42,6 +42,8 @@ export interface MockAgentWorkload {
   finalReplyChunkSize?: number;
   /** Hold the final response before sending headers, to exercise loading transitions. */
   finalReplyDelayMs?: number;
+  /** Chat Completions: emit a reasoning block before the final answer. */
+  finalReasoning?: string;
   /** Tool calls the agent makes before its final reply; empty answers directly. */
   steps: MockAgentToolStep[];
 }

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { eventually, observeTranscript, spec } from "@openwork/testkit";
-import { streamedMarkdown, streamedMarkdownMarker } from "../worlds/chat.ts";
+import { streamedMarkdown, streamedMarkdownMarker, streamedMarkdownReasoning } from "../worlds/chat.ts";
 
 const test = spec.world(streamedMarkdown, { timeout: 300_000 });
 const prompt = `Write the streamed markdown answer. ${streamedMarkdownMarker}`;
@@ -28,10 +28,11 @@ function expectSettledDocument(visibleText: string) {
 }
 
 test("a streaming answer renders as markdown block by block and settles to the same document", async ({ world, user, probe, step }) => {
-  await using transcript = await observeTranscript(probe, [
-    { role: "user", text: prompt },
+  const entries = [
+    { role: "user", text: prompt } satisfies { role: "user"; text: string },
     ...blockSentinels.map((text): { role: "assistant"; text: string } => ({ role: "assistant", text })),
-  ]);
+  ];
+  await using transcript = await observeTranscript(probe, entries);
   await user.type("composer", prompt);
   await user.click("Run task");
   await user.see({ text: prompt }, { timeoutMs: 2_000 });
@@ -40,7 +41,18 @@ test("a streaming answer renders as markdown block by block and settles to the s
     await user.see({ text: headingText }, { timeoutMs: 90_000 });
     await user.notSee({ text: closingText });
     await user.notSee({ text: "## Streamed" });
+    await user.notSee({ text: streamedMarkdownReasoning });
   });
+
+  await step("sent text and finished blocks stay visible before reloading the active stream", async () => {
+    // The observer belongs to this document and must be verified before navigation.
+    const continuity = await transcript.finish();
+    expect(continuity).toMatchObject({ violations: [], stopped: false, frames: expect.any(Number) });
+    expect(continuity.seen.slice(0, 2)).toEqual([true, true]);
+    await user.notSee({ text: closingText });
+    await user.reload();
+  });
+  await using reloadedTranscript = await observeTranscript(probe, entries);
 
   await step("the settled answer shows every block exactly once and no markdown syntax", async () => {
     await user.see({ text: closingText }, { timeoutMs: 120_000 });
@@ -49,10 +61,18 @@ test("a streaming answer renders as markdown block by block and settles to the s
     await user.see({ text: "alpha list item" });
     await user.see({ text: 'const streamed = "delta";' });
     await user.notSee({ text: /Something went wrong/ });
+    await user.notSee({ text: streamedMarkdownReasoning });
   });
 
-  await step("sent text and streamed blocks never disappear or duplicate", async () => {
-    expect(await transcript.finish()).toMatchObject({
+  await step("the settled reasoning is collapsed and can be inspected separately", async () => {
+    await user.click({ role: "button", label: "Thought" });
+    await user.see({ text: streamedMarkdownReasoning });
+    expect(occurrences(await probe.text(), streamedMarkdownReasoning)).toBe(1);
+    expectSettledDocument(await probe.text());
+  });
+
+  await step("sent text and streamed blocks never disappear or duplicate after reload", async () => {
+    expect(await reloadedTranscript.finish()).toMatchObject({
       seen: [true, ...blockSentinels.map(() => true)],
       violations: [],
       stopped: false,
@@ -83,5 +103,13 @@ test("a streaming answer renders as markdown block by block and settles to the s
       within: 30_000, until: (state) => state?.ready === true,
     });
     expect(video).toMatchObject({ controls: true, paused: true, autoplay: false, error: null });
+    await user.notSee({ text: streamedMarkdownReasoning });
+  });
+
+  await step("reloaded reasoning stays collapsed until inspected separately", async () => {
+    await user.click({ role: "button", label: "Thought" });
+    await user.see({ text: streamedMarkdownReasoning });
+    expect(occurrences(await probe.text(), streamedMarkdownReasoning)).toBe(1);
+    expectSettledDocument(await probe.text());
   });
 });

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -44,6 +44,17 @@ test("a streaming answer renders as markdown block by block and settles to the s
     await user.notSee({ text: streamedMarkdownReasoning });
   });
 
+  await step("live reasoning can be inspected before any reload while the answer is still streaming", async () => {
+    const reasoningControl = { role: "button", label: /^(Thinking…|Thought)$/ } as const;
+    await user.see(reasoningControl);
+    await user.click(reasoningControl);
+    await user.see({ text: streamedMarkdownReasoning });
+    expect(occurrences(await probe.text(), streamedMarkdownReasoning)).toBe(1);
+    await user.notSee({ text: closingText });
+    await user.click(reasoningControl);
+    await user.notSee({ text: streamedMarkdownReasoning });
+  });
+
   await step("sent text and finished blocks stay visible before reloading the active stream", async () => {
     // The observer belongs to this document and must be verified before navigation.
     const continuity = await transcript.finish();

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -2,7 +2,7 @@ import { expect } from "vitest";
 import { eventually, observeTranscript, spec } from "@openwork/testkit";
 import { streamedMarkdown, streamedMarkdownMarker, streamedMarkdownReasoning } from "../worlds/chat.ts";
 
-const test = spec.world(streamedMarkdown, { timeout: 300_000 });
+const test = spec.world(streamedMarkdown, { timeout: 420_000 });
 const prompt = `Write the streamed markdown answer. ${streamedMarkdownMarker}`;
 
 const headingText = "Streamed answer heading";

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -600,7 +600,8 @@ export async function streamedMarkdown(seed: Seed) {
       promptMarker: streamedMarkdownMarker,
       finalReply: streamedMarkdownAnswer,
       finalReasoning: streamedMarkdownReasoning,
-      finalReplyChunkSize: 8,
+      // Leave enough streaming time for the remote UI checks and mid-turn reload.
+      finalReplyChunkSize: 2,
       finalReplyDelayMs: 1500,
       steps: [],
     }],

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -565,6 +565,7 @@ export async function renderCycle(seed: Seed) {
 }
 
 export const streamedMarkdownMarker = "STREAM_MARKDOWN_ANSWER";
+export const streamedMarkdownReasoning = "Preparing the formatted response.";
 /** A multi-block answer: heading, prose, list, table, fenced code, closing prose. */
 export const streamedMarkdownAnswer = [
   "## Streamed answer heading",
@@ -598,6 +599,7 @@ export async function streamedMarkdown(seed: Seed) {
     agentWorkloads: [{
       promptMarker: streamedMarkdownMarker,
       finalReply: streamedMarkdownAnswer,
+      finalReasoning: streamedMarkdownReasoning,
       finalReplyChunkSize: 8,
       finalReplyDelayMs: 1500,
       steps: [],
@@ -612,7 +614,7 @@ export async function streamedMarkdown(seed: Seed) {
         npm: "@ai-sdk/openai-compatible",
         name: "Streamed markdown mock",
         options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-streamed-markdown" },
-        models: { [modelId]: { name: "Streamed markdown model" } },
+        models: { [modelId]: { name: "Streamed markdown model", reasoning: true } },
       },
     },
   });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -600,8 +600,8 @@ export async function streamedMarkdown(seed: Seed) {
       promptMarker: streamedMarkdownMarker,
       finalReply: streamedMarkdownAnswer,
       finalReasoning: streamedMarkdownReasoning,
-      // Leave enough streaming time for the remote UI checks and mid-turn reload.
-      finalReplyChunkSize: 2,
+      // Allow live reasoning inspection over remote CDP before the mid-turn reload.
+      finalReplyChunkSize: 1,
       finalReplyDelayMs: 1500,
       steps: [],
     }],

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -188,6 +188,9 @@ function validateAgentWorkloads(value) {
     if (finalReplyChunkSize !== null && (!Number.isInteger(finalReplyChunkSize) || finalReplyChunkSize < 1)) {
       throw new Error(`agent workload ${promptMarker} finalReplyChunkSize must be a positive integer`);
     }
+    if (workload.finalReasoning !== undefined && typeof workload.finalReasoning !== "string") {
+      throw new Error(`agent workload ${promptMarker} finalReasoning must be a string`);
+    }
     if (workload.latestUserTurn !== undefined && typeof workload.latestUserTurn !== "boolean") {
       throw new Error(`agent workload ${promptMarker} latestUserTurn must be a boolean`);
     }
@@ -213,7 +216,7 @@ function validateAgentWorkloads(value) {
     const finalReplyDelayMs = workload.finalReplyDelayMs ?? 0;
     if (!Number.isInteger(finalReplyDelayMs) || finalReplyDelayMs < 0 || finalReplyDelayMs > 10000)
       throw new Error("finalReplyDelayMs must be between 0 and 10000");
-    return { promptMarker, finalReply, finalReplyFrom: workload.finalReplyFrom, finalReplyChunkSize, finalReplyDelayMs, steps, latestUserTurn: workload.latestUserTurn === true };
+    return { promptMarker, finalReply, finalReplyFrom: workload.finalReplyFrom, finalReplyChunkSize, finalReplyDelayMs, finalReasoning: workload.finalReasoning, steps, latestUserTurn: workload.latestUserTurn === true };
   });
 }
 
@@ -417,6 +420,7 @@ async function handleAgentCompletion(req, res, entry) {
       : workload.finalReply;
     agentStream(res, model, [
       agentChunk(model, { role: "assistant" }),
+      ...(workload.finalReasoning ? [agentChunk(model, { reasoning_content: workload.finalReasoning })] : []),
       ...finalReplyChunks({ ...workload, finalReply }).map((content) => agentChunk(model, { content })),
       agentChunk(model, {}, "stop"),
     ]);

--- a/scripts/mock-oauth-mcp-server.test.mjs
+++ b/scripts/mock-oauth-mcp-server.test.mjs
@@ -172,6 +172,7 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     body: JSON.stringify({ workloads: [{
       promptMarker: "[The user selected @",
       finalReply: "Handoff received",
+      finalReasoning: "Checking the handoff result.",
       steps: [{ tool: "execute_capability", arguments: { ignored: true }, argumentsFrom: "computer-mention" }],
     }] }),
   });
@@ -195,6 +196,26 @@ test("mock OAuth HTML, Basic auth, and errors keep security boundaries", { timeo
     const call = frames.flatMap((frame) => frame.choices[0].delta.tool_calls ?? [])[0];
     assert.deepEqual(JSON.parse(call.function.arguments), { name: "remote-session:create", body: { target, prompt: task } });
   }
+
+  const finalCompletion = await fetch(`${origin}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "handoff-model",
+      messages: [
+        { role: "user", content: "[The user selected @cloud: complete the handoff.]" },
+        { role: "tool", content: "queued", tool_call_id: "call_handoff" },
+      ],
+      tools: [{ type: "function", function: { name: "execute_capability" } }],
+    }),
+  });
+  assert.equal(finalCompletion.status, 200);
+  const finalFrames = (await finalCompletion.text()).split("\n")
+    .filter((line) => line.startsWith("data: {")).map((line) => JSON.parse(line.slice(6)));
+  const deltas = finalFrames.map((frame) => frame.choices[0].delta);
+  assert.deepEqual(deltas.filter((delta) => delta.reasoning_content), [{ reasoning_content: "Checking the handoff result." }]);
+  assert.deepEqual(deltas.filter((delta) => delta.content), [{ content: "Handoff received" }]);
+  assert.ok(deltas.findIndex((delta) => delta.reasoning_content) < deltas.findIndex((delta) => delta.content));
 
   const discoveryWorkload = await fetch(`${origin}/admin/agent-workloads`, {
     method: "POST", headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Summary
Follow-up to #4533. The v2 compatibility layer still discarded supported content and could acknowledge a send before native admission.

- Use kind-specific text/reasoning ordinals consistently during streaming and history hydration. Mixed content no longer shifts text IDs, and explicitly mismatched fragments cannot fall into the latest unrelated stream.
- Translate native reasoning start/delta/end events and persisted reasoning into the existing collapsible reasoning UI, retaining timestamps.
- Preserve native tool-returned files as stable attachments in both live completion and saved history.
- Translate native subagent tool names, input fields, and child-session metadata into the existing task-card/navigation contract without changing unrelated tools.
- Await the native prompt-admission response and return actual HTTP failures or network rejection to the sender. Remove the instance-local synthetic-event queue that could not notify the separately created sync client.

Reconciled with current dev: existing question forms, first-message visibility, Code Mode provenance, and transcript/video coverage are preserved. No engine-version change and no new test files.

## Verification — Incomplete overall; streamed-answer journey Passed
Head: `13f608150a7c43729e2b5f7b858b3143d051d6f7`
Base: `726a73c34f54ca29156871666af6a1510a4328fd`

Passed on the final head:
- `OPENWORK_EVAL_REF=13f608150a7c43729e2b5f7b858b3143d051d6f7 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e streamed-markdown-answer` — exit 0; 1 passed, 0 failed, 0 skipped. Placement: `daytona (daytona CLI authenticated)`. Fresh Den and desktop checked out the exact head and were deleted afterward.
- The journey opens the Thought/Thinking control and verifies reasoning exactly once before any reload while the closing answer is still absent, then collapses it again. It also checks reasoning stays separate after reload, text remains intact through a mid-stream reload, settled/history answer blocks appear exactly once, and existing video behavior remains intact.
- `bun test --isolate apps/app/tests/opencode-v2-adapter.test.ts apps/app/tests/session-sync-tool-parts.test.ts` — exit 0; 65 passed, 0 failed.
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `node --test scripts/mock-oauth-mcp-server.test.mjs` — exit 0; 1 passed, 0 failed.
- `git diff --check` — passed.

An earlier journey run at `26c85ca33` failed because the fixture finished streaming before the reload checkpoint. The mock now emits smaller chunks, and the final-head run passes that same active-stream assertion; no local result was substituted.

Deferred proof: dedicated end-user journeys for tool-returned attachments, child-chat navigation, and rejected prompt admission. Those paths have focused native-contract adapter coverage, not complete UI evidence, so the broader PR verdict remains Incomplete.

Out of scope: retry/stop lifecycle reconciliation, archive support, and external fork discovery. These need their own bounded follow-up rather than expanding this transcript repair. No merge, release, or deployment is requested.

### Review follow-up
The live-reasoning coverage finding is addressed before the first reload. The final-head Daytona run passed all nine steps with zero failures/skips. A preceding run passed live inspection but reached the later reload checkpoint after the mock finished; one-character mock chunks now preserve the active-stream window without removing either assertion.