### PR TITLE
ci: make product journey coverage and team alerts readable

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,4 +1,5 @@
-name: OpenWork Tests
+name: Build and core checks
+run-name: ${{ github.event_name == 'schedule' && 'Full regression — component checks' || 'Build and core checks' }}
 
 on:
   pull_request:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -68,6 +68,8 @@ jobs:
         uses: ./.github/actions/setup-tests
       - name: Run core product regressions
         run: pnpm test:core
+      - name: Check journey selection, reporting, and alerts
+        run: node --test evals/scripts/journey-ci.test.mjs evals/scripts/flake-report.test.mjs
 
   openwork-tests-build:
     needs: classify-changes

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -231,22 +231,74 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+  local-handoff:
+    # The profile-permission fault and restart must run beside Electron.
+    # Keep this one journey scheduled even though it cannot use Daytona.
+    if: >-
+      github.repository == 'different-ai/openwork' &&
+      (github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.only == '' || contains('cross-server-handoff-atomic-commit.e2e.test.ts', inputs.only))))
+    name: E2E local (cross-server-handoff-atomic-commit.e2e.test.ts)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-tests
+      - name: Prepare local Den and Electron
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y xvfb x11-utils libgtk-3-0 libnss3 libasound2t64 libgbm1
+          pnpm --filter @openwork/types build
+          pnpm --filter @openwork-ee/den-db build
+          pnpm --filter @openwork/email build
+          pnpm dev:den:mysql
+      - name: Run local handoff journey
+        run: |
+          set -euo pipefail
+          # Permission failures must be real; root would bypass the fault.
+          test "$(id -u)" -ne 0
+          xvfb-run -a pnpm evals:e2e cross-server-handoff-atomic-commit.e2e.test.ts --local 2>&1 | tee /tmp/local-handoff-e2e.log
+      - name: Upload local handoff evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: local-handoff-e2e
+          path: |
+            evals/results/test-runs/
+            /tmp/local-handoff-e2e.log
+          retention-days: 14
+          if-no-files-found: warn
+
   verdict:
     needs:
       - plan
       - e2e
-    if: always() && needs.plan.outputs.enabled == 'true'
+      - local-handoff
+    if: always() && (needs.plan.outputs.enabled == 'true' || needs.local-handoff.result != 'skipped')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Report Daytona E2E verdict
         env:
           E2E_RESULT: ${{ needs.e2e.result }}
+          LOCAL_HANDOFF_RESULT: ${{ needs.local-handoff.result }}
           EVENT_NAME: ${{ github.event_name }}
           HAS_TESTS: ${{ needs.plan.outputs.has_tests }}
         run: |
           set -euo pipefail
 
+          echo "Local handoff E2E result: **$LOCAL_HANDOFF_RESULT**." >> "$GITHUB_STEP_SUMMARY"
+          if [ "$LOCAL_HANDOFF_RESULT" != "success" ] && [ "$LOCAL_HANDOFF_RESULT" != "skipped" ]; then
+            exit 1
+          fi
+          # A manual filter can select only the local journey.
+          if [ "$HAS_TESTS" != "true" ] && [ "$LOCAL_HANDOFF_RESULT" = "success" ]; then
+            exit 0
+          fi
           if [ "$EVENT_NAME" = "workflow_run" ] && [ "$HAS_TESTS" != "true" ]; then
             echo "Warden suggestion: add or update an evals/specs/<feature>.e2e.test.ts test for this PR." >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -188,18 +188,17 @@ jobs:
           OPENWORK_EVAL_MODEL="${MODEL}" pnpm evals:e2e "${SPEC_SLUG}" --daytona 2>&1 | tee /tmp/daytona-e2e.log
           cli_status="${PIPESTATUS[0]}"
           set -e
-          tail -1 /tmp/daytona-e2e.log | jq -r '"- `\(.files[0])`: **\(.verdict)** (\(.placement))"' >> "$GITHUB_STEP_SUMMARY" \
-            || echo "- \`${SPEC_SLUG}\`: CLI exit ${cli_status} (no JSON summary)" >> "$GITHUB_STEP_SUMMARY"
           exit "$cli_status"
 
       - name: Judge deferred vision claims
         id: vision
-        if: steps.run.outcome == 'success'
+        if: success() || failure()
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          EXPECTED_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          pnpm --dir evals evidence:judge -- --test-run latest
+          node evals/scripts/judge-journeys.mjs
 
       - name: Record journey outcome
         if: always()
@@ -207,7 +206,7 @@ jobs:
           SPEC_SLUG: ${{ matrix.journey.spec }}
           JOURNEY_LOG: /tmp/daytona-e2e.log
           EXECUTION: ${{ steps.run.outcome }}
-          VISION: ${{ steps.vision.outcome }}
+          VISION: ${{ steps.vision.outputs.result }}
         run: node evals/scripts/journey-report.mjs record
       - name: Upload journey evidence
         if: always()
@@ -266,17 +265,18 @@ jobs:
           xvfb-run -a pnpm evals:e2e "$SPEC_SLUG" --local 2>&1 | tee /tmp/local-handoff-e2e.log
       - name: Judge deferred vision claims
         id: vision
-        if: steps.run.outcome == 'success'
+        if: success() || failure()
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: pnpm --dir evals evidence:judge -- --test-run latest
+          EXPECTED_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+        run: node evals/scripts/judge-journeys.mjs
       - name: Record journey outcome
         if: always()
         env:
           SPEC_SLUG: ${{ matrix.journey.spec }}
           JOURNEY_LOG: /tmp/local-handoff-e2e.log
           EXECUTION: ${{ steps.run.outcome }}
-          VISION: ${{ steps.vision.outcome }}
+          VISION: ${{ steps.vision.outputs.result }}
         run: node evals/scripts/journey-report.mjs record
       - name: Upload journey evidence
         if: always()

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -307,6 +307,12 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
+      - name: Require a completed coverage plan
+        if: needs.plan.result != 'success' || needs.plan.outputs.enabled != 'true'
+        run: |
+          echo '## Product journeys — not tested' >> "$GITHUB_STEP_SUMMARY"
+          echo 'The coverage plan failed or execution was withheld by the PR authorization checks. See the plan job for the reason; no passing coverage is claimed.' >> "$GITHUB_STEP_SUMMARY"
+          exit 1
       - name: Download selected coverage
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -1,15 +1,16 @@
-# Runs one Daytona E2E spec per job so the testkit owns fresh topology
-# provisioning and each failure has one spec owner. CI does not grep test logs:
-# the evals:e2e exit code is the verdict (0 passed, 1 failed, 2 skipped and
-# therefore Incomplete). The explicit --daytona placement also fails loudly
-# when the Daytona CLI is missing or unauthenticated.
-name: Daytona E2E
+name: Product journeys
+run-name: ${{ github.event_name == 'workflow_run' && 'Critical user journeys' || inputs.suite == 'critical' && 'Critical user journeys' || 'Full regression' }}
 
 on:
   schedule:
     - cron: "0 6,18 * * *"
   workflow_dispatch:
     inputs:
+      suite:
+        description: "Which journeys to exercise"
+        type: choice
+        options: [full, critical]
+        default: full
       only:
         description: "Substring filter on E2E test filenames; empty runs all eligible tests"
         required: false
@@ -25,7 +26,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: daytona-e2e-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: product-journeys-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -38,9 +39,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
-      enabled: ${{ steps.config.outputs.enabled }}
-      tests: ${{ steps.matrix.outputs.tests }}
-      has_tests: ${{ steps.matrix.outputs.has_tests }}
+      enabled: ${{ steps.matrix.outputs.has_daytona != '' }}
+      daytona: ${{ steps.matrix.outputs.daytona }}
+      local: ${{ steps.matrix.outputs.local }}
+      has_daytona: ${{ steps.matrix.outputs.has_daytona }}
+      has_local: ${{ steps.matrix.outputs.has_local }}
+      suite: ${{ steps.matrix.outputs.suite }}
     steps:
       - name: Authorize Warden-cleared pull request
         id: authorize
@@ -71,7 +75,7 @@ jobs:
           fi
 
           guarded="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
-            | grep -E '^(\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
+            | grep -E '^(evals/scripts/|\.github/|warden\.toml$|\.warden/|\.agents/skills/|\.claude/skills/)' || true)"
           if [ -n "$guarded" ]; then
             echo "::notice::E2E regression withheld: PR changes trusted review machinery."
             echo "authorized=false" >> "$GITHUB_OUTPUT"
@@ -79,76 +83,48 @@ jobs:
           fi
           echo "authorized=true" >> "$GITHUB_OUTPUT"
 
-      - name: Check Daytona E2E configuration
-        id: config
-        if: github.event_name != 'workflow_run' || steps.authorize.outputs.authorized == 'true'
-        env:
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -euo pipefail
-
-          missing=""
-          [ -z "${DAYTONA_API_KEY:-}" ] && missing="$missing DAYTONA_API_KEY"
-          [ -z "${OPENAI_API_KEY:-}" ] && missing="$missing OPENAI_API_KEY"
-          if [ -n "$missing" ]; then
-            echo "::notice::Skipping Daytona E2E; missing GitHub configuration:$missing."
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "enabled=true" >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        if: steps.config.outputs.enabled == 'true'
+        if: github.event_name != 'workflow_run' || steps.authorize.outputs.authorized == 'true'
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Build E2E test matrix
+      - name: Select user journeys
         id: matrix
