### PR TITLE
feat(computer-use): preserve task context through takeover and refresh

### DIFF
--- a/evals/packages/labs/fixtures/computer-use-app.swift
+++ b/evals/packages/labs/fixtures/computer-use-app.swift
@@ -152,7 +152,10 @@ final class Fixture: NSObject, NSApplicationDelegate {
                         let button = self.findControl(pid: pid, title: "Continue", role: kAXButtonRole)
                         var enabled: CFTypeRef?
                         if let button { AXUIElementCopyAttributeValue(button, kAXEnabledAttribute as CFString, &enabled) }
-                        result = ["text": task.map(self.accessibleText) ?? "", "continue_enabled": enabled as? Bool ?? false,
+                        let restore = self.findControl(pid: pid, title: "Show Computer Use task", role: kAXMenuBarItemRole)
+                        var help: CFTypeRef?
+                        if let restore { AXUIElementCopyAttributeValue(restore, kAXHelpAttribute as CFString, &help) }
+                        result = ["restore_help": help as? String ?? "", "text": task.map(self.accessibleText) ?? "", "continue_enabled": enabled as? Bool ?? false,
                                   "restore_available": self.findControl(pid: pid, title: "Show Computer Use task", role: kAXMenuBarItemRole) != nil]
                     } else {
                         result = method == "select_helper_window" ? self.selectWindow(pid: pid, title: name) : ["ok": self.pressButton(pid: pid, title: name)]

--- a/evals/packages/labs/fixtures/computer-use-app.swift
+++ b/evals/packages/labs/fixtures/computer-use-app.swift
@@ -11,6 +11,20 @@ final class DragSurface: NSView {
     override func mouseUp(with event: NSEvent) { ups += 1 }
 }
 
+@MainActor
+final class RefreshLabel: NSTextField {
+    var remainingChanges = 0
+    var reads = 0
+    override func accessibilityValue() -> String? {
+        reads += 1
+        if remainingChanges != 0 {
+            if remainingChanges > 0 { remainingChanges -= 1 }
+            stringValue = remainingChanges == 0 ? "Ready after refresh" : "Updating \(reads)"
+        }
+        return super.accessibilityValue()
+    }
+}
+
 // Disposable, in-memory application and person-input driver for the native
 // journey. This is never included in the product helper or its package.
 @MainActor
@@ -20,6 +34,7 @@ final class Fixture: NSObject, NSApplicationDelegate {
     var count = 0
     var otherCount = 0
     let dragSurface = DragSurface(frame: NSRect(x: 20, y: 5, width: 360, height: 25))
+    let refreshLabel = RefreshLabel(labelWithString: "Ready after refresh")
     let counter = NSTextField(labelWithString: "Count: 0")
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Window IDs sort by creation: require choosing the nondefault window.
@@ -29,7 +44,7 @@ final class Fixture: NSObject, NSApplicationDelegate {
         draft.setAccessibilityLabel("Draft text")
         let secret = NSSecureTextField(string: "private-fixture-value")
         secret.setAccessibilityLabel("Password")
-        let stack = NSStackView(views: [NSTextField(labelWithString: "Computer Use Fixture"), draft, increment, counter, secret])
+        let stack = NSStackView(views: [NSTextField(labelWithString: "Computer Use Fixture"), draft, increment, counter, secret, refreshLabel])
         stack.orientation = .vertical; stack.alignment = .leading; stack.spacing = 16
         stack.frame = NSRect(x: 24, y: 35, width: 340, height: 250)
         first.contentView?.addSubview(stack)
@@ -63,6 +78,12 @@ final class Fixture: NSObject, NSApplicationDelegate {
         let method = request["method"] as? String ?? ""
         var result: [String: Any] = [:]
         switch method {
+        case "refresh_changes":
+            refreshLabel.reads = 0
+            refreshLabel.remainingChanges = (request["params"] as? [String: Any])?["continuous"] as? Bool == true ? -1 : 2
+            result = ["ok": true]
+        case "refresh_stable": refreshLabel.remainingChanges = 0; refreshLabel.stringValue = "Ready after refresh"; result = ["ok": true]
+        case "refresh_state": result = ["reads": refreshLabel.reads, "text": refreshLabel.stringValue]
         case "state": result = ["count": count, "otherCount": otherCount, "draft": draft.stringValue]
         case "minimized": result = ["minimized": windows[0].isMiniaturized]
         case "minimize": windows[0].miniaturize(nil); result = ["ok": true]
@@ -119,7 +140,7 @@ final class Fixture: NSObject, NSApplicationDelegate {
         case "press_helper_button", "select_helper_window", "helper_panel":
             Task.detached {
                 var result: [String: Any] = [:]
-                let buttons: Set<String> = ["Allow this session", "Cancel", "Take over", "Continue", "Stop"]
+                let buttons: Set<String> = ["Allow this session", "Cancel", "Take over", "Continue", "Stop", "Hide panel", "Show Computer Use task"]
                 if let params = request["params"] as? [String: Any], let pid = params["pid"] as? Int32,
                    let name = params["name"] as? String,
                    (method == "helper_panel" || (method == "select_helper_window" ? name == "Workspace window" : buttons.contains(name))),
@@ -128,7 +149,11 @@ final class Fixture: NSObject, NSApplicationDelegate {
                    process.executableURL?.resolvingSymlinksInPath().path == URL(fileURLWithPath: expected).resolvingSymlinksInPath().path {
                     if method == "helper_panel" {
                         let task = self.findControl(pid: pid, title: nil, role: kAXWindowRole)
-                        result = ["text": task.map(self.accessibleText) ?? ""]
+                        let button = self.findControl(pid: pid, title: "Continue", role: kAXButtonRole)
+                        var enabled: CFTypeRef?
+                        if let button { AXUIElementCopyAttributeValue(button, kAXEnabledAttribute as CFString, &enabled) }
+                        result = ["text": task.map(self.accessibleText) ?? "", "continue_enabled": enabled as? Bool ?? false,
+                                  "restore_available": self.findControl(pid: pid, title: "Show Computer Use task", role: kAXMenuBarItemRole) != nil]
                     } else {
                         result = method == "select_helper_window" ? self.selectWindow(pid: pid, title: name) : ["ok": self.pressButton(pid: pid, title: name)]
                     }
@@ -200,7 +225,7 @@ final class Fixture: NSObject, NSApplicationDelegate {
         return ["ok": true, "previous": previous as? String ?? "", "selected": selected as? String ?? ""]
     }
     nonisolated func pressButton(pid: pid_t, title: String) -> Bool {
-        guard let button = findControl(pid: pid, title: title, role: kAXButtonRole) else { return false }
+        guard let button = findControl(pid: pid, title: title, role: title == "Show Computer Use task" ? kAXMenuBarItemRole : kAXButtonRole) else { return false }
         return AXUIElementPerformAction(button, kAXPressAction as CFString) == .success
     }
 }

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -96,10 +96,11 @@ test("Computer Use respects window consent, fresh observations and the person's 
     const settled = toolState(await world.call("computer_observe", { session_id: session, include_image: false }));
     expect(settled.ok).toBe(true);
     expect(JSON.stringify(settled)).toContain("Ready after refresh");
-    expect(await world.refreshState()).toMatchObject({ text: "Ready after refresh" });
+    expect(await world.refreshState()).toMatchObject({ reads: 4, text: "Ready after refresh" });
     await world.refreshChanges(true);
     const changing = toolState(await world.call("computer_observe", { session_id: session, include_image: false }));
     expect(changing).toMatchObject({ code: "stale_observation", next: "observe" });
+    expect(await world.refreshState()).toMatchObject({ reads: 6 });
     expect(toolState(await action(settled, "after-failed-refresh", { type: "press", ref: refFor(settled, "Increment") })).code).toBe("observation_required");
     expect(await world.state()).toEqual({ count: 0, otherCount: 0, draft: "Initial draft" });
     await world.refreshStable();

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -48,6 +48,18 @@ test("Computer Use respects window consent, fresh observations and the person's 
     expect(panel).not.toContain("Other window");
   });
 
+  await step("Hiding the task panel preserves the grant and the menu bar restores its controls", async () => {
+    await world.pressControl("Hide panel");
+    expect(toolState(await world.call("computer_session_status", { session_id: session }))).toMatchObject({
+      state: "active", panel_visible: false, purpose: "Edit the disposable fixture draft and increment its counter.", window_title: "Workspace window",
+    });
+    expect(toolState(await world.peerCall("computer_session_status", { session_id: session })).code).toBe("session_unavailable");
+    await world.pressControl("Show Computer Use task");
+    expect(toolState(await world.call("computer_session_status", { session_id: session })).panel_visible).toBe(true);
+    expect(JSON.stringify(await world.panel())).toContain("Stop");
+    expect(await world.state()).toEqual({ count: 0, otherCount: 0, draft: "Initial draft" });
+  });
+
   await step("A different connection cannot read or act through the grant", async () => {
     const other = await world.peerCall("computer_observe", { session_id: session });
     expect(other).toMatchObject({ isError: true });
@@ -77,6 +89,21 @@ test("Computer Use respects window consent, fresh observations and the person's 
     expect(await world.state()).toEqual({ count: 0, otherCount: 0, draft: "Initial draft" });
   });
 
+  await step("Read-only refresh recovers from settling content and stops on continuous changes", async () => {
+    await world.refreshChanges(false);
+    const settled = toolState(await world.call("computer_observe", { session_id: session, include_image: false }));
+    expect(settled.ok).toBe(true);
+    expect(JSON.stringify(settled)).toContain("Ready after refresh");
+    expect(await world.refreshState()).toMatchObject({ text: "Ready after refresh" });
+    await world.refreshChanges(true);
+    const changing = toolState(await world.call("computer_observe", { session_id: session, include_image: false }));
+    expect(changing).toMatchObject({ code: "stale_observation", next: "observe" });
+    expect(toolState(await action(settled, "after-failed-refresh", { type: "press", ref: refFor(settled, "Increment") })).code).toBe("observation_required");
+    expect(await world.state()).toEqual({ count: 0, otherCount: 0, draft: "Initial draft" });
+    await world.refreshStable();
+    expect((await observe()).ok).toBe(true);
+  });
+
   await step("Accessible actions update the selected window once and leave the other window alone", async () => {
     const observed = await observe();
     const press = { type: "press", ref: refFor(observed, "Increment") };
@@ -100,7 +127,8 @@ test("Computer Use respects window consent, fresh observations and the person's 
     await world.pressControl("Continue");
     await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("active");
     const resumed = toolState(await world.call("computer_session_status", { session_id: session }));
-    expect(resumed).toMatchObject({ state: "active", next: "observe" });
+    expect(resumed).toMatchObject({ state: "active", phase: "refreshing", next: "observe" });
+    expect(JSON.stringify(await world.panel())).toContain("Refreshing the approved window");
     expect(resumed).not.toHaveProperty("pause_reason");
     expect(toolState(await action(observed, "pre-pause-observation", { type: "press", ref: refFor(observed, "Increment") })).code).toBe("observation_required");
     expect((await observe()).ok).toBe(true);
@@ -110,13 +138,20 @@ test("Computer Use respects window consent, fresh observations and the person's 
   await step("A person's typing pauses control until they explicitly resume with a fresh view", async () => {
     const before = await observe();
     expect(await world.humanEdit()).toEqual({ ok: true });
+    expect(toolState(await world.call("computer_session_status", { session_id: session })).phase).toBe("person_interacting");
+    expect(await world.panel()).toMatchObject({ continue_enabled: false });
     await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("paused");
     await expect.poll(() => world.state()).toEqual({ count: 1, otherCount: 0, draft: "Edited by person" });
+    await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).phase).toBe("ready_to_continue");
+    expect(toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("paused");
+    expect(await world.panel()).toMatchObject({ continue_enabled: true });
     expect(toolState(await action(before, "after-human-edit", { type: "press", ref: refFor(before, "Increment") })).code).toBe("session_paused");
     await world.pressControl("Continue");
     await expect.poll(async () => toolState(await world.call("computer_session_status", { session_id: session })).state).toBe("active");
     expect(toolState(await action(before, "after-human-resume", { type: "press", ref: refFor(before, "Increment") })).code).toBe("observation_required");
+    expect(toolState(await world.call("computer_session_status", { session_id: session })).phase).toBe("refreshing");
     expect(JSON.stringify(await observe())).toContain("Edited by person");
+    expect(toolState(await world.call("computer_session_status", { session_id: session })).phase).toBe("working");
   });
 
   await step("Stop revokes the session immediately and leaves both windows intact", async () => {
@@ -124,6 +159,7 @@ test("Computer Use respects window consent, fresh observations and the person's 
     expect(toolState(await world.call("computer_observe", { session_id: session })).code).toBe("session_unavailable");
     expect(await world.state()).toEqual({ count: 1, otherCount: 0, draft: "Edited by person" });
     expect(toolState(await world.call("cua_screenshot")).code).toBe("unknown_tool");
+    expect(await world.panel()).toMatchObject({ restore_available: false });
   });
 
   await step("Pausing an in-flight drag releases the pointer and never resumes the old path", async () => {

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -50,6 +50,8 @@ test("Computer Use respects window consent, fresh observations and the person's 
 
   await step("Hiding the task panel preserves the grant and the menu bar restores its controls", async () => {
     await world.pressControl("Hide panel");
+    expect(await world.panel()).toMatchObject({ restore_help: "Show Computer Use controls" });
+    expect(JSON.stringify(await world.panel())).not.toContain("Edit the disposable fixture draft");
     expect(toolState(await world.call("computer_session_status", { session_id: session }))).toMatchObject({
       state: "active", panel_visible: false, purpose: "Edit the disposable fixture draft and increment its counter.", window_title: "Workspace window",
     });

--- a/evals/worlds/computer-use.ts
+++ b/evals/worlds/computer-use.ts
@@ -99,6 +99,9 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
       peerCall: (name: string, args: Record<string, unknown> = {}) => peer.request("tools/call", { name, arguments: args }),
       list: () => helper.request("tools/list"),
       state: () => fixture.request("state"),
+      refreshChanges: (continuous: boolean) => fixture.request("refresh_changes", { continuous }),
+      refreshStable: () => fixture.request("refresh_stable"),
+      refreshState: () => fixture.request("refresh_state"),
       resize: () => fixture.request("resize"),
       panel: () => fixture.request("helper_panel", { name: "", pid: helper.pid, executable }),
       foregroundWindow: () => fixture.request("foreground_window"),
@@ -122,7 +125,7 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
         }
         throw new Error("The native window picker did not become available.");
       },
-      async pressControl(name: "Allow this session" | "Cancel" | "Take over" | "Continue" | "Stop") {
+      async pressControl(name: "Allow this session" | "Cancel" | "Take over" | "Continue" | "Stop" | "Hide panel" | "Show Computer Use task") {
         const deadline = Date.now() + 10_000;
         while (Date.now() < deadline) {
           const result = await fixture.request("press_helper_button", { name, pid: helper.pid, executable });

--- a/packages/computer-use/README.md
+++ b/packages/computer-use/README.md
@@ -177,8 +177,8 @@ control. Session status exposes `phase`: `person_interacting`,
 an observation succeeds. Old input is never replayed.
 
 **Hide panel** hides this session's floating controls without revoking access.
-The **OW** menu bar item restores the task panel; its tooltip identifies the
-requested task. Stop removes both surfaces. Session status includes the task
+The **OW** menu bar item restores the task panel; its tooltip is generic so
+hiding the panel also hides task details. Stop removes both surfaces. Session status includes the task
 purpose, approved window title, and panel visibility for the owning caller.
 This associates the native panel with the approved task; navigation back to an
 OpenWork conversation is not added by this package.

--- a/packages/computer-use/README.md
+++ b/packages/computer-use/README.md
@@ -169,6 +169,27 @@ only the approved window, checks that window is foreground, and requires the
 caller to observe again. It does not replay interrupted typing or dragging.
 **Stop** ends the grant. The access countdown continues while paused.
 
+During physical input, Continue is disabled until one second without another
+input event. That quiet period only makes Continue available; it never resumes
+control. Session status exposes `phase`: `person_interacting`,
+`ready_to_continue`, `refreshing`, or `working`, while preserving the existing
+`paused`/`active` state. After Continue, the panel says it is refreshing until
+an observation succeeds. Old input is never replayed.
+
+**Hide panel** hides this session's floating controls without revoking access.
+The **OW** menu bar item restores the task panel; its tooltip identifies the
+requested task. Stop removes both surfaces. Session status includes the task
+purpose, approved window title, and panel visibility for the owning caller.
+This associates the native panel with the approved task; navigation back to an
+OpenWork conversation is not added by this package.
+
+When the window changes during observation, the runtime makes at most three
+read-only capture attempts, 75 ms apart. Every attempt checks the same session
+generation, window identity, geometry, and semantic state. Continuous changes
+still return `stale_observation`; a failed refresh invalidates the old token.
+This does not relax the exact-image checks for visual actions, retry any input,
+or clear a person takeover.
+
 ## Build, migration and verification
 
 ```

--- a/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
@@ -114,7 +114,7 @@ final class SessionControls: NSObject {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.button?.title = "OW"
         item.button?.setAccessibilityTitle("Show Computer Use task")
-        item.button?.toolTip = "\(purpose) — Show Computer Use controls"
+        item.button?.toolTip = "Show Computer Use controls"
         item.button?.target = self
         item.button?.action = #selector(showPanel)
         statusItem = item

--- a/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
@@ -30,6 +30,9 @@ final class SessionControls: NSObject {
     private var stopObserver: NSObjectProtocol?
     private var timer: Timer?
     private var consentWindow: NSWindow?
+    private var statusItem: NSStatusItem?
+    var isVisible: Bool { panel?.isVisible == true }
+    var onUserInteraction: (() -> Void)?
     var onPause: ((String) -> Void)?
     var onResume: (() -> Void)?
     var onStop: (() -> Void)?
@@ -91,7 +94,8 @@ final class SessionControls: NSObject {
         let toggle = NSButton(title: "Take over", target: self, action: #selector(togglePause))
         let stop = NSButton(title: "Stop", target: self, action: #selector(stopSession))
         stop.bezelColor = .systemRed
-        let buttons = NSStackView(views: [toggle, stop])
+        let hide = NSButton(title: "Hide panel", target: self, action: #selector(hidePanel))
+        let buttons = NSStackView(views: [toggle, stop, hide])
         buttons.spacing = 8
         let stack = NSStackView(views: [title, window, task, status, expiry, buttons])
         stack.orientation = .vertical; stack.alignment = .leading; stack.spacing = 9
@@ -107,13 +111,20 @@ final class SessionControls: NSObject {
         }
         self.panel = panel; self.status = status; self.toggle = toggle; self.expiry = expiry
         panel.orderFrontRegardless()
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.button?.title = "OW"
+        item.button?.setAccessibilityTitle("Show Computer Use task")
+        item.button?.toolTip = "\(purpose) — Show Computer Use controls"
+        item.button?.target = self
+        item.button?.action = #selector(showPanel)
+        statusItem = item
         monitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown,
             .keyDown, .scrollWheel, .mouseMoved, .leftMouseDragged, .rightMouseDragged]) { [weak self] event in
             guard let self else { return }
             // Our own postToPid events cannot be mistaken for a person taking over.
             if event.cgEvent?.getIntegerValueField(.eventSourceUnixProcessID) == Int64(ProcessInfo.processInfo.processIdentifier) { return }
             if mode == .control || NSWorkspace.shared.frontmostApplication?.processIdentifier == app.pid {
-                self.onPause?("You have control. Click Continue when you are ready.")
+                self.onUserInteraction?()
             }
         }
         let center = NSWorkspace.shared.notificationCenter
@@ -137,20 +148,24 @@ final class SessionControls: NSObject {
             MainActor.assumeIsolated { self?.onTick?() }
         }
     }
-    func update(_ message: String, paused: Bool) {
+    func update(_ message: String, paused: Bool, canContinue: Bool = true) {
         isPaused = paused; status?.stringValue = message; toggle?.title = paused ? "Continue" : "Take over"
+        toggle?.isEnabled = !paused || canContinue
     }
     func updateExpiry(seconds: Int) {
         expiry?.stringValue = String(format: "Access ends in %d:%02d", seconds / 60, seconds % 60)
     }
     func close() {
         cancelConsent()
+        if let statusItem { NSStatusBar.system.removeStatusItem(statusItem) }; statusItem = nil
         panel?.close(); panel = nil; timer?.invalidate(); timer = nil
         if let monitor { NSEvent.removeMonitor(monitor) }; monitor = nil
         for observer in workspaceObservers { NSWorkspace.shared.notificationCenter.removeObserver(observer) }
         workspaceObservers.removeAll()
         if let stopObserver { DistributedNotificationCenter.default().removeObserver(stopObserver) }; stopObserver = nil
     }
+    @objc private func hidePanel() { panel?.orderOut(nil) }
+    @objc private func showPanel() { panel?.orderFrontRegardless() }
     @objc private func togglePause() { if isPaused { onResume?() } else { onPause?("You have control. Click Continue when you are ready.") } }
     @objc private func stopSession() { onStop?() }
 }

--- a/packages/computer-use/native/Sources/ComputerUse/SessionRuntime.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/SessionRuntime.swift
@@ -21,6 +21,9 @@ final class SessionRuntime {
         var generation = 0
         var paused = false
         var pauseReason: String?
+        var interactionDeadline: TimeInterval?
+        var needsRefresh = true
+        let purpose: String
         var observation: ObservationLease?
         var records: [ElementRecord] = []
         var actionCount = 0
@@ -29,6 +32,7 @@ final class SessionRuntime {
     }
     init() {
         controls.onPause = { [weak self] reason in self?.pause(reason) }
+        controls.onUserInteraction = { [weak self] in self?.personInteracted() }
         controls.onResume = { [weak self] in Task { await self?.resume() } }
         controls.onStop = { [weak self] in self?.close() }
         controls.onTick = { [weak self] in self?.expire() }
@@ -67,7 +71,7 @@ final class SessionRuntime {
             try Task.checkCancellation()
             _ = try access.validate(target, app: identity)
             let id = UUID().uuidString.lowercased()
-            session = Session(id: id, app: identity, target: target, mode: mode, started: now, lastUsed: now)
+            session = Session(id: id, app: identity, target: target, mode: mode, started: now, lastUsed: now, purpose: purpose)
             lease = reservation
             controls.show(app: identity, target: target, mode: mode, purpose: purpose)
             if mode == .control {
@@ -93,7 +97,9 @@ final class SessionRuntime {
             try a.only(["session_id"])
             let current = try current(try a.string("session_id"), allowPaused: true)
             var status: [String: Any] = ["ok": true, "session_id": current.id, "mode": current.mode.rawValue,
-                "state": current.paused ? "paused" : "active", "actions": current.actionCount,
+                "state": current.paused ? "paused" : "active", "phase": phase(current),
+                "purpose": current.purpose, "window_title": current.target.title, "panel_visible": controls.isVisible,
+                "actions": current.actionCount,
                 "expires_in_seconds": max(0, Int(900 - (now - current.started))),
                 "next": current.paused ? "human_takeover" : "observe"]
             if let reason = current.pauseReason { status["pause_reason"] = reason }
@@ -129,6 +135,23 @@ final class SessionRuntime {
         return current
     }
     private func observe(_ id: String, image: Bool) async throws -> [[String: Any]] {
+        // Retry only read-only capture races. Never repeat an action or cross takeover.
+        let generation = try current(id).generation
+        session?.needsRefresh = true
+        controls.update("Refreshing the approved window before continuing…", paused: false)
+        for attempt in 0..<3 {
+            guard try current(id).generation == generation else {
+                throw UseError("session_changed", "Control changed during refresh.", next: "human_takeover")
+            }
+            do { return try await observeAttempt(id, image: image) }
+            catch let error as UseError {
+                guard error.code == "stale_observation", attempt < 2 else { throw error }
+                try await Task.sleep(nanoseconds: 75_000_000)
+            }
+        }
+        throw UseError("stale_observation", "The window is still changing. Observe again.", next: "observe")
+    }
+    private func observeAttempt(_ id: String, image: Bool) async throws -> [[String: Any]] {
         let current = try current(id)
         // Invalidate the last token before attempting a fresh read, including failed captures.
         session?.observation = nil; session?.records = []
@@ -151,6 +174,8 @@ final class SessionRuntime {
         let observation = ObservationLease(id: UUID().uuidString.lowercased(), createdAt: now, generation: current.generation,
             frame: bounds, imageWidth: width, imageHeight: height, stateDigest: access.digest(state), imageDigest: imageDigest)
         session?.observation = observation; session?.records = state.records; session?.lastUsed = now
+        session?.needsRefresh = false
+        controls.update("OpenWork is working. You can take over at any time.", paused: false)
         let elements = state.records.map { record -> [String: Any] in
             var value: [String: Any] = ["ref": record.ref, "role": record.role, "label": record.label,
                 "enabled": record.enabled, "actions": record.actions.isEmpty ? [] : ["press"], "settable": record.settable,
@@ -220,15 +245,28 @@ final class SessionRuntime {
             return text(receipt)
         }
     }
+    private func phase(_ current: Session) -> String {
+        if let deadline = current.interactionDeadline, now < deadline { return "person_interacting" }
+        if current.paused { return "ready_to_continue" }
+        return current.needsRefresh ? "refreshing" : "working"
+    }
+    private func personInteracted() {
+        guard session != nil else { return }
+        pause("You have control. Click Continue when you are ready.")
+        session?.interactionDeadline = now + 1
+        controls.update("You have control. Waiting for your input to finish…", paused: true, canContinue: false)
+    }
     func pause(_ reason: String) {
         guard let current = session, !current.paused || resumingSessionID == current.id else { return }
         input.releaseAll()
         session?.pauseReason = reason
+        session?.needsRefresh = true
         session?.paused = true; session?.generation += 1; session?.observation = nil; session?.records = []
         controls.update(reason, paused: true)
     }
     private func resume() async {
-        guard let current = session, current.paused, resumingSessionID == nil else { return }
+        guard let current = session, current.paused, resumingSessionID == nil,
+              current.interactionDeadline.map({ now >= $0 }) ?? true else { return }
         resumingSessionID = current.id
         defer { if resumingSessionID == current.id { resumingSessionID = nil } }
         do {
@@ -251,8 +289,10 @@ final class SessionRuntime {
             _ = try access.validate(current.target, app: current.app, requireFrontmost: current.mode == .control)
             expire(); guard session != nil else { return }
             session?.pauseReason = nil
+            session?.interactionDeadline = nil
+            session?.needsRefresh = true
             session?.paused = false; session?.generation += 1; session?.observation = nil; session?.lastUsed = now
-            controls.update("OpenWork is working. You can take over at any time.", paused: false)
+            controls.update("Refreshing the approved window before continuing…", paused: false)
         } catch {
             guard session?.id == current.id else { return }
             session?.pauseReason = error.localizedDescription
@@ -261,6 +301,10 @@ final class SessionRuntime {
     }
     private func expire() {
         guard let current = session else { return }
+        if let deadline = current.interactionDeadline, now >= deadline {
+            session?.interactionDeadline = nil
+            controls.update(current.pauseReason ?? "You have control. Click Continue when you are ready.", paused: true)
+        }
         controls.updateExpiry(seconds: max(0, Int(900 - (now - current.started))))
         if now - current.started >= 900 || current.app.app.isTerminated { close(); return }
         if !current.paused && now - current.lastUsed >= 120 { pause("Paused after two minutes without activity.") }


### PR DESCRIPTION
Computer Use now distinguishes a person interacting, readiness to continue, refreshing the approved window, and working. Physical input releases control immediately and disables Continue until one second of quiet; continuation still requires the native button and a fresh observation.

The task panel can be hidden and restored from an OW menu-bar item with a generic tooltip, keeping task details inside the panel. Hiding preserves the grant; Stop removes both surfaces. The owning caller can read task purpose, approved window title, panel visibility, and phase through session status.

Observation makes at most three read-only attempts when content changes during capture, preserving session generation and window checks. Continuous changes return an error and invalidate old observations. Input is never retried, and exact-image validation for visual actions remains unchanged. This is native task context, not a conversation deep link or live video preview.

## Verification — Passed

Final head: `0633f144d9e1c5baccdb01f055914b6bf04831e6`.

- `pnpm evals:e2e computer-use-window-scope --local`: `placement: local (--local)`; exit 0, 1 passed, 0 failed, 0 skipped.
- Exact-head real Mac proof covers native consent and window isolation, hidden panel and generic tooltip, menu-bar restore and cleanup, disabled Continue during person input, explicit continuation and fresh observations, bounded read-only refresh (four reads to settle, six reads before rejecting continuous changes), interrupted drag release and no replay, and Stop.
- `pnpm --filter @openwork/computer-use check`: syntax checks and four native boundary tests pass. `pnpm --dir evals typecheck:spec-layer` and `git diff --check` pass.
- GitHub checks are green and all review findings are resolved.

Exact-head Passed evidence is published in the test-evidence comment. No new test files.

Earlier local attempts encountered a window-discovery failure also reproduced on unchanged dev, followed by one failed helper-identity lookup in the test driver. The final unchanged-head run passed; this does not establish that those environment/test-driver failures cannot recur. No permission or window-identity checks were weakened.
