### PR TITLE
fix(app): discover external v2 conversation forks

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1111,12 +1111,14 @@ export function translateV2Event(
 async function* translateV2Events(
   response: Response,
   signal: AbortSignal | undefined,
+  fetchSession: (sessionID: string, signal: AbortSignal) => Promise<Session | null>,
   directory?: string,
 ): AsyncGenerator<OpencodeEvent> {
   if (!response.body) return;
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   const state = createV2EventTranslationState();
+  const discoveredForks = new Set<string>();
   let buffer = "";
   try {
     while (!signal?.aborted) {
@@ -1138,6 +1140,34 @@ async function* translateV2Events(
         }
         const eventDirectory = isRecord(event) ? readString(readRecord(event, "location") ?? {}, "directory") : undefined;
         if (directory && (!eventDirectory || normalizeDirectoryPath(directory) !== normalizeDirectoryPath(eventDirectory))) continue;
+        if (isRecord(event) && event.type === "session.forked") {
+          const sessionID = readSessionID(eventProperties(event));
+          if (!sessionID || discoveredForks.has(sessionID)) continue;
+          // Fork events contain ancestry, not a session. In particular their
+          // parentID must not turn the new root conversation into a task child.
+          const timeout = AbortSignal.timeout(2_000);
+          const lookupSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+          let onAbort = () => {};
+          const aborted = new Promise<null>((resolve) => {
+            onAbort = () => resolve(null);
+            lookupSignal.addEventListener("abort", onAbort, { once: true });
+            if (lookupSignal.aborted) onAbort();
+          });
+          try {
+            // Desktop IPC may not cancel its transport; still bound SSE delay.
+            const info = await Promise.race([fetchSession(sessionID, lookupSignal), aborted]);
+            if (lookupSignal.aborted || !info || info.id !== sessionID || !info.directory) continue;
+            if (eventDirectory && normalizeDirectoryPath(info.directory) !== normalizeDirectoryPath(eventDirectory)) continue;
+            discoveredForks.add(sessionID);
+            yield { type: "session.created", properties: { info } };
+          } catch {
+            // Deleted sessions and unavailable lookups must not end the SSE
+            // stream. A replay or the normal list refresh can discover it later.
+          } finally {
+            lookupSignal.removeEventListener("abort", onAbort);
+          }
+          continue;
+        }
         const translated = translateV2Event(event, state);
         if (!translated) continue;
         for (const item of translated) yield item;
@@ -1674,7 +1704,10 @@ export function createClientV2(
           throw error;
         }
         return {
-          stream: translateV2Events(response, options?.signal, directory),
+          stream: translateV2Events(response, options?.signal, async (sessionID, signal) => {
+            const result = await request("GET", `/api/session/${encodeURIComponent(sessionID)}`, undefined, signal);
+            return result.response.ok ? mapV2Session(result.payload, undefined) : null;
+          }, directory),
         };
       },
     },

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -33,6 +33,14 @@ const capturedPermissionReplied = {
   data: { sessionID: "ses_child", requestID: "per_child", reply: "once" },
 };
 
+// Native beta-19086 fork schema: ancestry is not the new session's parentID.
+const nativeForkEvent = {
+  type: "session.forked",
+  created: 1_788_548_737_221,
+  location: { directory: "/workspace" },
+  data: { sessionID: "ses_fork", parentID: "ses_source", boundary: { type: "through", messageID: "msg_source" } },
+};
+
 // Captured from 0.0.0-beta-19086 after approving one shell call with `once`.
 const capturedV2ToolMessage = {
   id: "msg_06e0e76b900178zSuF55n4XEPY",
@@ -1112,6 +1120,109 @@ describe("OpenCode v2 client compatibility", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("discovers external forks from authoritative sessions once, without fetching foreign events or the source", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Request[] = [];
+    const info = {
+      id: "ses_fork", title: "Source (fork #1)", slug: "fork-slug", projectID: "project",
+      location: { directory: "/workspace/" }, version: "native",
+      time: { created: 100, updated: 200 },
+      fork: { sessionID: "ses_source", boundary: nativeForkEvent.data.boundary },
+    };
+    const events = [
+      { ...nativeForkEvent, location: undefined, data: { ...nativeForkEvent.data, sessionID: "ses_unscoped" } },
+      { ...nativeForkEvent, location: { directory: "/other" }, data: { ...nativeForkEvent.data, sessionID: "ses_foreign" } },
+      nativeForkEvent, nativeForkEvent, capturedPermissionAsked,
+    ];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      requests.push(request);
+      return request.url.endsWith("/api/event")
+        ? new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""))
+        : jsonResponse({ data: info });
+    };
+    try {
+      const client = createClientV2("http://opencode.test/workspace/owned/opencode2", "/workspace", { token: "fixture-token" });
+      const subscription = await client.event.subscribe();
+      const received = [];
+      for await (const event of subscription.stream) received.push(event);
+      expect(received).toHaveLength(2);
+      expect(received[0]).toEqual({ type: "session.created", properties: { info: {
+        id: info.id, title: info.title, slug: info.slug, projectID: info.projectID,
+        directory: info.location.directory, version: info.version, time: info.time,
+      } } });
+      expect(received[1]?.type).toBe("permission.asked");
+      expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
+        ["GET", "/workspace/owned/opencode2/api/event"], ["GET", "/workspace/owned/opencode2/api/session/ses_fork"],
+      ]);
+      expect(requests.every((request) => request.headers.get("Authorization") === "Bearer fixture-token")).toBe(true);
+      expect((await client.session.fork({ sessionID: "ses_source" })).response.status).toBe(501);
+      expect(requests).toHaveLength(2);
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
+  test.each(["deleted", "unavailable", "network", "missing", "wrong-id", "foreign", "unscoped", "timeout"])(
+    "skips a %s fork lookup, continues the stream, and allows recovery on replay", async (failure) => {
+      const originalFetch = globalThis.fetch;
+      let lookups = 0;
+      let lookupSignal: AbortSignal | undefined;
+      const info = { id: "ses_fork", title: "Recovered fork", location: { directory: "/workspace" }, time: { created: 100, updated: 200 } };
+      globalThis.fetch = async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (request.url.endsWith("/api/event")) return new Response(
+          [nativeForkEvent, capturedPermissionAsked, nativeForkEvent].map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+        );
+        lookups += 1;
+        if (lookups > 1) return jsonResponse({ data: info });
+        lookupSignal = request.signal;
+        if (failure === "deleted") return jsonResponse({}, 404);
+        if (failure === "unavailable") return jsonResponse({}, 503);
+        if (failure === "network") throw new TypeError("Network unavailable");
+        if (failure === "missing") return jsonResponse({ data: null });
+        if (failure === "wrong-id") return jsonResponse({ data: { ...info, id: "ses_source" } });
+        if (failure === "foreign") return jsonResponse({ data: { ...info, location: { directory: "/other" } } });
+        if (failure === "unscoped") return jsonResponse({ data: { ...info, location: undefined } });
+        // An IPC transport may ignore cancellation entirely.
+        return new Promise<Response>(() => {});
+      };
+      try {
+        const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+        const subscription = await client.event.subscribe();
+        const started = Date.now();
+        expect((await subscription.stream.next()).value?.type).toBe("permission.asked");
+        expect(Date.now() - started).toBeLessThan(3_000);
+        if (failure === "timeout") expect(lookupSignal?.aborted).toBe(true);
+        expect((await subscription.stream.next()).value).toMatchObject({
+          type: "session.created", properties: { info: { id: info.id, title: info.title } },
+        });
+        expect(await subscription.stream.next()).toEqual({ done: true, value: undefined });
+        expect(lookups).toBe(2);
+      } finally { globalThis.fetch = originalFetch; }
+    },
+  );
+
+  test("aborting a subscription cancels its fork lookup without emitting a session", async () => {
+    const originalFetch = globalThis.fetch;
+    const controller = new AbortController();
+    const dispatched = Promise.withResolvers<Request>();
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.endsWith("/api/event")) return new Response(`data: ${JSON.stringify(nativeForkEvent)}\n\n`);
+      dispatched.resolve(request);
+      return new Promise<Response>((_resolve, reject) => {
+        request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
+      });
+    };
+    try {
+      const subscription = await createClientV2("http://opencode.test/opencode2", "/workspace", {}).event.subscribe({}, { signal: controller.signal });
+      const pending = subscription.stream.next();
+      const request = await dispatched.promise;
+      controller.abort();
+      expect(await pending).toEqual({ done: true, value: undefined });
+      expect(request.signal.aborted).toBe(true);
+    } finally { controller.abort(); globalThis.fetch = originalFetch; }
   });
 
   test.each([400, 409, 500])("returns native prompt admission failure %i to a separate send client", async (status) => {

--- a/evals/specs/sidebar-external-session-visibility.e2e.test.ts
+++ b/evals/specs/sidebar-external-session-visibility.e2e.test.ts
@@ -152,4 +152,39 @@ test("sessions created outside the window appear in a non-selected workspace's s
     `Session ${selectedId} was absent for ${STALE_OBSERVATION_MS}ms while ${homeName} was selected, then appeared under ${otherName} once it was selected; the earlier session ${reloadedId} stayed listed and ${homeName}'s list was unchanged.`,
     true,
   );
+
+  if (world.engine === "v2") {
+    await step("an external native fork appears live without refetching or changing its source", async () => {
+      await sleep(EMPTY_LIST_RETRY_SETTLE_MS);
+      await using events = await world.observeWorkspaceEvents(otherId);
+      const fork = await world.forkSessionOutsideWindow(otherId, selectedId);
+      expect(fork.title).toBe(`${selectedTitle} (fork #1)`);
+      expect(fork.sourceAfter).toEqual(fork.sourceBefore);
+      const afterFork = await probe.eventually(() => world.route(), {
+        within: 30_000, intervalMs: 250, label: "external fork discovered by the selected workspace stream",
+        until: (route) => sessionIds(route, otherId).includes(fork.id),
+      });
+      expect(sessionIds(afterFork, otherId).filter((id) => id === fork.id)).toHaveLength(1);
+      expect(sessionTitle(afterFork, otherId, fork.id)).toBe(fork.title);
+      expect(sessionTitle(afterFork, otherId, selectedId)).toBe(selectedTitle);
+      expect(sessionIds(afterFork, homeId)).toEqual(homeSessionsBefore);
+      expect(afterFork.selectedWorkspaceId).toBe(otherId);
+      await user.see({ text: fork.title });
+      await user.see({ text: selectedTitle });
+      const nativeEvents = await probe.eventually(() => events.snapshot(), {
+        within: 15_000, intervalMs: 250, label: "native fork event observed",
+        until: (text) => text.includes(fork.id),
+      });
+      const payloads = nativeEvents.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) => JSON.parse(line.slice(5)));
+      expect(payloads).toEqual(expect.arrayContaining([expect.objectContaining({
+        type: "session.forked", data: expect.objectContaining({ sessionID: fork.id, parentID: selectedId }),
+      })]));
+      expect(payloads).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "session.created" })]));
+      evidence.recordAssertionEvidence(
+        "external v2 forks appear once with the authoritative title, without refetching or changing the source or another workspace",
+        "The native stream emitted session.forked, not session.created. Its new identity appeared as a visible root conversation while the source metadata, exported history, source title, workspace selection, and other workspace list remained unchanged.",
+        true,
+      );
+    });
+  }
 });

