### PR TITLE
Simplify the saved workflow run screen

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-overview-tab.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-overview-tab.tsx
@@ -119,9 +119,11 @@ export function WorkflowOverviewTab({
               ) : (
                 <p className="text-[13px] text-gray-500">This workflow uses structured input. Review its saved values under Advanced input before running.</p>
               )}
-              <details className="text-[12px] text-gray-500" open={showJsonInput} onToggle={(event) => onShowJsonInputChange(event.currentTarget.open)}>
-                <summary className="cursor-pointer font-medium">Advanced input</summary>
-                <label className="mt-3 block">
+              <div className="text-[12px] text-gray-500">
+                <DenButton type="button" variant="ghost" size="xs" aria-expanded={showJsonInput} onClick={() => onShowJsonInputChange(!showJsonInput)}>
+                  Advanced input
+                </DenButton>
+                {showJsonInput ? <label className="mt-3 block">
                   Workflow input (JSON)
                   <DenTextarea
                     aria-label="Run input details"
@@ -129,8 +131,8 @@ export function WorkflowOverviewTab({
                     value={fields.input}
                     onChange={(event) => onInputChange(event.currentTarget.value)}
                   />
-                </label>
-              </details>
+                </label> : null}
+              </div>
               <div className="border-t border-gray-100 pt-4">
                 <DenButton type="submit" icon={RefreshCw} loading={pending} className="w-full sm:w-auto">
                   {pending ? "Running…" : "Run workflow"}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-overview-tab.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-overview-tab.tsx
@@ -15,7 +15,7 @@ import { DenSwitch } from "../../_components/ui/switch";
 import { DenTextarea } from "../../_components/ui/textarea";
 import { WorkflowArtifactResult } from "./workflow-artifact-result";
 import { WorkflowFlowDiagram } from "./workflow-flow-diagram";
-import { WorkflowInputForm } from "./workflow-input-form";
+import { formFieldsFromSchema, WorkflowInputForm } from "./workflow-input-form";
 import { summarizeGraph } from "./workflow-plain-language";
 import {
   workflowDiagramInput,
@@ -93,7 +93,75 @@ export function WorkflowOverviewTab({
   const flowInput = workflowDiagramInput(latestReplay, replayVersion.exampleInput);
 
   return (
-    <div className="grid gap-6" data-tab="overview" role="tabpanel" aria-label="Overview">
+    <div className="grid gap-6" data-tab="overview" data-testid="workflow-overview" role="tabpanel" aria-label="Overview">
+      <DenCard>
+        <form
+          aria-label="Run workflow"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (detail.canRun && !pending) onRun();
+          }}
+        >
+          <DenSectionHeader title="Run workflow" description="Check the details below, then run. Your result will appear here." />
+          {detail.canRun ? (
+            <fieldset disabled={pending} className="mt-5 min-w-0 space-y-5">
+              {hasInputForm ? (
+                formFieldsFromSchema(parsedInputSchema)?.length === 0 ? (
+                  <p className="text-[13px] text-gray-500">No details needed. This workflow is ready to run.</p>
+                ) : (
+                  <WorkflowInputForm
+                    schema={parsedInputSchema}
+                    value={inputFormValue}
+                    onChange={(next) => onInputChange(JSON.stringify(next, null, 2))}
+                  />
+                )
+              ) : (
+                <p className="text-[13px] text-gray-500">This workflow uses structured input. Review its saved values under Advanced input before running.</p>
+              )}
+              <details className="text-[12px] text-gray-500" open={showJsonInput} onToggle={(event) => onShowJsonInputChange(event.currentTarget.open)}>
+                <summary className="cursor-pointer font-medium">Advanced input</summary>
+                <label className="mt-3 block">
+                  Workflow input (JSON)
+                  <DenTextarea
+                    aria-label="Run input details"
+                    className="mt-2 min-h-32 font-mono text-[11px]"
+                    value={fields.input}
+                    onChange={(event) => onInputChange(event.currentTarget.value)}
+                  />
+                </label>
+              </details>
+              <div className="border-t border-gray-100 pt-4">
+                <DenButton type="submit" icon={RefreshCw} loading={pending} className="w-full sm:w-auto">
+                  {pending ? "Running…" : "Run workflow"}
+                </DenButton>
+              </div>
+            </fieldset>
+          ) : (
+            <p className="mt-5 text-[13px] text-gray-500">You do not have permission to run this workflow.</p>
+          )}
+        </form>
+      </DenCard>
+
+      <DenCard>
+        <DenSectionHeader
+          title="Latest result"
+          description="The saved result from the most recent run."
+        />
+        <div className="mt-5">
+          {latestResult ? (
+            <WorkflowArtifactResult
+              snapshot={latestResult}
+              freshness={latestResult.receiptId === detail.latestSnapshot?.receiptId ? detail.freshness : undefined}
+              lastSuccessful={latestResult.receiptId === detail.latestSuccessfulSnapshot?.receiptId}
+              technical={technical}
+            />
+          ) : (
+            <p className="text-[13px] text-gray-400">Run this workflow to see its first result.</p>
+          )}
+        </div>
+      </DenCard>
+
       <DenCard>
         <DenSectionHeader
           title="How it works"
@@ -129,82 +197,8 @@ export function WorkflowOverviewTab({
         ) : null}
       </DenCard>
 
-      <DenCard>
-        <DenSectionHeader
-          title="Run it"
-          description="Fill in the details and run. Each run keeps its result."
-          action={detail.canRun ? (
-            <DenButton icon={RefreshCw} disabled={pending} onClick={onRun}>
-              Run now
-            </DenButton>
-          ) : null}
-        />
-        {detail.canRun ? (
-          hasInputForm ? (
-            <div className="mt-5">
-              <p className="text-[12px] font-medium text-gray-600">Run input</p>
-              <WorkflowInputForm
-                schema={parsedInputSchema}
-                value={inputFormValue}
-                onChange={(next) => onInputChange(JSON.stringify(next, null, 2))}
-              />
-              {technical ? (
-                <div className="mt-3">
-                  <DenButton
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => onShowJsonInputChange(!showJsonInput)}
-                  >
-                    {showJsonInput ? "Hide formatted input" : "Edit formatted input"}
-                  </DenButton>
-                  {showJsonInput ? (
-                    <DenTextarea
-                      aria-label="Run input details"
-                      className="mt-2 min-h-32 font-mono text-[11px]"
-                      value={fields.input}
-                      onChange={(event) => onInputChange(event.currentTarget.value)}
-                    />
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          ) : technical ? (
-            <label className="mt-5 block text-[12px] font-medium text-gray-600">
-              Run input
-              <DenTextarea
-                className="mt-1 min-h-32 font-mono text-[11px]"
-                value={fields.input}
-                onChange={(event) => onInputChange(event.currentTarget.value)}
-              />
-            </label>
-          ) : (
-            <p className="mt-5 text-[13px] text-gray-500">Show technical details to enter the run input for this workflow.</p>
-          )
-        ) : (
-          <p className="mt-5 text-[13px] text-gray-500">You do not have permission to run this workflow.</p>
-        )}
-      </DenCard>
-
-      <DenCard>
-        <DenSectionHeader
-          title="Latest result"
-          description="The saved result from the most recent run."
-        />
-        <div className="mt-5">
-          {latestResult ? (
-            <WorkflowArtifactResult
-              snapshot={latestResult}
-              freshness={latestResult.receiptId === detail.latestSnapshot?.receiptId ? detail.freshness : undefined}
-              lastSuccessful={latestResult.receiptId === detail.latestSuccessfulSnapshot?.receiptId}
-              technical={technical}
-            />
-          ) : (
-            <p className="text-[13px] text-gray-400">Run this workflow to see its first result.</p>
-          )}
-        </div>
-      </DenCard>
-
-      <DenCard>
+      <details className="rounded-2xl border border-gray-100 bg-white p-6">
+        <summary className="mb-5 cursor-pointer text-[13px] font-medium text-gray-600">Customize result display</summary>
         <DenSectionHeader
           title="Custom display"
           description="Show results as a chart, table, or card layout designed by your agent. Until then, results use the standard view."
@@ -303,7 +297,7 @@ export function WorkflowOverviewTab({
             </DenList>
           )}
         </div>
-      </DenCard>
+      </details>
     </div>
   );
 }

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -172,8 +172,12 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     await user.see({ testId: "workflow-overview" }, { text: /Run workflow[\s\S]*Latest result[\s\S]*How it works/, timeoutMs: 60_000 });
     await user.see({ testId: "den-workflow-input-form" });
     await user.notSee({ label: "Run input details" });
-    await user.notSee({ text: /No custom display yet/ });
     const beforeRun = await readRuns();
+    await user.see({ testId: "workflow-overview" }, { text: /^(?![\s\S]*No custom display yet)[\s\S]*Customize result display/ });
+    await user.click({ text: "Customize result display" });
+    await user.see({ text: /No custom display yet/ });
+    await user.click({ text: "Customize result display" });
+    await user.see({ testId: "workflow-overview" }, { text: /^(?![\s\S]*No custom display yet)[\s\S]*Customize result display/ });
     await user.type({ label: /^Topic/ }, "A fresh briefing", { replace: true });
     await user.click({ text: "Advanced input" });
     await user.see({ label: "Run input details" }, { value: JSON.stringify({ topic: "A fresh briefing" }, null, 2) });

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -57,7 +57,7 @@ const test = spec.world(async (seed) => {
   const configObjectVersionId = field(saved.body, "configObjectVersionId");
   const firstRun = await runWorkflow(den.admin, configObjectId, { pluginId, configObjectVersionId, input: { topic: "Weekly overview" } });
   // Save another version without running it. History must retain the first graph.
-  const nextCode = "const workers = await tools.den.getWorkers({}); return { revisedCount: workers.workers.length };";
+  const nextCode = "const workers = await tools.den.getWorkers({}); return { topic: input.topic, revisedCount: workers.workers.length };";
   await execute(nextCode);
   const revised = await saveWorkflow(den.admin, { name: "Weekly briefing", code: nextCode, inputSchema, currentInput: { topic: "Next week" } });
   if (revised.status !== 201) throw new Error(`Revising the setup workflow failed (${revised.status})`);
@@ -166,4 +166,31 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     expect((await probe.api(colleague, `/v1/workflows/${world.configObjectId}`)).response.status).toBe(403);
   });
   evidence.recordAssertionEvidence("Run previews follow workflow access without widening run visibility", "A member sees none of the admin's runs, then sees a redacted preview of their own shared workflow run. Revoking the workflow grant preserves their receipt but removes its preview and library metadata.", true);
+
+  await step("run the saved workflow from its simple form", async () => {
+    await user.navigate(`${world.den.ref.webUrl}/dashboard/library/workflows/${world.configObjectId}`);
+    await user.see({ testId: "workflow-overview" }, { text: /Run workflow[\s\S]*Latest result[\s\S]*How it works/, timeoutMs: 60_000 });
+    await user.see({ testId: "den-workflow-input-form" });
+    await user.notSee({ label: "Run input details" });
+    await user.notSee({ text: /No custom display yet/ });
+    const beforeRun = await readRuns();
+    await user.type({ label: /^Topic/ }, "A fresh briefing", { replace: true });
+    await user.click({ text: "Advanced input" });
+    await user.see({ label: "Run input details" }, { value: JSON.stringify({ topic: "A fresh briefing" }, null, 2) });
+    await user.click({ text: "Advanced input" });
+    await user.notSee({ label: "Run input details" });
+    expect(await readRuns()).toEqual(beforeRun);
+    await user.click({ role: "button", label: "Run workflow" });
+    await user.see({ testId: "den-workflow-artifact-result" }, { text: /A fresh briefing/, timeoutMs: 60_000 });
+    const afterRun = await readRuns();
+    expect(afterRun).toHaveLength(beforeRun.length + 1);
+    const added = afterRun.filter((run) => !beforeRun.some((previous) => previous.id === run.id));
+    expect(added).toHaveLength(1);
+    expect(added[0]).toMatchObject({ status: "succeeded", workflow: { configObjectId: world.configObjectId, graph: world.revisedGraph } });
+    await user.see({ role: "button", label: "Run workflow" });
+    await user.see({ testId: "den-workflow-flow-diagram" });
+    await user.screenshot();
+  });
+  evidence.recordAssertionEvidence("The workflow opens with a simple run form and shows the submitted result", "The form precedes the latest result and existing diagram. Advanced input starts hidden and stays synchronized with the named field; editing and inspecting it create no runs. Submitting creates exactly one successful run of the current saved version and displays the entered topic in its result.", true);
+
 });

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -178,7 +178,7 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     await user.see({ text: /No custom display yet/ });
     await user.click({ text: "Customize result display" });
     await user.see({ testId: "workflow-overview" }, { text: /^(?![\s\S]*No custom display yet)[\s\S]*Customize result display/ });
-    await user.type({ label: /^Topic/ }, "A fresh briefing", { replace: true });
+    await user.type({ role: "textbox", label: /^Topic/ }, "A fresh briefing", { replace: true, verify: true });
     await user.click({ text: "Advanced input" });
     await user.see({ label: "Run input details" }, { value: JSON.stringify({ topic: "A fresh briefing" }, null, 2) });
     await user.click({ text: "Advanced input" });


### PR DESCRIPTION
Opening a saved workflow currently puts its diagram ahead of the inputs and separates the run action from the fields. The overview now starts with the named input form and a Run workflow button, followed by the latest result and the existing diagram. Advanced input and result-display customization are expandable.

Submitting uses the existing workflow run endpoint and saved version. The run form keeps the same named fields and advanced JSON input synchronized.

Validation:

- Den web type check: passed.
- Existing workflow input and overview component tests: 6 passed, 0 failed.
- `OPENWORK_EVAL_REF=5e3885c7bd67a214b2e1dadc19a752ceaf32eab0 infisical run --silent --env dev -- pnpm evals:e2e workflow-run-previews` — **Passed**, Daytona: 1 passed, 0 failed, 0 skipped, exit 0. Verifies form-first content, collapsed and expandable settings, synchronized input, no run during editing, exactly one successful current-version run after submission, and the entered topic in the displayed result. Also covers existing activity previews and member access.

Manual check: open a saved workflow from the library, edit its named fields, and select Run workflow. The latest result appears below the form. Expand Advanced input to inspect the same values as JSON, or scroll to the existing workflow diagram.
