### PR TITLE
Give local tools and Ollama a native Connections home

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource react */
 import * as React from "react";
+import { useNavigate } from "react-router";
+import { workspaceSettingsRoute } from "../../../shell/workspace-routes";
 import {
   AlertCircle,
   AlertTriangle,
@@ -8,6 +10,7 @@ import {
   ArrowLeft,
   ArrowRight,
   Blocks,
+  Cable,
   Clock3,
   ChevronRight,
   Columns2,
@@ -906,6 +909,7 @@ function isSessionActivityStatus(status: string | undefined): status is SessionA
 }
 
 export function AppSidebar(props: AppSidebarProps) {
+  const navigate = useNavigate();
   // Lives in the UI store (not component state) so the open/closed state of
   // each workspace group survives this sidebar unmounting, e.g. while the
   // user is in Settings.
@@ -1167,6 +1171,12 @@ export function AppSidebar(props: AppSidebarProps) {
                 onSelect={props.onOpenAutomations}
               />
             ) : null}
+            <SidebarDestination
+              active={false}
+              icon={Cable}
+              label="Connections"
+              onSelect={() => navigate(workspaceSettingsRoute(props.selectedWorkspaceId, "connect"))}
+            />
             <SidebarDestination
               active={props.extensionsActive === true}
               icon={LayoutGrid}

--- a/apps/app/src/react-app/domains/settings/pages/connections-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connections-view.tsx
@@ -1,0 +1,61 @@
+/** @jsxImportSource react */
+import { ArrowRight, Cable, Cpu, Monitor, Globe, Mic, Image } from "lucide-react";
+import { isBuiltInOpenWorkExtension, type McpDirectoryInfo } from "../../../../app/constants";
+import { getMcpIdentityKey } from "../../../../app/mcp";
+
+export function ConnectionsView(props: {
+  entries: McpDirectoryInfo[];
+  onNavigate: (path: string) => void;
+  builtInsDisabled: boolean;
+}) {
+  const builtIns = props.entries.filter(isBuiltInOpenWorkExtension);
+  const groups = [
+    { title: "On your computer", description: "Give OpenWork access to the apps and tools you use on this device.", entries: builtIns.filter((entry) => entry.extensionManifest?.id !== "ollama") },
+    { title: "Local AI", description: "Run models on your computer with Ollama.", entries: builtIns.filter((entry) => entry.extensionManifest?.id === "ollama") },
+  ];
+  return (
+    <div className="w-full max-w-3xl space-y-8" data-testid="connections-home">
+      {props.builtInsDisabled ? <p role="status" className="rounded-xl border p-4 text-sm text-muted-foreground">Built-in features are disabled by your organization. You can review their setup, but cannot enable them.</p> : null}
+      {groups.filter((group) => group.entries.length > 0).map((group) => (
+        <section key={group.title} className="space-y-3" aria-label={group.title}>
+          <div>
+            <h3 className="text-sm font-medium">{group.title}</h3>
+            <p className="mt-1 text-sm text-muted-foreground">{group.description}</p>
+          </div>
+          <div className="divide-y rounded-xl border bg-card">
+            {group.entries.map((entry) => (
+              <button key={getMcpIdentityKey(entry)} type="button"
+                onClick={() => props.onNavigate(`connect/${encodeURIComponent(getMcpIdentityKey(entry))}`)}
+                className="flex w-full items-center gap-4 p-4 text-left transition-colors first:rounded-t-xl last:rounded-b-xl hover:bg-muted focus-visible:outline-2 focus-visible:outline-ring">
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+                  {entry.extensionManifest?.id === "ollama" ? <Cpu size={20} /> : entry.extensionManifest?.id === "openwork-browser" ? <Globe size={20} /> : entry.extensionManifest?.id === "openwork-voice" ? <Mic size={20} /> : entry.extensionManifest?.id === "computer-use" ? <Monitor size={20} /> : <Image size={20} />}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">{entry.name}</span>
+                  <span className="mt-1 block text-sm text-muted-foreground">{entry.extensionManifest?.id === "ollama" ? "Choose or download a local model." : entry.description}</span>
+                </span>
+                <ArrowRight size={16} className="shrink-0 text-muted-foreground" />
+              </button>
+            ))}
+          </div>
+        </section>
+      ))}
+      <section className="space-y-3" aria-label="Apps and services">
+        <h3 className="text-sm font-medium">Apps and services</h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {[
+            { title: "Connected accounts", description: "Manage accounts and services available through your organization.", path: "extensions/connections" },
+            { title: "Custom tools", description: "Connect an MCP server to this workspace.", path: "extensions/mcps" },
+            { title: "AI providers", description: "Connect services that provide AI models.", path: "ai" },
+          ].map((item) => (
+            <button key={item.path} type="button" onClick={() => props.onNavigate(item.path)}
+              className="flex items-start gap-3 rounded-xl border p-4 text-left transition-colors hover:bg-muted focus-visible:outline-2 focus-visible:outline-ring">
+              <Cable size={18} className="mt-0.5 shrink-0 text-muted-foreground" />
+              <span><span className="block text-sm font-medium">{item.title}</span><span className="mt-1 block text-sm text-muted-foreground">{item.description}</span></span>
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -3,6 +3,7 @@ import {
   ArrowRight,
   ArrowUpRight,
   Cloud,
+  Cable,
   Cog,
   FolderLock,
   LifeBuoy,
@@ -32,6 +33,7 @@ type SettingsCardDefinition = { tab: SettingsTab; icon: typeof Sparkles } & (
 );
 
 const workspaceCards: SettingsCardDefinition[] = [
+  { tab: "connect", icon: Cable, title: "Connections", desc: "Computer Use, Ollama, browser, and connected services." },
   { tab: "preferences", icon: Cog, title: "Preferences", desc: "Default model, reasoning, and compaction." },
   { tab: "permissions", icon: FolderLock, title: "Permissions", desc: "Authorized folders and file access." },
   { tab: "advanced", icon: Wrench, title: "Advanced", desc: "Runtime, engine, recovery, and developer options." },

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -185,6 +185,7 @@ export type McpViewProps = {
   allowManageExtensions: boolean;
   selectedMcp: string | null;
   setSelectedMcp: (name: string | null) => void;
+  detailBackLabel?: string;
   quickConnect: McpDirectoryInfo[];
   connectMcp: (entry: McpDirectoryInfo) => Promise<McpConnectResult>;
   authorizeMcp: (entry: McpServerEntry) => void;
@@ -1005,7 +1006,7 @@ export function McpView(props: McpViewProps) {
             open={!!detailEntry}
             onClose={closeDetail}
             presentation={detailPresentation}
-            backLabel={t("extensions.title")}
+            backLabel={props.detailBackLabel ?? t("extensions.title")}
             name={detailEntry.name}
             description={detailEntry.description}
             iconSlug={detailEntry.iconSlug}

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -108,7 +108,7 @@ export function getSettingsTabLabel(tab: SettingsTab) {
     case "cloud-account":
       return t("settings.tab_cloud_account");
     case "connect":
-      return t("settings.tab_connect");
+      return "Connections";
     case "cloud-marketplaces":
       return t("settings.tab_cloud_marketplaces");
     case "cloud-providers":
@@ -147,7 +147,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
     case "cloud-account":
       return t("settings.tab_description_cloud_account");
     case "connect":
-      return t("settings.tab_description_connect");
+      return "Set up computer access, local AI, and connected services";
     case "cloud-marketplaces":
       return t("settings.tab_description_cloud_marketplaces");
     case "cloud-providers":
@@ -176,7 +176,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
 }
 
 export function getWorkspaceSettingsTabs(): SettingsTab[] {
-  return ["preferences", "permissions", "extensions", "advanced"];
+  return ["preferences", "permissions", "connect", "extensions", "advanced"];
 }
 
 export function getGlobalSettingsTabs(

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -831,6 +831,7 @@ export function OpenworkRouteControlActions() {
         capabilities: [
           { id: "browse", label: "Browse the web", description: "Control a browser to navigate, scrape, and automate web tasks." },
           { id: "providers", label: "AI model providers", description: "Connect Anthropic, OpenAI, Google, OpenRouter, Ollama, or other LLM providers." },
+          { id: "connect", label: "Connections", description: "Set up Computer Use, browser, Ollama, and connected services in Settings." },
           { id: "extensions", label: "Library", description: "Skills, connections, and tools your agent can use." },
           { id: "voice", label: "Voice mode", description: "Talk to OpenWork with real-time voice using OpenAI Realtime." },
           { id: "files", label: "File management", description: "Read, write, and organize files in your workspace." },

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -82,6 +82,7 @@ import { useSettingsExtensionController } from "@/react-app/domains/settings/set
 import { buildExtensionItems } from "@/react-app/domains/settings/extension-items";
 import { isOpenWorkExtensionEnabled, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
 import { PreferencesView } from "@/react-app/domains/settings/pages/preferences-view";
+import { ConnectionsView } from "@/react-app/domains/settings/pages/connections-view";
 import { GeneralSettingsView } from "@/react-app/domains/settings/pages/general-view";
 import { AuthorizedFoldersPanel } from "@/react-app/domains/settings/panels/authorized-folders-panel";
 import { BrowserLoginsPanel } from "../domains/browser-logins/browser-logins-panel";
@@ -316,7 +317,7 @@ export function parseSettingsPath(pathname: string): {
     case "cloud-providers":
       return { tab: head, redirectPath: null };
     case "connect":
-      return { tab: "extensions", redirectPath: "extensions", extensionsSection: "all" };
+      return { tab: "connect", redirectPath: null, ...(tail ? { extensionDetailId: decodeURIComponent(tail) } : {}) };
     case "recovery":
       return { tab: "advanced", redirectPath: "advanced" };
     case "skills":
@@ -423,8 +424,8 @@ function findSessionWorkspaceId(
 
 export function settingsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
   if (route.tab === "advanced" && route.advancedSection) return `advanced/${route.advancedSection}`;
-  if (route.tab === "extensions" && route.extensionDetailId) {
-    return `extensions/${encodeURIComponent(route.extensionDetailId)}`;
+  if ((route.tab === "extensions" || route.tab === "connect") && route.extensionDetailId) {
+    return `${route.tab}/${encodeURIComponent(route.extensionDetailId)}`;
   }
   if (route.tab === "extensions" && route.extensionsSection && route.extensionsSection !== "all") {
     return `extensions/${route.extensionsSection}`;
@@ -2446,6 +2447,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             }}
           />
         );
+      case "connect":
+        if (!route.extensionDetailId) {
+          return <ConnectionsView entries={extensionItems.quickConnectEntries} builtInsDisabled={builtInExtensionsDisabled} onNavigate={navigateSettingsPath} />;
+        }
+        // Reuse the same policy checks and setup controllers for native settings.
       case "extensions":
         return (
           <ExtensionsView
@@ -2461,7 +2467,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             initialSection={route.extensionsSection}
             detailId={route.extensionDetailId ?? null}
             onDetailIdChange={(id) => {
-              navigateSettingsPath(id ? `extensions/${encodeURIComponent(id)}` : "extensions");
+              const home = route.tab === "connect" ? "connect" : "extensions";
+              navigateSettingsPath(id ? `${home}/${encodeURIComponent(id)}` : home);
             }}
             setSectionRoute={(section) => {
               const path = section === "all" ? "extensions" : `extensions/${section}`;
@@ -2481,6 +2488,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             }}
             mcpView={({ initialFilter, onFilterChange, initialState, onStateChange, detailId, onDetailIdChange, onRefresh }) => (
               <McpView
+                detailBackLabel={route.tab === "connect" ? "Connections" : undefined}
                 busy={busy}
                 selectedWorkspaceRoot={selectedWorkspaceRoot}
                 isRemoteWorkspace={isRemoteWorkspace}

--- a/apps/app/tests/settings-route.test.ts
+++ b/apps/app/tests/settings-route.test.ts
@@ -36,17 +36,21 @@ describe("settings route parsing", () => {
     });
   });
 
-  test("redirects Connect settings into Extensions", () => {
+  test("opens native Connections settings", () => {
     expect(parseSettingsPath("/settings/connect")).toEqual({
-      tab: "extensions",
-      redirectPath: "extensions",
-      extensionsSection: "all",
+      tab: "connect",
+      redirectPath: null,
     });
     expect(parseSettingsPath("/workspace/workspace_1/settings/connect")).toEqual({
-      tab: "extensions",
-      redirectPath: "extensions",
-      extensionsSection: "all",
+      tab: "connect",
+      redirectPath: null,
     });
+  });
+
+  test("round-trips Connections setup deep links", () => {
+    const route = parseSettingsPath("/workspace/workspace_1/settings/connect/ollama");
+    expect(route).toEqual({ tab: "connect", redirectPath: null, extensionDetailId: "ollama" });
+    expect(settingsPathForRoute(route)).toBe("connect/ollama");
   });
 
   test("preserves extension section deep links", () => {
@@ -102,7 +106,7 @@ describe("settings route parsing", () => {
 
 describe("settings navigation", () => {
   test("includes Library in workspace settings", () => {
-    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "extensions", "advanced"]);
+    expect(getWorkspaceSettingsTabs()).toEqual(["preferences", "permissions", "connect", "extensions", "advanced"]);
     expect(getSettingsTabLabel("extensions")).toBe("Library");
   });
 

--- a/evals/specs/library-add-connector-discovery.e2e.test.ts
+++ b/evals/specs/library-add-connector-discovery.e2e.test.ts
@@ -73,6 +73,58 @@ test(title, async ({ evidence, place }) => {
     deviceScaleFactor: 1,
     mobile: false,
   });
+  await waitFor(desktop, `[...document.querySelectorAll('button')].some((button) => button.textContent?.trim() === 'Connections')`, {
+    timeoutMs: 90_000, label: "Connections in app navigation",
+  });
+  expect(await evalIn(desktop, `(() => {
+    const button = [...document.querySelectorAll('button')].find((item) => item.textContent?.trim() === 'Connections');
+    if (!button) return false;
+    button.click();
+    return true;
+  })()`)).toBe(true);
+  await waitFor(desktop, `Boolean(document.querySelector('[data-testid="connections-home"]'))`, {
+    timeoutMs: 30_000, label: "native Connections home",
+  });
+  const home = await evalIn(desktop, `(() => {
+    const home = document.querySelector('[data-testid="connections-home"]');
+    return { text: home?.textContent, route: location.hash, overflow: document.documentElement.scrollWidth > innerWidth };
+  })()`);
+  expect(home).toMatchObject({ route: expect.stringContaining('/settings/connect'), overflow: false });
+  for (const label of ['On your computer', 'Local AI', 'Ollama', 'Connected accounts', 'Custom tools', 'AI providers']) {
+    expect(home).toMatchObject({ text: expect.stringContaining(label) });
+  }
+  await screenshot(desktop);
+  for (const name of ['OpenWork Browser', 'Ollama']) {
+    expect(await evalIn(desktop, `(() => {
+      const button = [...document.querySelectorAll('[data-testid="connections-home"] button')]
+        .find((item) => item.textContent?.includes(${JSON.stringify(name)}));
+      if (!button) return false;
+      button.click();
+      return true;
+    })()`)).toBe(true);
+    await waitFor(desktop, `location.hash.includes('/settings/connect/') && !document.querySelector('[data-testid="connections-home"]')
+      && [...document.querySelectorAll('button')].some((button) => button.textContent?.trim() === 'Connections')`, {
+      timeoutMs: 30_000, label: `${name} setup within Connections`,
+    });
+    expect(await evalIn(desktop, `document.body.textContent.includes(${JSON.stringify(name)})`)).toBe(true);
+    // Navigate using the detail's own back button, excluding sidebar destinations.
+    expect(await evalIn(desktop, `(() => {
+      const button = [...document.querySelectorAll('button')].find((item) =>
+        item.textContent?.trim() === 'Connections' && !item.hasAttribute('data-sidebar'));
+      if (!button) return false;
+      button.click();
+      return true;
+    })()`)).toBe(true);
+    await waitFor(desktop, `Boolean(document.querySelector('[data-testid="connections-home"]')) && !location.hash.includes('/extensions')`, {
+      timeoutMs: 30_000, label: `${name} returns to Connections rather than Library`,
+    });
+  }
+  evidence.recordAssertionEvidence(
+    "Connections is discoverable from the app and local setup returns to its native home",
+    "App navigation opened Connections; device tools, Ollama, account and custom-tool entry points fit the viewport. Browser and Ollama detail routes returned to Connections without entering Library.",
+    true,
+  );
+
   await go(desktop, `/workspace/${desktop.workspaceId}/extensions`);
   await waitFor(desktop, `[...document.querySelectorAll("button")]
     .some((button) => (button.textContent ?? "").trim() === "Add")`, {

--- a/evals/specs/library-add-connector-discovery.e2e.test.ts
+++ b/evals/specs/library-add-connector-discovery.e2e.test.ts
@@ -68,7 +68,7 @@ test(title, async ({ evidence, place }) => {
   });
 
   await desktop.client.send("Emulation.setDeviceMetricsOverride", {
-    width: 820,
+    width: 1280,
     height: 760,
     deviceScaleFactor: 1,
     mobile: false,
@@ -84,6 +84,9 @@ test(title, async ({ evidence, place }) => {
   })()`)).toBe(true);
   await waitFor(desktop, `Boolean(document.querySelector('[data-testid="connections-home"]'))`, {
     timeoutMs: 30_000, label: "native Connections home",
+  });
+  await desktop.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 820, height: 760, deviceScaleFactor: 1, mobile: false,
   });
   const home = await evalIn(desktop, `(() => {
     const home = document.querySelector('[data-testid="connections-home"]');


### PR DESCRIPTION
Computer Use, Browser, and Ollama currently require users to discover them among Library items. Add a direct **Connections** destination in the app sidebar and Settings, with device capabilities, local AI, and entry points for connected accounts, custom tools, and AI providers.

Built-in setup opens at `/settings/connect/:id` and returns to Connections. The home reads the existing feature catalog, and detail pages reuse the existing setup controllers and organization restrictions. Existing Library URLs and management screens remain available.

Validation on `5a3482c8478ef11c45e68ba4a5fbeba81e354a36`:

- `pnpm --filter @openwork/app typecheck` — passed.
- `pnpm --filter @openwork/app exec bun test tests/settings-route.test.ts` — 14 passed, 0 failed; 41 assertions.
- `OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e library-add-connector-discovery` — `placement: daytona (daytona CLI authenticated)`; 1 passed, 0 failed, 0 skipped. Checks sidebar discovery, compact layout, Browser/Ollama setup returning to Connections, and the existing Library connector picker.

The runtime journey uses Linux. macOS Computer Use permissions and actual model downloads are not exercised by this discovery/navigation test.

Reproduce: `OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e library-add-connector-discovery`.
