### PR TITLE
feat(computer-use): make takeover and continuation clear

### DIFF
--- a/evals/packages/labs/fixtures/computer-use-app.swift
+++ b/evals/packages/labs/fixtures/computer-use-app.swift
@@ -52,7 +52,7 @@ final class Fixture: NSObject, NSApplicationDelegate {
         }
     }
     func makeWindow(_ title: String, x: CGFloat) -> NSWindow {
-        let window = NSWindow(contentRect: NSRect(x: x, y: 250, width: 420, height: 330), styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
+        let window = NSWindow(contentRect: NSRect(x: x, y: 250, width: 420, height: 330), styleMask: [.titled, .closable, .miniaturizable, .resizable], backing: .buffered, defer: false)
         window.title = title; window.isReleasedWhenClosed = false
         window.orderFront(nil)
         return window
@@ -64,8 +64,12 @@ final class Fixture: NSObject, NSApplicationDelegate {
         var result: [String: Any] = [:]
         switch method {
         case "state": result = ["count": count, "otherCount": otherCount, "draft": draft.stringValue]
+        case "minimized": result = ["minimized": windows[0].isMiniaturized]
+        case "minimize": windows[0].miniaturize(nil); result = ["ok": true]
+        case "restore": windows[0].deminiaturize(nil); result = ["ok": true]
         case "prepare_drag": windows[0].makeFirstResponder(nil); result = ["ok": true]
         case "drag_state": result = ["downs": dragSurface.downs, "moves": dragSurface.moves, "ups": dragSurface.ups]
+        case "foreground_window": result = ["title": NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier ? (NSApp.keyWindow?.title ?? "") : ""]
         case "human_edit":
             windows[0].makeKeyAndOrderFront(nil)
             Task { @MainActor in
@@ -112,17 +116,22 @@ final class Fixture: NSObject, NSApplicationDelegate {
         case "resize":
             windows[0].setContentSize(NSSize(width: 440, height: 350)); result = ["ok": true]
         case "front": windows[0].makeKeyAndOrderFront(nil); NSApp.activate(ignoringOtherApps: true); result = ["ok": true]
-        case "press_helper_button", "select_helper_window":
+        case "press_helper_button", "select_helper_window", "helper_panel":
             Task.detached {
                 var result: [String: Any] = [:]
-                let buttons: Set<String> = ["Allow this session", "Cancel", "Pause", "Resume", "Stop"]
+                let buttons: Set<String> = ["Allow this session", "Cancel", "Take over", "Continue", "Stop"]
                 if let params = request["params"] as? [String: Any], let pid = params["pid"] as? Int32,
                    let name = params["name"] as? String,
-                   (method == "select_helper_window" ? name == "Workspace window" : buttons.contains(name)),
+                   (method == "helper_panel" || (method == "select_helper_window" ? name == "Workspace window" : buttons.contains(name))),
                    let expected = params["executable"] as? String,
                    let process = NSRunningApplication(processIdentifier: pid),
                    process.executableURL?.resolvingSymlinksInPath().path == URL(fileURLWithPath: expected).resolvingSymlinksInPath().path {
-                    result = method == "select_helper_window" ? self.selectWindow(pid: pid, title: name) : ["ok": self.pressButton(pid: pid, title: name)]
+                    if method == "helper_panel" {
+                        let task = self.findControl(pid: pid, title: nil, role: kAXWindowRole)
+                        result = ["text": task.map(self.accessibleText) ?? ""]
+                    } else {
+                        result = method == "select_helper_window" ? self.selectWindow(pid: pid, title: name) : ["ok": self.pressButton(pid: pid, title: name)]
+                    }
                 } else { result = ["ok": false] }
                 await self.respond(request, result: result)
             }
@@ -135,6 +144,24 @@ final class Fixture: NSObject, NSApplicationDelegate {
         if let data = try? JSONSerialization.data(withJSONObject: ["id": request["id"] ?? NSNull(), "result": result], options: [.sortedKeys]) {
             FileHandle.standardOutput.write(data + Data([10]))
         }
+    }
+    nonisolated func accessibleText(_ root: AXUIElement) -> String {
+        var visited = 0
+        func read(_ element: AXUIElement, depth: Int) -> [String] {
+            visited += 1
+            guard depth < 18, visited < 800 else { return [] }
+            var result: [String] = []
+            for attribute in [kAXTitleAttribute, kAXValueAttribute] {
+                var value: CFTypeRef?
+                AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+                if let text = value as? String { result.append(text) }
+            }
+            var children: CFTypeRef?
+            AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &children)
+            for child in children as? [AXUIElement] ?? [] { result += read(child, depth: depth + 1) }
+            return result
+        }
+        return read(root, depth: 0).joined(separator: "\n")
     }
     nonisolated func findControl(pid: pid_t, title: String?, role expectedRole: String) -> AXUIElement? {
         let root = AXUIElementCreateApplication(pid)

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -38,6 +38,16 @@ test("Computer Use respects window consent, fresh observations and the person's 
     return result.session_id;
   });
 
+  await step("The floating controls show the task, selected window and remaining access", async () => {
+    const panel = JSON.stringify(await world.panel());
+    expect(panel).toContain("Edit the disposable fixture draft and increment its counter.");
+    expect(panel).toContain("Workspace window");
+    expect(panel).toContain("Access ends in");
+    expect(panel).toContain("Take over");
+    expect(panel).toContain("Stop");
+    expect(panel).not.toContain("Other window");
+  });
+
   await step("A different connection cannot read or act through the grant", async () => {
     const other = await world.peerCall("computer_observe", { session_id: session });
     expect(other).toMatchObject({ isError: true });
@@ -84,10 +94,11 @@ test("Computer Use respects window consent, fresh observations and the person's 
     const observed = await observe();
     await world.resize();
     expect(toolState(await action(observed, "stale-layout", { type: "press", ref: refFor(observed, "Increment") })).code).toBe("stale_observation");
-    await world.pressControl("Pause");
+    await world.pressControl("Take over");
     expect(toolState(await world.call("computer_observe", { session_id: session })).code).toBe("session_paused");
-    expect(toolState(await world.call("computer_session_status", { session_id: session }))).toMatchObject({ state: "paused", pause_reason: "Paused by you.", next: "human_takeover" });
-    await world.pressControl("Resume");
+    expect(toolState(await world.call("computer_session_status", { session_id: session }))).toMatchObject({ state: "paused", pause_reason: "You have control. Click Continue when you are ready.", next: "human_takeover" });
+    await world.pressControl("Continue");
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("active");
     const resumed = toolState(await world.call("computer_session_status", { session_id: session }));
     expect(resumed).toMatchObject({ state: "active", next: "observe" });
     expect(resumed).not.toHaveProperty("pause_reason");
@@ -102,7 +113,8 @@ test("Computer Use respects window consent, fresh observations and the person's 
     await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("paused");
     await expect.poll(() => world.state()).toEqual({ count: 1, otherCount: 0, draft: "Edited by person" });
     expect(toolState(await action(before, "after-human-edit", { type: "press", ref: refFor(before, "Increment") })).code).toBe("session_paused");
-    await world.pressControl("Resume");
+    await world.pressControl("Continue");
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("active");
     expect(toolState(await action(before, "after-human-resume", { type: "press", ref: refFor(before, "Increment") })).code).toBe("observation_required");
     expect(JSON.stringify(await observe())).toContain("Edited by person");
   });
@@ -123,8 +135,10 @@ test("Computer Use respects window consent, fresh observations and the person's 
     const opened = toolState(await pending);
     expect(opened).toMatchObject({ ok: true, state: "paused", window_title: "Workspace window" });
     const id = opened.session_id;
-    await world.front();
-    await world.pressControl("Resume");
+    expect(await world.foregroundWindow()).toEqual({ title: "" });
+    await world.pressControl("Continue");
+    await expect.poll(() => world.foregroundWindow()).toEqual({ title: "Workspace window" });
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: id })).state).toBe("active");
     const observed = toolState(await world.call("computer_observe", { session_id: id }));
     const elements = observed.elements;
     if (!Array.isArray(elements)) throw new Error("No controls in drag observation");
@@ -140,14 +154,26 @@ test("Computer Use respects window consent, fresh observations and the person's 
       expect.poll(() => world.dragState(), { timeout: 10_000, interval: 20 }).toMatchObject({ downs: 1 }),
       drag.then(async (reply) => { throw new Error(`Drag finished before takeover: ${JSON.stringify(toolState(reply))}; ${JSON.stringify(await world.dragState())}; surface ${JSON.stringify(bounds)}`); }),
     ]);
-    await world.pressControl("Pause");
+    await world.pressControl("Take over");
     const interrupted = toolState(await drag);
     expect(interrupted).toMatchObject({ ok: false, may_have_acted: true, next: "human_takeover" });
     await expect.poll(() => world.dragState()).toMatchObject({ downs: 1, ups: 1 });
     const stopped = await world.dragState();
-    await world.pressControl("Resume");
+    await world.pressControl("Continue");
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: id })).state).toBe("active");
     expect(await world.dragState()).toEqual(stopped);
     expect(toolState(await world.call("computer_act", { session_id: id, observation_id: observed.observation_id, request_id: "old-drag", action: { type: "drag", path } })).code).toBe("observation_required");