-        if: steps.config.outputs.enabled == 'true'
+        if: github.event_name != 'workflow_run' || steps.authorize.outputs.authorized == 'true'
         env:
           ONLY_FILTER: ${{ inputs.only }}
+          SUITE: ${{ inputs.suite }}
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-
-          raw_desktop="$(node evals/scripts/list-daytona-raw-desktop-tests.mjs)"
-          excluded="$(printf '%s\n' "$raw_desktop" | jq -Rsc 'split("\n") | map(select(length > 0))')"
-          # shellcheck disable=SC2012
-          eligible_tests="$(ls evals/specs/*.e2e.test.ts | sed 's#^evals/specs/##' | jq -Rsc --argjson excluded "$excluded" 'split("\n") | map(select(length > 0)) | map(select(. as $test | $excluded | index($test) | not))')"
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            matched_tests="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" | { grep -E '^evals/specs/[^/]+\.e2e\.test\.ts$' || true; } | sed 's#^evals/specs/##' | jq -Rsc 'split("\n") | map(select(length > 0))')"
-            only_filter=""
-          else
-            matched_tests='[]'
-            only_filter="$ONLY_FILTER"
+            git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" | jq -Rsc 'split("\n") | map(select(length > 0))' > /tmp/journey-changes.json
+            export CHANGED_FILES=/tmp/journey-changes.json
           fi
-
-          tests="$(echo "$eligible_tests" | jq -c --arg event "$EVENT_NAME" --arg only "$only_filter" --argjson matched "$matched_tests" 'map(select(if $event == "workflow_run" then (. as $test | ($matched | index($test)) != null) else ($only == "" or contains($only)) end))')"
-          count="$(echo "$tests" | jq 'length')"
-          has_tests=false
-          if [ "$count" -gt 0 ]; then
-            has_tests=true
-          fi
-          echo "tests=$tests" >> "$GITHUB_OUTPUT"
-          echo "has_tests=$has_tests" >> "$GITHUB_OUTPUT"
-          echo "### Daytona E2E plan: $count spec(s)" >> "$GITHUB_STEP_SUMMARY"
-          echo "$tests" | jq -r '.[] | "- `\(.)`"' >> "$GITHUB_STEP_SUMMARY"
+          node --test evals/scripts/journey-ci.test.mjs
+          node evals/scripts/plan-journeys.mjs
+      - name: Save selected coverage
+        if: steps.matrix.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: journey-plan
+          path: journey-plan/plan.json
+          retention-days: 14
 
   e2e:
     needs: plan
