### PR TITLE
Keep conversation links and working pages in the sidebar browser

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -30,6 +30,8 @@ import { openDesktopUrl, revealDesktopItemInDir } from "@/app/lib/desktop"
 import { isElectronRuntime } from "@/app/lib/runtime-env"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { t } from "@/i18n"
+import { useOpenTargets } from "@/lib/target-provider"
+import { openTargetFromUrl } from "@/react-app/domains/session/artifacts/open-target"
 import { sessionErrorPresentationFromUIMessage } from "@/react-app/domains/session/sync/session-error"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
@@ -680,6 +682,15 @@ function renderUserTextWithSkillChips(text: string, highlightQuery: string | und
 const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
     const { onRevertToUserMessage, onForkAtMessage, onEditUserMessage, highlightQuery } = useMessageList()
+    const { onOpenTarget } = useOpenTargets()
+    const openLink = (event: React.MouseEvent) => {
+      if (!onOpenTarget || !(event.target instanceof Element)) return
+      const link = event.target.closest("a[href]")
+      const target = openTargetFromUrl(link?.getAttribute("href") ?? "")
+      if (!target) return
+      event.preventDefault()
+      onOpenTarget(target)
+    }
     const messageText = React.useMemo(() => getMessagesText([message]), [message])
     const inlineParts = React.useMemo(
       () => message.parts.filter((part) => (part.type === "text" && Boolean(part.text)) || isFileUIPart(part)),
@@ -706,6 +717,7 @@ const UserMessage = React.memo(
                   <MessageContent
                     className="bg-muted text-foreground max-w-[85%] rounded-3xl px-4 py-2.5 leading-6 sm:max-w-[75%] !select-text not-prose"
                     style={{ userSelect: "text" }}
+                    onClick={openLink}
                   >
                     {inlineParts.map((part, index) => {
                       if (part.type === "text") {

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -9,7 +9,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useOpenTargets } from "@/lib/target-provider";
 import { useOpenArtifactPath } from "@/lib/artifacts";
-import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
+import { openTargetFromUrl, type OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
 
 import { applyTextHighlights } from "./text-highlights";
 import {
@@ -78,6 +78,10 @@ function filePathMatchesTarget(path: string, targetValue: string) {
 }
 
 function openTargetForHref(href: string, openTargets: OpenTarget[]) {
+  // A website in the transcript is a conversation target too. Let its owner
+  // open the built-in browser instead of Chromium spawning a separate window.
+  const urlTarget = openTargetFromUrl(href);
+  if (urlTarget) return urlTarget;
   const path = localPathFromHref(href);
 
   if (!path) {

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -28,6 +28,20 @@ export type OpenTarget = {
   updatedAt?: number;
 };
 
+/** Explicit links preserve the full address, unlike URLs extracted from prose. */
+export function openTargetFromUrl(href: string): OpenTarget | null {
+  const value = href.trim();
+  try {
+    if (!["http:", "https:"].includes(new URL(value).protocol)) return null;
+  } catch {
+    return null;
+  }
+  return {
+    id: `url:${value}`, kind: "url", value, name: value,
+    preview: "browser", confidence: 100, reason: "explicit link",
+  };
+}
+
 export function sameOpenTargets(left: OpenTarget[], right: OpenTarget[]): boolean {
   return left.length === right.length && left.every((target, index) => {
     const other = right[index];

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -529,7 +529,6 @@ export function SessionPage(props: SessionPageProps) {
   const [createGroupLabel, setCreateGroupLabel] = useState("");
   const [createGroupWorkspaceId, setCreateGroupWorkspaceId] = useState<string | null>(null);
   const browserPanelRef = usePanelRef();
-  const preserveSidePanelOnPanelOpenRef = useRef(false);
 
   const selectNarrowPane = useCallback((pane: NarrowSessionPane) => {
     setNarrowPane(pane);
@@ -622,9 +621,11 @@ export function SessionPage(props: SessionPageProps) {
     const browser = (window as Window).__OPENWORK_ELECTRON__?.browser;
     if (!browser) return;
     const unsubOpen = browser.onPanelOpened?.((payload) => {
-      if (preserveSidePanelOnPanelOpenRef.current) {
-        preserveSidePanelOnPanelOpenRef.current = false;
-        return;
+      const ownerSessionId = payload?.ownerSessionId ?? props.selectedSessionId;
+      if (ownerSessionId && payload?.tab) {
+        // A requested navigation selects its page, even when an artifact was
+        // active. Passive title/loading updates still preserve that artifact.
+        openTab(ownerSessionId, payload.tab);
       }
       openOwnerSidePanel(payload?.ownerSessionId);
     });
@@ -638,7 +639,7 @@ export function SessionPage(props: SessionPageProps) {
       setSidePanelState(ownerKey, null);
     });
     return () => { unsubOpen?.(); unsubClose?.(); };
-  }, [openOwnerSidePanel, setCurrentSidePanel, setSidePanelState, sidePanelSessionKey]);
+  }, [openOwnerSidePanel, openTab, props.selectedSessionId, setCurrentSidePanel, setSidePanelState, sidePanelSessionKey]);
   const {
     leftSidebarResizing,
     leftSidebarWidth,
@@ -737,7 +738,6 @@ export function SessionPage(props: SessionPageProps) {
         preview: fileTarget.preview,
         target: fileTarget,
       });
-      preserveSidePanelOnPanelOpenRef.current = true;
       setCurrentSidePanel("panel");
     };
 
@@ -857,9 +857,6 @@ export function SessionPage(props: SessionPageProps) {
     if (panelRailActive && activeTab?.type === "artifact") {
       toggleCurrentSidePanel("panel");
       return;
-    }
-    if (!panelRailActive) {
-      preserveSidePanelOnPanelOpenRef.current = true;
     }
     if (!panelRailActive) {
       toggleCurrentSidePanel("panel");

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -699,6 +699,15 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
     } else {
       sendBrowserState();
     }
+    if (select) {
+      // Explicit opens select their page in the owner's unified panel. Later
+      // navigations may keep that panel open, but must not displace an artifact
+      // the user selected while a page was loading or refreshing itself.
+      sendToRenderer("openwork:browser:panel-opened", {
+        ownerSessionId: registry.ownerOf(tabId),
+        tab: browserTabToPanelTab(tabId, tab),
+      });
+    }
     const finalUrl = normalizeBrowserUrl(url, "about:blank");
     if (finalUrl !== "about:blank") {
       runDetachedTask("navigate new browser tab", () => view.webContents.loadURL(finalUrl));
@@ -1048,7 +1057,12 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink, che
         view.setBounds(scaleRendererBounds(bounds));
       }
     });
-    ipcMain.handle("openwork:browser:state", () => ({ ...browserStatePayload(), nativeViews: browserNativeViews() }));
+    ipcMain.handle("openwork:browser:state", () => ({
+      ...browserStatePayload(),
+      nativeViews: browserNativeViews(),
+      backgroundWindowVisible: Boolean(backgroundWindow && !backgroundWindow.isDestroyed() && backgroundWindow.isVisible()),
+      visibleWindowCount: BrowserWindow.getAllWindows().filter((host) => host.isVisible()).length,
+    }));
     ipcMain.handle("openwork:browser:createTab", (_event, url, sessionId) => {
       const target = typeof url === "string" && url.trim() ? url : BROWSER_NEW_TAB_URL;
       const ownerSessionId = sessionId === undefined ? registry.visibleSessionId() : normalizeSessionId(sessionId);

--- a/apps/desktop/electron/browser-panel.test.mjs
+++ b/apps/desktop/electron/browser-panel.test.mjs
@@ -13,6 +13,7 @@ export const session = { fromPartition() { return { webRequest: { onBeforeReques
 export const shell = { async openExternal(url) { effects.push({ type: "external", url }); } };
 export const createdViews = [];
 export class BrowserWindow {
+  static getAllWindows() { return []; }
   constructor(options) {
     if (options.show !== false || options.focusable !== false) throw new Error("background host must never show or focus");
     const children = [];
@@ -24,6 +25,7 @@ export class BrowserWindow {
     this.destroyed = false;
   }
   isDestroyed() { return this.destroyed; }
+  isVisible() { return false; }
   destroy() { this.destroyed = true; }
 }
 export class WebContentsView {
@@ -264,7 +266,8 @@ test("a tab opened for a background conversation loads silently and leaves the v
   assert.deepEqual(commands(backgroundView), BACKGROUND_SEQUENCE, "the page lays out and focuses like a visible one");
   assert.equal(backgroundView.webContents.debugger.isAttached(), true, "our emulation session stays open while unseen");
   assert.deepEqual(commands(visibleView), [], "the visible tab is untouched");
-  assert.deepEqual(messages("openwork:browser:panel-opened"), [], "no panel pops for a silent tab until it navigates");
+  assert.equal(messages("openwork:browser:panel-opened").at(-1).tab.id, tabId, "the explicit open selects B's page only in B's panel");
+  assert.equal(messages("openwork:browser:panel-opened").at(-1).ownerSessionId, "B");
 
   // Even an unexpectedly large background surface must not intercept the app.
   backgroundView.setBounds({ x: 0, y: 0, width: 1280, height: 800 });
@@ -279,7 +282,7 @@ test("navigating a background conversation's tab reports its owner instead of ta
   invoke("openwork:browser:show", PANEL_BOUNDS, "A");
   invoke("openwork:browser:createTab", "https://a.example", "A");
   const visibleView = onScreen();
-  invoke("openwork:browser:createTab", "https://b.example", "B");
+  const { tabId } = invoke("openwork:browser:createTab", "https://b.example", "B");
   const backgroundView = views().find((view) => view !== visibleView);
   await flush();
 
@@ -287,7 +290,9 @@ test("navigating a background conversation's tab reports its owner instead of ta
   await flush();
 
   assert.equal(onScreen(), visibleView, "A's tab stays on screen");
-  assert.deepEqual(messages("openwork:browser:panel-opened"), [{ ownerSessionId: "B" }]);
+  const opens = messages("openwork:browser:panel-opened");
+  assert.equal(opens.at(-2).tab.id, tabId, "the explicit open selects its page");
+  assert.deepEqual(opens.at(-1), { ownerSessionId: "B" }, "later navigation does not override an artifact selection");
 });
 
 test("switching to the background conversation swaps its tab on screen and restores a normal viewport", async () => {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2570,14 +2570,15 @@ async function createMainWindow() {
       return { action: "deny" };
     }
 
-    const local =
-      url.startsWith("http://127.0.0.1") ||
-      url.startsWith("http://localhost");
-    if (!local) {
+    if (/^https?:\/\//i.test(url)) {
+      // Transcript links and local previews belong in the thread's browser,
+      // never an unmanaged BrowserWindow. Explicit external/auth actions use
+      // the shell bridge and do not pass through this popup handler.
+      browserPanel.routeBlockedMainWindowNavigation(url);
+    } else {
       runDetachedTask("open external URL", () => openExternalUrl(url));
-      return { action: "deny" };
     }
-    return { action: "allow" };
+    return { action: "deny" };
   });
 
   mainWindow.webContents.on("will-navigate", (event, url) => {

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -278,7 +278,7 @@ test("a transcript link replaces the selected artifact with its own live sidebar
   await user.see(tabButton(otherTab.name), { timeoutMs: 30_000 });
   await user.click(conversation(reading.title));
   await user.see({ role: "link", text: link.url }, { timeoutMs: 30_000 });
-  await user.click({ role: "button", text: link.artifactName });
+  await user.click({ role: "button", label: /^browser-handoff\.md\b/ });
   await user.see({ role: "button", label: `Select tab: ${link.artifactName}` }, { timeoutMs: 30_000 });
   await user.see({ text: link.artifactText }, { timeoutMs: 30_000 });
   const before = await world.readBrowserState();

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -36,6 +36,7 @@ test("a background conversation's agent browses silently and its page is waiting
     expect(opened).toMatchObject({ ownerSessionId: researching.sessionId, visible: false });
 
     const state = await world.readBrowserState();
+    expect(state).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
     expect(state.visibleSessionId).toBe(reading.sessionId);
     expect(state.activeTabId).toBe(readingTab.tabId);
     expect(state.tabs.find((tab) => tab.id === opened.tabId)?.ownerSessionId).toBe(researching.sessionId);
@@ -74,6 +75,7 @@ test("a background conversation's agent browses silently and its page is waiting
       label: "no native browser view covers OpenWork after the panel closes",
     });
     expect(hidden.nativeViews.find((view) => view.tabId === readingTab.tabId)?.attached).toBe(false);
+    expect(hidden).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
     expect(hidden.nativeViews.find((view) => view.tabId === researchTab.tabId)).toMatchObject({ attached: false, aboveApp: false });
     expect(await world.clickAndType(researchTab, "ok")).toEqual({ clicks: 2, value: "okok" });
     const screenshot = await world.screenshotSize(researchTab);
@@ -244,31 +246,126 @@ test("a transcript link's menu copies its exact address and opens only its own c
     await user.see({ placeholder: "Enter URL..." }, { value: world.linkUrl });
   });
 
-  await step("Normal click keeps the existing loopback-popup behavior without launching a system browser", async () => {
-    // Main-window target=_blank links to loopback are allowed as Electron popups.
-    // Do not substitute a public URL here: those launch the user's system browser.
-    expect(["127.0.0.1", "localhost"]).toContain(new URL(world.linkUrl).hostname);
+  await step("Normal click opens an owned sidebar tab instead of a separate native window", async () => {
     const before = await world.pageTargets();
     const browserBefore = await world.readBrowserState();
     await user.click(link);
-    const after = await eventually(() => world.pageTargets(), {
-      within: 15_000,
-      until: value => value.some(page => page.url === world.linkUrl && !before.some(previous => previous.id === page.id)),
-      label: "a normal link click opens its existing Electron popup",
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: value => value.tabs.some(tab => tab.url === world.linkUrl && tab.id === value.activeTabId
+        && !browserBefore.tabs.some(previous => previous.id === tab.id))
+        && value.nativeViews.some(view => view.tabId === value.activeTabId && view.attached),
+      label: "a normal link click selects its owned sidebar page",
     });
-    const popups = after.filter(page => !before.some(previous => previous.id === page.id));
-    try {
-      expect(popups).toHaveLength(1);
-      expect(popups[0]?.url).toBe(world.linkUrl);
-      expect((await world.readBrowserState()).tabs).toEqual(browserBefore.tabs);
-      expect(await world.readMainUrl()).toBe(mainUrl);
-      expect(await world.menuShown(overlay)).toBe(false);
-    } finally {
-      for (const popup of popups) await world.closePopup(popup.id);
-    }
-    expect(await eventually(() => world.pageTargets(), {
-      within: 10_000, until: value => value.length === before.length,
-      label: "the normal-click popup is closed without changing existing pages",
-    })).toEqual(before);
+    expect(state.tabs).toHaveLength(browserBefore.tabs.length + 1);
+    expect(state.tabs.find(tab => tab.id === state.activeTabId)?.ownerSessionId).toBe(world.reading.sessionId);
+    expect(state.tabs.filter(tab => tab.id !== state.activeTabId)).toEqual(browserBefore.tabs);
+    expect(state).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
+    const newPages = (await world.pageTargets()).filter(page => !before.some(previous => previous.id === page.id));
+    expect(newPages).toHaveLength(1);
+    expect(newPages[0].url).toBe(world.linkUrl);
+    expect(await world.readMainUrl()).toBe(mainUrl);
+    expect(await world.menuShown(overlay)).toBe(false);
+  });
+});
+
+test("a transcript link replaces the selected artifact with its own live sidebar tab, not a native window", async ({ world, user, step }) => {
+  const reading = { ...world.session, title: "Linked research" };
+  await world.renameSession(reading.sessionId, reading.title);
+  const link = await world.seedTranscriptLink(reading.sessionId);
+  const other = await world.openSession("Other conversation");
+  const otherTab = await world.openTabAs("other-conversation", other.sessionId);
+  await user.see(tabButton(otherTab.name), { timeoutMs: 30_000 });
+  await user.click(conversation(reading.title));
+  await user.click({ role: "button", text: link.artifactName });
+  await user.see({ role: "button", label: `Select tab: ${link.artifactName}` }, { timeoutMs: 30_000 });
+  await user.see({ text: link.artifactText }, { timeoutMs: 30_000 });
+  const before = await world.readBrowserState();
+  expect(before.tabs).toHaveLength(1);
+  expect(before.tabs.filter((tab) => tab.ownerSessionId === reading.sessionId)).toEqual([]);
+  expect(before).toMatchObject({ visibleSessionId: reading.sessionId, visibleWindowCount: 1, backgroundWindowVisible: false });
+
+  const linkedTab = await step("Clicking the real transcript link selects exactly one owned sidebar page with the complete URL", async () => {
+    await user.click({ role: "link", text: link.url });
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: (value) => value.tabs.some((tab) => tab.url === link.url && tab.id === value.activeTabId
+        && value.nativeViews.some((view) => view.tabId === tab.id && view.attached && view.aboveApp)),
+      label: "the transcript URL is selected and attached in the sidebar",
+    });
+    const owned = state.tabs.filter((tab) => tab.ownerSessionId === reading.sessionId);
+    expect(owned).toHaveLength(1);
+    expect(owned[0]).toMatchObject({ id: state.activeTabId, url: link.url });
+    expect(state).toMatchObject({ visibleSessionId: reading.sessionId, visibleWindowCount: 1, backgroundWindowVisible: false });
+    expect(state.tabs.filter((tab) => tab.ownerSessionId !== reading.sessionId)).toEqual(before.tabs);
+    expect(state.nativeViews.filter((view) => view.attached || view.aboveApp).map((view) => view.tabId)).toEqual([owned[0].id]);
+    await user.see({ role: "button", label: `Select tab: ${owned[0].label}` });
+    await user.notSee({ text: link.artifactText });
+    await user.notSee(tabButton(otherTab.name));
+    return eventually(() => world.tabHandle(owned[0]), { within: 15_000, label: "the exact transcript URL has one CDP target" });
+  });
+
+  await step("Hiding and showing the sidebar keeps the same CDP page and its live input", async () => {
+    await world.loadInputProbe(linkedTab);
+    expect(await world.clickAndType(linkedTab, "before")).toEqual({ clicks: 1, value: "before" });
+    const viewport = await world.readViewport(linkedTab);
+    await user.click({ role: "button", label: "Close side panel" });
+    const hidden = await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: (state) => state.nativeViews.every((view) => !view.attached && !view.aboveApp),
+      label: "closing the sidebar hides every native browser view",
+    });
+    expect(hidden).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
+    expect(await world.readInputProbe(linkedTab)).toEqual({ clicks: 1, value: "before" });
+    await user.click({ role: "button", label: "Open side panel" });
+    const shown = await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: (state) => state.activeTabId === linkedTab.tabId
+        && state.nativeViews.some((view) => view.tabId === linkedTab.tabId && view.attached && view.aboveApp),
+      label: "the same browser tab returns to the sidebar",
+    });
+    expect(shown).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
+    expect(await world.clickAndType(linkedTab, "-shown")).toEqual({ clicks: 2, value: "before-shown" });
+    expect(await eventually(() => world.readViewport(linkedTab), {
+      within: 15_000,
+      until: (value) => value.width === viewport.width && value.height === viewport.height,
+      label: "the preserved page returns to its sidebar viewport",
+    })).toEqual(viewport);
+  });
+
+  await step("A page refresh preserves the selected artifact, but a new browser request selects its working page", async () => {
+    await user.click({ role: "button", label: `Select tab: ${link.artifactName}` });
+    await user.see({ text: link.artifactText });
+    await world.reloadTab(linkedTab);
+    await user.see({ text: link.artifactText });
+    expect((await world.readBrowserState()).nativeViews.every((view) => !view.attached)).toBe(true);
+
+    const requested = await world.openTabAs("requested-preview", reading.sessionId);
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 15_000,
+      until: (value) => value.activeTabId === requested.tabId
+        && value.nativeViews.some((view) => view.tabId === requested.tabId && view.attached),
+      label: "the explicit browser request replaces the artifact with its working page",
+    });
+    expect(state).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
+    await user.see(tabButton(requested.name));
+    await user.notSee({ text: link.artifactText });
+  });
+
+  await step("The other conversation keeps its original tab and page", async () => {
+    await user.click(conversation(other.title));
+    const state = await eventually(() => world.readBrowserState(), {
+      within: 30_000,
+      until: (value) => value.visibleSessionId === other.sessionId && value.activeTabId === otherTab.tabId
+        && value.nativeViews.some((view) => view.tabId === otherTab.tabId && view.attached && view.aboveApp),
+      label: "the other conversation restores only its original browser tab",
+    });
+    expect(state.tabs.filter((tab) => tab.ownerSessionId === other.sessionId)).toEqual(before.tabs);
+    expect(state.tabs).toHaveLength(3);
+    expect(state).toMatchObject({ visibleWindowCount: 1, backgroundWindowVisible: false });
+    expect(state.nativeViews.find((view) => view.tabId === linkedTab.tabId)).toMatchObject({ attached: false, aboveApp: false });
+    expect((await world.tabHandle(before.tabs[0])).targetId).toBe(otherTab.targetId);
+    await user.see(tabButton(otherTab.name));
+    await user.notSee({ role: "link", text: link.url });
   });
 });

--- a/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
+++ b/evals/specs/browser-tabs-owned-by-thread.e2e.test.ts
@@ -277,6 +277,7 @@ test("a transcript link replaces the selected artifact with its own live sidebar
   const otherTab = await world.openTabAs("other-conversation", other.sessionId);
   await user.see(tabButton(otherTab.name), { timeoutMs: 30_000 });
   await user.click(conversation(reading.title));
+  await user.see({ role: "link", text: link.url }, { timeoutMs: 30_000 });
   await user.click({ role: "button", text: link.artifactName });
   await user.see({ role: "button", label: `Select tab: ${link.artifactName}` }, { timeoutMs: 30_000 });
   await user.see({ text: link.artifactText }, { timeoutMs: 30_000 });
@@ -334,6 +335,7 @@ test("a transcript link replaces the selected artifact with its own live sidebar
   });
 
   await step("A page refresh preserves the selected artifact, but a new browser request selects its working page", async () => {
+    await world.navigateTab(linkedTab, link.url);
     await user.click({ role: "button", label: `Select tab: ${link.artifactName}` });
     await user.see({ text: link.artifactText });
     await world.reloadTab(linkedTab);

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -30,6 +30,8 @@ export interface BrowserTabState {
 export interface BrowserState {
   activeTabId: string | null;
   visibleSessionId: string | null;
+  visibleWindowCount: number;
+  backgroundWindowVisible: boolean;
   tabs: BrowserTabState[];
   nativeViews: Array<{
     tabId: string;
@@ -64,9 +66,14 @@ function pngSize(png: Buffer): Viewport {
 function parseBrowserState(value: unknown): BrowserState {
   if (!isRecord(value) || !Array.isArray(value.tabs)) throw new Error("The desktop bridge did not report browser state.");
   if (!Array.isArray(value.nativeViews)) throw new Error("The desktop bridge did not report native browser views.");
+  if (typeof value.visibleWindowCount !== "number" || typeof value.backgroundWindowVisible !== "boolean") {
+    throw new Error("The desktop bridge did not report native window visibility.");
+  }
   return {
     activeTabId: typeof value.activeTabId === "string" ? value.activeTabId : null,
     visibleSessionId: typeof value.visibleSessionId === "string" ? value.visibleSessionId : null,
+    visibleWindowCount: value.visibleWindowCount,
+    backgroundWindowVisible: value.backgroundWindowVisible,
     nativeViews: value.nativeViews.map((view) => {
       if (!isRecord(view) || typeof view.attached !== "boolean" || typeof view.aboveApp !== "boolean"
         || !isRecord(view.bounds) || typeof view.bounds.x !== "number" || typeof view.bounds.y !== "number") {
@@ -151,7 +158,8 @@ function parsePageProbe(value: unknown): PageProbe {
  */
 async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string>) {
   const app = await seed.desktop({ name: "builtin-browser", env });
-  const workspace = await seed.workspace(app, seed.tmpPath("builtin-browser"));
+  const workspacePath = seed.tmpPath("builtin-browser");
+  const workspace = await seed.workspace(app, workspacePath);
   const session = await seed.session(app);
   const origin = await embeddedServerUrl(seed, app);
 
@@ -159,6 +167,37 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     app,
     workspace,
     session,
+
+    /** Persist a real transcript link and an attached file without invoking a model. */
+    async seedTranscriptLink(sessionId: string) {
+      const url = `${origin}/?viewport-probe=transcript-link&source=chat%20link#working-page`;
+      const artifactName = "browser-handoff.md";
+      const artifactText = "Keep these notes open while following the research link.";
+      await seed.evalIn(app, `async (workspaceId, sessionId, url, artifactName, artifactText, fileUrl) => {
+        const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
+        const base = info.baseUrl.replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId);
+        const headers = { Authorization: "Bearer " + (info.ownerToken ?? info.clientToken), "Content-Type": "application/json" };
+        const file = await fetch(base + "/files/content", {
+          method: "POST", headers, signal: AbortSignal.timeout(15000),
+          body: JSON.stringify({ path: artifactName, content: artifactText, baseUpdatedAt: null }),
+        });
+        if (!file.ok) throw new Error("Could not seed the handoff file: " + file.status);
+        const message = await fetch(base + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
+          method: "POST", headers, signal: AbortSignal.timeout(30000),
+          body: JSON.stringify({ noReply: true, parts: [
+            { type: "text", text: "Continue research at " + url },
+            { type: "file", mime: "text/plain", filename: artifactName, url: fileUrl },
+          ] }),
+        });
+        if (!message.ok) throw new Error("Could not seed the transcript link: " + message.status);
+        await message.json();
+      }`, {
+        args: [workspace.workspaceId, sessionId, url, artifactName, artifactText, new URL(`file://${workspacePath}/${artifactName}`).href],
+        awaitPromise: true,
+        timeoutMs: 50_000,
+      });
+      return { url, artifactName, artifactText };
+    },
 
     /** Create another conversation in the same workspace; the app shows it. */
     async openSession(title: string): Promise<{ sessionId: string; title: string }> {
@@ -371,6 +410,13 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       ));
     },
 
+    /** Resolve a user-opened tab without opening or selecting another page. */
+    async tabHandle(tab: BrowserTabState): Promise<BuiltinBrowserTab> {
+      const targets = (await listTargets(app.handle.cdpUrl)).filter((target) => target.type === "page" && target.url === tab.url);
+      if (targets.length !== 1) throw new Error(`Expected one CDP page for ${tab.url}, found ${targets.length}.`);
+      return { tabId: tab.id, targetId: targets[0].id, name: tab.label };
+    },
+
     /** The viewport a tab lays out for and whether its page believes it has focus. */
     async readPageProbe(tab: BuiltinBrowserTab): Promise<PageProbe> {
       return withTabClient(app, tab.targetId, async (client) => parsePageProbe(
@@ -412,6 +458,12 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
         }
         return { clicks: result.clicks, value: result.value };
       });
+    },
+
+    /** Observe the existing document without focusing its hidden native view. */
+    async readInputProbe(tab: BuiltinBrowserTab): Promise<unknown> {
+      return withTabClient(app, tab.targetId, (client) => evaluate(client,
+        "({ clicks: window.__clicks, value: document.getElementById('field').value })"));
     },
 
     /**

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -186,11 +186,15 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
           method: "POST", headers, signal: AbortSignal.timeout(30000),
           body: JSON.stringify({ noReply: true, parts: [
             { type: "text", text: "Continue research at " + url },
-            { type: "file", mime: "text/plain", filename: artifactName, url: fileUrl },
+            { type: "text", synthetic: true, text: "Attached workspace file: " + artifactName,
+              metadata: { openworkAttachments: [{ filename: artifactName, mime: "text/markdown", url: fileUrl }] } },
           ] }),
         });
         if (!message.ok) throw new Error("Could not seed the transcript link: " + message.status);
-        await message.json();
+        const saved = await message.json();
+        if (!Array.isArray(saved.parts) || !saved.parts.some(part => part.type === "text" && part.text.includes(url))) {
+          throw new Error("Transcript seed did not persist the requested link.");
+        }
       }`, {
         args: [workspace.workspaceId, sessionId, url, artifactName, artifactText, new URL(`file://${workspacePath}/${artifactName}`).href],
         awaitPromise: true,
@@ -387,6 +391,11 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     /** What the page inside a tab can read from `document.cookie`. */
     async readDocumentCookie(tab: BuiltinBrowserTab): Promise<string> {
       return withTabClient(app, tab.targetId, async (client) => String(await evaluate(client, "document.cookie")));
+    },
+
+    /** Navigate the existing CDP page without opening a replacement tab. */
+    async navigateTab(tab: BuiltinBrowserTab, url: string): Promise<void> {
+      await withTabClient(app, tab.targetId, (client) => navigate(client, url));
     },
 
     /** Reload a tab over CDP and wait for it to settle. */

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -157,7 +157,7 @@ function parsePageProbe(value: unknown): PageProbe {
  * home, plus helpers that play an automation client against its tabs.
  */
 async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string>) {
-  const app = await seed.desktop({ name: "builtin-browser", env: { OPENWORK_EVAL_BROWSER_LOGIN_SYNC: "1", ...env } });
+  const app = await seed.desktop({ name: "builtin-browser", env });
   const workspacePath = seed.tmpPath("builtin-browser");
   const workspace = await seed.workspace(app, workspacePath);
   const session = await seed.session(app);

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -157,7 +157,7 @@ function parsePageProbe(value: unknown): PageProbe {
  * home, plus helpers that play an automation client against its tabs.
  */
 async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string>) {
-  const app = await seed.desktop({ name: "builtin-browser", env });
+  const app = await seed.desktop({ name: "builtin-browser", env: { OPENWORK_EVAL_BROWSER_LOGIN_SYNC: "1", ...env } });
   const workspacePath = seed.tmpPath("builtin-browser");
   const workspace = await seed.workspace(app, workspacePath);
   const session = await seed.session(app);

--- a/packages/browser-tabs/index.d.ts
+++ b/packages/browser-tabs/index.d.ts
@@ -45,6 +45,8 @@ export type BrowserStatePayload = {
 
 export type BrowserPanelOwnerPayload = {
   ownerSessionId: string | null;
+  /** The page to select on a panel-opened event; absent on panel-closed. */
+  tab?: BrowserPanelTab;
 };
 
 export type OpenBrowserUrlResult = {


### PR DESCRIPTION
## Summary

- Open conversation HTTP(S) links, including local previews, in the conversation's built-in browser instead of an unmanaged native window. User-message and Markdown links use the owner-aware target handler; the native popup handler provides the fallback.
- Select the requested working page in the right sidebar even when an artifact was active. Later page refreshes preserve an artifact the user deliberately selected.
- Keep the existing hidden-host isolation and the same live page/CDP target through sidebar hide/show. Other conversations retain their own tabs.
- Preserve the browser-choice context menu from #4588 and update its normal-click assertion to the intended embedded-browser behavior. Explicit external-browser and authentication actions remain separate.

## Verification — Passed

The focused checks passed on `f2f9d5f30385c6d38aa4ea7ba9c0223640bb3a86`. Exact-head evidence for all three journey tests is published in the PR comments.

- `OPENWORK_EVAL_REF=f2f9d5f30385c6d38aa4ea7ba9c0223640bb3a86 pnpm evals:e2e browser-tabs-owned-by-thread` — **3 passed, 0 failed, 0 skipped**, exit 0. `placement: daytona (daytona CLI authenticated)`. Each test cold-booted its own desktop.
- `node --test apps/desktop/electron/browser-panel.test.mjs` — **15 passed, 0 failed, 0 skipped**.
- `pnpm --filter @openwork/app typecheck` — passed.
- `pnpm --filter @openwork/desktop exec tsc --noEmit -p tsconfig.electron.json --typeRoots ../../node_modules/@types` — passed.
- `git diff --check` — passed.

The journey checks exact URL/query/hash retention, no additional visible native window, artifact-to-browser selection, document/input continuity, background typing/screenshots, conversation isolation, and context-menu compatibility. Earlier fixture setup and attachment-target failures were corrected before the passing run.

Deferred: native macOS/Windows confirmation and an explicit secondary-split-pane click journey. No inline browser redesign, website-popup policy changes, merge, or release.

## Manual check

1. Open an artifact, then click a local-preview link in the conversation. The right sidebar should select the page; no separate native window should appear.
2. Hide and reopen the sidebar. The page and its state should still be there.
3. Select the artifact again, then request a new browser page. The requested page should become visible; ordinary refreshes of an existing page should not replace the selected artifact.
4. Switch to another conversation and back. Each conversation should retain its own tabs. Right-click choices should still allow an explicit external browser.