+    await world.pressControl("Take over");
+    await world.minimize();
+    await expect.poll(() => world.minimized()).toEqual({ minimized: true });
+    await world.pressControl("Continue");
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: id }))).toMatchObject({ state: "paused", pause_reason: "The approved window is closed, minimized, or no longer on this desktop.", next: "human_takeover" });
+    expect(await world.dragState()).toEqual(stopped);
+    await world.restore();
+    await expect.poll(() => world.minimized()).toEqual({ minimized: false });
+    await world.pressControl("Continue");
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: id })).state).toBe("active");
+    expect(await world.dragState()).toEqual(stopped);
     await world.pressControl("Stop");
     expect(toolState(await world.call("computer_session_status", { session_id: id })).code).toBe("session_unavailable");
     expect(await world.state()).toEqual({ count: 1, otherCount: 0, draft: "Edited by person" });

--- a/evals/worlds/computer-use.ts
+++ b/evals/worlds/computer-use.ts
@@ -100,6 +100,11 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
       list: () => helper.request("tools/list"),
       state: () => fixture.request("state"),
       resize: () => fixture.request("resize"),
+      panel: () => fixture.request("helper_panel", { name: "", pid: helper.pid, executable }),
+      foregroundWindow: () => fixture.request("foreground_window"),
+      minimized: () => fixture.request("minimized"),
+      minimize: () => fixture.request("minimize"),
+      restore: () => fixture.request("restore"),
       humanEdit: async () => {
         const activated = spawnSync("/usr/bin/osascript", ["-e", `tell application "System Events" to set frontmost of (first application process whose unix id is ${fixture.pid}) to true`], { encoding: "utf8", timeout: 5000 });
         if (activated.status !== 0) throw new Error(activated.stderr);
@@ -117,7 +122,7 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
         }
         throw new Error("The native window picker did not become available.");
       },
