### PR TITLE
fix(app): surface delegated questions in the parent conversation

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -593,6 +593,22 @@ function sortQuestions(a: PendingQuestion, b: PendingQuestion) {
   return a.receivedAt - b.receivedAt || a.id.localeCompare(b.id);
 }
 
+// Keep settlements with the owning question cache, shared by every pane/client.
+// A list already in flight must not resurrect a request after its reply event.
+const settledQuestionsKey = (workspaceId: string, sessionId: string) =>
+  [...questionKey(workspaceId, sessionId), "settled"];
+
+export function settleQuestionState(workspaceId: string, sessionId: string, requestId: string) {
+  const queryClient = getReactQueryClient();
+  queryClient.setQueryData<string[]>(settledQuestionsKey(workspaceId, sessionId), (current = []) =>
+    current.includes(requestId) ? current : [...current, requestId],
+  );
+  queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId), (current = []) =>
+    current.filter((question) => question.id !== requestId),
+  );
+  useSessionActivityStore.getState().setWaitingRequest(workspaceId, sessionId, "question", requestId, false);
+}
+
 export function seedPermissionState(
   workspaceId: string,
   sessionId: string,
@@ -633,18 +649,14 @@ export function seedQuestionState(
   questions: QuestionRequest[],
   options: { snapshotStartedAt?: number } = {},
 ) {
-  useSessionActivityStore.getState().replaceWaitingRequests(
-    workspaceId,
-    sessionId,
-    "question",
-    questions.flatMap((question) => question.sessionID === sessionId ? [question.id] : []),
-  );
   const queryClient = getReactQueryClient();
   const now = Date.now();
-  queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId), (current = []) => {
+  const settled = new Set(queryClient.getQueryData<string[]>(settledQuestionsKey(workspaceId, sessionId)) ?? []);
+  const nextQuestions = queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, sessionId), (current = []) => {
     const receivedAtById = new Map(current.map((question) => [question.id, question.receivedAt]));
     const seeded = questions.flatMap((question) =>
-      question.sessionID === sessionId ? [questionWithReceivedAt(question, receivedAtById.get(question.id) ?? now)] : [],
+      question.sessionID === sessionId && !settled.has(question.id)
+        ? [questionWithReceivedAt(question, receivedAtById.get(question.id) ?? now)] : [],
     );
     const seededIds = new Set(seeded.map((question) => question.id));
     const snapshotStartedAt = options.snapshotStartedAt;
@@ -659,6 +671,12 @@ export function seedQuestionState(
         : [];
     return [...seeded, ...liveAfterSnapshot].sort(sortQuestions);
   });
+  useSessionActivityStore.getState().replaceWaitingRequests(
+    workspaceId,
+    sessionId,
+    "question",
+    (nextQuestions ?? []).map((question) => question.id),
+  );
 }
 
 function fileProviderMetadata(part: FilePart) {
@@ -971,13 +989,13 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "question.asked") {
     const question = event.properties as QuestionRequest;
     if (!question?.id || !question.sessionID) return;
+    if (queryClient.getQueryData<string[]>(settledQuestionsKey(workspaceId, question.sessionID))?.includes(question.id)) return;
     notifyDesktopEvent({
       type: "question.asked",
       sessionId: question.sessionID,
       question: questionNotificationText(question),
     });
     useSessionActivityStore.getState().setWaitingRequest(workspaceId, question.sessionID, "question", question.id, true);
-    if (!isTrackedSession(entry, question.sessionID)) return;
     const receivedAt = Date.now();
     queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, question.sessionID), (current = []) => {
       const existing = current.find((item) => item.id === question.id);
@@ -993,11 +1011,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "question.replied" || event.type === "question.rejected") {
     const props = (event.properties ?? {}) as { sessionID?: string; requestID?: string };
     if (!props.sessionID || !props.requestID) return;
-    useSessionActivityStore.getState().setWaitingRequest(workspaceId, props.sessionID, "question", props.requestID, false);
-    if (!isTrackedSession(entry, props.sessionID)) return;
-    queryClient.setQueryData<PendingQuestion[]>(questionKey(workspaceId, props.sessionID), (current = []) =>
-      current.filter((question) => question.id !== props.requestID),
-    );
+    settleQuestionState(workspaceId, props.sessionID, props.requestID);
     return;
   }
 

--- a/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
@@ -1,7 +1,5 @@
-// Pending permissions, questions, and todos for the selected session:
-// query-cache subscriptions, snapshot seeding, and reply handlers.
-// Extracted verbatim from session-route.tsx (cluster had no readers of its
-// internals besides the JSX).
+// Pending interactions for a conversation and its descendants. Requests stay
+// owned by the session that asked; only their presentation bubbles to the parent.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -17,6 +15,7 @@ import {
   questionKey,
   seedPermissionState,
   seedQuestionState,
+  settleQuestionState,
   todoKey,
 } from "./session-sync";
 
