### PR TITLE
Keep Library controls stable while MCP status loads

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1329,12 +1329,6 @@ export function McpView(props: McpViewProps) {
 
   return (
     <section className="w-full max-w-3xl animate-in fade-in duration-300">
-      {props.mcpStatus ? (
-        <div className="mb-5 whitespace-pre-wrap wrap-break-word rounded-xl border border-dls-border bg-dls-hover px-4 py-3 text-xs text-dls-secondary">
-          {props.mcpStatus}
-        </div>
-      ) : null}
-
       {props.builtInExtensionsDisabled && props.allowManageExtensions ? (
         <div className="mb-5 rounded-xl border border-amber-6 bg-amber-2 px-4 py-3 text-xs text-amber-11">
           Built-in OpenWork extensions are disabled by your organization. Use Show hidden to review blocked built-ins.
@@ -1428,6 +1422,13 @@ export function McpView(props: McpViewProps) {
           ) : null}
         </div>
       </div>
+
+      {/* Async refresh status must not move the Add button or filter controls. */}
+      {props.mcpStatus ? (
+        <div className="mb-5 whitespace-pre-wrap wrap-break-word rounded-xl border border-dls-border bg-dls-hover px-4 py-3 text-xs text-dls-secondary">
+          {props.mcpStatus}
+        </div>
+      ) : null}
 
       <McpQuickConnectSection
         skillCount={skillCount}


### PR DESCRIPTION
Library's asynchronous MCP status could appear between pointer-down and pointer-up, pushing Add and the filter controls down and losing the user's click. Move the existing status message below those controls, above the inventory, so feedback remains visible without moving action targets.

The [September 5 restricted-policy job](https://github.com/different-ai/openwork/actions/runs/33983213474/job/101352075584) exposed this product interaction bug. A clean dev run reproduced the picker timeout. A diagnostic trace then captured “No MCP servers configured yet.” appearing 30 ms after pointer-down and moving Add exactly 62 px while scrollTop stayed 0; pointer-up landed outside the button. Permission behavior was correct.

The final change is limited to the status block's position in `mcp-view.tsx`. Both existing policy journeys and all their positive/negative permission assertions are retained. They cover default restrictions, overlapping team grants, outsider isolation, private skill access, Custom restoration, and member write denial; generic Library coverage cannot replace those boundaries. No click-helper changes, sleeps, retries, weakened assertions, or new test files are included.

## Verification

Final head: `cf1c29e2f2f5a74fe614d5e2602c7116daee1ed1`.

- Fixed-product counterexample: original click timing, both original Team picker checks plus all 12 repeated Library openings passed. This was a temporary diagnostic run (Team selected, default test filtered out), not full-suite proof.
- `OPENWORK_EVAL_REF=cf1c29e2f2f5a74fe614d5e2602c7116daee1ed1 pnpm evals:e2e desktop-policy-restricted-mode --daytona`: **2 passed, 0 failed, 0 skipped**, exit 0, 787.29s. Placement: `daytona (--daytona)`. All 12 screenshots passed review; 39 expectations passed, none failed or pending.
- `OPENWORK_EVAL_REF=cf1c29e2f2f5a74fe614d5e2602c7116daee1ed1 pnpm evals:e2e library-add-connector-discovery --daytona`: **1 passed, 0 failed, 0 skipped**, exit 0, 221.01s. Placement: `daytona (--daytona)`. Both screenshots passed review; all 10 expectations passed, none failed or pending.
- All remote runs explicitly pin `OPENWORK_EVAL_REF` to the tested SHA. Temporary diagnostics are removed from the final tree.

The original `85a5dfccb` product/spec/harness also passed a clean rerun (2 passed, 0 failed, 0 skipped), so the failure is timing-dependent rather than a deterministic policy denial. The verified late status insertion, not a green retry alone, identifies the cause.


## Published evidence

- [Default policy — passed](https://github.com/different-ai/openwork/pull/4566#issuecomment-5560826905)
- [Team policy — passed (part 1)](https://github.com/different-ai/openwork/pull/4566#issuecomment-5560832476)
- [Team policy — passed (part 2)](https://github.com/different-ai/openwork/pull/4566#issuecomment-5560832762)
- [Library connector discovery — passed](https://github.com/different-ai/openwork/pull/4566#issuecomment-5560833020)
