### PR TITLE
Keep model usage and enterprise workflow runs inside Analytics

### DIFF
--- a/ee/apps/den-api/src/routes/org/codemode-runs.ts
+++ b/ee/apps/den-api/src/routes/org/codemode-runs.ts
@@ -5,9 +5,10 @@ import { workflowRunPreviewSchema } from "@openwork/types/workflows"
 import { listWorkflowRuns } from "../../workflow-runs.js"
 import { workflowRunPreviews } from "../../workflows.js"
 import { listTeamsForMember } from "../../orgs.js"
+import { checkEntitlement } from "../../entitlements.js"
 import { db } from "../../db.js"
 import { orgMemberRoute, queryValidator } from "../../middleware/index.js"
-import { denTypeIdSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { denTypeIdSchema, enterprisePlanRequiredSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { memberHasRole } from "./shared.js"
 
@@ -46,12 +47,15 @@ export function registerOrgWorkflowRunRoutes<T extends { Variables: OrgRouteVari
         200: jsonResponse("Workflow runs returned successfully.", workflowRunListResponseSchema),
         400: jsonResponse("The Workflow run list query was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to list Workflow runs.", unauthorizedSchema),
+        402: jsonResponse("Workflow run analytics requires an Enterprise plan.", enterprisePlanRequiredSchema),
       },
     }),
     orgMemberRoute(),
     queryValidator(listWorkflowRunsQuerySchema),
     async (c) => {
       const context = c.get("organizationContext")
+      const entitlement = checkEntitlement(context.organization.metadata, "analytics")
+      if (!entitlement.ok) return c.json(entitlement.response, entitlement.status)
       const member = context.currentMember
       const isAdmin = member.isOwner || memberHasRole(member.role, "admin")
       const rows = await listWorkflowRuns(db, {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -519,6 +519,10 @@ export function getAnalyticsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/analytics`;
 }
 
+export function getModelsAnalyticsRoute(orgSlug?: string | null): string {
+  return `${getAnalyticsRoute(orgSlug)}/models`;
+}
+
 export function getManageMembersRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/manage-members`;
 }
@@ -536,7 +540,7 @@ export function getBackgroundAgentsRoute(orgSlug?: string | null): string {
 }
 
 export function getWorkflowRunsRoute(orgSlug?: string | null): string {
-  return `${getOrgDashboardRoute(orgSlug)}/workflow-runs`;
+  return `${getAnalyticsRoute(orgSlug)}/workflow-runs`;
 }
 
 export function getAutomationsRoute(orgSlug?: string | null): string {

--- a/ee/apps/den-web/app/(den)/_lib/inference-status.ts
+++ b/ee/apps/den-web/app/(den)/_lib/inference-status.ts
@@ -1,0 +1,73 @@
+type InferenceWindowType = "five_hour" | "weekly" | "monthly";
+
+export type InferenceUsageBucket = {
+  windowType: InferenceWindowType;
+  windowStartAt: string;
+  windowEndAt: string;
+  limitAmount: number;
+  usedAmount: number;
+};
+
+export type InferenceStatus = {
+  enabled: boolean;
+  tier: "tier1" | "tier2";
+  memberCount: number;
+  proxyBaseUrl: string;
+  upstreamProviderConfigured: boolean;
+  subscribed: boolean;
+  buckets: InferenceUsageBucket[];
+};
+
+function isWindowType(value: unknown): value is InferenceWindowType {
+  return value === "five_hour" || value === "weekly" || value === "monthly";
+}
+
+function parseUsageBuckets(value: unknown): InferenceUsageBucket[] {
+  if (!Array.isArray(value)) return [];
+  const buckets: InferenceUsageBucket[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const candidate = item as Partial<InferenceUsageBucket>;
+    if (
+      !isWindowType(candidate.windowType) ||
+      typeof candidate.windowStartAt !== "string" ||
+      typeof candidate.windowEndAt !== "string" ||
+      typeof candidate.limitAmount !== "number" ||
+      typeof candidate.usedAmount !== "number"
+    ) {
+      continue;
+    }
+    buckets.push({
+      windowType: candidate.windowType,
+      windowStartAt: candidate.windowStartAt,
+      windowEndAt: candidate.windowEndAt,
+      limitAmount: candidate.limitAmount,
+      usedAmount: candidate.usedAmount,
+    });
+  }
+  return buckets;
+}
+
+export function parseInferencePayload(payload: unknown): InferenceStatus | null {
+  if (!payload || typeof payload !== "object" || !("inference" in payload)) {
+    return null;
+  }
+  const inference = (payload as { inference?: unknown }).inference;
+  if (!inference || typeof inference !== "object") {
+    return null;
+  }
+  const value = inference as Partial<InferenceStatus> & { buckets?: unknown };
+  if (typeof value.enabled !== "boolean" || (value.tier !== "tier1" && value.tier !== "tier2")) {
+    return null;
+  }
+  return {
+    enabled: value.enabled,
+    tier: value.tier,
+    memberCount: typeof value.memberCount === "number" ? value.memberCount : 0,
+    proxyBaseUrl: typeof value.proxyBaseUrl === "string" ? value.proxyBaseUrl : "",
+    upstreamProviderConfigured: value.upstreamProviderConfigured === true,
+    subscribed: value.subscribed === true,
+    buckets: parseUsageBuckets(value.buckets),
+  };
+}
+

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/analytics/models/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/analytics/models/page.tsx
@@ -1,0 +1,5 @@
+import { ModelsAnalyticsScreen } from "../../../_features/analytics/models-analytics-screen";
+
+export default function ModelsAnalyticsPage() {
+  return <ModelsAnalyticsScreen />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/analytics/workflow-runs/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/analytics/workflow-runs/page.tsx
@@ -1,0 +1,5 @@
+import { WorkflowRunsScreen } from "../../../_components/workflow-runs-screen";
+
+export default function WorkflowRunsPage() {
+  return <WorkflowRunsScreen />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/script-runs/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/script-runs/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
+import { getWorkflowRunsRoute } from "../../../_lib/den-org";
 
-export default function LegacyScriptRunsPage() {
-  redirect("/dashboard/workflow-runs");
+export default function LegacyWorkflowRunsPage() {
+  redirect(getWorkflowRunsRoute());
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/workflow-runs/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/workflow-runs/page.tsx
@@ -1,5 +1,6 @@
-import { WorkflowRunsScreen } from "../../_components/workflow-runs-screen";
+import { redirect } from "next/navigation";
+import { getWorkflowRunsRoute } from "../../../_lib/den-org";
 
-export default function WorkflowRunsPage() {
-  return <WorkflowRunsScreen />;
+export default function LegacyWorkflowRunsPage() {
+  redirect(getWorkflowRunsRoute());
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -1,145 +1,20 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
 import { DenButton } from "../../_components/ui/button";
+import { DenPageHeader } from "../../_components/ui/page-header";
 import { DenCard } from "../../_components/ui/card";
 import { DenNotice } from "../../_components/ui/notice";
-import { AnalyticsPageHeader, analyticsPageClass, analyticsSurfaceClass } from "../_features/analytics/analytics-layout";
+import { parseInferencePayload, type InferenceStatus } from "../../_lib/inference-status";
 import { DenSectionHeader } from "../../_components/ui/section-header";
 import { DenTable, type DenTableColumn } from "../../_components/ui/table";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { getBillingRoute, getCustomLlmProvidersRoute, getOrgAccessFlags } from "../../_lib/den-org";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
-import { ModelsAnalyticsPanel } from "./models-analytics-panel";
-
-type InferenceWindowType = "five_hour" | "weekly" | "monthly";
-
-type InferenceUsageBucket = {
-  windowType: InferenceWindowType;
-  windowStartAt: string;
-  windowEndAt: string;
-  limitAmount: number;
-  usedAmount: number;
-};
-
-type InferenceStatus = {
-  enabled: boolean;
-  tier: "tier1" | "tier2";
-  memberCount: number;
-  proxyBaseUrl: string;
-  upstreamProviderConfigured: boolean;
-  subscribed: boolean;
-  buckets: InferenceUsageBucket[];
-};
-
-const WINDOW_LABEL: Record<InferenceWindowType, string> = {
-  five_hour: "5 hour usage limit",
-  weekly: "Weekly usage limit",
-  monthly: "Monthly usage limit",
-};
-
-const WINDOW_ORDER: InferenceWindowType[] = ["five_hour", "weekly", "monthly"];
-
-function isWindowType(value: unknown): value is InferenceWindowType {
-  return value === "five_hour" || value === "weekly" || value === "monthly";
-}
-
-function parseUsageBuckets(value: unknown): InferenceUsageBucket[] {
-  if (!Array.isArray(value)) return [];
-  const buckets: InferenceUsageBucket[] = [];
-  for (const item of value) {
-    if (!item || typeof item !== "object") continue;
-    const candidate = item as Partial<InferenceUsageBucket>;
-    if (
-      !isWindowType(candidate.windowType) ||
-      typeof candidate.windowStartAt !== "string" ||
-      typeof candidate.windowEndAt !== "string" ||
-      typeof candidate.limitAmount !== "number" ||
-      typeof candidate.usedAmount !== "number"
-    ) {
-      continue;
-    }
-    buckets.push({
-      windowType: candidate.windowType,
-      windowStartAt: candidate.windowStartAt,
-      windowEndAt: candidate.windowEndAt,
-      limitAmount: candidate.limitAmount,
-      usedAmount: candidate.usedAmount,
-    });
-  }
-  return buckets;
-}
-
-function parseInferencePayload(payload: unknown): InferenceStatus | null {
-  if (!payload || typeof payload !== "object" || !("inference" in payload)) {
-    return null;
-  }
-  const inference = (payload as { inference?: unknown }).inference;
-  if (!inference || typeof inference !== "object") {
-    return null;
-  }
-  const value = inference as Partial<InferenceStatus> & { buckets?: unknown };
-  if (typeof value.enabled !== "boolean" || (value.tier !== "tier1" && value.tier !== "tier2")) {
-    return null;
-  }
-  return {
-    enabled: value.enabled,
-    tier: value.tier,
-    memberCount: typeof value.memberCount === "number" ? value.memberCount : 0,
-    proxyBaseUrl: typeof value.proxyBaseUrl === "string" ? value.proxyBaseUrl : "",
-    upstreamProviderConfigured: value.upstreamProviderConfigured === true,
-    subscribed: value.subscribed === true,
-    buckets: parseUsageBuckets(value.buckets),
-  };
-}
-
-function formatResetLabel(bucket: InferenceUsageBucket): string {
-  const reset = new Date(bucket.windowEndAt);
-  if (Number.isNaN(reset.getTime())) return "—";
-  if (bucket.windowType === "five_hour") {
-    return `Resets ${reset.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}`;
-  }
-  return `Resets ${reset.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
-}
-
-function computeRemainingPercent(bucket: InferenceUsageBucket): number {
-  if (bucket.limitAmount <= 0) return 0;
-  const ratio = 1 - bucket.usedAmount / bucket.limitAmount;
-  if (!Number.isFinite(ratio)) return 0;
-  return Math.max(0, Math.min(100, ratio * 100));
-}
-
-function UsageLimitsCard({ buckets }: { buckets: InferenceUsageBucket[] }) {
-  const ordered = WINDOW_ORDER
-    .map((windowType) => buckets.find((bucket) => bucket.windowType === windowType))
-    .filter((bucket): bucket is InferenceUsageBucket => Boolean(bucket));
-
-  if (ordered.length === 0) return null;
-
-  return <section aria-label="Usage limits" className="grid gap-3">
-    <div className="flex flex-wrap items-baseline justify-between gap-2">
-      <h2 className="text-sm font-semibold text-[#07192C]">Shared usage limits</h2>
-      <p className="text-xs text-[#637291]">Included in your plan · Shared across active members</p>
-    </div>
-    <div className="grid gap-3.5 sm:grid-cols-3">
-      {ordered.map((bucket) => {
-        const remaining = computeRemainingPercent(bucket);
-        return <div key={bucket.windowType} className={`${analyticsSurfaceClass} p-5`}>
-          <p className="text-xs font-medium text-[#637291]">{WINDOW_LABEL[bucket.windowType]}</p>
-          <p className="mt-3 text-[26px] font-semibold tracking-tight text-[#07192C] tabular-nums">{remaining.toFixed(1)}% <span className="text-sm font-normal text-[#637291]">left</span></p>
-          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[#edf0f5]" role="progressbar" aria-label={`${WINDOW_LABEL[bucket.windowType]} remaining`} aria-valuemin={0} aria-valuemax={100} aria-valuenow={remaining}>
-            <div className={`h-full rounded-full transition-[width] ${remaining <= 10 ? "bg-amber-500" : "bg-[#6F3DFF]"}`} style={{ width: `${remaining}%` }} />
-          </div>
-          <p className="mt-2.5 text-xs text-[#637291]">{formatResetLabel(bucket)}</p>
-        </div>;
-      })}
-    </div>
-  </section>;
-}
 
 /**
  * Editorial detail per model: what a knowledge worker should reach for it for,
@@ -206,54 +81,6 @@ const MODEL_COLUMNS: readonly DenTableColumn<LineupModel>[] = [
     render: (model) => <span className="whitespace-nowrap font-mono text-[12px] text-gray-500">{model.id}</span>,
   },
 ];
-
-const PILLARS = [
-  {
-    label: "You or your whole team",
-    body: "One subscription activates OpenWork Models across your organization and lets everyone use battle-tested LLMs without setting anything up.",
-  },
-  {
-    label: "Nothing to set up",
-    body: "Every member is provisioned automatically. No provider accounts, no API keys.",
-  },
-  {
-    label: "No lock-in",
-    body: "Keep your own provider keys alongside these models and switch whenever you want.",
-  },
-];
-
-const STEPS: ReactNode[] = [
-  "Subscribe — one plan covers the whole workspace",
-  "Every member is provisioned automatically — nothing to send",
-  <>
-    Open OpenWork and pick any model from the{" "}
-    <code className="rounded-md bg-gray-100 px-2 py-1 font-mono text-[12px] text-gray-700">OpenWork</code> group
-  </>,
-  "Start working — usage limits are shared and scale with active members",
-];
-
-function GettingStartedCard() {
-  return (
-    <DenCard className="grid gap-6">
-      <div className="grid gap-4 sm:grid-cols-3">
-        {PILLARS.map((pillar) => (
-          <div key={pillar.label} className="grid gap-2 rounded-[16px] border border-gray-100 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-gray-400">{pillar.label}</p>
-            <p className="text-[13px] leading-5 text-gray-500">{pillar.body}</p>
-          </div>
-        ))}
-      </div>
-      <ol className="grid gap-3 border-t border-gray-100 px-1 pt-6">
-        {STEPS.map((step, index) => (
-          <li key={index} className="flex items-baseline gap-3">
-            <span className="shrink-0 font-mono text-[12px] text-gray-400">{index + 1}.</span>
-            <span className="text-[13.5px] leading-6 text-gray-700">{step}</span>
-          </li>
-        ))}
-      </ol>
-    </DenCard>
-  );
-}
 
 function ModelsLineup({ subscribed }: { subscribed: boolean }) {
   return (
@@ -411,23 +238,14 @@ export function InferenceScreen() {
     : "billed per active member";
 
   return (
-    <div className={analyticsPageClass}>
-      <AnalyticsPageHeader orgSlug={activeOrgSlug} active="models"
-        title="OpenWork Models"
-        description={subscribed ? "Your team’s model activity, consumption, and shared limits in one place." : "Reliable, hand-picked models for knowledge work. No API keys to manage."}
-        action={
-          <DenButton
-            type="button"
-            onClick={subscribed ? toggleEnabled : () => void startSubscribeCheckout()}
-            loading={loading || saving || subscribeBusy}
-            disabled={!canManageModels}
-            variant={enabled ? "secondary" : "primary"}
-          >
-            {actionLabel}
-          </DenButton>
-        }
+    <div className="mx-auto grid w-full max-w-[960px] gap-6 px-4 pb-12 pt-5 sm:px-6 lg:px-8">
+      <DenPageHeader title="OpenWork Models"
+        description="Reliable, hand-picked models for knowledge work. No API keys to manage."
         caption={`$10 / user / month · ${memberCaption}`}
-      />
+        action={<DenButton type="button" onClick={subscribed ? toggleEnabled : () => void startSubscribeCheckout()}
+          loading={loading || saving || subscribeBusy} disabled={!canManageModels} variant={enabled ? "secondary" : "primary"}>
+          {actionLabel}
+        </DenButton>} />
 
       {error ? <DenNotice message={error} tone="error" /> : null}
 
@@ -438,16 +256,11 @@ export function InferenceScreen() {
         />
       )}
 
-      {showGettingStarted ? <GettingStartedCard /> : null}
+      {showGettingStarted ? <DenCard>
+        <p className="text-sm leading-6 text-[#637291]">One subscription activates models for everyone in your workspace. After subscribing, choose a model from the OpenWork group in the app and start a task.</p>
+      </DenCard> : null}
 
-      {enabled && status ? <UsageLimitsCard buckets={status.buckets} /> : null}
-
-      {enabled && subscribed && canManageModels ? <ModelsAnalyticsPanel key={orgContext?.organization.id} /> : null}
-
-      {subscribed ? <details className={`${analyticsSurfaceClass} group p-5`}>
-        <summary className="cursor-pointer text-sm font-semibold text-[#30405F]">Included models <span className="ml-2 text-xs font-normal text-[#637291]">{MODEL_LINEUP.length} models available to every member</span></summary>
-        <div className="mt-5"><ModelsLineup subscribed={subscribed} /></div>
-      </details> : <ModelsLineup subscribed={subscribed} />}
+      <ModelsLineup subscribed={subscribed} />
 
       <p className="text-[13px] text-gray-400">
         Prefer your own provider accounts?{" "}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/workflow-runs-screen.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { ScrollText } from "lucide-react";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { RefreshCw } from "lucide-react";
+import { DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { EnterprisePlanNotice } from "./enterprise-plan-notice";
+import { AnalyticsEmptyState, AnalyticsPageHeader, analyticsPageClass, analyticsSurfaceClass } from "../_features/analytics/analytics-layout";
 import { DenCard } from "../../_components/ui/card";
 import { DenChip } from "../../_components/ui/chip";
 import { WorkflowFlowDiagram } from "./workflow-flow-diagram";
@@ -57,45 +61,34 @@ function WorkflowRunCard({ run }: { run: WorkflowRun }) {
 }
 
 export function WorkflowRunsScreen() {
-  const [runs, setRuns] = useState<WorkflowRun[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { activeOrg, orgContext } = useOrgDashboard();
+  const entitled = orgContext?.entitlements.analytics === true;
+  const { data: runs, isPending, isFetching, isError, refetch } = useQuery({
+    queryKey: ["workflow-runs", orgContext?.organization.id],
+    enabled: entitled,
+    refetchInterval: 30_000,
+    queryFn: async () => {
+      const { response, payload } = await requestJson("/v1/workflow-runs", { method: "GET" }, 12000);
+      if (!response.ok) throw new Error(getErrorMessage(payload, "Could not load workflow runs."));
+      return getWorkflowRuns(payload);
+    },
+  });
 
-  useEffect(() => {
-    let active = true;
-    void requestJson("/v1/workflow-runs", { method: "GET" }, 12000)
-      .then(({ response, payload }) => {
-        if (!response.ok) throw new Error(getErrorMessage(payload, `Failed to load Workflow runs (${response.status}).`));
-        if (active) setRuns(getWorkflowRuns(payload));
-      })
-      .catch((reason: unknown) => {
-        if (active) setError(reason instanceof Error ? reason.message : "Failed to load Workflow runs.");
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  return (
-    <DashboardPageTemplate
-      icon={ScrollText}
-      title="Workflow Runs"
+  return <div className={analyticsPageClass}>
+    <AnalyticsPageHeader orgSlug={activeOrg?.slug} active="workflows" title="Workflow Runs"
       description="Workflows are repeatable tasks you and your team can save, share, and run again. See their recent activity here."
-      colors={["#EEF2FF", "#6366F1", "#C7D2FE", "#A5B4FC"]}
-    >
-      {error ? <div className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">{error}</div> : null}
-      {loading ? (
-        <DenCard><p className="text-[13px] text-gray-500">Loading Workflow runs...</p></DenCard>
-      ) : runs.length === 0 ? (
-        <DenCard><p className="text-[13px] text-gray-500">No Workflow runs yet.</p></DenCard>
-      ) : (
-        <ol className="space-y-4" aria-label="Workflow runs">
+      caption="Enterprise analytics · Saved and one-off workflow activity"
+      action={entitled ? <DenButton variant="secondary" disabled={isFetching} onClick={() => void refetch()}>
+        <RefreshCw className={`mr-2 h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} aria-hidden="true" />Refresh runs
+      </DenButton> : null} />
+    {!entitled ? <EnterprisePlanNotice feature="Workflow Runs" /> : <>
+      {isError ? <DenNotice tone="error" message="Could not load workflow runs. Try refreshing." /> : null}
+      {isPending ? <p role="status" className="text-sm text-[#637291]">Loading workflow runs…</p>
+        : runs?.length === 0 ? <div className={analyticsSurfaceClass}>
+          <AnalyticsEmptyState title="No workflow runs yet">Run a saved workflow or a one-off task to see its activity here.</AnalyticsEmptyState>
+        </div> : runs ? <ol className="space-y-4" aria-label="Workflow runs">
           {runs.map((run) => <WorkflowRunCard key={run.id} run={run} />)}
-        </ol>
-      )}
-    </DashboardPageTemplate>
-  );
+        </ol> : null}
+    </>}
+  </div>;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_features/analytics/analytics-layout.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_features/analytics/analytics-layout.tsx
@@ -2,21 +2,24 @@
 
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { ArrowUpRight, BarChart3, Sparkles } from "lucide-react";
-import { getAnalyticsRoute, getInferenceRoute } from "../../../_lib/den-org";
+import { ArrowUpRight, BarChart3, Sparkles, ScrollText } from "lucide-react";
+import { getAnalyticsRoute, getModelsAnalyticsRoute, getWorkflowRunsRoute } from "../../../_lib/den-org";
+import { useOrgDashboard } from "../../_providers/org-dashboard-provider";
 import { useDenFlow } from "../../../_providers/den-flow-provider";
 
 export const analyticsSurfaceClass = "rounded-2xl border border-[#e3e7ee] bg-white";
 export const analyticsPageClass = "mx-auto grid w-full max-w-[1160px] gap-6 px-4 pb-12 pt-5 sm:px-6 lg:px-8";
 
 export function AnalyticsPageHeader({ orgSlug, active, title, description, action, caption }: {
-  orgSlug?: string | null; active: "adoption" | "models";
+  orgSlug?: string | null; active: "adoption" | "models" | "workflows";
   title: string; description: string; action?: ReactNode; caption?: ReactNode;
 }) {
   const { runtimeConfig } = useDenFlow();
+  const { orgContext } = useOrgDashboard();
   const pages = [
     { id: "adoption", label: "Usage & adoption", href: getAnalyticsRoute(orgSlug), icon: BarChart3 },
-    ...(runtimeConfig.orgMode === "single_org" ? [] : [{ id: "models", label: "Models & usage", href: getInferenceRoute(orgSlug), icon: Sparkles }]),
+    ...(runtimeConfig.orgMode === "single_org" ? [] : [{ id: "models", label: "Models & usage", href: getModelsAnalyticsRoute(orgSlug), icon: Sparkles }]),
+    ...(orgContext?.capabilities.workflows && orgContext.entitlements.analytics ? [{ id: "workflows", label: "Workflow Runs", href: getWorkflowRunsRoute(orgSlug), icon: ScrollText }] : []),
   ];
   return <header className="grid gap-5">
     <p className="text-xs font-medium text-[#637291]">Analytics</p>
@@ -28,7 +31,7 @@ export function AnalyticsPageHeader({ orgSlug, active, title, description, actio
       </div>
       {action}
     </div>
-    <nav aria-label="Analytics views" className="flex gap-6 border-b border-[#e3e7ee]">
+    <nav aria-label="Analytics views" className="flex flex-wrap gap-x-6 border-b border-[#e3e7ee]">
       {pages.map(({ id, label, href, icon: Icon }) => <Link key={id} href={href} aria-current={active === id ? "page" : undefined}
         className={`-mb-px inline-flex items-center gap-2 border-b-2 pb-3 text-sm font-medium transition-colors focus-visible:outline-offset-4 ${active === id ? "border-[#6F3DFF] text-[#6F3DFF]" : "border-transparent text-[#637291] hover:text-[#07192C]"}`}>
         <Icon className="h-4 w-4" aria-hidden="true" />{label}

--- a/ee/apps/den-web/app/(den)/dashboard/_features/analytics/models-analytics-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_features/analytics/models-analytics-screen.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { DenButton } from "../../../_components/ui/button";
+import { DenNotice } from "../../../_components/ui/notice";
+import { getErrorMessage, requestJson } from "../../../_lib/den-flow";
+import { getInferenceRoute } from "../../../_lib/den-org";
+import { parseInferencePayload } from "../../../_lib/inference-status";
+import { useDenFlow } from "../../../_providers/den-flow-provider";
+import { ModelsAnalyticsPanel } from "../../_components/models-analytics-panel";
+import { useOrgDashboard } from "../../_providers/org-dashboard-provider";
+import { AnalyticsEmptyState, AnalyticsPageHeader, analyticsPageClass, analyticsSurfaceClass } from "./analytics-layout";
+import { UsageLimitsCard } from "./usage-limits-card";
+
+export function ModelsAnalyticsScreen() {
+  const { activeOrg, orgContext } = useOrgDashboard();
+  const { runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const hosted = runtimeConfigLoaded && runtimeConfig.orgMode === "multi_org";
+  const status = useQuery({
+    queryKey: ["models-usage-limits", orgContext?.organization.id],
+    enabled: hosted && Boolean(orgContext),
+    refetchInterval: 30_000,
+    queryFn: async () => {
+      const { response, payload } = await requestJson("/v1/inference", { method: "GET" }, 12000);
+      if (!response.ok) throw new Error(getErrorMessage(payload, "Could not load model usage."));
+      const parsed = parseInferencePayload(payload);
+      if (!parsed) throw new Error("Could not load model usage.");
+      return parsed;
+    },
+  });
+
+  return <div className={analyticsPageClass}>
+    <AnalyticsPageHeader orgSlug={activeOrg?.slug} active="models" title="Models & usage"
+      description="Understand your team’s OpenWork Models activity, consumption, and shared limits."
+      caption="Included with OpenWork Models · Task analytics requires your team’s opt-in" />
+    {!runtimeConfigLoaded ? <p role="status">Loading model usage…</p> : !hosted ? (
+      <div className={analyticsSurfaceClass}><AnalyticsEmptyState title="OpenWork Models is available on OpenWork Cloud">
+        Usage &amp; adoption covers activity across your connected providers.
+      </AnalyticsEmptyState></div>
+    ) : <>
+      {status.isError ? <DenNotice tone="error" message="Could not load model usage. Refresh this page to try again." /> : null}
+      {status.isPending ? <p role="status" className="text-sm text-[#637291]">Loading model usage…</p> : null}
+      {status.data?.enabled && status.data.subscribed ? <>
+        <UsageLimitsCard buckets={status.data.buckets} />
+        <ModelsAnalyticsPanel key={orgContext?.organization.id} />
+      </> : status.data ? <div className={analyticsSurfaceClass}>
+        <AnalyticsEmptyState title="Model insights are included with OpenWork Models"
+          action={<DenButton href={getInferenceRoute(activeOrg?.slug)}>Set up OpenWork Models</DenButton>}>
+          Enable OpenWork Models for your workspace to see shared limits and choose whether to collect task analytics.
+        </AnalyticsEmptyState>
+      </div> : null}
+    </>}
+  </div>;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_features/analytics/usage-limits-card.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_features/analytics/usage-limits-card.tsx
@@ -1,0 +1,57 @@
+import type { InferenceUsageBucket } from "../../../_lib/inference-status";
+import { analyticsSurfaceClass } from "./analytics-layout";
+
+type InferenceWindowType = InferenceUsageBucket["windowType"];
+
+const WINDOW_LABEL: Record<InferenceWindowType, string> = {
+  five_hour: "5 hour usage limit",
+  weekly: "Weekly usage limit",
+  monthly: "Monthly usage limit",
+};
+
+const WINDOW_ORDER: InferenceWindowType[] = ["five_hour", "weekly", "monthly"];
+
+function formatResetLabel(bucket: InferenceUsageBucket): string {
+  const reset = new Date(bucket.windowEndAt);
+  if (Number.isNaN(reset.getTime())) return "—";
+  if (bucket.windowType === "five_hour") {
+    return `Resets ${reset.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}`;
+  }
+  return `Resets ${reset.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
+}
+
+function computeRemainingPercent(bucket: InferenceUsageBucket): number {
+  if (bucket.limitAmount <= 0) return 0;
+  const ratio = 1 - bucket.usedAmount / bucket.limitAmount;
+  if (!Number.isFinite(ratio)) return 0;
+  return Math.max(0, Math.min(100, ratio * 100));
+}
+
+export function UsageLimitsCard({ buckets }: { buckets: InferenceUsageBucket[] }) {
+  const ordered = WINDOW_ORDER
+    .map((windowType) => buckets.find((bucket) => bucket.windowType === windowType))
+    .filter((bucket): bucket is InferenceUsageBucket => Boolean(bucket));
+
+  if (ordered.length === 0) return null;
+
+  return <section aria-label="Usage limits" className="grid gap-3">
+    <div className="flex flex-wrap items-baseline justify-between gap-2">
+      <h2 className="text-sm font-semibold text-[#07192C]">Shared usage limits</h2>
+      <p className="text-xs text-[#637291]">Included in your plan · Shared across active members</p>
+    </div>
+    <div className="grid gap-3.5 sm:grid-cols-3">
+      {ordered.map((bucket) => {
+        const remaining = computeRemainingPercent(bucket);
+        return <div key={bucket.windowType} className={`${analyticsSurfaceClass} p-5`}>
+          <p className="text-xs font-medium text-[#637291]">{WINDOW_LABEL[bucket.windowType]}</p>
+          <p className="mt-3 text-[26px] font-semibold tracking-tight text-[#07192C] tabular-nums">{remaining.toFixed(1)}% <span className="text-sm font-normal text-[#637291]">left</span></p>
+          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[#edf0f5]" role="progressbar" aria-label={`${WINDOW_LABEL[bucket.windowType]} remaining`} aria-valuemin={0} aria-valuemax={100} aria-valuenow={remaining}>
+            <div className={`h-full rounded-full transition-[width] ${remaining <= 10 ? "bg-amber-500" : "bg-[#6F3DFF]"}`} style={{ width: `${remaining}%` }} />
+          </div>
+          <p className="mt-2.5 text-xs text-[#637291]">{formatResetLabel(bucket)}</p>
+        </div>;
+      })}
+    </div>
+  </section>;
+}
+

--- a/ee/apps/den-web/app/(den)/dashboard/_lib/dashboard-navigation.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_lib/dashboard-navigation.ts
@@ -7,7 +7,6 @@ import {
   LayoutDashboard,
   LibraryBig,
   Plug,
-  ScrollText,
   Settings2,
   SlidersHorizontal,
   Sparkles,
@@ -39,7 +38,6 @@ import {
   getSsoRoute,
   getToolTesterRoute,
   getWebRoute,
-  getWorkflowRunsRoute,
 } from "../../_lib/den-org";
 import type { DenOrgMode } from "../../_lib/runtime-config";
 
@@ -159,14 +157,6 @@ export function buildDashboardNavSections({
     : [];
   const observabilityItems: DashboardNavItem[] = access.isAdmin && orgSlug
     ? [
-        ...(workflowsEnabled
-          ? [{
-              href: getWorkflowRunsRoute(orgSlug),
-              label: "Workflow Runs",
-              icon: ScrollText,
-              testId: "nav-workflow-runs",
-            }]
-          : []),
         { href: getAnalyticsRoute(orgSlug), label: "Analytics", icon: BarChart3 },
       ]
     : [];
@@ -210,7 +200,7 @@ export function buildDashboardNavSections({
 // Alias order is ranking priority in the command palette.
 const PAGE_KEYWORDS: Record<string, string[]> = {
   Advanced: ["policy", "desktop policies", "mdm", "lock", "marketplace", "branding"],
-  Analytics: ["usage", "stats"],
+  Analytics: ["usage", "stats", "consumption", "workflow runs", "history", "langfuse"],
   "API Keys": ["token", "secret"],
   Billing: ["plan", "invoice", "payment"],
   "Bring your Own Keys": ["llm", "provider", "byok", "api key"],
@@ -230,7 +220,6 @@ const PAGE_KEYWORDS: Record<string, string[]> = {
   Settings: ["organization", "workspace"],
   SSO: ["single sign on", "saml", "oidc"],
   "Tool Tester": ["tools", "test", "mcp"],
-  "Workflow Runs": ["workflows", "logs", "history"],
 };
 
 function keywordsFor(...labels: string[]): string[] {

--- a/ee/apps/den-web/tests/dashboard-navigation.test.ts
+++ b/ee/apps/den-web/tests/dashboard-navigation.test.ts
@@ -46,13 +46,14 @@ describe("dashboard navigation index", () => {
     ]);
   });
 
-  test("gates Workflow Runs on the workflows capability", () => {
+  test("keeps workflow analytics inside the Analytics destination", () => {
     const withoutWorkflows = buildFor("admin").flatMap((section) => section.items);
     const withWorkflows = buildFor("admin", { ...baseCapabilities, workflows: true })
       .flatMap((section) => section.items);
 
     expect(withoutWorkflows.some((item) => item.label === "Workflow Runs")).toBe(false);
-    expect(withWorkflows.some((item) => item.label === "Workflow Runs")).toBe(true);
+    expect(withWorkflows.some((item) => item.label === "Workflow Runs")).toBe(false);
+    expect(withWorkflows.some((item) => item.label === "Analytics")).toBe(true);
   });
 
   test("flattens grouped pages with their plain-language search keywords", () => {

--- a/ee/apps/den-web/tests/org-dashboard-sidebar-ia.test.ts
+++ b/ee/apps/den-web/tests/org-dashboard-sidebar-ia.test.ts
@@ -45,7 +45,6 @@ describe("Den org sidebar information architecture", () => {
     const toolTester = indexOfNeedle('label: "Tool Tester"');
     const managedDashboards = indexOfNeedle('label: "Dashboards"');
     const advanced = indexOfNeedle('label: "Advanced"');
-    const workflowRuns = indexOfNeedle('label: "Workflow Runs"');
     const analytics = indexOfNeedle('label: "Analytics"');
     const workSection = indexOfNeedle('{ label: "Work", items: workItems }');
     const manageSection = indexOfNeedle('{ label: "Manage", items: manageItems }');
@@ -56,7 +55,8 @@ describe("Den org sidebar information architecture", () => {
     expect(connectors).toBeLessThan(toolTester);
     expect(toolTester).toBeLessThan(managedDashboards);
     expect(managedDashboards).toBeLessThan(advanced);
-    expect(workflowRuns).toBeLessThan(analytics);
+    expect(advanced).toBeLessThan(analytics);
+    expect(navigation).not.toContain('label: "Workflow Runs"');
     expect(workSection).toBeLessThan(manageSection);
     expect(manageSection).toBeLessThan(observabilitySection);
     expect(observabilitySection).toBeLessThan(teamSection);
@@ -74,6 +74,6 @@ describe("Den org sidebar information architecture", () => {
   });
 
   test("redirects the old Script runs path to Workflow runs", () => {
-    expect(legacyRunsPage).toContain('redirect("/dashboard/workflow-runs")');
+    expect(legacyRunsPage).toContain('redirect(getWorkflowRunsRoute())');
   });
 });

--- a/evals/specs/models-analytics-upgrade.e2e.test.ts
+++ b/evals/specs/models-analytics-upgrade.e2e.test.ts
@@ -21,7 +21,8 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   expect(baseline).toMatchObject({ enabled: true, subscribed: true, tier: "tier1" });
   await user.see({ role: "button", label: "Manage subscription" }, { timeoutMs: 90_000 });
   await user.notSee({ text: "Unlock custom insights" });
-  await user.notSee({ label: "Analytics views" });
+  await user.notSee({ role: "link", label: "Models & usage" });
+  await user.notSee({ role: "link", label: /^Usage & adoption$/ });
   await user.notSee({ text: "Shared usage limits" });
   await user.notSee({ role: "tab", label: "Activity" });
   await user.screenshot();
@@ -74,7 +75,8 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   expect(await settings()).toMatchObject({ enabled: true, consentVersion: 1 });
   await user.navigate(`${world.den.ref.webUrl}/dashboard/inference`);
   await user.see({ role: "button", label: "Manage subscription" });
-  await user.notSee({ label: "Analytics views" });
+  await user.notSee({ role: "link", label: "Models & usage" });
+  await user.notSee({ role: "link", label: /^Usage & adoption$/ });
   await user.notSee({ text: "Task analytics" });
   await user.notSee({ text: "Shared usage limits" });
   await user.notSee({ role: "tab", label: "Integrations" });

--- a/evals/specs/models-analytics-upgrade.e2e.test.ts
+++ b/evals/specs/models-analytics-upgrade.e2e.test.ts
@@ -21,6 +21,19 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   expect(baseline).toMatchObject({ enabled: true, subscribed: true, tier: "tier1" });
   await user.see({ role: "button", label: "Manage subscription" }, { timeoutMs: 90_000 });
   await user.notSee({ text: "Unlock custom insights" });
+  await user.notSee({ label: "Analytics views" });
+  await user.notSee({ text: "Shared usage limits" });
+  await user.notSee({ role: "tab", label: "Activity" });
+  await user.screenshot();
+  await user.click({ role: "link", label: /^Analytics$/ });
+  await user.see({ text: "Usage analytics is part of the Enterprise plan." });
+  await user.notSee({ role: "link", label: "Workflow Runs" });
+  await user.click({ role: "link", label: "Models & usage" });
+  await user.see({ text: "Shared usage limits" });
+  await user.notSee({ role: "button", label: "Manage subscription" });
+  await user.notSee({ text: "Unlock custom insights" });
+  evidence.recordAssertionEvidence("Paid Models usage lives in Analytics independently of the Enterprise plan", "The existing subscriber's Models page contains subscription controls without analytics or usage limits. Analytics exposes Models & usage and shared limits, while enterprise adoption analytics is locked and Workflow Runs is absent.", true);
+
   expect(await settings()).toMatchObject({ available: false, enabled: false });
   const beforeRollout = await world.complete({ sessionId: "existing-conversation", taskId: "before-rollout" });
   expect(beforeRollout.status).toBe(200);
@@ -59,6 +72,19 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   await user.click({ role: "button", label: "Enable task analytics" });
   await user.see({ role: "tab", label: "Activity" });
   expect(await settings()).toMatchObject({ enabled: true, consentVersion: 1 });
+  await user.navigate(`${world.den.ref.webUrl}/dashboard/inference`);
+  await user.see({ role: "button", label: "Manage subscription" });
+  await user.notSee({ label: "Analytics views" });
+  await user.notSee({ text: "Task analytics" });
+  await user.notSee({ text: "Shared usage limits" });
+  await user.notSee({ role: "tab", label: "Integrations" });
+  await user.click({ role: "link", label: /^Analytics$/ });
+  await user.click({ role: "link", label: "Models & usage" });
+  await user.see({ role: "tab", label: "Activity" });
+  await user.see({ role: "button", label: "Turn off analytics" });
+  expect(await settings()).toMatchObject({ enabled: true, consentVersion: 1 });
+  evidence.recordAssertionEvidence("Moving between Models and Analytics preserves consent and keeps the Models page focused", "After opting in, the Models page still contains no task analytics, usage limits, analytics navigation or integrations. Returning through Analytics restores the enabled Activity view without asking again.", true);
+
   expect(await activity()).toHaveLength(0);
   await user.see({ text: "Your next OpenWork Models task appears here" });
   await user.see({ text: "Tasks using your own provider connections" });

--- a/evals/specs/org-model-analytics.e2e.test.ts
+++ b/evals/specs/org-model-analytics.e2e.test.ts
@@ -134,9 +134,10 @@ test("organization model analytics aggregate session dimensions without cross-or
   await user.notSee({ text: "Could not load analytics." });
   evidence.recordAssertionEvidence("An analytics outage is shown as an error and can recover without inventing zero usage", "An analytics storage outage returned HTTP 500 and produced the error state with no empty charts; Refresh restored the previously ingested models after recovery", true);
   await user.click({ role: "link", label: "Models & usage" });
-  await user.see({ text: "Reliable, hand-picked models for knowledge work." });
+  await user.see({ text: "Understand your team’s OpenWork Models activity, consumption, and shared limits." });
+  await user.notSee({ role: "button", label: "Subscribe" });
   await user.click({ role: "link", label: /^Usage & adoption$/ });
   await user.see({ text: "Understand how your team works in OpenWork" });
   await user.see({ text: "prov/model-b" });
-  evidence.recordAssertionEvidence("Shared navigation connects adoption analytics and OpenWork Models", "Both views are reachable through the shared navigation and returning preserves access to the same organization’s model analytics", true);
+  evidence.recordAssertionEvidence("Shared navigation connects adoption and Models analytics", "Both views are reachable through the shared navigation and returning preserves access to the same organization’s model analytics", true);
 });

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -1,5 +1,7 @@
 import { expect } from "vitest";
 import { runWorkflow, saveWorkflow } from "@openwork/behaviors";
+import { queryDenDatabase } from "@openwork/env";
+import { defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
 import { spec } from "@openwork/testkit";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -26,8 +28,23 @@ function runs(value: unknown): Record<string, unknown>[] {
 // New journey: browse organization workflow activity and open the saved workflow
 // from the visualization of the version that produced a particular run.
 const test = spec.world(async (seed) => {
-  const den = await seed.den({ org: { name: "Workflow activity", members: { colleague: { name: "Teammate" } } } });
+  const den = await seed.den({ env: { DEN_PLAN_GATING_ENABLED: "true", DEN_ORG_MODE: "multi_org" }, org: { name: "Workflow activity", members: { colleague: { name: "Teammate" } } } });
   const organizationId = field(record((await seed.api(den.admin, "/v1/org")).body).organization, "id");
+  const setEnterprise = async (enabled: boolean) => {
+    const statement = "UPDATE organization SET metadata = JSON_SET(COALESCE(metadata, JSON_OBJECT()), '$.plan', JSON_OBJECT('tier', ?, 'source', 'manual')) WHERE id = ?";
+    const values = [enabled ? "enterprise" : "free", organizationId];
+    if (den.placement?.kind === "daytona") {
+      const script = `import { createConnection } from "/workspace/ee/packages/den-db/node_modules/mysql2/promise.js";
+        const connection = await createConnection("mysql://root:password@127.0.0.1:3306/openwork_den");
+        try { await connection.execute(${JSON.stringify(statement)}, ${JSON.stringify(values)}); } finally { await connection.end(); }`;
+      const encoded = Buffer.from(script).toString("base64");
+      const result = await execInSandbox(defaultDaytonaExec, den.placement.sandboxId, `printf %s ${encoded} | base64 -d | node --input-type=module`, { timeoutMs: 15_000, context: "Arrange isolated workspace plan" });
+      if (result.code !== 0) throw new Error("Could not arrange the workspace plan");
+    } else {
+      if (!den.database) throw new Error("Plan transition proof requires its own database");
+      await queryDenDatabase(den.database.url, statement, values);
+    }
+  };
   const token = field((await seed.api(den.admin, "/v1/mcp/token", {
     method: "POST", headers: { "x-openwork-org-id": organizationId }, body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
   })).body, "token");
@@ -66,7 +83,7 @@ const test = spec.world(async (seed) => {
   });
   if (failed.response.ok) throw new Error("Missing workflow input must fail");
   const web = await seed.web({ den, signedInAs: "admin", startPath: "/dashboard/workflow-runs", headless: true, viewport: { width: 1440, height: 1000 } });
-  return { den, web, configObjectId, pluginId, configObjectVersionId, receiptId: field(firstRun, "receiptId"), originalGraph: record(saved.body).graph, revisedGraph: record(revised.body).graph };
+  return { den, web, setEnterprise, configObjectId, pluginId, configObjectVersionId, receiptId: field(firstRun, "receiptId"), originalGraph: record(saved.body).graph, revisedGraph: record(revised.body).graph };
 }, { timeout: 600_000 });
 
 test("workflow activity shows linked version diagrams and keeps one-off and inaccessible runs readable", async ({ world, user, probe, seed, evidence, step }) => {
@@ -75,7 +92,33 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     expect(response.response.status, response.text).toBe(200);
     return runs(response.body);
   };
+  await step("restrict workflow analytics before an Enterprise upgrade", async () => {
+    for (const path of ["/v1/workflow-runs", "/v1/codemode-runs"]) {
+      const blocked = await probe.api(world.den.admin, path);
+      expect(blocked.response.status).toBe(402);
+      expect(blocked.body).toMatchObject({ error: "enterprise_plan_required", feature: "analytics" });
+      expect(record(blocked.body).runs).toBeUndefined();
+    }
+    // The old URL redirects into Analytics and receives the same gate.
+    await user.see({ text: "Workflow Runs is part of the Enterprise plan." }, { timeoutMs: 90_000 });
+    await user.see({ label: "Analytics views" });
+    await user.notSee({ testId: "nav-workflow-runs" });
+    await user.notSee({ role: "link", label: "Workflow Runs" });
+    await user.notSee({ testId: `workflow-run-link-${world.receiptId}` });
+    await user.navigate(`${world.den.ref.webUrl}/dashboard/analytics/workflow-runs`);
+    await user.see({ text: "Workflow Runs is part of the Enterprise plan." });
+    await user.notSee({ testId: `workflow-run-link-${world.receiptId}` });
+    await user.screenshot();
+  });
+  evidence.recordAssertionEvidence("Workflow run analytics is Enterprise-only through navigation, saved links and both API paths", "The free workspace's already executed workflows are hidden from analytics: both API aliases return 402 without runs, both old and new page URLs show the Enterprise gate, and there is no standalone sidebar destination or Workflow Runs analytics link.", true);
+  await world.setEnterprise(true);
+  await user.reload();
+  await user.click({ role: "link", label: /^Usage & adoption$/ });
+  await user.click({ role: "link", label: "Workflow Runs" });
+  await user.notSee({ text: "Workflow Runs is part of the Enterprise plan." });
+  await user.notSee({ testId: "nav-workflow-runs" });
   const before = await readRuns();
+  evidence.recordAssertionEvidence("An Enterprise upgrade unlocks Workflow Runs inside Analytics with existing history intact", "The upgraded workspace opens Workflow Runs from the shared Analytics navigation and the API returns its pre-upgrade receipts, including the original saved version.", before.some((run) => run.id === world.receiptId));
   const first = before.find((run) => run.id === world.receiptId);
   expect(first).toMatchObject({ workflow: { configObjectId: world.configObjectId, title: "Weekly briefing", graph: world.originalGraph } });
   expect(record(first?.workflow).graph).not.toEqual(world.revisedGraph);
@@ -196,5 +239,22 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     await user.screenshot();
   });
   evidence.recordAssertionEvidence("The workflow opens with a simple run form and shows the submitted result", "The form precedes the latest result and existing diagram. Advanced input starts hidden and stays synchronized with the named field; editing and inspecting it create no runs. Submitting creates exactly one successful run of the current saved version and displays the entered topic in its result.", true);
+
+  await step("keep workflow execution working after Enterprise access is removed", async () => {
+    await world.setEnterprise(false);
+    await user.navigate(`${world.den.ref.webUrl}/dashboard/analytics/workflow-runs`);
+    await user.see({ text: "Workflow Runs is part of the Enterprise plan." });
+    await user.notSee({ testId: `workflow-run-link-${world.receiptId}` });
+    await user.notSee({ role: "link", label: "Workflow Runs" });
+    expect((await probe.api(world.den.admin, "/v1/workflow-runs")).response.status).toBe(402);
+    await user.navigate(`${world.den.ref.webUrl}/dashboard/library/workflows/${world.configObjectId}`);
+    await user.see({ role: "button", label: "Run workflow" });
+    await user.type({ role: "textbox", label: /^Topic/ }, "Briefing after plan change", { replace: true, verify: true });
+    await user.click({ role: "button", label: "Run workflow" });
+    await user.see({ testId: "den-workflow-artifact-result" }, { text: /Briefing after plan change/, timeoutMs: 60_000 });
+    expect((await probe.api(world.den.admin, "/v1/workflow-runs")).response.status).toBe(402);
+    await user.screenshot();
+  });
+  evidence.recordAssertionEvidence("Removing Enterprise access hides history without breaking workflow execution", "After the downgrade, previously viewed receipts and the Workflow Runs link are absent and the API is locked. Running the saved workflow from the Library still succeeds and displays the newly submitted result.", true);
 
 });

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -101,6 +101,10 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     }
     // The old URL redirects into Analytics and receives the same gate.
     await user.see({ text: "Workflow Runs is part of the Enterprise plan." }, { timeoutMs: 90_000 });
+    expect(await probe.eval(world.web, "location.pathname")).toBe("/dashboard/analytics/workflow-runs");
+    await user.navigate(`${world.den.ref.webUrl}/dashboard/script-runs`);
+    await user.see({ text: "Workflow Runs is part of the Enterprise plan." });
+    expect(await probe.eval(world.web, "location.pathname")).toBe("/dashboard/analytics/workflow-runs");
     await user.see({ role: "link", label: /^Usage & adoption$/ });
     await user.see({ role: "link", label: "Models & usage" });
     await user.notSee({ testId: "nav-workflow-runs" });
@@ -111,7 +115,7 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     await user.notSee({ testId: `workflow-run-link-${world.receiptId}` });
     await user.screenshot();
   });
-  evidence.recordAssertionEvidence("Workflow run analytics is Enterprise-only through navigation, saved links and both API paths", "The free workspace's already executed workflows are hidden from analytics: both API aliases return 402 without runs, both old and new page URLs show the Enterprise gate, and there is no standalone sidebar destination or Workflow Runs analytics link.", true);
+  evidence.recordAssertionEvidence("Workflow run analytics is Enterprise-only through navigation, saved links and both API paths", "The free workspace's already executed workflows are hidden from analytics: both API aliases return 402 without runs, both legacy page URLs resolve to /dashboard/analytics/workflow-runs, which shows the Enterprise gate, and there is no standalone sidebar destination or Workflow Runs analytics link.", true);
   await world.setEnterprise(true);
   await user.reload();
   await user.click({ role: "link", label: /^Usage & adoption$/ });
@@ -170,6 +174,7 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     expect(await readRuns()).toEqual(before);
     await user.navigate(`${world.den.ref.webUrl}/dashboard/workflow-runs`);
     await user.see({ text: "Workflow Runs" });
+    expect(await probe.eval(world.web, "location.pathname")).toBe("/dashboard/analytics/workflow-runs");
     await user.click({ testId: `workflow-run-details-${world.receiptId}` });
     await user.see({ text: `plugin:${world.pluginId}:${world.configObjectId}` });
 

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -101,7 +101,8 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     }
     // The old URL redirects into Analytics and receives the same gate.
     await user.see({ text: "Workflow Runs is part of the Enterprise plan." }, { timeoutMs: 90_000 });
-    await user.see({ label: "Analytics views" });
+    await user.see({ role: "link", label: /^Usage & adoption$/ });
+    await user.see({ role: "link", label: "Models & usage" });
     await user.notSee({ testId: "nav-workflow-runs" });
     await user.notSee({ role: "link", label: "Workflow Runs" });
     await user.notSee({ testId: `workflow-run-link-${world.receiptId}` });

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -7991,6 +7991,10 @@ export type GetV1WorkflowRunsErrors = {
    * The caller must be signed in to list Workflow runs.
    */
   401: UnauthorizedError;
+  /**
+   * Workflow run analytics requires an Enterprise plan.
+   */
+  402: EnterprisePlanRequiredError;
 };
 
 export type GetV1WorkflowRunsError = GetV1WorkflowRunsErrors[keyof GetV1WorkflowRunsErrors];


### PR DESCRIPTION
Model activity, consumption, Langfuse integrations, and shared usage limits now live under Analytics → Models & usage. OpenWork Models is a compact subscription and model catalog page. Workflow Runs joins the shared Analytics navigation, with no standalone sidebar destination; existing run-history URLs redirect there.

Workflow run history uses the existing Enterprise analytics entitlement on both the page and API aliases. Paid Models analytics retains its separate subscription and explicit opt-in requirements. Running workflows and viewing their results in the Library remain available after an Enterprise downgrade. The generated SDK includes the new 402 response.

Validation on `12ec3029129778e60dd0cf25f5d94d3e6f6da5e1`: **36 assertions passed, zero failures and zero skips**, across three cold Daytona journeys.

- `pnpm evals:e2e workflow-run-previews`: 8 assertions, passed; upgrade/downgrade, explicit redirects from both legacy URLs, both API aliases, saved version previews, member isolation, and workflow execution.
- `pnpm evals:e2e models-analytics-upgrade`: 22 assertions, passed; compact Models page, navigation and consent persistence, existing subscription and model key, live desktop tasks, model switches, privacy, consumption, and Langfuse.
- `pnpm evals:e2e org-model-analytics`: 6 assertions, passed; organization isolation, displayed session totals, error recovery, and shared navigation.
- Den web typecheck passed. Warden and CodeQL are clear.

All E2E runs use cold Daytona environments with Infisical injection; no production customer data or real provider credentials are included in the evidence. Screenshots and assertion evidence are published in the PR's test-evidence comment.