-    if: needs.plan.outputs.enabled == 'true' && needs.plan.outputs.has_tests == 'true'
-    name: E2E (${{ matrix.spec }})
+    if: needs.plan.outputs.has_daytona == 'true'
+    name: Journey — ${{ matrix.journey.name }}
     environment: ${{ github.event_name == 'workflow_run' && 'pr-slow-specs' || 'scheduled-e2e-regression' }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        spec: ${{ fromJSON(needs.plan.outputs.tests) }}
+        journey: ${{ fromJSON(needs.plan.outputs.daytona) }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
@@ -197,11 +173,13 @@ jobs:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           NIGHTLY_MODEL: ${{ vars.OPENWORK_EVAL_NIGHTLY_MODEL }}
-          SPEC_SLUG: ${{ matrix.spec }}
+          SPEC_SLUG: ${{ matrix.journey.spec }}
+          MODEL_KIND: ${{ matrix.journey.model }}
+          OPENWORK_EVAL_REF: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
         run: |
           set -euo pipefail
 
-          if [ "$SPEC_SLUG" = "org-team-lifecycle-critical-path.e2e.test.ts" ]; then
+          if [ "$MODEL_KIND" = "live" ]; then
             MODEL="${NIGHTLY_MODEL:-gpt-5.6-luna}"
           else
             MODEL="big-pickle"
@@ -215,6 +193,7 @@ jobs:
           exit "$cli_status"
 
       - name: Judge deferred vision claims
+        id: vision
         if: steps.run.outcome == 'success'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -222,29 +201,49 @@ jobs:
           set -euo pipefail
           pnpm --dir evals evidence:judge -- --test-run latest
 
-      - name: Upload E2E test artifacts
+      - name: Record journey outcome
+        if: always()
+        env:
+          SPEC_SLUG: ${{ matrix.journey.spec }}
+          JOURNEY_LOG: /tmp/daytona-e2e.log
+          EXECUTION: ${{ steps.run.outcome }}
+          VISION: ${{ steps.vision.outcome }}
+        run: node evals/scripts/journey-report.mjs record
+      - name: Upload journey evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: daytona-e2e-${{ strategy.job-index }}
-          path: evals/results/test-runs/
+          name: journey-evidence-${{ matrix.journey.spec }}
+          path: |
+            evals/results/test-runs/
+            /tmp/daytona-e2e.log
           retention-days: 14
-          if-no-files-found: ignore
+          if-no-files-found: warn
+      - name: Save journey result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: journey-result-${{ matrix.journey.spec }}
+          path: journey-result.json
+          retention-days: 14
+          if-no-files-found: warn
 
-  local-handoff:
-    # The profile-permission fault and restart must run beside Electron.
-    # Keep this one journey scheduled even though it cannot use Daytona.
-    if: >-
-      github.repository == 'different-ai/openwork' &&
-      (github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' &&
-      (inputs.only == '' || contains('cross-server-handoff-atomic-commit.e2e.test.ts', inputs.only))))
-    name: E2E local (cross-server-handoff-atomic-commit.e2e.test.ts)
+  local-journey:
+    needs: plan
+    if: needs.plan.outputs.has_local == 'true'
+    name: Journey — ${{ matrix.journey.name }}
+    environment: ${{ github.event_name == 'workflow_run' && 'pr-slow-specs' || 'scheduled-e2e-regression' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        journey: ${{ fromJSON(needs.plan.outputs.local) }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-tests
       - name: Prepare local Den and Electron
@@ -256,54 +255,77 @@ jobs:
           pnpm --filter @openwork-ee/den-db build
           pnpm --filter @openwork/email build
           pnpm dev:den:mysql
-      - name: Run local handoff journey
+      - name: Run user journey
+        id: run
+        env:
+          SPEC_SLUG: ${{ matrix.journey.spec }}
         run: |
           set -euo pipefail
           # Permission failures must be real; root would bypass the fault.
           test "$(id -u)" -ne 0
-          xvfb-run -a pnpm evals:e2e cross-server-handoff-atomic-commit.e2e.test.ts --local 2>&1 | tee /tmp/local-handoff-e2e.log
-      - name: Upload local handoff evidence
+          xvfb-run -a pnpm evals:e2e "$SPEC_SLUG" --local 2>&1 | tee /tmp/local-handoff-e2e.log
+      - name: Judge deferred vision claims
+        id: vision
+        if: steps.run.outcome == 'success'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: pnpm --dir evals evidence:judge -- --test-run latest
+      - name: Record journey outcome
+        if: always()
+        env:
+          SPEC_SLUG: ${{ matrix.journey.spec }}
+          JOURNEY_LOG: /tmp/local-handoff-e2e.log
+          EXECUTION: ${{ steps.run.outcome }}
+          VISION: ${{ steps.vision.outcome }}
+        run: node evals/scripts/journey-report.mjs record
+      - name: Upload journey evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: local-handoff-e2e
+          name: journey-evidence-${{ matrix.journey.spec }}
           path: |
             evals/results/test-runs/
             /tmp/local-handoff-e2e.log
           retention-days: 14
           if-no-files-found: warn
+      - name: Save journey result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: journey-result-${{ matrix.journey.spec }}
+          path: journey-result.json
+          retention-days: 14
+          if-no-files-found: warn
 
   verdict:
-    needs:
-      - plan
-      - e2e
-      - local-handoff
-    if: always() && (needs.plan.outputs.enabled == 'true' || needs.local-handoff.result != 'skipped')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    name: ${{ needs.plan.outputs.suite || 'Product journeys' }}
+    needs: [plan, e2e, local-journey]
+    if: always()
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Report Daytona E2E verdict
-        env:
-          E2E_RESULT: ${{ needs.e2e.result }}
-          LOCAL_HANDOFF_RESULT: ${{ needs.local-handoff.result }}
-          EVENT_NAME: ${{ github.event_name }}
-          HAS_TESTS: ${{ needs.plan.outputs.has_tests }}
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Download selected coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: journey-plan
+          path: journey-plan
+      - name: Download outcomes
+        uses: actions/download-artifact@v4
+        with:
+          pattern: journey-result-*
+          path: journey-results
+      - name: Report verified coverage
         run: |
-          set -euo pipefail
-
-          echo "Local handoff E2E result: **$LOCAL_HANDOFF_RESULT**." >> "$GITHUB_STEP_SUMMARY"
-          if [ "$LOCAL_HANDOFF_RESULT" != "success" ] && [ "$LOCAL_HANDOFF_RESULT" != "skipped" ]; then
-            exit 1
-          fi
-          # A manual filter can select only the local journey.
-          if [ "$HAS_TESTS" != "true" ] && [ "$LOCAL_HANDOFF_RESULT" = "success" ]; then
-            exit 0
-          fi
-          if [ "$EVENT_NAME" = "workflow_run" ] && [ "$HAS_TESTS" != "true" ]; then
-            echo "Warden suggestion: add or update an evals/specs/<feature>.e2e.test.ts test for this PR." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          echo "Daytona E2E matrix result: **$E2E_RESULT**." >> "$GITHUB_STEP_SUMMARY"
-          if [ "$E2E_RESULT" != "success" ]; then
-            exit 1
-          fi
+          mkdir -p journey-results
+          node evals/scripts/journey-report.mjs
+      - name: Save readable report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: journey-report
+          path: journey-report.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -105,7 +105,6 @@ jobs:
             git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" | jq -Rsc 'split("\n") | map(select(length > 0))' > /tmp/journey-changes.json
             export CHANGED_FILES=/tmp/journey-changes.json
           fi
-          node --test evals/scripts/journey-ci.test.mjs
           node evals/scripts/plan-journeys.mjs
       - name: Save selected coverage
         if: steps.matrix.outcome == 'success'

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -309,12 +309,12 @@ jobs:
           echo 'The coverage plan failed or execution was withheld by the PR authorization checks. See the plan job for the reason; no passing coverage is claimed.' >> "$GITHUB_STEP_SUMMARY"
           exit 1
       - name: Download selected coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: journey-plan
           path: journey-plan
       - name: Download outcomes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: journey-result-*
           path: journey-results

--- a/.github/workflows/daytona-e2e.yml
+++ b/.github/workflows/daytona-e2e.yml
@@ -184,11 +184,7 @@ jobs:
           else
             MODEL="big-pickle"
           fi
-          set +e
           OPENWORK_EVAL_MODEL="${MODEL}" pnpm evals:e2e "${SPEC_SLUG}" --daytona 2>&1 | tee /tmp/daytona-e2e.log
-          cli_status="${PIPESTATUS[0]}"
-          set -e
-          exit "$cli_status"
 
       - name: Judge deferred vision claims
         id: vision
@@ -300,7 +296,7 @@ jobs:
   verdict:
     name: ${{ needs.plan.outputs.suite || 'Product journeys' }}
     needs: [plan, e2e, local-journey]
-    if: always()
+    if: always() && needs.plan.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/e2e-test-failure-alerts.yml
+++ b/.github/workflows/e2e-test-failure-alerts.yml
@@ -1,95 +1,42 @@
-# Opens a developer-facing issue when a scheduled E2E workflow fails or times out.
-# Set E2E_TEST_ALERT_MENTION to route alerts to a GitHub team instead of the
-# developer who triggered the run.
-name: E2E Test Failure Alerts
+name: Test alerts
 
 on:
   workflow_run:
-    workflows:
-      - Daytona E2E
-      - Nightly Flake Report
-    types:
-      - completed
+    workflows: [Product journeys, Build and core checks, Test reliability]
+    types: [completed]
 
 permissions:
   actions: read
   contents: read
-  issues: write
+
+concurrency:
+  group: test-alerts-${{ github.event.workflow_run.workflow_id }}
+  cancel-in-progress: false
 
 jobs:
   notify:
-    if: >-
-      github.repository == 'different-ai/openwork' &&
-      (github.event.workflow_run.conclusion == 'failure' ||
-      github.event.workflow_run.conclusion == 'timed_out')
+    if: github.repository == 'different-ai/openwork' && github.event.workflow_run.event == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-      - name: Notify developers
-        shell: bash
+      # Execute trusted default-branch code, never code/artifacts from a PR.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+      - name: Report failures or recovery to the team
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}
-          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_NAME: ${{ github.event.workflow_run.name }}
-          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          ALERT_MENTION: ${{ vars.E2E_TEST_ALERT_MENTION }}
-        run: |
-          set -euo pipefail
-
-          case "$RUN_NAME" in
-            "Daytona E2E") issue_title="Daytona E2E failed" ;;
-            "Nightly Flake Report") issue_title="Nightly flake report found unreliable specs" ;;
-            *) echo "Unexpected workflow: $RUN_NAME" >&2; exit 1 ;;
-          esac
-
-          gh label create e2e-test-failure \
-            --color B60205 \
-            --description "Automated E2E test workflow failures" \
-            --force
-
-          issue_number="$(gh issue list \
-            --state open \
-            --search "\"$issue_title\" in:title" \
-            --json number,title \
-            --jq "map(select(.title == \"$issue_title\"))[0].number // empty")"
-
-          if [ -z "$issue_number" ]; then
-            issue_url="$(gh issue create \
-              --title "$issue_title" \
-              --label e2e-test-failure \
-              --body "This issue tracks failures from the **$RUN_NAME** workflow. Each failed run is posted as a comment.")"
-            issue_number="${issue_url##*/}"
-          else
-            gh issue edit "$issue_number" --add-label e2e-test-failure
-          fi
-
-          mention="${ALERT_MENTION:-@$RUN_ACTOR}"
-          failed_jobs="$(gh api --paginate "repos/$GH_REPO/actions/runs/$RUN_ID/jobs" \
-            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | "- [\(.name)](\(.html_url))"')"
-
-          {
-            echo "$mention, **$RUN_NAME** completed with \`$RUN_CONCLUSION\`."
-            echo
-            echo "- Run: [$RUN_ID (attempt $RUN_ATTEMPT)]($RUN_URL)"
-            echo "- Branch: \`$RUN_BRANCH\`"
-            echo "- Commit: \`$RUN_SHA\`"
-            echo
-            echo "### Failed jobs"
-            echo
-            if [ -n "$failed_jobs" ]; then
-              echo "$failed_jobs"
-            else
-              echo "No failed job metadata was returned. Open the workflow run for details."
-            fi
-          } > "$RUNNER_TEMP/e2e-test-failure.md"
-
-          gh issue comment "$issue_number" --body-file "$RUNNER_TEMP/e2e-test-failure.md"
-          gh issue edit "$issue_number" --add-assignee "$RUN_ACTOR" || true
-          echo "Developer alert: $GITHUB_SERVER_URL/$GH_REPO/issues/$issue_number" >> "$GITHUB_STEP_SUMMARY"
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_TEST_ALERT_CHANNEL_ID: ${{ vars.SLACK_TEST_ALERT_CHANNEL_ID }}
+          SLACK_TEST_ALERT_TEAM_ID: ${{ vars.SLACK_TEST_ALERT_TEAM_ID }}
+        run: node evals/scripts/notify-journeys.mjs
+      - name: Preserve incident thread for the next scheduled run
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: test-alert-state-${{ github.event.workflow_run.workflow_id }}
+          path: alert-state/state.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/nightly-flake-report.yml
+++ b/.github/workflows/nightly-flake-report.yml
@@ -3,7 +3,7 @@
 # the report to the run summary and artifacts, and fails when any spec is
 # flaky or below the pass-rate threshold so the failure-alert workflow files
 # a developer-facing issue.
-name: Nightly Flake Report
+name: Test reliability
 
 on:
   schedule:

