### PR TITLE
Show saved workflow visualizations in run activity

### DIFF
--- a/ee/apps/den-api/src/routes/org/codemode-runs.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-runs.ts
@@ -1,7 +1,10 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { workflowRunPreviewSchema } from "@openwork/types/workflows"
 import { listWorkflowRuns } from "../../workflow-runs.js"
+import { workflowRunPreviews } from "../../workflows.js"
+import { listTeamsForMember } from "../../orgs.js"
 import { db } from "../../db.js"
 import { orgMemberRoute, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
@@ -25,6 +28,7 @@ const workflowRunSchema = z.object({
   finishedAt: z.string().datetime(),
   createdAt: z.string().datetime(),
   orgMembershipId: denTypeIdSchema("member").nullable(),
+  workflow: workflowRunPreviewSchema.nullable(),
 })
 
 const workflowRunListResponseSchema = z.object({
@@ -55,6 +59,14 @@ export function registerOrgWorkflowRunRoutes<T extends { Variables: OrgRouteVari
         ...(isAdmin ? {} : { orgMembershipId: member.id }),
         limit: c.req.valid("query").limit,
       })
+      const previews = await workflowRunPreviews({
+        context: {
+          organizationContext: context,
+          memberTeams: await listTeamsForMember({ organizationId: context.organization.id, memberId: member.id }),
+          session: c.get("session"),
+        },
+        runs: rows,
+      })
 
       return c.json({
         runs: rows.map((row) => ({
@@ -70,6 +82,7 @@ export function registerOrgWorkflowRunRoutes<T extends { Variables: OrgRouteVari
           finishedAt: row.finished_at.toISOString(),
           createdAt: row.created_at.toISOString(),
           orgMembershipId: row.org_membership_id,
+          workflow: previews.get(row.id) ?? null,
         })),
       })
     },

--- a/ee/apps/den-api/src/workflow-projections.ts
+++ b/ee/apps/den-api/src/workflow-projections.ts
@@ -1,4 +1,4 @@
-import type { WorkflowGraphNode, WorkflowVersion } from "@openwork/types/workflows"
+import type { WorkflowGraph, WorkflowGraphNode, WorkflowVersion } from "@openwork/types/workflows"
 
 function redactWorkflowGraphNodeLabel(node: WorkflowGraphNode): WorkflowGraphNode {
   switch (node.kind) {
@@ -13,6 +13,10 @@ function redactWorkflowGraphNodeLabel(node: WorkflowGraphNode): WorkflowGraphNod
     case "search":
       return node
   }
+}
+
+export function redactWorkflowGraphAuthoringDetails(graph: WorkflowGraph): WorkflowGraph {
+  return { ...graph, nodes: graph.nodes.map(redactWorkflowGraphNodeLabel) }
 }
 
 export function redactWorkflowNormalizedPayloadAuthoringDetails(
@@ -30,7 +34,7 @@ export function redactWorkflowVersionAuthoringDetails(
     ...version,
     code: null,
     graph: version.graph
-      ? { ...version.graph, nodes: version.graph.nodes.map(redactWorkflowGraphNodeLabel) }
+      ? redactWorkflowGraphAuthoringDetails(version.graph)
       : null,
     exampleInput: null,
     automationReferences: version.automationReferences.map((reference) => ({

--- a/ee/apps/den-api/src/workflows.ts
+++ b/ee/apps/den-api/src/workflows.ts
@@ -4,6 +4,7 @@ import type {
 import type {
   WorkflowArtifactSnapshot,
   WorkflowDetail,
+  WorkflowRunPreview,
   WorkflowVersion,
 } from "@openwork/types/workflows"
 import { WorkflowGraph } from "@openwork/codemode"
@@ -35,8 +36,9 @@ import {
   workflowArtifactSource,
   WORKFLOW_MARKDOWN_RENDERER_VERSION,
 } from "./workflow-artifacts.js"
-import { redactWorkflowVersionAuthoringDetails } from "./workflow-projections.js"
+import { redactWorkflowGraphAuthoringDetails, redactWorkflowVersionAuthoringDetails } from "./workflow-projections.js"
 import {
+  PluginArchAuthorizationError,
   requirePluginArchResourceRole,
   resolvePluginArchGrantRole,
   resolvePluginArchResourceRole,
@@ -299,6 +301,58 @@ export async function listWorkflowVersions(input: { context: PluginArchActorCont
     resourceKind: "config_object",
   })
   return workflowVersions(input.context, resource.configObject.id, role === "manager")
+}
+
+export async function workflowRunPreviews(input: {
+  context: PluginArchActorContext
+  runs: Pick<WorkflowRunRow, "id" | "config_object_id" | "config_object_version_id">[]
+}): Promise<Map<string, WorkflowRunPreview>> {
+  const previews = new Map<string, WorkflowRunPreview>()
+  const workflowIds = [...new Set(input.runs.flatMap((run) => run.config_object_id ? [run.config_object_id] : []))]
+  const resources = await Promise.all(workflowIds.map(async (configObjectId) => {
+    try {
+      const resource = await workflowResource(input.context, configObjectId, "viewer")
+      const role = await resolvePluginArchResourceRole({
+        context: input.context, resourceId: configObjectId, resourceKind: "config_object",
+      })
+      return { resource, role }
+    } catch (error) {
+      if (error instanceof PluginArchAuthorizationError || (error instanceof Error && error.message === "workflow_not_found")) return null
+      throw error
+    }
+  }))
+  const visible = new Map(resources.flatMap((entry) => entry ? [[entry.resource.configObject.id, entry] as const] : []))
+  if (visible.size === 0) return previews
+  const versionIds = [...new Set(input.runs.flatMap((run) =>
+    run.config_object_id && visible.has(run.config_object_id) && run.config_object_version_id ? [run.config_object_version_id] : []))]
+  const versions = versionIds.length === 0 ? [] : await db.select({
+    id: ConfigObjectVersionTable.id,
+    configObjectId: ConfigObjectVersionTable.configObjectId,
+    code: ConfigObjectVersionTable.rawSourceText,
+  }).from(ConfigObjectVersionTable).where(and(
+    eq(ConfigObjectVersionTable.organizationId, input.context.organizationContext.organization.id),
+    inArray(ConfigObjectVersionTable.id, versionIds),
+    inArray(ConfigObjectVersionTable.configObjectId, [...visible.keys()]),
+    eq(ConfigObjectVersionTable.isDeletedVersion, false),
+  ))
+  const graphs = new Map(versions.map((version) => {
+    const graph = version.code === null ? null : WorkflowGraph.analyze(version.code)
+    return [version.id, {
+      configObjectId: version.configObjectId,
+      graph: graph && visible.get(version.configObjectId)?.role !== "manager" ? redactWorkflowGraphAuthoringDetails(graph) : graph,
+    }] as const
+  }))
+  for (const run of input.runs) {
+    const entry = run.config_object_id ? visible.get(run.config_object_id) : undefined
+    if (!entry) continue
+    const version = run.config_object_version_id ? graphs.get(run.config_object_version_id) : undefined
+    previews.set(run.id, {
+      configObjectId: entry.resource.configObject.id,
+      title: entry.resource.configObject.title,
+      graph: version?.configObjectId === run.config_object_id ? version.graph : null,
+    })
+  }
+  return previews
 }
 
 export async function listWorkflowSnapshots(input: {

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -1,3 +1,4 @@
+import { workflowRunPreviewSchema, type WorkflowRunPreview } from "@openwork/types/workflows";
 import { DEN_WORKER_POLL_INTERVAL_MS } from "./CONSTS";
 import { denApiCredentials, denApiEndpoint } from "./den-api-origin";
 import { ORG_SCOPE_HEADER, getRequestOrgScope, shouldPinOrgScopePath } from "./org-scope";
@@ -166,6 +167,7 @@ export type WorkerListItem = {
 
 export type WorkflowRun = {
   id: string;
+  workflow: WorkflowRunPreview | null;
   source: string;
   status: "succeeded" | "failed";
   errorKind: string | null;
@@ -900,9 +902,11 @@ function parseWorkflowRun(value: unknown): WorkflowRun | null {
         isRecord(call) && typeof call.name === "string" ? [{ name: call.name }] : [],
       )
     : [];
+  const workflow = workflowRunPreviewSchema.safeParse(value.workflow);
 
   return {
     id: value.id,
+    workflow: workflow.success ? workflow.data : null,
     source: value.source,
     status: value.status,
     errorKind: typeof value.errorKind === "string" ? value.errorKind : null,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { ScrollText } from "lucide-react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenCard } from "../../_components/ui/card";
-import { DenTable, type DenTableColumn } from "../../_components/ui/table";
+import { DenChip } from "../../_components/ui/chip";
+import { WorkflowFlowDiagram } from "./workflow-flow-diagram";
 import {
   getWorkflowRuns,
   getErrorMessage,
@@ -16,38 +18,43 @@ function formatDuration(durationMs: number): string {
   return durationMs < 1_000 ? `${durationMs} ms` : `${(durationMs / 1_000).toFixed(1)} s`;
 }
 
-const columns: readonly DenTableColumn<WorkflowRun>[] = [
-  {
-    key: "status",
-    header: "Status",
-    render: (run) => (
-      <span className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${run.status === "succeeded" ? "bg-emerald-50 text-emerald-700" : "bg-rose-50 text-rose-700"}`}>
-        {run.status === "succeeded" ? "Succeeded" : "Failed"}
-      </span>
-    ),
-  },
-  {
-    key: "source",
-    header: "Source",
-    render: (run) => (
-      <span className="block max-w-[280px] truncate font-mono text-[12px] text-gray-700" title={run.source}>
-        {run.source}
-      </span>
-    ),
-  },
-  {
-    key: "tools",
-    header: "Tool calls",
-    render: (run) => (
-      <div className="max-w-[360px] text-[12px] text-gray-600">
-        <span className="font-medium text-gray-900">{run.toolCallCount}</span>
-        {run.toolCalls.length > 0 ? <span className="ml-2 break-words text-gray-400">{run.toolCalls.map((call) => call.name).join(", ")}</span> : null}
-      </div>
-    ),
-  },
-  { key: "duration", header: "Duration", render: (run) => <span className="text-gray-600">{formatDuration(run.durationMs)}</span> },
-  { key: "when", header: "When", render: (run) => <span className="whitespace-nowrap text-gray-500">{new Date(run.createdAt).toLocaleString()}</span> },
-];
+function WorkflowRunCard({ run }: { run: WorkflowRun }) {
+  return (
+    <li data-run-id={run.id}>
+      <DenCard>
+        <h2 className="text-[15px] font-medium text-gray-950">
+          {run.workflow ? (
+            <Link data-testid={`workflow-run-link-${run.id}`} className="underline-offset-4 hover:underline" href={`/dashboard/library/workflows/${encodeURIComponent(run.workflow.configObjectId)}`}>
+              {run.workflow.title}
+            </Link>
+          ) : run.source === "adhoc" ? "One-off task" : "Workflow run"}
+        </h2>
+        {run.workflow?.graph ? (
+          <div className="mt-4 max-h-96 overflow-auto rounded-xl border border-gray-100 bg-gray-50/50 px-4 pb-4" role="region" aria-label={`${run.workflow.title} workflow visualization`} tabIndex={0}>
+            <WorkflowFlowDiagram graph={run.workflow.graph} />
+          </div>
+        ) : run.workflow ? (
+          <p className="mt-3 text-[13px] text-gray-500">The visualization for this run is unavailable.</p>
+        ) : null}
+        <div className="mt-4 flex flex-wrap items-center gap-3 text-[12px] text-gray-500">
+          <DenChip tone={run.status === "succeeded" ? "success" : "danger"}>
+            {run.status === "succeeded" ? "Succeeded" : "Failed"}
+          </DenChip>
+          <time dateTime={run.finishedAt}>{new Date(run.finishedAt).toLocaleString()}</time>
+        </div>
+        <details className="mt-4 border-t border-gray-100 pt-3 text-[12px] text-gray-500">
+          <summary data-testid={`workflow-run-details-${run.id}`} className="cursor-pointer font-medium">Technical details</summary>
+          <dl className="mt-3 space-y-2">
+            <div><dt>Source</dt><dd className="break-all font-mono">{run.source}</dd></div>
+            <div><dt>Tool calls</dt><dd>{run.toolCallCount}{run.toolCalls.length > 0 ? <span className="ml-2 break-all font-mono">{run.toolCalls.map((call) => call.name).join(", ")}</span> : null}</dd></div>
+            <div><dt>Duration</dt><dd>{formatDuration(run.durationMs)}</dd></div>
+            {run.errorMessage ? <div><dt>Error</dt><dd className="break-words text-red-700">{run.errorMessage}</dd></div> : null}
+          </dl>
+        </details>
+      </DenCard>
+    </li>
+  );
+}
 
 export function WorkflowRunsScreen() {
   const [runs, setRuns] = useState<WorkflowRun[]>([]);
@@ -76,17 +83,19 @@ export function WorkflowRunsScreen() {
     <DashboardPageTemplate
       icon={ScrollText}
       title="Workflow Runs"
-      description="Review recent Workflow run activity and the capabilities each run called."
+      description="Workflows are repeatable tasks you and your team can save, share, and run again. See their recent activity here."
       colors={["#EEF2FF", "#6366F1", "#C7D2FE", "#A5B4FC"]}
     >
       {error ? <div className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">{error}</div> : null}
-      <DenCard className="!p-0">
-        {loading ? (
-          <p className="px-6 py-5 text-[13px] text-gray-500">Loading Workflow runs...</p>
-        ) : (
-          <DenTable columns={columns} rows={runs} getRowKey={(run) => run.id} emptyLabel="No Workflow runs yet." />
-        )}
-      </DenCard>
+      {loading ? (
+        <DenCard><p className="text-[13px] text-gray-500">Loading Workflow runs...</p></DenCard>
+      ) : runs.length === 0 ? (
+        <DenCard><p className="text-[13px] text-gray-500">No Workflow runs yet.</p></DenCard>
+      ) : (
+        <ol className="space-y-4" aria-label="Workflow runs">
+          {runs.map((run) => <WorkflowRunCard key={run.id} run={run} />)}
+        </ol>
+      )}
     </DashboardPageTemplate>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
@@ -40,7 +40,7 @@ function WorkflowRunCard({ run }: { run: WorkflowRun }) {
           <DenChip tone={run.status === "succeeded" ? "success" : "danger"}>
             {run.status === "succeeded" ? "Succeeded" : "Failed"}
           </DenChip>
-          <time dateTime={run.finishedAt}>{new Date(run.finishedAt).toLocaleString()}</time>
+          <time data-testid={`workflow-run-time-${run.id}`} dateTime={run.finishedAt}>{new Date(run.finishedAt).toLocaleString()}</time>
         </div>
         <details className="mt-4 border-t border-gray-100 pt-3 text-[12px] text-gray-500">
           <summary data-testid={`workflow-run-details-${run.id}`} className="cursor-pointer font-medium">Technical details</summary>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
@@ -30,7 +30,7 @@ function WorkflowRunCard({ run }: { run: WorkflowRun }) {
           ) : run.source === "adhoc" ? "One-off task" : "Workflow run"}
         </h2>
         {run.workflow?.graph ? (
-          <div className="mt-4 max-h-96 overflow-auto rounded-xl border border-gray-100 bg-gray-50/50 px-4 pb-4" role="region" aria-label={`${run.workflow.title} workflow visualization`} tabIndex={0}>
+          <div data-testid={`workflow-run-visualization-${run.id}`} className="mt-4 max-h-96 overflow-auto rounded-xl border border-gray-100 bg-gray-50/50 px-4 pb-4" role="region" aria-label={`${run.workflow.title} workflow visualization`} tabIndex={0}>
             <WorkflowFlowDiagram graph={run.workflow.graph} />
           </div>
         ) : run.workflow ? (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
@@ -20,7 +20,7 @@ function formatDuration(durationMs: number): string {
 
 function WorkflowRunCard({ run }: { run: WorkflowRun }) {
   return (
-    <li data-run-id={run.id}>
+    <li data-run-id={run.id} data-testid={`workflow-run-${run.id}`}>
       <DenCard>
         <h2 className="text-[15px] font-medium text-gray-950">
           {run.workflow ? (

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -85,43 +85,32 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
   await step("read existing diagrams directly in the run list", async () => {
     await user.see({ text: "Workflow Runs" }, { timeoutMs: 90_000 });
     await user.see({ text: "Workflows are repeatable tasks you and your team can save, share, and run again. See their recent activity here." });
-    await probe.eventually(() => probe.eval(`Boolean(document.querySelector('[data-run-id="${world.receiptId}"] [data-testid="den-workflow-flow-diagram"]'))`), { within: 30_000, label: "saved run diagram", until: (value) => value === true });
-    const rendered = await probe.eval(`(() => {
-      const row = document.querySelector('[data-run-id="${world.receiptId}"]');
-      const diagram = row.querySelector('[data-testid="den-workflow-flow-diagram"]');
-      const details = row.querySelector('details');
-      return {
-        title: row.querySelector('h2 a')?.textContent,
-        href: row.querySelector('h2 a')?.getAttribute('href'),
-        nodes: [...diagram.querySelectorAll('[data-node-id]')].map(node => node.getAttribute('data-node-id')),
-        status: row.innerText.includes('Succeeded'),
-        time: Boolean(row.querySelector('time')?.dateTime),
-        detailsClosed: !details.open,
-        rawSourceHidden: details.querySelector('dd').getClientRects().length === 0,
-      };
-    })()`);
-    const graphNodes = record(world.originalGraph).nodes;
-    if (!Array.isArray(graphNodes)) throw new Error("Expected graph nodes");
-    expect(rendered).toEqual({ title: "Weekly briefing", href: `/dashboard/library/workflows/${world.configObjectId}`, nodes: graphNodes.map((node) => field(node, "id")), status: true, time: true, detailsClosed: true, rawSourceHidden: true });
+    await user.see({ testId: "den-workflow-flow-diagram", nth: 1 }, { timeoutMs: 30_000 });
+    await user.notSee({ testId: "den-workflow-flow-diagram", nth: 2 });
+    await user.see({ testId: `workflow-run-link-${world.receiptId}` }, { text: "Weekly briefing" });
+    await user.see({ testId: `workflow-run-time-${world.receiptId}` });
+    await user.see({ text: "Succeeded" });
+    await user.see({ text: "Failed" });
+    await user.notSee({ text: `plugin:${world.pluginId}:${world.configObjectId}` });
     await user.see({ text: "One-off task" });
-    const adhoc = before.find((run) => run.source === "adhoc");
-    expect(adhoc).toBeDefined();
-    expect(await probe.eval(`Boolean(document.querySelector('[data-run-id="${adhoc?.id}"] a, [data-run-id="${adhoc?.id}"] [data-testid="den-workflow-flow-diagram"]'))`)).toBe(false);
+    await user.notSee({ role: "link", label: "One-off task" });
+    await user.notSee({ label: "One-off task workflow visualization" });
     await user.screenshot();
   });
-  evidence.recordAssertionEvidence("Saved runs show the existing visualization of their executed version", "The API graph matches the original version and differs from the later edit. The rendered run includes every original graph node, a library link, status and time; one-off runs have neither a fabricated link nor a diagram.", true);
+  evidence.recordAssertionEvidence("Saved runs show the existing visualization of their executed version", "The API graph matches the original version and differs from the later edit. The activity page renders both saved-run diagrams with a library link, status and time; one-off runs have neither a fabricated link nor a visualization.", true);
   evidence.recordAssertionEvidence("Workflow activity explains reuse and keeps raw run details collapsed", "The introduction is visible and the closed details element keeps raw source values out of the visible run card.", true);
 
   await step("open the linked workflow in the existing library", async () => {
     await user.click({ testId: `workflow-run-link-${world.receiptId}` });
     await user.see({ testId: "den-workflow-detail" }, { timeoutMs: 60_000 });
-    expect(await probe.eval("location.pathname")).toBe(`/dashboard/library/workflows/${world.configObjectId}`);
+    await user.see({ text: "How it works" });
+    await user.see({ text: "Weekly briefing" });
     expect(await readRuns()).toEqual(before);
     await user.navigate(`${world.den.ref.webUrl}/dashboard/workflow-runs`);
     await user.see({ text: "Workflow Runs" });
     await user.click({ testId: `workflow-run-details-${world.receiptId}` });
     await user.see({ text: `plugin:${world.pluginId}:${world.configObjectId}` });
-    expect(await probe.eval(`document.querySelector('[data-run-id="${world.receiptId}"] details').open`)).toBe(true);
+
   });
   evidence.recordAssertionEvidence("The run opens its library workflow and technical details remain available", "Clicking the workflow name opens the existing library detail without creating any new runs. Expanding Technical details reveals its saved source.", true);
 

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -109,7 +109,7 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     await user.notSee({ testId: `workflow-run-link-${oneOffReceiptId}` });
     await user.notSee({ testId: `workflow-run-visualization-${oneOffReceiptId}` });
     await user.click({ testId: `workflow-run-details-${oneOffReceiptId}` });
-    await user.see({ testId: `workflow-run-${oneOffReceiptId}` }, { text: /Source[\s\S]*adhoc[\s\S]*Tool calls[\s\S]*den.getWorkers[\s\S]*Duration[\s\S]*ms/ });
+    await user.see({ testId: `workflow-run-${oneOffReceiptId}` }, { text: /Source[\s\S]*adhoc[\s\S]*Tool calls[\s\S]*den.getWorkers[\s\S]*Duration[\s\S]*\d+(?:\.\d+)? (?:ms|s)/ });
     await user.click({ testId: `workflow-run-details-${oneOffReceiptId}` });
     await user.notSee({ role: "link", label: "One-off task" });
     await user.notSee({ label: "One-off task workflow visualization" });

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -47,7 +47,7 @@ const test = spec.world(async (seed) => {
     const message = record(JSON.parse(data ? data.slice(5) : text));
     if (message.error || record(message.result).isError) throw new Error("The setup execution failed");
   };
-  const code = "const workers = await tools.den.getWorkers({}); return { topic: input.topic, count: workers.workers.length };";
+  const code = "const workers = await tools.den.getWorkers({}); let count = 0; for (const worker of workers.workers) { count += 1; } if (input.topic) { return { topic: input.topic, count }; } return { count };";
   const inputSchema = { type: "object", properties: { topic: { type: "string" } }, required: ["topic"] };
   await execute(code);
   const saved = await saveWorkflow(den.admin, { name: "Weekly briefing", code, currentInput: { topic: "Weekly overview" }, inputSchema });
@@ -80,12 +80,22 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
   expect(first).toMatchObject({ workflow: { configObjectId: world.configObjectId, title: "Weekly briefing", graph: world.originalGraph } });
   expect(record(first?.workflow).graph).not.toEqual(world.revisedGraph);
   expect(before.filter((run) => run.source === "adhoc").every((run) => run.workflow === null)).toBe(true);
-  expect(before.some((run) => run.status === "failed" && record(run.workflow).configObjectId === world.configObjectId)).toBe(true);
+  const failed = before.find((run) => run.status === "failed" && isRecord(run.workflow) && run.workflow.configObjectId === world.configObjectId);
+  expect(failed).toMatchObject({ workflow: { graph: world.originalGraph } });
+  const failedReceiptId = field(failed, "id");
 
   await step("read existing diagrams directly in the run list", async () => {
     await user.see({ text: "Workflow Runs" }, { timeoutMs: 90_000 });
     await user.see({ text: "Workflows are repeatable tasks you and your team can save, share, and run again. See their recent activity here." });
-    await user.see({ testId: "den-workflow-flow-diagram", nth: 1 }, { timeoutMs: 30_000 });
+    for (const receiptId of [world.receiptId, failedReceiptId]) {
+      // Scope rendered node text to each receipt; an empty diagram or the latest
+      // version (Revised count) must fail even when another card is correct.
+      await user.see({ testId: `workflow-run-visualization-${receiptId}` }, {
+        text: /^(?![\s\S]*Revised count)(?=[\s\S]*Get workers)(?=[\s\S]*For each item in workers workers)(?=[\s\S]*Topic is set)(?=[\s\S]*Finish with: Topic, Count)[\s\S]*$/,
+      });
+      await user.see({ testId: `workflow-run-link-${receiptId}` }, { text: "Weekly briefing" });
+      await user.see({ testId: `workflow-run-time-${receiptId}` });
+    }
     await user.notSee({ testId: "den-workflow-flow-diagram", nth: 2 });
     await user.see({ testId: `workflow-run-link-${world.receiptId}` }, { text: "Weekly briefing" });
     await user.see({ testId: `workflow-run-time-${world.receiptId}` });
@@ -130,7 +140,16 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     expect(visible[0]).toMatchObject({ id: memberRun.receiptId, workflow: { configObjectId: world.configObjectId } });
     const memberNodes = record(record(visible[0].workflow).graph).nodes;
     if (!Array.isArray(memberNodes)) throw new Error("Expected the shared workflow graph");
-    expect(memberNodes.map(record).find((node) => node.kind === "return")?.label).toBe("Result");
+    const originalNodes = record(world.originalGraph).nodes;
+    if (!Array.isArray(originalNodes)) throw new Error("Expected the authored workflow graph");
+    for (const [kind, label] of [["branch", "Condition"], ["loop", "Repeat"], ["return", "Result"]]) {
+      const authored = originalNodes.map(record).filter((node) => node.kind === kind);
+      const shared = memberNodes.map(record).filter((node) => node.kind === kind);
+      expect(authored.length).toBeGreaterThan(0);
+      expect(authored.every((node) => node.label !== label)).toBe(true);
+      expect(shared.map((node) => node.id)).toEqual(authored.map((node) => node.id));
+      expect(shared.map((node) => node.label)).toEqual(authored.map(() => label));
+    }
     const removed = await seed.api(world.den.admin, `/v1/config-objects/${world.configObjectId}/access/${field(record(grant.body).item, "id")}`, { method: "DELETE" });
     expect(removed.response.ok, removed.text).toBe(true);
     const revoked = await readRuns(colleague);

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "vitest";
+import { runWorkflow, saveWorkflow } from "@openwork/behaviors";
+import { spec } from "@openwork/testkit";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected an object response");
+  return value;
+}
+
+function field(value: unknown, name: string): string {
+  const result = record(value)[name];
+  if (typeof result !== "string") throw new Error(`Expected ${name}`);
+  return result;
+}
+
+function runs(value: unknown): Record<string, unknown>[] {
+  const items = record(value).runs;
+  if (!Array.isArray(items)) throw new Error("Expected workflow runs");
+  return items.map(record);
+}
+
+// New journey: browse organization workflow activity and open the saved workflow
+// from the visualization of the version that produced a particular run.
+const test = spec.world(async (seed) => {
+  const den = await seed.den({ org: { name: "Workflow activity", members: { colleague: { name: "Teammate" } } } });
+  const organizationId = field(record((await seed.api(den.admin, "/v1/org")).body).organization, "id");
+  const token = field((await seed.api(den.admin, "/v1/mcp/token", {
+    method: "POST", headers: { "x-openwork-org-id": organizationId }, body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  })).body, "token");
+  let requestId = 0;
+  const execute = async (code: string) => {
+    const response = await fetch(`${den.ref.apiUrl}/mcp/agent`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method: "tools/call", params: {
+        name: "execute_capability_script", arguments: { code, input: { topic: "Weekly overview" } },
+      } }),
+      signal: AbortSignal.timeout(90_000),
+    });
+    const text = await response.text();
+    if (!response.ok) throw new Error(`Workflow setup failed (${response.status})`);
+    const data = text.split("\n").find((line) => line.startsWith("data:"));
+    const message = record(JSON.parse(data ? data.slice(5) : text));
+    if (message.error || record(message.result).isError) throw new Error("The setup execution failed");
+  };
+  const code = "const workers = await tools.den.getWorkers({}); return { topic: input.topic, count: workers.workers.length };";
+  const inputSchema = { type: "object", properties: { topic: { type: "string" } }, required: ["topic"] };
+  await execute(code);
+  const saved = await saveWorkflow(den.admin, { name: "Weekly briefing", code, currentInput: { topic: "Weekly overview" }, inputSchema });
+  if (saved.status !== 201) throw new Error(`Saving the setup workflow failed (${saved.status})`);
+  const configObjectId = field(saved.body, "configObjectId");
+  const pluginId = field(saved.body, "pluginId");
+  const configObjectVersionId = field(saved.body, "configObjectVersionId");
+  const firstRun = await runWorkflow(den.admin, configObjectId, { pluginId, configObjectVersionId, input: { topic: "Weekly overview" } });
+  // Save another version without running it. History must retain the first graph.
+  const nextCode = "const workers = await tools.den.getWorkers({}); return { revisedCount: workers.workers.length };";
+  await execute(nextCode);
+  const revised = await saveWorkflow(den.admin, { name: "Weekly briefing", code: nextCode, inputSchema, currentInput: { topic: "Next week" } });
+  if (revised.status !== 201) throw new Error(`Revising the setup workflow failed (${revised.status})`);
+  const failed = await seed.api(den.admin, `/v1/workflows/${configObjectId}/run`, {
+    method: "POST", body: JSON.stringify({ pluginId, configObjectVersionId, input: {} }),
+  });
+  if (failed.response.ok) throw new Error("Missing workflow input must fail");
+  const web = await seed.web({ den, signedInAs: "admin", startPath: "/dashboard/workflow-runs", headless: true, viewport: { width: 1440, height: 1000 } });
+  return { den, web, configObjectId, pluginId, configObjectVersionId, receiptId: field(firstRun, "receiptId"), originalGraph: record(saved.body).graph, revisedGraph: record(revised.body).graph };
+}, { timeout: 600_000 });
+
+test("workflow activity shows linked version diagrams and keeps one-off and inaccessible runs readable", async ({ world, user, probe, seed, evidence, step }) => {
+  const readRuns = async (session = world.den.admin) => {
+    const response = await probe.api(session, "/v1/workflow-runs");
+    expect(response.response.status, response.text).toBe(200);
+    return runs(response.body);
+  };
+  const before = await readRuns();
+  const first = before.find((run) => run.id === world.receiptId);
+  expect(first).toMatchObject({ workflow: { configObjectId: world.configObjectId, title: "Weekly briefing", graph: world.originalGraph } });
+  expect(record(first?.workflow).graph).not.toEqual(world.revisedGraph);
+  expect(before.filter((run) => run.source === "adhoc").every((run) => run.workflow === null)).toBe(true);
+  expect(before.some((run) => run.status === "failed" && record(run.workflow).configObjectId === world.configObjectId)).toBe(true);
+
+  await step("read existing diagrams directly in the run list", async () => {
+    await user.see({ text: "Workflow Runs" }, { timeoutMs: 90_000 });
+    await user.see({ text: "Workflows are repeatable tasks you and your team can save, share, and run again. See their recent activity here." });
+    await probe.eventually(() => probe.eval(`Boolean(document.querySelector('[data-run-id="${world.receiptId}"] [data-testid="den-workflow-flow-diagram"]'))`), { within: 30_000, label: "saved run diagram", until: (value) => value === true });
+    const rendered = await probe.eval(`(() => {
+      const row = document.querySelector('[data-run-id="${world.receiptId}"]');
+      const diagram = row.querySelector('[data-testid="den-workflow-flow-diagram"]');
+      const details = row.querySelector('details');
+      return {
+        title: row.querySelector('h2 a')?.textContent,
+        href: row.querySelector('h2 a')?.getAttribute('href'),
+        nodes: [...diagram.querySelectorAll('[data-node-id]')].map(node => node.getAttribute('data-node-id')),
+        status: row.innerText.includes('Succeeded'),
+        time: Boolean(row.querySelector('time')?.dateTime),
+        detailsClosed: !details.open,
+        rawSourceHidden: details.querySelector('dd').getClientRects().length === 0,
+      };
+    })()`);
+    const graphNodes = record(world.originalGraph).nodes;
+    if (!Array.isArray(graphNodes)) throw new Error("Expected graph nodes");
+    expect(rendered).toEqual({ title: "Weekly briefing", href: `/dashboard/library/workflows/${world.configObjectId}`, nodes: graphNodes.map((node) => field(node, "id")), status: true, time: true, detailsClosed: true, rawSourceHidden: true });
+    await user.see({ text: "One-off task" });
+    const adhoc = before.find((run) => run.source === "adhoc");
+    expect(adhoc).toBeDefined();
+    expect(await probe.eval(`Boolean(document.querySelector('[data-run-id="${adhoc?.id}"] a, [data-run-id="${adhoc?.id}"] [data-testid="den-workflow-flow-diagram"]'))`)).toBe(false);
+    await user.screenshot();
+  });
+  evidence.recordAssertionEvidence("Saved runs show the existing visualization of their executed version", "The API graph matches the original version and differs from the later edit. The rendered run includes every original graph node, a library link, status and time; one-off runs have neither a fabricated link nor a diagram.", true);
+  evidence.recordAssertionEvidence("Workflow activity explains reuse and keeps raw run details collapsed", "The introduction is visible and the closed details element keeps raw source values out of the visible run card.", true);
+
+  await step("open the linked workflow in the existing library", async () => {
+    await user.click({ testId: `workflow-run-link-${world.receiptId}` });
+    await user.see({ testId: "den-workflow-detail" }, { timeoutMs: 60_000 });
+    expect(await probe.eval("location.pathname")).toBe(`/dashboard/library/workflows/${world.configObjectId}`);
+    expect(await readRuns()).toEqual(before);
+    await user.navigate(`${world.den.ref.webUrl}/dashboard/workflow-runs`);
+    await user.see({ text: "Workflow Runs" });
+    await user.click({ testId: `workflow-run-details-${world.receiptId}` });
+    await user.see({ text: `plugin:${world.pluginId}:${world.configObjectId}` });
+    expect(await probe.eval(`document.querySelector('[data-run-id="${world.receiptId}"] details').open`)).toBe(true);
+  });
+  evidence.recordAssertionEvidence("The run opens its library workflow and technical details remain available", "Clicking the workflow name opens the existing library detail without creating any new runs. Expanding Technical details reveals its saved source.", true);
+
+  await step("respect member access when enriching activity", async () => {
+    const colleague = world.den.members.colleague;
+    expect(await readRuns(colleague)).toEqual([]);
+    const org = record((await probe.api(world.den.admin, "/v1/org")).body);
+    if (!Array.isArray(org.members)) throw new Error("Expected organization members");
+    const member = org.members.map(record).find((entry) => record(entry.user).email === colleague.email);
+    const grant = await seed.api(world.den.admin, `/v1/config-objects/${world.configObjectId}/access`, {
+      method: "POST", body: JSON.stringify({ orgMembershipId: field(member, "id"), role: "editor" }),
+    });
+    expect(grant.response.status, grant.text).toBe(201);
+    const memberRun = await runWorkflow(colleague, world.configObjectId, { pluginId: world.pluginId, configObjectVersionId: world.configObjectVersionId, input: { topic: "Member briefing" } });
+    const visible = await readRuns(colleague);
+    expect(visible).toHaveLength(1);
+    expect(visible[0]).toMatchObject({ id: memberRun.receiptId, workflow: { configObjectId: world.configObjectId } });
+    expect(JSON.stringify(visible[0].workflow)).not.toContain("workers.workers.length");
+    const removed = await seed.api(world.den.admin, `/v1/config-objects/${world.configObjectId}/access/${field(record(grant.body).item, "id")}`, { method: "DELETE" });
+    expect(removed.response.ok, removed.text).toBe(true);
+    const revoked = await readRuns(colleague);
+    expect(revoked).toHaveLength(1);
+    expect(revoked[0]).toMatchObject({ id: memberRun.receiptId, workflow: null });
+    expect((await probe.api(colleague, `/v1/workflows/${world.configObjectId}`)).response.status).toBe(403);
+  });
+  evidence.recordAssertionEvidence("Run previews follow workflow access without widening run visibility", "A member sees none of the admin's runs, then sees a redacted preview of their own shared workflow run. Revoking the workflow grant preserves their receipt but removes its preview and library metadata.", true);
+});

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -128,7 +128,9 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     const visible = await readRuns(colleague);
     expect(visible).toHaveLength(1);
     expect(visible[0]).toMatchObject({ id: memberRun.receiptId, workflow: { configObjectId: world.configObjectId } });
-    expect(JSON.stringify(visible[0].workflow)).not.toContain("workers.workers.length");
+    const memberNodes = record(record(visible[0].workflow).graph).nodes;
+    if (!Array.isArray(memberNodes)) throw new Error("Expected the shared workflow graph");
+    expect(memberNodes.map(record).find((node) => node.kind === "return")?.label).toBe("Result");
     const removed = await seed.api(world.den.admin, `/v1/config-objects/${world.configObjectId}/access/${field(record(grant.body).item, "id")}`, { method: "DELETE" });
     expect(removed.response.ok, removed.text).toBe(true);
     const revoked = await readRuns(colleague);

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -83,6 +83,8 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
   const failed = before.find((run) => run.status === "failed" && isRecord(run.workflow) && run.workflow.configObjectId === world.configObjectId);
   expect(failed).toMatchObject({ workflow: { graph: world.originalGraph } });
   const failedReceiptId = field(failed, "id");
+  const oneOff = before.find((run) => run.source === "adhoc" && run.status === "succeeded");
+  const oneOffReceiptId = field(oneOff, "id");
 
   await step("read existing diagrams directly in the run list", async () => {
     await user.see({ text: "Workflow Runs" }, { timeoutMs: 90_000 });
@@ -102,7 +104,13 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     await user.see({ text: "Succeeded" });
     await user.see({ text: "Failed" });
     await user.notSee({ text: `plugin:${world.pluginId}:${world.configObjectId}` });
-    await user.see({ text: "One-off task" });
+    await user.see({ testId: `workflow-run-${oneOffReceiptId}` }, { text: /One-off task[\s\S]*Succeeded[\s\S]*Technical details/ });
+    await user.see({ testId: `workflow-run-time-${oneOffReceiptId}` });
+    await user.notSee({ testId: `workflow-run-link-${oneOffReceiptId}` });
+    await user.notSee({ testId: `workflow-run-visualization-${oneOffReceiptId}` });
+    await user.click({ testId: `workflow-run-details-${oneOffReceiptId}` });
+    await user.see({ testId: `workflow-run-${oneOffReceiptId}` }, { text: /Source[\s\S]*adhoc[\s\S]*Tool calls[\s\S]*den.getWorkers[\s\S]*Duration[\s\S]*ms/ });
+    await user.click({ testId: `workflow-run-details-${oneOffReceiptId}` });
     await user.notSee({ role: "link", label: "One-off task" });
     await user.notSee({ label: "One-off task workflow visualization" });
     await user.screenshot();

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -731,6 +731,57 @@ export type WorkflowRunListResponse = {
     finishedAt: string;
     createdAt: string;
     orgMembershipId: string | null;
+    workflow: {
+      configObjectId: string;
+      title: string;
+      graph: {
+        nodes: Array<
+          | {
+              id: string;
+              kind: "input";
+              label: string;
+              fields: Array<string>;
+            }
+          | {
+              id: string;
+              kind: "tool";
+              label: string;
+              namespace: string;
+              tool: string;
+              scriptPath: string;
+              assignsTo: string | null;
+              parallelGroup: string | null;
+            }
+          | {
+              id: string;
+              kind: "search";
+              label: string;
+            }
+          | {
+              id: string;
+              kind: "branch";
+              label: string;
+            }
+          | {
+              id: string;
+              kind: "loop";
+              label: string;
+            }
+          | {
+              id: string;
+              kind: "return";
+              label: string;
+            }
+        >;
+        edges: Array<{
+          from: string;
+          to: string;
+          label: string | null;
+          kind: "flow" | "data";
+        }>;
+        parseError: string | null;
+      } | null;
+    } | null;
   }>;
 };
 

--- a/packages/types/src/workflows.ts
+++ b/packages/types/src/workflows.ts
@@ -74,6 +74,13 @@ export const workflowGraphSchema = z.object({
 })
 export type WorkflowGraph = z.infer<typeof workflowGraphSchema>
 
+export const workflowRunPreviewSchema = z.object({
+  configObjectId: idSchema,
+  title: z.string(),
+  graph: workflowGraphSchema.nullable(),
+})
+export type WorkflowRunPreview = z.infer<typeof workflowRunPreviewSchema>
+
 export const workflowVersionSchema = z.object({
   id: idSchema,
   // Authoring source and example input are OpenWork management data, not MCP


### PR DESCRIPTION
Workflow Runs currently shows raw source strings and tool calls, even when a run belongs to a saved workflow. Show the existing workflow visualization and a linked workflow name for those runs, with status and time underneath and technical details collapsed. Add a short explanation of what workflows are.

Previews use the version that executed and the library's existing workflow permissions and graph redaction. One-off or inaccessible workflows remain readable activity entries without a fabricated preview. The generated API client includes the new preview field.

Validation:

- `OPENWORK_EVAL_REF=6eb2263093359c0be3468099dbb245ea5d72cae7 infisical run --silent --env dev -- pnpm evals:e2e workflow-run-previews` — **Passed: 1 passed, 0 failed, 0 skipped; exit 0.** Placement: daytona (daytona CLI authenticated). Covers original rendered steps scoped to both successful and failed receipts, branch/loop/return label redaction, historical version matching, library navigation, expandable details, receipt-specific one-off status/time/details, member isolation, and access revocation. See the published test evidence below.
- API and Den web type checks pass; `pnpm sdk:check` passes.
- Existing diagram and plain-language component tests: 9 passed, 0 failed.
- The broad `pnpm evals:typecheck` reports 337 errors; a clean control at base `726a73c34` reports the identical 337 errors after path normalization. The spec boundary/channel checks also reproduce on the clean base, with no new violations in this journey.

Manual check: open `/dashboard/workflow-runs` after running a saved workflow. Its card shows the existing diagram, linked title, status, and time. Open the title to reach the library workflow, or expand Technical details to inspect the run. One-off tasks remain simple entries.
