### PR TITLE
Initialize Electron accessibility before Computer Use sessions

### DIFF
--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -243,3 +243,24 @@ test("Computer Use enables workspace tools from the desktop setup page", async (
     expect(await evalIn(app, `[...document.querySelectorAll("button")].some(b => /^(Enable|Reconnect) Computer Use$/.test(b.textContent.trim()))`)).toBe(false);
   });
 });
+
+test("Computer Use prepares an Electron accessibility tree before window consent", async ({ world, step }) => {
+  await using electron = await world.electronFixture();
+  await step("A fresh Electron app starts with its accessibility tree disabled", async () => {
+    expect(await electron.state()).toEqual({ accessibility: false });
+  });
+  const session = await step("Opening a session enables the tree and still requires window approval", async () => {
+    const pending = world.call("computer_open_session", { app_id: electron.appId, pid: electron.pid, mode: "observe", purpose: "Read the disposable Electron fixture." });
+    const [reply] = await Promise.all([pending, world.pressControl("Allow this session")]);
+    const result = toolState(reply);
+    expect(result).toMatchObject({ ok: true, mode: "observe", window_title: "Electron Fixture" });
+    return result.session_id;
+  });
+  await step("The approved Electron window exposes its rendered controls", async () => {
+    const observation = toolState(await world.call("computer_observe", { session_id: session }));
+    expect(observation.ok).toBe(true);
+    expect(JSON.stringify(observation)).toContain("Fixture action");
+    expect(JSON.stringify(observation)).toContain("Fixture draft value");
+    expect(toolState(await world.call("computer_close_session", { session_id: session }))).toMatchObject({ ok: true });
+  });
+});

--- a/evals/worlds/computer-use.ts
+++ b/evals/worlds/computer-use.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline";
+import { createRequire } from "node:module";
 import { needs, SkipError } from "@openwork/env";
 import type { Place, Seed } from "@openwork/env";
 import { desktop } from "@openwork/hosts";
@@ -94,6 +95,33 @@ export async function computerUseWorld(_seed: Seed, { place }: { place: Place })
     await helper.request("initialize", { protocolVersion: "2025-11-25", clientInfo: { name: "native-journey", version: "1" }, capabilities: {} });
     await peer.request("initialize", { protocolVersion: "2025-11-25", clientInfo: { name: "peer-journey", version: "1" }, capabilities: {} });
     return {
+      async electronFixture() {
+        const main = join(directory, "electron-fixture.cjs");
+        await writeFile(main, `
+          const { app, BrowserWindow } = require('electron');
+          const readline = require('node:readline');
+          let window;
+          const ready = app.whenReady().then(async () => {
+            window = new BrowserWindow({ width: 600, height: 420, title: 'Electron Fixture' });
+            await window.loadURL('data:text/html,' + encodeURIComponent('<title>Electron Fixture</title><main><h1>Fixture workspace</h1><button>Fixture action</button><input aria-label="Fixture draft" value="Fixture draft value"></main>'));
+          });
+          readline.createInterface({ input: process.stdin }).on('line', async (line) => {
+            const request = JSON.parse(line); await ready;
+            process.stdout.write(JSON.stringify({ id: request.id, result: { accessibility: app.isAccessibilitySupportEnabled() } }) + '\\n');
+          }).on('close', () => app.quit());
+        `);
+        const require = createRequire(join(root, "apps/desktop/package.json"));
+        const electron: unknown = require("electron");
+        if (typeof electron !== "string") throw new Error("Electron executable unavailable");
+        const client = pipeClient(electron, [main]);
+        try {
+          await client.request("state");
+          const discovered = toolState(await helper.request("tools/call", { name: "computer_discover", arguments: {} }));
+          const identity = Array.isArray(discovered.apps) ? discovered.apps.find((entry: unknown) => record(entry) && entry.pid === client.pid) : undefined;
+          if (!record(identity) || typeof identity.app_id !== "string") throw new Error("Electron fixture was not discoverable");
+          return { appId: identity.app_id, pid: client.pid, state: () => client.request("state"), [Symbol.asyncDispose]: () => client.close() };
+        } catch (error) { await client.close(); throw error; }
+      },
       desktop: () => desktop({ name: "computer-use-setup", host: place.host(), env: { OPENWORK_COMPUTER_USE_BINARY: executable } }),
       workspacePath: join(directory, "workspace"),
       appId: "org.example.openwork.computer-use-fixture",

--- a/packages/computer-use/native/Sources/ComputerUse/MacAccessibility.swift
+++ b/packages/computer-use/native/Sources/ComputerUse/MacAccessibility.swift
@@ -86,6 +86,20 @@ final class MacAccessibility {
         try app.validate()
         let root = AXUIElementCreateApplication(app.pid)
         AXUIElementSetMessagingTimeout(root, 0.2)
+        // Electron exposes its accessibility tree on demand. This is its
+        // documented assistive-technology handshake, not a macOS permission grant.
+        // Native apps can reject the optional attribute and still expose windows.
+        if (attribute(root, "AXManualAccessibility") as? Bool) == false,
+           AXUIElementSetAttributeValue(root, "AXManualAccessibility" as CFString, kCFBooleanTrue) == .success {
+            // Electron debounces activation for two seconds. Do not keep setting
+            // the attribute during retries: that restarts its countdown.
+            let deadline = ProcessInfo.processInfo.systemUptime + 3
+            while ProcessInfo.processInfo.systemUptime < deadline {
+                try app.validate()
+                if (attribute(root, "AXManualAccessibility") as? Bool) == true { break }
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+        }
         for attempt in 0..<5 {
             let axWindows = attribute(root, kAXWindowsAttribute) as? [AXUIElement] ?? []
             let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)


### PR DESCRIPTION
Electron applications can keep their accessibility trees disabled until assistive technology requests them. Recent Electron versions debounce activation for two seconds, so immediately enumerating or reading a window can produce an unavailable or empty accessibility surface.

Before window discovery, initialize the selected application's documented `AXManualAccessibility` attribute when it reports disabled. Wait up to three seconds for activation without repeatedly setting the attribute and restarting Electron's debounce. Native apps that do not expose the attribute follow the existing path. Process identity, exact window matching, consent, and input scope checks remain in place.

Validation on final head: `pnpm evals:e2e computer-use-window-scope --local` — placement local, 3 passed, 0 failed, 0 skipped. The new real Electron fixture begins with accessibility disabled; the test opens a session, approves its native consent window, and asserts that the first observation contains the rendered button and input value. Existing native takeover and desktop Enable → Ready journeys also pass. Spec-layer typecheck and whitespace checks pass.

The focused Electron test failed before adding the bounded activation wait, exposing only native window chrome. It passes with the wait. This verifies Electron initialization; it does not claim that a reported window-unavailable error in an external app was reproduced or that an external messaging task has completed.

References: [Electron accessibility protocol](https://www.electronjs.org/docs/latest/tutorial/accessibility), [Electron 43.2.0 debounce implementation](https://github.com/electron/electron/blob/v43.2.0/shell/browser/mac/electron_application.mm).