@@ -28,7 +27,7 @@ export type UseSessionInteractionsInput = {
   client: Client | null;
   workspaceId: string;
   sessionId: string | null;
-  permissionSessionIds?: string[];
+  interactionSessionIds?: string[];
   workspaceRoot: string;
 };
 
@@ -40,15 +39,15 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
   const [questionReplyBusy, setQuestionReplyBusy] = useState(false);
   const questionReplyBusyRef = useRef(false);
 
-  const requestedPermissionSessionIdsKey = (input.permissionSessionIds ?? []).join("\u0000");
-  const permissionSessionIds = useMemo(() => {
+  const requestedSessionIdsKey = (input.interactionSessionIds ?? []).join("\u0000");
+  const interactionSessionIds = useMemo(() => {
     if (!sessionId) return [];
-    const requested = requestedPermissionSessionIdsKey ? requestedPermissionSessionIdsKey.split("\u0000") : [];
+    const requested = requestedSessionIdsKey ? requestedSessionIdsKey.split("\u0000") : [];
     return Array.from(new Set([sessionId, ...requested].map((id) => id.trim()).filter(Boolean)));
-  }, [requestedPermissionSessionIdsKey, sessionId]);
+  }, [requestedSessionIdsKey, sessionId]);
   const permissionQueryKeys = useMemo(
-    () => workspaceId ? permissionSessionIds.map((id) => permissionKey(workspaceId, id)) : [],
-    [permissionSessionIds, workspaceId],
+    () => workspaceId ? interactionSessionIds.map((id) => permissionKey(workspaceId, id)) : [],
+    [interactionSessionIds, workspaceId],
   );
   const cachedPermissions = useQueryCacheArrayState<PendingPermission>(
     permissionQueryKeys,
@@ -58,13 +57,17 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
     () => [...cachedPermissions].sort((left, right) => left.receivedAt - right.receivedAt || left.id.localeCompare(right.id)),
     [cachedPermissions],
   );
