### PR TITLE
fix(app): preserve v2 retry and stop reliability

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -784,25 +784,6 @@ function failedToolPart(
   };
 }
 
-function sessionErrorEvent(sessionID: string, error: unknown): OpencodeEvent {
-  return {
-    type: "session.error",
-    properties: {
-      sessionID,
-      error: { name: "UnknownError", data: { message: errorMessage(error) } },
-    },
-  };
-}
-
-function terminalEvents(sessionID: string, error?: unknown): OpencodeEvent[] {
-  const events: OpencodeEvent[] = error === undefined ? [] : [sessionErrorEvent(sessionID, error)];
-  events.push(
-    { type: "session.status", properties: { sessionID, status: { type: "idle" } } },
-    { type: "session.idle", properties: { sessionID } },
-  );
-  return events;
-}
-
 export function createV2EventTranslationState(): V2EventTranslationState {
   return {
     streams: new Map(),
@@ -850,9 +831,31 @@ export function translateV2Event(
       : null;
   }
 
-  if (type === "session.execution.started") {
+  if (type.startsWith("session.execution.")) {
     if (!sessionID) return null;
-    return [{ type: "session.status", properties: { sessionID, status: { type: "busy" } } }];
+    return [{ type, properties: {
+      ...properties, sequence: readNumber(value.durable, "seq"),
+      ...(type === "session.execution.failed" ? {
+        error: { name: "UnknownError", data: { message: errorMessage(properties.error) } },
+      } : {}),
+    } }];
+  }
+
+  if (type === "session.retry.scheduled") {
+    const attempt = readNumber(properties, "attempt");
+    const next = readNumber(properties, "at");
+    if (!sessionID || attempt === undefined || next === undefined) return null;
+    return [{ type: "session.status", properties: {
+      sessionID,
+      sequence: readNumber(value.durable, "seq"),
+      status: { type: "retry", attempt, message: errorMessage(properties.error), next },
+    } }];
+  }
+
+  if (type === "session.step.started") {
+    return sessionID ? [{ type: "session.execution.progress", properties: {
+      sessionID, sequence: readNumber(value.durable, "seq"),
+    } }] : null;
   }
 
   const kind = type.startsWith("session.reasoning.") || type.startsWith("session.next.reasoning.") ? "reasoning" : "text";
@@ -1027,17 +1030,6 @@ export function translateV2Event(
     stream.metadata = readRecord(properties, "metadata") ?? stream.metadata;
     const part = failedToolPart(stream, properties, toolEventTimestamp(value, properties));
     return [{ type: "message.part.updated", properties: { part } }];
-  }
-
-  if (
-    type === "session.execution.succeeded" ||
-    type === "session.execution.interrupted"
-  ) {
-    return sessionID ? terminalEvents(sessionID) : null;
-  }
-
-  if (type === "session.execution.failed") {
-    return sessionID ? terminalEvents(sessionID, properties.error ?? properties) : null;
   }
 
   if (type === "permission.asked" || type === "permission.v2.asked") {
@@ -1624,7 +1616,12 @@ export function createClientV2(
         {},
         options?.signal,
       );
-      return result.response.ok ? successfulResult(result, true) : failedResult(result);
+      if (!result.response.ok) return failedResult(result);
+      const data = responseData(result.payload);
+      if (!isRecord(data) || typeof data.interrupted !== "boolean") {
+        return failedResult({ ...result, payload: { name: "InvalidV2InterruptResponse" } });
+      }
+      return successfulResult(result, data.interrupted);
     },
     update: async (
       parameters: SessionUpdateParameters,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/components/ui/sonner";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
 import { createClient, unwrap } from "@/app/lib/opencode";
+import { createClientV2, isOpencodeV2BaseUrl } from "@/app/lib/opencode-v2-adapter";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { composeNativeSessionSnapshot } from "@/app/lib/opencode-session-native";
 import { setThemeMode } from "@/app/theme";
@@ -1152,8 +1153,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const autoOpenedTargetRef = useRef<string | null>(null);
   const initializedAutoOpenSessionRef = useRef<string | null>(null);
   const opencodeClient = useMemo(
-    () => createClient(props.opencodeBaseUrl, undefined, { token: props.openworkToken, mode: "openwork" }),
-    [props.opencodeBaseUrl, props.openworkToken],
+    () => isOpencodeV2BaseUrl(props.opencodeBaseUrl)
+      ? createClientV2(props.opencodeBaseUrl, props.workspaceRoot || undefined, { token: props.openworkToken })
+      : createClient(props.opencodeBaseUrl, undefined, { token: props.openworkToken, mode: "openwork" }),
+    [props.opencodeBaseUrl, props.openworkToken, props.workspaceRoot],
   );
 
   const snapshotQueryKey = useMemo(

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -102,6 +102,9 @@ type SyncEntry = {
   statusReconcileAbort: AbortController | null;
   runActiveObservedAt: Map<string, number>;
   assistantMessageCompletedAt: Map<string, number>;
+  nativeSequenceBySession: Map<string, number>;
+  nativeTerminalSessions: Set<string>;
+  permissionReconciles: Map<string, AbortController>;
   titleRecovery: SessionTitleRecovery | null;
 };
 
@@ -202,6 +205,9 @@ const defaultSessionStatusFetcher: SessionStatusFetcher = async (baseUrl, openwo
 
 let syncSubscriptionFactory = defaultSyncSubscriptionFactory;
 let sessionStatusFetcher = defaultSessionStatusFetcher;
+const defaultSessionPermissionFetcher = async (baseUrl: string, token: string, sessionID: string, signal: AbortSignal) =>
+  unwrap(await createSyncClient(baseUrl, token).v2.session.permission.list({ sessionID }, { signal })).data;
+let sessionPermissionFetcher = defaultSessionPermissionFetcher;
 
 const defaultDeltaFlushScheduler: DeltaFlushScheduler = (lane, run) => {
   if (
@@ -521,6 +527,8 @@ function disposeWorkspaceSync(key: string, entry: SyncEntry) {
   entry.statusReconcileTimer = null;
   entry.statusReconcileAbort?.abort();
   entry.statusReconcileAbort = null;
+  for (const controller of entry.permissionReconciles.values()) controller.abort();
+  entry.permissionReconciles.clear();
   entry.liveSessionIds.clear();
   entry.runActiveObservedAt.clear();
   entry.assistantMessageCompletedAt.clear();
@@ -598,6 +606,19 @@ function sortQuestions(a: PendingQuestion, b: PendingQuestion) {
 // A list already in flight must not resurrect a request after its reply event.
 const settledQuestionsKey = (workspaceId: string, sessionId: string) =>
   [...questionKey(workspaceId, sessionId), "settled"];
+const settledPermissionsKey = (workspaceId: string, sessionId: string) =>
+  [...permissionKey(workspaceId, sessionId), "settled"];
+
+export function settlePermissionState(workspaceId: string, sessionId: string, requestId: string) {
+  const queryClient = getReactQueryClient();
+  queryClient.setQueryData<string[]>(settledPermissionsKey(workspaceId, sessionId), (current = []) =>
+    current.includes(requestId) ? current : [...current, requestId],
+  );
+  queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId), (current = []) =>
+    current.filter((permission) => permission.id !== requestId),
+  );
+  useSessionActivityStore.getState().setWaitingRequest(workspaceId, sessionId, "permission", requestId, false);
+}
 
 export function settleQuestionState(workspaceId: string, sessionId: string, requestId: string) {
   const queryClient = getReactQueryClient();
@@ -614,14 +635,28 @@ export function seedPermissionState(
   workspaceId: string,
   sessionId: string,
   permissions: PermissionSeed[],
-  options: { snapshotStartedAt?: number } = {},
+  options: { snapshotStartedAt?: number; snapshotRevision?: number } = {},
 ) {
   const queryClient = getReactQueryClient();
   const now = Date.now();
+  const settled = new Set(queryClient.getQueryData<string[]>(settledPermissionsKey(workspaceId, sessionId)) ?? []);
+  const changedDuringRead = options.snapshotRevision === undefined
+    || options.snapshotRevision !== (queryClient.getQueryState(permissionKey(workspaceId, sessionId))?.dataUpdateCount ?? 0);
+  const snapshotKey = [...permissionKey(workspaceId, sessionId), "snapshot-started-at"];
+  if (options.snapshotStartedAt !== undefined) {
+    if (options.snapshotStartedAt < (queryClient.getQueryData<number>(snapshotKey) ?? 0)) return;
+    queryClient.setQueryData(snapshotKey, options.snapshotStartedAt);
+    const ids = new Set(permissions.filter((permission) => permission.sessionID === sessionId).map((permission) => permission.id));
+    for (const permission of queryClient.getQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId)) ?? []) {
+      if (!ids.has(permission.id) && (!changedDuringRead || permission.receivedAt < options.snapshotStartedAt)) settled.add(permission.id);
+    }
+    queryClient.setQueryData(settledPermissionsKey(workspaceId, sessionId), [...settled]);
+  }
   const nextPermissions = queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId), (current = []) => {
     const receivedAtById = new Map(current.map((permission) => [permission.id, permission.receivedAt]));
     const seeded = permissions.flatMap((permission) =>
-      permission.sessionID === sessionId ? [permissionWithReceivedAt(permission, receivedAtById.get(permission.id) ?? now)] : [],
+      permission.sessionID === sessionId && !settled.has(permission.id)
+        ? [permissionWithReceivedAt(permission, receivedAtById.get(permission.id) ?? now)] : [],
     );
     const seededIds = new Set(seeded.map((permission) => permission.id));
     const snapshotStartedAt = options.snapshotStartedAt;
@@ -630,7 +665,8 @@ export function seedPermissionState(
         ? current.filter(
             (permission) =>
               permission.sessionID === sessionId &&
-              permission.receivedAt > snapshotStartedAt &&
+              changedDuringRead &&
+              permission.receivedAt >= snapshotStartedAt &&
               !seededIds.has(permission.id),
           )
         : [];
@@ -812,6 +848,51 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   const queryClient = getReactQueryClient();
   const input = entry.input;
 
+  // Native durable sequence numbers order lifecycle edges across successor
+  // executions. A replayed terminal must never settle a newer run.
+  if (event.type.startsWith("session.execution.") || event.type === "session.status") {
+    const props = event.properties;
+    const sessionId = sessionIdFromProperties(props);
+    const sequence = props && typeof props === "object" && "sequence" in props ? props.sequence : undefined;
+    if (sessionId && typeof sequence === "number") {
+      if (sequence <= (entry.nativeSequenceBySession.get(sessionId) ?? -1)) return;
+      entry.nativeSequenceBySession.set(sessionId, sequence);
+    }
+  }
+
+  if (event.type.startsWith("session.execution.")) {
+    const sessionId = sessionIdFromProperties(event.properties);
+    if (!sessionId) return;
+    if (event.type === "session.execution.started") {
+      entry.nativeTerminalSessions.delete(sessionId);
+      applySessionRunStatus(entry, workspaceId, sessionId, { type: "busy" });
+    } else if (event.type === "session.execution.progress") {
+      clearSessionRetry(entry, workspaceId, sessionId);
+    } else if (event.type === "session.execution.failed") {
+      entry.nativeTerminalSessions.add(sessionId);
+      applyEvent(entry, workspaceId, { type: "session.error", properties: event.properties });
+      void reconcileSessionPermissions(entry, sessionId);
+    } else if (event.type === "session.execution.succeeded") {
+      entry.nativeTerminalSessions.add(sessionId);
+      applySessionRunStatus(entry, workspaceId, sessionId, idleStatus, { completed: true, terminalEvent: true });
+    } else if (event.type === "session.execution.interrupted") {
+      const props = event.properties;
+      const reason = props && typeof props === "object" && "reason" in props ? props.reason : undefined;
+      if (reason === "user") {
+        entry.nativeTerminalSessions.add(sessionId);
+        applySessionRunStatus(entry, workspaceId, sessionId, idleStatus, { completed: false, terminalEvent: true });
+      } else {
+        // Shutdown retains durable intent; supersession may already have a
+        // successor. Reconcile ownership rather than manufacturing an idle edge.
+        clearSessionRetry(entry, workspaceId, sessionId);
+        entry.liveSessionIds.add(sessionId);
+        scheduleActiveSessionStatusReconciliation(entry);
+        void reconcileSessionPermissions(entry, sessionId);
+      }
+    }
+    return;
+  }
+
   if (event.type === "session.created") {
     const session = getSessionCreatedInfo(event);
     if (!session) return;
@@ -939,6 +1020,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "permission.asked") {
     const permission = event.properties as PermissionRequest;
     if (!permission?.id || !permission.sessionID) return;
+    if (queryClient.getQueryData<string[]>(settledPermissionsKey(workspaceId, permission.sessionID))?.includes(permission.id)) return;
     notifyDesktopEvent({
       type: "permission.asked",
       sessionId: permission.sessionID,
@@ -960,6 +1042,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "permission.v2.asked") {
     const permission = event.properties as PermissionV2Request;
     if (!permission?.id || !permission.sessionID) return;
+    if (queryClient.getQueryData<string[]>(settledPermissionsKey(workspaceId, permission.sessionID))?.includes(permission.id)) return;
     notifyDesktopEvent({
       type: "permission.asked",
       sessionId: permission.sessionID,
@@ -981,10 +1064,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
   if (event.type === "permission.replied" || event.type === "permission.v2.replied") {
     const props = (event.properties ?? {}) as { sessionID?: string; requestID?: string };
     if (!props.sessionID || !props.requestID) return;
-    useSessionActivityStore.getState().setWaitingRequest(workspaceId, props.sessionID, "permission", props.requestID, false);
-    queryClient.setQueryData<PendingPermission[]>(permissionKey(workspaceId, props.sessionID), (current = []) =>
-      current.filter((permission) => permission.id !== props.requestID),
-    );
+    settlePermissionState(workspaceId, props.sessionID, props.requestID);
     return;
   }
 
@@ -1079,6 +1159,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const part = props.part;
     if (!part?.sessionID || !part.messageID) return;
     if (partHasVisibleAssistantOutput(part)) {
+      clearSessionRetry(entry, workspaceId, part.sessionID);
       useSessionActivityStore.getState().markAssistantOutput(workspaceId, part.sessionID, part.messageID);
     }
     if (!isTrackedSession(entry, part.sessionID)) return;
@@ -1143,6 +1224,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
       delta?: string;
     };
     if (!props.sessionID || !props.messageID || !props.partID || !props.delta) return;
+    clearSessionRetry(entry, workspaceId, props.sessionID);
     useSessionActivityStore.getState().markAssistantOutput(workspaceId, props.sessionID, props.messageID, { allowUnknownMessageRole: true });
     if (!isTrackedSession(entry, props.sessionID)) return;
     // Note: we do NOT trust `props.field` to disambiguate reasoning vs
@@ -1297,11 +1379,23 @@ function applySessionRunStatus(
     snapshotStartedAt?: number;
     source?: SessionStatusSource;
     terminalEvent?: boolean;
+    completed?: boolean;
   } = {},
 ) {
   const snapshotStartedAt = options.snapshotStartedAt;
   const store = useSessionActivityStore.getState();
   const previousRecord = store.recordsByWorkspaceId[workspaceId]?.[sessionId];
+  const v2 = isOpencodeV2BaseUrl(entry.input.baseUrl);
+  // /active only says running. Preserve the richer stream retry across polls
+  // from independent clients until actual execution progress or a terminal.
+  if (v2 && snapshotStartedAt !== undefined && status.type === "busy") {
+    if (entry.nativeTerminalSessions.has(sessionId)) {
+      if (options.source !== "connect-reconcile") return;
+      entry.nativeTerminalSessions.delete(sessionId);
+    }
+    const current = getReactQueryClient().getQueryData<SessionStatus>(statusKey(workspaceId, sessionId));
+    if (current?.type === "retry") status = current;
+  }
   const wasTrackedLive = entry.liveSessionIds.has(sessionId);
   const wasLive = wasTrackedLive || previousRecord?.runActive === true;
   if (typeof snapshotStartedAt === "number") {
@@ -1312,6 +1406,10 @@ function applySessionRunStatus(
   }
 
   const live = isLiveStatus(status);
+  if (v2 && !live) {
+    store.replaceWaitingRequests(workspaceId, sessionId, "permission",
+      (getReactQueryClient().getQueryData<PendingPermission[]>(permissionKey(workspaceId, sessionId)) ?? []).map((permission) => permission.id));
+  }
   const observedAt = perfNow();
   if (live) {
     entry.liveSessionIds.add(sessionId);
@@ -1330,14 +1428,13 @@ function applySessionRunStatus(
   }
 
   const tracked = isTrackedSession(entry, sessionId);
-  if (tracked) getReactQueryClient().setQueryData(statusKey(workspaceId, sessionId), status);
-  for (const listener of entry.sessionStatusListeners.keys()) listener({ sessionId, status });
+  if (tracked || v2) getReactQueryClient().setQueryData(statusKey(workspaceId, sessionId), status);
   if (!live) {
     // A level-triggered idle response is as authoritative as the SSE edge.
     // Converge through the same terminal path so a missed status event also
     // flushes final deltas and refreshes any final persisted message parts.
     const runStartedAt = takeTaskRunStart(sessionId);
-    if (runStartedAt !== null) {
+    if (runStartedAt !== null && (options.completed ?? !v2)) {
       captureAnalyticsEvent("task_run_completed", {
         duration_ms: Date.now() - runStartedAt,
       });
@@ -1347,6 +1444,7 @@ function applySessionRunStatus(
     }
     const shouldRecordTerminal = wasLive || runStartedAt !== null;
     const shouldConvergeTerminal = shouldRecordTerminal || options.terminalEvent === true;
+    if (shouldConvergeTerminal) void reconcileSessionPermissions(entry, sessionId);
     if (tracked && shouldConvergeTerminal) {
       flushSessionDeltas(entry, workspaceId, sessionId);
       void getReactQueryClient().invalidateQueries({
@@ -1372,6 +1470,34 @@ function applySessionRunStatus(
     entry.assistantMessageCompletedAt.delete(sessionId);
     if (entry.input && tracked) releaseRetainedSessionSoon(entry.input, entry, sessionId);
   }
+  // A listener can admit a queued successor synchronously. Consume the old
+  // run's analytics marker before notifying it, never the successor's marker.
+  for (const listener of entry.sessionStatusListeners.keys()) listener({ sessionId, status });
+}
+
+function clearSessionRetry(entry: SyncEntry, workspaceId: string, sessionId: string) {
+  if (!isOpencodeV2BaseUrl(entry.input.baseUrl)) return;
+  const status = getReactQueryClient().getQueryData<SessionStatus>(statusKey(workspaceId, sessionId));
+  if (status?.type === "retry") applySessionRunStatus(entry, workspaceId, sessionId, { type: "busy" });
+}
+
+async function reconcileSessionPermissions(entry: SyncEntry, sessionId: string) {
+  if (!isOpencodeV2BaseUrl(entry.input.baseUrl)) return;
+  entry.permissionReconciles.get(sessionId)?.abort();
+  const controller = new AbortController();
+  entry.permissionReconciles.set(sessionId, controller);
+  const snapshotStartedAt = Date.now();
+  const snapshotRevision = getReactQueryClient().getQueryState(permissionKey(entry.input.workspaceId, sessionId))?.dataUpdateCount ?? 0;
+  try {
+    const permissions = await sessionPermissionFetcher(entry.input.baseUrl, entry.openworkToken, sessionId,
+      AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)]));
+    if (controller.signal.aborted || syncs.get(syncKey(entry.input)) !== entry) return;
+    seedPermissionState(entry.input.workspaceId, sessionId, permissions, { snapshotStartedAt, snapshotRevision });
+  } catch {
+    // Failed reads are not permission settlements. Reconnect will retry.
+  } finally {
+    if (entry.permissionReconciles.get(sessionId) === controller) entry.permissionReconciles.delete(sessionId);
+  }
 }
 
 async function reconcileSessionRunStatuses(
@@ -1381,6 +1507,13 @@ async function reconcileSessionRunStatuses(
   source: Exclude<SessionStatusSource, "stream">,
 ) {
   const startedAt = Date.now();
+  const sequences = new Map(entry.nativeSequenceBySession);
+  if (source === "connect-reconcile") {
+    const records = useSessionActivityStore.getState().recordsByWorkspaceId[input.workspaceId] ?? {};
+    for (const sessionId of new Set([...Object.keys(records), ...entry.trackedSessionRefs.keys()])) {
+      void reconcileSessionPermissions(entry, sessionId);
+    }
+  }
   let statuses: Record<string, SessionStatus>;
   try {
     statuses = await sessionStatusFetcher(input.baseUrl, entry.openworkToken, signal);
@@ -1410,6 +1543,7 @@ async function reconcileSessionRunStatuses(
     ...entry.liveSessionIds,
   ]);
   for (const sessionId of sessionIds) {
+    if (sequences.get(sessionId) !== entry.nativeSequenceBySession.get(sessionId)) continue;
     applySessionRunStatus(entry, input.workspaceId, sessionId, statuses[sessionId] ?? idleStatus, {
       snapshotStartedAt: startedAt,
       source,
@@ -1529,6 +1663,9 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     statusReconcileAbort: null,
     runActiveObservedAt: new Map(),
     assistantMessageCompletedAt: new Map(),
+    nativeSequenceBySession: new Map(),
+    nativeTerminalSessions: new Set(),
+    permissionReconciles: new Map(),
     titleRecovery: null,
   };
   created.titleRecovery = createSessionTitleRecovery({
@@ -1602,15 +1739,20 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   const snapshotStartedAt = sessionSnapshotFetchStarts.get(snapshot);
   if (typeof snapshotStartedAt === "number") {
     const record = useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[snapshot.session.id];
+    const currentStatus = queryClient.getQueryData<SessionStatus>(statusKey(workspaceId, snapshot.session.id));
+    const terminal = [...syncs.values()].some((entry) => entry.input.workspaceId === workspaceId
+      && entry.nativeTerminalSessions.has(snapshot.session.id));
+    const status = snapshot.status.type === "busy" && currentStatus && (currentStatus.type === "retry" || terminal)
+      ? currentStatus : snapshot.status;
     useSessionActivityStore.getState().seedSessionRun(
       workspaceId,
       snapshot.session.id,
-      snapshot.status,
+      status,
       assistantOutputAfterLatestUser(incoming),
       { snapshotStartedAt },
     );
     if (snapshotStartedAt >= (record?.runStatusAt ?? 0)) {
-      queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), snapshot.status);
+      queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), status);
     }
   }
 
@@ -1729,6 +1871,9 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     statusReconcileAbort: null,
     runActiveObservedAt: new Map(),
     assistantMessageCompletedAt: new Map(),
+    nativeSequenceBySession: new Map(),
+    nativeTerminalSessions: new Set(),
+    permissionReconciles: new Map(),
     titleRecovery: null,
   });
   return () => {
@@ -1737,6 +1882,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
       for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
       if (entry.statusReconcileTimer) clearTimeout(entry.statusReconcileTimer);
       entry.statusReconcileAbort?.abort();
+      for (const controller of entry.permissionReconciles.values()) controller.abort();
     }
     syncs.delete(key);
   };
@@ -1777,4 +1923,8 @@ export function __setWorkspaceSessionSyncSubscriptionFactoryForTest(factory: Syn
 
 export function __setWorkspaceSessionSyncStatusFetcherForTest(fetcher: SessionStatusFetcher | null) {
   sessionStatusFetcher = fetcher ?? defaultSessionStatusFetcher;
+}
+
+export function __setWorkspaceSessionSyncPermissionFetcherForTest(fetcher: typeof defaultSessionPermissionFetcher | null) {
+  sessionPermissionFetcher = fetcher ?? defaultSessionPermissionFetcher;
 }

--- a/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
@@ -7,16 +7,15 @@ import { unwrap } from "@/app/lib/opencode";
 import { isOpencodeV2Client } from "@/app/lib/opencode-v2-adapter";
 import type { Client, PendingPermission, PendingQuestion, TodoItem } from "@/app/types";
 import { t } from "@/i18n";
-import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useQueryCacheArrayState, useQueryCacheState } from "@/react-app/infra/query-cache-state";
 import { describeRouteError } from "@/react-app/shell/route-workspaces";
-import { useSessionActivityStore } from "../status/session-activity-store";
 import {
   permissionKey,
   questionKey,
   seedPermissionState,
   seedQuestionState,
   settleQuestionState,
+  settlePermissionState,
   todoKey,
 } from "./session-sync";
 
@@ -177,20 +176,8 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
             }),
           );
         }
-        for (const permissionSessionId of interactionSessionIds) {
-          getReactQueryClient().setQueryData<PendingPermission[]>(
-            permissionKey(workspaceId, permissionSessionId),
-            (current = []) => current.filter((permission) => permission.id !== requestID),
-          );
-        }
         if (pendingPermission) {
-          useSessionActivityStore.getState().setWaitingRequest(
-            workspaceId,
-            pendingPermission.sessionID,
-            "permission",
-            requestID,
-            false,
-          );
+          settlePermissionState(workspaceId, pendingPermission.sessionID, requestID);
         }
       } catch (error) {
         toast.error(t("app.error_request_failed"), {

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -690,7 +690,7 @@ describe("OpenCode v2 client compatibility", () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async (input) => {
       expect(input instanceof Request && input.url.endsWith("/api/session/s/interrupt")).toBe(true);
-      return jsonResponse({ data: { interrupted } });
+      return jsonResponse({ interrupted });
     };
     try {
       expect((await createClientV2("http://opencode.test/opencode2", undefined, {}).session.abort({ sessionID: "s" })).data)

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -177,6 +177,22 @@ function eventStream() {
 }
 
 describe("OpenCode v2 event translation", () => {
+  test("preserves native retry detail and sequenced interruption reasons without claiming success", () => {
+    const state = createV2EventTranslationState();
+    expect(translateV2Event({ type: "session.retry.scheduled", durable: { seq: 12 }, data: {
+      sessionID: "s", assistantMessageID: "m", attempt: 3, at: 10_000, error: { message: "Rate limited" },
+    } }, state)).toEqual([{ type: "session.status", properties: {
+      sessionID: "s", sequence: 12, status: { type: "retry", attempt: 3, message: "Rate limited", next: 10_000 },
+    } }]);
+    for (const reason of ["user", "shutdown", "superseded", "future-reason"]) {
+      expect(translateV2Event({ type: "session.execution.interrupted", durable: { seq: 13 },
+        data: { sessionID: "s", reason } }, state)).toEqual([{
+        type: "session.execution.interrupted", properties: { sessionID: "s", reason, sequence: 13 },
+      }]);
+    }
+    expect(translateV2Event({ type: "session.step.started", durable: { seq: 14 }, data: { sessionID: "s" } }, state))
+      .toEqual([{ type: "session.execution.progress", properties: { sessionID: "s", sequence: 14 } }]);
+  });
   test("renders an admitted user message before execution using its persisted identity", () => {
     const state = createV2EventTranslationState();
     const admitted = {
@@ -367,7 +383,7 @@ describe("OpenCode v2 event translation", () => {
     ]));
   });
 
-  test("translates captured v2 text lifecycle events through terminal idle", () => {
+  test("translates captured v2 text lifecycle events through explicit execution success", () => {
     const state = createV2EventTranslationState();
     const captured = [
       { type: "session.text.started", data: { sessionID: "s", assistantMessageID: "m", ordinal: 0 } },
@@ -411,8 +427,7 @@ describe("OpenCode v2 event translation", () => {
           part: { id: "m:0", messageID: "m", sessionID: "s", type: "text", text: "hello world" },
         },
       },
-      { type: "session.status", properties: { sessionID: "s", status: { type: "idle" } } },
-      { type: "session.idle", properties: { sessionID: "s" } },
+      { type: "session.execution.succeeded", properties: { sessionID: "s", sequence: undefined } },
     ]);
   });
 
@@ -595,21 +610,20 @@ describe("OpenCode v2 event translation", () => {
     }
   });
 
-  test("emits an error before terminal idle events for failed execution", () => {
+  test("preserves execution failure for sequenced terminal handling", () => {
     const state = createV2EventTranslationState();
     expect(translateV2Event({
       type: "session.execution.failed",
       properties: { sessionID: "ses_2", error: { message: "provider failed" } },
     }, state)).toEqual([
       {
-        type: "session.error",
+        type: "session.execution.failed",
         properties: {
           sessionID: "ses_2",
+          sequence: undefined,
           error: { name: "UnknownError", data: { message: "provider failed" } },
         },
       },
-      { type: "session.status", properties: { sessionID: "ses_2", status: { type: "idle" } } },
-      { type: "session.idle", properties: { sessionID: "ses_2" } },
     ]);
   });
 
@@ -623,7 +637,7 @@ describe("OpenCode v2 event translation", () => {
     ].flatMap((event) => translateV2Event(event, state) ?? []);
 
     expect(translated).toEqual([
-      { type: "session.status", properties: { sessionID: "ses_child", status: { type: "busy" } } },
+      { type: "session.execution.started", properties: { sessionID: "ses_child", sequence: undefined } },
       {
         type: "permission.asked",
         properties: {
@@ -640,8 +654,7 @@ describe("OpenCode v2 event translation", () => {
         type: "permission.replied",
         properties: { sessionID: "ses_child", requestID: "per_child", reply: "once" },
       },
-      { type: "session.status", properties: { sessionID: "ses_child", status: { type: "idle" } } },
-      { type: "session.idle", properties: { sessionID: "ses_child" } },
+      { type: "session.execution.succeeded", properties: { sessionID: "ses_child", sequence: undefined } },
     ]);
   });
 });
@@ -671,6 +684,28 @@ describe("OpenCode v2 client compatibility", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test.each([true, false])("returns the actual native interrupt acknowledgement %s", async (interrupted) => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+      expect(input instanceof Request && input.url.endsWith("/api/session/s/interrupt")).toBe(true);
+      return jsonResponse({ data: { interrupted } });
+    };
+    try {
+      expect((await createClientV2("http://opencode.test/opencode2", undefined, {}).session.abort({ sessionID: "s" })).data)
+        .toBe(interrupted);
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
+  test("rejects a malformed native interrupt acknowledgement", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => jsonResponse({ data: {} });
+    try {
+      const result = await createClientV2("http://opencode.test/opencode2", undefined, {}).session.abort({ sessionID: "s" });
+      expect(result.data).toBeUndefined();
+      expect(result.error).toEqual({ name: "InvalidV2InterruptResponse" });
+    } finally { globalThis.fetch = originalFetch; }
   });
 
   test("saved native instruction updates stay out of the visible conversation", async () => {

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
 import type { UIMessage } from "ai";
 import type { PermissionRequest, PermissionV2Request, QuestionRequest } from "@opencode-ai/sdk/v2/client";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
@@ -18,6 +18,9 @@ import {
   __hasWorkspaceSessionSyncForTest,
   __queueSessionSyncDeltaForTest,
   __setSessionSyncDeltaFlushSchedulerForTest,
+  __setWorkspaceSessionSyncPermissionFetcherForTest,
+  __setWorkspaceSessionSyncStatusFetcherForTest,
+  __revalidateWorkspaceSyncsForTest,
   applyPendingDeltasToTranscript,
   coalescePendingDeltas,
   ensureWorkspaceSessionSync,
@@ -26,6 +29,7 @@ import {
   seedPermissionState,
   seedQuestionState,
   settleQuestionState,
+  settlePermissionState,
   seedSessionState,
   trackWorkspaceSessionSync,
   transcriptKey,
@@ -112,6 +116,9 @@ function snapshotWithMessages(
 }
 
 afterEach(() => {
+  __setWorkspaceSessionSyncPermissionFetcherForTest(null);
+  __setWorkspaceSessionSyncStatusFetcherForTest(null);
+  setSystemTime();
   getReactQueryClient().clear();
   for (const sessionId of ["session-a", "session-b", "session-child"]) {
     useSessionActivityStore.getState().removeSession("workspace-a", sessionId);
@@ -198,6 +205,71 @@ describe("session permission sync", () => {
     });
   }
 
+  test("terminal cancellation and reconnect reconcile native permissions without reply events", async () => {
+    const input = { workspaceId: "workspace-a", baseUrl: "http://permissions.test/opencode2", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    const reads: string[] = [];
+    __setWorkspaceSessionSyncPermissionFetcherForTest(async (_url, _token, sessionID) => {
+      reads.push(sessionID);
+      return sessionID === "session-b" ? [v2Permission("other", "session-b")] : [];
+    });
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+    try {
+      setSystemTime(100);
+      seedPermissionState("workspace-a", "session-a", [v2Permission("cancelled", "session-a")]);
+      seedPermissionState("workspace-a", "session-b", [v2Permission("other", "session-b")]);
+      // An unchanged cache revision also settles requests from the same clock tick.
+      __applySessionSyncEventForTest(input, { type: "session.execution.interrupted", properties: {
+        sessionID: "session-a", reason: "user", sequence: 2,
+      } });
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(reads).toEqual(["session-a"]);
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toEqual([]);
+      expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-a")).toBe("idle");
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-b"))).toMatchObject([{ id: "other" }]);
+      seedPermissionState("workspace-a", "session-child", [v2Permission("missed", "session-child")]);
+      setSystemTime(300);
+      __revalidateWorkspaceSyncsForTest();
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+      expect(reads).toContain("session-child");
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-child"))).toEqual([]);
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-b"))).toMatchObject([{ id: "other" }]);
+    } finally { cleanup(); }
+  });
+
+  test("late reads cannot clear a same-clock new approval, resurrect a reply, or undo a newer cancellation snapshot", async () => {
+    const input = { workspaceId: "workspace-a", baseUrl: "http://permissions.test/opencode2", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    let resolve: (items: PermissionV2Request[]) => void = () => {};
+    __setWorkspaceSessionSyncPermissionFetcherForTest(() => new Promise((done) => { resolve = done; }));
+    try {
+      setSystemTime(100);
+      seedPermissionState("workspace-a", "session-a", [v2Permission("cancelled", "session-a"), v2Permission("replied", "session-a")]);
+      setSystemTime(200);
+      __applySessionSyncEventForTest(input, { type: "session.execution.interrupted", properties: { sessionID: "session-a", reason: "user" } });
+      __applySessionSyncEventForTest(input, { type: "session.execution.started", properties: { sessionID: "session-a" } });
+      __applySessionSyncEventForTest(input, { type: "permission.v2.asked", properties: v2Permission("new", "session-a") });
+      settlePermissionState("workspace-a", "session-a", "replied");
+      resolve([v2Permission("replied", "session-a")]);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      seedPermissionState("workspace-a", "session-a", [v2Permission("cancelled", "session-a")], { snapshotStartedAt: 150 });
+      __applySessionSyncEventForTest(input, { type: "permission.v2.asked", properties: v2Permission("replied", "session-a") });
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toMatchObject([{ id: "new" }]);
+      expect(useSessionActivityStore.getState().getStatus("workspace-a", "session-a")).toBe("waiting");
+    } finally { cleanup(); }
+  });
+
+  test("failed permission reconciliation preserves the pending request", async () => {
+    const input = { workspaceId: "workspace-a", baseUrl: "http://permissions.test/opencode2", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(input);
+    __setWorkspaceSessionSyncPermissionFetcherForTest(async () => { throw new Error("offline"); });
+    try {
+      seedPermissionState("workspace-a", "session-a", [v2Permission("pending", "session-a")]);
+      __applySessionSyncEventForTest(input, { type: "session.execution.interrupted", properties: { sessionID: "session-a", reason: "shutdown" } });
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toMatchObject([{ id: "pending" }]);
+    } finally { cleanup(); }
+  });
   test("seeds only permissions for the selected session", () => {
     seedPermissionState("workspace-a", "session-a", [
       permission("perm-a", "session-a"),

--- a/apps/app/tests/session-sync-run-status.test.ts
+++ b/apps/app/tests/session-sync-run-status.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, jest, setSystemTime, test } from "bun:test";
+import { afterEach, describe, expect, jest, setSystemTime, spyOn, test } from "bun:test";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { markTaskRunStart, takeTaskRunStart } from "../src/app/lib/analytics";
+import * as notifications from "../src/react-app/shell/desktop-notifications";
+import { createClientV2, createV2EventTranslationState, translateV2Event } from "../src/app/lib/opencode-v2-adapter";
 import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
 import {
   __applySessionSyncEventForTest,
@@ -165,6 +168,8 @@ function applyCompletedToolAndFinalAnswer(input: SyncInput) {
 }
 
 afterEach(() => {
+  jest.restoreAllMocks();
+  takeTaskRunStart(sessionId);
   jest.useRealTimers();
   for (const input of syncInputs) __disposeWorkspaceSessionSyncForTest(input);
   syncInputs.length = 0;
@@ -176,6 +181,104 @@ afterEach(() => {
   __resetWorkspaceSyncReconcileHealthForTest();
   getReactQueryClient().clear();
   setSystemTime();
+});
+
+describe("native v2 run lifecycle", () => {
+  function nativeSync() {
+    const input = { workspaceId, baseUrl: "https://run-status.example/opencode2", openworkToken: "token" };
+    syncInputs.push(input);
+    __createWorkspaceSessionSyncForTest(input);
+    trackWorkspaceSessionSync(input, sessionId);
+    const state = createV2EventTranslationState();
+    return { input, emit(type: string, sequence: number, data: Record<string, unknown> = {}) {
+      for (const event of translateV2Event({ type, durable: { seq: sequence }, data: { sessionID: sessionId, ...data } }, state) ?? []) {
+        __applySessionSyncEventForTest(input, event);
+      }
+    } };
+  }
+
+  test("independent native active clients cannot erase retry detail, but progress can", async () => {
+    jest.useFakeTimers();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => Response.json({ data: { [sessionId]: { type: "running" } } });
+    __setWorkspaceSessionSyncStatusFetcherForTest(async (url, token, signal) => {
+      const result = await createClientV2(url, undefined, { token }).session.status(undefined, { signal });
+      if (!result.data) throw result.error;
+      return result.data;
+    });
+    try {
+      const { emit } = nativeSync();
+      emit("session.execution.started", 1);
+      const retry = { type: "retry", attempt: 2, message: "Rate limited", next: 1_000 };
+      emit("session.retry.scheduled", 2, { attempt: 2, at: 1_000, error: { message: "Rate limited" } });
+      for (let i = 0; i < 3; i++) {
+        jest.advanceTimersByTime(5_000);
+        await flushMicrotasks();
+        expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual(retry);
+      }
+      const snapshot = createSnapshot({ type: "busy" });
+      markSessionSnapshotFetchStart(snapshot, Date.now());
+      seedSessionState(workspaceId, snapshot);
+      expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual(retry);
+      emit("session.step.started", 3);
+      expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+      emit("session.retry.scheduled", 2, { attempt: 2, at: 1_000, error: { message: "Rate limited" } });
+      expect(getReactQueryClient().getQueryData(statusKey(workspaceId, sessionId))).toEqual({ type: "busy" });
+    } finally { globalThis.fetch = originalFetch; }
+  });
+
+  test.each(["user", "shutdown", "superseded", "unknown"])("%s interruption never reports completed or stops a newer execution", async (reason) => {
+    jest.useFakeTimers();
+    const notify = spyOn(notifications, "notifyDesktopEvent").mockImplementation(() => {});
+    __setWorkspaceSessionSyncStatusFetcherForTest(async () => ({}));
+    const { emit } = nativeSync();
+    markTaskRunStart(sessionId);
+    emit("session.execution.started", 1);
+    emit("session.execution.interrupted", 2, { reason });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(reason !== "user");
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    expect(notify.mock.calls.some(([event]) => event.type === "task.completed")).toBe(false);
+    markTaskRunStart(sessionId);
+    emit("session.execution.started", 3);
+    emit("session.execution.interrupted", 2, { reason });
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+    emit("session.execution.succeeded", 4);
+    emit("session.execution.succeeded", 4);
+    expect(notify.mock.calls.filter(([event]) => event.type === "task.completed")).toHaveLength(1);
+  });
+
+  test("a same-clock late idle read cannot settle a successor and coarse idle is not success", async () => {
+    jest.useFakeTimers();
+    const notify = spyOn(notifications, "notifyDesktopEvent").mockImplementation(() => {});
+    let resolve: (value: Record<string, SessionStatus>) => void = () => {};
+    __setWorkspaceSessionSyncStatusFetcherForTest(() => new Promise((done) => { resolve = done; }));
+    const { emit } = nativeSync();
+    markTaskRunStart(sessionId);
+    emit("session.execution.started", 1);
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    emit("session.execution.started", 3);
+    resolve({});
+    await flushMicrotasks();
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(true);
+    jest.advanceTimersByTime(250);
+    await flushMicrotasks();
+    resolve({});
+    await flushMicrotasks();
+    expect(useSessionActivityStore.getState().recordsByWorkspaceId[workspaceId]?.[sessionId]?.runActive).toBe(false);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test("terminal listeners cannot have a queued successor's tracking consumed", () => {
+    const input = { workspaceId, baseUrl: "https://run-status.example/opencode2", openworkToken: "token",
+      onSessionStatus: ({ status }: { status: SessionStatus }) => { if (status.type === "idle") markTaskRunStart(sessionId); } };
+    syncInputs.push(input);
+    __createWorkspaceSessionSyncForTest(input);
+    markTaskRunStart(sessionId);
+    __applySessionSyncEventForTest(input, { type: "session.execution.interrupted", properties: { sessionID: sessionId, reason: "user", sequence: 2 } });
+    expect(takeTaskRunStart(sessionId)).not.toBeNull();
+  });
 });
 
 describe("session run status ordering", () => {

--- a/evals/packages/labs/src/mock-mcp.ts
+++ b/evals/packages/labs/src/mock-mcp.ts
@@ -32,6 +32,8 @@ export interface MockAgentToolStep {
 }
 
 export interface MockAgentWorkload {
+  /** Chat Completions: return this many 429s with Retry-After before serving the workload. */
+  rateLimitAttempts?: number;
   /** Chat Completions: match the latest user message and count only its tool rounds. */
   latestUserTurn?: boolean;
   promptMarker: string;

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -4,7 +4,7 @@ import { parentChildPermissionWorld, scopedPermissionRefreshWorld } from "../wor
 import { delegatedQuestionHandoff, permissionStopRecovery } from "../worlds/chat.ts";
 
 describe("Parent permission presentation", () => {
-const test = spec.world(parentChildPermissionWorld);
+const test = spec.world(parentChildPermissionWorld, { scope: "file" });
 
 const scopeTest = spec.world(scopedPermissionRefreshWorld, { timeout: 600_000 });
 
@@ -98,7 +98,7 @@ function text(value: unknown): string {
 }
 
 describe("Stop and retry reliability", () => {
-const stopTest = spec.world(permissionStopRecovery, { timeout: 600_000 });
+const stopTest = spec.world(permissionStopRecovery, { scope: "file", timeout: 600_000 });
 
 stopTest("retry recovery and stopping a permission leave other requests and fresh work intact", async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
@@ -180,8 +180,8 @@ stopTest("retry recovery and stopping a permission leave other requests and fres
 });
 
 describe("Delegated question handoff", () => {
-const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
-questionTest("a parent answers its real child question without settling an unrelated root question", async ({ world, user, probe, step }) => {
+const questionTest = spec.world(delegatedQuestionHandoff, { scope: "file", timeout: 600_000 });
+questionTest("a parent answers its real child question without settling an unrelated root question", { timeout: 1_200_000 }, async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
   const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
   const sessionPath = (id: string) => `/session/${encodeURIComponent(id)}`;

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect } from "vitest";
+import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { parentChildPermissionWorld, scopedPermissionRefreshWorld } from "../worlds/first-run.ts";
 import { delegatedQuestionHandoff, permissionStopRecovery } from "../worlds/chat.ts";
 
-describe("Parent permission presentation", () => {
-const test = spec.world(parentChildPermissionWorld, { scope: "file" });
+const test = spec.world(parentChildPermissionWorld);
 
 const scopeTest = spec.world(scopedPermissionRefreshWorld, { timeout: 600_000 });
 
@@ -76,7 +75,6 @@ test("a parent task surfaces and resolves its child session permission request",
     })))).toEqual({ permissionPanelVisible: false, waitingIconVisible: false, runningTreatmentVisible: true });
   });
 });
-});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -97,8 +95,7 @@ function text(value: unknown): string {
   return value;
 }
 
-describe("Stop and retry reliability", () => {
-const stopTest = spec.world(permissionStopRecovery, { scope: "file", timeout: 600_000 });
+const stopTest = spec.world(permissionStopRecovery, { timeout: 600_000 });
 
 stopTest("retry recovery and stopping a permission leave other requests and fresh work intact", async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
@@ -177,10 +174,8 @@ stopTest("retry recovery and stopping a permission leave other requests and fres
     await user.screenshot();
   });
 });
-});
 
-describe("Delegated question handoff", () => {
-const questionTest = spec.world(delegatedQuestionHandoff, { scope: "file", timeout: 600_000 });
+const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
 questionTest("a parent answers its real child question without settling an unrelated root question", { timeout: 1_200_000 }, async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
   const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
@@ -350,5 +345,4 @@ questionTest("a parent answers its real child question without settling an unrel
     expect(await transcript(child.sessionID)).toEqual(finished.child);
     await user.screenshot();
   });
-});
 });

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -1,8 +1,9 @@
-import { expect } from "vitest";
+import { describe, expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { parentChildPermissionWorld, scopedPermissionRefreshWorld } from "../worlds/first-run.ts";
 import { delegatedQuestionHandoff, permissionStopRecovery } from "../worlds/chat.ts";
 
+describe("Parent permission presentation", () => {
 const test = spec.world(parentChildPermissionWorld);
 
 const scopeTest = spec.world(scopedPermissionRefreshWorld, { timeout: 600_000 });
@@ -75,6 +76,7 @@ test("a parent task surfaces and resolves its child session permission request",
     })))).toEqual({ permissionPanelVisible: false, waitingIconVisible: false, runningTreatmentVisible: true });
   });
 });
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -95,8 +97,7 @@ function text(value: unknown): string {
   return value;
 }
 
-const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
-
+describe("Stop and retry reliability", () => {
 const stopTest = spec.world(permissionStopRecovery, { timeout: 600_000 });
 
 stopTest("retry recovery and stopping a permission leave other requests and fresh work intact", async ({ world, user, probe, step }) => {
@@ -176,7 +177,10 @@ stopTest("retry recovery and stopping a permission leave other requests and fres
     await user.screenshot();
   });
 });
+});
 
+describe("Delegated question handoff", () => {
+const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
 questionTest("a parent answers its real child question without settling an unrelated root question", async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";
   const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
@@ -346,4 +350,5 @@ questionTest("a parent answers its real child question without settling an unrel
     expect(await transcript(child.sessionID)).toEqual(finished.child);
     await user.screenshot();
   });
+});
 });

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { parentChildPermissionWorld, scopedPermissionRefreshWorld } from "../worlds/first-run.ts";
-import { delegatedQuestionHandoff } from "../worlds/chat.ts";
+import { delegatedQuestionHandoff, permissionStopRecovery } from "../worlds/chat.ts";
 
 const test = spec.world(parentChildPermissionWorld);
 
@@ -96,6 +96,86 @@ function text(value: unknown): string {
 }
 
 const questionTest = spec.world(delegatedQuestionHandoff, { timeout: 600_000 });
+
+const stopTest = spec.world(permissionStopRecovery, { timeout: 600_000 });
+
+stopTest("retry recovery and stopping a permission leave other requests and fresh work intact", async ({ world, user, probe, step }) => {
+  const v2 = world.engine === "v2";
+  const mount = `/workspace/${encodeURIComponent(world.workspace.workspaceId)}/${v2 ? "opencode2/api" : "opencode"}`;
+  const read = async (path: string): Promise<unknown> => {
+    const result = await probe.desktopApi(`${mount}${path}`);
+    expect(result.status, path).toBe(200);
+    return v2 ? record(result.body).data : result.body;
+  };
+  const pending = async (id: string) => records(await read(v2 ? `/session/${id}/permission` : "/permission"))
+    .filter((item) => item.sessionID === id);
+  const send = async (prompt: string) => { await user.type("composer", prompt, { verify: true }); await user.press("Enter"); };
+  const open = async (session: { title: string; sessionId: string }) => {
+    await user.click({ text: session.title });
+    await probe.eventually(() => probe.hash(), { within: 30_000, label: "the intended conversation is selected",
+      until: (hash) => hash.includes(`/session/${session.sessionId}`) });
+  };
+
+  await step("a native retry survives active polling and then recovers", async () => {
+    await send(world.retry.prompt);
+    await user.see({ text: /Rate limited for lifecycle verification/ }, { timeoutMs: 45_000 });
+    // Several authoritative reads span the sync poll cadence while the native
+    // engine still owns the retry. None is evidence of completion.
+    const observingUntil = Date.now() + 1_000;
+    do {
+      const active = record(await read(v2 ? "/session/active" : "/session/status"));
+      expect(active[world.other.sessionId]).toBeDefined();
+      await user.see({ text: /Rate limited for lifecycle verification/ });
+    } while (Date.now() < observingUntil);
+    await user.see({ text: world.retry.reply }, { timeoutMs: 45_000 });
+    await user.notSee({ text: /Rate limited for lifecycle verification/ });
+    const calls = await world.mock.agentRequests({ promptMarker: world.retry.prompt });
+    expect(calls.filter((call) => call.kind === "error")).toHaveLength(1);
+    expect(calls.filter((call) => call.kind === "final")).toHaveLength(1);
+  });
+
+  const unrelated = await step("two conversations own separate real approvals", async () => {
+    await send(world.other.prompt);
+    await user.see({ text: world.other.command }, { timeoutMs: 45_000 });
+    const other = await probe.eventually(() => pending(world.other.sessionId), { within: 30_000,
+      label: "the unrelated approval is pending", until: (items) => items.length === 1 });
+    await open(world.stopped);
+    await send(world.stopped.prompt);
+    await user.see({ text: world.stopped.command }, { timeoutMs: 45_000 });
+    expect(await pending(world.stopped.sessionId)).toHaveLength(1);
+    expect(await pending(world.other.sessionId)).toEqual(other);
+    return other;
+  });
+
+  await step("Stop removes its cancelled approval without a permission reply and preserves the other session", async () => {
+    await user.click({ role: "button", label: "Stop" });
+    await probe.eventually(() => pending(world.stopped.sessionId), { within: 30_000,
+      label: "native interruption cleanup removes the pending permission", until: (items) => items.length === 0 });
+    await user.notSee("Allow once", { timeoutMs: 15_000 });
+    await user.notSee({ role: "button", label: "Stop" });
+    if (v2) expect(record(await read(`/session/${world.stopped.sessionId}`)).outcome).toBe("interrupted");
+    expect(await pending(world.other.sessionId)).toEqual(unrelated);
+    expect((await world.mock.agentRequests({ promptMarker: world.stopped.prompt })).some((call) => call.kind === "final")).toBe(false);
+    await user.reload();
+    await user.see("composer", { editable: true, timeoutMs: 45_000 });
+    await user.notSee("Allow once");
+    expect(await pending(world.other.sessionId)).toEqual(unrelated);
+  });
+
+  await step("fresh work completes once and the unrelated approval remains answerable", async () => {
+    await send(world.followup.prompt);
+    await user.see({ text: world.followup.reply }, { timeoutMs: 45_000 });
+    expect((await world.mock.agentRequests({ promptMarker: world.followup.prompt })).filter((call) => call.kind === "final")).toHaveLength(1);
+    await open(world.other);
+    await user.see("Allow once");
+    expect(await pending(world.other.sessionId)).toEqual(unrelated);
+    await user.click("Allow once");
+    await user.see({ text: "Permission work finished." }, { timeoutMs: 45_000 });
+    await user.notSee("Allow once");
+    expect(await pending(world.stopped.sessionId)).toEqual([]);
+    await user.screenshot();
+  });
+});
 
 questionTest("a parent answers its real child question without settling an unrelated root question", async ({ world, user, probe, step }) => {
   const v2 = world.engine === "v2";

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -302,6 +302,28 @@ export async function delegatedQuestionHandoff(seed: Seed) {
   return { ...base, engine, delegationTool, root: { ...root, prompt: rootPrompt }, child, unrelated: { ...other, ...unrelated } };
 }
 
+/** Real native permissions and a provider retry, without synthetic UI events. */
+export async function permissionStopRecovery(seed: Seed) {
+  const engine = resolveEvalEngine();
+  const retry = { prompt: "Prepare the retry reliability summary", reply: "Retry recovery finished." };
+  const stopped = { prompt: "Inspect the stopped permission workspace", command: "printf STOP_PERMISSION_WITNESS" };
+  const other = { prompt: "Inspect the other permission workspace", command: "printf OTHER_PERMISSION_WITNESS" };
+  const followup = { prompt: "Continue with a fresh summary instead", reply: "Fresh work finished after stop." };
+  const base = await splitPaneQuestions(seed, "permission-stop-recovery", [
+    { promptMarker: retry.prompt, latestUserTurn: true, rateLimitAttempts: 1, finalReply: retry.reply, steps: [] },
+    ...[stopped, other].map((item): MockAgentWorkload => ({
+      promptMarker: item.prompt, latestUserTurn: true, finalReply: "Permission work finished.",
+      steps: [{ tool: engine === "v2" ? "shell" : "bash", arguments: {
+        command: item.command, description: "Inspect the permission workspace", timeout: 30_000,
+      } }],
+    })),
+    { promptMarker: followup.prompt, latestUserTurn: true, finalReply: followup.reply, steps: [] },
+  ], { permission: { bash: "ask" } });
+  const stoppedSession = await seedSessionRetry(seed, base.app, { title: "Stop permission task" });
+  const otherSession = await seedSessionRetry(seed, base.app, { title: "Keep permission task" });
+  return { ...base, engine, retry, followup, stopped: { ...stopped, ...stoppedSession }, other: { ...other, ...otherSession } };
+}
+
 export async function newSplitPrimary(seed: Seed) {
   const primaryPrompt = "Reply to the primary split message";
   const secondaryPrompt = "Reply to the secondary split message";

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -216,7 +216,10 @@ function validateAgentWorkloads(value) {
     const finalReplyDelayMs = workload.finalReplyDelayMs ?? 0;
     if (!Number.isInteger(finalReplyDelayMs) || finalReplyDelayMs < 0 || finalReplyDelayMs > 10000)
       throw new Error("finalReplyDelayMs must be between 0 and 10000");
-    return { promptMarker, finalReply, finalReplyFrom: workload.finalReplyFrom, finalReplyChunkSize, finalReplyDelayMs, finalReasoning: workload.finalReasoning, steps, latestUserTurn: workload.latestUserTurn === true };
+    const rateLimitAttempts = workload.rateLimitAttempts ?? 0;
+    if (!Number.isInteger(rateLimitAttempts) || rateLimitAttempts < 0 || rateLimitAttempts > 3)
+      throw new Error("rateLimitAttempts must be between 0 and 3");
+    return { promptMarker, finalReply, finalReplyFrom: workload.finalReplyFrom, finalReplyChunkSize, finalReplyDelayMs, finalReasoning: workload.finalReasoning, steps, latestUserTurn: workload.latestUserTurn === true, rateLimitAttempts };
   });
 }
 
@@ -410,6 +413,13 @@ async function handleAgentCompletion(req, res, entry) {
     return;
   }
   if (!workload) throw new Error("matched agent workload disappeared");
+  if (workload.rateLimitAttempts > 0) {
+    workload.rateLimitAttempts -= 1;
+    entry.agentCompletion = { ...baseRequest, kind: "error", promptMarker: workload.promptMarker, toolName: null, arguments: {} };
+    res.setHeader("retry-after", "5");
+    json(res, 429, { error: { message: "Rate limited for lifecycle verification" } });
+    return;
+  }
   if (completedTools >= workload.steps.length) {
     if (workload.finalReplyDelayMs) await new Promise(resolve => setTimeout(resolve, workload.finalReplyDelayMs));
     entry.agentCompletion = { ...baseRequest, kind: "final", promptMarker: workload.promptMarker, toolName: null, arguments: {} };


### PR DESCRIPTION
## Summary
- Preserve native v2 retry attempt, message, and next-at across independent active-session polls. Clear retry on progress or terminal observations, never elapsed time alone.
- Route conversation Stop through the selected engine: the existing v1 client or the native v2 adapter. Preserve the actual interruption acknowledgement.
- Distinguish v2 success from user interruption, shutdown, supersession, and idle with unknown outcome. Durable sequence ordering protects successor executions.
- Protect shared permission settlement and snapshots against stale reads, and consume terminal tracking before listeners can admit queued work. Native terminal/reconnect permission reconciliation is v2-specific.

## Current Verification: Incomplete
Head: d52e5dd87366a6bb1685fdafa5bd0360b840b6d1
Base: 7874bf927 (dev)

Rebased onto current dev and resolved two test conflicts by retaining both the newly merged v1/v2 scoped-permission hydration coverage and this lifecycle coverage. No assertions were removed or weakened. All four rebased commits have verified signatures.

Passed on this head:
- `pnpm --dir apps/app exec bun test --isolate tests/opencode-v2-adapter.test.ts tests/session-sync-run-status.test.ts tests/session-sync-permissions.test.ts`: exit 0; 121 passed, 0 failed, 0 skipped; 657 assertions. Includes v1/v2 permission hydration, native v2 lifecycle, and shared status/permission regression coverage.
- `pnpm --dir apps/app typecheck`: exit 0.
- `git diff --check origin/dev...HEAD`: exit 0.

Not run on this head:
- `OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e parent-child-permission-approval`
- `OPENWORK_EVAL_ENGINE=v2 pnpm evals:e2e parent-child-permission-approval`

The CLI placement resolver reports `placement: daytona (daytona CLI authenticated)`. These cold-boot journeys provision cloud resources; execution is pending approval for that resource usage. No local lane override was used. This is an execution-authorization blocker, not a failed product assertion. Both exact-head journey runs and their published evidence are required before declaring merge readiness.

The existing evidence comment at cf14cd8c7 is historical v2 evidence only and does not validate this rebased head. It also does not establish v1 journey coverage.

## Scope And Limits
Automatic task resumption after desktop restart is not implemented here. A separate follow-up must support both engines using durable OpenWork-owned recovery intent, explicit Stop/approval/completion exclusions, engine-specific reconciliation, and bounded staggered starts. Live shutdown/restart and supersession remain outside the current journey proof; focused tests cover their lifecycle handling.

No merge, release, or deployment was performed.