--- a/docs/product-journeys-ci.md
+++ b/docs/product-journeys-ci.md
@@ -1,0 +1,101 @@
+# What our automated checks prove
+
+| Check | Question | Trigger |
+| --- | --- | --- |
+| Build and core checks | Does the app build, and do foundational behaviors work? | Pull requests and pushes to dev |
+| Critical user journeys | Can users start the app, set up a team, apply permissions, and recover a server switch? | Eligible Warden-cleared PRs, or manual critical selection |
+| Full regression | Do all supported automatic journeys work together? | 06:00 and 18:00 UTC, or manual full selection |
+| Full regression — component checks | Do broader Linux/macOS component, PR, and engine checks pass? | Nightly at 07:37 UTC |
+| Test reliability | Are repeated PR-suite results consistent? | Nightly at 04:17 UTC |
+
+GitHub Actions coordinates the checks. Daytona provides isolated environments
+for most journeys; local jobs run on the isolated CI computer itself, not a
+teammate's laptop. Both environments contribute to one Product journeys verdict.
+The existing workflow filenames and build-check job IDs stay stable for API
+consumers and branch rules; visible workflow names describe their purpose.
+
+## Selection and coverage
+
+`evals/scripts/journey-catalog.mjs` owns readable names, critical membership,
+model requirements, and execution placement. New `evals/specs/*.e2e.test.ts`
+files automatically enter full regression. Existing raw-desktop specs remain
+manual-only unless explicitly supported in the catalog. Every plan lists those
+coverage gaps; “full regression passed” means all selected automatic coverage,
+not every possible scenario or every manual test.
+
+The four critical specs cover startup, the two-person team lifecycle (including
+real model/skill use), default/team permissions, and atomic enrollment recovery.
+PR selection runs this whole set plus any additional changed journey files.
+It no longer relies on the author changing a test file to exercise critical
+behavior. Existing Warden authorization, same-repository restrictions, head-SHA
+checks, protected review-machinery guards, and GitHub environment approvals remain.
+Changes to the CI scripts themselves also require scheduled/manual validation.
+A withheld plan does not silently receive a passing coverage report.
+
+A manual run chooses `suite=full` or `suite=critical`, with an optional filename
+substring `only`. An unmatched filter fails instead of reporting a green empty
+run. Both the test checkout and remote product are pinned to the selected SHA.
+
+The initial critical group is an explicit starting set, not a claim of a measured
+PR latency budget. Inspect run durations before enlarging it. No branch rules
+are changed by this PR: making the critical verdict a required merge gate needs
+an intentional branch-rule update after observing this workflow in use.
+
+## Read the result
+
+The summary counts **spec files**, each of which may contain multiple tests.
+
+- **Passed:** actual tests passed with no skips and the evidence judging step
+  completed successfully.
+- **Failed:** the runner recorded a failing test or evidence judgment failed.
+  This still requires investigation: the product, test, or fixture can be at fault.
+- **Not tested:** setup failed, tests skipped, the result is missing, or execution
+  or evidence validation was incomplete. It never counts as passed.
+
+The plan, small machine-readable results, final report, raw logs, and test
+artifacts are attached to the run. A failure in one job doesn't cancel the rest.
+Results describe the tested revision; a new commit requires new verification.
+
+## Slack configuration
+
+1. Create a Slack app with bot scope `chat:write`, install it in the workspace,
+   and invite the bot to the team's test-alert channel.
+2. In GitHub repository Settings → Secrets and variables → Actions, create secret
+   `SLACK_BOT_TOKEN` with that bot token.
+3. Create variable `SLACK_TEST_ALERT_CHANNEL_ID` with the channel's ID.
+4. Optionally set `SLACK_TEST_ALERT_TEAM_ID` to the Slack user-group ID (for example,
+   `S0123456`). New failures mention that group; recurring failures don't.
+
+Use Slack's [chat.postMessage setup](https://docs.slack.dev/reference/methods/chat.postMessage/).
+Keep tokens in Actions secrets, not repository files or PR comments.
+No live Slack delivery is verified until these credentials are configured.
+
+Only completed **scheduled** runs notify. Healthy runs are quiet. An incident
+starts one channel message; following failures reply in its thread, with critical
+journey status and a run link. New failures mention the configured team. One
+recovery reply closes the incident; the next healthy run stays quiet.
+Component and reliability runs each have their own incident thread because they
+exercise different checks; they use job-level results rather than claiming
+journey assertion counts. Their reports are linked from the same Slack channel.
+
+The notifier retains incident state in Actions artifacts for up to 90 days,
+refreshed on successful notifier runs. Older/out-of-order results don't overwrite
+newer state. If state expires or is deleted, a subsequent failure starts a fresh
+thread. Slack delivery and artifact persistence are separate operations: a crash
+between them can duplicate a message on retry. This is not exactly-once delivery.
+Missing credentials or a Slack error fail the notification job visibly; they do
+not mark an alert delivered or generate fallback issue-comment spam.
+
+The former automatic failure-issue comments and repeated assignee changes are
+removed. Existing issues remain available; this workflow doesn't close them.
+Vercel's deployment comments are independent: disable them in that project's Git
+settings or remove Slack comment subscriptions if the channel still receives them.
+
+## Verify this plumbing
+
+Run `node --test evals/scripts/journey-ci.test.mjs` for selection, result handling,
+threading, recovery, escaping, and failed-delivery checks. These are infrastructure
+checks, not substitutes for the actual product journeys. Dispatch Product journeys
+on the pushed branch with `suite=critical` to exercise all four existing specs and
+inspect both the uploaded report and their real assertions. No Slack messages are
+sent by manual validation runs.

--- a/docs/product-journeys-ci.md
+++ b/docs/product-journeys-ci.md
@@ -95,7 +95,8 @@ settings or remove Slack comment subscriptions if the channel still receives the
 
 Run `node --test evals/scripts/journey-ci.test.mjs` for selection, result handling,
 threading, recovery, escaping, and failed-delivery checks. These are infrastructure
-checks, not substitutes for the actual product journeys. Dispatch Product journeys
-on the pushed branch with `suite=critical` to exercise all four existing specs and
+checks, not substitutes for the actual product journeys. They also run in the
+normal PR core-check job. Dispatch Product journeys on the pushed branch with
+`suite=critical` to exercise all four existing specs and
 inspect both the uploaded report and their real assertions. No Slack messages are
 sent by manual validation runs.

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -38,6 +38,24 @@ export async function evalIn(
   });
 }
 
+/** Quit through Chromium before disposing a surface. Process-group signals
+ * are cleanup, not a user quit: they can lose pending localStorage writes.
+ * Matches the graceful restart used by the updater-channel journey. */
+export async function quitDesktop(app: Surface): Promise<void> {
+  await app.client.send("Browser.close").catch((error: unknown) => {
+    if (!/CDP websocket (?:failed|closed)/i.test(messageText(error))) throw error;
+  });
+  const deadline = Date.now() + DEFAULT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const stopped = await fetch(`${app.handle.cdpUrl.replace(/\/$/, "")}/json/version`, {
+      signal: AbortSignal.timeout(1_000),
+    }).then(() => false, () => true);
+    if (stopped) return;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error("Desktop did not quit within 30000ms.");
+}
+
 async function timeoutError(app: Surface, message: string): Promise<Error> {
   return new Error(`${message} On screen: ${await dumpScreenState(app)}.`);
 }

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -1,4 +1,4 @@
-export { control, createDesktopHandoffGrant, evalIn, signInDesktopAs } from "@openwork/behaviors";
+export { control, createDesktopHandoffGrant, evalIn, quitDesktop, signInDesktopAs } from "@openwork/behaviors";
 export { requestDenLoopback } from "@openwork/labs";
 export { desktop as relaunchDesktop, electronProfilePaths } from "@openwork/hosts";
 export type { DesktopHandle } from "@openwork/hosts";