-  const questionQueryKey = useMemo(
-    () => (workspaceId && sessionId ? questionKey(workspaceId, sessionId) : null),
-    [sessionId, workspaceId],
+  const questionQueryKeys = useMemo(
+    () => workspaceId ? interactionSessionIds.map((id) => questionKey(workspaceId, id)) : [],
+    [interactionSessionIds, workspaceId],
   );
-  const pendingQuestions = useQueryCacheState<PendingQuestion[]>(
-    questionQueryKey,
+  const cachedQuestions = useQueryCacheArrayState<PendingQuestion>(
+    questionQueryKeys,
     emptyPendingQuestions,
+  );
+  const pendingQuestions = useMemo(
+    () => [...cachedQuestions].sort((left, right) => left.receivedAt - right.receivedAt || left.id.localeCompare(right.id)),
+    [cachedQuestions],
   );
   const todoQueryKey = useMemo(
     () => (workspaceId && sessionId ? todoKey(workspaceId, sessionId) : null),
@@ -73,7 +76,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
   const todos = useQueryCacheState<TodoItem[]>(todoQueryKey, emptyTodos);
 
   useEffect(() => {
-    if (!client || !workspaceId || permissionSessionIds.length === 0) return;
+    if (!client || !workspaceId || interactionSessionIds.length === 0) return;
     let cancelled = false;
     const directory = workspaceRoot || undefined;
     void (async () => {
@@ -88,7 +91,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
           // Older/newer OpenCode permission APIs can fail independently.
         }
 
-        const v2Reads = await Promise.all(permissionSessionIds.map(async (permissionSessionId) => {
+        const v2Reads = await Promise.all(interactionSessionIds.map(async (permissionSessionId) => {
           try {
             const permissions = unwrap(
               await client.v2.session.permission.list({ sessionID: permissionSessionId }),
@@ -117,18 +120,19 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
     return () => {
       cancelled = true;
     };
-  }, [client, permissionSessionIds, workspaceId, workspaceRoot]);
+  }, [client, interactionSessionIds, workspaceId, workspaceRoot]);
 
   useEffect(() => {
-    if (!client || !workspaceId || !sessionId) return;
+    if (!client || !workspaceId || interactionSessionIds.length === 0) return;
     let cancelled = false;
     const directory = workspaceRoot || undefined;
     void (async () => {
       const snapshotStartedAt = Date.now();
       try {
         const list = unwrap(await client.question.list({ directory }));
-        if (!cancelled) {
-          seedQuestionState(workspaceId, sessionId, list, { snapshotStartedAt });
+        if (cancelled) return;
+        for (const questionSessionId of interactionSessionIds) {
+          seedQuestionState(workspaceId, questionSessionId, list, { snapshotStartedAt });
         }
       } catch {
         // Keep event-synced question state if the snapshot read fails.
@@ -138,7 +142,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
     return () => {
       cancelled = true;
     };
-  }, [client, sessionId, workspaceId, workspaceRoot]);
+  }, [client, interactionSessionIds, workspaceId, workspaceRoot]);
 
   const activePermission = pendingPermissions[0] ?? null;
   const respondPermission = useCallback(
@@ -167,7 +171,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
             }),
           );
         }
-        for (const permissionSessionId of permissionSessionIds) {
+        for (const permissionSessionId of interactionSessionIds) {
           getReactQueryClient().setQueryData<PendingPermission[]>(
             permissionKey(workspaceId, permissionSessionId),
             (current = []) => current.filter((permission) => permission.id !== requestID),
@@ -191,7 +195,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
         setPermissionReplyBusy(false);
       }
     },
-    [client, pendingPermissions, permissionSessionIds, sessionId, workspaceId, workspaceRoot],
+    [client, pendingPermissions, interactionSessionIds, sessionId, workspaceId, workspaceRoot],
   );
 
   const activeQuestion = pendingQuestions[0] ?? null;
@@ -202,6 +206,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
       questionReplyBusyRef.current = true;
       setQuestionReplyBusy(true);
       try {
+        const pendingQuestion = pendingQuestions.find((question) => question.id === requestID);
         unwrap(
           await client.question.reply({
             requestID,
@@ -209,10 +214,9 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
             directory: workspaceRoot || undefined,
           }),
         );
-        getReactQueryClient().setQueryData<PendingQuestion[]>(
-          questionKey(workspaceId, sessionId),
-          (current = []) => current.filter((question) => question.id !== requestID),
-        );
+        if (pendingQuestion) {
+          settleQuestionState(workspaceId, pendingQuestion.sessionID, requestID);
+        }
       } catch (error) {
         toast.error(t("app.error_request_failed"), {
           description: describeRouteError(error),
@@ -222,7 +226,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
         setQuestionReplyBusy(false);
       }
     },
-    [client, sessionId, workspaceId, workspaceRoot],
+    [client, pendingQuestions, sessionId, workspaceId, workspaceRoot],
   );
 
   return {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -624,7 +624,7 @@ export function SessionRoute() {
         }),
     [sessionsByWorkspaceId],
   );
-  const selectedPermissionSessionIds = useMemo(() => {
+  const selectedInteractionSessionIds = useMemo(() => {
     const selected = selectedSessionId?.trim();
     if (!selected) return [];
     const sessions = sessionsByWorkspaceId[selectedWorkspaceId] ?? [];
@@ -632,14 +632,14 @@ export function SessionRoute() {
   }, [selectedSessionId, selectedWorkspaceId, sessionsByWorkspaceId]);
   const activeSelectedWorkspaceSessionIds = useMemo(
     () => Array.from(new Set([
-      ...selectedPermissionSessionIds,
+      ...selectedInteractionSessionIds,
       ...(sessionsByWorkspaceId[selectedWorkspaceId] ?? []).flatMap((session) => {
         if (!isActiveSessionStatus(getSessionStatus(session))) return [];
         const id = String(session?.id ?? "").trim();
         return id ? [id] : [];
       }),
     ])),
-    [selectedPermissionSessionIds, selectedWorkspaceId, sessionsByWorkspaceId],
+    [selectedInteractionSessionIds, selectedWorkspaceId, sessionsByWorkspaceId],
   );
   const remoteAccessRestart = useRemoteAccessRestart({
     isEnabled: () => openworkServerSettings.remoteAccessEnabled === true,
@@ -1089,7 +1089,7 @@ export function SessionRoute() {
     // a client-only prefix, while interaction caches use the server workspace.
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspaceId,
     sessionId: selectedSessionId,
-    permissionSessionIds: selectedPermissionSessionIds,
+    interactionSessionIds: selectedInteractionSessionIds,
     workspaceRoot: selectedWorkspaceRoot,
   });
   const activePermissionSourceTitle = useMemo(() => {

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -19,6 +19,7 @@ import {
   questionKey,
   seedPermissionState,
   seedQuestionState,
+  settleQuestionState,
   seedSessionState,
   trackWorkspaceSessionSync,
   transcriptKey,
@@ -237,6 +238,73 @@ describe("session permission sync", () => {
 });
 
 describe("session question sync", () => {
+  test("a late snapshot cannot resurrect a settled child request or clear another request", () => {
+    const answered = question("question-answered", "session-child");
+    const pending = question("question-pending", "session-child");
+    seedQuestionState("workspace-a", "session-child", [answered, pending]);
+    settleQuestionState("workspace-a", "session-child", answered.id);
+    seedQuestionState("workspace-a", "session-child", [answered, pending], { snapshotStartedAt: 100 });
+    expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-child"))).toMatchObject([
+      { id: pending.id, sessionID: "session-child" },
+    ]);
+    expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-child")).toBe("waiting");
+
+    settleQuestionState("workspace-a", "session-child", pending.id);
+    seedQuestionState("workspace-a", "session-child", [answered, pending], { snapshotStartedAt: 100 });
+    expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-child"))).toEqual([]);
+    expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-child")).not.toBe("waiting");
+  });
+
+  test("retains a child question before its transcript is tracked and settles only that request", () => {
+    const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+    try {
+      for (const request of [question("question-child", "session-child"), question("question-other", "session-b")]) {
+        __applySessionSyncEventForTest(syncInput, { type: "question.asked", properties: request });
+      }
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-child"))).toMatchObject([
+        { id: "question-child", sessionID: "session-child" },
+      ]);
+      expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-child")).toBe("waiting");
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-a"))).toBeUndefined();
+
+      __applySessionSyncEventForTest(syncInput, {
+        type: "question.replied",
+        properties: { sessionID: "session-child", requestID: "question-child", answers: [["Yes"]] },
+      });
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-child"))).toEqual([]);
+      expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-child")).not.toBe("waiting");
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-b"))).toMatchObject([
+        { id: "question-other", sessionID: "session-b" },
+      ]);
+      expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-b")).toBe("waiting");
+
+      __applySessionSyncEventForTest(syncInput, {
+        type: "question.rejected",
+        properties: { sessionID: "session-b", requestID: "question-other" },
+      });
+      expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-b"))).toEqual([]);
+      expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-b")).not.toBe("waiting");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("retains the waiting marker for a live question newer than the snapshot", () => {
+    getReactQueryClient().setQueryData(questionKey("workspace-a", "session-child"), [
+      { ...question("question-live", "session-child"), receivedAt: 200 },
+    ]);
+    seedQuestionState("workspace-a", "session-child", [], { snapshotStartedAt: 100 });
+    expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-child"))).toMatchObject([
+      { id: "question-live", sessionID: "session-child", receivedAt: 200 },
+    ]);
+    expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-child")).toBe("waiting");
+
+    seedQuestionState("workspace-a", "session-child", [], { snapshotStartedAt: 300 });
+    expect(getReactQueryClient().getQueryData(questionKey("workspace-a", "session-child"))).toEqual([]);
+    expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-child")).not.toBe("waiting");
+  });
+
   test("seeds only questions for the selected session", () => {
     seedQuestionState("workspace-a", "session-a", [
       question("question-a", "session-a"),

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { parentChildPermissionWorld } from "../worlds/first-run.ts";
+import { delegatedQuestionHandoff } from "../worlds/chat.ts";
 
 const test = spec.world(parentChildPermissionWorld);
 
@@ -37,5 +38,195 @@ test("a parent task surfaces and resolves its child session permission request",
       waitingIconVisible: Boolean(document.querySelector('[data-subagent-permission="pending"]')),
       runningTreatmentVisible: Boolean(document.querySelector('[data-subagent-activity="shimmer"] .ow-text-shimmer')),
     })`)).toEqual({ permissionPanelVisible: false, waitingIconVisible: false, runningTreatmentVisible: true });
+  });
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Expected a native engine object");
+  return value;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error("Expected a native engine list");
+  return value.map(record);
+}
+
+function text(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Expected a native engine string");
+  return value;
+}
+
+const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
+
+questionTest("a parent answers its real child question without settling an unrelated root question", async ({ world, user, agent, probe, step }) => {
+  const v2 = world.engine === "v2";
+  const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
+  const sessionPath = (id: string) => `/session/${encodeURIComponent(id)}`;
+  const read = async (path: string): Promise<unknown> => {
+    const result = await probe.desktopApi(`${mount}${path}`);
+    expect(result.status, path).toBe(200);
+    return v2 ? record(result.body).data : result.body;
+  };
+  const pending = async () => records(await read(v2 ? "/form/request" : "/question"))
+    .filter((request) => !v2 || record(request.metadata).kind === "question")
+    .map((request) => {
+      const tool = record(v2 ? record(request.metadata).tool : request.tool);
+      const [question] = records(v2 ? request.fields : request.questions);
+      if (!question) throw new Error("Expected a question in the native request");
+      return {
+        id: text(request.id), sessionID: text(request.sessionID),
+        messageID: text(tool.messageID), callID: text(tool[v2 ? "id" : "callID"]),
+        question: text(question[v2 ? "description" : "question"]),
+      };
+    }).sort((a, b) => a.id.localeCompare(b.id));
+  const transcript = async (id: string) => records(await read(`${sessionPath(id)}/${v2 ? "context" : "message?limit=50"}`))
+    .flatMap((message) => {
+      const info = v2 ? message : record(message.info);
+      if (info[v2 ? "type" : "role"] !== "assistant") return [];
+      const parts = records(v2 ? message.content : message.parts);
+      return [{
+        id: text(info.id), completed: typeof record(info.time).completed === "number",
+        text: parts.filter((part) => part.type === "text").map((part) => text(part.text)).join(""),
+        tools: parts.filter((part) => part.type === "tool").map((part) => ({
+          callID: text(part[v2 ? "id" : "callID"]), name: text(part[v2 ? "name" : "tool"]),
+          status: text(record(part.state).status), metadata: record(part.state).metadata,
+        })),
+      }];
+    });
+  const open = async (sessionId: string) => {
+    await agent.run("session.open", { sessionId });
+    await probe.eventually(() => probe.hash(), {
+      within: 30_000, label: "the requested root conversation is selected",
+      until: (hash) => hash.includes(`/session/${sessionId}`),
+    });
+  };
+  const send = async (prompt: string) => {
+    await user.type("composer", prompt, { verify: true });
+    await user.press("Enter");
+  };
+  const complete = async (id: string, promptMarker: string, tool: string, answer: string, excluded: string) => {
+    const state = await probe.eventually(async () => ({
+      messages: await transcript(id), calls: await world.mock.agentRequests({ promptMarker }),
+    }), {
+      within: 60_000, label: `${tool} settles and its session returns the actual answer`,
+      until: ({ messages, calls }) => messages.some((message) => message.completed && message.text.includes(answer))
+        && messages.some((message) => message.tools.some((part) => part.name === tool && part.status === "completed"))
+        && calls.some((call) => call.kind === "final" && call.completedTools === 1),
+    });
+    const final = state.messages.at(-1);
+    expect(final).toMatchObject({ completed: true, text: expect.stringContaining(answer) });
+    expect(final?.text).not.toContain(excluded);
+    expect(state.calls.filter((call) => call.kind === "tool").map((call) => call.toolName)).toEqual([tool]);
+    expect(state.calls.some((call) => call.kind === "error")).toBe(false);
+    if (v2) await probe.eventually(() => read(sessionPath(id)), {
+      within: 15_000, label: "the native session records successful completion",
+      until: (value) => record(value).outcome === "succeeded",
+    });
+    return state.messages;
+  };
+
+  const unrelated = await step("an unrelated root waits for its own answer", async () => {
+    await send(world.unrelated.prompt);
+    await user.see({ text: world.unrelated.question }, { timeoutMs: 45_000 });
+    const requests = await probe.eventually(pending, {
+      within: 30_000, label: "the unrelated root owns a real question request",
+      until: (items) => items.some((item) => item.sessionID === world.unrelated.sessionId),
+    });
+    expect(requests).toHaveLength(1);
+    const request = requests[0];
+    if (!request) throw new Error("Missing unrelated question");
+    expect(request).toMatchObject({ sessionID: world.unrelated.sessionId, question: world.unrelated.question });
+    expect(record(await read(sessionPath(request.sessionID))).parentID).toBeUndefined();
+    return request;
+  });
+
+  const child = await step("the parent displays only its delegated child's question", async () => {
+    await open(world.root.sessionId);
+    await user.notSee({ text: world.unrelated.question });
+    await send(world.root.prompt);
+    const requests = await probe.eventually(pending, {
+      within: 45_000, label: "the real subagent asks its question",
+      until: (items) => items.some((item) => item.question === world.child.question),
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests).toContainEqual(unrelated);
+    const request = requests.find((item) => item.question === world.child.question);
+    if (!request) throw new Error("Missing child question");
+    expect(request.id).not.toBe(unrelated.id);
+    expect([world.root.sessionId, unrelated.sessionID]).not.toContain(request.sessionID);
+    const owner = record(await read(sessionPath(request.sessionID)));
+    const root = record(await read(sessionPath(world.root.sessionId)));
+    const other = record(await read(sessionPath(unrelated.sessionID)));
+    expect(owner).toMatchObject({ id: request.sessionID, parentID: world.root.sessionId });
+    expect(root.parentID).toBeUndefined();
+    expect(owner[v2 ? "location" : "directory"]).toEqual(root[v2 ? "location" : "directory"]);
+    expect(other[v2 ? "location" : "directory"]).toEqual(root[v2 ? "location" : "directory"]);
+    await user.see({ text: world.child.question }, { timeoutMs: 30_000 });
+    await user.notSee({ text: world.unrelated.question });
+    await user.notSee({ role: "button", label: /^Unrelated outline/ });
+    expect(await probe.hash()).toContain(`/session/${world.root.sessionId}`);
+    expect((await transcript(request.sessionID)).find((message) => message.id === request.messageID)?.tools)
+      .toContainEqual(expect.objectContaining({ callID: request.callID, name: "question", status: "running" }));
+    return request;
+  });
+
+  await step("reloading the parent restores the same unanswered requests", async () => {
+    await user.reload();
+    await user.see({ text: world.child.question }, { timeoutMs: 45_000 });
+    expect(await probe.hash()).toContain(`/session/${world.root.sessionId}`);
+    expect(await pending()).toEqual([child, unrelated].sort((a, b) => a.id.localeCompare(b.id)));
+    await user.notSee({ text: world.unrelated.question });
+    for (const promptMarker of [world.root.prompt, world.child.prompt, world.unrelated.prompt]) {
+      expect((await world.mock.agentRequests({ promptMarker })).some((call) => call.kind === "final")).toBe(false);
+    }
+    await user.screenshot();
+  });
+
+  const finished = await step("answering in the parent resumes the original child and then the parent", async () => {
+    await user.click({ role: "button", label: /^Child checklist/ });
+    await probe.eventually(pending, {
+      within: 30_000, label: "only the original child request is settled",
+      until: (items) => items.length === 1 && items[0]?.id === unrelated.id,
+    });
+    if (v2) {
+      expect(await read(`${sessionPath(child.sessionID)}/form/${encodeURIComponent(child.id)}/state`))
+        .toEqual({ status: "answered", answer: { q0: world.child.answer } });
+      expect(await read(`${sessionPath(unrelated.sessionID)}/form/${encodeURIComponent(unrelated.id)}/state`))
+        .toEqual({ status: "pending" });
+    }
+    const answer = `"${world.child.question}"="${world.child.answer}"`;
+    const childFinished = await complete(child.sessionID, world.child.prompt, "question", answer, world.unrelated.answer);
+    expect(childFinished.find((message) => message.id === child.messageID)?.tools).toContainEqual(expect.objectContaining({
+      callID: child.callID, name: "question", status: "completed", metadata: expect.objectContaining({ answers: [[world.child.answer]] }),
+    }));
+    const parentFinished = await complete(world.root.sessionId, world.root.prompt, world.delegationTool, answer, world.unrelated.answer);
+    expect(parentFinished.flatMap((message) => message.tools)).toContainEqual(expect.objectContaining({
+      name: world.delegationTool, status: "completed",
+      metadata: expect.objectContaining(v2 ? { sessionID: child.sessionID } : { sessionId: child.sessionID }),
+    }));
+    await user.see({ text: /User has answered your questions:.*="Child checklist"/ });
+    await user.notSee({ role: "button", label: /^Child checklist/ });
+    expect(await probe.hash()).toContain(`/session/${world.root.sessionId}`);
+    expect(await pending()).toEqual([unrelated]);
+    expect((await world.mock.agentRequests({ promptMarker: world.unrelated.prompt })).some((call) => call.kind === "final")).toBe(false);
+    expect((await transcript(unrelated.sessionID)).map((message) => message.text).join("\n")).not.toContain(world.child.answer);
+    return { parent: parentFinished, child: childFinished };
+  });
+
+  await step("the unrelated root remains answerable without changing the parent's result", async () => {
+    await open(unrelated.sessionID);
+    await user.see({ text: world.unrelated.question });
+    await user.notSee({ text: world.child.question });
+    await user.click({ role: "button", label: /^Unrelated outline/ });
+    await complete(unrelated.sessionID, world.unrelated.prompt, "question", `"${world.unrelated.question}"="${world.unrelated.answer}"`, world.child.answer);
+    await user.see({ text: /User has answered your questions:.*="Unrelated outline"/ });
+    expect(await pending()).toEqual([]);
+    expect(await transcript(world.root.sessionId)).toEqual(finished.parent);
+    expect(await transcript(child.sessionID)).toEqual(finished.child);
+    await user.screenshot();
   });
 });

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -100,7 +100,7 @@ questionTest("a parent answers its real child question without settling an unrel
   const open = async (sessionId: string, title: string) => {
     // A pending question replaces the composer. Navigate as a person rather
     // than waiting for the control rail's composer-based readiness check.
-    await user.click({ role: "button", label: title });
+    await user.click({ text: title });
     await probe.eventually(() => probe.hash(), {
       within: 30_000, label: "the requested root conversation is selected",
       until: (hash) => hash.includes(`/session/${sessionId}`),

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -62,7 +62,7 @@ function text(value: unknown): string {
 
 const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
 
-questionTest("a parent answers its real child question without settling an unrelated root question", async ({ world, user, agent, probe, step }) => {
+questionTest("a parent answers its real child question without settling an unrelated root question", async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
   const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
   const sessionPath = (id: string) => `/session/${encodeURIComponent(id)}`;
@@ -97,8 +97,10 @@ questionTest("a parent answers its real child question without settling an unrel
         })),
       }];
     });
-  const open = async (sessionId: string) => {
-    await agent.run("session.open", { sessionId });
+  const open = async (sessionId: string, title: string) => {
+    // A pending question replaces the composer. Navigate as a person rather
+    // than waiting for the control rail's composer-based readiness check.
+    await user.click({ role: "button", label: title });
     await probe.eventually(() => probe.hash(), {
       within: 30_000, label: "the requested root conversation is selected",
       until: (hash) => hash.includes(`/session/${sessionId}`),
@@ -145,7 +147,7 @@ questionTest("a parent answers its real child question without settling an unrel
   });
 
   const child = await step("the parent displays only its delegated child's question", async () => {
-    await open(world.root.sessionId);
+    await open(world.root.sessionId, "Delegated question parent");
     await user.notSee({ text: world.unrelated.question });
     await send(world.root.prompt);
     const requests = await probe.eventually(pending, {
@@ -218,7 +220,7 @@ questionTest("a parent answers its real child question without settling an unrel
   });
 
   await step("the unrelated root remains answerable without changing the parent's result", async () => {
-    await open(unrelated.sessionID);
+    await open(unrelated.sessionID, "Unrelated question root");
     await user.see({ text: world.unrelated.question });
     await user.notSee({ text: world.child.question });
     await user.click({ role: "button", label: /^Unrelated outline/ });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -219,16 +219,99 @@ export async function paletteSessionActions(seed: Seed) {
   return { app, workspace, session };
 }
 
-export async function newSplitPrimary(seed: Seed) {
+async function splitPaneQuestions(
+  seed: Seed,
+  name: string,
+  agentWorkloads: MockAgentWorkload[],
+  policy: Record<string, unknown> = { permission: { question: "allow" } },
+) {
   const providerId = "split-send-mock";
   const modelId = "split-send-model";
+  const mock = seed.mock({ agentWorkloads });
+  const den = await seed.den({ mocks: { agent: mock } });
+  const app = await seed.desktop({ name, den, as: "admin", model: `${providerId}/${modelId}` });
+  const workspace = await seed.workspace(app, seed.tmpPath(name));
+  // Arrange an allowed native question tool independently of custom-agent defaults.
+  // TODO(primitive): write workspace fixture files through a first-class seed API.
+  const questionPolicyWritten = await seed.evalIn(app, `async (workspaceId, content) => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/files/content", {
+      method: "POST",
+      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "opencode.json", content }),
+    });
+    return response.ok;
+  }`, { args: [workspace.workspaceId, JSON.stringify(policy)], awaitPromise: true });
+  if (questionPolicyWritten !== true) throw new Error("Could not arrange the question-tool policy.");
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    provider: {
+      [providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Split send mock",
+        options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-split-send" },
+        models: { [modelId]: { name: "Split send model" } },
+      },
+    },
+  });
+  return { app, workspace, mock: den.mocks.agent };
+}
+
+export async function delegatedQuestionHandoff(seed: Seed) {
+  const engine = resolveEvalEngine();
+  const delegationTool = engine === "v2" ? "subagent" : "task";
+  const rootPrompt = "Delegate choosing the task format, then report the result.";
+  const child = {
+    prompt: "Help me choose the delegated task format",
+    question: "Which format should the child task use?",
+    answer: "Child checklist",
+    alternative: "Child outline",
+  };
+  const unrelated = {
+    prompt: "Help me choose the unrelated task format",
+    question: "Which format should the unrelated task use?",
+    answer: "Unrelated outline",
+    alternative: "Unrelated checklist",
+  };
+  const base = await splitPaneQuestions(seed, "delegated-question-handoff", [
+    {
+      promptMarker: rootPrompt, latestUserTurn: true,
+      finalReply: "Unused: return the actual child result.", finalReplyFrom: "last-tool-text",
+      steps: [{ tool: delegationTool, arguments: {
+        description: "Choose delegated task format", prompt: child.prompt,
+        // v2 beta-19086 calls this subagent; foreground must await the child's answer.
+        ...(engine === "v2" ? { agent: "general", background: false } : { subagent_type: "general" }),
+      } }],
+    },
+    ...[child, unrelated].map((question): MockAgentWorkload => ({
+      promptMarker: question.prompt, latestUserTurn: true,
+      finalReply: "Unused: return the actual question result.", finalReplyFrom: "last-tool-text",
+      steps: [{ tool: "question", arguments: { questions: [{
+        header: "Task format", question: question.question,
+        options: [
+          { label: question.answer, description: "Use this format" },
+          { label: question.alternative, description: "Use the other format" },
+        ],
+      }] } }],
+    })),
+  ], {
+    permission: { question: "allow", task: "allow" },
+    // Both engines deny questions for general by default; v2 migrates task to subagent.
+    agent: { general: { permission: { question: "allow" } } },
+  });
+  const root = await seedSessionRetry(seed, base.app, { title: "Delegated question parent" });
+  const other = await seedSessionRetry(seed, base.app, { title: "Unrelated question root" });
+  return { ...base, engine, delegationTool, root: { ...root, prompt: rootPrompt }, child, unrelated: { ...other, ...unrelated } };
+}
+
+export async function newSplitPrimary(seed: Seed) {
   const primaryPrompt = "Reply to the primary split message";
   const secondaryPrompt = "Reply to the secondary split message";
   const switchPrompt = "Reply after switching the primary session";
   const primaryQuestionPrompt = "Help me choose the main task format";
   const secondaryQuestionPrompt = "Help me choose the side task format";
   const contextPrompt = "Describe your conversation context";
-  const mock = seed.mock({ agentWorkloads: [
+  const { app, workspace } = await splitPaneQuestions(seed, "new-split-session", [
     ...["Main", "Side"].map((pane): MockAgentWorkload => ({
       promptMarker: pane === "Main" ? primaryQuestionPrompt : secondaryQuestionPrompt,
       latestUserTurn: true, finalReply: "Answered the format question.", finalReplyFrom: "last-tool-text",
@@ -241,33 +324,7 @@ export async function newSplitPrimary(seed: Seed) {
     { latestUserTurn: true, promptMarker: primaryPrompt, finalReply: "Primary split received", steps: [] },
     { latestUserTurn: true, promptMarker: secondaryPrompt, finalReply: "Secondary split received", steps: [] },
     { latestUserTurn: true, promptMarker: switchPrompt, finalReply: "Switched session received", steps: [] },
-  ] });
-  const den = await seed.den({ mocks: { agent: mock } });
-  const app = await seed.desktop({ name: "new-split-session", den, as: "admin", model: `${providerId}/${modelId}` });
-  const workspace = await seed.workspace(app, seed.tmpPath("new-split-session"));
-  // Arrange an allowed native question tool independently of custom-agent defaults.
-  // TODO(primitive): write workspace fixture files through a first-class seed API.
-  const questionPolicyWritten = await seed.evalIn(app, `async (workspaceId) => {
-    const port = localStorage.getItem("openwork.server.port");
-    const token = localStorage.getItem("openwork.server.token");
-    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/files/content", {
-      method: "POST",
-      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
-      body: JSON.stringify({ path: "opencode.json", content: JSON.stringify({ permission: { question: "allow" } }) }),
-    });
-    return response.ok;
-  }`, { args: [workspace.workspaceId], awaitPromise: true });
-  if (questionPolicyWritten !== true) throw new Error("Could not arrange the question-tool policy.");
-  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
-    provider: {
-      [providerId]: {
-        npm: "@ai-sdk/openai-compatible",
-        name: "Split send mock",
-        options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-split-send" },
-        models: { [modelId]: { name: "Split send model" } },
-      },
-    },
-  });
+  ]);
   const switchSession = await seedSessionRetry(seed, app, { title: "Split switch target" });
   const session = await seedSessionRetry(seed, app, { title: "New split primary" });
   const splitFacts = () => evalIn(app, `(() => {


### PR DESCRIPTION
## Summary

Restore the ability to answer a delegated session's question from its parent conversation, so the child and the waiting parent can continue.

- Use the parent's existing descendant scope for questions as well as permissions. Unrelated roots remain isolated.
- Retain incoming child questions even before their transcripts are tracked.
- Reply using the original request ID and clear the actual owning child's queue and waiting state only after success.
- Preserve live questions during snapshot refresh and prevent a late list or replay from resurrecting a settled request.
- Extend the existing parent/child approval journey with real v2 delegation, native question forms, reload, original-request settlement, both sessions completing, and an unrelated pending-question control. No new test files or engine changes.

## What regressed

The working cross-session question handoff was introduced in #705. The React cutover in #1470 removed that store path. #1867 restored inline questions but subscribed only to the selected session's question cache. The descendant aggregation later restored for permissions in #4270 never reached questions.

There was a separate recent v2 transport omission in #4388: question listing was empty and native form events/replies were not bridged. #4550 fixed that transport path, but left the parent-only selector intact. A native child form could therefore be pending while the parent displayed no answer control. The parent waits for its child; the child waits for the unseen answer.

These findings are from source/history review and an isolated real-engine journey, not an inspection of any particular user's private session.

## Verification — Incomplete overall; targeted v2 handoff Passed

Head: `c6fe518c14a069e0f704cece3a48903b243c60e7`
Base: `89933074f80ad68fbe3f0fad725ab1f9ff5f19a4`

Passed on the final head:

- `OPENWORK_EVAL_REF=c6fe518c14a069e0f704cece3a48903b243c60e7 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e parent-child-permission-approval` — exit 0; **2 passed, 0 failed, 0 skipped**. `placement: daytona (daytona CLI authenticated)`. Fresh desktop and Den resources checked out the exact head and were deleted after the run.
- `bun test --isolate apps/app/tests/session-sync-permissions.test.ts` — exit 0; **19 passed, 0 failed**. Covers early child events, owner isolation, rejection, stale snapshots, and waiting-state preservation.
- `pnpm --filter @openwork/app typecheck` — exit 0.
- `git diff --check origin/dev...HEAD` — passed.

Earlier attempts were repaired in the same Daytona lane: local collection first needed the existing world-package dependency links; the new test then needed sidebar navigation instead of a composer-readiness-gated control call, and a visible-title locator for restored session rows. Final runtime assertions pass without weakening question ownership or completion checks.

Incomplete tooling checks: the full `pnpm --dir evals run typecheck` returned missing dependency/build declarations and errors outside the edited files in the initially partial install. The repository-wide channel ratchet also reported failures in other specs; the chained boundary check consequently did not run. Neither broad check is claimed green or classified as pre-existing without a clean control. They were not expanded into unrelated repairs.

Deferred: v1 runtime matrix, secondary-pane descendant discovery (especially cross-workspace), and stream-disconnect recovery. This PR fixes main-thread handoff; it does not change child-card presentation/navigation, engine permissions, or expose a new reject control. No merge, release, or deployment is included.
