### PR TITLE
Choose a browser when right-clicking links

### DIFF
--- a/apps/app/src/overlay/index.tsx
+++ b/apps/app/src/overlay/index.tsx
@@ -17,7 +17,7 @@ type ContextMenuItem = {
 
 type ContextMenuRequest = {
   id: string;
-  source: "tab" | "page" | "sidebar";
+  source: "tab" | "page" | "sidebar" | "link";
   items: ContextMenuItem[];
 };
 
@@ -46,7 +46,7 @@ function ContextMenuSurface({
   onClose: () => void;
 }) {
   React.useEffect(() => {
-    // document.querySelector<HTMLButtonElement>(MENU_ITEM_SELECTOR)?.focus();
+    document.querySelector<HTMLButtonElement>(MENU_ITEM_SELECTOR)?.focus();
   }, [request.id]);
 
   return (
@@ -70,7 +70,7 @@ function ContextMenuSurface({
       <ContextMenuContent
         role="menu"
         aria-label={`${request.source} context menu`}
-        className="w-full"
+        className="w-full max-h-full"
       >
         {request.items.map((item) => {
           return (

--- a/apps/app/src/overlay/index.tsx
+++ b/apps/app/src/overlay/index.tsx
@@ -23,7 +23,7 @@ type ContextMenuRequest = {
 
 type MenuOverlayApi = {
   ready: () => void;
-  onShow: (callback: (request: ContextMenuRequest) => void) => () => void;
+  onShow: (callback: (request: ContextMenuRequest | null) => void) => () => void;
   choose: (requestId: string, itemId: string) => void;
   close: (requestId?: string) => void;
 };

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -388,6 +388,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     if (!view || !mainWindow) return;
     const restoreFocus = !view.webContents.isDestroyed() && view.webContents.isFocused?.();
     view.setVisible?.(false);
+    if (!view.webContents.isDestroyed()) view.webContents.send("openwork:menu-overlay:hide");
     try {
       if (mainWindow.contentView.children.includes(view)) {
         mainWindow.contentView.removeChildView(view);

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -4,7 +4,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, WebContentsView, clipboard, session, shell } from "electron";
+import { app, BrowserWindow, WebContentsView, clipboard, dialog, session, shell } from "electron";
 import {
   BACKGROUND_TAB_VIEWPORT,
   backgroundTabEmulationCommands,
@@ -12,6 +12,7 @@ import {
   foregroundTabEmulationCommands,
 } from "@openwork/browser-tabs";
 import { runDetachedTask } from "./process-resilience.mjs";
+import { listInstalledBrowsers } from "./installed-browsers.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BROWSER_SESSION_PARTITION = "persist:openwork-browser";
@@ -311,13 +312,15 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     return { x: Math.round(x), y: Math.round(y) };
   }
 
-  function menuOverlayBounds(point) {
+  function menuOverlayBounds(point, size = { width: MENU_OVERLAY_WIDTH, height: MENU_OVERLAY_HEIGHT }) {
     const [contentWidth, contentHeight] = window()?.getContentSize?.() ?? [MENU_OVERLAY_WIDTH, MENU_OVERLAY_HEIGHT];
+    const width = Math.min(size.width, contentWidth);
+    const height = Math.min(size.height, contentHeight);
     return {
-      x: Math.min(Math.max(point.x, 0), Math.max(contentWidth - MENU_OVERLAY_WIDTH - 4, 0)),
-      y: Math.min(Math.max(point.y, 0), Math.max(contentHeight - MENU_OVERLAY_HEIGHT - 4, 0)),
-      width: MENU_OVERLAY_WIDTH,
-      height: MENU_OVERLAY_HEIGHT,
+      x: Math.min(Math.max(point.x, 0), Math.max(contentWidth - width - 4, 0)),
+      y: Math.min(Math.max(point.y, 0), Math.max(contentHeight - height - 4, 0)),
+      width,
+      height,
     };
   }
 
@@ -383,6 +386,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     menuOverlayShowSerial += 1;
     menuOverlayRequest = null;
     if (!view || !mainWindow) return;
+    const restoreFocus = !view.webContents.isDestroyed() && view.webContents.isFocused?.();
     view.setVisible?.(false);
     try {
       if (mainWindow.contentView.children.includes(view)) {
@@ -391,6 +395,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     } catch {
       // already removed
     }
+    if (restoreFocus && !mainWindow.webContents.isDestroyed()) mainWindow.webContents.focus();
   }
 
   function bringMenuOverlayToTop(view) {
@@ -427,9 +432,40 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     const tab = getBrowserTab(String(tabId ?? ""));
     if (!window() || !tab || tab.view.webContents.isDestroyed()) return;
 
-    const showSerial = menuOverlayShowSerial + 1;
-    menuOverlayShowSerial = showSerial;
     const request = tabMenuRequest(tab, point ? scaleRendererPoint(point) : point);
+    await showMenuOverlay(request, ++menuOverlayShowSerial);
+  }
+
+  async function showLinkContextMenu({ url, point, sessionId }) {
+    if (typeof url !== "string" || !isHttpUrl(url) || url.length > 32_768) return;
+    const parsed = new URL(url);
+    if (parsed.username || parsed.password || /[\u0000-\u001f\u007f]/.test(url)) return;
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) return;
+    // Capture ownership before discovery; a later focus change must not retarget
+    // the link. Dismissals invalidate pending discovery through the serial.
+    const ownerSessionId = normalizeSessionId(sessionId) ?? registry.visibleSessionId();
+    hideMenuOverlay();
+    const showSerial = ++menuOverlayShowSerial;
+    const browsers = await listInstalledBrowsers();
+    if (showSerial !== menuOverlayShowSerial) return;
+    const items = [
+      { id: "open-builtin", label: "Open in OpenWork" },
+      { id: "open-external", label: "Open in Default Browser" },
+      ...browsers.map(({ id, name }) => ({ id: `browser:${id}`, label: `Open in ${name}` })),
+      { id: "copy-url", label: "Copy Link Address", separatorBefore: true },
+    ];
+    await showMenuOverlay({
+      id: `link-menu:${showSerial}`,
+      source: "link",
+      url,
+      ownerSessionId,
+      browsers,
+      items,
+      bounds: menuOverlayBounds(scaleRendererPoint(point), { width: 264, height: items.length * 36 + 28 }),
+    }, showSerial);
+  }
+
+  async function showMenuOverlay(request, showSerial) {
     const view = await ensureMenuOverlayView();
     if (showSerial !== menuOverlayShowSerial || menuOverlayView !== view) return;
     menuOverlayRequest = request;
@@ -452,8 +488,35 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
   function handleMenuOverlayChoice(payload) {
     if (!payload || payload.requestId !== menuOverlayRequest?.id) return;
     const request = menuOverlayRequest;
+    if (!request.items.some((item) => item.id === payload.itemId && !item.disabled)) return;
     const tab = getBrowserTab(request.tabId);
     hideMenuOverlay();
+
+    if (request.source === "link" && payload.itemId !== "copy-url") {
+      runDetachedTask("open link", async () => {
+        try {
+          const external = payload.itemId !== "open-builtin";
+          await checkPolicy?.({ url: request.url, external });
+          if (!external) {
+            createBrowserTab(request.url, { ownerSessionId: request.ownerSessionId, initializeBlank: false });
+          } else if (payload.itemId === "open-external") {
+            await shell.openExternal(request.url);
+          } else {
+            const browser = request.browsers.find(({ id }) => `browser:${id}` === payload.itemId);
+            await browser.open(request.url);
+          }
+        } catch {
+          const mainWindow = window();
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            await dialog.showMessageBox(mainWindow, {
+              type: "error", message: "Could not open this link",
+              detail: "Your browser may be unavailable, or your organization may restrict this destination. You can copy the link address instead.",
+            });
+          }
+        }
+      });
+      return;
+    }
 
     switch (payload.itemId) {
       case "copy-url":
@@ -1003,6 +1066,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     ipcMain.handle("openwork:browser:setProxy", (_event, proxy) => setBrowserProxy(proxy));
     ipcMain.handle("openwork:browser:getProxy", () => browserProxyState());
     ipcMain.handle("openwork:browser:tabContextMenu", (_event, tabId, point) => showBrowserTabContextMenu(tabId, point));
+    ipcMain.on("openwork:browser:linkContextMenu", (event, payload) => {
+      const mainContents = window()?.webContents;
+      if (event.sender !== mainContents || event.senderFrame !== mainContents?.mainFrame) return;
+      if (!payload || typeof payload !== "object") return;
+      runDetachedTask("show link context menu", () => showLinkContextMenu(payload));
+    });
     ipcMain.handle("openwork:browser:destroy", () => destroyBrowserView());
     ipcMain.on("openwork:menu-overlay:ready", (event) => {
       if (event.sender !== menuOverlayView?.webContents) return;

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -2,14 +2,15 @@ import assert from "node:assert/strict";
 import { register } from "node:module";
 import test from "node:test";
 
-// browser-panel.mjs imports "electron" at module scope. Resolve that specifier
-// to an in-memory stub so the panel's tab and view bookkeeping can run under
-// plain Node.
+// Keep Electron and installed-browser discovery in memory: these guards must
+// never touch the clipboard, show a dialog, or launch a real browser.
 const electronStub = `
+export const effects = [];
 export const app = { on() {} };
-export const clipboard = { writeText() {} };
+export const clipboard = { writeText(url) { effects.push({ type: "copy", url }); } };
+export const dialog = { async showMessageBox() { effects.push({ type: "dialog" }); } };
 export const session = { fromPartition() { return { webRequest: { onBeforeRequest() {} } }; } };
-export const shell = { openExternal() { return Promise.resolve(); } };
+export const shell = { async openExternal(url) { effects.push({ type: "external", url }); } };
 export const createdViews = [];
 export class BrowserWindow {
   constructor(options) {
@@ -33,6 +34,8 @@ export class WebContentsView {
     this.bounds = { x: 0, y: 0, width: 0, height: 0 };
     this.webContents = {
       url: "about:blank",
+      sent: [],
+      send(channel, payload) { this.sent.push({ channel, payload }); },
       debugger: {
         commands: [],
         isAttached: () => attached,
@@ -60,30 +63,46 @@ export class WebContentsView {
 }
 `;
 
+const installedBrowsersStub = `
+import { effects } from "electron";
+export async function listInstalledBrowsers() {
+  return [["chrome", "Google Chrome"], ["firefox", "Firefox"]].map(([id, name]) => ({
+    id, name,
+    async open(url) { effects.push({ type: "browser", id, url }); },
+  }));
+}
+`;
+
 const hooks = `
 const stub = ${JSON.stringify(electronStub)};
+const browsers = ${JSON.stringify(installedBrowsersStub)};
 export function resolve(specifier, context, next) {
   if (specifier === "electron") return { url: "electron-stub:main", shortCircuit: true };
+  if (specifier === "./installed-browsers.mjs") return { url: "installed-browsers-stub:main", shortCircuit: true };
   return next(specifier, context);
 }
 export function load(url, context, next) {
   if (url === "electron-stub:main") return { format: "module", source: stub, shortCircuit: true };
+  if (url === "installed-browsers-stub:main") return { format: "module", source: browsers, shortCircuit: true };
   return next(url, context);
 }
 `;
 
 register(`data:text/javascript,${encodeURIComponent(hooks)}`);
 const { createBrowserPanel } = await import("./browser-panel.mjs");
-// @ts-expect-error The registered test-only Electron stub exports its view inventory.
-const { createdViews } = await import("electron");
+// @ts-expect-error The registered test-only Electron stub exports its witnesses.
+const { createdViews, effects } = await import("electron");
 
 const PANEL_BOUNDS = { x: 800, y: 40, width: 400, height: 900 };
+const LINK = { url: "https://example.com/a%2Fb?x=one%20two&x=%2F#section", point: { x: 20, y: 30 }, sessionId: "A" };
 const RESET_SEQUENCE = [
   { method: "Emulation.setDeviceMetricsOverride", params: { width: 0, height: 0, deviceScaleFactor: 0, mobile: false } },
   { method: "Emulation.clearDeviceMetricsOverride", params: undefined },
 ];
 
-function createPanel() {
+function createPanel(checkPolicy = async () => {}) {
+  effects.length = 0;
+  const policies = [];
   const children = [];
   const firstView = createdViews.length;
   const sent = [];
@@ -98,7 +117,13 @@ function createPanel() {
       },
       removeChildView(view) { children.splice(children.indexOf(view), 1); },
     },
-    webContents: { getZoomFactor: () => 1, isDestroyed: () => false, send(channel, payload) { sent.push({ channel, payload }); } },
+    webContents: {
+      mainFrame: {},
+      getURL: () => "http://localhost/index.html",
+      getZoomFactor: () => 1,
+      isDestroyed: () => false,
+      send(channel, payload) { sent.push({ channel, payload }); },
+    },
     isDestroyed: () => false,
   };
   const handlers = new Map();
@@ -106,14 +131,31 @@ function createPanel() {
     handle(channel, handler) { handlers.set(channel, handler); },
     on(channel, handler) { handlers.set(channel, handler); },
   };
-  createBrowserPanel({ getWindow: () => mainWindow, remoteDebugPort: 0, onDeepLink: () => {}, checkPolicy: async () => {} }).registerIpc(ipcMain);
-  const invoke = (channel, ...args) => handlers.get(channel)(null, ...args);
+  createBrowserPanel({
+    getWindow: () => mainWindow, remoteDebugPort: 0, onDeepLink: () => {},
+    checkPolicy: async (request) => { policies.push(request); await checkPolicy(request); },
+  }).registerIpc(ipcMain);
+  const mainContents = mainWindow.webContents;
+  const emit = (channel, event, ...args) => handlers.get(channel)(event, ...args);
+  const invoke = (channel, ...args) => emit(channel, { sender: mainContents, senderFrame: mainContents.mainFrame }, ...args);
   // Electron paints every child above the BrowserWindow's primary renderer.
   const onScreen = () => children.find((view) => view.getBounds().width > 1) ?? null;
   const views = () => createdViews.slice(firstView);
   const commands = (view) => view.webContents.debugger.commands;
   const messages = (channel) => sent.filter((entry) => entry.channel === channel).map((entry) => entry.payload);
-  return { invoke, onScreen, commands, children, messages, views };
+  async function openLinkMenu(payload = LINK) {
+    invoke("openwork:browser:linkContextMenu", payload);
+    await flush();
+    const view = views().find((view) => view.webContents.getURL() === "http://localhost/overlay.html");
+    assert.ok(view, "the link menu creates an overlay renderer");
+    emit("openwork:menu-overlay:ready", { sender: view.webContents });
+    await flush();
+    const request = view.webContents.sent.findLast((entry) => entry.channel === "openwork:menu-overlay:show")?.payload;
+    assert.ok(request, "the ready overlay receives its menu");
+    const choose = (itemId) => emit("openwork:menu-overlay:choose", { sender: view.webContents }, { requestId: request.id, itemId });
+    return { view, request, choose };
+  }
+  return { invoke, emit, mainContents, onScreen, commands, children, messages, views, policies, openLinkMenu };
 }
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
@@ -303,4 +345,95 @@ test("tabs created without a conversation stay shared and behave as before", asy
   assert.ok(onScreen(), "a shared tab stays on screen for every conversation");
   invoke("openwork:browser:closeAllTabs");
   assert.deepEqual(messages("openwork:browser:panel-closed"), [{ ownerSessionId: null }]);
+});
+
+test("a catalog choice launches only the selected browser with the exact link, not a built-in tab", async () => {
+  const { openLinkMenu, invoke, policies } = createPanel();
+  const { request, choose } = await openLinkMenu();
+  assert.equal(request.source, "link");
+  assert.equal(request.items.find((item) => item.id === "browser:firefox")?.label, "Open in Firefox");
+  choose("browser:firefox");
+  await flush();
+
+  assert.deepEqual(policies, [{ url: LINK.url, external: true }]);
+  assert.deepEqual(effects, [{ type: "browser", id: "firefox", url: LINK.url }]);
+  assert.deepEqual(invoke("openwork:browser:state").tabs, []);
+});
+
+test("external policy denial prevents catalog and default launches without a built-in fallback", async () => {
+  for (const itemId of ["browser:firefox", "open-external"]) {
+    const { openLinkMenu, invoke, policies } = createPanel(async () => { throw new Error("blocked"); });
+    const { choose } = await openLinkMenu();
+    choose(itemId);
+    await flush();
+
+    assert.deepEqual(policies, [{ url: LINK.url, external: true }], itemId);
+    assert.deepEqual(effects, [{ type: "dialog" }], itemId);
+    assert.deepEqual(invoke("openwork:browser:state").tabs, [], itemId);
+  }
+});
+
+test("copying a link neither checks policy nor launches a browser", async () => {
+  const { openLinkMenu, invoke, policies } = createPanel(async () => { throw new Error("blocked"); });
+  const { choose } = await openLinkMenu();
+  choose("copy-url");
+  await flush();
+
+  assert.deepEqual(effects, [{ type: "copy", url: LINK.url }]);
+  assert.deepEqual(policies, []);
+  assert.deepEqual(invoke("openwork:browser:state").tabs, []);
+});
+
+test("link menus reject untrusted senders, subframes, and non-HTTP payloads", async () => {
+  const { emit, invoke, mainContents, views, policies } = createPanel();
+  emit("openwork:browser:linkContextMenu", { sender: {}, senderFrame: mainContents.mainFrame }, LINK);
+  emit("openwork:browser:linkContextMenu", { sender: mainContents, senderFrame: {} }, LINK);
+  for (const url of ["javascript:alert(1)", "file:///tmp/link.html", "data:text/html,link", "openwork://settings"]) {
+    invoke("openwork:browser:linkContextMenu", { ...LINK, url });
+  }
+  await flush();
+
+  assert.deepEqual(views(), [], "rejected requests never create an overlay or tab");
+  assert.deepEqual(policies, []);
+  assert.deepEqual(effects, []);
+});
+
+test("the built-in choice retains the captured owner when focus changes before policy completes", async () => {
+  let allow;
+  const { openLinkMenu, invoke, policies } = createPanel(() => new Promise((resolve) => { allow = resolve; }));
+  invoke("openwork:browser:setVisibleSession", "B");
+  const { choose } = await openLinkMenu();
+  choose("open-builtin");
+  await flush();
+  assert.deepEqual(policies, [{ url: LINK.url, external: false }]);
+  assert.deepEqual(invoke("openwork:browser:state").tabs, [], "navigation waits for policy");
+  invoke("openwork:browser:setVisibleSession", "C");
+  allow();
+  await flush();
+
+  const state = invoke("openwork:browser:state");
+  assert.equal(state.visibleSessionId, "C");
+  assert.deepEqual(state.tabs.map(({ url, ownerSessionId }) => ({ url, ownerSessionId })), [{ url: LINK.url, ownerSessionId: "A" }]);
+  assert.equal(state.activeTabId, null, "the captured owner's tab does not take the visible conversation");
+  assert.deepEqual(effects, []);
+});
+
+test("forged menu requests, senders, and action IDs are ignored without dismissing the valid menu", async () => {
+  const { openLinkMenu, invoke, emit, policies, children } = createPanel();
+  invoke("openwork:browser:createTab", "https://existing.example");
+  const { view, request, choose } = await openLinkMenu();
+  const tabs = invoke("openwork:browser:state").tabs;
+  emit("openwork:menu-overlay:choose", { sender: view.webContents }, { requestId: "forged", itemId: "browser:firefox" });
+  invoke("openwork:menu-overlay:choose", { requestId: request.id, itemId: "browser:firefox" });
+  choose("browser:unlisted");
+  choose("close-all-tabs");
+  await flush();
+
+  assert.deepEqual(policies, []);
+  assert.deepEqual(effects, []);
+  assert.deepEqual(invoke("openwork:browser:state").tabs, tabs);
+  assert.ok(children.includes(view), "invalid choices leave the menu open");
+  choose("copy-url");
+  assert.deepEqual(effects, [{ type: "copy", url: LINK.url }]);
+  assert.ok(!children.includes(view), "a valid choice still works and dismisses the menu");
 });

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -133,7 +133,7 @@ function createPanel(checkPolicy = async () => {}) {
   };
   createBrowserPanel({
     getWindow: () => mainWindow, remoteDebugPort: 0, onDeepLink: () => {},
-    checkPolicy: async (request) => { policies.push(request); await checkPolicy(request); },
+    checkPolicy: async (request) => { policies.push(request); await checkPolicy(); },
   }).registerIpc(ipcMain);
   const mainContents = mainWindow.webContents;
   const emit = (channel, event, ...args) => handlers.get(channel)(event, ...args);
@@ -399,6 +399,7 @@ test("link menus reject untrusted senders, subframes, and non-HTTP payloads", as
 });
 
 test("the built-in choice retains the captured owner when focus changes before policy completes", async () => {
+  /** @type {(() => void) | undefined} */
   let allow;
   const { openLinkMenu, invoke, policies } = createPanel(() => new Promise((resolve) => { allow = resolve; }));
   invoke("openwork:browser:setVisibleSession", "B");
@@ -408,6 +409,7 @@ test("the built-in choice retains the captured owner when focus changes before p
   assert.deepEqual(policies, [{ url: LINK.url, external: false }]);
   assert.deepEqual(invoke("openwork:browser:state").tabs, [], "navigation waits for policy");
   invoke("openwork:browser:setVisibleSession", "C");
+  assert.ok(allow, "the pending policy check exposes its completion");
   allow();
   await flush();
 

--- a/apps/desktop/electron/installed-browsers.mjs
+++ b/apps/desktop/electron/installed-browsers.mjs
@@ -1,0 +1,213 @@
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+// Deliberately a catalog, not universal application enumeration. Only these
+// stable browser installations are supported (Safari and Arc are macOS-only).
+// No registry command strings, desktop Exec fields, profiles, or history are read.
+const BROWSERS = [
+  { id: "safari", name: "Safari", mac: ["Safari.app", "Safari"] },
+  {
+    id: "chrome", name: "Google Chrome",
+    mac: ["Google Chrome.app", "Google Chrome"],
+    win: "Google/Chrome/Application/chrome.exe",
+    linux: ["google-chrome", "google-chrome-stable"],
+  },
+  {
+    id: "firefox", name: "Firefox",
+    mac: ["Firefox.app", "firefox"],
+    win: "Mozilla Firefox/firefox.exe",
+    linux: ["firefox", "firefox-esr"],
+  },
+  {
+    id: "edge", name: "Microsoft Edge",
+    mac: ["Microsoft Edge.app", "Microsoft Edge"],
+    win: "Microsoft/Edge/Application/msedge.exe",
+    linux: ["microsoft-edge", "microsoft-edge-stable"],
+  },
+  {
+    id: "brave", name: "Brave",
+    mac: ["Brave Browser.app", "Brave Browser"],
+    win: "BraveSoftware/Brave-Browser/Application/brave.exe",
+    linux: ["brave-browser", "brave"],
+  },
+  { id: "arc", name: "Arc", mac: ["Arc.app", "Arc"] },
+  {
+    id: "chromium", name: "Chromium",
+    mac: ["Chromium.app", "Chromium"],
+    win: "Chromium/Application/chrome.exe",
+    linux: ["chromium", "chromium-browser"],
+  },
+  {
+    id: "vivaldi", name: "Vivaldi",
+    mac: ["Vivaldi.app", "Vivaldi"],
+    win: "Vivaldi/Application/vivaldi.exe",
+    linux: ["vivaldi", "vivaldi-stable"],
+  },
+  {
+    id: "opera", name: "Opera",
+    mac: ["Opera.app", "Opera"],
+    win: "Opera/launcher.exe",
+    linux: ["opera"],
+  },
+];
+
+// Reject raw and percent-encoded controls without rejecting UTF-8 continuation
+// bytes in otherwise ordinary encoded URLs.
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]|%(?:0[0-9a-f]|1[0-9a-f]|7f)|%c2%[89][0-9a-f]/i;
+
+async function isFile(file, mode) {
+  try {
+    if (!(await stat(file)).isFile()) return false;
+    await access(file, mode);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function launchBrowser(name, executable, args, waitForExit) {
+  return new Promise((resolve, reject) => {
+    let child;
+    let timer;
+    let settled = false;
+    function finish(failed) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child?.unref();
+      // Never propagate child-process errors containing the URL or output.
+      if (failed) reject(new Error(`Could not launch ${name}.`));
+      else resolve();
+    }
+
+    try {
+      child = spawn(executable, args, {
+        shell: false,
+        detached: !waitForExit,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch {
+      finish(true);
+      return;
+    }
+
+    timer = setTimeout(() => {
+      finish(true);
+      if (waitForExit) {
+        try { child.kill("SIGKILL"); } catch { /* Already exited. */ }
+      }
+    }, 5_000);
+    child.once("error", () => finish(true));
+    child.once("exit", (code) => finish(code !== 0));
+    child.once("spawn", () => {
+      if (waitForExit || settled) return;
+      clearTimeout(timer);
+      // A browser can live indefinitely. Observe early startup failures, then
+      // acknowledge startup, not page load or the browser's eventual exit.
+      timer = setTimeout(() => finish(false), 1_500);
+    });
+  });
+}
+
+/**
+ * Main-process-only descriptors: retain this list for one menu and expose only
+ * id/name to the renderer. Executable paths stay captured here, never in IPC.
+ *
+ * macOS: /Applications, ~/Applications, /System/Applications; require the known
+ * bundle executable and Info.plist. Relocated/renamed bundles are not enumerated.
+ * Windows: ProgramW6432, ProgramFiles, ProgramFiles(x86), LOCALAPPDATA and its
+ * Programs subdirectory, using only the relative .exe paths in BROWSERS.
+ * Linux: the catalog's executable names in the first 64 distinct absolute PATH
+ * directories; skip empty/relative entries. Symlinks and executable wrappers
+ * work; Flatpak-only registrations, arbitrary desktop files and other browsers
+ * are not enumerated. Unsupported platforms return an empty list.
+ *
+ * Discovery has a two-second budget and returns any completed matches in catalog
+ * order. It never executes a browser or a discovery command.
+ * @returns {Promise<Array<{ id: string, name: string, open: (url: string) => Promise<void> }>>}
+ */
+export async function listInstalledBrowsers() {
+  if (process.type && process.type !== "browser") {
+    throw new Error("Installed browser discovery is main-process-only.");
+  }
+
+  const platform = process.platform;
+  let roots;
+  if (platform === "darwin") {
+    roots = ["/Applications", path.join(homedir(), "Applications"), "/System/Applications"];
+  } else if (platform === "win32") {
+    roots = [
+      process.env.ProgramW6432,
+      process.env.ProgramFiles,
+      process.env["ProgramFiles(x86)"],
+      process.env.LOCALAPPDATA,
+      process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Programs"),
+    ];
+  } else if (platform === "linux") {
+    roots = (process.env.PATH ?? "").split(path.delimiter);
+  } else {
+    return [];
+  }
+  roots = [...new Set(roots.filter((root) => typeof root === "string" && path.isAbsolute(root)))].slice(0, 64);
+
+  const found = new Map();
+  let expired = false;
+  let timer;
+  try {
+    await Promise.race([
+      Promise.all(BROWSERS.map(async (browser) => {
+        const names = platform === "darwin"
+          ? [path.join(browser.mac[0], "Contents", "MacOS", browser.mac[1])]
+          : platform === "win32"
+            ? (browser.win ? [browser.win] : [])
+            : (browser.linux ?? []);
+        for (const root of roots) {
+          for (const name of names) {
+            if (expired) return;
+            const executable = path.join(root, name);
+            if (!await isFile(executable, platform === "win32" ? constants.F_OK : constants.X_OK)) continue;
+            const application = platform === "darwin" ? path.join(root, browser.mac[0]) : null;
+            if (application && !await isFile(path.join(application, "Contents", "Info.plist"), constants.R_OK)) continue;
+            if (expired) return;
+
+            found.set(browser.id, {
+              id: browser.id,
+              name: browser.name,
+              async open(url) {
+                let target;
+                try {
+                  if (typeof url !== "string" || url !== url.trim() || !/^https?:\/\//i.test(url)
+                    || url.includes("\\") || CONTROL_CHARACTERS.test(url)) throw new Error();
+                  target = new URL(url);
+                  if (!target.hostname || target.username || target.password
+                    || !["http:", "https:"].includes(target.protocol)
+                    || url.slice(url.indexOf("://") + 3).split(/[/?#]/, 1)[0].includes("@")) throw new Error();
+                } catch {
+                  throw new Error("Expected an HTTP(S) URL without credentials or control characters.");
+                }
+                await launchBrowser(
+                  browser.name,
+                  application ? "/usr/bin/open" : executable,
+                  application ? ["-a", application, target.href] : [target.href],
+                  application !== null,
+                );
+              },
+            });
+            return;
+          }
+        }
+      })),
+      new Promise((resolve) => {
+        timer = setTimeout(() => { expired = true; resolve(); }, 2_000);
+      }),
+    ]);
+  } finally {
+    expired = true;
+    clearTimeout(timer);
+  }
+  return BROWSERS.flatMap(({ id }) => found.has(id) ? [found.get(id)] : []);
+}

--- a/apps/desktop/electron/menu-overlay-preload.mjs
+++ b/apps/desktop/electron/menu-overlay-preload.mjs
@@ -8,6 +8,11 @@ ipcRenderer.on("openwork:menu-overlay:show", (_event, request) => {
   showCallback?.(request);
 });
 
+ipcRenderer.on("openwork:menu-overlay:hide", () => {
+  latestRequest = null;
+  showCallback?.(null);
+});
+
 contextBridge.exposeInMainWorld("__OPENWORK_MENU_OVERLAY__", {
   ready() {
     ipcRenderer.send("openwork:menu-overlay:ready");

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -49,6 +49,26 @@ function installMenuOverlayDismissListeners() {
   }
 }
 
+// Capture before message-bubble menus, but leave files, app routes, editable
+// text, and ordinary clicks to their existing handlers.
+window.addEventListener("contextmenu", (event) => {
+  const anchor = event.composedPath().find((node) => node instanceof HTMLAnchorElement);
+  if (!anchor || anchor.isContentEditable || anchor.hasAttribute("download")) return;
+  const href = anchor.getAttribute("href") ?? "";
+  if (!/^(https?:)?\/\//i.test(href)) return;
+  let url;
+  try { url = new URL(anchor.href); } catch { return; }
+  if (!["http:", "https:"].includes(url.protocol)) return;
+  if (url.origin === location.origin && url.pathname === location.pathname && url.search === location.search) return;
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  ipcRenderer.send("openwork:browser:linkContextMenu", {
+    url: url.href,
+    point: { x: event.clientX, y: event.clientY },
+    sessionId: anchor.closest("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? null,
+  });
+}, { capture: true });
+
 let desktopBootstrap = null;
 let desktopDistribution = null;
 try {

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -158,10 +158,11 @@ linkTest("a transcript link's menu copies its exact address and opens only its o
 
   await step("Right-click and Escape leave the transcript and every browser page unchanged", async () => {
     await menuFocus(true);
-    await menu.see({ role: "menu", label: "link context menu" });
     for (const label of ["Open in OpenWork", "Open in Default Browser", "Copy Link Address"]) {
       await menu.see(menuItem(label));
     }
+    // TargetRole excludes menu; keep its container semantics as a DOM observation.
+    expect(await world.menuLabels(overlay)).toEqual(["link context menu"]);
     await user.notSee(menuItem("Edit message"));
     await unchanged();
     await menu.press("Escape");

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -3,7 +3,10 @@ import type { Target } from "@openwork/cdp";
 import { eventually, spec } from "@openwork/testkit";
 import { builtinBrowserWorld, transcriptLinkWorld } from "../worlds/browser-panel.ts";
 
-const test = spec.world(builtinBrowserWorld);
+const test = spec.world(async (seed) => {
+  const world = await builtinBrowserWorld(seed);
+  return { ...world, withTranscriptLink: () => transcriptLinkWorld(seed, world) };
+});
 
 // A user reads one conversation while another conversation's agent browses the
 // web. The browser tab belongs to the conversation whose agent opened it: it
@@ -117,9 +120,8 @@ test("a background conversation's agent browses silently and its page is waiting
   });
 });
 
-const linkTest = spec.world(transcriptLinkWorld);
-
-linkTest("a transcript link's menu copies its exact address and opens only its own conversation's browser", async ({ world, user, step }) => {
+test("a transcript link's menu copies its exact address and opens only its own conversation's browser", async ({ world: browserWorld, user, step }) => {
+  const world = await browserWorld.withTranscriptLink();
   const link: Target = { role: "link", label: world.linkUrl };
   const menuItem = (label: string): Target => ({ role: "menuitem", label });
   await user.see(link);

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import type { Target } from "@openwork/cdp";
 import { eventually, spec } from "@openwork/testkit";
-import { builtinBrowserWorld } from "../worlds/browser-panel.ts";
+import { builtinBrowserWorld, transcriptLinkWorld } from "../worlds/browser-panel.ts";
 
 const test = spec.world(builtinBrowserWorld);
 
@@ -114,5 +114,158 @@ test("a background conversation's agent browses silently and its page is waiting
     });
     await user.see(tabButton(readingTab.name), { timeoutMs: 30_000 });
     expect(await world.readViewport(readingTab)).toEqual(panelViewport);
+  });
+});
+
+const linkTest = spec.world(transcriptLinkWorld);
+
+linkTest("a transcript link's menu copies its exact address and opens only its own conversation's browser", async ({ world, user, step }) => {
+  const link: Target = { role: "link", label: world.linkUrl };
+  const menuItem = (label: string): Target => ({ role: "menuitem", label });
+  await user.see(link);
+  expect(await world.readLink()).toEqual({ href: world.linkUrl, sessionId: world.reading.sessionId });
+  const initial = await eventually(() => world.readBrowserState(), {
+    within: 15_000,
+    until: state => state.visibleSessionId === world.reading.sessionId,
+    label: "the link's conversation is on screen",
+  });
+  expect(initial.tabs.map(tab => ({ id: tab.id, ownerSessionId: tab.ownerSessionId }))).toEqual([
+    { id: world.neighborTab.tabId, ownerSessionId: world.neighbor.sessionId },
+  ]);
+  const mainUrl = await world.readMainUrl();
+  const pages = await world.pageTargets();
+  const unchanged = async () => {
+    const state = await world.readBrowserState();
+    expect(state.tabs).toEqual(initial.tabs);
+    expect(state.activeTabId).toBe(initial.activeTabId);
+    expect(state.visibleSessionId).toBe(world.reading.sessionId);
+    expect(await world.readMainUrl()).toBe(mainUrl);
+    expect(await world.pageTargets()).toEqual(pages);
+    await user.see(link);
+  };
+
+  await user.rightClick(link);
+  const attached = await eventually(() => world.menuOverlay(), {
+    within: 15_000, until: value => value !== null, label: "the native overlay.html menu target appears",
+  });
+  if (!attached) throw new Error("The link context menu has no native overlay surface.");
+  await using overlay = attached;
+  const menu = user.on(overlay);
+  const menuFocus = (focused: boolean) => eventually(() => world.menuFocused(overlay), {
+    within: 10_000, until: value => value === focused,
+    label: focused ? "the native link menu receives keyboard focus" : "the native link menu releases keyboard focus",
+  });
+
+  await step("Right-click and Escape leave the transcript and every browser page unchanged", async () => {
+    await menuFocus(true);
+    await menu.see({ role: "menu", label: "link context menu" });
+    for (const label of ["Open in OpenWork", "Open in Default Browser", "Copy Link Address"]) {
+      await menu.see(menuItem(label));
+    }
+    await user.notSee(menuItem("Edit message"));
+    await unchanged();
+    await menu.press("Escape");
+    await menuFocus(false);
+    await unchanged();
+  });
+
+  await step("Copy Link Address copies the exact URL, not the whole message, without opening a page", async () => {
+    await user.rightClick(link);
+    await menuFocus(true);
+    await menu.click(menuItem("Copy Link Address"));
+    await menuFocus(false);
+    // Clipboard reads require the app document to be focused.
+    await user.click("composer");
+    expect(await world.readClipboard()).toBe(world.linkUrl);
+    await unchanged();
+  });
+
+  await step("Right-clicking nonlink message text still offers the message menu", async () => {
+    await user.rightClick({ text: world.note });
+    await user.see(menuItem("Edit message"));
+    await user.see(menuItem("Copy"));
+    await user.notSee(menuItem("Open in OpenWork"));
+    expect(await world.menuFocused(overlay)).toBe(false);
+    await user.press("Escape");
+    await user.notSee(menuItem("Edit message"));
+    await unchanged();
+  });
+
+  const opened = await step("Open in OpenWork creates exactly one tab owned by the link's conversation", async () => {
+    await user.rightClick(link);
+    await menuFocus(true);
+    await menu.click(menuItem("Open in OpenWork"));
+    await menuFocus(false);
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: value => value.tabs.some(tab => tab.url === world.linkUrl && tab.id === value.activeTabId),
+      label: "the selected built-in tab loads the exact transcript URL",
+    });
+    const tab = state.tabs.find(tab => tab.id === state.activeTabId);
+    if (!tab) throw new Error("The transcript link did not select a built-in browser tab.");
+    expect(tab).toMatchObject({ url: world.linkUrl, ownerSessionId: world.reading.sessionId });
+    expect(state.tabs).toHaveLength(initial.tabs.length + 1);
+    expect(state.tabs.filter(candidate => candidate.id !== tab.id)).toEqual(initial.tabs);
+    expect(state.visibleSessionId).toBe(world.reading.sessionId);
+    await user.see({ role: "button", label: `Select tab: ${tab.label}` });
+    await user.see({ placeholder: "Enter URL..." }, { value: world.linkUrl });
+    await user.notSee(tabButton(world.neighborTab.name));
+    await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: value => value.nativeViews.some(view => view.tabId === tab.id && view.attached && view.aboveApp),
+      label: "the new owned browser page is visible in the side panel",
+    });
+    expect(await world.readMainUrl()).toBe(mainUrl);
+    return tab;
+  });
+
+  await step("Switching conversations never shows or duplicates the other conversation's tab", async () => {
+    await user.click(conversation(world.neighbor.title));
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: value => value.visibleSessionId === world.neighbor.sessionId && value.activeTabId === world.neighborTab.tabId,
+      label: "the unrelated conversation restores only its original browser tab",
+    });
+    expect(state.tabs.filter(tab => tab.ownerSessionId === world.neighbor.sessionId)).toEqual(initial.tabs);
+    expect(state.tabs.filter(tab => tab.ownerSessionId === world.reading.sessionId)).toEqual([opened]);
+    expect(state.tabs).toHaveLength(2);
+    await user.see(tabButton(world.neighborTab.name));
+    await user.notSee({ role: "button", label: `Select tab: ${opened.label}` });
+    await user.click(conversation(world.reading.title));
+    await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: value => value.visibleSessionId === world.reading.sessionId && value.activeTabId === opened.id,
+      label: "the link's conversation restores its selected browser tab",
+    });
+    await user.see(link);
+    await user.see({ placeholder: "Enter URL..." }, { value: world.linkUrl });
+  });
+
+  await step("Normal click keeps the existing loopback-popup behavior without launching a system browser", async () => {
+    // Main-window target=_blank links to loopback are allowed as Electron popups.
+    // Do not substitute a public URL here: those launch the user's system browser.
+    expect(["127.0.0.1", "localhost"]).toContain(new URL(world.linkUrl).hostname);
+    const before = await world.pageTargets();
+    const browserBefore = await world.readBrowserState();
+    await user.click(link);
+    const after = await eventually(() => world.pageTargets(), {
+      within: 15_000,
+      until: value => value.some(page => page.url === world.linkUrl && !before.some(previous => previous.id === page.id)),
+      label: "a normal link click opens its existing Electron popup",
+    });
+    const popups = after.filter(page => !before.some(previous => previous.id === page.id));
+    try {
+      expect(popups).toHaveLength(1);
+      expect(popups[0]?.url).toBe(world.linkUrl);
+      expect((await world.readBrowserState()).tabs).toEqual(browserBefore.tabs);
+      expect(await world.readMainUrl()).toBe(mainUrl);
+      expect(await world.menuFocused(overlay)).toBe(false);
+    } finally {
+      for (const popup of popups) await world.closePopup(popup.id);
+    }
+    expect(await eventually(() => world.pageTargets(), {
+      within: 10_000, until: value => value.length === before.length,
+      label: "the normal-click popup is closed without changing existing pages",
+    })).toEqual(before);
   });
 });

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -153,13 +153,13 @@ test("a transcript link's menu copies its exact address and opens only its own c
   if (!attached) throw new Error("The link context menu has no native overlay surface.");
   await using overlay = attached;
   const menu = user.on(overlay);
-  const menuFocus = (focused: boolean) => eventually(() => world.menuFocused(overlay), {
-    within: 10_000, until: value => value === focused,
-    label: focused ? "the native link menu receives keyboard focus" : "the native link menu releases keyboard focus",
+  const menuShown = (shown: boolean) => eventually(() => world.menuShown(overlay), {
+    within: 10_000, until: value => value === shown,
+    label: shown ? "the native link menu is rendered" : "the dismissed link menu is cleared",
   });
 
   await step("Right-click and Escape leave the transcript and every browser page unchanged", async () => {
-    await menuFocus(true);
+    await menuShown(true);
     for (const label of ["Open in OpenWork", "Open in Default Browser", "Copy Link Address"]) {
       await menu.see(menuItem(label));
     }
@@ -168,15 +168,15 @@ test("a transcript link's menu copies its exact address and opens only its own c
     await user.notSee(menuItem("Edit message"));
     await unchanged();
     await menu.press("Escape");
-    await menuFocus(false);
+    await menuShown(false);
     await unchanged();
   });
 
   await step("Copy Link Address copies the exact URL, not the whole message, without opening a page", async () => {
     await user.rightClick(link);
-    await menuFocus(true);
+    await menuShown(true);
     await menu.click(menuItem("Copy Link Address"));
-    await menuFocus(false);
+    await menuShown(false);
     // Clipboard reads require the app document to be focused.
     await user.click("composer");
     expect(await world.readClipboard()).toBe(world.linkUrl);
@@ -188,7 +188,7 @@ test("a transcript link's menu copies its exact address and opens only its own c
     await user.see(menuItem("Edit message"));
     await user.see(menuItem("Copy"));
     await user.notSee(menuItem("Open in OpenWork"));
-    expect(await world.menuFocused(overlay)).toBe(false);
+    expect(await world.menuShown(overlay)).toBe(false);
     await user.press("Escape");
     await user.notSee(menuItem("Edit message"));
     await unchanged();
@@ -196,9 +196,9 @@ test("a transcript link's menu copies its exact address and opens only its own c
 
   const opened = await step("Open in OpenWork creates exactly one tab owned by the link's conversation", async () => {
     await user.rightClick(link);
-    await menuFocus(true);
+    await menuShown(true);
     await menu.click(menuItem("Open in OpenWork"));
-    await menuFocus(false);
+    await menuShown(false);
     const state = await eventually(() => world.readBrowserState(), {
       within: 30_000,
       until: value => value.tabs.some(tab => tab.url === world.linkUrl && tab.id === value.activeTabId),
@@ -262,7 +262,7 @@ test("a transcript link's menu copies its exact address and opens only its own c
       expect(popups[0]?.url).toBe(world.linkUrl);
       expect((await world.readBrowserState()).tabs).toEqual(browserBefore.tabs);
       expect(await world.readMainUrl()).toBe(mainUrl);
-      expect(await world.menuFocused(overlay)).toBe(false);
+      expect(await world.menuShown(overlay)).toBe(false);
     } finally {
       for (const popup of popups) await world.closePopup(popup.id);
     }

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -1,6 +1,6 @@
 import { control } from "@openwork/behaviors";
 import { captureScreenshot, connect, debuggerUrlFor, evaluate, listTargets, navigate } from "@openwork/cdp";
-import type { CdpClient, Surface } from "@openwork/cdp";
+import type { AttachedSurface, CdpClient, Surface } from "@openwork/cdp";
 import type { Seed } from "@openwork/env";
 
 export interface BuiltinBrowserTab {
@@ -23,6 +23,7 @@ export interface PageProbe extends Viewport {
 export interface BrowserTabState {
   id: string;
   label: string;
+  url: string;
   ownerSessionId: string | null;
 }
 
@@ -83,6 +84,7 @@ function parseBrowserState(value: unknown): BrowserState {
       return {
         id: stringField(tab.id),
         label: stringField(tab.label),
+        url: stringField(tab.url),
         ownerSessionId: typeof tab.ownerSessionId === "string" ? tab.ownerSessionId : null,
       };
     }),
@@ -442,4 +444,90 @@ export function builtinBrowserWorld(seed: Seed) {
 
 export function browserLoginSyncWorld(seed: Seed) {
   return createBuiltinBrowserWorld(seed, { OPENWORK_EVAL_BROWSER_LOGIN_SYNC: "1" });
+}
+
+/** Persist a real user message with a link; no model turn or injected DOM. */
+export async function transcriptLinkWorld(seed: Seed) {
+  const world = await builtinBrowserWorld(seed);
+  const { app, workspace } = world;
+  const reading = { ...world.session, title: "Reading a shared link" };
+  await world.renameSession(reading.sessionId, reading.title);
+  const neighbor = await world.openSession("Unrelated browser research");
+  const neighborTab = await world.openTabAs("link-neighbor", neighbor.sessionId);
+  const origin = await embeddedServerUrl(seed, app);
+  const linkUrl = `${origin}/?link-context=alpha%20beta&encoded=%2Fkeep%3Fyes%3D1#thread-link`;
+  const note = "Keep this note in its own conversation.";
+  await seed.evalIn(app, `async (workspaceId, sessionId, note, url) => {
+    const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
+    const response = await fetch(info.baseUrl.replace(/\\/+$/, "")
+      + "/workspace/" + encodeURIComponent(workspaceId)
+      + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
+      method: "POST",
+      headers: { Authorization: "Bearer " + info.ownerToken, "Content-Type": "application/json" },
+      body: JSON.stringify({ noReply: true, parts: [
+        { type: "text", text: note },
+        { type: "text", text: "Reference: " + url },
+      ] }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error("Transcript message seed failed: " + response.status);
+    return true;
+  }`, { args: [workspace.workspaceId, reading.sessionId, note, linkUrl], awaitPromise: true, timeoutMs: 35_000 });
+  await world.showSession(reading.sessionId);
+
+  return {
+    ...world,
+    reading,
+    neighbor,
+    neighborTab,
+    linkUrl,
+    note,
+
+    async readLink() {
+      return evaluate(app.client, `(() => {
+        const link = [...document.querySelectorAll('[data-message-role="user"] a[href]')]
+          .find(node => node.getAttribute("href") === ${JSON.stringify(linkUrl)});
+        return link ? { href: link.href, sessionId: link.closest("[data-session-surface-id]")?.dataset.sessionSurfaceId } : null;
+      })()`);
+    },
+
+    async readMainUrl() {
+      return evaluate(app.client, "location.href");
+    },
+
+    async readClipboard() {
+      return evaluate(app.client, "navigator.clipboard.readText()", { awaitPromise: true });
+    },
+
+    /** Exclude the menu document, but include popups and all built-in pages. */
+    async pageTargets() {
+      return (await listTargets(app.handle.cdpUrl))
+        .filter(target => target.type === "page" && !/\/overlay\.html(?:[?#]|$)/.test(target.url))
+        .map(({ id, url }) => ({ id, url }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+    },
+
+    /** Attach to the real WebContentsView, never invoke its choice/close bridge. */
+    async menuOverlay(): Promise<AttachedSurface | null> {
+      const target = (await listTargets(app.handle.cdpUrl))
+        .find(target => target.type === "page" && /\/overlay\.html(?:[?#]|$)/.test(target.url));
+      if (!target) return null;
+      const client = await connect(debuggerUrlFor(app.handle.cdpUrl, target));
+      return {
+        handle: { ...app.handle, name: "link-context-menu" },
+        client,
+        async stop() { client.close(); },
+        async [Symbol.asyncDispose]() { client.close(); },
+      };
+    },
+
+    async menuFocused(surface: Surface) {
+      // Native hiding retains the DOM; backgroundThrottling also affects visibilityState.
+      return await evaluate(surface.client, "document.hasFocus()") === true;
+    },
+
+    async closePopup(targetId: string) {
+      await app.client.send("Target.closeTarget", { targetId });
+    },
+  };
 }

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -111,6 +111,14 @@ async function embeddedServerUrl(seed: Seed, app: Surface): Promise<string> {
   return stringField(info.baseUrl).replace(/\/+$/, "");
 }
 
+async function loginWitnessUrl(seed: Seed, app: Surface): Promise<string> {
+  return stringField(await seed.evalIn(
+    app,
+    "window.__OPENWORK_ELECTRON__.browserLogins.testWitnessUrl()",
+    { awaitPromise: true },
+  ));
+}
+
 async function withTabClient<T>(app: Surface, targetId: string, run: (client: CdpClient) => Promise<T>): Promise<T> {
   const target = (await listTargets(app.handle.cdpUrl)).find((candidate) => candidate.id === targetId);
   if (!target) throw new Error(`Built-in browser tab target ${targetId} is not listed by the app's CDP endpoint.`);
@@ -146,11 +154,6 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
   const workspace = await seed.workspace(app, seed.tmpPath("builtin-browser"));
   const session = await seed.session(app);
   const origin = await embeddedServerUrl(seed, app);
-  const loginWitnessOrigin = stringField(await seed.evalIn(
-    app,
-    "window.__OPENWORK_ELECTRON__.browserLogins.testWitnessUrl()",
-    { awaitPromise: true },
-  ));
 
   return {
     app,
@@ -209,7 +212,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
 
     /** Open a page that reports only whether an HttpOnly session cookie arrived. */
     async openLoginWitnessTab(name: string): Promise<BuiltinBrowserTab> {
-      const url = `${loginWitnessOrigin}/?login-probe=${encodeURIComponent(name)}`;
+      const url = `${await loginWitnessUrl(seed, app)}/?login-probe=${encodeURIComponent(name)}`;
       const result = await seed.evalIn(
         app,
         `window.__OPENWORK_ELECTRON__.browser.openUrl(${JSON.stringify(url)})`,
@@ -221,7 +224,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
 
     /** Open the value-free login witness from a conversation that is not on screen. */
     async openLoginWitnessTabAs(name: string, ownerSessionId: string): Promise<OpenedTab> {
-      const url = `${loginWitnessOrigin}/?login-probe=${encodeURIComponent(name)}`;
+      const url = `${await loginWitnessUrl(seed, app)}/?login-probe=${encodeURIComponent(name)}`;
       const result = await seed.evalIn(
         app,
         `window.__openworkControl.command(${JSON.stringify({
@@ -275,9 +278,6 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
 
     /** The page origin the built-in browser can always reach: the embedded OpenWork server. */
     origin,
-
-    /** Host used by the value-free HttpOnly login witness. */
-    loginWitnessHost: new URL(loginWitnessOrigin).hostname,
 
     /**
      * Seed a Firefox-shaped cookie store the import dialog can find, so the
@@ -442,13 +442,18 @@ export function builtinBrowserWorld(seed: Seed) {
   return createBuiltinBrowserWorld(seed);
 }
 
-export function browserLoginSyncWorld(seed: Seed) {
-  return createBuiltinBrowserWorld(seed, { OPENWORK_EVAL_BROWSER_LOGIN_SYNC: "1" });
+export async function browserLoginSyncWorld(seed: Seed) {
+  const world = await createBuiltinBrowserWorld(seed, { OPENWORK_EVAL_BROWSER_LOGIN_SYNC: "1" });
+  const loginWitnessOrigin = await loginWitnessUrl(seed, world.app);
+  return {
+    ...world,
+    /** Host used by the value-free HttpOnly login witness. */
+    loginWitnessHost: new URL(loginWitnessOrigin).hostname,
+  };
 }
 
-/** Persist a real user message with a link; no model turn or injected DOM. */
-export async function transcriptLinkWorld(seed: Seed) {
-  const world = await builtinBrowserWorld(seed);
+/** Add a persisted transcript link to an existing world without launching another desktop. */
+export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<typeof builtinBrowserWorld>>) {
   const { app, workspace } = world;
   const reading = { ...world.session, title: "Reading a shared link" };
   await world.renameSession(reading.sessionId, reading.title);

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -521,6 +521,11 @@ export async function transcriptLinkWorld(seed: Seed) {
       };
     },
 
+    async menuLabels(surface: Surface) {
+      return evaluate(surface.client, `Array.from(document.querySelectorAll('[role="menu"]'),
+        menu => menu.getAttribute("aria-label"))`);
+    },
+
     async menuFocused(surface: Surface) {
       // Native hiding retains the DOM; backgroundThrottling also affects visibilityState.
       return await evaluate(surface.client, "document.hasFocus()") === true;

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -531,9 +531,10 @@ export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<
         menu => menu.getAttribute("aria-label"))`);
     },
 
-    async menuFocused(surface: Surface) {
-      // Native hiding retains the DOM; backgroundThrottling also affects visibilityState.
-      return await evaluate(surface.client, "document.hasFocus()") === true;
+    async menuShown(surface: Surface) {
+      // Chromium can retain document.hasFocus() on a detached native view. The
+      // renderer clears its menu on dismissal, so stale choices cannot persist.
+      return await evaluate(surface.client, 'Boolean(document.querySelector(\'[role="menu"]\'))') === true;
     },
 
     async closePopup(targetId: string) {


### PR DESCRIPTION
## Summary
- Add a link context menu in OpenWork Desktop: Open in OpenWork, Open in Default Browser, detected installed browsers, and Copy Link Address.
- Keep normal clicks, file links, app routes, and non-link message menus unchanged. Built-in tabs retain the originating conversation.
- Reuse the native-view menu overlay with keyboard dismissal and scrolling. Clear dismissed choices; keep launch paths in the main process, validate IPC and URLs, and enforce browser policy before opening.

## Scope
Installed-browser discovery uses a bounded catalog in standard macOS/Windows locations and Linux PATH (Safari, Chrome, Firefox, Edge, Brave, Arc, Chromium, Vivaldi, Opera where supported). Custom locations, profiles, and arbitrary browser registrations are not enumerated. Open in Default Browser remains available. This is the Desktop app document; web-host browser menus and embedded website menus are unchanged.

## Verification — Incomplete (external launch coverage deferred)
Head: `8e39e8ca12cb16fa16f9a25a58a875f9aa091747`, based on `dev@172897cae`.

### Passed
- `pnpm --filter @openwork/desktop typecheck:electron` — exit 0. Fixed the two test-helper TypeScript errors that blocked the build job.
- `node --test apps/desktop/electron/browser-panel.test.mjs` — exit 0; 15 passed, 0 failed, 0 skipped. Covers selected-browser dispatch, policy denial, copy isolation, sender validation, captured ownership, and forged choices.
- `OPENWORK_EVAL_REF=8e39e8ca12cb16fa16f9a25a58a875f9aa091747 pnpm evals:e2e browser-tabs-owned-by-thread` — exit 0; 2 passed, 0 failed, 0 skipped. `placement: daytona (daytona CLI authenticated)`. Cold-booted desktops checked out this exact SHA.
- Runtime coverage: real transcript link right-click, Escape dismissal, exact clipboard contents, built-in selection, conversation isolation, message-menu continuity, and unchanged normal-click behavior for loopback links. Evidence is posted below.
- GitHub `openwork-tests-build`, `openwork-tests-core`, and `openwork-tests-required` are passing on this head.

### Failed / skipped
No failures or skips in the selected local checks or final desktop journey. Unselected CI lanes were skipped by change classification, not claimed as proof.

### Deferred
Real external-browser launch and complete OS-specific catalog verification remain untested end-to-end; unit dispatch witnesses are not launch proof. Discovery observed Safari/Chrome on macOS and Chromium in the Linux desktop journey. Screenshots were not attached by the evidence publisher because the installed gh version lacks attachment support.

## Manual check
Right-click an HTTP(S) link in a conversation. Choose Open in OpenWork and confirm it stays with that conversation; copy the address; choose an installed browser. Confirm a normal click and right-click on non-link message text still behave as before.