### PR TITLE
Fix Computer Use enabling and clarify setup readiness

### DIFF
--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -908,10 +908,11 @@ export function createConnectionsStore(options: {
       }
 
       if (entryType === "local") {
-        if (!entry.command?.length) {
+        const command = await resolveLocalMcpCommand(entry);
+        if (!command?.length) {
           throw new Error("Missing MCP command.");
         }
-        mcpEntryConfig["command"] = await resolveLocalMcpCommand(entry);
+        mcpEntryConfig["command"] = command;
         const environment = await resolveLocalMcpEnvironment(entry);
         if (environment) {
           mcpEntryConfig["environment"] = environment;

--- a/apps/app/src/react-app/domains/settings/computer-use-config.tsx
+++ b/apps/app/src/react-app/domains/settings/computer-use-config.tsx
@@ -67,6 +67,10 @@ export function ComputerUseConfig({ connected, connecting, onConnect, onRefresh,
     retry: false,
     refetchOnWindowFocus: true,
     staleTime: 0,
+    refetchInterval: 2_000,
+  });
+  const connect = useMutation({
+    mutationFn: async () => { await onConnect?.(); await onRefresh?.(); },
   });
   const setup = useMutation({
     mutationFn: async () => parsePermissionResult(await desktopBridge.openComputerUsePermissionSetup()),
@@ -76,18 +80,19 @@ export function ComputerUseConfig({ connected, connecting, onConnect, onRefresh,
     if (result) onPermissionsChange?.({ accessibility: result.accessibility, screenRecording: result.screenRecording });
   }, [result, onPermissionsChange]);
 
-  const error = (setup.error ?? checkError)?.message ?? result?.error;
+  const error = (connect.error ?? setup.error ?? checkError)?.message ?? result?.error;
   const supported = hasDesktopBridge() && result?.supported !== false;
-  const ready = connected && result?.ok === true;
+  const permissionsReady = result?.ok === true;
+  const ready = connected && permissionsReady;
   const busy = isFetching || setup.isPending;
-  const refresh = async () => { setup.reset(); await refetch(); await onRefresh?.(); };
+  const refresh = async () => { setup.reset(); connect.reset(); await refetch(); await onRefresh?.(); };
 
   return (
     <Card variant="outline" size="sm">
       <CardHeader>
         <CardTitle>Work in an app you choose</CardTitle>
         <CardDescription>
-          Approve one Mac app, choose its window, and decide how OpenWork can help. Each session has its own Pause and Stop controls.
+          Approve one Mac app, choose its window, and decide how OpenWork can help. Each session has its own Take over and Stop controls.
         </CardDescription>
         <CardAction>
           <Button variant="ghost" size="icon-sm" aria-label="Refresh Computer Use status" onClick={() => void refresh()} disabled={busy}>
@@ -98,8 +103,14 @@ export function ComputerUseConfig({ connected, connecting, onConnect, onRefresh,
       <CardContent className="space-y-5">
         <div className="flex items-center gap-2 rounded-xl border border-border bg-muted/40 px-3 py-3 text-sm" role="status" aria-live="polite">
           {ready ? <CheckCircle2 className="size-4 shrink-0 text-green-11" /> : <ShieldCheck className="size-4 shrink-0 text-muted-foreground" />}
-          <span>{ready ? "Ready · app access is approved when a session starts" : !supported ? "Available in OpenWork for macOS 14 or later" : !connected ? "Enable Computer Use to get started" : "Finish macOS permissions below"}</span>
+          <span>{ready ? "Ready · app access is approved when a session starts" : !supported ? "Available in OpenWork for macOS 14 or later" : !connected ? permissionsReady ? "Permissions are ready. Enable Computer Use for this workspace." : "Set up Computer Use for this workspace" : "Connected · finish macOS permissions below"}</span>
         </div>
+        {!ready ? (
+          <Button className="w-full" onClick={() => { if (!connected) connect.mutate(); else setup.mutate(); }} disabled={!supported || connecting || connect.isPending || setup.isPending || (!connected && !onConnect)}>
+            {connecting || connect.isPending || setup.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+            {connecting || connect.isPending ? "Enabling…" : !connected ? "Enable Computer Use" : "Allow macOS access"}
+          </Button>
+        ) : null}
         {error ? <Alert variant="destructive"><CircleAlert /><AlertDescription className="break-words">{error}</AlertDescription></Alert> : null}
         <div className="space-y-3">
           <p className="text-sm font-medium">You choose the scope</p>
@@ -126,16 +137,8 @@ export function ComputerUseConfig({ connected, connecting, onConnect, onRefresh,
         </p>
       </CardContent>
       <CardFooter className="flex flex-wrap items-center justify-between gap-3 border-t border-border">
-        <p className="max-w-sm text-xs text-muted-foreground">{ready ? "Mention an app in your next message, then approve the window when asked." : "Enable the extension and allow both macOS permissions."}</p>
-        {!connected ? (
-          <Button onClick={() => void onConnect?.()} disabled={!supported || !onConnect || connecting}>
-            {connecting ? <Loader2 className="size-4 animate-spin" /> : null}
-            {connecting ? "Enabling…" : "Enable Computer Use"}
-          </Button>
-        ) : <div className="flex flex-wrap gap-2">
-          <Button variant="outline" onClick={() => void onConnect?.()} disabled={!onConnect || connecting}>{connecting ? "Reconnecting…" : "Reconnect Computer Use"}</Button>
-          <Button variant="outline" onClick={() => void refresh()} disabled={busy}>Check readiness</Button>
-        </div>}
+        <p className="max-w-sm text-xs text-muted-foreground">{ready ? "Mention an app in your next message, then approve the window when asked." : !connected ? "macOS access and enabling tools for this workspace are separate steps." : "Allow access, then return here. Status updates automatically."}</p>
+        {ready ? <Button variant="outline" onClick={() => void refresh()} disabled={busy}>Check readiness</Button> : null}
       </CardFooter>
     </Card>
   );

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1863,10 +1863,12 @@ function McpQuickConnectSection(props: {
     const connecting = props.connectingName === entry.name;
     const hidden = props.isEntryHidden(entry);
     const disabledReason = props.disabledReasonForEntry(entry);
+    const isComputerUse = entry.id === "computer-use";
+    const ready = isComputerUse ? enablement?.active === true : configured || enablement?.active;
     const entryUrl = typeof entry.url === "string" ? entry.url : undefined;
     const group: ExtensionInventoryGroup = disabledReason
       ? "disabled"
-      : configured || enablement?.active
+      : ready
         ? "ready"
         : "available";
     cards.push({
@@ -1881,7 +1883,7 @@ function McpQuickConnectSection(props: {
           iconSrc={entry.iconSrc}
           url={entryUrl}
           taxonomy={taxonomyForDirectoryEntry(entry)}
-          connected={configured}
+          connected={isComputerUse ? ready : configured}
           enablement={enablement?.results}
           connecting={connecting}
           hidden={hidden}
@@ -1890,7 +1892,7 @@ function McpQuickConnectSection(props: {
           disabled={props.busy}
           meta={t("extensions.surface_this_device")}
           actionLabel={configured ? "View details" : t("mcp.tap_to_connect")}
-          nextActionLabel={configured || disabledReason ? undefined : t("connect.row_action_connect")}
+          nextActionLabel={isComputerUse ? ready || disabledReason ? undefined : "Set up" : configured || disabledReason ? undefined : t("connect.row_action_connect")}
           onClick={() => props.onDetail(entry)}
         />
       ),

--- a/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
+++ b/apps/app/src/react-app/domains/settings/settings-extension-controller.ts
@@ -62,7 +62,7 @@ export function useSettingsExtensionController(input: SettingsExtensionControlle
     hostOpenworkServerClient: input.hostOpenworkServerClient,
     restartLocalServer: input.restartLocalServer,
     computerUse: {
-      connected: input.mcpServers.some((server) => server.name === "computer-use"),
+      connected: input.enablementContext.mcpStatuses?.["computer-use"]?.status === "connected",
       connecting: input.mcpConnectingName === entry.name,
       onConnect: () => input.connectMcp(entry),
       onRefresh: input.refreshMcpServers,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2004,7 +2004,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     onComputerUsePermissionsChange: setComputerUsePermissions,
     restartLocalServer: restartExtensionLocalServer,
     connectMcp: async (entry) => {
-      await connectionsStore.connectMcp(entry);
+      const result = await connectionsStore.connectMcp(entry);
+      if (!result.ok) throw new Error(result.error);
     },
     refreshMcpServers: () => connectionsStore.refreshMcpServers(),
     providers,

--- a/apps/app/tests/mcp-local-server-recovery.test.ts
+++ b/apps/app/tests/mcp-local-server-recovery.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { MCP_QUICK_CONNECT } from "../src/app/constants";
+import { createOpenworkServerClient } from "../src/app/lib/openwork-server";
+import { createOpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
 import type { McpDirectoryInfo } from "../src/app/constants";
 import { submitMcpEntry } from "../src/react-app/domains/connections/modals/add-mcp-submission";
 import type { OpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
@@ -69,5 +72,50 @@ describe("local MCP server recovery", () => {
     expect(result).not.toBe("still pending");
     expect(result).not.toBeNull();
     expect(store.getSnapshot().mcpConnectingName).toBeNull();
+  });
+});
+
+describe("bundled Computer Use setup", () => {
+  async function connectWithHelper(command: string[] | null) {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { __OPENWORK_ELECTRON__: { invokeDesktop: async (name: string) => name === "getComputerUseMcpCommand" ? command : null } },
+    });
+    const server = createOpenworkServerStore({
+      startupPreference: () => "server", documentVisible: () => true, developerMode: () => false,
+      runtimeWorkspaceId: () => "setup-workspace", activeClient: () => null,
+      selectedWorkspaceDisplay: () => ({ id: "setup-workspace", name: "Setup", path: "/tmp/setup", preset: "starter", workspaceType: "local" }),
+      restartLocalServer: async () => false, createRemoteWorkspaceFlow: async () => false,
+    });
+    const saved: Array<Parameters<ReturnType<typeof createOpenworkServerClient>["addMcp"]>[1]> = [];
+    const client = {
+      ...createOpenworkServerClient({ baseUrl: "http://127.0.0.1:1" }),
+      addMcp: async (_workspace: string, payload: Parameters<ReturnType<typeof createOpenworkServerClient>["addMcp"]>[1]) => { saved.push(payload); return { items: [] }; },
+      listMcp: async () => ({ items: [] }),
+    };
+    const getSnapshot: typeof server.getSnapshot = () => ({ ...server.getSnapshot(), openworkServerStatus: "connected", openworkServerClient: client });
+    const store = createConnectionsStore({
+      checkDesktopAppRestriction: () => false, client: () => null, setClient: () => {},
+      projectDir: () => "/tmp/setup", selectedWorkspaceId: () => "setup-workspace", selectedWorkspaceRoot: () => "/tmp/setup",
+      workspaceType: () => "local", openworkServer: { ...server, getSnapshot }, runtimeWorkspaceId: () => "setup-workspace", developerMode: () => false,
+    });
+    const entry = MCP_QUICK_CONNECT.find((entry) => entry.id === "computer-use");
+    if (!entry) throw new Error("Computer Use catalog entry missing");
+    expect(entry.command).toEqual([]);
+    const result = await store.connectMcp(entry);
+    return { result, saved };
+  }
+
+  test("resolves the desktop helper before validating the empty catalog command", async () => {
+    const command = ["/Applications/OpenWork.app/Contents/Resources/helpers/OpenWork Computer Use.app/Contents/MacOS/ComputerUse", "mcp"];
+    const { result, saved } = await connectWithHelper(command);
+    expect(result).toEqual({ ok: true });
+    expect(saved).toEqual([{ name: "computer-use", config: { type: "local", enabled: true, command } }]);
+  });
+
+  test("missing helper returns an actionable error without saving a connection", async () => {
+    const { result, saved } = await connectWithHelper(null);
+    expect(result).toEqual({ ok: false, error: "Computer Use requires the bundled OpenWork helper on macOS." });
+    expect(saved).toEqual([]);
   });
 });

--- a/apps/desktop/electron/computer-use.mjs
+++ b/apps/desktop/electron/computer-use.mjs
@@ -7,7 +7,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, shell } from "electron";
+import { app } from "electron";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -55,7 +55,8 @@ function getComputerUseMcpCommand() {
 
 // ---------------------------------------------------------------------------
 // Permission checks — spawn the binary with --check, read stdout, done.
-// Fresh process = fresh TCC read = always accurate. No HTTP server needed.
+// Check in the same launch context as setup. TCC can attribute a child process
+// differently from a helper opened separately through LaunchServices.
 // ---------------------------------------------------------------------------
 
 function resolveComputerUseExecutable() {
@@ -148,21 +149,28 @@ async function listRunningApps() {
   });
 }
 
+let setupProcess = null;
+
 async function openComputerUseSetupApp() {
   if (process.platform !== "darwin") throw new Error("Desktop Computer Use requires macOS 14 or later.");
-  // Open the GUI. Use the .app bundle if available so macOS shows it as
-  // a real app with its own dock icon and permission identity.
-  const appPath = computerUseHelperAppPath();
-  if (appPath) {
-    const result = await shell.openPath(appPath);
-    if (result) console.error("[ComputerUse] shell.openPath error:", result);
+  const bin = resolveComputerUseExecutable();
+  if (!bin) throw new Error("The Computer Use helper is unavailable. Rebuild or reinstall OpenWork.");
+  // Keep the responsible application consistent with --check and the MCP
+  // child. LaunchServices gives the GUI its own TCC identity instead.
+  if (setupProcess && setupProcess.exitCode === null && !setupProcess.killed) {
+    setupProcess.kill("SIGUSR1");
     return;
   }
-
-  // Fallback: spawn the raw binary (opens the same GUI).
-  const bin = resolveComputerUseExecutable();
-  if (!bin) throw new Error("Helper binary not found. Run pnpm dev to build it.");
-  const child = spawn(bin, [], { detached: true, stdio: "ignore" });
+  const child = spawn(bin, ["setup"], { stdio: "ignore" });
+  setupProcess = child;
+  child.once("exit", () => { if (setupProcess === child) setupProcess = null; });
+  await new Promise((resolve, reject) => {
+    child.once("spawn", resolve);
+    child.once("error", (error) => {
+      if (setupProcess === child) setupProcess = null;
+      reject(error);
+    });
+  });
   child.unref();
 }
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1896,7 +1896,7 @@ const desktopCommandHandlers = {
       return getComputerUseMcpCommand();
   },
   "checkComputerUsePermissions": async (event, ...args) => {
-      // Spawn --check → fresh TCC read → always accurate.
+      // Read permissions in the same child-process context as setup.
       return checkComputerUsePermissions();
   },
   "listRunningApps": async (event, ...args) => {

--- a/evals/packages/labs/fixtures/computer-use-app.swift
+++ b/evals/packages/labs/fixtures/computer-use-app.swift
@@ -111,7 +111,8 @@ final class Fixture: NSObject, NSApplicationDelegate {
                     CGEvent(mouseEventSource: nil, mouseType: type, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
                 }
                 for _ in 0..<20 {
-                    if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier { break }
+                    if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier,
+                       NSApp.keyWindow == self.windows[0] { break }
                     try? await Task.sleep(nanoseconds: 50_000_000)
                 }
                 // Only post person-input events while our disposable window owns focus.

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -18,6 +18,14 @@ test("Computer Use respects window consent, fresh observations and the person's 
     expect(await world.state()).toEqual({ count: 0, otherCount: 0, draft: "Initial draft" });
   });
 
+  await step("Setup launched alongside the runtime reports the same granted permissions", async () => {
+    const panel = JSON.stringify(await world.setupPanel());
+    expect(panel).toContain("Accessibility · Allowed");
+    expect(panel).toContain("Screen Recording · Allowed");
+    expect(panel).not.toContain("Needed to read");
+    expect(toolState(await world.call("computer_discover")).permissions).toMatchObject({ accessibility: true, screenRecording: true });
+  });
+
   const session = await step("The person chooses a window and grants app controls", async () => {
     const pending = world.call("computer_open_session", { app_id: world.appId, pid: world.appPid, mode: "assist", purpose: "Edit the disposable fixture draft and increment its counter." });
     // A trusted person-input fixture presses the real native approval button.

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { computerUseWorld, toolState } from "../worlds/computer-use.ts";
+import { createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
 
 // New journey: a person grants one native window and can revoke it. The helper
 // is a real stdio process; the fixture app has two independent, disposable windows.
@@ -226,4 +227,19 @@ test("Computer Use respects window consent, fresh observations and the person's 
     expect(await world.state()).toEqual({ count: 1, otherCount: 0, draft: "Edited by person" });
   });
 
+});
+
+test("Computer Use enables workspace tools from the desktop setup page", async ({ world, step }) => {
+  await using app = await world.desktop();
+  const { workspaceId } = await createAndSelectWorkspace(app, { path: world.workspacePath });
+  await step("Granted macOS access still requires explicit workspace enablement", async () => {
+    await evalIn(app, `location.hash = ${JSON.stringify(`#/workspace/${workspaceId}/extensions/computer-use`)}`);
+    await waitFor(app, `document.body.innerText.includes("Permissions are ready. Enable Computer Use for this workspace.")`, { timeoutMs: 60_000 });
+    expect(await evalIn(app, `[...document.querySelectorAll("button")].some(b => b.textContent.trim() === "Enable Computer Use" && !b.disabled)`)).toBe(true);
+  });
+  await step("Enable resolves the bundled helper and reaches Ready", async () => {
+    await evalIn(app, `[...document.querySelectorAll("button")].find(b => b.textContent.trim() === "Enable Computer Use").click()`);
+    await waitFor(app, `document.body.innerText.includes("Ready · app access is approved when a session starts")`, { timeoutMs: 60_000 });
+    expect(await evalIn(app, `[...document.querySelectorAll("button")].some(b => /^(Enable|Reconnect) Computer Use$/.test(b.textContent.trim()))`)).toBe(false);
+  });
 });

--- a/evals/worlds/computer-use.ts
+++ b/evals/worlds/computer-use.ts
@@ -108,12 +108,14 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
         try {
           await new Promise<void>((resolve, reject) => { setup.once("spawn", resolve); setup.once("error", reject); });
           const deadline = Date.now() + 5_000;
+          let lastPanel: unknown;
           while (Date.now() < deadline) {
             const result = await fixture.request("helper_panel", { name: "", pid: setup.pid, executable });
+            lastPanel = result;
             if (record(result) && typeof result.text === "string" && result.text.includes("Accessibility")) return result;
             await new Promise((resolve) => setTimeout(resolve, 100));
           }
-          throw new Error("The setup window did not show permission status.");
+          throw new Error(`The setup window did not show permission status: ${JSON.stringify(lastPanel)}`);
         } finally {
           setup.kill("SIGTERM");
           await new Promise<void>((resolve) => {

--- a/evals/worlds/computer-use.ts
+++ b/evals/worlds/computer-use.ts
@@ -103,6 +103,26 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
       refreshStable: () => fixture.request("refresh_stable"),
       refreshState: () => fixture.request("refresh_state"),
       resize: () => fixture.request("resize"),
+      async setupPanel() {
+        const setup = spawn(executable, ["setup"], { stdio: "ignore" });
+        try {
+          await new Promise<void>((resolve, reject) => { setup.once("spawn", resolve); setup.once("error", reject); });
+          const deadline = Date.now() + 5_000;
+          while (Date.now() < deadline) {
+            const result = await fixture.request("helper_panel", { name: "", pid: setup.pid, executable });
+            if (record(result) && typeof result.text === "string" && result.text.includes("Accessibility")) return result;
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+          throw new Error("The setup window did not show permission status.");
+        } finally {
+          setup.kill("SIGTERM");
+          await new Promise<void>((resolve) => {
+            if (setup.exitCode !== null || setup.signalCode !== null || !setup.pid) { resolve(); return; }
+            const timeout = setTimeout(() => { setup.kill("SIGKILL"); resolve(); }, 2_000);
+            setup.once("exit", () => { clearTimeout(timeout); resolve(); });
+          });
+        }
+      },
       panel: () => fixture.request("helper_panel", { name: "", pid: helper.pid, executable }),
       foregroundWindow: () => fixture.request("foreground_window"),
       minimized: () => fixture.request("minimized"),

--- a/evals/worlds/computer-use.ts
+++ b/evals/worlds/computer-use.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline";
 import { needs, SkipError } from "@openwork/env";
 import type { Place, Seed } from "@openwork/env";
+import { desktop } from "@openwork/hosts";
 
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -93,6 +94,8 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
     await helper.request("initialize", { protocolVersion: "2025-11-25", clientInfo: { name: "native-journey", version: "1" }, capabilities: {} });
     await peer.request("initialize", { protocolVersion: "2025-11-25", clientInfo: { name: "peer-journey", version: "1" }, capabilities: {} });
     return {
+      desktop: () => desktop({ name: "computer-use-setup", host: place.host(), env: { OPENWORK_COMPUTER_USE_BINARY: executable } }),
+      workspacePath: join(directory, "workspace"),
       appId: "org.example.openwork.computer-use-fixture",
       appPid: fixture.pid,
       call: (name: string, args: Record<string, unknown> = {}) => helper.request("tools/call", { name, arguments: args }),

--- a/packages/computer-use/README.md
+++ b/packages/computer-use/README.md
@@ -7,8 +7,11 @@ legacy whole-desktop tool is required.
 
 ## Start
 
-In OpenWork, enable **Library → Computer Use**, open its settings, and grant
-Accessibility and Screen Recording to **OpenWork Computer Use**. Mention a
+In OpenWork, open **Library → Computer Use** and choose **Enable Computer Use**
+for the current workspace. If macOS access is missing, open permission setup
+from that page and grant Accessibility and Screen Recording to the app macOS
+identifies. Return to OpenWork and wait for **Ready**. macOS permissions alone
+do not enable the workspace connection. Mention a
 running app in a message. The helper asks you to choose its window and approve
 the requested mode. The floating panel provides **Take over**, **Continue**, and
 **Stop**. The setup window can stop all sessions.

--- a/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/SessionControls.swift
@@ -187,7 +187,7 @@ final class PermissionSetup: NSObject, NSApplicationDelegate {
         let axButton = NSButton(title: "Open Accessibility settings", target: self, action: #selector(openAccessibility))
         let captureButton = NSButton(title: "Open Screen Recording settings", target: self, action: #selector(openCapture))
         let stop = NSButton(title: "Stop all Computer Use sessions", target: self, action: #selector(stopAll))
-        let footer = NSTextField(wrappingLabelWithString: "If macOS asks you to restart after changing permissions, reconnect Computer Use in OpenWork. Windows and Linux desktop control are not available in this version.")
+        let footer = NSTextField(wrappingLabelWithString: "After allowing access, return to Library → Computer Use in OpenWork to finish setup. If macOS asks you to restart, quit and reopen OpenWork. Windows and Linux desktop control are not available in this version.")
         footer.font = .systemFont(ofSize: 12); footer.textColor = .secondaryLabelColor
         let stack = NSStackView(views: [title, description, accessibility, axButton, capture, captureButton, stop, footer])
         stack.orientation = .vertical; stack.alignment = .leading; stack.spacing = 12

--- a/packages/computer-use/native/Sources/ComputerUse/main.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/main.swift
@@ -58,7 +58,16 @@ case "setup":
     NSApplication.shared.setActivationPolicy(.regular)
     let delegate = PermissionSetup()
     NSApplication.shared.delegate = delegate
-    withExtendedLifetime(delegate) { NSApplication.shared.run() }
+    signal(SIGUSR1, SIG_IGN)
+    let reopen = DispatchSource.makeSignalSource(signal: SIGUSR1, queue: .main)
+    reopen.setEventHandler {
+        MainActor.assumeIsolated {
+            NSApp.windows.first?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+    reopen.resume()
+    withExtendedLifetime((delegate, reopen)) { NSApplication.shared.run() }
 default:
     fputs("Usage: ComputerUse [mcp|--check|--list-apps|setup]\n", stderr)
     exit(1)


### PR DESCRIPTION
Computer Use's Enable action rejected the built-in empty command before resolving the bundled helper, so granting both macOS permissions still left workspace tools unavailable. Resolve the desktop command first and display connection errors instead of silently swallowing them.

Move the required setup action above the scope explanation, distinguish workspace enablement from macOS access, refresh permissions while setup is visible, and derive readiness from the live MCP connection. Launch native setup as a child of OpenWork like permission checks; reopening setup raises its existing window.

Validation on final head: `pnpm evals:e2e computer-use-window-scope --local` — placement local, 2 passed, 0 failed, 0 skipped. The native journey covers setup/runtime permission agreement, consent, scoped actions, takeover and Stop. The new real Electron journey starts a fresh local workspace, confirms that permissions alone do not enable tools, clicks Enable, and asserts Ready with no Enable/Reconnect button remaining. Published assertion evidence is below.

Connection regression tests pass (3 tests); app/spec-layer typechecks and Electron syntax check pass. The fixture's person-input operation now waits for key-window focus as well as foreground ownership, preserving its safety guard.

An earlier signed-in Library stability test could not start its local MySQL dependency. The new focused Electron journey verifies this connection flow without Den. No installer update is included.
