### PR TITLE
Add model-aware video attachments and fix streaming Markdown recovery

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -422,6 +422,7 @@ async function desktopFetchThroughMain(
     method,
     headers,
     body,
+    responseType: "arraybuffer",
     timeoutMs: options.timeoutMs,
     agentContextDiagnostics: diagnosticsDeadlineAtMs === undefined
       ? undefined
@@ -431,7 +432,7 @@ async function desktopFetchThroughMain(
   // Response constructor rejects bodies for null-body status codes, so we
   // must pass null instead of an empty string for those.
   const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
-  const responseBody = NULL_BODY_STATUSES.has(result.status) ? null : result.body;
+  const responseBody = NULL_BODY_STATUSES.has(result.status) ? null : result.bodyBytes ?? result.body;
 
   return new Response(responseBody, {
     status: result.status,

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -76,6 +76,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
 import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge"
+import { VideoAttachment } from "@/components/chat/video-attachment"
 import { Image } from "@/components/ui/image"
 import {
   Message,
@@ -120,6 +121,7 @@ import { isToolPartInFlight } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
 import { useOpenArtifactPath } from "@/lib/artifacts"
 import { cn } from "@/lib/utils"
+import { videoMimeType } from "@/lib/video-source"
 import { DevProfiler } from "@/react-app/shell/dev-profiler"
 import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl, getSafeFileRevealPath } from "./utils"
 import type { AnyToolPart } from "@/lib/tool-aggregate"
@@ -339,6 +341,7 @@ function FileMessage({ part, tone }: FileMessageProps) {
   const title = getFileTitle(part)
   const badge = getMediaBadge(part)
   const isImage = part.mediaType.startsWith("image/") && Boolean(part.url)
+  const isVideo = part.mediaType.startsWith("video/") || Boolean(videoMimeType(part.filename ?? part.url))
   const downloadUrl = getSafeFileDownloadUrl(part)
   const revealPath = getSafeFileRevealPath(part)
   const canReveal = isElectronRuntime() && Boolean(revealPath)
@@ -393,7 +396,7 @@ function FileMessage({ part, tone }: FileMessageProps) {
     )
   }
 
-  return (
+  const fileCard = (
     <div className="flex h-auto w-fit min-w-0 max-w-full shrink items-center justify-start gap-2 rounded-xl border border-border/70 bg-background/40 ps-2 pe-2 py-1 text-left text-sm font-medium whitespace-normal">
       {revealPath ? (
         <button
@@ -439,6 +442,13 @@ function FileMessage({ part, tone }: FileMessageProps) {
       ) : null}
     </div>
   )
+
+  return isVideo ? (
+    <div className="flex w-full min-w-0 max-w-lg flex-col gap-2">
+      <VideoAttachment src={part.url} title={title} mediaType={part.mediaType} />
+      {fileCard}
+    </div>
+  ) : fileCard
 }
 
 interface CopyMessageButtonProps {

--- a/apps/app/src/components/chat/video-attachment.tsx
+++ b/apps/app/src/components/chat/video-attachment.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from "react";
+import { useOpenTargets } from "@/lib/target-provider";
+import { attachVideoSource } from "@/lib/video-source";
+
+export function VideoAttachment({ src, title, mediaType }: { src: string; title: string; mediaType: string }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const noticeRef = useRef<HTMLSpanElement>(null);
+  const { client, workspaceId, workspaceRoot } = useOpenTargets();
+  useEffect(() => {
+    if (!videoRef.current || !noticeRef.current) return;
+    return attachVideoSource(videoRef.current, noticeRef.current, { href: src, mediaType, client, workspaceId, workspaceRoot });
+  }, [src, mediaType, client, workspaceId, workspaceRoot]);
+
+  return (
+    <div className="w-full min-w-0 max-w-lg">
+      <video ref={videoRef} controls playsInline preload="metadata" aria-label={title} className="block max-h-80 w-full rounded-lg border border-border/70 bg-black" />
+      <span ref={noticeRef} role="status" className="text-sm text-muted-foreground">Loading video...</span>
+    </div>
+  );
+}

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -9,6 +9,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useOpenTargets } from "@/lib/target-provider";
 import { useOpenArtifactPath } from "@/lib/artifacts";
+import { attachVideoSource } from "@/lib/video-source";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 
 import { applyTextHighlights } from "./text-highlights";
@@ -255,41 +256,12 @@ function MarkdownBlockInner({
     for (const video of root.querySelectorAll("video[data-openwork-video-path]")) {
       if (!(video instanceof HTMLVideoElement)) continue;
       if (videoCleanups.current.has(video)) continue;
-      let cancelled = false;
-      let objectUrl: string | null = null;
       const href = video.dataset.openworkVideoPath ?? "";
-      const showError = () => {
-        const notice = video.parentElement?.querySelector("[data-openwork-video-error]");
-        if (notice instanceof HTMLElement) notice.hidden = false;
-      };
-      video.addEventListener("error", showError);
-      videoCleanups.current.set(video, () => {
-        cancelled = true;
-        video.removeEventListener("error", showError);
-        if (objectUrl) URL.revokeObjectURL(objectUrl);
-      });
-      if (/^https?:/i.test(href)) continue;
-      let path = localPathFromHref(href);
-      try { if (!/^file:/i.test(href)) path = decodeURIComponent(path); } catch { /* Keep literal percent signs in filenames. */ }
-      const rootPath = workspaceRoot?.replace(/\\/g, "/").replace(/\/+$/, "");
-      path = path.replace(/\\/g, "/");
-      if (rootPath && path.startsWith(`${rootPath}/`)) path = path.slice(rootPath.length + 1);
-      if (!client || !workspaceId || !path) {
-        showError();
-        continue;
-      }
-      const target = openTargetForHref(href, openTargets);
-      void client.downloadWorkspaceFile(workspaceId, target?.value ?? path).then((result) => {
-        if (cancelled) return;
-        const extension = path.split(".").pop()?.toLowerCase();
-        const fallbackType = extension === "webm" ? "video/webm" : extension === "ogv" ? "video/ogg" : extension === "mov" ? "video/quicktime" : "video/mp4";
-        const contentType = result.contentType && result.contentType !== "application/octet-stream" ? result.contentType : fallbackType;
-        const url = URL.createObjectURL(new Blob([result.data], { type: contentType }));
-        objectUrl = url;
-        video.src = url;
-      }).catch(() => { if (!cancelled) showError(); });
+      const notice = video.parentElement?.querySelector("[data-openwork-video-error]");
+      if (!(notice instanceof HTMLElement)) continue;
+      videoCleanups.current.set(video, attachVideoSource(video, notice, { href, client, workspaceId, workspaceRoot }));
     }
-  }, [client, workspaceId, workspaceRoot, openTargets, rendered]);
+  }, [client, workspaceId, workspaceRoot, rendered]);
 
   useEffect(() => {
     const root = rootRef.current;

--- a/apps/app/src/lib/video-source.ts
+++ b/apps/app/src/lib/video-source.ts
@@ -1,0 +1,139 @@
+import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+
+type VideoSourceOptions = {
+  href: string;
+  mediaType?: string;
+  client?: Pick<OpenworkServerClient, "baseUrl" | "downloadWorkspaceFile">;
+  workspaceId?: string;
+  workspaceRoot?: string;
+};
+
+export function videoMimeType(path: string): string | undefined {
+  const extension = path.split(/[?#]/)[0]?.split(".").pop()?.toLowerCase();
+  switch (extension) {
+    case "mp4":
+    case "m4v": return "video/mp4";
+    case "webm": return "video/webm";
+    case "mov": return "video/quicktime";
+    case "ogv": return "video/ogg";
+    default: return undefined;
+  }
+}
+
+/** Resolve only contained paths; a matching filename suffix is never authorization. */
+export function workspaceVideoPath(href: string, workspaceRoot?: string): string | null {
+  let path = href.trim();
+  if (!path || /[\u0000-\u001f\u007f]/.test(path)) return null;
+  if (/^file:/i.test(path)) {
+    try {
+      const url = new URL(path);
+      path = decodeURIComponent(url.pathname);
+      if (/^\/[A-Za-z]:\//.test(path)) path = path.slice(1);
+      if (url.hostname && url.hostname !== "localhost") path = `//${url.hostname}${path}`;
+    } catch {
+      return null;
+    }
+  } else {
+    path = path.split(/[?#]/)[0] ?? "";
+    try { path = decodeURIComponent(path); } catch { /* Preserve literal percent signs. */ }
+  }
+  path = path.replace(/\\/g, "/");
+  if (!path || /[\u0000-\u001f\u007f]/.test(path) || path.split("/").includes("..")) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path) && !/^[A-Za-z]:\//.test(path)) return null;
+
+  if (path.startsWith("/") || /^[A-Za-z]:\//.test(path)) {
+    if (!workspaceRoot) return null;
+    const root = workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+    const prefix = `${root}/`;
+    const windows = /^[A-Za-z]:\//.test(prefix) || prefix.startsWith("//");
+    if (!(windows ? path.toLowerCase().startsWith(prefix.toLowerCase()) : path.startsWith(prefix))) return null;
+    path = path.slice(prefix.length);
+  } else {
+    path = path.replace(/^\.\//, "")
+      .replace(/^workspaces\/[^/]+\//i, "")
+      .replace(/^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i, "")
+      .replace(/^workspace\//i, "");
+  }
+  const parts = path.split("/");
+  if (parts.some((part) => !part || part === "." || part === ".." || part.includes(":"))) return null;
+  return path;
+}
+
+export async function resolveVideoSource({ href, mediaType, client, workspaceId, workspaceRoot }: VideoSourceOptions): Promise<string | Blob> {
+  const source = href.trim();
+  if (!source || /[\u0000-\u001f\u007f]/.test(source)) throw new Error("Invalid video source");
+  let path: string | null;
+  if (/^https?:/i.test(source)) {
+    const url = new URL(source);
+    if (url.username || url.password) throw new Error("Invalid video source");
+    // Workspace URLs still need the client's authentication, never credentials on an external URL.
+    const rawUrl = client && workspaceId
+      ? new URL(`${client.baseUrl}/workspace/${encodeURIComponent(workspaceId)}/files/raw`)
+      : null;
+    if (!rawUrl || url.origin !== rawUrl.origin || url.pathname !== rawUrl.pathname) return url.href;
+    path = workspaceVideoPath(url.searchParams.get("path") ?? "", workspaceRoot);
+  } else if (/^data:video\/[a-z0-9.+-]+(?:;[^,]*)?,/i.test(source)) {
+    return source;
+  } else if (/^blob:/i.test(source)) {
+    const origin = source.slice(5);
+    if (!origin.startsWith("null/") && !["http:", "https:", "file:"].includes(new URL(origin).protocol)) {
+      throw new Error("Invalid video source");
+    }
+    return source;
+  } else {
+    path = workspaceVideoPath(source, workspaceRoot);
+  }
+  if (!client || !workspaceId || !path) throw new Error("Video is not available in this workspace");
+  const result = await client.downloadWorkspaceFile(workspaceId, path);
+  const type = result.contentType?.toLowerCase().startsWith("video/")
+    ? result.contentType
+    : mediaType?.toLowerCase().startsWith("video/") ? mediaType : videoMimeType(path);
+  return new Blob([result.data], { type });
+}
+
+/** Shared by React attachments and the native players inside rendered Markdown. */
+export function attachVideoSource(video: HTMLVideoElement, notice: HTMLElement, options: VideoSourceOptions): () => void {
+  let cancelled = false;
+  let objectUrl: string | undefined;
+  let hasSource = false;
+  video.controls = true;
+  video.playsInline = true;
+  video.autoplay = false;
+  video.preload = "metadata";
+  if (video.hasAttribute("src")) {
+    video.removeAttribute("src");
+    video.load();
+  }
+  notice.setAttribute("role", "status");
+  notice.textContent = "Loading video...";
+  notice.hidden = false;
+  const showError = () => {
+    if (cancelled) return;
+    notice.textContent = "Video preview unavailable. Open or download the file to play it.";
+    notice.hidden = false;
+  };
+  const onError = () => { if (hasSource) showError(); };
+  const onReady = () => { if (!cancelled && hasSource) notice.hidden = true; };
+  video.addEventListener("error", onError);
+  video.addEventListener("loadedmetadata", onReady);
+  void resolveVideoSource(options).then((source) => {
+    if (cancelled) return;
+    // Allocate only after checking cancellation, so late downloads cannot leak a URL.
+    hasSource = true;
+    if (typeof source === "string") {
+      video.src = source;
+    } else {
+      objectUrl = URL.createObjectURL(source);
+      video.src = objectUrl;
+    }
+  }).catch(showError);
+  return () => {
+    cancelled = true;
+    video.removeEventListener("error", onError);
+    video.removeEventListener("loadedmetadata", onReady);
+    video.pause();
+    video.removeAttribute("src");
+    video.load();
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+  };
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2806,7 +2806,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   </div>
                 )}
               </div>
-            ) : renderedMessages.length === 0 && effectiveActivityStatus !== "idle" ? (
+            ) : renderedMessages.length === 0 && effectiveActivityStatus !== "idle" && !error ? (
               <div className="px-6 py-12">
                 <AssistantWaitingCard label={getSessionActivityStatusLabel(effectiveActivityStatus)} />
               </div>

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -66,6 +66,9 @@ const EXTENSION_MIME_TYPES: Record<string, string> = {
   m4v: "video/x-m4v",
   avi: "video/x-msvideo",
   mkv: "video/x-matroska",
+  mpeg: "video/mpeg",
+  mpg: "video/mpeg",
+  ogv: "video/ogg",
   pdf: "application/pdf",
   docx: DOCX_MIME,
   pptx: PPTX_MIME,
@@ -168,21 +171,18 @@ function isTextLikeAttachmentMime(mime: string) {
 }
 
 /**
- * AI SDK provider adapters only accept `image/*`, `application/pdf`, and
- * `text/plain` file parts; anything else throws UnsupportedFunctionalityError
- * server-side and poisons the session history. So model-facing file parts are
- * routed by one rule:
+ * Only emit file parts the send path has qualified for its provider transport:
  * - text-like mimes are re-mimed to `text/plain` so opencode inlines their
  *   content via the Read tool (the proven `@file` mention mechanism);
  * - images, PDFs, and Office mimes pass through (Office parts are rewritten
  *   to text by the OpenWorkOfficeAttachments plugin before the provider);
- * - everything else returns `null`: workspace (`file://`) attachments fall
- *   back to a `text/plain` part that opencode mediates through the Read tool,
- *   while data-URL attachments are dropped (inlining binary bytes as text is
- *   garbage); the synthetic workspace-path note gives tools the bytes.
+ * - video requires an explicit send-time capability/transport check;
+ * - everything else returns `null`; the synthetic workspace-path note gives
+ *   tools the bytes without asking the engine to read binary data as text.
  */
-export function modelFacingAttachmentMime(mimeType: string): string | null {
+export function modelFacingAttachmentMime(mimeType: string, video = false): string | null {
   const mime = normalizedMime(mimeType);
+  if (video && mime.startsWith("video/")) return mime === "video/x-m4v" ? "video/mp4" : mime;
   if (isTextLikeAttachmentMime(mime)) return "text/plain";
   if (mime.startsWith("image/") || mime === "application/pdf" || isOfficeMime(mime)) return mime;
   return null;
@@ -298,7 +298,7 @@ function uploadErrorMessage(filename: string, error: unknown) {
   return `Failed to copy attachment "${filename}" into this worker workspace: ${detail}`;
 }
 
-function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInput {
+function attachmentPathNotePart(uploaded: UploadedChatAttachment[], video: boolean): TextPartInput {
   // Synthetic: model/tools still see workspace paths, but the chat UI renders
   // file parts as compact badges instead of this wall of path text.
   return {
@@ -306,7 +306,7 @@ function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInp
     synthetic: true,
     metadata: {
       openworkAttachments: uploaded
-        .filter((item) => modelFacingAttachmentMime(item.mime) === null)
+        .filter((item) => modelFacingAttachmentMime(item.mime, video) === null)
         .map((item) => ({ filename: item.filename, mime: item.mime, url: item.url })),
     },
     text: [
@@ -317,12 +317,12 @@ function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInp
   };
 }
 
-async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise<FilePartInput | null> {
+async function uploadedAttachmentFilePart(item: UploadedChatAttachment, video: boolean): Promise<FilePartInput | null> {
   // Binary/unknown mimes get no model-facing file part. A `text/plain`
   // `file://` part would make opencode run the Read tool on the bytes, which
   // refuses with "Cannot read binary file" as a session error and drops the
   // part anyway; the synthetic workspace-path note already gives tools the file.
-  const modelMime = modelFacingAttachmentMime(item.mime);
+  const modelMime = modelFacingAttachmentMime(item.mime, video);
   if (!modelMime) return null;
 
   // Images need a browser-displayable URL so the transcript can show the same
@@ -358,6 +358,8 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
   sessionId: string;
   workspaceRoot: string;
   createId?: () => string;
+  /** Granted only after validating the exact send model and runtime. */
+  video?: boolean;
 }): Promise<WorkspaceAttachmentParts | null> {
   if (input.attachments.length === 0) return null;
 
@@ -419,8 +421,8 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
   }
 
   return {
-    note: attachmentPathNotePart(uploaded),
-    files: await Promise.all(uploaded.map(uploadedAttachmentFilePart)),
+    note: attachmentPathNotePart(uploaded, input.video === true),
+    files: await Promise.all(uploaded.map((item) => uploadedAttachmentFilePart(item, input.video === true))),
   };
 }
 

--- a/apps/app/src/react-app/domains/session/sync/draft-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-parts.ts
@@ -4,9 +4,12 @@ import type {
   TextPartInput,
 } from "@opencode-ai/sdk/v2/client";
 
-import type { ComposerDraft, ComposerPart } from "@/app/types";
+import type { Client, ComposerDraft, ComposerPart, ModelRef } from "@/app/types";
+import { unwrap } from "@/app/lib/opencode";
+import { isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import {
   composerAttachmentsToWorkspaceFileParts,
+  resolveAttachmentMime,
   type ChatAttachmentWorkspaceEndpoint,
 } from "./attachment-file-part";
 import {
@@ -19,6 +22,44 @@ import { mentionPromptParts } from "./mention-parts";
 import { parseConnectSkillToken } from "../surface/composer/connect-skill-token";
 import { decodeComposerMentionValue } from "../surface/composer/mention-encoding";
 
+const VIDEO_INPUT_MIMES = new Set([
+  "video/mp4", "video/x-m4v", "video/mpeg", "video/quicktime", "video/webm",
+  "video/x-msvideo", "video/x-flv", "video/mpg", "video/wmv", "video/3gpp",
+]);
+
+/** Run before uploads, edits, or command dispatch; use the same captured model when sending. */
+export async function validateVideoDraft(
+  draft: ComposerDraft,
+  context: { client: Pick<Client, "provider">; model: ModelRef | null | undefined; baseUrl: string },
+): Promise<boolean> {
+  const videos = draft.attachments.filter((attachment) => resolveAttachmentMime(attachment.file).startsWith("video/"));
+  if (!videos.length) return false;
+  if (draft.mode === "shell" || draft.command) {
+    throw new Error("Send videos as a chat message, not a shell or slash command. Your draft has been kept.");
+  }
+  if (isOpencodeV2BaseUrl(context.baseUrl)) {
+    throw new Error("Video input is not available in the experimental engine. Switch to the standard engine before sending.");
+  }
+  const selection = context.model;
+  if (!selection) throw new Error("Choose a video-capable model before sending this attachment.");
+  // Query this workspace's runtime rather than trusting names, image support,
+  // a different pane's catalog, or the model that was selected at attach time.
+  const catalog = unwrap(await context.client.provider.list());
+  const provider = catalog.all.find((item) => item.id === selection.providerID && catalog.connected.includes(item.id));
+  const model = provider?.models[selection.modelID];
+  if (model?.capabilities.input.video !== true
+    || !["@ai-sdk/google", "@ai-sdk/google-vertex"].includes(model.api.npm)) {
+    throw new Error("This model connection does not support video input. Choose a video-capable Google or Vertex model, or remove the video. Your draft has been kept.");
+  }
+  for (const attachment of videos) {
+    if (!VIDEO_INPUT_MIMES.has(resolveAttachmentMime(attachment.file))) {
+      throw new Error(`Video format for "${attachment.file.name}" is not supported by this connection. Convert it to MP4 or WebM before sending.`);
+    }
+    if (attachment.file.size === 0) throw new Error(`Video "${attachment.file.name}" is empty. Choose a playable file before sending.`);
+  }
+  return true;
+}
+
 // All workspace-scoped server URLs/clients/tokens come from
 // `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
 // Don't compose `<baseUrl>/workspace/<id>` here.
@@ -27,6 +68,7 @@ export async function draftToParts(
   workspaceRoot: string,
   sessionId: string,
   endpoint: ChatAttachmentWorkspaceEndpoint | null,
+  video = false,
 ) {
   const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
   const root = workspaceRoot.trim();
@@ -56,6 +98,7 @@ export async function draftToParts(
       endpoint,
       sessionId,
       workspaceRoot: root,
+      video,
     });
     if (uploaded) {
       parts.push(uploaded.note);

--- a/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
+++ b/apps/app/src/react-app/domains/session/sync/global-queue-drainer.ts
@@ -20,7 +20,7 @@ import {
   subscribeQueuedDrain,
 } from "../surface/queued-drain-machine";
 import { getSessionModelSelection, useSessionModelStore } from "../surface/session-model-store";
-import { draftToParts } from "./draft-parts";
+import { draftToParts, validateVideoDraft } from "./draft-parts";
 import { buildOpenworkSessionSystemContext } from "./env-context";
 import {
   clearQueuedSendContext,
@@ -102,6 +102,7 @@ async function performQueuedDraftSend(
     context.workspaceRoot || undefined,
     { token: context.openworkToken, mode: "openwork" },
   );
+  const video = await validateVideoDraft(draft, { client: opencodeClient, model: sendModel, baseUrl: context.opencodeBaseUrl });
 
   if (draft.mode === "shell") {
     await shellInSession(opencodeClient, sessionId, text);
@@ -121,7 +122,7 @@ async function performQueuedDraftSend(
   const parts = await draftToParts(draft, context.workspaceRoot, sessionId, {
     client: context.client,
     workspaceId: context.workspaceId,
-  });
+  }, video);
   const system = await buildOpenworkSessionSystemContext(context.client, {
     workspaceId: context.workspaceId,
     cacheKey: sessionId,

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -1258,6 +1258,17 @@ function startSync(input: SyncOptions, entry: SyncEntry) {
       const event = normalizeEvent(raw);
       if (!event) return;
       applyEvent(entry, input.workspaceId, event);
+      if (event.type === "server.connected") {
+        // The SDK's iterator is lazy: subscribe() can return before the SSE
+        // connection opens. Recover missed message/role declarations at the
+        // actual handshake, not at iterator creation or only after run idle.
+        for (const sessionId of entry.trackedSessionRefs.keys()) {
+          void getReactQueryClient().invalidateQueries({
+            queryKey: snapshotKey(input.workspaceId, sessionId),
+            exact: true,
+          });
+        }
+      }
     },
     // Level-reconcile run statuses on every (re)connect before trusting any
     // cached idle: the server may have started or finished work while the

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -120,7 +120,7 @@ import {
   applySessionUnrevert,
   permissionKey,
 } from "@/react-app/domains/session/sync/session-sync";
-import { draftToParts } from "@/react-app/domains/session/sync/draft-parts";
+import { draftToParts, validateVideoDraft } from "@/react-app/domains/session/sync/draft-parts";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { getModelBehaviorSummary, nextModelBehaviorValue, previousModelBehaviorValue } from "@/app/lib/model-behavior";
@@ -1314,6 +1314,7 @@ export function SessionRoute() {
         if (resolveModelAvailability(sendModel ?? null).status === "unavailable") {
           throw new Error("Selected model is unavailable. Choose another model before sending.");
         }
+        const video = await validateVideoDraft(draft, { client: opencodeClient, model: sendModel, baseUrl: opencodeBaseUrl });
 
         return submitWithCloudMcpReadiness({
           // Temporarily bypass the pre-send Cloud MCP gate: it blocks every
@@ -1383,7 +1384,7 @@ export function SessionRoute() {
                   return;
                 }
 
-                const parts = await draftToParts(draft, selectedWorkspaceRoot, targetSessionId, selectedWorkspaceEndpoint);
+                const parts = await draftToParts(draft, selectedWorkspaceRoot, targetSessionId, selectedWorkspaceEndpoint, video);
                 const system = await buildOpenworkSessionSystemContext(client, {
                   workspaceId: selectedWorkspaceId,
                   cacheKey: targetSessionId,
@@ -1652,6 +1653,7 @@ export function SessionRoute() {
         const sessionModelSelection = getSessionModelSelection(targetSessionId);
         const sendModel = sessionModelSelection?.model ?? local.prefs.defaultModel;
         const sendVariant = sessionModelSelection ? sessionModelSelection.variant : modelVariantValue;
+        const video = await validateVideoDraft(draft, { client: workspaceOpencodeClient, model: sendModel, baseUrl: endpoint.opencodeBaseUrl });
         return submitWithCloudMcpReadiness({
           skipGate: true,
           send: async () => {
@@ -1703,7 +1705,7 @@ export function SessionRoute() {
                   if (result.error) throw new Error(serializeSDKError(result.error));
                   return;
                 }
-                const parts = await draftToParts(draft, workspaceRoot, targetSessionId, endpoint);
+                const parts = await draftToParts(draft, workspaceRoot, targetSessionId, endpoint, video);
                 const system = await buildOpenworkSessionSystemContext(endpoint.client, {
                   workspaceId: workspace.id,
                   cacheKey: targetSessionId,

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
 import { attachmentNoteToUIParts } from "../src/react-app/domains/session/sync/usechat-adapter";
-import type { ComposerAttachment } from "../src/app/types";
+import { draftToParts, validateVideoDraft } from "../src/react-app/domains/session/sync/draft-parts";
+import type { ComposerAttachment, ComposerDraft } from "../src/app/types";
 import {
   buildChatAttachmentInboxPath,
   composerAttachmentsToWorkspaceFileParts,
@@ -527,4 +529,75 @@ test("video upload preserves a display card without a model-facing binary part",
   expect(attachmentNoteToUIParts({ ...note, ignored: true })).toEqual([]);
   expect(attachmentNoteToUIParts({ ...note, synthetic: false })).toEqual([]);
   expect(attachmentNoteToUIParts({ ...note, metadata: { openworkAttachments: [{ url: "javascript:alert(1)" }] } })).toEqual([]);
+});
+
+describe("video input qualification", () => {
+  const videoModel = (npm: string, video: boolean) => ({ api: { npm }, capabilities: { input: { video } } });
+  const models = {
+    google: videoModel("@ai-sdk/google", true),
+    vertex: videoModel("@ai-sdk/google-vertex", true),
+    imageOnly: videoModel("@ai-sdk/google", false),
+    incompatible: videoModel("@ai-sdk/openai-compatible", true),
+  };
+  const draftFor = (file = new File([new Uint8Array([0, 1, 255, 128])], "clip.mp4")): ComposerDraft => ({
+    text: "Describe [attachment attachment-1]",
+    parts: [{ type: "text", text: "Describe " }],
+    attachments: [attachmentFor(file)],
+    mode: "prompt",
+  });
+  function runtime(modelID = "google", connected = true) {
+    let requests = 0;
+    const baseUrl = "http://runtime.test/workspace/a/opencode";
+    const client = createOpencodeClient({
+      baseUrl,
+      fetch: async () => {
+        requests += 1;
+        return Response.json({ all: [{ id: "custom", models }], connected: connected ? ["custom"] : [], default: {} });
+      },
+    });
+    return { client, baseUrl, model: { providerID: "custom", modelID }, requests: () => requests };
+  }
+
+  test("checks the exact connected model and adapter, not its name or generic attachments flag", async () => {
+    for (const id of ["google", "vertex"]) expect(await validateVideoDraft(draftFor(), runtime(id))).toBe(true);
+    for (const id of ["imageOnly", "incompatible", "missing"]) {
+      await expect(validateVideoDraft(draftFor(), runtime(id))).rejects.toThrow("does not support video input");
+    }
+    await expect(validateVideoDraft(draftFor(), runtime("google", false))).rejects.toThrow("does not support video input");
+    await expect(validateVideoDraft(draftFor(), { ...runtime(), model: null })).rejects.toThrow("Choose a video-capable model");
+  });
+
+  test("revalidates after model switches and emits one native video with original uploaded bytes", async () => {
+    const context = runtime();
+    const draft = draftFor();
+    const { endpoint, calls } = uploadRecorder("workspace-a");
+    const allowed = await validateVideoDraft(draft, context);
+    const parts = await draftToParts(draft, "/workspace", "ses_video", endpoint, allowed);
+    expect(calls[0]?.bytes).toEqual([0, 1, 255, 128]);
+    expect(parts.filter((part) => part.type === "file")).toEqual([
+      { type: "file", filename: "clip.mp4", mime: "video/mp4", url: expect.stringContaining("file:///workspace/.opencode/openwork/inbox/") },
+    ]);
+    expect(parts[0]).toMatchObject({ type: "text", synthetic: true, metadata: { openworkAttachments: [] } });
+    context.model.modelID = "imageOnly";
+    await expect(validateVideoDraft(draft, context)).rejects.toThrow("does not support video input");
+    expect(context.requests()).toBe(2);
+    expect(calls).toHaveLength(1);
+    expect(draft.attachments).toHaveLength(1);
+  });
+
+  test("rejects unsupported formats and empty clips without uploading", async () => {
+    await expect(validateVideoDraft(draftFor(new File(["bytes"], "clip.mkv")), runtime())).rejects.toThrow("Convert it to MP4 or WebM");
+    await expect(validateVideoDraft(draftFor(new File([], "clip.mp4")), runtime())).rejects.toThrow("is empty");
+    expect(modelFacingAttachmentMime("video/x-m4v", true)).toBe("video/mp4");
+    expect(modelFacingAttachmentMime("video/mp4")).toBeNull();
+  });
+
+  test("rejects commands and v2 before requesting a catalog; ordinary drafts do not request one", async () => {
+    const context = runtime();
+    await expect(validateVideoDraft({ ...draftFor(), mode: "shell" }, context)).rejects.toThrow("not a shell or slash command");
+    await expect(validateVideoDraft({ ...draftFor(), command: { name: "review", arguments: "" } }, context)).rejects.toThrow("not a shell or slash command");
+    await expect(validateVideoDraft(draftFor(), { ...context, baseUrl: "http://runtime.test/workspace/a/opencode2" })).rejects.toThrow("experimental engine");
+    expect(await validateVideoDraft({ ...draftFor(), attachments: [] }, context)).toBe(false);
+    expect(context.requests()).toBe(0);
+  });
 });

--- a/apps/app/tests/desktop-web-url.test.ts
+++ b/apps/app/tests/desktop-web-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { assertDesktopWebUrl } from "../src/app/lib/desktop";
+import { assertDesktopWebUrl, desktopFetch, desktopUploadMultipart } from "../src/app/lib/desktop";
+import type { DesktopFetchInit, DesktopFetchResult } from "../src/app/lib/desktop-types";
 
 describe("desktop external web URLs", () => {
   test("allows HTTP and HTTPS browser destinations", () => {
@@ -16,5 +17,71 @@ describe("desktop external web URLs", () => {
     expect(() => assertDesktopWebUrl("javascript:alert(1)")).toThrow("not allowed");
     expect(() => assertDesktopWebUrl("file:///tmp/provider-controlled")).toThrow("not allowed");
     expect(() => assertDesktopWebUrl("openwork://provider-controlled")).toThrow("not allowed");
+  });
+});
+
+describe("desktop fetch response bytes", () => {
+  async function withBridge(result: DesktopFetchResult, run: (requests: Array<{ command: string; url: unknown; init?: DesktopFetchInit }>) => Promise<void>) {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const requests: Array<{ command: string; url: unknown; init?: DesktopFetchInit }> = [];
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        __OPENWORK_ELECTRON__: {
+          invokeDesktop: async (command: string, url: unknown, init?: DesktopFetchInit) => {
+            requests.push({ command, url, init });
+            return structuredClone(result);
+          },
+        },
+      },
+    });
+    try {
+      await run(requests);
+    } finally {
+      if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+      else Reflect.deleteProperty(globalThis, "window");
+    }
+  }
+
+  test("preserves binary response bytes and request authentication across the bridge", async () => {
+    const bytes = Uint8Array.from([0, 1, 127, 128, 200, 254, 255]);
+    await withBridge({ status: 200, statusText: "OK", headers: [["content-type", "video/mp4"]], body: "", bodyBytes: bytes.buffer }, async (requests) => {
+      const response = await desktopFetch(new Request("https://worker.example.test/video", {
+        method: "POST", headers: { Authorization: "Bearer test", "Content-Type": "text/plain" }, body: "request text",
+      }));
+      expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+      expect(response.headers.get("content-type")).toBe("video/mp4");
+      expect(requests).toEqual([{
+        command: "__fetch",
+        url: "https://worker.example.test/video",
+        init: {
+          method: "POST", headers: { authorization: "Bearer test", "content-type": "text/plain" },
+          body: "request text", responseType: "arraybuffer", timeoutMs: undefined, agentContextDiagnostics: undefined,
+        },
+      }]);
+    });
+  });
+
+  test("retains text responses from older bridges and multipart uploads", async () => {
+    const result = { status: 200, statusText: "OK", headers: [], body: '{"ok":true}' };
+    await withBridge(result, async (requests) => {
+      expect(await (await desktopFetch("https://worker.example.test/data")).json()).toEqual({ ok: true });
+      expect(await desktopUploadMultipart(new File(["test"], "clip.mp4"), { url: "https://worker.example.test/inbox" })).toEqual(result);
+      expect(requests[1]?.command).toBe("__uploadMultipart");
+    });
+  });
+
+  test("decodes JSON bytes and keeps empty responses bodyless", async () => {
+    await withBridge({ status: 200, statusText: "OK", headers: [], body: "", bodyBytes: new TextEncoder().encode('{"ok":true}').buffer }, async () => {
+      expect(await (await desktopFetch("https://worker.example.test/data")).json()).toEqual({ ok: true });
+    });
+    for (const status of [204, 205, 304]) {
+      await withBridge({ status, statusText: "", headers: [], body: "", bodyBytes: new ArrayBuffer(0) }, async () => {
+        const response = await desktopFetch("https://worker.example.test/data");
+        expect(response.status).toBe(status);
+        expect(response.body).toBeNull();
+        expect(await response.text()).toBe("");
+      });
+    }
   });
 });

--- a/apps/app/tests/markdown-streaming-blocks.test.ts
+++ b/apps/app/tests/markdown-streaming-blocks.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
+import { attachVideoSource, resolveVideoSource, workspaceVideoPath } from "../src/lib/video-source";
 
 import {
   createStreamingMarkdownRenderer,
@@ -160,4 +161,99 @@ test("video references render native players without autoplay or unsafe sources"
   }
   expect(renderMarkdownHtml("[Bad](javascript:evil.mp4)")).not.toContain("<video");
   expect(renderMarkdownHtml("[Document](notes.md)")).not.toContain("<video");
+});
+
+describe("shared video sources", () => {
+  const data = Uint8Array.from([0, 128, 200, 254, 255]).buffer;
+  const workspace = { workspaceId: "ws_video", workspaceRoot: "/workspace" };
+  const download = { data, contentType: "application/octet-stream", filename: null };
+
+  test("normalizes contained file URLs and relative paths without suffix matching", () => {
+    for (const path of ["clip.mp4", "./clip.mp4", "workspace/clip.mp4", "workspaces/ws_video/clip.mp4", "file:///workspace/clip.mp4", "/workspace/clip.mp4"]) {
+      expect(workspaceVideoPath(path, "/workspace")).toBe("clip.mp4");
+    }
+    expect(workspaceVideoPath("file:///workspace/a%20b.mp4", "/workspace")).toBe("a b.mp4");
+    expect(workspaceVideoPath("file:///C:/Work/clip.mp4", "c:\\Work")).toBe("clip.mp4");
+    expect(workspaceVideoPath("file://server/share/clip.mp4", "\\\\server\\share")).toBe("clip.mp4");
+    for (const path of ["/outside/clip.mp4", "/workspace-other/clip.mp4", "../clip.mp4", "%2e%2e/clip.mp4", "file:///workspace/../outside/clip.mp4", "file://outside/workspace/clip.mp4", "//outside/clip.mp4", "javascript:clip.mp4", "java\nscript:clip.mp4", "https://example.com/clip.mp4"]) {
+      expect(workspaceVideoPath(path, "/workspace")).toBeNull();
+    }
+    expect(workspaceVideoPath("/workspace/clip.mp4")).toBeNull();
+  });
+
+  test("downloads through the authenticated client with intact bytes and MIME fallback", async () => {
+    const requests: string[][] = [];
+    const client = {
+      baseUrl: "https://worker.example.test/api",
+      downloadWorkspaceFile: async (id: string, path: string) => { requests.push([id, path]); return download; },
+    };
+    for (const href of ["file:///workspace/clip.MOV", "./clip.MOV", `${client.baseUrl}/workspace/ws_video/files/raw?path=clip.MOV`]) {
+      const result = await resolveVideoSource({ href, client, ...workspace });
+      expect(result).toBeInstanceOf(Blob);
+      if (!(result instanceof Blob)) throw new Error("Expected video bytes");
+      expect(result.type).toBe("video/quicktime");
+      expect(await result.arrayBuffer()).toEqual(data);
+    }
+    expect(requests).toEqual(Array.from({ length: 3 }, () => ["ws_video", "clip.MOV"]));
+    await expect(resolveVideoSource({ href: "file:///outside/clip.MOV", client, ...workspace })).rejects.toThrow();
+    expect(requests).toHaveLength(3);
+  });
+
+  test("allows public, data and blob videos without sending workspace credentials", async () => {
+    const client = { baseUrl: "https://worker.example.test", downloadWorkspaceFile: async () => { throw new Error("Must not download"); } };
+    for (const href of ["https://example.com/clip.mp4?signature=test", "data:video/mp4;base64,AA==", "blob:https://example.com/clip", "blob:null/clip"]) {
+      expect(await resolveVideoSource({ href, client, ...workspace })).toBe(href);
+    }
+    for (const href of ["javascript:clip.mp4", "data:text/html,<script></script>", "blob:javascript:clip", "ftp://example.com/clip.mp4", "https://user:secret@example.com/clip.mp4"]) {
+      await expect(resolveVideoSource({ href, client, ...workspace })).rejects.toThrow();
+    }
+  });
+
+  test("shows loading and errors, releases URLs, and ignores late resolution after cleanup", async () => {
+    const { GlobalRegistrator } = await import("@happy-dom/global-registrator");
+    GlobalRegistrator.register({ url: "https://app.example.test" });
+    const created = spyOn(URL, "createObjectURL").mockReturnValue("blob:https://app.example.test/video");
+    const revoked = spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    let cleanup: (() => void) | undefined;
+    try {
+      const video = document.createElement("video");
+      const notice = document.createElement("span");
+      const pending = Promise.withResolvers<typeof download>();
+      const client = { baseUrl: "https://worker.example.test", downloadWorkspaceFile: () => pending.promise };
+      cleanup = attachVideoSource(video, notice, { href: "clip.mp4", client, ...workspace });
+      expect(notice.textContent).toBe("Loading video...");
+      expect(video.controls).toBe(true);
+      expect(video.autoplay).toBe(false);
+      cleanup();
+      pending.resolve(download);
+      await pending.promise;
+      await Promise.resolve();
+      expect(created).not.toHaveBeenCalled();
+      expect(video.hasAttribute("src")).toBe(false);
+
+      cleanup = attachVideoSource(video, notice, { href: "clip.mp4", client, ...workspace });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(created).toHaveBeenCalledTimes(1);
+      video.dispatchEvent(new Event("loadedmetadata"));
+      expect(notice.hidden).toBe(true);
+      video.dispatchEvent(new Event("error"));
+      expect(notice.hidden).toBe(false);
+      expect(notice.textContent).toContain("Video preview unavailable");
+      cleanup();
+      expect(revoked).toHaveBeenCalledWith("blob:https://app.example.test/video");
+      expect(video.hasAttribute("src")).toBe(false);
+
+      cleanup = attachVideoSource(video, notice, { href: "../clip.mp4", client, ...workspace });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(notice.textContent).toContain("Video preview unavailable");
+      expect(created).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup?.();
+      created.mockRestore();
+      revoked.mockRestore();
+      await GlobalRegistrator.unregister();
+    }
+  });
 });

--- a/apps/app/tests/message-list-loading.test.tsx
+++ b/apps/app/tests/message-list-loading.test.tsx
@@ -44,6 +44,35 @@ function renderList(messages: UIMessage[], status: ThreadStatus, syncHealth?: Ru
 }
 
 describe("message-list loading feedback", () => {
+  test("renders native video for either role while preserving file actions", () => {
+    const roles: UIMessage["role"][] = ["user", "assistant"];
+    for (const role of roles) {
+      const markup = renderList([{
+        id: `video-${role}`, role,
+        parts: [{ type: "file", mediaType: "video/mp4", filename: "clip.mp4", url: "file:///workspace/clip.mp4" }],
+      }], "ready");
+      expect(markup).toContain("<video");
+      expect(markup).toContain('controls=""');
+      expect(markup.toLowerCase()).toContain('playsinline=""');
+      expect(markup).toContain('preload="metadata"');
+      expect(markup).toContain("Loading video...");
+      expect(markup).toContain("Open clip.mp4 in Artifacts");
+      expect(markup.toLowerCase()).not.toContain("autoplay");
+      expect(markup).not.toContain('src="file:');
+    }
+    const remoteMarkup = renderList([{
+      id: "video-remote", role: "user",
+      parts: [{ type: "file", mediaType: "application/octet-stream", filename: "clip.webm", url: "https://example.com/clip.webm" }],
+    }], "ready");
+    expect(remoteMarkup).toContain("<video");
+    // Public links retain the existing card policy: no direct-download action.
+    expect(remoteMarkup).not.toContain("More actions for clip.webm");
+    expect(renderList([{
+      id: "document", role: "user",
+      parts: [{ type: "file", mediaType: "application/pdf", filename: "notes.pdf", url: "file:///workspace/notes.pdf" }],
+    }], "ready")).not.toContain("<video");
+  });
+
   test("acknowledges a submitted message before streaming starts", () => {
     const markup = renderList([userMessage], "submitted");
 

--- a/apps/app/tests/session-sync-lifecycle.test.ts
+++ b/apps/app/tests/session-sync-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, jest, setSystemTime, test } from "bun:test";
+import { getReactQueryClient } from "../src/react-app/infra/query-client";
 
 type SyncInput = {
   workspaceId: string;
@@ -22,6 +23,8 @@ const {
   __setWorkspaceSessionSyncStatusFetcherForTest,
   __setWorkspaceSessionSyncSubscriptionFactoryForTest,
   ensureWorkspaceSessionSync,
+  snapshotKey,
+  trackWorkspaceSessionSync,
 } = await import("../src/react-app/domains/session/sync/session-sync");
 
 const inputs: SyncInput[] = [];
@@ -78,6 +81,41 @@ afterEach(() => {
 });
 
 describe("workspace session sync lifecycle", () => {
+  test("recovers only tracked snapshots at the actual handshake, not lazy iterator creation", async () => {
+    const connected = Promise.withResolvers<void>();
+    __setWorkspaceSessionSyncSubscriptionFactoryForTest(async (_baseUrl, _token, signal) => {
+      const ended = new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+      async function* stream() {
+        await connected.promise;
+        yield { type: "server.connected", properties: {} };
+        await ended;
+      }
+      return stream();
+    });
+    const syncInput = input("https://handshake.example/opencode", "token");
+    const client = getReactQueryClient();
+    const tracked = snapshotKey(syncInput.workspaceId, "session-tracked");
+    const untracked = snapshotKey(syncInput.workspaceId, "session-untracked");
+    const otherWorkspace = snapshotKey("ws_other", "session-tracked");
+    for (const key of [tracked, untracked, otherWorkspace]) client.setQueryData(key, {});
+    const release = ensureWorkspaceSessionSync(syncInput);
+    const untrack = trackWorkspaceSessionSync(syncInput, "session-tracked");
+    try {
+      await delay(10);
+      expect(client.getQueryState(tracked)?.isInvalidated).toBe(false);
+      connected.resolve();
+      const deadline = Date.now() + 2_000;
+      while (!client.getQueryState(tracked)?.isInvalidated && Date.now() < deadline) await delay(5);
+      expect(client.getQueryState(tracked)?.isInvalidated).toBe(true);
+      expect(client.getQueryState(untracked)?.isInvalidated).toBe(false);
+      expect(client.getQueryState(otherWorkspace)?.isInvalidated).toBe(false);
+    } finally {
+      untrack();
+      release();
+      for (const key of [tracked, untracked, otherWorkspace]) client.removeQueries({ queryKey: key, exact: true });
+    }
+  });
+
   test("keeps a reattached observer after the older attachment releases", async () => {
     __setWorkspaceSessionSyncSubscriptionFactoryForTest(createSubscription);
     const syncInput = input("https://one.example/opencode", "token");

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2331,7 +2331,9 @@ const desktopCommandHandlers = {
         status: response.status,
         statusText: response.statusText,
         headers: Array.from(response.headers.entries()),
-        body: await response.text(),
+        // Opt-in keeps legacy fetch callers and multipart upload responses textual.
+        body: init.responseType === "arraybuffer" ? "" : await response.text(),
+        ...(init.responseType === "arraybuffer" ? { bodyBytes: await response.arrayBuffer() } : {}),
       };
   },
   "__uploadMultipart": async (event, ...args) => {

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -214,6 +214,10 @@ function contentTypeForPath(path: string): string {
   if (lowered.endsWith(".jpg") || lowered.endsWith(".jpeg")) return "image/jpeg";
   if (lowered.endsWith(".gif")) return "image/gif";
   if (lowered.endsWith(".webp")) return "image/webp";
+  if (lowered.endsWith(".mp4") || lowered.endsWith(".m4v")) return "video/mp4";
+  if (lowered.endsWith(".webm")) return "video/webm";
+  if (lowered.endsWith(".mov")) return "video/quicktime";
+  if (lowered.endsWith(".ogv")) return "video/ogg";
   if (lowered.endsWith(".pdf")) return "application/pdf";
   if (lowered.endsWith(".docx")) return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
   if (lowered.endsWith(".csv")) return "text/csv; charset=utf-8";

--- a/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
+++ b/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isSupportedWorkspaceTextFilePath, normalizeWorkspaceRelativePath } from "./server.js";
+import { resolveWorkspaceArtifactTargets } from "./routes/files.js";
 
 describe("normalizeWorkspaceRelativePath", () => {
   test("accepts a plain workspace-relative path", () => {
@@ -89,6 +90,18 @@ describe("normalizeWorkspaceRelativePath", () => {
 });
 
 describe("isSupportedWorkspaceTextFilePath", () => {
+  test("identifies native video MIME types without treating videos as text", async () => {
+    const types = [
+      ["clip.mp4", "video/mp4"], ["clip.m4v", "video/mp4"], ["clip.webm", "video/webm"],
+      ["clip.MOV", "video/quicktime"], ["clip.ogv", "video/ogg"], ["clip.bin", "application/octet-stream"],
+    ];
+    for (const [value, contentType] of types) {
+      const items = await resolveWorkspaceArtifactTargets(import.meta.dir, [{ kind: "file", value }]);
+      expect(items[0]).toMatchObject({ value, contentType });
+      expect(isSupportedWorkspaceTextFilePath(value)).toBe(false);
+    }
+  });
+
   test("accepts workspace text artifact extensions", () => {
     expect(isSupportedWorkspaceTextFilePath("reports/revenue.csv")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath("reports/revenue.tsv")).toBe(true);

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -54,6 +54,8 @@ export interface MockAgentRequest {
   kind: "utility" | "tool" | "final" | "error";
   toolName: string | null;
   arguments: Record<string, unknown>;
+  /** Native Google inlineData entries, preserving the submitted MIME and base64 bytes. */
+  inlineMedia?: { mimeType: string; data: string }[];
   at: string;
 }
 
@@ -114,7 +116,7 @@ export interface StartMockMcpOptions {
   extraToolCount?: number;
   /** Serve one app-visible MCP App launch tool (`_meta.ui.resourceUri`) under this name. */
   appToolName?: string;
-  /** Script deterministic OpenAI-compatible agent turns through this mock. */
+  /** Script deterministic agent turns; native Google supports empty-step text replies with media input. */
   agentWorkloads?: MockAgentWorkload[];
   /** Verify native provider requests retain this private model header. */
   agentRequiredHeader?: { name: string; value: string };
@@ -437,6 +439,11 @@ export async function startMockMcp(options: StartMockMcpOptions = {}): Promise<M
         kind,
         toolName: typeof completion.toolName === "string" ? completion.toolName : null,
         arguments: isRecord(completion.arguments) ? completion.arguments : {},
+        ...(Array.isArray(completion.inlineMedia) ? {
+          inlineMedia: completion.inlineMedia.flatMap(media => isRecord(media)
+            && typeof media.mimeType === "string" && typeof media.data === "string"
+            ? [{ mimeType: media.mimeType, data: media.data }] : []),
+        } : {}),
         at,
       });
     }

--- a/evals/packages/labs/test/mock-mcp.test.ts
+++ b/evals/packages/labs/test/mock-mcp.test.ts
@@ -175,3 +175,61 @@ test("native Responses preserve the configured provider header", async () => {
   assert.ok(events.some(event => event.type === "response.completed"));
   assert.equal(events.filter(event => event.type === "response.output_text.delta").map(event => event.delta).join(""), "The header reached the provider");
 });
+
+test("Google generation and streaming retain exact native media and return configured text", async () => {
+  const marker = "native-video-proof";
+  const reply = "The video reached the model";
+  const media = { mimeType: "video/mp4", data: Buffer.from([0, 255, 128, 1, 254]).toString("base64") };
+  await using mock = await startMockMcp({
+    port: await allocateFreePort(),
+    agentWorkloads: [{ promptMarker: marker, finalReply: reply, finalReplyChunkSize: 5, steps: [] }],
+    agentRequiredHeader: { name: "x-goog-api-key", value: "google-fixture-key" },
+  });
+  for (const method of ["generateContent", "streamGenerateContent"]) {
+    const body = JSON.stringify({ contents: [{ role: "user", parts: [{ text: marker }, { inlineData: media }] }] });
+    const url = `${mock.url}/v1beta/models/video-fixture:${method}?alt=sse`;
+    const denied = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body });
+    assert.equal(denied.status, 401);
+    await denied.text();
+    const accepted = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-goog-api-key": "google-fixture-key" },
+      body,
+    });
+    assert.equal(accepted.status, 200);
+    if (method === "generateContent") {
+      const result = await accepted.json();
+      assert.equal(result.candidates[0].content.parts[0].text, reply);
+      assert.equal(result.candidates[0].finishReason, "STOP");
+    } else {
+      assert.match(accepted.headers.get("content-type") ?? "", /text\/event-stream/);
+      const events = (await accepted.text()).split("\n").filter(line => line.startsWith("data: ")).map(line => JSON.parse(line.slice(6)));
+      assert.ok(events.length > 2);
+      assert.equal(events.map(event => event.candidates[0].content.parts[0].text).join(""), reply);
+      assert.equal(events.at(-1)?.candidates[0].finishReason, "STOP");
+    }
+  }
+  const requests = await mock.agentRequests({ promptMarker: marker });
+  assert.deepEqual(requests.map(request => request.kind), ["error", "final", "error", "final"]);
+  for (const request of requests) {
+    assert.equal(request.model, "video-fixture");
+    assert.deepEqual(request.inlineMedia, [media]);
+  }
+});
+
+test("Google generation rejects tool workloads rather than silently ignoring their steps", async () => {
+  await using mock = await startMockMcp({
+    port: await allocateFreePort(),
+    agentWorkloads: [{ promptMarker: "tool-required", finalReply: "must not be returned", steps: [{ tool: "read", arguments: {} }] }],
+  });
+  for (const method of ["generateContent", "streamGenerateContent"]) {
+    const response = await fetch(`${mock.url}/v1beta/models/video-fixture:${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "tool-required" }] }] }),
+    });
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /empty steps/);
+  }
+  assert.deepEqual((await mock.agentRequests()).map(request => request.kind), ["error", "error"]);
+});

--- a/evals/packages/testkit/src/transcript-observer.ts
+++ b/evals/packages/testkit/src/transcript-observer.ts
@@ -5,7 +5,7 @@ export async function observeTranscript(probe: Probe, entries: readonly { role: 
   const key = `transcript-observer-${crypto.randomUUID()}`;
   await probe.eval(`(key, entriesJson) => {
     const entries = JSON.parse(entriesJson);
-    const state = { frames: 0, seen: entries.map(() => false), violations: [], stopped: false };
+    const state = { frames: 0, seen: entries.map(() => false), firstSeenFrames: entries.map(() => null), violations: [], stopped: false };
     let frame;
     const started = performance.now();
     const sample = () => {
@@ -14,7 +14,10 @@ export async function observeTranscript(probe: Probe, entries: readonly { role: 
         const nodes = [...document.querySelectorAll('[data-message-role="' + entry.role + '"]')]
           .filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== "hidden");
         const count = nodes.reduce((sum, node) => sum + ((node.innerText ?? "").split(entry.text).length - 1), 0);
-        if (count > 0) state.seen[index] = true;
+        if (count > 0) {
+          if (!state.seen[index]) state.firstSeenFrames[index] = state.frames;
+          state.seen[index] = true;
+        }
         if (state.seen[index] && count !== 1 && state.violations.length < 30)
           state.violations.push({ index, count, atMs: Math.round(performance.now() - started) });
       });
@@ -25,6 +28,13 @@ export async function observeTranscript(probe: Probe, entries: readonly { role: 
     window[key] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
   }`, { args: [key, JSON.stringify(entries)] });
   return {
+    async firstSeenFrames(): Promise<Array<number | null>> {
+      const frames = await probe.eval(`(key) => window[key]?.state.firstSeenFrames`, { args: [key] });
+      if (!Array.isArray(frames) || !frames.every((frame): frame is number | null => frame === null || typeof frame === "number")) {
+        throw new Error("Transcript frame observations were unavailable");
+      }
+      return frames;
+    },
     read() {
       return probe.eval(`(key) => {
         const observer = window[key];

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -12,7 +12,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-test("attaching an image shows its chip instantly and sends with a visible uploading state", async ({ world, user, seed, probe, step }) => {
+test("video keeps the draft on incompatible models, sends intact with the image on Google, and plays after reload", async ({ world, user, seed, probe, step }) => {
   await step("manual approval exempts only chat-attachment inbox uploads", async () => {
     expect(world.uploadStatus).toBe(200);
     expect(world.uploadElapsedMs).toBeLessThan(world.approvalTimeoutMs);
@@ -64,29 +64,72 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   expect(attached.chipStatus).toBe("ready");
   await user.screenshot();
 
-  await step("paste a video alongside the image", async () => {
-    expect(await seed.evalIn(world.app, `(() => {
-      const editor = document.querySelector('[contenteditable="true"]');
-      if (!(editor instanceof HTMLElement)) return false;
-      const transfer = new DataTransfer();
-      transfer.items.add(new File([new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112])], "pasted-recording.mp4", { type: "video/mp4" }));
-      editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: transfer }));
-      return true;
-    })()`)).toBe(true);
-    await user.see({ text: "pasted-recording.mp4" });
+  await step("paste a real video alongside the image", async () => {
+    await world.pasteVideo();
+    await user.see({ text: world.videoName });
+    expect(await world.draftAttachments()).toEqual([
+      { id: expect.any(String), name: attachmentName, status: "ready" },
+      { id: expect.any(String), name: world.videoName, status: "ready" },
+    ]);
+  });
+
+  const draft = await probe.composer();
+  const attachments = await world.draftAttachments();
+  const rejection = "This model connection does not support video input.";
+  for (const modelName of [world.imageModelName, world.modelName]) {
+    await step(`${modelName} rejects video without losing the draft or calling the model`, async () => {
+      await user.click({ role: "button", label: "Change model" });
+      await user.click({ role: "button", label: /^Model\s/ });
+      await user.type({ placeholder: "Search models..." }, modelName, { replace: true });
+      await user.screenshot();
+      await user.click({ role: "option", label: new RegExp(modelName) });
+      await user.see({ role: "button", label: "Change model" }, { text: new RegExp(modelName) });
+      expect(await world.modelRequests()).toEqual([]);
+      await user.click("Run task");
+      await user.see({ text: rejection });
+      await user.see("composer", { editable: true, text: /Describe the attached image\./ });
+      expect(await probe.composer()).toMatchObject({
+        draftText: draft.draftText,
+        userMessageCount: draft.userMessageCount,
+        assistantMessageCount: draft.assistantMessageCount,
+      });
+      expect(await world.draftAttachments()).toEqual(attachments);
+      expect(await world.modelRequests()).toEqual([]);
+      await user.notSee({ text: /1 queued/ });
+      await user.click({ role: "button", label: "Dismiss error" });
+      await user.notSee({ text: rejection });
+      expect(await probe.eventually(() => probe.composer(), {
+        within: 5_000,
+        label: "retained draft can be sent after dismissing the error",
+        until: (state) => state.runTaskEnabled,
+      })).toMatchObject({ runTaskEnabled: true, draftText: draft.draftText });
+    });
+  }
+
+  await step("select a supported Google model without changing the retained draft", async () => {
+    await user.click({ role: "button", label: "Change model" });
+    await user.click({ role: "button", label: /^Model\s/ });
+    await user.type({ placeholder: "Search models..." }, world.videoModelName, { replace: true });
+    await user.click({ role: "option", label: new RegExp(world.videoModelName) });
+    await user.see({ role: "button", label: "Change model" }, { text: new RegExp(world.videoModelName) });
+    await user.see("composer", { editable: true, text: /Describe the attached image\./ });
+    expect((await probe.composer()).draftText).toBe(draft.draftText);
+    expect(await world.draftAttachments()).toEqual(attachments);
+    expect(await world.modelRequests()).toEqual([]);
   });
 
   // TODO(primitive): observe a transient attachment status during a user send.
-  await seed.evalIn(world.app, `(() => {
+  await seed.evalIn(world.app, `(attachmentName) => {
     globalThis.__attachmentUploadingSeen = false;
     const record = () => {
-      if (document.querySelector('[data-attachment-status="uploading"]')) globalThis.__attachmentUploadingSeen = true;
+      if (Array.from(document.querySelectorAll('[data-attachment-status="uploading"]'))
+        .some(chip => chip.getAttribute("title") === attachmentName)) globalThis.__attachmentUploadingSeen = true;
     };
     const observer = new MutationObserver(record);
     observer.observe(document.body, { subtree: true, attributes: true, attributeFilter: ["data-attachment-status"], childList: true });
     record();
     return true;
-  })()`);
+  }`, { args: [attachmentName] });
   await user.click("Run task");
 
   // TODO(primitive): await a transient attachment-status witness.
@@ -99,15 +142,60 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   await user.notSee({ text: /1 queued/ });
   expect((await probe.hash()).includes("/session/ses_")).toBe(true);
   // TODO(primitive): inspect attachment cleanup and error-toast state after send.
-  expect(await probe.eval(`!document.querySelector("[data-attachment-id]")
-    && !document.querySelector('[data-sonner-toast][data-type="error"]')`)).toBe(true);
-  await step("sent video remains visible without a binary model error", async () => {
-    await user.see({ text: "pasted-recording.mp4" });
-    await user.see({ text: "attachment upload loading proof" });
+  expect(await probe.eventually(() => probe.eval(`!document.querySelector("[data-attachment-id]")
+    && !document.querySelector('[data-sonner-toast][data-type="error"]')`), {
+    within: 30_000,
+    label: "attachment cleanup after send",
+    until: (value) => value === true,
+  })).toBe(true);
+  await step("Google receives the exact video MIME and bytes alongside the image", async () => {
+    await user.see({ text: world.reply }, { timeoutMs: 90_000 });
+    const requests = await probe.eventually(() => world.agentRequests(), {
+      within: 30_000,
+      label: "native Google completion with attachments",
+      until: (requests) => requests.some(request => request.model === world.videoModelId && request.kind === "final"),
+    });
+    expect(requests.some(request => request.kind === "error")).toBe(false);
+    // Judge the content of every video-bearing request, not the engine's
+    // number of main/auxiliary inference requests for a single user turn.
+    const completed = requests.filter(request => request.model === world.videoModelId && request.kind === "final"
+      && request.inlineMedia?.some(media => media.mimeType.startsWith("video/")));
+    expect(completed.length).toBeGreaterThan(0);
+    for (const request of completed) {
+      expect(request.inlineMedia?.filter(media => media.mimeType.startsWith("video/"))).toEqual([world.expectedVideo]);
+      expect(request.inlineMedia?.some(media => media.mimeType.startsWith("image/"))).toBe(true);
+    }
+    expect((await probe.composer()).userMessageCount).toBe(1);
     await user.notSee({ text: /Cannot read binary file|UnsupportedFunctionalityError/ });
   });
-  await user.reload();
-  await user.see({ text: "pasted-recording.mp4" });
-  expect(await probe.eval(`document.querySelectorAll('button[title="Open pasted-recording.mp4 in Artifacts"]').length`)).toBe(1);
-  await user.screenshot();
+
+  for (const reload of [false, true]) {
+    await step(`${reload ? "reloaded" : "sent"} video has one player with controls and plays only when requested`, async () => {
+      if (reload) {
+        await user.reload();
+        await user.see({ text: world.reply }, { timeoutMs: 60_000 });
+      }
+      await user.see({ text: world.videoName });
+      for (const reference of [false, true]) {
+        const idle = await probe.eventually(() => world.videoState(false, reference), {
+          within: 30_000,
+          label: `${reference ? "workspace reference" : "attachment"} decoded without autoplay`,
+          until: (state) => state?.ready === true,
+        });
+        expect(idle).toMatchObject({
+          count: 1, totalPlayers: 2, controls: true, autoplay: false, paused: true, time: 0, error: null,
+        });
+        if (reference) expect(idle?.blobSource).toBe(true);
+        await world.videoState(true, reference);
+        const playing = await probe.eventually(() => world.videoState(false, reference), {
+          within: 5_000,
+          label: "video playback advances",
+          until: (state) => state !== null && state.time > 0,
+        });
+        expect(playing).toMatchObject({ count: 1, totalPlayers: 2, controls: true, autoplay: false, error: null });
+        expect(playing?.time).toBeGreaterThan(0);
+      }
+      await user.screenshot();
+    });
+  }
 });

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -31,6 +31,8 @@ test("a streaming answer renders as markdown block by block and settles to the s
   await using transcript = await observeTranscript(probe, [
     { role: "user", text: prompt },
     ...blockSentinels.map((text): { role: "assistant"; text: string } => ({ role: "assistant", text })),
+    ...rawSyntax.map((text): { role: "assistant"; text: string } => ({ role: "assistant", text })),
+    ...rawSyntax.map((text): { role: "user"; text: string } => ({ role: "user", text })),
   ]);
   await user.type("composer", prompt);
   await probe.eventually(() => probe.composer(), {
@@ -49,7 +51,14 @@ test("a streaming answer renders as markdown block by block and settles to the s
 
   await step("finished blocks render as markdown while later blocks are still arriving", async () => {
     await user.see({ text: headingText }, { timeoutMs: 90_000 });
-    await user.notSee({ text: closingText });
+    await user.see({ text: closingText }, { timeoutMs: 120_000 });
+    // Judge the frames observed throughout streaming, not how quickly this
+    // process polls after the heading. A buffered whole answer fails this too.
+    const frames = await transcript.firstSeenFrames();
+    const headingFrame = frames[1];
+    const closingFrame = frames[blockSentinels.length];
+    expect(headingFrame).toEqual(expect.any(Number));
+    expect(closingFrame).toBeGreaterThan(headingFrame ?? Number.POSITIVE_INFINITY);
     await user.notSee({ text: "## Streamed" });
   });
 
@@ -64,7 +73,7 @@ test("a streaming answer renders as markdown block by block and settles to the s
 
   await step("sent text and streamed blocks never disappear or duplicate", async () => {
     expect(await transcript.finish()).toMatchObject({
-      seen: [true, ...blockSentinels.map(() => true)],
+      seen: [true, ...blockSentinels.map(() => true), ...rawSyntax.map(() => false), ...rawSyntax.map(() => false)],
       violations: [],
       stopped: false,
       frames: expect.any(Number),

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { eventually, observeTranscript, spec } from "@openwork/testkit";
+import { eventually, observeTranscript, readTranscriptMessages, spec } from "@openwork/testkit";
 import { streamedMarkdown, streamedMarkdownMarker } from "../worlds/chat.ts";
 
 const test = spec.world(streamedMarkdown, { timeout: 300_000 });
@@ -33,8 +33,19 @@ test("a streaming answer renders as markdown block by block and settles to the s
     ...blockSentinels.map((text): { role: "assistant"; text: string } => ({ role: "assistant", text })),
   ]);
   await user.type("composer", prompt);
+  await probe.eventually(() => probe.composer(), {
+    within: 10_000,
+    label: "composer is ready to send the typed draft",
+    until: (state) => state.runTaskEnabled && state.draftText === prompt,
+  });
   await user.click("Run task");
-  await user.see({ text: prompt }, { timeoutMs: 2_000 });
+  // Cold engine initialization is not a Markdown-rendering latency contract.
+  // Observe the real user bubble (which also contains its timestamp), not the draft.
+  expect(await probe.eventually(() => readTranscriptMessages(probe, "user"), {
+    within: 30_000,
+    label: "sent text appears in the transcript, not just the composer",
+    until: (messages) => messages.some(message => message.includes(prompt)),
+  })).toEqual([expect.stringContaining(prompt)]);
 
   await step("finished blocks render as markdown while later blocks are still arriving", async () => {
     await user.see({ text: headingText }, { timeoutMs: 90_000 });

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -205,6 +205,22 @@ async function seedSessionRetry(
   throw new Error(`Session creation did not settle: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
 }
 
+async function readySessionComposer(seed: Seed, app: Awaited<ReturnType<Seed["desktop"]>>, sessionId: string) {
+  // Session creation returns before its routed composer necessarily mounts.
+  const ready = await seed.evalIn(app, `async (sessionId) => {
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+      if (editor?.closest('[data-session-surface-id]')?.getAttribute('data-session-surface-id') === sessionId) return true;
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    return false;
+  }`, { args: [sessionId], awaitPromise: true, timeoutMs: 35000 });
+  if (ready !== true) throw new Error("The session composer did not mount");
+  // A background Electron window can ignore CDP input without focus emulation.
+  await app.client.send("Emulation.setFocusEmulationEnabled", { enabled: true });
+}
+
 export async function emptyChat(seed: Seed) {
   const app = await seed.desktop({ name: "chat-empty" });
   const workspace = await seed.workspace(app, seed.tmpPath("chat-empty"));
@@ -537,6 +553,7 @@ export async function attachmentUpload(seed: Seed) {
       if (!response.ok) throw new Error("Video fixture write failed: " + response.status);
     }`, { args: [workspace.workspaceId, videoBase64], awaitPromise: true });
     const session = await seedSessionRetry(seed, app);
+    await readySessionComposer(seed, app, session.sessionId);
     return {
       app,
       workspace,
@@ -796,6 +813,7 @@ export async function streamedMarkdown(seed: Seed) {
   }`, { args: [workspace.workspaceId, engine, providerId, modelId], awaitPromise: true, timeoutMs: 65000 });
   if (ready !== true) throw new Error(`Selected ${engine} engine was not ready for the streaming journey`);
   const session = await seedSessionRetry(seed, app);
+  await readySessionComposer(seed, app, session.sessionId);
   return { app, den, workspace, session,
     async videoState(play = false) {
       return seed.evalIn(app, `async (play) => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { join, resolve } from "node:path";
 import { evalIn, assertNoLiveSecret, liveOpenAiEnabled, liveOpenAiModel, liveProviderId, provisionLiveOpenAi } from "@openwork/behaviors";
-import { resolveEvalEngine, type Seed } from "@openwork/env";
+import { resolveEvalEngine, SkipError, type Seed } from "@openwork/env";
 import type { MockAgentWorkload } from "@openwork/labs";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -462,21 +462,25 @@ async function startManualApprovalServer(approvalTimeoutMs: number) {
 }
 
 export async function attachmentUpload(seed: Seed) {
+  if (resolveEvalEngine() !== "v1") {
+    throw new SkipError("native video send and playback require OPENWORK_EVAL_ENGINE=v1; v2 rejects video input");
+  }
   const providerId = "attachment-upload-mock";
   const modelId = "attachment-upload-model";
+  const modelName = "Attachment unsupported-video model";
+  const imageProviderId = "attachment-google-mock";
+  const imageModelId = "attachment-image-model";
+  const imageModelName = "Attachment image-only model";
+  const videoModelId = "attachment-video-model";
+  const videoModelName = "Attachment video model";
+  const videoName = "assistant-video.mp4";
+  const videoBase64 = (await readFile(new URL("../fixtures/assistant-video.mp4", import.meta.url))).toString("base64");
   const reply = "attachment upload loading proof";
   const mock = seed.mock({
     agentWorkloads: [{
       promptMarker: "Describe the attached image.",
-      finalReply: reply,
-      steps: [{
-        tool: "bash",
-        arguments: {
-          command: "printf '%s\\n' 'attachment-upload-ready'",
-          timeout: 30_000,
-          description: "Acknowledge the attachment upload",
-        },
-      }],
+      finalReply: `${reply}\n\n[Play workspace video](clip.mp4)`,
+      steps: [],
     }],
   });
   const den = await seed.den({ mocks: { agent: mock } });
@@ -500,23 +504,111 @@ export async function attachmentUpload(seed: Seed) {
     });
     const writeElapsedMs = Date.now() - writeStartedAt;
 
-    const app = await seed.desktop({ den, as: "admin", model: `${providerId}/${modelId}` });
+    const app = await seed.desktop({ den, as: "admin", model: `${imageProviderId}/${imageModelId}` });
     const workspace = await seed.workspace(app, seed.tmpPath("attachment-upload"));
-    await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    await configureProvider(seed, app, workspace.workspaceId, imageProviderId, imageModelId, {
+      small_model: `${providerId}/${modelId}`,
       provider: {
+        [imageProviderId]: {
+          npm: "@ai-sdk/google",
+          name: "Attachment Google mock",
+          options: { baseURL: `${den.mocks.agent.url}/v1beta`, apiKey: "attachment-google-fixture" },
+          models: {
+            [imageModelId]: { name: imageModelName, modalities: { input: ["text", "image"], output: ["text"] } },
+            [videoModelId]: { name: videoModelName, modalities: { input: ["text", "image", "video"], output: ["text"] } },
+          },
+        },
         [providerId]: {
           npm: "@ai-sdk/openai-compatible",
           name: "Attachment upload mock",
           options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-attachment-upload" },
-          models: { [modelId]: { name: "Attachment upload model" } },
+          models: { [modelId]: { name: modelName, modalities: { input: ["text", "image", "video"], output: ["text"] } } },
         },
       },
     });
+    // Exercise authenticated workspace playback as well as the native attachment.
+    await seed.evalIn(app, `async (workspaceId, dataBase64) => {
+      const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
+      const response = await fetch(base + "/workspace/" + encodeURIComponent(workspaceId) + "/files/raw", {
+        method: "POST",
+        headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token"), "Content-Type": "application/json" },
+        body: JSON.stringify({ path: "clip.mp4", dataBase64 }),
+      });
+      if (!response.ok) throw new Error("Video fixture write failed: " + response.status);
+    }`, { args: [workspace.workspaceId, videoBase64], awaitPromise: true });
     const session = await seedSessionRetry(seed, app);
     return {
       app,
       workspace,
       session,
+      modelName,
+      imageModelName,
+      videoModelId,
+      videoModelName,
+      videoName,
+      expectedVideo: { mimeType: "video/mp4", data: videoBase64 },
+      reply,
+      async pasteVideo() {
+        // TODO(primitive): paste a fixture file through the composer clipboard.
+        const pasted = await seed.evalIn(app, `(name, dataBase64) => {
+          const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+          if (!(editor instanceof HTMLElement)) throw new Error("No composer to paste into");
+          const bytes = Uint8Array.from(atob(dataBase64), character => character.charCodeAt(0));
+          const transfer = new DataTransfer();
+          transfer.items.add(new File([bytes], name, { type: "video/mp4" }));
+          editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: transfer }));
+          return bytes.length;
+        }`, { args: [videoName, videoBase64] });
+        if (typeof pasted !== "number" || pasted === 0) throw new Error("Video fixture was not pasted");
+      },
+      draftAttachments() {
+        // Observe attachment identities rather than their DOM representations.
+        return evalIn(app, `Array.from(new Map(Array.from(document.querySelectorAll('[data-attachment-id]'), chip => [
+          chip.getAttribute('data-attachment-id'), {
+            id: chip.getAttribute('data-attachment-id'),
+            name: chip.getAttribute('title'),
+            status: chip.getAttribute('data-attachment-status'),
+          }
+        ])).values())`);
+      },
+      async modelRequests() {
+        // Count attempted calls as well as successful completions.
+        return (await den.mocks.agent.requests()).filter(request => request.method === "POST"
+          && /\/(?:chat\/completions|responses)$|:(?:streamGenerateContent|generateContent)$/.test(request.path));
+      },
+      agentRequests() {
+        return den.mocks.agent.agentRequests({ promptMarker: "Describe the attached image." });
+      },
+      async videoState(play = false, reference = false) {
+        const state = await seed.evalIn(app, `async (name, play, reference) => {
+          const players = Array.from(document.querySelectorAll('video'));
+          const matches = players.filter(video => reference
+            ? video.getAttribute('data-openwork-video-path') === 'clip.mp4'
+            : video.getAttribute('aria-label') === name);
+          const video = matches[0];
+          if (!video) return null;
+          if (play) await video.play();
+          return {
+            count: matches.length, totalPlayers: players.length,
+            controls: video.controls, autoplay: video.autoplay, paused: video.paused,
+            ready: video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0,
+            blobSource: video.currentSrc.startsWith('blob:'),
+            time: video.currentTime, error: video.error?.message ?? null,
+          };
+        }`, { args: [videoName, play, reference], awaitPromise: true, timeoutMs: 10_000 });
+        if (state === null) return null;
+        if (!isRecord(state) || typeof state.count !== "number" || typeof state.totalPlayers !== "number"
+          || typeof state.time !== "number" || (state.error !== null && typeof state.error !== "string")
+          || !["controls", "autoplay", "paused", "ready"].every(key => typeof state[key] === "boolean")) {
+          throw new Error("Invalid video playback observation");
+        }
+        return {
+          count: state.count, totalPlayers: state.totalPlayers, time: state.time, error: state.error,
+          controls: state.controls === true, autoplay: state.autoplay === true,
+          paused: state.paused === true, ready: state.ready === true,
+          blobSource: state.blobSource === true,
+        };
+      },
       approvalTimeoutMs,
       uploadStatus: uploadResponse.status,
       uploadElapsedMs,

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -303,6 +303,7 @@ export type DesktopFetchInit = {
   headers?: Record<string, string>;
   body?: string;
   timeoutMs?: number;
+  responseType?: "arraybuffer";
   agentContextDiagnostics?: {
     deadlineAtMs: number;
   };
@@ -313,6 +314,7 @@ export type DesktopFetchResult = {
   statusText: string;
   headers: [string, string][];
   body: string;
+  bodyBytes?: ArrayBuffer;
 };
 
 export type DesktopMultipartUploadInput = {

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -373,6 +373,60 @@ async function handleAgentResponse(req, res, entry) {
   res.end();
 }
 
+// Google native media stays in the witness exactly as received; no fixture bytes are substituted.
+async function handleGoogleContent(req, res, entry, model, streaming) {
+  const body = await readJson(req);
+  if (!Array.isArray(body?.contents)) {
+    json(res, 400, { error: { message: "Google generation requires contents" } });
+    return;
+  }
+  const contents = body.contents;
+  const conversationText = contents.map(content => agentContentText(content.parts)).join("\n");
+  const latestUserText = agentContentText(contents.findLast(content => content.role === "user")?.parts);
+  const matched = agentWorkloads.filter(workload =>
+    (workload.latestUserTurn ? latestUserText : conversationText).includes(workload.promptMarker));
+  const workload = matched[0];
+  entry.agentCompletion = {
+    model,
+    matchedMarkers: matched.map(item => item.promptMarker),
+    promptMarker: workload?.promptMarker ?? null,
+    completedTools: 0,
+    kind: "error",
+    toolName: null,
+    arguments: {},
+    inlineMedia: contents.flatMap(content => (Array.isArray(content.parts) ? content.parts : [])
+      .flatMap(part => typeof part.inlineData?.mimeType === "string" && typeof part.inlineData?.data === "string"
+        ? [{ mimeType: part.inlineData.mimeType, data: part.inlineData.data }] : [])),
+  };
+  if (agentRequiredHeader && req.headers[agentRequiredHeader.name.toLowerCase()] !== agentRequiredHeader.value) {
+    json(res, 401, { error: { message: "provider authentication handler was bypassed" } });
+    return;
+  }
+  if (matched.length > 1 || (workload && (workload.steps.length > 0 || workload.finalReplyFrom))) {
+    json(res, 400, { error: { message: "Google witness requires one workload with empty steps and a literal final reply" } });
+    return;
+  }
+  entry.agentCompletion.kind = workload ? "final" : "utility";
+  if (workload?.finalReplyDelayMs) await new Promise(resolve => setTimeout(resolve, workload.finalReplyDelayMs));
+  const reply = workload?.finalReply ?? "Active session workload";
+  const response = text => ({
+    candidates: [{ index: 0, content: { role: "model", parts: [{ text }] }, finishReason: "STOP" }],
+    modelVersion: model,
+    usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+  });
+  if (!streaming) {
+    json(res, 200, response(reply));
+    return;
+  }
+  res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", "access-control-allow-origin": "*" });
+  const chunks = workload ? finalReplyChunks(workload) : [reply];
+  for (const text of chunks) {
+    res.write(`data: ${JSON.stringify({ candidates: [{ index: 0, content: { role: "model", parts: [{ text }] } }] })}\n\n`);
+    await new Promise(resolve => setTimeout(resolve, 80));
+  }
+  res.end(`data: ${JSON.stringify(response(""))}\n\n`);
+}
+
 async function handleAgentCompletion(req, res, entry) {
   const body = await readJson(req);
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -1062,6 +1116,12 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method === "POST" && (url.pathname === "/v1/responses" || url.pathname === "/responses")) {
       await handleAgentResponse(req, res, entry);
+      return;
+    }
+
+    const googleGeneration = url.pathname.match(/^\/v1(?:beta)?\/models\/([^/]+):(generateContent|streamGenerateContent)$/);
+    if (req.method === "POST" && googleGeneration) {
+      await handleGoogleContent(req, res, entry, decodeURIComponent(googleGeneration[1]), googleGeneration[2] === "streamGenerateContent");
       return;
     }
 


### PR DESCRIPTION
## Summary

- Send native video only when the exact connected model advertises video input and uses a supported Google/Vertex adapter. Reject incompatible selections before upload and keep the draft, including queued and split-workspace sends.
- Play attached videos in the thread with native controls and no autoplay. Share authenticated workspace-video loading with Markdown, preserve binary response bytes across Desktop IPC, and return video content types from the server.
- Recover active transcript snapshots at the real `server.connected` handshake. The SDK returns a lazy stream iterator before the connection opens; missing initial message declarations could otherwise assign assistant deltas an inferred user role and delay proper Markdown until completion.
- Show the useful send error on empty threads instead of a generic Error waiting state.

## Verification

**Overall verdict: Incomplete.** Both focused local journeys passed on head `352a639926faa8bc0366bb1e843f5ff8819557f5`; remote Desktop playback still needs end-to-end proof. This PR is ready for review, not a release assertion.

### Passed

Both commands printed `placement: local (--local)`, cold-started their isolated resources, and exited 0 with **1 passed, 0 failed, 0 skipped** each:

```sh
OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e streamed-markdown-answer --local
OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e attachment-upload-loading-state --local
```

The streaming journey now targets the mounted composer, verifies the actual sent bubble rather than composer text, and records the first frame for each block. It requires the heading to appear before the closing paragraph and forbids raw Markdown under either message role throughout the stream. It also checks continuity, reload, and video playback. Focus emulation makes trusted input work in background Electron; the cold-start wait is separate from the per-frame rendering assertion.

The attachment journey checks incompatible-model draft preservation, exact video MIME/base64 received by a mock native Google endpoint, authenticated workspace playback, no duplicate players or autoplay, and playback after reload.

Supporting checks passed: app typecheck; 63 focused app tests (attachments, IPC, Markdown, message rendering, and handshake isolation); 16 server path/MIME tests; 15 binary-transfer/mock-provider tests; changed-spec channel ratchet and diff checks. Screenshots are supplementary, not the source of the verdict.

### Failed — reproduced on clean base

`bun test --isolate tests/prompt-file-parts.test.ts` exits 1 with **20 passed, 1 failed** on both this branch and clean base `9a64fe1087aff7f5c552a446595d1325e1d1a91b`. The unchanged app-mention assertion expects `computer-use tools`, while the current instruction names `computer_discover` and `computer_open_session`. That unrelated wording mismatch is not changed here.

### Skipped / deferred

- No skips in the two focused journeys.
- Remote Desktop in-thread playback has byte-preservation checks but no full remote end-to-end run yet.
- Native video in the experimental engine, progressive/range streaming, transcoding, and large-video Files-API transport are outside this change. Workspace videos download fully before playback; codec and provider limits still apply.
- Provider traffic in the journeys is mocked; no live-provider inference or deployment was performed.

Exact-head evidence for both journeys is attached in the PR comments.
