### PR TITLE
fix(den): eliminate signup flashes during Cloud reload

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -5,45 +5,11 @@ import { useEffect, useRef } from "react";
 import { isSamePathname } from "../_lib/client-route";
 import { getMcpOAuthSelectOrganizationRoute } from "../_lib/mcp-oauth-route";
 import { useDenFlow } from "../_providers/den-flow-provider";
+import { WorkspaceLoadingScreen } from "./workspace-loading-screen";
 import { AuthPanel } from "./auth-panel";
 import { OnboardingTexture } from "./onboarding-texture";
 import { SetupFrame } from "./setup-frame";
 import { TemporaryAuthNotice } from "./temporary-auth-notice";
-
-function SessionStatusPanel({ mode }: { mode: "checking" | "redirecting" }) {
-  const status = mode === "checking"
-    ? {
-        title: "Checking account",
-        body: "If you are already signed in, we will open your workspace. Otherwise you can continue here.",
-      }
-    : {
-        title: "Opening workspace",
-        body: "You are signed in. We are taking you to the right Cloud destination.",
-      };
-
-  return (
-    <div className="grid gap-6" role="status" aria-live="polite">
-      <div className="grid gap-3">
-        <p className="den-eyebrow">Account</p>
-        <div className="rounded-[1.5rem] border border-[var(--dls-border)] bg-[var(--dls-hover)]/60 p-4">
-          <div className="flex items-start gap-3">
-            <span className="relative mt-1 flex h-2.5 w-2.5 shrink-0">
-              <span className="absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full bg-[var(--dls-text-primary)] opacity-30" />
-              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--dls-text-primary)]" />
-            </span>
-            <div className="min-w-0">
-              <p className="m-0 text-[14px] font-medium text-[var(--dls-text-primary)]">{status.title}</p>
-              <p className="mt-1 text-[13px] leading-6 text-[var(--dls-text-secondary)]">{status.body}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <p className="m-0 text-xs leading-5 text-[var(--dls-text-secondary)]">
-        No action needed.
-      </p>
-    </div>
-  );
-}
 
 export function AuthScreen() {
   const router = useRouter();
@@ -75,6 +41,10 @@ export function AuthScreen() {
       });
   }, [hasResolvedSession, pathname, resolveUserLandingRoute, router]);
 
+  if (!sessionHydrated || hasResolvedSession) {
+    return <WorkspaceLoadingScreen />;
+  }
+
   return (
     <SetupFrame
       step="account"
@@ -84,16 +54,10 @@ export function AuthScreen() {
     >
       <div data-testid="auth-landing-frame">
         <div data-testid="auth-landing-form">
-          {!sessionHydrated ? (
-            <SessionStatusPanel mode="checking" />
-          ) : hasResolvedSession ? (
-            <SessionStatusPanel mode="redirecting" />
-          ) : (
-            <div className="grid gap-5">
-              <TemporaryAuthNotice />
-              <AuthPanel bare emailFirstFlow />
-            </div>
-          )}
+          <div className="grid gap-5">
+            <TemporaryAuthNotice />
+            <AuthPanel bare emailFirstFlow />
+          </div>
         </div>
       </div>
     </SetupFrame>

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -25,19 +25,23 @@ export function AuthScreen() {
 
     const oauthRoute = typeof window === "undefined" ? null : getMcpOAuthSelectOrganizationRoute(window.location.search);
     if (oauthRoute && !isSamePathname(pathname, oauthRoute)) {
+      routingRef.current = true;
       router.replace(oauthRoute);
       return;
     }
 
     routingRef.current = true;
+    let navigationStarted = false;
     void resolveUserLandingRoute()
       .then((target) => {
         if (target && !isSamePathname(pathname, target)) {
+          navigationStarted = true;
           router.replace(target);
         }
       })
       .finally(() => {
-        routingRef.current = false;
+        // Hold the guard until unmount: provider updates can arrive before navigation commits.
+        if (!navigationStarted) routingRef.current = false;
       });
   }, [hasResolvedSession, pathname, resolveUserLandingRoute, router]);
 

--- a/ee/apps/den-web/app/(den)/_components/dashboard-redirect-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-redirect-screen.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { WorkspaceLoadingScreen } from "./workspace-loading-screen";
+
 import { useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { isSamePathname } from "../_lib/client-route";
@@ -29,11 +31,5 @@ export function DashboardRedirectScreen() {
       });
   }, [pathname, resolveUserLandingRoute, router, sessionHydrated]);
 