--- a/evals/specs/sidebar-external-session-visibility.e2e.test.ts
+++ b/evals/specs/sidebar-external-session-visibility.e2e.test.ts
@@ -156,6 +156,18 @@ test("sessions created outside the window appear in a non-selected workspace's s
   if (world.engine === "v2") {
     await step("an external native fork appears live without refetching or changing its source", async () => {
       await sleep(EMPTY_LIST_RETRY_SETTLE_MS);
+      await using requests = await world.observeSessionRequests(otherId);
+      // Positive control: prove the witness sees the real desktop list transport.
+      await agent.run("workspace.reload_sessions", { workspaceId: otherId });
+      await probe.eventually(() => requests.snapshot().lists, {
+        within: 15_000, intervalMs: 250, label: "request witness detects deliberate session-list reload",
+        until: (count) => count > 0,
+      });
+      await probe.eventually(() => world.route(), {
+        within: 15_000, intervalMs: 250, label: "deliberate reload settled before fork observation",
+        until: (route) => route.workspaces.find((workspace) => workspace.id === otherId)?.loading === false,
+      });
+      const listsBeforeFork = requests.snapshot().lists;
       await using events = await world.observeWorkspaceEvents(otherId);
       const fork = await world.forkSessionOutsideWindow(otherId, selectedId);
       expect(fork.title).toBe(`${selectedTitle} (fork #1)`);
@@ -180,9 +192,15 @@ test("sessions created outside the window appear in a non-selected workspace's s
         type: "session.forked", data: expect.objectContaining({ sessionID: fork.id, parentID: selectedId }),
       })]));
       expect(payloads).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "session.created" })]));