--- a/evals/scripts/journey-catalog.mjs
+++ b/evals/scripts/journey-catalog.mjs
@@ -1,0 +1,33 @@
+import { readdir, readFile } from 'node:fs/promises';
+
+// One home for CI grouping, readable names, and execution requirements.
+// Unlisted specs are discovered automatically as full-regression journeys.
+const definitions = {
+  'app-smoke.e2e.test.ts': { name: 'Open a working desktop', critical: true },
+  'org-team-lifecycle-critical-path.e2e.test.ts': { name: 'Set up a working two-person team', critical: true, model: 'live' },
+  'desktop-policy-restricted-mode.e2e.test.ts': { name: 'Apply organization and team permissions', critical: true },
+  'cross-server-handoff-atomic-commit.e2e.test.ts': { name: 'Switch servers and recover enrollment', critical: true, placement: 'local' },
+};
+
+export async function catalog(root = new URL('../specs/', import.meta.url)) {
+  const files = (await readdir(root)).filter(file => file.endsWith('.e2e.test.ts')).sort();
+  for (const file of Object.keys(definitions)) {
+    if (!files.includes(file)) throw new Error(`Registered journey missing: ${file}`);
+  }
+  return Promise.all(files.map(async spec => {
+    const source = await readFile(new URL(spec, root), 'utf8');
+    const rawDesktop = /import\s*\{[^}]*\bdesktop\b[^}]*\}\s*from\s*["']@openwork\/hosts["']/s.test(source);
+    return {
+      spec,
+      name: spec.replace('.e2e.test.ts', '').replaceAll('-', ' '),
+      critical: false,
+      model: 'mock',
+      placement: rawDesktop ? 'manual' : 'daytona',
+      ...definitions[spec],
+    };
+  }));
+}
+
+export function selectJourneys(entries, { critical = false, only = '', changed = [] } = {}) {
+  return entries.filter(entry => (!critical || entry.critical || changed.includes(entry.spec)) && entry.spec.includes(only));
+}

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { catalog, selectJourneys } from './journey-catalog.mjs';
+import { aggregate, classify, markdown } from './journey-report.mjs';
+import { notification, deliver, validateReport } from './notify-journeys.mjs';
+
+const summary = { command: 'evals:e2e', verdict: 'passed', passed: 1, failed: 0, skipped: 0 };
+const entry = { spec: 'permissions.e2e.test.ts', name: 'Apply permissions', critical: true, placement: 'daytona' };
+const plan = { suite: 'Full regression', entries: [entry], manual: [] };
+const run = { name: 'Product journeys', run_number: 10, run_attempt: 1, html_url: 'https://github.com/different-ai/openwork/actions/runs/10' };
+const report = status => validateReport({ entries: [{ ...entry, status }] });
+
+test('critical PR selection includes existing critical journeys even when only product source changes', async () => {
+  const entries = await catalog();
+  const selected = selectJourneys(entries, { critical: true, changed: ['apps/app/src/view.tsx'] });
+  assert.equal(selected.length, 4);
+  assert(selected.some(value => value.placement === 'local'));
+  assert(selected.some(value => value.model === 'live'));
+  assert(selected.every(value => value.critical));
+});
+
+test('changed additional journey joins critical selection; manual filters work for either placement', async () => {
+  const entries = await catalog();
+  const extra = entries.find(value => !value.critical && value.placement === 'daytona');
+  assert(selectJourneys(entries, { critical: true, changed: [extra.spec] }).includes(extra));
+  const handoff = selectJourneys(entries, { only: 'cross-server-handoff-atomic-commit' });
+  assert.equal(handoff.length, 1);
+  assert.equal(handoff[0].placement, 'local');
+  assert.equal(selectJourneys(entries, { only: 'does-not-exist' }).length, 0);
+});
+
+test('skips, no tests, missing summaries, setup and judging failures never pass', () => {
+  assert.equal(classify(summary, 'success', 'success'), 'passed');
+  assert.equal(classify({ ...summary, skipped: 1 }, 'success', 'success'), 'not tested');
+  assert.equal(classify({ ...summary, passed: 0 }, 'success', 'success'), 'not tested');
+  assert.equal(classify(undefined, 'failure', 'skipped'), 'not tested');
+  assert.equal(classify(summary, 'failure', 'success'), 'not tested');
+  assert.equal(classify(summary, 'success', 'skipped'), 'not tested');
+  assert.equal(classify(summary, 'success', 'failure'), 'failed');
+  assert.equal(classify({ ...summary, failed: 1 }, 'failure', 'skipped'), 'failed');
+});
+
+test('missing or duplicate result cannot turn a selected journey green', () => {
+  for (const results of [[], [{ spec: entry.spec, status: 'passed' }, { spec: entry.spec, status: 'passed' }]]) {
+    const output = aggregate(plan, results);
+    assert.equal(output.ok, false);
+    assert.equal(output.counts['not tested'], 1);
+    assert.match(markdown(output), /Critical journeys: action needed/);
+  }
+  const output = aggregate(plan, [{ spec: entry.spec, status: 'passed' }]);
+  assert.equal(output.ok, true);
+  assert.match(markdown(output), /Critical journeys: all passed/);
+});
+
+test('notification distinguishes new failure, repeat, recovery and healthy run', () => {
+  const first = notification(undefined, run, report('failed'), 'S123');
+  assert.match(first.message.text, /<!subteam\^S123>/);
+  assert.match(first.message.text, /Critical journeys: \*ACTION NEEDED\*/);
+  assert.equal(first.message.thread_ts, undefined);
+  const previous = { ...first.state, thread: '123.456' };
+  const repeat = notification(previous, { ...run, run_number: 11 }, report('failed'), 'S123');
+  assert.equal(repeat.message.thread_ts, '123.456');
+  assert.doesNotMatch(repeat.message.text, /<!subteam/);
+  const recovered = notification(repeat.state, { ...run, run_number: 12 }, report('passed'), 'S123');
+  assert.match(recovered.message.text, /Recovered/);
+  assert.equal(recovered.message.thread_ts, '123.456');
+  assert.equal(recovered.state.thread, undefined);
+  assert.equal(notification(recovered.state, { ...run, run_number: 13 }, report('passed')).message, null);
+  assert.equal(notification(undefined, run, report('passed')).message, null);
+});
+
+test('older runs and identical reruns do not regress incident state', () => {
+  const previous = { sequence: [11, 1], failures: [], thread: undefined };
+  assert.equal(notification(previous, run, report('failed')).message, null);
+  assert.equal(notification(previous, { ...run, run_number: 11 }, report('failed')).message, null);
+  assert(notification(previous, { ...run, run_number: 11, run_attempt: 2 }, report('failed')).message);
+});
+
+test('not tested remains actionable and untrusted names cannot mention Slack users', () => {
+  const output = notification(undefined, run, validateReport({ entries: [{ ...entry, name: '<!channel>', status: 'not tested' }] }));
+  assert.match(output.message.text, /1 not tested/);
+  assert.doesNotMatch(output.message.text, /Recovered/);
+  assert.match(output.message.text, /&lt;!channel&gt;/);
+  assert.throws(() => validateReport({ entries: [] }));
+  assert.throws(() => validateReport({ entries: [{ ...entry, status: 'green-ish' }] }));
+});
+
+test('Slack delivery carries thread and state only advances after accepted response', async () => {
+  let requestBody;
+  const options = { token: 'test-token', channel: 'C123', teamId: 'S123', request: async (url, options) => {
+    assert.equal(url, 'https://slack.com/api/chat.postMessage');
+    requestBody = JSON.parse(options.body);
+    return { ok: true, json: async () => ({ ok: true, ts: '123.456' }) };
+  } };
+  const state = await deliver(undefined, run, report('failed'), options);
+  assert.equal(state.thread, '123.456');
+  assert.equal(requestBody.channel, 'C123');
+  await deliver(state, { ...run, run_number: 11 }, report('failed'), options);
+  assert.equal(requestBody.thread_ts, '123.456');
+  await assert.rejects(() => deliver(state, { ...run, run_number: 12 }, report('passed'), {
+    ...options, request: async () => ({ ok: true, json: async () => ({ ok: false, error: 'not_in_channel' }) }),
+  }), /not_in_channel/);
+  assert.equal(state.failures.length, 1);
+});

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -1,4 +1,8 @@
 import test from 'node:test';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { judgeJourneys } from './judge-journeys.mjs';
 import assert from 'node:assert/strict';
 import { catalog, selectJourneys } from './journey-catalog.mjs';
 import { aggregate, classify, markdown } from './journey-report.mjs';
@@ -104,4 +108,30 @@ test('Slack delivery carries thread and state only advances after accepted respo
     ...options, request: async () => ({ ok: true, json: async () => ({ ok: false, error: 'not_in_channel' }) }),
   }), /not_in_channel/);
   assert.equal(state.failures.length, 1);
+});
+
+
+test('every journey record is judged; the last passing test cannot hide earlier failure or pending evidence', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'journey-evidence-'));
+  try {
+    for (const name of ['first', 'second']) {
+      await mkdir(join(root, name));
+      await writeFile(join(root, name, 'test-run.json'), JSON.stringify({ gitSha: 'expected' }));
+    }
+    const visited = [];
+    assert.deepEqual(await judgeJourneys(root, 'expected', path => { visited.push(path); return path.endsWith('first') ? 1 : 0; }), { count: 2, result: 'failure' });
+    assert.equal(visited.length, 2);
+    assert.deepEqual(await judgeJourneys(root, 'expected', path => path.endsWith('first') ? 2 : 0), { count: 2, result: 'incomplete' });
+    assert.deepEqual(await judgeJourneys(root, 'expected', () => 0), { count: 2, result: 'success' });
+    assert.deepEqual(await judgeJourneys(root, 'wrong-sha', () => { throw new Error('must not judge mismatched evidence'); }), { count: 0, result: 'incomplete' });
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test('missing evidence and a different executed spec are not passing coverage', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'journey-empty-'));
+  try {
+    assert.deepEqual(await judgeJourneys(root, 'expected'), { count: 0, result: 'incomplete' });
+    assert.equal(classify({ ...summary, files: ['other.e2e.test.ts'] }, 'success', 'success', entry.spec), 'not tested');
+    assert.equal(classify({ ...summary, files: [entry.spec] }, 'success', 'success', entry.spec), 'passed');
+  } finally { await rm(root, { recursive: true, force: true }); }
 });

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -97,6 +97,9 @@ test('Slack delivery carries thread and state only advances after accepted respo
   assert.equal(requestBody.channel, 'C123');
   await deliver(state, { ...run, run_number: 11 }, report('failed'), options);
   assert.equal(requestBody.thread_ts, '123.456');
+  await deliver(state, { ...run, run_number: 12 }, report('failed'), { ...options, channel: 'C456' });
+  assert.equal(requestBody.channel, 'C456');
+  assert.equal(requestBody.thread_ts, undefined);
   await assert.rejects(() => deliver(state, { ...run, run_number: 12 }, report('passed'), {
     ...options, request: async () => ({ ok: true, json: async () => ({ ok: false, error: 'not_in_channel' }) }),
   }), /not_in_channel/);

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -1,5 +1,5 @@
 import test from 'node:test';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { judgeJourneys } from './judge-journeys.mjs';
@@ -148,5 +148,22 @@ test('missing evidence and a different executed spec are not passing coverage', 
     assert.deepEqual(await judgeJourneys(root, 'expected'), { count: 0, result: 'incomplete' });
     assert.equal(classify({ ...summary, files: ['other.e2e.test.ts'] }, 'success', 'success', entry.spec), 'not tested');
     assert.equal(classify({ ...summary, files: [entry.spec] }, 'success', 'success', entry.spec), 'passed');
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test('evidence paths cannot escape the run directory through traversal or symlinks', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'journey-paths-'));
+  const directory = join(root, 'run');
+  try {
+    await mkdir(directory);
+    await writeFile(join(root, 'outside.png'), 'outside');
+    await writeFile(join(directory, 'inside.png'), 'inside');
+    await symlink(join(root, 'outside.png'), join(directory, 'linked.png'));
+    for (const fileName of ['../outside.png', join(root, 'outside.png'), 'linked.png', 'missing.png']) {
+      await writeFile(join(directory, 'test-run.json'), JSON.stringify({ gitSha: 'expected', artifacts: [{ fileName }] }));
+      assert.deepEqual(await judgeJourneys(root, 'expected', () => { throw new Error('must not judge unsafe evidence'); }), { count: 0, result: 'incomplete' });
+    }
+    await writeFile(join(directory, 'test-run.json'), JSON.stringify({ gitSha: 'expected', artifacts: [{ fileName: 'inside.png' }] }));
+    assert.deepEqual(await judgeJourneys(root, 'expected', () => 0), { count: 1, result: 'success' });
   } finally { await rm(root, { recursive: true, force: true }); }
 });

--- a/evals/scripts/journey-ci.test.mjs
+++ b/evals/scripts/journey-ci.test.mjs
@@ -6,13 +6,28 @@ import { judgeJourneys } from './judge-journeys.mjs';
 import assert from 'node:assert/strict';
 import { catalog, selectJourneys } from './journey-catalog.mjs';
 import { aggregate, classify, markdown } from './journey-report.mjs';