-  return (
-    <section className="mx-auto grid w-full max-w-[52rem] gap-4 rounded-[32px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.22)]">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">OpenWork Cloud</p>
-      <p className="text-2xl font-semibold tracking-[-0.04em] text-gray-900">Loading your workspace.</p>
-      <p className="text-sm text-gray-500">Routing you to the right organization and billing destination now.</p>
-    </section>
-  );
+  return <WorkspaceLoadingScreen />;
 }

--- a/ee/apps/den-web/app/(den)/_components/dashboard-redirect-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-redirect-screen.tsx
@@ -19,15 +19,18 @@ export function DashboardRedirectScreen() {
     }
 
     redirectingRef.current = true;
+    let navigationStarted = false;
     void resolveUserLandingRoute()
       .then((target) => {
         const nextTarget = target ?? "/";
         if (!isSamePathname(pathname, nextTarget)) {
+          navigationStarted = true;
           router.replace(nextTarget);
         }
       })
       .finally(() => {
-        redirectingRef.current = false;
+        // Hold the guard until unmount: provider updates can arrive before navigation commits.
+        if (!navigationStarted) redirectingRef.current = false;
       });
   }, [pathname, resolveUserLandingRoute, router, sessionHydrated]);
 

--- a/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { WorkspaceLoadingScreen } from "./workspace-loading-screen";
+
 import Link from "next/link";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