-      async pressControl(name: "Allow this session" | "Cancel" | "Pause" | "Resume" | "Stop") {
+      async pressControl(name: "Allow this session" | "Cancel" | "Take over" | "Continue" | "Stop") {
         const deadline = Date.now() + 10_000;
         while (Date.now() < deadline) {
           const result = await fixture.request("press_helper_button", { name, pid: helper.pid, executable });

--- a/packages/computer-use/README.md
+++ b/packages/computer-use/README.md
@@ -10,7 +10,7 @@ legacy whole-desktop tool is required.
 In OpenWork, enable **Library → Computer Use**, open its settings, and grant
 Accessibility and Screen Recording to **OpenWork Computer Use**. Mention a
 running app in a message. The helper asks you to choose its window and approve
-the requested mode. The floating panel provides **Pause**, **Resume**, and
+the requested mode. The floating panel provides **Take over**, **Continue**, and
 **Stop**. The setup window can stop all sessions.
 
 | Mode | Access | Foreground behavior |
@@ -21,8 +21,10 @@ the requested mode. The floating panel provides **Pause**, **Resume**, and
 
 The app and mode are fixed for the session. Changing either requires a new
 approval. A session lasts at most 15 minutes, pauses after two minutes without
-an operation, and permits at most 200 action attempts. Resume is a native
-person-only control. There is no resume, scope-upgrade, clipboard, URL-open,
+an operation, and permits at most 200 action attempts. Continue is a native
+person-only control. In control mode, it brings the approved window forward
+and requires a fresh observation before any further input. The floating
+panel shows the requested task and remaining access time. There is no resume, scope-upgrade, clipboard, URL-open,
 shell, whole-screen, or permission-grant tool.
 
 The default is a new app approval for every session. There are no persistent
@@ -38,7 +40,7 @@ OpenWork / any compatible MCP client
           └─ SessionRuntime: native consent, app/window identity, limits, receipts
               ├─ MacAccessibility: public AX APIs + window-only ScreenCaptureKit
               ├─ MacInput: exact-process input, window and focus checks
-              └─ SessionControls: native approval, Pause / Resume / Stop
+              └─ SessionControls: native approval, Take over / Continue / Stop
 ```
 
 The executable owns authority. A JavaScript client or orchestration script
@@ -157,6 +159,16 @@ is no background-activation or global-input fallback.
   and provider policies. Runtime in-memory retention is not a promise about
   the host's transcripts.
 
+## Handoff behavior
+
+The native panel keeps the requested task and chosen window visible throughout
+access, including while paused. **Take over** releases held pointer input and
+invalidates the current observation. Local typing and pointer input also pause
+access. **Continue** is an explicit person action; in control mode it raises
+only the approved window, checks that window is foreground, and requires the
+caller to observe again. It does not replay interrupted typing or dragging.
+**Stop** ends the grant. The access countdown continues while paused.
+
 ## Build, migration and verification
 
 ```
@@ -177,7 +189,8 @@ remain separate and are not part of this implementation.
 The native journey owns two disposable windows and drives the real helper
 over stdio. It verifies native consent, isolated connection grants, accessible
 actions, replay protection, read scope, protected-field omission, stale
-geometry, Pause and Stop. Its person-input fixture uses the real approval UI,
+geometry, person takeover during typing, pointer release during interrupted
+drags, Continue and Stop. Its person-input fixture uses the real approval UI,
 never a production auto-approve flag. It requires macOS plus existing person-
 granted Accessibility and Screen Recording; it never changes TCC permissions.
 If the selected placement is Linux/Daytona, it skips explicitly and the

--- a/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
@@ -24,6 +24,7 @@ final class SessionControls: NSObject {
     private var panel: NSPanel?
     private var status: NSTextField?
     private var toggle: NSButton?
+    private var expiry: NSTextField?
     private var monitor: Any?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var stopObserver: NSObjectProtocol?
@@ -65,8 +66,8 @@ final class SessionControls: NSObject {
         if let host = consentWindow, let sheet = host.attachedSheet { host.endSheet(sheet, returnCode: .cancel) }
     }
 
-    func show(app: AppIdentity, target: WindowTarget, mode: AccessMode) {
-        let panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 380, height: 155),
+    func show(app: AppIdentity, target: WindowTarget, mode: AccessMode, purpose: String) {
+        let panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 380, height: 230),
             styleMask: [.titled, .nonactivatingPanel], backing: .buffered, defer: false)
         panel.title = "OpenWork Computer Use"
         panel.level = .floating
@@ -77,15 +78,22 @@ final class SessionControls: NSObject {
         title.font = .boldSystemFont(ofSize: 14)
         let window = NSTextField(labelWithString: String(target.title.prefix(80)))
         window.lineBreakMode = .byTruncatingTail
-        let status = NSTextField(wrappingLabelWithString: "Ready · expires in 15 minutes")
+        let task = NSTextField(wrappingLabelWithString: String(purpose.prefix(500)))
+        task.maximumNumberOfLines = 3
+        task.lineBreakMode = .byTruncatingTail
+        task.setAccessibilityLabel("Current task")
+        let expiry = NSTextField(labelWithString: "Access ends in 15:00")
+        expiry.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        expiry.textColor = .secondaryLabelColor
+        let status = NSTextField(wrappingLabelWithString: "OpenWork is working. You can take over at any time.")
         status.font = .systemFont(ofSize: 12)
         status.textColor = .secondaryLabelColor
-        let toggle = NSButton(title: "Pause", target: self, action: #selector(togglePause))
+        let toggle = NSButton(title: "Take over", target: self, action: #selector(togglePause))
         let stop = NSButton(title: "Stop", target: self, action: #selector(stopSession))
         stop.bezelColor = .systemRed
         let buttons = NSStackView(views: [toggle, stop])
         buttons.spacing = 8
-        let stack = NSStackView(views: [title, window, status, buttons])
+        let stack = NSStackView(views: [title, window, task, status, expiry, buttons])
         stack.orientation = .vertical; stack.alignment = .leading; stack.spacing = 9
         stack.translatesAutoresizingMaskIntoConstraints = false
         panel.contentView?.addSubview(stack)
@@ -97,7 +105,7 @@ final class SessionControls: NSObject {
         if let screen = NSScreen.main {
             panel.setFrameTopLeftPoint(NSPoint(x: screen.visibleFrame.maxX - 400, y: screen.visibleFrame.maxY - 20))
         }
-        self.panel = panel; self.status = status; self.toggle = toggle
+        self.panel = panel; self.status = status; self.toggle = toggle; self.expiry = expiry
         panel.orderFrontRegardless()
         monitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown,
             .keyDown, .scrollWheel, .mouseMoved, .leftMouseDragged, .rightMouseDragged]) { [weak self] event in
@@ -105,20 +113,20 @@ final class SessionControls: NSObject {
             // Our own postToPid events cannot be mistaken for a person taking over.
             if event.cgEvent?.getIntegerValueField(.eventSourceUnixProcessID) == Int64(ProcessInfo.processInfo.processIdentifier) { return }
             if mode == .control || NSWorkspace.shared.frontmostApplication?.processIdentifier == app.pid {
-                self.onPause?("Paused after local input. Resume here when ready.")
+                self.onPause?("You have control. Click Continue when you are ready.")
             }
         }
         let center = NSWorkspace.shared.notificationCenter
         for name in [NSWorkspace.willSleepNotification, NSWorkspace.screensDidSleepNotification, NSWorkspace.sessionDidResignActiveNotification] {
             workspaceObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
-                MainActor.assumeIsolated { self?.onPause?("Paused while the desktop is unavailable. Resume here when ready.") }
+                MainActor.assumeIsolated { self?.onPause?("Paused while the desktop is unavailable. Click Continue when you are ready.") }
             })
         }
         workspaceObservers.append(center.addObserver(forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main) { [weak self] notification in
             MainActor.assumeIsolated {
                 if mode == .control, let activated = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
                    activated.processIdentifier != app.pid {
-                    self?.onPause?("Paused after switching apps. Bring the approved window forward and resume here.")
+                    self?.onPause?("You switched apps. Continue will return to the approved window.")
                 }
             }
         })
@@ -130,7 +138,10 @@ final class SessionControls: NSObject {
         }
     }
     func update(_ message: String, paused: Bool) {
-        isPaused = paused; status?.stringValue = message; toggle?.title = paused ? "Resume" : "Pause"
+        isPaused = paused; status?.stringValue = message; toggle?.title = paused ? "Continue" : "Take over"
+    }
+    func updateExpiry(seconds: Int) {
+        expiry?.stringValue = String(format: "Access ends in %d:%02d", seconds / 60, seconds % 60)
     }
     func close() {
         cancelConsent()
@@ -140,7 +151,7 @@ final class SessionControls: NSObject {
         workspaceObservers.removeAll()
         if let stopObserver { DistributedNotificationCenter.default().removeObserver(stopObserver) }; stopObserver = nil
     }
-    @objc private func togglePause() { if isPaused { onResume?() } else { onPause?("Paused by you.") } }
+    @objc private func togglePause() { if isPaused { onResume?() } else { onPause?("You have control. Click Continue when you are ready.") } }
     @objc private func stopSession() { onStop?() }
 }
 

--- a/packages/computer-use/native/Sources/ComputerUse/SessionRuntime.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/SessionRuntime.swift
@@ -9,6 +9,7 @@ final class SessionRuntime {
     private var session: Session?
     private var lease: ControlLease?
     private var busy = false
+    private var resumingSessionID: String?
 
     private struct Session {
         let id: String
@@ -28,7 +29,7 @@ final class SessionRuntime {
     }
     init() {
         controls.onPause = { [weak self] reason in self?.pause(reason) }
-        controls.onResume = { [weak self] in self?.resume() }
+        controls.onResume = { [weak self] in Task { await self?.resume() } }
         controls.onStop = { [weak self] in self?.close() }
         controls.onTick = { [weak self] in self?.expire() }
     }
@@ -68,10 +69,10 @@ final class SessionRuntime {
             let id = UUID().uuidString.lowercased()
             session = Session(id: id, app: identity, target: target, mode: mode, started: now, lastUsed: now)
             lease = reservation
-            controls.show(app: identity, target: target, mode: mode)
+            controls.show(app: identity, target: target, mode: mode, purpose: purpose)
             if mode == .control {
                 // Consent surfaced our app. Only the person chooses when foreground control starts.
-                pause("Bring the approved window forward, then click Resume here.")
+                pause("Ready when you are. Continue will bring the approved window forward.")
             }
             return text(["ok": true, "session_id": id, "app_id": identity.bundleID, "pid": Int(identity.pid),
                 "window_id": Int(target.id), "window_title": target.title, "mode": mode.rawValue,
@@ -122,7 +123,7 @@ final class SessionRuntime {
     private func current(_ id: String, allowPaused: Bool = false) throws -> Session {
         expire()
         guard let current = session, current.id == id else { throw UseError("session_unavailable", "This session ended or belongs to another connection. Open a new session.", next: "open_session") }
-        guard allowPaused || !current.paused else { throw UseError("session_paused", "The person must resume in the Computer Use panel. Do not retry automatically.", next: "human_takeover") }
+        guard allowPaused || !current.paused else { throw UseError("session_paused", "The person must click Continue in the Computer Use panel. Do not retry automatically.", next: "human_takeover") }
         try Task.checkCancellation()
         try current.app.validate()
         return current
@@ -220,33 +221,56 @@ final class SessionRuntime {
         }
     }
     func pause(_ reason: String) {
-        guard let current = session, !current.paused else { return }
+        guard let current = session, !current.paused || resumingSessionID == current.id else { return }
         input.releaseAll()
         session?.pauseReason = reason
         session?.paused = true; session?.generation += 1; session?.observation = nil; session?.records = []
         controls.update(reason, paused: true)
     }
-    private func resume() {
-        guard let current = session else { return }
+    private func resume() async {
+        guard let current = session, current.paused, resumingSessionID == nil else { return }
+        resumingSessionID = current.id
+        defer { if resumingSessionID == current.id { resumingSessionID = nil } }
         do {
+            // This is called only by the person's native Continue button, never MCP.
+            if current.mode == .control {
+                _ = try access.validate(current.target, app: current.app)
+                guard AXUIElementPerformAction(current.target.element, kAXRaiseAction as CFString) == .success,
+                      current.app.app.activate(options: []) else {
+                    throw UseError("window_unavailable", "Open the approved window, then click Continue.", next: "human_takeover")
+                }
+                // Activation is asynchronous. Request it once and wait briefly, without
+                // repeatedly stealing focus if the person changes their mind.
+                for attempt in 0..<10 {
+                    guard session?.id == current.id, session?.generation == current.generation else { return }
+                    if (try? access.validate(current.target, app: current.app, requireFrontmost: true)) != nil { break }
+                    if attempt < 9 { try await Task.sleep(nanoseconds: 50_000_000) }
+                }
+            }
+            guard session?.id == current.id, session?.generation == current.generation else { return }
             _ = try access.validate(current.target, app: current.app, requireFrontmost: current.mode == .control)
             expire(); guard session != nil else { return }
             session?.pauseReason = nil
             session?.paused = false; session?.generation += 1; session?.observation = nil; session?.lastUsed = now
-            controls.update("Active · observe again before continuing", paused: false)
-        } catch { controls.update(error.localizedDescription, paused: true) }
+            controls.update("OpenWork is working. You can take over at any time.", paused: false)
+        } catch {
+            guard session?.id == current.id else { return }
+            session?.pauseReason = error.localizedDescription
+            controls.update(error.localizedDescription, paused: true)
+        }
     }
     private func expire() {
         guard let current = session else { return }
+        controls.updateExpiry(seconds: max(0, Int(900 - (now - current.started))))
         if now - current.started >= 900 || current.app.app.isTerminated { close(); return }
         if !current.paused && now - current.lastUsed >= 120 { pause("Paused after two minutes without activity.") }
     }
     func close() {
-        input.releaseAll(); session = nil; lease = nil; controls.close()
+        input.releaseAll(); resumingSessionID = nil; session = nil; lease = nil; controls.close()
     }
     func cancel() {
         controls.cancelConsent()
-        pause("Paused after cancellation. Resume here to continue.")
+        pause("Cancelled. You have control; click Continue when ready.")
     }
     private func text(_ payload: [String: Any]) -> [[String: Any]] {
         let data = try! JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])


### PR DESCRIPTION
The Computer Use panel shows the requested task, approved window and remaining access time, with **Take over**, **Continue** and **Stop** controls. Clicking Continue in control mode returns to the approved window once and requires a fresh observation before input. A minimized or unavailable window keeps the session paused with the same explanation in the panel and session status. Only the native button can resume.

This follows the merged #4463. The branch has been rebuilt on current `dev`; its six-file diff contains only the handoff UX and journey assertions.

## Verification — Passed

Head: `d5b7f022a68e8822219192e07654f8cb9ac5a482`.

- `pnpm evals:e2e computer-use-window-scope --local` — exit 0; 1 passed, 0 failed, 0 skipped. Printed placement: `placement: local (--local)`.
- The real Mac journey verifies panel task/window controls, native window selection, isolated grants, accessible edits, automatic takeover from typing, pointer release during an interrupted drag, explicit continuation, failure explanations for minimized windows, fresh observations and Stop.
- Exact-head Passed evidence is published in the sticky test-evidence comment.
- `pnpm --filter @openwork/computer-use check`: JavaScript syntax and 4 native boundary tests pass.
- `pnpm --dir evals typecheck:spec-layer`, fixture compilation during the live journey, and `git diff --check` pass.

All CI checks are green on this updated head. GitHub reports APPROVED and CLEAN. This PR is ready to merge and remains unmerged as requested. No background input or persistent app grant is added. The underlying pointer compatibility dependency is documented in the package README.
