### PR TITLE
fix(app): open workspace New task without waiting for the engine

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -3373,6 +3373,16 @@ export function SessionRoute() {
         },
         onPrefetchSession: () => {},
         onCreateTaskInWorkspace: (workspaceId, groupId) => {
+          const { focusedPane, secondary } = useWorkbenchStore.getState();
+          if (!groupId && !(focusedPane === "secondary" && secondary)) {
+            // The empty composer creates its session on submit. Opening it must
+            // not wait for an engine request, especially on a cold v2 runtime.
+            setLegacySelectedWorkspaceId(workspaceId);
+            writeActiveWorkspaceId(workspaceId);
+            navigateToWorkspaceSession(workspaceId);
+            focusPromptSoon();
+            return;
+          }
           void handleCreateTaskInWorkspace(workspaceId).then((sessionId) => {
             if (sessionId && groupId) {
               sessionManagementStore.getState().assignGroup(workspaceId, sessionId, groupId);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -3374,7 +3374,9 @@ export function SessionRoute() {
         onPrefetchSession: () => {},
         onCreateTaskInWorkspace: (workspaceId, groupId) => {
           const { focusedPane, secondary } = useWorkbenchStore.getState();
-          if (!groupId && !(focusedPane === "secondary" && secondary)) {
+          const hasWorkspaceError = Boolean(errorsByWorkspaceId[workspaceId]?.trim())
+            || workspaceConnectionStateById[workspaceId]?.status === "error";
+          if (!groupId && !hasWorkspaceError && !(focusedPane === "secondary" && secondary)) {
             // The empty composer creates its session on submit. Opening it must
             // not wait for an engine request, especially on a cold v2 runtime.
             setLegacySelectedWorkspaceId(workspaceId);

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -15,7 +15,7 @@ test("workspace New task opens an editable composer immediately and creates one 
   await step("the plus remains the topmost hit target", async () => {
     // TODO(primitive): probe.hitTarget should identify the painted element at a visible control's center.
     const hit = await probe.eval(`(() => {
-      const plus = document.querySelector('[data-workspace-new-task]');
+      const plus = document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]');
       if (!(plus instanceof HTMLElement)) return { hitPlus: false, hitTitle: false, tag: "" };
       const rect = plus.getBoundingClientRect();
       const node = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
@@ -34,11 +34,11 @@ test("workspace New task opens an editable composer immediately and creates one 
   const before = (await agent.list()).map((session) => session.sessionId).sort();
   const requests = () => probe.eval(`window.__newTaskRequests`);
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
-  const expandedBefore = await probe.eval(`document.querySelector('[data-workspace-new-task]')
+  const expandedBefore = await probe.eval(`document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
   // TODO(primitive): probe.paintTiming should measure input-to-visible-content in the renderer.
   await probe.eval(`(() => {
-    const button = document.querySelector('[data-workspace-new-task]');
+    const button = document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]');
     button.addEventListener("click", () => {
       const started = performance.now();
       const observer = new MutationObserver(() => {
@@ -79,7 +79,7 @@ test("workspace New task opens an editable composer immediately and creates one 
   expect(JSON.stringify(creationRequests)).toContain(world.workspace.workspaceId);
   expect((await agent.list()).length).toBe(before.length + 1);
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
-  const expandedAfter = await probe.eval(`document.querySelector('[data-workspace-new-task]')
+  const expandedAfter = await probe.eval(`document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
   expect(expandedAfter).toBe(expandedBefore);
 });

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -36,8 +36,24 @@ test("workspace New task opens an editable composer immediately and creates one 
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
   const expandedBefore = await probe.eval(`document.querySelector('[data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
+  // TODO(primitive): probe.paintTiming should measure input-to-visible-content in the renderer.
+  await probe.eval(`(() => {
+    const button = document.querySelector('[data-workspace-new-task]');
+    button.addEventListener("click", () => {
+      const started = performance.now();
+      const observer = new MutationObserver(() => {
+        const heading = [...document.querySelectorAll("h2")]
+          .find((node) => node.textContent === "What do you need done?" && node.getClientRects().length);
+        if (!heading) return;
+        window.__newTaskOpenedAfterMs = performance.now() - started;
+        observer.disconnect();
+      });
+      observer.observe(document.body, { subtree: true, childList: true });
+    }, { once: true, capture: true });
+  })()`);
   await user.click({ role: "button", label: `New session · ${workspaceName}` });
   await user.see({ text: "What do you need done?" });
+  expect(await probe.eval(`window.__newTaskOpenedAfterMs`)).toBeLessThan(1000);
   expect(await probe.hash()).not.toContain("/session/ses_");
   expect(await requests()).toEqual([]);
   expect((await agent.list()).map((session) => session.sessionId).sort()).toEqual(before);

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -8,7 +8,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-test("the per-workspace New task plus stays clickable over a long truncated workspace name", async ({ world, user, agent, probe, step }) => {
+test("workspace New task opens an editable composer immediately and creates one task on submit", async ({ world, user, agent, probe, step }) => {
   const workspaceName = world.workspacePath.split("/").at(-1) ?? world.workspacePath;
   await user.hover({ role: "button", label: workspaceName });
 
@@ -31,17 +31,37 @@ test("the per-workspace New task plus stays clickable over a long truncated work
     expect(hit.hitTitle).toBe(false);
   });
 
-  const before = (await agent.list()).length;
+  const before = (await agent.list()).map((session) => session.sessionId).sort();
+  const requests = () => probe.eval(`window.__newTaskRequests`);
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
   const expandedBefore = await probe.eval(`document.querySelector('[data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
   await user.click({ role: "button", label: `New session · ${workspaceName}` });
+  await user.see({ text: "What do you need done?" });
+  expect(await probe.hash()).not.toContain("/session/ses_");
+  expect(await requests()).toEqual([]);
+  expect((await agent.list()).map((session) => session.sessionId).sort()).toEqual(before);
+
+  await step("the empty composer accepts and keeps a draft without creating a session", async () => {
+    await user.type({ placeholder: "Describe your task..." }, world.prompt, { verify: true });
+    await user.hover({ role: "button", label: workspaceName });
+    await user.click({ role: "button", label: `New session · ${workspaceName}` });
+    expect(await probe.eval(`document.querySelector('[contenteditable="true"]')?.textContent`)).toBe(world.prompt);
+    expect(await requests()).toEqual([]);
+  });
+  await user.click({ placeholder: "Describe your task..." });
+  await user.press("Enter");
   await probe.eventually(() => agent.list(), {
     within: 60_000,
-    label: "session created by workspace New task",
-    until: (sessions) => sessions.length > before,
+    label: "submitting creates exactly one session after the slow engine responds",
+    until: (sessions) => sessions.length === before.length + 1,
   });
+  await user.see({ text: world.reply });
   expect(await probe.hash()).toContain("/session/ses_");
+  const creationRequests = await requests();
+  expect(Array.isArray(creationRequests) && creationRequests.length).toBe(1);
+  expect(JSON.stringify(creationRequests)).toContain(world.workspace.workspaceId);
+  expect((await agent.list()).length).toBe(before.length + 1);
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
   const expandedAfter = await probe.eval(`document.querySelector('[data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -65,6 +65,7 @@ test("workspace New task opens an editable composer immediately and creates one 
     expect(await probe.eval(`document.querySelector('[contenteditable="true"]')?.textContent`)).toBe(world.prompt);
     expect(await requests()).toEqual([]);
   });
+  await user.see({ text: "New task model" });
   await user.click({ placeholder: "Describe your task..." });
   await user.press("Enter");
   await probe.eventually(() => agent.list(), {

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -8,7 +8,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-test("workspace New task opens an editable composer immediately and creates one task on submit", async ({ world, user, agent, probe, step }) => {
+test("workspace New task opens an editable composer immediately and creates one task on submit", async ({ world, user, agent, probe, step, evidence }) => {
   const workspaceName = world.workspacePath.split("/").at(-1) ?? world.workspacePath;
   await user.hover({ role: "button", label: workspaceName });
 
@@ -29,6 +29,10 @@ test("workspace New task opens an editable composer immediately and creates one 
     if (!isRecord(hit)) throw new Error(`New task plus returned malformed hit facts: ${JSON.stringify(hit)}`);
     expect(hit.hitPlus).toBe(true);
     expect(hit.hitTitle).toBe(false);
+    evidence.recordAssertionEvidence(
+      "The workspace New task plus remains clickable over a long workspace name",
+      "The painted element at the plus center belongs to the plus, not the truncated title.", true,
+    );
   });
 
   const before = (await agent.list()).map((session) => session.sessionId).sort();
@@ -53,10 +57,15 @@ test("workspace New task opens an editable composer immediately and creates one 
   })()`);
   await user.click({ role: "button", label: `New session · ${workspaceName}` });
   await user.see({ text: "What do you need done?" });
-  expect(await probe.eval(`window.__newTaskOpenedAfterMs`)).toBeLessThan(1000);
+  const openedAfterMs = await probe.eval(`window.__newTaskOpenedAfterMs`);
+  expect(openedAfterMs).toBeLessThan(1000);
   expect(await probe.hash()).not.toContain("/session/ses_");
   expect(await requests()).toEqual([]);
   expect((await agent.list()).map((session) => session.sessionId).sort()).toEqual(before);
+  evidence.recordAssertionEvidence(
+    "New task opens without waiting for engine session creation",
+    `The visible composer appeared ${openedAfterMs} ms after clicking; the limit was 1000 ms. Session POSTs were delayed 5000 ms, but opening issued none and left all existing session IDs unchanged.`, true,
+  );
 
   await step("the empty composer accepts and keeps a draft without creating a session", async () => {
     await user.type({ placeholder: "Describe your task..." }, world.prompt, { verify: true });
@@ -64,6 +73,10 @@ test("workspace New task opens an editable composer immediately and creates one 
     await user.click({ role: "button", label: `New session · ${workspaceName}` });
     expect(await probe.eval(`document.querySelector('[contenteditable="true"]')?.textContent`)).toBe(world.prompt);
     expect(await requests()).toEqual([]);
+    evidence.recordAssertionEvidence(
+      "The empty composer accepts a draft and preserves it on another New task click",
+      "Typing was verified in the visible editor; clicking New task again retained the exact draft text and still issued no session creation request.", true,
+    );
   });
   await user.see({ text: "New task model" });
   await user.click({ placeholder: "Describe your task..." });
@@ -78,9 +91,15 @@ test("workspace New task opens an editable composer immediately and creates one 
   const creationRequests = await requests();
   expect(Array.isArray(creationRequests) && creationRequests.length).toBe(1);
   expect(JSON.stringify(creationRequests)).toContain(world.workspace.workspaceId);
-  expect((await agent.list()).length).toBe(before.length + 1);
+  const after = (await agent.list()).map((session) => session.sessionId);
+  expect(after.length).toBe(before.length + 1);
+  expect(after).toEqual(expect.arrayContaining(before));
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
   const expandedAfter = await probe.eval(`document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]')
     ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
   expect(expandedAfter).toBe(expandedBefore);
+  evidence.recordAssertionEvidence(
+    "Submitting creates exactly one task in the intended workspace and receives the mock reply",
+    "The mock model was visible before submission and its reply appeared afterward. Exactly one session POST targeted the selected workspace, one session was added, every existing session remained, and the workspace expansion state was unchanged.", true,
+  );
 });

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,9 +1,8 @@
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { mkdir, rm } from "node:fs/promises";
-import { engineSessionProbe, readAvailableModels, waitFor } from "@openwork/behaviors";
+import { engineSessionProbe, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
 import { resolveEvalEngine } from "@openwork/env";
 import type { Seed } from "@openwork/env";
-import { configureProvider } from "./chat.ts";
 import { daytonaSandbox, desktop as launchDesktop } from "@openwork/hosts";
 
 const stormProviderId = "active-session-storm-mock";
@@ -222,20 +221,15 @@ export async function workspaceNewTask(seed: Seed) {
   const prompt = "Confirm the new task is ready";
   const reply = "The new task is ready.";
   const mock = seed.mock({ agentWorkloads: [{ promptMarker: prompt, finalReply: reply, steps: [] }] });
-  const den = await seed.den({ mocks: { agent: mock } });
-  const app = await seed.desktop({ name: "workspace-new-task", den, as: "admin", model: `${providerId}/${modelId}` });
+  const den = await seed.den({ mocks: { agent: mock }, provision: false });
+  const app = await seed.desktop({ name: "workspace-new-task", model: `${providerId}/${modelId}` });
   const workspacePath = seed.tmpPath(`openwork-workspace-new-task-long-name-${Date.now()}`);
   const workspace = await seed.workspace(app, workspacePath, { create: true });
-  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
-    provider: {
-      [providerId]: {
-        npm: "@ai-sdk/openai-compatible",
-        name: "New task mock",
-        options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-new-task-mock" },
-        models: { [modelId]: { name: "New task model" } },
-      },
-    },
+  await configureWorkspaceProvider(seed, app, [workspace.workspaceId], {
+    providerId, modelId, modelName: "New task model", baseUrl: `${den.mocks.agent.url}/v1`,
   });
+  const selectedModel = await selectModel(app, modelId);
+  if (!selectedModel.selected) throw new Error("The mock task model was not selected.");
   const sessions = await seed.sessions(app, ["Existing task"]);
   // TODO(primitive): seed.networkFault should delay and observe renderer requests.
   // Keep real session creation behind a slow transport boundary. Opening the

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -3,6 +3,7 @@ import { mkdir, rm } from "node:fs/promises";
 import { engineSessionProbe, readAvailableModels, waitFor } from "@openwork/behaviors";
 import { resolveEvalEngine } from "@openwork/env";
 import type { Seed } from "@openwork/env";
+import { configureProvider } from "./chat.ts";
 import { daytonaSandbox, desktop as launchDesktop } from "@openwork/hosts";
 
 const stormProviderId = "active-session-storm-mock";
@@ -225,8 +226,15 @@ export async function workspaceNewTask(seed: Seed) {
   const app = await seed.desktop({ name: "workspace-new-task", den, as: "admin", model: `${providerId}/${modelId}` });
   const workspacePath = seed.tmpPath(`openwork-workspace-new-task-long-name-${Date.now()}`);
   const workspace = await seed.workspace(app, workspacePath, { create: true });
-  await configureWorkspaceProvider(seed, app, [workspace.workspaceId], {
-    providerId, modelId, modelName: "New task model", baseUrl: `${den.mocks.agent.url}/v1`,
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "New task mock",
+        options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-new-task-mock" },
+        models: { [modelId]: { name: "New task model" } },
+      },
+    },
   });
   const sessions = await seed.sessions(app, ["Existing task"]);
   // TODO(primitive): seed.networkFault should delay and observe renderer requests.

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -216,7 +216,37 @@ export async function sidebarWorkspaceTitles(seed: Seed) {
 }
 
 export async function workspaceNewTask(seed: Seed) {
-  return oneWorkspace(seed, `openwork-kitchen-vercel-env-hit-target-${Date.now()}`);
+  const providerId = "new-task-mock";
+  const modelId = "new-task-model";
+  const prompt = "Confirm the new task is ready";
+  const reply = "The new task is ready.";
+  const mock = seed.mock({ agentWorkloads: [{ promptMarker: prompt, finalReply: reply, steps: [] }] });
+  const den = await seed.den({ mocks: { agent: mock } });
+  const app = await seed.desktop({ name: "workspace-new-task", den, as: "admin", model: `${providerId}/${modelId}` });
+  const workspacePath = seed.tmpPath(`openwork-workspace-new-task-long-name-${Date.now()}`);
+  const workspace = await seed.workspace(app, workspacePath);
+  await configureWorkspaceProvider(seed, app, [workspace.workspaceId], {
+    providerId, modelId, modelName: "New task model", baseUrl: `${den.mocks.agent.url}/v1`,
+  });
+  const sessions = await seed.sessions(app, ["Existing task"]);
+  // TODO(primitive): seed.networkFault should delay and observe renderer requests.
+  // Keep real session creation behind a slow transport boundary. Opening the
+  // composer must not reach this boundary; submitting must reach it only once.
+  await seed.evalIn(app, `(() => {
+    window.__newTaskRequests = [];
+    const originalFetch = window.fetch;
+    window.fetch = async function (...args) {
+      const request = args[0];
+      const url = typeof request === "string" ? request : request.url;
+      const method = args[1]?.method ?? request.method ?? "GET";
+      if (method.toUpperCase() === "POST" && new URL(url, location.href).pathname.endsWith("/session")) {
+        window.__newTaskRequests.push(url);
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+      return originalFetch.apply(this, args);
+    };
+  })()`);
+  return { app, workspace, workspacePath, sessions, prompt, reply };
 }
 
 export async function pinnedSessions(seed: Seed) {

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -224,7 +224,7 @@ export async function workspaceNewTask(seed: Seed) {
   const den = await seed.den({ mocks: { agent: mock } });
   const app = await seed.desktop({ name: "workspace-new-task", den, as: "admin", model: `${providerId}/${modelId}` });
   const workspacePath = seed.tmpPath(`openwork-workspace-new-task-long-name-${Date.now()}`);
-  const workspace = await seed.workspace(app, workspacePath);
+  const workspace = await seed.workspace(app, workspacePath, { create: true });
   await configureWorkspaceProvider(seed, app, [workspace.workspaceId], {
     providerId, modelId, modelName: "New task model", baseUrl: `${den.mocks.agent.url}/v1`,
   });


### PR DESCRIPTION
Opening New task from a workspace waited for session creation before showing the composer, making a slow engine request feel like an unresponsive click. Ordinary primary New task now opens the existing empty composer immediately and creates the engine session when the prompt is submitted. Grouped tasks, side chats, and workspace-error Retry keep their existing creation behavior.

Validation: **Passed** on OpenCode v2 in an isolated, cold-booted Daytona desktop. The existing workspace New task journey verifies:
- The long workspace name does not intercept the New task plus.
- The composer appears within one second despite an injected five-second session POST delay; opening creates no session.
- Typing works and another New task click retains the draft without creating a session.
- Submission uses the mock model, creates exactly one session in the intended workspace, receives the mock reply, and preserves existing sessions and expansion state.

Reproduce on this PR head:
```sh
OPENWORK_EVAL_REF=2fe6f4cead418ee317f2d52b39b24f9ea20fd608 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e workspace-new-task-hit-target
```
Placement: `daytona (daytona CLI authenticated)`. Verdict: 1 passed, 0 failed, 0 skipped. Exact-head assertion evidence is published in the test-evidence comment.

`pnpm typecheck` passed. The optional `pnpm evals:typecheck` exits 2 with the same 337 diagnostics on the change and unchanged base `ec5a74546`, after normalizing checkout paths; first failure is TS1294 in `apps/server/src/agent-context-cloud-probe.ts:216`.