@@ -211,11 +213,7 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
   }, [router, sessionHydrated, user]);
 
   if (!sessionHydrated || !user || onboardingDecisionBusy) {
-    return (
-      <section className="mx-auto grid w-full max-w-[52rem] gap-4 rounded-[32px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-6">
-        <p className="text-sm text-[var(--dls-text-secondary)]">Preparing your dashboard...</p>
-      </section>
-    );
+    return <WorkspaceLoadingScreen />;
   }
 
   const currentWorker = activeWorker ?? (selectedWorker ? { workerName: selectedWorker.workerName, status: selectedWorker.status } : null);

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { WorkspaceLoadingScreen } from "./workspace-loading-screen";
+
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { LogOut, Settings } from "lucide-react";
@@ -184,11 +186,7 @@ export function OrganizationScreen() {
   }
 
   if (!sessionHydrated || !runtimeConfigLoaded || busy) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-[#fafafa]">
-        <p className="text-sm text-gray-500">Loading organizations...</p>
-      </div>
-    );
+    return <WorkspaceLoadingScreen />;
   }
 
   if (!isSingleOrgMode && (showDirectCreateFlow || showCreate)) {

--- a/ee/apps/den-web/app/(den)/_components/workspace-loading-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/workspace-loading-screen.tsx
@@ -1,0 +1,14 @@
+/** One stable surface from server render through session and workspace resolution. */
+export function WorkspaceLoadingScreen() {
+  return (
+    <div
+      data-testid="workspace-loading-screen"
+      className="flex min-h-screen min-h-dvh w-full items-center justify-center bg-[var(--dls-app-bg)]"
+    >
+      <div role="status" aria-live="polite" className="flex items-center gap-3 text-sm text-[var(--dls-text-secondary)]">
+        <span aria-hidden="true" className="h-4 w-4 shrink-0 rounded-full border-2 border-[var(--dls-border)] border-t-[var(--dls-text-secondary)] motion-safe:animate-spin" />
+        <span>Loading OpenWork…</span>
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/workspace-loading-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/workspace-loading-screen.tsx
@@ -5,7 +5,7 @@ export function WorkspaceLoadingScreen() {
       data-testid="workspace-loading-screen"
       className="flex min-h-screen min-h-dvh w-full items-center justify-center bg-[var(--dls-app-bg)]"
     >
-      <div role="status" aria-live="polite" className="flex items-center gap-3 text-sm text-[var(--dls-text-secondary)]">
+      <div role="status" aria-live="polite" className="flex h-6 w-48 items-center gap-3 text-sm text-[var(--dls-text-secondary)]">
         <span aria-hidden="true" className="h-4 w-4 shrink-0 rounded-full border-2 border-[var(--dls-border)] border-t-[var(--dls-text-secondary)] motion-safe:animate-spin" />
         <span>Loading OpenWork…</span>
       </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-home-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-home-screen.tsx
@@ -6,13 +6,12 @@ import { DashboardOverviewScreen } from "./dashboard-overview-screen";
 import { MemberDashboardScreen } from "./member-dashboard-screen";
 
 export function DashboardHomeScreen() {
-  const { orgContext, orgBusy, mutationBusy } = useOrgDashboard();
+  const { orgContext, mutationBusy } = useOrgDashboard();
 
   // A workspace switch keeps the previous orgContext around while the next one
-  // loads. Rendering the neutral placeholder during that window (and while the
-  // directory is loading) avoids flashing the wrong admin/member home layout.
+  // loads. Keep refreshes in place, but avoid showing the wrong home while switching.
   const switching = mutationBusy === "switch-organization";
-  if (!orgContext || orgBusy || switching) {
+  if (!orgContext || switching) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center px-6 text-[14px] text-gray-500">
         Loading your workspace...

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -312,6 +312,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     mutationBusy,
     switchOrganization,
   } = useOrgDashboard();
+  const [workspaceReady, setWorkspaceReady] = useState(false);
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -387,9 +388,13 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     };
   }, [switcherOpen]);
 
+  useEffect(() => {
+    if (orgContext && !orgBusy) setWorkspaceReady(true);
+  }, [orgContext, orgBusy]);
+
   // Do not briefly render member navigation or an empty workspace before access resolves.
   // Keep an already loaded shell visible during background refreshes; errors remain actionable.
-  if (!sessionHydrated || !user || !runtimeConfigLoaded || (!orgContext && !orgSelectionOpen && !orgError)) {
+  if (!sessionHydrated || !user || !runtimeConfigLoaded || ((!orgContext || !workspaceReady) && !orgSelectionOpen && !orgError)) {
     return <WorkspaceLoadingScreen />;
   }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { WorkspaceLoadingScreen } from "../../_components/workspace-loading-screen";
+
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -299,7 +301,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const onboardingRoute = getMarketplaceOnboardingRoute();
   const isOnboarding = pathname === onboardingRoute || pathname.startsWith(`${onboardingRoute}/`);
-  const { user, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const { user, sessionHydrated, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const {
     activeOrg,
     orgDirectory,
@@ -384,6 +386,12 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [switcherOpen]);
+
+  // Do not briefly render member navigation or an empty workspace before access resolves.
+  // Keep an already loaded shell visible during background refreshes; errors remain actionable.
+  if (!sessionHydrated || !user || !runtimeConfigLoaded || (!orgContext && !orgSelectionOpen && !orgError)) {
+    return <WorkspaceLoadingScreen />;
+  }
 
   // The picker replaces the whole shell until a workspace is chosen.
   if (orgSelectionOpen) {

--- a/ee/apps/den-web/app/(den)/loading.tsx
+++ b/ee/apps/den-web/app/(den)/loading.tsx
@@ -1,0 +1,1 @@
+export { WorkspaceLoadingScreen as default } from "./_components/workspace-loading-screen";

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -194,6 +194,58 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready fill the viewport with a 1130px desktop content area and matching footer edges, with the logo aligned to the story and the stepper aligned to both panel edges, without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
   });
 
+  await step("signed-in reload keeps one loading surface without flashing signup", async () => {
+    const script = await world.web.client.send("Page.addScriptToEvaluateOnNewDocument", { source: `
+      window.__reloadWitness = { signup: false, loadingSeen: false, positions: [] };
+      const originalFetch = window.fetch;
+      window.fetch = async (...args) => {
+        const input = args[0];
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes('/api/auth/') || url.includes('/v1/')) {
+          await new Promise(resolve => setTimeout(resolve, 350));
+        }
+        return originalFetch(...args);
+      };
+      const observe = () => {
+        const witness = window.__reloadWitness;
+        witness.signup ||= Boolean(document.querySelector('[data-testid="auth-landing-frame"]'));
+        const loader = document.querySelector('[data-testid="workspace-loading-screen"] [role="status"]');
+        if (loader) {
+          witness.loadingSeen = true;
+          const rect = loader.getBoundingClientRect();
+          const position = [Math.round(rect.x), Math.round(rect.y), Math.round(rect.width), Math.round(rect.height)];
+          if (!witness.positions.some(previous => JSON.stringify(previous) === JSON.stringify(position))) {
+            witness.positions.push(position);
+          }
+        }
+        requestAnimationFrame(observe);
+      };
+      requestAnimationFrame(observe);
+    ` });
+    if (!isRecord(script) || typeof script.identifier !== "string") throw new Error("Expected reload observer script");
+    try {
+      for (const path of ["/", "/dashboard"]) {
+        if (path === "/") {
+          await user.navigate(new URL(path, world.den.ref.webUrl).toString());
+        } else {
+          await user.reload();
+        }
+        await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 90_000 });
+        await user.notSee({ testId: "workspace-loading-screen" });
+        await user.notSee({ testId: "auth-landing-frame" });
+        expect(await world.pathname()).toBe("/dashboard");
+        const witness = await probe.eval("window.__reloadWitness");
+        expect(witness).toMatchObject({ signup: false, loadingSeen: true });
+        if (!isRecord(witness) || !Array.isArray(witness.positions)) throw new Error("Missing loading geometry");
+        expect(witness.positions).toHaveLength(1);
+      }
+      evidence.recordAssertionEvidence("Signed-in root and dashboard reloads keep a stable loading indicator without signup flashes", "Observed every animation frame with auth and organization fetches delayed 350ms: loading appeared at one fixed rectangle, signup never appeared, and both reloads reached the dashboard.", true);
+    } finally {
+      await world.web.client.send("Page.removeScriptToEvaluateOnNewDocument", { identifier: script.identifier });
+    }
+  });
+
+
   let flexibleId = "";
   await step("a flexible team keeps existing defaults without opening policy setup", async () => {
     await user.navigate(new URL("/organization", world.den.ref.webUrl).toString());


### PR DESCRIPTION
Reloading OpenWork Cloud currently flashes the signup story and several different loading layouts before the workspace appears. Use one accessible, fixed-size loading indicator from the route fallback through session and organization resolution, and render signup only after a signed-out session is confirmed.

Hold the redirect guard until navigation commits to avoid repeated route replacements during provider updates.

Wait for initial organization access and worker loading before mounting dashboard navigation. Keep the loaded home visible during background refreshes, while retaining the neutral state during workspace switches.

Validation:
- `pnpm --filter @openwork-ee/den-web typecheck` — passed.
- Extended `signup-workspace-intent` with frame-by-frame observations during delayed auth/organization requests: signed-in root navigation and dashboard reload must never show signup and must keep one loading-indicator rectangle.
- `pnpm --dir evals exec tsc --noEmit --pretty false` — exit 2; clean control at `cf6cdf341` produces the same 238 distinct diagnostics (paths and line numbers normalized). First diagnostic: `agent-context-cloud-probe.ts(216,15): TS1294` (`erasableSyntaxOnly`). No branch-only diagnostics.
- `OPENWORK_EVAL_REF=788337554d428a31cdc6d81a9594e1a069af0842 pnpm evals:e2e signup-workspace-intent` — `placement: daytona (daytona CLI authenticated)`; exit 1, 0 passed / 1 failed / 0 skipped: the 600-second overall timeout expired while provisioning the final public-mobile browser. All ten completed journey steps passed, including the new delayed-response reload assertions (17.4 seconds), signed-out signup, desktop navigation, team setup, and authenticated mobile setup. The final narrow signed-out signup step has no verdict.

Overall verification: **Incomplete**. The PR remains draft because the complete journey timed out; this is not reported as a passing test suite. [Test evidence](https://github.com/different-ai/openwork/pull/4594#issuecomment-5563728371) contains 16 passing recorded assertions, including the reload witness. Nine visual validations remain pending because the configured vision credential returned HTTP 401 (`invalid_api_key`). The raw publisher was used to make these incomplete results and screenshots inspectable; no passing visual verdict is claimed.

To finish verification, rerun the command above with enough journey time for cold provisioning of the three browser sandboxes. Manual reproduction: sign in with an existing workspace, throttle the browser network, hard-reload `/` and `/dashboard`, and verify one centered Loading OpenWork indicator until the dashboard appears, with no signup story or changing navigation. In a signed-out browser, `/` must resolve to the email form.
