### PR TITLE
fix(app): make v2 session archive availability explicit

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -67,6 +67,8 @@ type SessionUpdateParameters = SessionParameters & {
   time?: { archived?: number };
 };
 
+export const V2_SESSION_ARCHIVE_UNAVAILABLE = "Archiving and unarchiving are not available in the OpenCode v2 preview.";
+
 type PermissionReply = "once" | "always" | "reject";
 
 type PermissionReplyParameters = DirectoryParameters & {
@@ -1196,9 +1198,9 @@ function localResult<T>(baseUrl: string, path: string, data: T): FieldsResult<T>
   };
 }
 
-function unsupportedResult<T>(baseUrl: string, operation: string): FieldsResult<T> {
+function unsupportedResult<T>(baseUrl: string, operation: string, message?: string): FieldsResult<T> {
   return {
-    error: { name: "UnsupportedInV2Preview", operation },
+    error: { name: "UnsupportedInV2Preview", operation, ...(message ? { message } : {}) },
     request: new Request(`${baseUrl}/unsupported/${encodeURIComponent(operation)}`),
     response: new Response(null, { status: 501, statusText: "Unsupported in OpenCode v2 preview" }),
   };
@@ -1523,6 +1525,12 @@ export function createClientV2(
       parameters: SessionUpdateParameters,
       options?: RequestOptions,
     ): Promise<FieldsResult<Session>> => {
+      // The native preview exposes archived state but no archive mutation.
+      // Reject the entire update before a rename or read can imply success.
+      if (parameters.time?.archived !== undefined) {
+        if (options?.throwOnError) throw new Error(V2_SESSION_ARCHIVE_UNAVAILABLE);
+        return unsupportedResult(baseUrl, "session.archive", V2_SESSION_ARCHIVE_UNAVAILABLE);
+      }
       if (!parameters.title) return getSession(parameters, options);
       const result = await request(
         "POST",

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -271,6 +271,7 @@ export type SessionPageProps = {
   onRenameSession?: (sessionId: string, title: string) => Promise<void> | void;
   onDeleteSession?: (sessionId: string) => Promise<void> | void;
   onArchiveSession?: (sessionId: string, archived: boolean) => Promise<void> | void;
+  archiveDisabledReason?: string;
   onAccessibleTargetsChange?: (targets: OpenTarget[]) => void;
   /** Settings content rendered inside the right pane when the settings rail icon is active. */
   settingsSlot?: React.ReactNode;
@@ -1418,6 +1419,7 @@ export function SessionPage(props: SessionPageProps) {
           onArchiveSession={props.onArchiveSession ? (sessionId, archived) => {
             void props.onArchiveSession?.(sessionId, archived);
           } : undefined}
+          archiveDisabledReason={props.archiveDisabledReason}
           onOpenCreateGroupModal={(workspaceId) => {
             setCreateGroupWorkspaceId(workspaceId);
             setCreateGroupLabel("");

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -33,6 +33,7 @@ type UseSessionControlActionsInput = {
   canCreateTask: boolean;
   openworkClient: OpenworkServerClient | null;
   opencodeClient: ReturnType<typeof createClient> | null;
+  archiveDisabledReason?: string;
   endpointForWorkspace: (workspace: SessionControlWorkspace | null | undefined) => ResolvedWorkspaceEndpoint | null;
   navigateToSession: (sessionId: string) => void;
   navigateToSessionRoot: () => void;
@@ -78,6 +79,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
     openModelPicker,
     openworkClient,
     opencodeClient,
+    archiveDisabledReason,
     refreshRouteState,
     selectedSessionId,
     selectedWorkspaceId,
@@ -281,17 +283,18 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const archiveControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.archive",
     label: "Archive or unarchive a session",
-    description: "Archive a session (non-destructive, preserves context). Archived sessions move to the Archived section. Pass archived=false to unarchive.",
+    description: archiveDisabledReason ?? "Archive a session (non-destructive, preserves context). Archived sessions move to the Archived section. Pass archived=false to unarchive.",
     sideEffect: "mutation",
     requiresArgs: true,
     args: [
       { name: "sessionId", type: "string", required: true, description: "Session ID." },
       { name: "archived", type: "boolean", required: true, description: "true to archive, false to unarchive." },
     ],
-    disabled: !opencodeClient,
+    disabled: !opencodeClient || Boolean(archiveDisabledReason),
     execute: async (args) => {
       const sessionId = stringArg(args, "sessionId");
       const archived = booleanArg(args, "archived");
+      if (archiveDisabledReason) return { ok: false, error: archiveDisabledReason };
       if (!sessionId) return { ok: false, error: "sessionId is required" };
       if (!opencodeClient) return { ok: false, error: "OpenCode client is not connected" };
       const targetWorkspace = findSessionWorkspace(workspaces, sessionsByWorkspaceId, sessionId);
@@ -299,7 +302,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
       await refreshRouteState();
       return { ok: true, sessionId, archived };
     },
-  }), [opencodeClient, refreshRouteState, selectedWorkspaceRoot, sessionsByWorkspaceId, workspaces]);
+  }), [archiveDisabledReason, opencodeClient, refreshRouteState, selectedWorkspaceRoot, sessionsByWorkspaceId, workspaces]);
   useControlAction(archiveControlAction);
 
   const groupCreateControlAction = useMemo<OpenworkControlAction>(() => ({

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -20,6 +20,7 @@ export type SidebarContextValue = {
   onOpenRenameSession?: (sessionId: string) => void;
   onOpenDeleteSession?: (sessionId: string) => void;
   onArchiveSession?: (sessionId: string, archived: boolean) => void;
+  archiveDisabledReason?: string;
   onOpenCreateGroupModal?: (workspaceId: string) => void;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -372,10 +372,13 @@ function SessionMenuContent({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         {ctx.onArchiveSession ? (
-          <DropdownMenuItem onClick={() => ctx.onArchiveSession?.(sessionId, !isArchived)}>
+          <DropdownMenuItem disabled={Boolean(ctx.archiveDisabledReason)} onClick={() => ctx.onArchiveSession?.(sessionId, !isArchived)}>
             {isArchived ? <ArchiveRestore className="size-4" /> : <Archive className="size-4" />}
             {isArchived ? t("session_management.unarchive_session") : t("session_management.archive_session")}
           </DropdownMenuItem>
+        ) : null}
+        {ctx.onArchiveSession && ctx.archiveDisabledReason ? (
+          <p className="px-2 py-1 text-xs text-muted-foreground">{ctx.archiveDisabledReason}</p>
         ) : null}
         {ctx.onOpenDeleteSession ? (
           <>
@@ -463,10 +466,13 @@ function SessionMenuContent({
         </ContextMenuSubContent>
       </ContextMenuSub>
       {ctx.onArchiveSession ? (
-        <ContextMenuItem onClick={() => ctx.onArchiveSession?.(sessionId, !isArchived)}>
+        <ContextMenuItem disabled={Boolean(ctx.archiveDisabledReason)} onClick={() => ctx.onArchiveSession?.(sessionId, !isArchived)}>
           {isArchived ? <ArchiveRestore className="size-4" /> : <Archive className="size-4" />}
           {isArchived ? t("session_management.unarchive_session") : t("session_management.archive_session")}
         </ContextMenuItem>
+      ) : null}
+      {ctx.onArchiveSession && ctx.archiveDisabledReason ? (
+        <p className="px-2 py-1 text-xs text-muted-foreground">{ctx.archiveDisabledReason}</p>
       ) : null}
       {ctx.onOpenDeleteSession ? (
         <>
@@ -553,6 +559,8 @@ function SessionHoverQuickActions({
           size="icon"
           className="size-5 text-muted-foreground hover:bg-transparent hover:text-foreground"
           aria-label={isArchived ? t("session_management.unarchive_session") : t("session_management.archive_session")}
+          disabled={Boolean(ctx.archiveDisabledReason)}
+          title={ctx.archiveDisabledReason}
           onClick={(event) => {
             event.stopPropagation();
             ctx.onArchiveSession?.(sessionId, !isArchived);
@@ -861,6 +869,7 @@ export type AppSidebarProps = {
   onOpenRenameSession?: (sessionId: string) => void;
   onOpenDeleteSession?: (sessionId: string) => void;
   onArchiveSession?: (sessionId: string, archived: boolean) => void;
+  archiveDisabledReason?: string;
   onOpenCreateGroupModal?: (workspaceId: string) => void;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
@@ -1001,6 +1010,7 @@ export function AppSidebar(props: AppSidebarProps) {
     onOpenRenameSession: props.onOpenRenameSession,
     onOpenDeleteSession: props.onOpenDeleteSession,
     onArchiveSession: props.onArchiveSession,
+    archiveDisabledReason: props.archiveDisabledReason,
     onOpenCreateGroupModal: props.onOpenCreateGroupModal,
     onOpenRenameWorkspace: props.onOpenRenameWorkspace,
     onShareWorkspace: props.onShareWorkspace,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -18,6 +18,7 @@ import { buildDiagnosticsBundleJson } from "@/app/lib/diagnostics-bundle";
 import { downloadTextAsFile } from "@/app/lib/download";
 import { canCreateWorkspaces } from "@/app/lib/workspace-creation-policy";
 import { createClient, unwrap } from "@/app/lib/opencode";
+import { isOpencodeV2BaseUrl, V2_SESSION_ARCHIVE_UNAVAILABLE } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe, forkSession, listCommands, revertSession, setSessionArchived, shellInSession, unrevertSession } from "@/app/lib/opencode-session";
 import { getNativeSessionMessages } from "@/app/lib/opencode-session-native";
 import { useSessionManagementStore as sessionManagementStore } from "@/react-app/domains/session/sidebar/session-management-store";
@@ -495,6 +496,7 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
+  const archiveDisabledReason = isOpencodeV2BaseUrl(opencodeBaseUrl) ? V2_SESSION_ARCHIVE_UNAVAILABLE : undefined;
   // The dashboard is user-scoped while MCP servers are workspace-scoped: the
   // selected workspace's runtime is primary, and every other available one is
   // a per-tile fallback so tiles keep working when the selected workspace does
@@ -2364,6 +2366,7 @@ export function SessionRoute() {
     canCreateTask,
     openworkClient: client,
     opencodeClient,
+    archiveDisabledReason,
     endpointForWorkspace,
     navigateToSession: navigateToSessionForControl,
     navigateToSessionRoot: navigateToSessionRootForControl,
@@ -3529,6 +3532,7 @@ export function SessionRoute() {
           : undefined
       }
       onArchiveSession={opencodeClient ? handleArchiveSession : undefined}
+      archiveDisabledReason={archiveDisabledReason}
       statusBar={{
         // No per-session loading state here: the account row renders only
         // app-scoped facts. Session loading lives in the pane; an unresolved

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -623,6 +623,32 @@ describe("OpenCode v2 event translation", () => {
 });
 
 describe("OpenCode v2 client compatibility", () => {
+  test.each([0, 1_788_548_737_221])("rejects archived=%i without reading, renaming, or deleting the session", async (archived) => {
+    const originalFetch = globalThis.fetch;
+    const requests: Request[] = [];
+    globalThis.fetch = async (input, init) => {
+      requests.push(input instanceof Request ? input : new Request(input, init));
+      return jsonResponse({ data: { id: "ses_archive", title: "Keep this session", time: { created: 1 } } });
+    };
+    try {
+      const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
+      for (const title of [undefined, "Do not partially rename"]) {
+        const parameters = { sessionID: "ses_archive", title, time: { archived } };
+        const result = await client.session.update(parameters);
+        expect(result.response.status).toBe(501);
+        expect(result.data).toBeUndefined();
+        expect(result.error).toMatchObject({
+          name: "UnsupportedInV2Preview", operation: "session.archive",
+          message: "Archiving and unarchiving are not available in the OpenCode v2 preview.",
+        });
+        await expect(client.session.update(parameters, { throwOnError: true })).rejects.toThrow("Archiving and unarchiving are not available");
+      }
+      expect(requests).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("saved native instruction updates stay out of the visible conversation", async () => {
     const originalFetch = globalThis.fetch;
     const notice = "New skills are available in addition to those previously listed.";

--- a/evals/specs/session-archive-undo.e2e.test.ts
+++ b/evals/specs/session-archive-undo.e2e.test.ts
@@ -10,7 +10,7 @@ const undoButton: Target = { role: "button", label: "Undo" };
 const viewButton: Target = { role: "button", label: "View" };
 const archiveMenuItem: Target = { role: "menuitem", label: "Archive session" };
 
-test("archiving a session from the sidebar confirms quietly and can be undone", async ({ world, user, agent, probe, step }) => {
+test("session archive is honest about availability and can be undone when supported", async ({ world, user, agent, probe, step }) => {
   const candidateId = world.candidate.sessionId;
   const neighborId = world.neighbor.sessionId;
   const archiveCandidate = async () => {
@@ -45,6 +45,31 @@ test("archiving a session from the sidebar confirms quietly and can be undone", 
     expect(sidebar.archivedSection).toBe(false);
     await user.notSee(archivedToast);
   });
+
+  if (world.engine === "v2") {
+    await step("v2 archive is unavailable without changing either session or claiming success", async () => {
+      await user.rightClick({ text: world.candidate.title });
+      await user.see(archiveMenuItem);
+      expect((await world.sidebar()).archiveMenuDisabled).toBe(true);
+      await user.see({ text: "Archiving and unarchiving are not available in the OpenCode v2 preview." });
+      await user.screenshot();
+      await user.press("Escape");
+      for (const archived of [true, false]) {
+        await expect(agent.run("session.archive", { sessionId: candidateId, archived })).rejects.toThrow("Action is disabled");
+      }
+      const stamps = await world.archivedAt();
+      expect(stamps[candidateId]).toBe(0);
+      expect(stamps[neighborId]).toBe(0);
+      const sidebar = await world.sidebar();
+      expect(sidebar.active).toContain(candidateId);
+      expect(sidebar.active).toContain(neighborId);
+      expect(sidebar.archivedSection).toBe(false);
+      await user.notSee(archivedToast);
+      await user.notSee({ text: "Session unarchived" });
+      await user.notSee(undoButton);
+    });
+    return;
+  }
 
   await step("archiving the candidate moves only it and offers a way back", async () => {
     await archiveCandidate();

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -305,6 +305,7 @@ export async function commandPaletteSearch(seed: Seed) {
 }
 
 export async function archiveSessions(seed: Seed) {
+  const engine = resolveEvalEngine();
   const app = await seed.desktop({ name: "session-archive-undo" });
   const workspacePath = seed.tmpPath("session-archive-undo");
   const workspace = await seed.workspace(app, workspacePath);
@@ -317,11 +318,11 @@ export async function archiveSessions(seed: Seed) {
    */
   // TODO(primitive): probe.sessions should expose the workspace's native session list.
   async function archivedAt(): Promise<Record<string, number>> {
-    const value = await seed.evalIn(app, `async (workspaceId) => {
+    const value = await seed.evalIn(app, `async (workspaceId, engine) => {
       const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
       if (!info?.running || !info.baseUrl) throw new Error("OpenWork server is unavailable");
       const response = await fetch(
-        String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId) + "/opencode/session?limit=200",
+        String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId) + (engine === "v2" ? "/opencode2/api/session?limit=200" : "/opencode/session?limit=200"),
         {
           headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
           signal: AbortSignal.timeout(15000),
@@ -329,11 +330,12 @@ export async function archiveSessions(seed: Seed) {
       );
       if (!response.ok) throw new Error("Workspace session listing failed with HTTP " + response.status);
       const body = await response.json();
-      if (!Array.isArray(body)) throw new Error("Workspace session listing was not an array");
-      return Object.fromEntries(body
+      const sessions = engine === "v2" ? body.data : body;
+      if (!Array.isArray(sessions)) throw new Error("Workspace session listing was not an array");
+      return Object.fromEntries(sessions
         .filter((session) => typeof session?.id === "string")
         .map((session) => [session.id, typeof session?.time?.archived === "number" ? session.time.archived : 0]));
-    }`, { args: [workspace.workspaceId], awaitPromise: true, timeoutMs: 20_000 });
+    }`, { args: [workspace.workspaceId, engine], awaitPromise: true, timeoutMs: 20_000 });
     if (!isRecord(value)) throw new Error(`Workspace archived state was malformed: ${JSON.stringify(value)}`);
     const stamps: Record<string, number> = {};
     for (const [sessionId, stamp] of Object.entries(value)) {
@@ -345,22 +347,25 @@ export async function archiveSessions(seed: Seed) {
 
   /** Which rows the workspace's own session tree shows, and whether the global Archived section exists. */
   // TODO(primitive): probe.sidebar should expose the workspace tree and the Archived section.
-  async function sidebar(): Promise<{ active: string[]; archivedSection: boolean }> {
+  async function sidebar(): Promise<{ active: string[]; archivedSection: boolean; archiveMenuDisabled: boolean }> {
     const value = await seed.evalIn(app, `(workspaceId) => {
       const tree = document.querySelector('[data-sidebar-workspace-id="' + workspaceId + '"]');
       return {
         active: [...(tree?.querySelectorAll("[data-sidebar-session-id]") ?? [])]
           .map((row) => row.getAttribute("data-sidebar-session-id")),
         archivedSection: Boolean(document.querySelector("[data-global-archived-sessions]")),
+        archiveMenuDisabled: [...document.querySelectorAll('[role="menuitem"][aria-disabled="true"]')]
+          .some((item) => item.textContent?.trim() === "Archive session"),
       };
     }`, { args: [workspace.workspaceId] });
     if (!isRecord(value)
       || !Array.isArray(value.active)
       || !value.active.every((sessionId) => typeof sessionId === "string")
-      || typeof value.archivedSection !== "boolean") {
+      || typeof value.archivedSection !== "boolean"
+      || typeof value.archiveMenuDisabled !== "boolean") {
       throw new Error(`Sidebar archive facts were malformed: ${JSON.stringify(value)}`);
     }
-    return { active: value.active, archivedSection: value.archivedSection };
+    return { active: value.active, archivedSection: value.archivedSection, archiveMenuDisabled: value.archiveMenuDisabled };
   }
 
   /** True once the undo pill is on screen and its slide-in has finished, i.e. when a person would reach for it. */
@@ -376,7 +381,7 @@ export async function archiveSessions(seed: Seed) {
     return value === true;
   }
 
-  return { app, workspace, workspacePath, candidate, neighbor, archivedAt, sidebar, undoToastSettled };
+  return { app, engine, workspace, workspacePath, candidate, neighbor, archivedAt, sidebar, undoToastSettled };
 }
 
 export async function responsiveSessions(seed: Seed) {


### PR DESCRIPTION
## Summary
- Disable archive and unarchive controls with a visible explanation when the active session client routes through OpenCode v2. The session.archive control also reports unavailable.
- Reject time.archived updates with UnsupportedInV2Preview (501), before any read or partial rename. Never delete sessions or invent local archive persistence.
- Preserve the v1 archive, Undo, and View paths. Extend the existing archive journey and adapter tests; no new test files.

## Native Contract
The current pin is 0.0.0-beta-19086. The native contract at anomalyco/opencode b09a74591cbd4d2ea1488e56177898a13f21278d exposes Session.Info.time.archived but no archive mutation. Availability follows the routed /opencode2 client, not the preview preference alone.

## Verification
Head: e403c50e4dcaa101d7408e950c3621b0b374aa60
Base: dev at f58b627c993b981fe16bfa2723665e57c2811844

Archive journey verdict: **Passed** on the exact head for both engines. Overall verification: **Incomplete** because the broader eval typecheck remains unresolved.

- pnpm exec bun test apps/app/tests/opencode-v2-adapter.test.ts: exit 0, 49 passed, 0 failed. Covers archive/unarchive, combined rename rejection, throwOnError, and zero transport requests.
- pnpm typecheck: exit 0.
- OPENWORK_EVAL_REF=e403c50e4dcaa101d7408e950c3621b0b374aa60 OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e session-archive-undo: exit 0, 1 passed, 0 failed, 0 skipped.
- OPENWORK_EVAL_REF=e403c50e4dcaa101d7408e950c3621b0b374aa60 OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e session-archive-undo: exit 0, 1 passed, 0 failed, 0 skipped.
- Both runs: placement: daytona (daytona CLI authenticated). Fresh sandboxes, both deleted by the runner.
- pnpm --dir evals run typecheck: exit 2, errors across Den/schema exports and eval tooling, including api-keys.ts TS7006 and browser-film.ts TS18046. Broader typecheck remains unresolved; not claimed as a baseline failure and not changed in this archive-only PR.

Both completed runs were published with pnpm evals:e2e --publish --pr 4587 --test-run <run-directory>. The publisher keeps one sticky section, so the v1 output is retained below and the sticky comment contains v2 evidence. Expected rejection of the disabled session.archive action appears as two rejected calls in the v2 trace; the surrounding negative assertions pass. Screenshots are supplementary and unvalidated; the installed gh version cannot attach them.

## Limits
Native v2 archive remains unsupported. This change does not add an endpoint, migrate data, change engine selection, or address other v2 operations. No skipped journey tests. Broader eval typecheck repair is deferred.

## Published v1 Regression Evidence


## Test evidence — session-archive-is-honest-about-availability-and-can-be-undone-when-supported — ✅ passed

SHA e403c50e4dcaa101d7408e950c3621b0b374aa60 · engine v1

✅ **0/2 screenshots passed** · 0 expectations passed · 0 failed · 0 pending

> screenshots not attached (gh < 2.99; run `brew upgrade gh`)

**[world]** desktop(daytona) · workspace(/tmp/openwork-session-archive-undo-1788734965803) · sessions(2)
**[agent]** run(session.open)
**[probe]** hash · eventually(neighbor session route opens) · eventually(both sessions listed as active)
**[user]** notSee(text=Session archived) · rightClick(text=Archive candidate) · see(label=Archive session) · label=Archive session · click(label=Archive session) · see(text=Session archived, timeoutMs=30000)
**[probe]** eventually(undo pill finishes sliding in)
**[user]** see(label=Undo) · see(label=View) · screenshot
**[probe]** eventually(candidate archived on the server) · eventually(candidate leaves the workspace tree for the Archived section)
**[user]** label=Undo · click(label=Undo) · notSee(text=Session archived)
**[probe]** eventually(candidate active again on the server) · eventually(candidate back in the workspace tree with no Archived section)
**[user]** notSee(text=Session unarchived) · notSee(label=Undo) · rightClick(text=Archive candidate) · see(label=Archive session) · label=Archive session · click(label=Archive session) · see(text=Session archived, timeoutMs=30000)
**[probe]** eventually(undo pill finishes sliding in)
**[user]** label=View · click(label=View)
**[probe]** hash · eventually(candidate session route opens from View)
**[user]** notSee(text=Session archived) · screenshot
**steps** 1 ✅ both sessions are active and nothing is archived (4.2s) · 2 ✅ archiving the candidate moves only it and offers a way back (3.5s) · 3 ✅ Undo restores the candidate without announcing itself (10.1s) · 4 ✅ View opens the archived session and leaves it archived (6.6s)
**verdict** passed · 13 user observations (notSee ×5, see ×6, screenshot ×2) · 11 probes · steps 4/4

### ⚪ UNVALIDATED — 1. session-archive-is-honest-about-availability-and-can-be-undone-when-supported artifact 1

- ⚪ **UNVALIDATED** — no visual expectations recorded.

### ⚪ UNVALIDATED — 2. session-archive-is-honest-about-availability-and-can-be-undone-when-supported artifact 2

- ⚪ **UNVALIDATED** — no visual expectations recorded.

---
_Test run created 2026-09-06T22:47:51.009Z · Source: `evals/results/test-runs/2026-09-06T22-47-51-009Z-session-archive-is-honest-about-availability-and-can-be-undone-when-supported/test-run.json` · Repro: `pnpm --dir evals artifacts:publish -- --pr 4587 --test-run 2026-09-06T22-47-51-009Z-session-archive-is-honest-about-availability-and-can-be-undone-when-supported`_