-import { notification, deliver, validateReport } from './notify-journeys.mjs';
+import { notification, deliver, validateReport, findStateRun } from './notify-journeys.mjs';
 
 const summary = { command: 'evals:e2e', verdict: 'passed', passed: 1, failed: 0, skipped: 0 };
 const entry = { spec: 'permissions.e2e.test.ts', name: 'Apply permissions', critical: true, placement: 'daytona' };
 const plan = { suite: 'Full regression', entries: [entry], manual: [] };
 const run = { name: 'Product journeys', run_number: 10, run_attempt: 1, html_url: 'https://github.com/different-ai/openwork/actions/runs/10' };
 const report = status => validateReport({ entries: [{ ...entry, status }] });
+
+test('incident state survives more than 100 newer unrelated alert runs', async () => {
+  const pages = [];
+  const stateName = 'test-alert-state-42';
+  const found = await findStateRun(stateName, '200', async page => {
+    pages.push(page);
+    return page === 1 ? Array.from({ length: 100 }, (_, i) => ({ id: 200 - i })) : [{ id: 100 }, { id: 99 }];
+  }, async id => {
+    assert.notEqual(id, 200);
+    return [{ name: id === 99 || id === 100 ? stateName : 'test-alert-state-43', expired: id === 100 }];
+  });
+  assert.equal(found, 99);
+  assert.deepEqual(pages, [1, 2]);
+  assert.equal(await findStateRun(stateName, '200', async () => [], async () => []), undefined);
+});
 
 test('critical PR selection includes existing critical journeys even when only product source changes', async () => {
   const entries = await catalog();

--- a/evals/scripts/journey-report.mjs
+++ b/evals/scripts/journey-report.mjs
@@ -2,7 +2,8 @@ import { readdir, readFile, writeFile, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-export function classify(summary, execution, vision) {
+export function classify(summary, execution, vision, expectedSpec) {
+  if (expectedSpec && !summary?.files?.includes(expectedSpec)) return 'not tested';
   if (!summary || summary.command !== 'evals:e2e' || !['passed', 'failed', 'skipped'].every(key => Number.isInteger(summary[key]) && summary[key] >= 0)) return 'not tested';
   if (summary.failed > 0 || vision === 'failure') return 'failed';
   if (summary.skipped > 0 || summary.passed === 0 || execution !== 'success' || vision !== 'success' || summary.verdict !== 'passed') return 'not tested';
@@ -33,7 +34,7 @@ async function main() {
         try { const value = JSON.parse(line); if (value.command === 'evals:e2e') summary = value; } catch { /* non-summary log line */ }
       }
     } catch { /* setup never reached the test command */ }
-    const status = classify(summary, process.env.EXECUTION, process.env.VISION);
+    const status = classify(summary, process.env.EXECUTION, process.env.VISION, process.env.SPEC_SLUG);
     await writeFile('journey-result.json', JSON.stringify({ spec: process.env.SPEC_SLUG, status, summary }, null, 2));
     await appendFile(process.env.GITHUB_STEP_SUMMARY, `\nJourney result: **${status}**\n`);
   } else {

--- a/evals/scripts/journey-report.mjs
+++ b/evals/scripts/journey-report.mjs
@@ -1,0 +1,56 @@
+import { readdir, readFile, writeFile, appendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export function classify(summary, execution, vision) {
+  if (!summary || summary.command !== 'evals:e2e' || !['passed', 'failed', 'skipped'].every(key => Number.isInteger(summary[key]) && summary[key] >= 0)) return 'not tested';
+  if (summary.failed > 0 || vision === 'failure') return 'failed';
+  if (summary.skipped > 0 || summary.passed === 0 || execution !== 'success' || vision !== 'success' || summary.verdict !== 'passed') return 'not tested';
+  return 'passed';
+}
+
+export function aggregate(plan, results) {
+  const entries = plan.entries.map(entry => {
+    const matching = results.filter(result => result.spec === entry.spec);
+    const result = matching.length === 1 ? matching[0] : null;
+    return { ...entry, status: ['passed', 'failed', 'not tested'].includes(result?.status) ? result.status : 'not tested' };
+  });
+  const counts = Object.fromEntries(['passed', 'failed', 'not tested'].map(status => [status, entries.filter(entry => entry.status === status).length]));
+  return { suite: plan.suite, entries, counts, manual: plan.manual, ok: counts.failed === 0 && counts['not tested'] === 0 && entries.length > 0 };
+}
+
+export function markdown(report) {
+  const critical = report.entries.filter(entry => entry.critical);
+  return `## ${report.suite} — ${report.ok ? 'passed' : 'action needed'}\n\n${report.counts.passed} passed · ${report.counts.failed} failed · ${report.counts['not tested']} not tested (spec files)\n\nCritical journeys: ${critical.length === 0 ? 'not selected' : critical.every(entry => entry.status === 'passed') ? 'all passed' : 'action needed'}\n\n| Journey | Result |\n|---|---|\n${report.entries.map(entry => `| ${entry.name}${entry.critical ? ' **(critical)**' : ''} | ${entry.status} |`).join('\n')}\n\n${report.manual.length} manual-only specs are outside automatic coverage. See the plan for their names.\n\nEvidence and logs are attached to this run. “Not tested” includes skipped tests, setup failures, missing results, and incomplete evidence.\n`;
+}
+
+async function main() {
+  if (process.argv[2] === 'record') {
+    let summary;
+    try {
+      const lines = (await readFile(process.env.JOURNEY_LOG, 'utf8')).split('\n');
+      for (const line of lines) {
+        try { const value = JSON.parse(line); if (value.command === 'evals:e2e') summary = value; } catch { /* non-summary log line */ }
+      }
+    } catch { /* setup never reached the test command */ }
+    const status = classify(summary, process.env.EXECUTION, process.env.VISION);
+    await writeFile('journey-result.json', JSON.stringify({ spec: process.env.SPEC_SLUG, status, summary }, null, 2));
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `\nJourney result: **${status}**\n`);
+  } else {
+    const plan = JSON.parse(await readFile('journey-plan/plan.json', 'utf8'));
+    const results = [];
+    async function visit(directory) {
+      for (const entry of await readdir(directory, { withFileTypes: true })) {
+        const path = join(directory, entry.name);
+        if (entry.isDirectory()) await visit(path);
+        else if (entry.name === 'journey-result.json') results.push(JSON.parse(await readFile(path, 'utf8')));
+      }
+    }
+    await visit('journey-results');
+    const report = aggregate(plan, results);
+    await writeFile('journey-report.json', JSON.stringify(report, null, 2));
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown(report));
+    if (!report.ok) process.exitCode = 1;
+  }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/evals/scripts/judge-journeys.mjs
+++ b/evals/scripts/judge-journeys.mjs
@@ -1,0 +1,35 @@
+import { appendFile, readdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+export async function judgeJourneys(directory, expectedSha, run = path => spawnSync('pnpm', ['--dir', 'evals', 'evidence:judge', '--', '--test-run', path], { stdio: 'inherit' }).status) {
+  const entries = await readdir(directory, { withFileTypes: true }).catch(error => {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  });
+  let count = 0;
+  let failed = false;
+  let incomplete = false;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const path = resolve(directory, entry.name);
+    const record = JSON.parse(await readFile(join(path, 'test-run.json'), 'utf8').catch(() => 'null'));
+    if (!record || !expectedSha || record.gitSha !== expectedSha) {
+      incomplete = true;
+      continue;
+    }
+    count++;
+    const status = await run(path);
+    if (status === 1) failed = true;
+    else if (status !== 0) incomplete = true;
+  }
+  return { count, result: failed ? 'failure' : incomplete || count === 0 ? 'incomplete' : 'success' };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { count, result } = await judgeJourneys('evals/results/test-runs', process.env.EXPECTED_SHA);
+  await appendFile(process.env.GITHUB_OUTPUT, `result=${result}\n`);
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, `\nEvidence: ${count} journey record(s) checked — **${result}**.\n`);
+  process.exitCode = result === 'success' ? 0 : result === 'failure' ? 1 : 2;
+}

--- a/evals/scripts/judge-journeys.mjs
+++ b/evals/scripts/judge-journeys.mjs
@@ -1,5 +1,5 @@
-import { appendFile, readdir, readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { appendFile, readdir, readFile, realpath } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
@@ -16,6 +16,16 @@ export async function judgeJourneys(directory, expectedSha, run = path => spawnS
     const path = resolve(directory, entry.name);
     const record = JSON.parse(await readFile(join(path, 'test-run.json'), 'utf8').catch(() => 'null'));
     if (!record || !expectedSha || record.gitSha !== expectedSha) {
+      incomplete = true;
+      continue;
+    }
+    const root = await realpath(path);
+    const artifacts = await Promise.all((record.artifacts ?? []).map(async artifact => {
+      if (!artifact.fileName) return true;
+      const target = await realpath(resolve(root, artifact.fileName)).catch(() => '');
+      return target.startsWith(`${root}${sep}`);
+    }));
+    if (artifacts.includes(false)) {
       incomplete = true;
       continue;
     }

--- a/evals/scripts/list-daytona-raw-desktop-tests.mjs
+++ b/evals/scripts/list-daytona-raw-desktop-tests.mjs
@@ -1,21 +1,5 @@
-import { readdir, readFile } from "node:fs/promises";
-
-const specs = new URL("../specs/", import.meta.url);
-const files = (await readdir(specs))
-  .filter((file) => file.endsWith(".e2e.test.ts"))
-  .sort();
-
-for (const file of files) {
-  // This journey uses app(), but chmods its local Electron profile and
-  // restarts it against two independent local Den servers. Keep its full
-  // rollback/recovery proof runnable with evals:e2e <slug> --local; selecting
-  // it for Daytona only produces an Incomplete skip, never product evidence.
-  if (file === "cross-server-handoff-atomic-commit.e2e.test.ts") {
-    console.log(file);
-    continue;
-  }
-  const source = await readFile(new URL(file, specs), "utf8");
-  if (/import\s*\{[^}]*\bdesktop\b[^}]*\}\s*from\s*["']@openwork\/hosts["']/s.test(source)) {
-    console.log(file);
-  }
+// Compatibility entry point; CI selection is owned by journey-catalog.mjs.
+import { catalog } from './journey-catalog.mjs';
+for (const entry of await catalog()) {
+  if (entry.placement !== 'daytona') console.log(entry.spec);
 }

--- a/evals/scripts/list-daytona-raw-desktop-tests.mjs
+++ b/evals/scripts/list-daytona-raw-desktop-tests.mjs
@@ -6,6 +6,14 @@ const files = (await readdir(specs))
   .sort();
 
 for (const file of files) {
+  // This journey uses app(), but chmods its local Electron profile and
+  // restarts it against two independent local Den servers. Keep its full
+  // rollback/recovery proof runnable with evals:e2e <slug> --local; selecting
+  // it for Daytona only produces an Incomplete skip, never product evidence.
+  if (file === "cross-server-handoff-atomic-commit.e2e.test.ts") {
+    console.log(file);
+    continue;
+  }
   const source = await readFile(new URL(file, specs), "utf8");
   if (/import\s*\{[^}]*\bdesktop\b[^}]*\}\s*from\s*["']@openwork\/hosts["']/s.test(source)) {
     console.log(file);

--- a/evals/scripts/notify-journeys.mjs
+++ b/evals/scripts/notify-journeys.mjs
@@ -33,7 +33,8 @@ export function notification(previous, run, report, teamId = '') {
 }
 
 export async function deliver(previous, run, report, { token, channel, teamId, request = fetch }) {
-  const decision = notification(previous, run, report, teamId);
+  const decision = notification(previous?.channel === channel ? previous : undefined, run, report, teamId);
+  decision.state = { ...decision.state, channel };
   if (!decision.message) return decision.state;
   const response = await request('https://slack.com/api/chat.postMessage', {
     method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/evals/scripts/notify-journeys.mjs
+++ b/evals/scripts/notify-journeys.mjs
@@ -1,0 +1,96 @@
+import { execFileSync } from 'node:child_process';
+import { appendFile, mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const escape = text => String(text).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+const statuses = new Set(['passed', 'failed', 'not tested']);
+export function validateReport(report) {
+  if (!report || !Array.isArray(report.entries) || report.entries.length === 0 || report.entries.length > 1000) throw new Error('Missing or invalid coverage report');
+  const entries = report.entries.map(entry => {
+    if (typeof entry.spec !== 'string' || typeof entry.name !== 'string' || !statuses.has(entry.status)) throw new Error('Invalid journey result');
+    return { spec: entry.spec.slice(0, 200), name: entry.name.slice(0, 200), status: entry.status, critical: entry.critical === true };
+  });
+  if (new Set(entries.map(entry => entry.spec)).size !== entries.length) throw new Error('Duplicate journey results');
+  return { entries, counts: Object.fromEntries([...statuses].map(status => [status, entries.filter(entry => entry.status === status).length])) };
+}
+
+export function notification(previous, run, report, teamId = '') {
+  const sequence = [run.run_number, run.run_attempt];
+  if (previous && (previous.sequence[0] > sequence[0] || (previous.sequence[0] === sequence[0] && previous.sequence[1] >= sequence[1]))) return { state: previous, message: null };
+  const bad = report.entries.filter(entry => entry.status !== 'passed');
+  const failures = bad.map(entry => `${entry.spec}:${entry.status}`).sort();
+  const newFailures = failures.some(key => !previous?.failures.includes(key));
+  const critical = report.entries.filter(entry => entry.critical);
+  const state = { sequence, failures, thread: bad.length ? previous?.thread : undefined };
+  if (bad.length === 0 && !previous?.failures.length) return { state, message: null };
+  const title = run.name === 'Product journeys' ? 'Full regression — user journeys' : run.name === 'Build and core checks' ? 'Full regression — component checks' : 'Test reliability';
+  const mention = bad.length && newFailures && /^[A-Z0-9]+$/.test(teamId) ? `<!subteam^${teamId}> ` : '';
+  const summary = bad.length ? `${report.counts.passed} passed · ${report.counts.failed} failed · ${report.counts['not tested']} not tested` : 'Recovered — all selected checks passed';
+  const criticalText = critical.length ? `\nCritical journeys: ${critical.every(entry => entry.status === 'passed') ? 'all passed' : '*ACTION NEEDED*'}` : '';
+  const details = bad.slice(0, 30).map(entry => `• ${escape(entry.name)} — ${entry.status}`).join('\n');
+  const text = `${mention}*${title}*\n${summary}${criticalText}${details ? `\n${details}` : ''}${bad.length > 30 ? `\n…and ${bad.length - 30} more; see the run.` : ''}\n<${run.html_url}|View run and evidence>`;
+  return { state, message: { text, ...(previous?.thread ? { thread_ts: previous.thread } : {}), unfurl_links: false, unfurl_media: false } };
+}
+
+export async function deliver(previous, run, report, { token, channel, teamId, request = fetch }) {
+  const decision = notification(previous, run, report, teamId);
+  if (!decision.message) return decision.state;
+  const response = await request('https://slack.com/api/chat.postMessage', {
+    method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ channel, ...decision.message }), signal: AbortSignal.timeout(30_000),
+  });
+  const result = await response.json();
+  if (!response.ok || !result.ok || typeof result.ts !== 'string') throw new Error(`Slack delivery failed: ${result.error || response.status}`);
+  if (decision.state.failures.length) decision.state.thread = decision.message.thread_ts || result.ts;
+  return decision.state;
+}
+
+const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+const api = path => JSON.parse(gh('api', path));
+async function main() {
+  const { workflow_run: run } = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, 'utf8'));
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (run.event !== 'schedule') throw new Error('Only scheduled runs may notify the team');
+  const artifacts = api(`repos/${repo}/actions/runs/${run.id}/artifacts?per_page=100`).artifacts;
+  let report;
+  if (run.name === 'Product journeys' && artifacts.some(artifact => artifact.name === 'journey-report' && !artifact.expired)) {
+    gh('run', 'download', String(run.id), '--repo', repo, '--name', 'journey-report', '--dir', 'incoming-report');
+    report = validateReport(JSON.parse(await readFile('incoming-report/journey-report.json', 'utf8')));
+  } else {
+    const pages = gh('api', '--paginate', '--slurp', `repos/${repo}/actions/runs/${run.id}/jobs?per_page=100`);
+    const jobs = JSON.parse(pages).flatMap(page => page.jobs);
+    const entries = jobs.filter(job => job.conclusion !== 'skipped').map(job => ({
+      spec: job.name, name: job.name, critical: false,
+      status: job.conclusion === 'success' ? 'passed' : job.conclusion === 'failure' ? 'failed' : 'not tested',
+    }));
+    if (!entries.length || run.name === 'Product journeys') entries.push({ spec: 'missing-coverage', name: 'Journey report unavailable — coverage could not be verified', critical: false, status: 'not tested' });
+    report = validateReport({ entries });
+  }
+  // Missing reports, upload failures and aggregate failures cannot send a recovery.
+  if (run.conclusion !== 'success' && report.entries.every(entry => entry.status === 'passed')) {
+    report = validateReport({ entries: [...report.entries, { spec: 'workflow-incomplete', name: 'Workflow did not complete successfully', critical: false, status: 'not tested' }] });
+  }
+  const stateName = `test-alert-state-${run.workflow_id}`;
+  let previous;
+  const runs = api(`repos/${repo}/actions/workflows/e2e-test-failure-alerts.yml/runs?status=success&per_page=100`).workflow_runs;
+  for (const candidate of runs) {
+    if (String(candidate.id) === process.env.GITHUB_RUN_ID) continue;
+    const available = api(`repos/${repo}/actions/runs/${candidate.id}/artifacts?per_page=100`).artifacts;
+    if (!available.some(artifact => artifact.name === stateName && !artifact.expired)) continue;
+    gh('run', 'download', String(candidate.id), '--repo', repo, '--name', stateName, '--dir', 'previous-state');
+    previous = JSON.parse(await readFile('previous-state/state.json', 'utf8'));
+    break;
+  }
+  await mkdir('alert-state', { recursive: true });
+  if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_TEST_ALERT_CHANNEL_ID) {
+    // Do not mark undelivered alerts as sent. Keep last delivered state intact.
+    if (previous) await writeFile('alert-state/state.json', JSON.stringify(previous));
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, '## Slack setup required\n\nSet the SLACK_BOT_TOKEN secret and SLACK_TEST_ALERT_CHANNEL_ID variable, and invite the bot to that channel. No Slack message was sent.\n');
+    throw new Error('Slack notification credentials are not configured');
+  }
+  const state = await deliver(previous, run, report, { token: process.env.SLACK_BOT_TOKEN, channel: process.env.SLACK_TEST_ALERT_CHANNEL_ID, teamId: process.env.SLACK_TEST_ALERT_TEAM_ID });
+  await writeFile('alert-state/state.json', JSON.stringify(state));
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, `## Team notification\n\n${report.counts.passed} passed · ${report.counts.failed} failed · ${report.counts['not tested']} not tested. Healthy runs stay quiet; repeated failures reply in the existing incident thread.\n`);
+  await rm('incoming-report', { recursive: true, force: true });
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/evals/scripts/notify-journeys.mjs
+++ b/evals/scripts/notify-journeys.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { appendFile, mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 const escape = text => String(text).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
@@ -48,6 +48,19 @@ export async function deliver(previous, run, report, { token, channel, teamId, r
 
 const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
 const api = path => JSON.parse(gh('api', path));
+
+export async function findStateRun(stateName, currentRunId, loadRuns, loadArtifacts) {
+  for (let page = 1; ; page++) {
+    const runs = await loadRuns(page);
+    for (const candidate of runs) {
+      if (String(candidate.id) === currentRunId) continue;
+      const artifacts = await loadArtifacts(candidate.id);
+      if (artifacts.some(artifact => artifact.name === stateName && !artifact.expired)) return candidate.id;
+    }
+    if (runs.length < 100) return undefined;
+  }
+}
+
 async function main() {
   const { workflow_run: run } = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, 'utf8'));
   const repo = process.env.GITHUB_REPOSITORY;
@@ -73,25 +86,20 @@ async function main() {
   }
   const stateName = `test-alert-state-${run.workflow_id}`;
   let previous;
-  const runs = api(`repos/${repo}/actions/workflows/e2e-test-failure-alerts.yml/runs?status=success&per_page=100`).workflow_runs;
-  for (const candidate of runs) {
-    if (String(candidate.id) === process.env.GITHUB_RUN_ID) continue;
-    const available = api(`repos/${repo}/actions/runs/${candidate.id}/artifacts?per_page=100`).artifacts;
-    if (!available.some(artifact => artifact.name === stateName && !artifact.expired)) continue;
-    gh('run', 'download', String(candidate.id), '--repo', repo, '--name', stateName, '--dir', 'previous-state');
+  const stateRun = await findStateRun(stateName, process.env.GITHUB_RUN_ID,
+    page => api(`repos/${repo}/actions/workflows/e2e-test-failure-alerts.yml/runs?status=success&per_page=100&page=${page}`).workflow_runs,
+    id => api(`repos/${repo}/actions/runs/${id}/artifacts?per_page=100`).artifacts);
+  if (stateRun !== undefined) {
+    gh('run', 'download', String(stateRun), '--repo', repo, '--name', stateName, '--dir', 'previous-state');
     previous = JSON.parse(await readFile('previous-state/state.json', 'utf8'));
-    break;
   }
   await mkdir('alert-state', { recursive: true });
   if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_TEST_ALERT_CHANNEL_ID) {
-    // Do not mark undelivered alerts as sent. Keep last delivered state intact.
-    if (previous) await writeFile('alert-state/state.json', JSON.stringify(previous));
     await appendFile(process.env.GITHUB_STEP_SUMMARY, '## Slack setup required\n\nSet the SLACK_BOT_TOKEN secret and SLACK_TEST_ALERT_CHANNEL_ID variable, and invite the bot to that channel. No Slack message was sent.\n');
     throw new Error('Slack notification credentials are not configured');
   }
   const state = await deliver(previous, run, report, { token: process.env.SLACK_BOT_TOKEN, channel: process.env.SLACK_TEST_ALERT_CHANNEL_ID, teamId: process.env.SLACK_TEST_ALERT_TEAM_ID });
   await writeFile('alert-state/state.json', JSON.stringify(state));
   await appendFile(process.env.GITHUB_STEP_SUMMARY, `## Team notification\n\n${report.counts.passed} passed · ${report.counts.failed} failed · ${report.counts['not tested']} not tested. Healthy runs stay quiet; repeated failures reply in the existing incident thread.\n`);
-  await rm('incoming-report', { recursive: true, force: true });
 }
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/evals/scripts/plan-journeys.mjs
+++ b/evals/scripts/plan-journeys.mjs
@@ -1,0 +1,18 @@
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { catalog, selectJourneys } from './journey-catalog.mjs';
+
+const changed = process.env.CHANGED_FILES ? JSON.parse(await readFile(process.env.CHANGED_FILES, 'utf8')) : [];
+const critical = process.env.EVENT_NAME === 'workflow_run' || process.env.SUITE === 'critical';
+const all = await catalog();
+const selected = selectJourneys(all, { critical, only: process.env.ONLY_FILTER || '', changed: changed.map(file => file.replace('evals/specs/', '')) });
+const automatic = selected.filter(entry => entry.placement !== 'manual');
+if (automatic.length === 0) throw new Error('No automated journeys matched. Check the filter; this is not a passing run.');
+const plan = { suite: critical ? 'Critical user journeys' : 'Full regression', entries: automatic, manual: selected.filter(entry => entry.placement === 'manual') };
+await mkdir('journey-plan', { recursive: true });
+await writeFile('journey-plan/plan.json', JSON.stringify(plan, null, 2));
+for (const placement of ['daytona', 'local']) {
+  const entries = automatic.filter(entry => entry.placement === placement);
+  await appendFile(process.env.GITHUB_OUTPUT, `${placement}=${JSON.stringify(entries)}\nhas_${placement}=${entries.length > 0}\n`);
+}
+await appendFile(process.env.GITHUB_OUTPUT, `suite=${plan.suite}\n`);
+await appendFile(process.env.GITHUB_STEP_SUMMARY, `## ${plan.suite}\n\n${automatic.length} spec files selected. Each can contain multiple tests.\n\n${automatic.map(entry => `- ${entry.name}${entry.critical ? ' (critical)' : ''} — ${entry.placement}`).join('\n')}\n\n${plan.manual.length} additional specs require manual execution and are outside automatic coverage.\n${plan.manual.map(entry => `- ${entry.spec}`).join('\n')}\n`);

--- a/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
+++ b/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
@@ -12,6 +12,7 @@ import {
   eventually,
   localMysqlIsRunning,
   needs,
+  quitDesktop,
   readDenClientState,
   relaunchDesktop,
   server,
@@ -250,6 +251,9 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(
       // port would otherwise rotate the origin that scopes localStorage.
       const rendererPort = desktop.handle.meta?.vitePort;
       if (!rendererPort) throw new Error("The first launch did not record its renderer port.");
+      // Exercise a user quit, allowing Chromium to persist renderer storage,
+      // before disposing the dev processes. stop() alone sends SIGINT.
+      await quitDesktop(desktop);
       await desktop.stop();
       desktop = null;
       // The dev server auto-increments a busy port instead of failing, which


### PR DESCRIPTION
This makes CI show what was exercised: build checks, four critical user journeys, and full automatic regression. Eligible PRs select the critical journeys plus changed supported specs; scheduled runs retain full coverage and list manual-only gaps.

Journey reports distinguish passed, failed, and not tested. Every evidence record is checked against the selected SHA, and artifact paths must stay inside its run directory. Missing results and skips cannot pass. Ineligible workflow triggers skip the verdict. The infrastructure tests now run in normal PR core checks.

Scheduled Slack alerts replace failure-issue spam with an incident thread and recovery reply. Incident lookup paginates past unrelated runs; repeat failures avoid repeated team mentions. Build job IDs, schedules, Warden checks, and environment approvals remain in place.

## Validation

- `node --test evals/scripts/journey-ci.test.mjs evals/scripts/flake-report.test.mjs`: 17 passed, 0 failed, 0 skipped. Includes pagination, traversal/symlink rejection, selection, reporting, delivery failures, and recovery.
- `actionlint -ignore 'label "blacksmith'` passed for all four modified workflows; `git diff --check` passed.
- Final-head critical journey validation at `a460465dd`: https://github.com/different-ai/openwork/actions/runs/34072331363 **passed: 4 spec files, 5 runtime tests, 0 failed, 0 not tested**. All five journey records were judged on the final SHA and published in the PR evidence comments.
- Normal PR CI, including the infrastructure-test step, and Warden are green on the final commit: https://github.com/different-ai/openwork/actions/runs/34072333938 . Warden resolved the outstanding review threads.

## Review notes

- Live scheduled Slack delivery is still unverified. Repository secret `SLACK_BOT_TOKEN` and variable `SLACK_TEST_ALERT_CHANNEL_ID` are absent; optional `SLACK_TEST_ALERT_TEAM_ID` enables group mentions. Missing configuration fails the notification job visibly. Manual journey runs do not notify Slack.
- PR E2E jobs use the existing `pr-slow-specs` environment, which currently requires maintainer approval before secrets are released. Same-repository and Warden checks also apply; automatic selection alone does not authorize execution.
- This branch includes the local handoff CI/test changes also proposed in #4559. Review the overlap when choosing merge order.
- Full automatic regression has not been rerun for this PR. Artifact-backed Slack state is not exactly-once delivery; limitations and setup are documented in `docs/product-journeys-ci.md`.