+      await probe.eventually(() => requests.snapshot().reads, {
+        within: 15_000, intervalMs: 250, label: "desktop fetches the fork session directly",
+        until: (paths) => paths.some((path) => path.endsWith(`/api/session/${fork.id}`)),
+      });
+      await sleep(STALE_OBSERVATION_MS);
+      expect(requests.snapshot().lists).toBe(listsBeforeFork);
       evidence.recordAssertionEvidence(
         "external v2 forks appear once with the authoritative title, without refetching or changing the source or another workspace",
-        "The native stream emitted session.forked, not session.created. Its new identity appeared as a visible root conversation while the source metadata, exported history, source title, workspace selection, and other workspace list remained unchanged.",
+        "A CDP request witness detected the deliberate session-list reload before the fork, then the direct GET for the fork with no additional list requests through visibility and a quiet window. The native stream emitted session.forked, not session.created. Its new identity appeared as a visible root conversation while the source metadata, exported history, source title, workspace selection, and other workspace list remained unchanged.",
         true,
       );
     });

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -504,6 +504,63 @@ export async function externalSessionVisibility(seed: Seed) {
     other,
     homePath,
     engine: resolveEvalEngine(),
+    async observeSessionRequests(workspaceId: string) {
+      const debuggerUrl = app.client.webSocketDebuggerUrl;
+      if (!debuggerUrl) throw new Error("Session request witness needs a desktop CDP endpoint");
+      const socket = new WebSocket(debuggerUrl);
+      const ready = Promise.withResolvers<void>();
+      const requests: { method: string; path: string }[] = [];
+      const prefixes = ["workspace", "w"].map((mount) => `/${mount}/${encodeURIComponent(workspaceId)}/opencode2/api/session`);
+      let failure: Error | undefined;
+      let disposed = false;
+      const fail = () => {
+        if (disposed) return;
+        failure = new Error("Session request witness lost its CDP connection");
+        ready.reject(failure);
+      };
+      const timeout = setTimeout(() => ready.reject(new Error("Session request witness did not become ready")), 15_000);
+      socket.addEventListener("open", () => socket.send(JSON.stringify({ id: 1, method: "Network.enable" })));
+      socket.addEventListener("error", fail);
+      socket.addEventListener("close", fail);
+      socket.addEventListener("message", (event) => {
+        const message: unknown = JSON.parse(String(event.data));
+        if (!isRecord(message)) return;
+        if (message.id === 1) {
+          if (message.error) ready.reject(new Error("Session request witness could not enable Network events"));
+          else ready.resolve();
+        }
+        if (message.method !== "Network.requestWillBeSent" || !isRecord(message.params)) return;
+        const request = message.params.request;
+        if (!isRecord(request) || typeof request.url !== "string" || typeof request.method !== "string") return;
+        const url = new URL(request.url);
+        const path = url.pathname.replace(/\/+$/, "");
+        if (url.origin !== serverUrl.origin || !prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))) return;
+        // Retain only method/path: headers and request bodies may contain secrets.
+        requests.push({ method: request.method, path });
+      });
+      try {
+        await ready.promise;
+      } catch (error) {
+        disposed = true;
+        socket.close();
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+      return {
+        snapshot() {
+          if (failure) throw failure;
+          return {
+            lists: requests.filter((request) => request.method === "GET" && prefixes.includes(request.path)).length,
+            reads: requests.filter((request) => request.method === "GET").map((request) => request.path),
+          };
+        },
+        async [Symbol.asyncDispose]() {
+          disposed = true;
+          socket.close();
+        },
+      };
+    },
     async observeWorkspaceEvents(workspaceId: string) {
       const abort = new AbortController();
       const url = new URL(`${externalServerUrl}/workspace/${encodeURIComponent(workspaceId)}/opencode2/api/event`);

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -546,6 +546,32 @@ export async function externalSessionVisibility(seed: Seed) {
       if (!response.ok) throw new Error(`Session list returned HTTP ${response.status}`);
       return response.data.map((session) => session.id);
     },
+    async forkSessionOutsideWindow(workspaceId: string, sessionId: string) {
+      const base = `${externalServerUrl}/workspace/${encodeURIComponent(workspaceId)}/opencode2/api/session/${encodeURIComponent(sessionId)}`;
+      const request = async (path: string, body?: unknown): Promise<unknown> => {
+        const response = await fetch(`${base}${path}`, {
+          method: body === undefined ? "GET" : "POST",
+          headers: { Authorization: `Bearer ${serverToken}`, "Content-Type": "application/json" },
+          ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+          signal: AbortSignal.timeout(30_000),
+        });
+        if (!response.ok) throw new Error(`External fork setup ${path} returned HTTP ${response.status}`);
+        return response.status === 204 ? null : response.json();
+      };
+      // A settled native shell message supplies a fork boundary without a model.
+      await request("/shell", { command: "printf 'External fork history\\n'" });
+      const sourceBefore = { info: await request(""), history: await request("/export") };
+      const response = await request("/fork", { boundary: { type: "through" } });
+      if (!isRecord(response) || !isRecord(response.data) || typeof response.data.id !== "string" || typeof response.data.title !== "string") {
+        throw new Error("Native fork did not return a complete session identity and title");
+      }
+      return {
+        id: response.data.id,
+        title: response.data.title,
+        sourceBefore,
+        sourceAfter: { info: await request(""), history: await request("/export") },
+      };
+    },
     /** The sidebar's own per-workspace session lists and load state. */
     // TODO(primitive): probe.route should expose the sidebar's per-workspace session lists.
     async route(): Promise<SidebarRouteFacts> {


### PR DESCRIPTION
## Summary
External native v2 forks now appear in the selected workspace sidebar without selecting the workspace again or reloading its session list.

- Handle `session.forked` by fetching the new session through the existing authenticated workspace mount, then use the existing `session.created` discovery path.
- Preserve the authoritative title, timestamps, directory, and root-session identity instead of interpreting fork ancestry as a task-child relationship.
- Deduplicate successful discoveries per subscription; skip missing, deleted, failed, or mismatched lookups without ending SSE. Bound each lookup wait to two seconds, including transports that ignore cancellation. A failed lookup remains eligible for replay or normal list refresh.
- Leave the unsupported user-facing fork command, source conversation, other v2 lifecycle behavior, and sidebar design unchanged.

## Verification
Verdict: **Passed**.

Head: `9c02af9e51507eed6b1ba1c3381bdd51545b0988`
Base and merge-base: `68afcc7420a72b7b8d601169ff14b30d3eab09c4` (`dev`). Commit signature verified (`G`).

- `pnpm --filter @openwork/app exec bun test tests/opencode-v2-adapter.test.ts`: exit 0; 59 passed, 0 failed. Covers authoritative mapping, replay deduplication, workspace scoping, lookup failures/timeouts, cancellation, and the unchanged unsupported fork command.
- `OPENWORK_EVAL_REF=9c02af9e51507eed6b1ba1c3381bdd51545b0988 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e sidebar-external-session-visibility`: exit 0; 1 passed, 0 failed, 0 skipped.
- Placement: `daytona (daytona CLI authenticated)`. Fresh sandbox checked out the exact head; teardown confirmed deletion.
- Extended the existing sidebar journey and world, with no new test files. The journey asserts the native fork-only event, one visible root conversation with its authoritative title, unchanged source metadata/exported history/title, unchanged selection, and unchanged other-workspace list.
- `git diff --check`: passed.

## Limits
Live discovery applies to the subscribed workspace. Non-selected workspace discovery retains its existing selection/reload behavior. Lookup failures are skipped rather than retried in a loop. No broader v1, cross-platform, or unrelated lifecycle test campaign was run.

Head-matching test evidence is published in the accompanying sticky comment.

## Review follow-up
Added a read-only CDP Network request witness. A deliberate workspace.reload_sessions call first proves that the witness observes the real desktop list transport. During the subsequent fork and visibility window, it observes the targeted session GET and asserts the session-list request count does not increase, including a quiet window afterward. Only HTTP methods and paths are retained; no request headers or bodies are recorded. The strengthened exact-head v2 Daytona journey passes with zero failures or skips.