### PR TITLE
Type-check browser callbacks across the test stack

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -169,9 +169,9 @@ world. Mid-flow seeding after an act is explicit and allowed; probes do not
 change the ordering state.
 
 `seed.evalIn()` (`[seed:raw]`) and `probe.eval()` (`[probe:raw]`) are migration
-escape hatches. Both accept `{ awaitPromise?: boolean, timeoutMs?: number }`;
-`probe.eval` accepts the options after either `(expression)` or
-`(surface, expression)`. New specs must not use them. The channel ratchet
+escape hatches. Both take type-checked browser callbacks and await promises automatically.
+`probe.eval` accepts `{ timeoutMs?: number }` after either `(callback)` or
+`(surface, callback)`. Raw JavaScript strings are rejected. New specs must not use them. The channel ratchet
 records current legacy usage per E2E file and fails on increases or stale
 baseline entries.
 
@@ -516,3 +516,37 @@ bash .devcontainer/test-on-daytona.sh <ref> \
   --den-base-url <DEN_WEB_URL> \
   --den-api-base-url <DEN_API_URL>
 ```
+
+
+### Type-checked browser code
+
+Use the existing user/locator helpers for ordinary interaction. When an existing
+probe needs browser-only logic, author a self-contained TypeScript callback:
+
+```ts
+const fits: boolean = await probe.eval(
+  () => document.documentElement.scrollWidth <= window.innerWidth,
+);
+const count: number = await probe.eval(browserScript(
+  (selector) => document.querySelectorAll(selector).length,
+  ["[data-message-role=assistant]"],
+));
+```
+
+Import `browserScript` from `@openwork/testkit` in specs and `@openwork/cdp` in
+worlds and lower layers. It binds explicit serializable arguments; browser code
+cannot capture test variables or imported runtime helpers. Return plain data,
+not elements or functions. API JSON remains `unknown` where the contract is
+unknown; validate it before relying on a shape.
+
+For code that must run before navigation, worlds use
+`addInitScript(client, browserScript(callback, [args]))`. Its `dispose()` and
+`Symbol.asyncDispose` remove the registration for future documents; an observer
+already running in the current page still needs its own cleanup.
+
+`pnpm evals:check-browser` checks browser callback bodies, argument/result types,
+closure captures (including imported aliases), and raw CDP execution bypasses.
+It runs in the test-framework CI command. Unlike running a TypeScript test,
+this invokes the TypeScript checker. The full `evals:typecheck` also includes
+legacy server imports; the browser check does not suppress their diagnostics or
+claim that those unrelated projects compile.

--- a/evals/docs-shots/inpage.ts
+++ b/evals/docs-shots/inpage.ts
@@ -1,19 +1,9 @@
+import { browserScript } from "@openwork/cdp";
 import { evalIn } from "@openwork/behaviors";
-import type { Surface } from "@openwork/cdp";
+import type { Surface, EvaluateOptions } from "@openwork/cdp";
+export type InPageOptions = EvaluateOptions;
 
-export interface InPageOptions {
-  awaitPromise?: boolean;
-  timeoutMs?: number;
-}
-
-/** Execute function source in the page with one JSON-serialized argument. */
-export function inPage(
-  surface: Surface,
-  fnSource: string,
-  args: unknown,
-  options: InPageOptions = {},
-): Promise<unknown> {
-  const injected = JSON.stringify(args);
-  if (injected === undefined) throw new Error("inPage arguments must be JSON-serializable.");
-  return evalIn(surface, `(${fnSource})(${injected})`, options);
+/** Execute a checked browser callback with one explicit argument. */
+export function inPage<A, R>(surface: Surface, callback: (args: A) => R, args: A, options: InPageOptions = {}): Promise<Awaited<R>> {
+  return evalIn(surface, browserScript(callback, [args]), options);
 }

--- a/evals/docs-shots/shots/desktop.ts
+++ b/evals/docs-shots/shots/desktop.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { clickButton, denFetch, waitFor } from "@openwork/behaviors";
 import { connect, debuggerUrlFor, evaluate, listTargets } from "@openwork/cdp";
 import { provider } from "../ctx.ts";
@@ -116,14 +117,12 @@ async function openEmptyTeamPromptSession(surface: DesktopShotSurface): Promise<
     || JSON.stringify(actualTitles) !== JSON.stringify(expectedTitles)) {
     throw new Error(`The docs member did not receive the seeded prompt policy: HTTP ${config.response.status} ${config.text.slice(0, 600)}`);
   }
-  const titlesVisible = expectedTitles
-    .map((title) => `document.body.innerText.includes(${JSON.stringify(title)})`)
-    .join(" && ");
+  const titlesVisible = browserScript((titles) => titles.every(title => document.body.innerText.includes(title)), [expectedTitles]);
   await waitFor(surface, titlesVisible, {
     timeoutMs: 60_000,
     label: "organization prompt config settled",
   });
-  const task = await inPage(surface, `async () => {
+  const task = await inPage(surface, async () => {
     const deadline = Date.now() + 60000;
     let last = null;
     while (Date.now() < deadline) {
@@ -132,25 +131,25 @@ async function openEmptyTeamPromptSession(surface: DesktopShotSurface): Promise<
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     return last;
-  }`, {}, { awaitPromise: true, timeoutMs: 70_000 });
+  }, {}, { awaitPromise: true, timeoutMs: 70_000 });
   if (!isRecord(task) || task.ok !== true) throw new Error(`Creating an empty prompt-card session failed: ${JSON.stringify(task)}`);
-  await waitFor(surface, `document.body.innerText.includes(${JSON.stringify(ORGANIZATION_PROMPT_INTRO)}) && ${titlesVisible}`, {
+  await waitFor(surface, browserScript((intro, titles) => document.body.innerText.includes(intro) && titles.every(title => document.body.innerText.includes(title)), [ORGANIZATION_PROMPT_INTRO, expectedTitles]), {
     timeoutMs: 60_000,
     label: "member-facing organization prompt cards",
   });
-  await inPage(surface, `() => {
+  await inPage(surface, () => {
     const label = [...document.querySelectorAll("span")]
       .find((element) => (element.textContent ?? "").trim() === "Notifications");
     const item = label?.closest("a, button");
     const badge = item && [...item.querySelectorAll("span")]
       .find((element) => (element.textContent ?? "").trim() === "1");
     if (badge instanceof HTMLElement) badge.style.display = "none";
-    const account = document.querySelector('[data-testid="account-status-menu"]');
+    const account = document.querySelector<HTMLElement>('[data-testid="account-status-menu"]');
     const status = account && [...account.children]
       .find((element) => element instanceof HTMLElement && element.classList.contains("size-4"));
     if (status instanceof HTMLElement) status.style.display = "none";
     return true;
-  }`, {});
+  }, {});
 }
 
 export const desktopTeamPromptCards = shot("desktop-team-prompt-cards", {
@@ -174,13 +173,13 @@ const skillForm = fillForm({
 const showAdvancedSettings = keepExpanded("Advanced settings", "Add workspace MCP");
 
 async function scrollAdvancedSettingsIntoView(surface: DesktopShotSurface): Promise<void> {
-  await inPage(surface, `() => {
-    document.querySelector("[data-inventory-group]")?.scrollIntoView({ block: "start" });
+  await inPage(surface, () => {
+    document.querySelector<HTMLElement>("[data-inventory-group]")?.scrollIntoView({ block: "start" });
     const toggle = [...document.querySelectorAll("button")]
       .find((button) => (button.textContent ?? "").includes("Advanced settings"));
     toggle?.scrollIntoView({ block: "center" });
     return true;
-  }`, {});
+  }, {});
 }
 
 export const librarySkills = shot("library-skills", {
@@ -231,7 +230,7 @@ async function waitForMountedSkillCard(surface: DesktopShotSurface, timeoutMs: n
     if (sandbox) {
       const client = await connect(debuggerUrlFor(surface.handle.cdpUrl, sandbox));
       try {
-        const text = await evaluate(client, `document.querySelector("iframe")?.contentDocument?.body?.innerText ?? ""`);
+        const text = await evaluate(client, () => (document.querySelector("iframe")?.contentDocument?.body?.innerText ?? ""));
         if (typeof text === "string") {
           lastText = text;
           const normalized = text.toLocaleLowerCase();
@@ -247,7 +246,7 @@ async function waitForMountedSkillCard(surface: DesktopShotSurface, timeoutMs: n
 }
 
 async function createSkillFromChat(surface: DesktopShotSurface): Promise<void> {
-  const reconciled = await inPage(surface, `async (args) => {
+  const reconciled = await inPage(surface, async (args) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
@@ -272,7 +271,7 @@ async function createSkillFromChat(surface: DesktopShotSurface): Promise<void> {
     const health = JSON.parse(text);
     if (health?.phase !== "ready") return "Cloud MCP reconcile was not ready: " + JSON.stringify(health).slice(0, 1000);
     return "ok";
-  }`, {
+  }, {
     workspaceId: surface.workspaceId,
     mcpUrl: `${surface.organization.den.ref.apiUrl}/mcp/agent`,
     mcpToken: surface.organization.mcpToken,
@@ -281,7 +280,7 @@ async function createSkillFromChat(surface: DesktopShotSurface): Promise<void> {
   }, { awaitPromise: true, timeoutMs: 90_000 });
   if (reconciled !== "ok") throw new Error(`Connecting the Cloud MCP failed: ${String(reconciled)}`);
 
-  const task = await inPage(surface, `async () => {
+  const task = await inPage(surface, async () => {
     const deadline = Date.now() + 60000;
     let last = null;
     while (Date.now() < deadline) {
@@ -290,38 +289,38 @@ async function createSkillFromChat(surface: DesktopShotSurface): Promise<void> {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     return last;
-  }`, {}, { awaitPromise: true, timeoutMs: 70_000 });
+  }, {}, { awaitPromise: true, timeoutMs: 70_000 });
   if (!isRecord(task) || task.ok !== true) throw new Error(`Creating a task failed: ${JSON.stringify(task)}`);
-  await waitFor(surface, `Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]'))`, {
+  await waitFor(surface, () => (Boolean(document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]'))), {
     timeoutMs: 30_000,
     label: "composer ready",
   });
-  const focused = await inPage(surface, `() => {
-    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+  const focused = await inPage(surface, () => {
+    const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
     if (!(editor instanceof HTMLElement)) return false;
     editor.focus();
     return true;
-  }`, {});
+  }, {});
   if (focused !== true) throw new Error("Focusing the composer failed.");
   await surface.client.send("Input.insertText", { text: composerMessage });
   await clickButton(surface, "Run task", { timeoutMs: 30_000 });
-  await waitFor(surface, `document.body.innerText.includes(${JSON.stringify(CHAT_CLOSING_REPLY)})`, {
+  await waitFor(surface, browserScript((CHAT_CLOSING_REPLY) => (document.body.innerText.includes(CHAT_CLOSING_REPLY)), [CHAT_CLOSING_REPLY]), {
     timeoutMs: 180_000,
     label: "closing reply",
   });
-  await waitFor(surface, `Boolean(document.querySelector(${JSON.stringify(`[data-mcp-app-resource="${resourceUri}"] iframe`)}))`, {
+  await waitFor(surface, browserScript((value) => (Boolean(document.querySelector<HTMLElement>(value))), [`[data-mcp-app-resource="${resourceUri}"] iframe`]), {
     timeoutMs: 60_000,
     label: "skill-created MCP App frame",
   });
   await waitForMountedSkillCard(surface, 60_000);
-  await waitFor(surface, `!document.body.innerText.includes("Pulling in the latest messages")`, {
+  await waitFor(surface, () => (!document.body.innerText.includes("Pulling in the latest messages")), {
     timeoutMs: 60_000,
     label: "session sync settled",
   });
-  await inPage(surface, `(args) => {
-    document.querySelector('[data-mcp-app-resource="' + args.resourceUri + '"]')?.scrollIntoView({ block: "center" });
+  await inPage(surface, (args) => {
+    document.querySelector<HTMLElement>('[data-mcp-app-resource="' + args.resourceUri + '"]')?.scrollIntoView({ block: "center" });
     return true;
-  }`, { resourceUri });
+  }, { resourceUri });
 }
 
 export const skillCreatedCard = shot("skill-created-card", {

--- a/evals/docs-shots/shots/shot.ts
+++ b/evals/docs-shots/shots/shot.ts
@@ -38,7 +38,7 @@ export interface ShotOptions<T extends ShotSurface> {
 async function waitForExpectedText(surface: Surface, expect: readonly string[]): Promise<void> {
   const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
-    const ready = await inPage(surface, `(args) => args.expect.every((text) => document.body.innerText.includes(text))`, {
+    const ready = await inPage(surface, (args) => args.expect.every((text) => document.body.innerText.includes(text)), {
       expect,
     }, { timeoutMs: 8_000 }).catch(() => false);
     if (ready === true) return;

--- a/evals/docs-shots/shots/web-tab.ts
+++ b/evals/docs-shots/shots/web-tab.ts
@@ -6,13 +6,13 @@ import { shot } from "./shot.ts";
 const browser = webTab({ org });
 
 async function waitForOpenWorkWeb(surface: Awaited<ReturnType<typeof browser.load>>): Promise<void> {
-  await waitFor(surface, "Boolean(window.__openworkControl)", {
+  await waitFor(surface, () => (Boolean(window.__openworkControl)), {
     timeoutMs: 120_000,
     label: "OpenWork Web booted",
   });
-  await waitFor(surface, `document.body.innerText.includes("acme-robotics")
+  await waitFor(surface, () => (document.body.innerText.includes("acme-robotics")
     && document.body.innerText.includes("Describe your task")
-    && !document.body.innerText.includes("Pulling in the latest messages")`, {
+    && !document.body.innerText.includes("Pulling in the latest messages")), {
     timeoutMs: 120_000,
     label: "OpenWork Web settled on the demo workspace",
   });

--- a/evals/docs-shots/steps.ts
+++ b/evals/docs-shots/steps.ts
@@ -20,7 +20,7 @@ export async function dismissOverlays(surface: Surface): Promise<void> {
 async function waitForText(surface: Surface, text: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const found = await inPage(surface, `(args) => document.body.innerText.includes(args.text)`, { text }, { timeoutMs: 8_000 })
+    const found = await inPage(surface, (args) => document.body.innerText.includes(args.text), { text }, { timeoutMs: 8_000 })
       .catch(() => false);
     if (found === true) return;
     await delay(250);
@@ -35,13 +35,13 @@ export function keepExpanded(label: string, proofText: string): Step {
     const deadline = Date.now() + 60_000;
     let stableChecks = 0;
     while (Date.now() < deadline) {
-      const expanded = await inPage(surface, `(args) => {
+      const expanded = await inPage(surface, (args) => {
         if (document.body.innerText.includes(args.proofText)) return true;
         const toggle = [...document.querySelectorAll("button")]
           .find((button) => (button.textContent ?? "").includes(args.label));
         if (toggle) toggle.click();
         return document.body.innerText.includes(args.proofText);
-      }`, { label, proofText }, { timeoutMs: 8_000 }).catch(() => false);
+      }, { label, proofText }, { timeoutMs: 8_000 }).catch(() => false);
       if (expanded === true) {
         stableChecks += 1;
         if (stableChecks >= 2) return;

--- a/evals/docs-shots/surfaces.ts
+++ b/evals/docs-shots/surfaces.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { spawn } from "node:child_process";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -46,11 +47,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 async function configureWorkspaceModel(app: App, model: WorkspaceModel): Promise<void> {
-  const configured = await inPage(app, `async (args) => {
+  const configured = await inPage(app, async (args) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
-    const request = async (path, init) => {
+    const request = async (path: string, init?: RequestInit) => {
       const response = await fetch("http://127.0.0.1:" + port + path, {
         ...init,
         headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
@@ -77,7 +78,7 @@ async function configureWorkspaceModel(app: App, model: WorkspaceModel): Promise
     const reloaded = await request("/workspace/" + encodeURIComponent(args.workspaceId) + "/engine/reload", { method: "POST" });
     if (reloaded !== "ok" && !reloaded.includes("opencode_reload_timeout")) return reloaded;
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
@@ -89,16 +90,16 @@ async function configureWorkspaceModel(app: App, model: WorkspaceModel): Promise
     localStorage.setItem("openwork.defaultModel", args.providerId + "/" + args.modelId);
     localStorage.removeItem("openwork.sessionModels." + args.workspaceId);
     return "ok";
-  }`, {
+  }, {
     workspaceId: app.workspaceId,
     providerId: model.providerId,
     modelId: model.modelId,
     baseUrl: model.baseUrl,
   }, { awaitPromise: true, timeoutMs: 90_000 });
   if (configured !== "ok") throw new Error(`Configuring the workspace model failed: ${String(configured)}`);
-  await inPage(app, `() => { location.reload(); return true; }`, {});
-  await waitFor(app, "Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "desktop control after reload" });
-  await waitFor(app, `window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`, {
+  await inPage(app, () => { location.reload(); return true; }, {});
+  await waitFor(app, () => (Boolean(window.__openworkControl)), { timeoutMs: 60_000, label: "desktop control after reload" });
+  await waitFor(app, () => (window.__openworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)), {
     timeoutMs: 60_000,
     label: "desktop ready after model configuration",
   });
@@ -135,21 +136,21 @@ export function denWeb(options: { org: Provider<SeededOrg>; as: string }): Provi
       host: organization.place.host(),
     });
     ctx.onDispose(() => browser[Symbol.asyncDispose]());
-    await waitFor(browser, `location.href.startsWith(${JSON.stringify(organization.den.ref.webUrl)}) && document.readyState === "complete"`, {
+    await waitFor(browser, browserScript((webUrl) => (location.href.startsWith(webUrl) && document.readyState === "complete"), [organization.den.ref.webUrl]), {
       timeoutMs: 60_000,
       label: "Den Web origin before auth token handoff",
     });
-    const stored = await inPage(browser, `(args) => {
+    const stored = await inPage(browser, (args) => {
       localStorage.setItem("openwork:web:auth-token", args.token);
       return localStorage.getItem("openwork:web:auth-token") === args.token;
-    }`, { token: member.token });
+    }, { token: member.token });
     if (stored !== true) throw new Error("Storing the Den Web auth token failed.");
     return {
       ...browser,
       organization,
       open: async (path) => {
         await navigate(browser.client, `${organization.den.ref.webUrl}${path}`);
-        await waitFor(browser, `document.readyState === "complete"`, {
+        await waitFor(browser, () => (document.readyState === "complete"), {
           timeoutMs: 60_000,
           label: `Den Web ${path}`,
         });
@@ -234,7 +235,7 @@ export function webTab(options: { org: Provider<SeededOrg> }): Provider<ShotSurf
       ...browser,
       open: async (path) => {
         await navigate(browser.client, new URL(path, info.webUrl).toString());
-        await waitFor(browser, `document.readyState === "complete"`, {
+        await waitFor(browser, () => (document.readyState === "complete"), {
           timeoutMs: 60_000,
           label: `OpenWork Web ${path}`,
         });

--- a/evals/drivers/desktop-policies-two-surface.mts
+++ b/evals/drivers/desktop-policies-two-surface.mts
@@ -265,7 +265,7 @@ async function main() {
   await sleep(500);
   await shot(admin, "admin", "01-logo-typed",
     "Admin: typed OpenWork demo logo URL into the Logo URL field.",
-    [{ label: "logo URL in field", passed: await evaluate(admin, () => ([...document.querySelectorAll('input')].some(i => i.value.includes('openworklabs.com')))) }]);
+    [{ label: "logo URL in field", passed: await evaluate(admin, browserScript((expectedLogo) => [...document.querySelectorAll('input')].some(input => input.value === expectedLogo), [DEMO_LOGO])) }]);
 
   await adminClickSave(admin);
   await sleep(2500); // let the PATCH land

--- a/evals/drivers/desktop-policies-two-surface.mts
+++ b/evals/drivers/desktop-policies-two-surface.mts
@@ -1,3 +1,5 @@
+import type { CdpClient, BrowserEvaluation } from "@openwork/cdp";
+import { browserScript } from "@openwork/cdp";
 /**
  * Two-surface desktop policies demo driver.
  *
@@ -17,7 +19,7 @@
  *   - Chrome   :9224  signed in as alex@acme.test, on /dashboard/org-settings
  *   - Electron :9823  signed into Acme Robotics via handoff grant
  *
- * Usage: node evals/drivers/desktop-policies-two-surface.mjs
+ * Usage: node evals/drivers/desktop-policies-two-surface.mts
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
@@ -32,17 +34,17 @@ const DEN_API = "http://localhost:8790";
 const DEN_WEB = "http://localhost:3005";
 const ADMIN_EMAIL = "alex@acme.test";
 const ADMIN_PASSWORD = "OpenWorkDemo123!";
-const GENPACT_LOGO = "https://upload.wikimedia.org/wikipedia/commons/5/50/Genpact_Logo_Black_%283%29.png";
+const DEMO_LOGO = "https://openworklabs.com/favicon.ico";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const runId = new Date().toISOString().replace(/[:.]/g, "-");
 const outDir = join(__dirname, "..", "results", `two-surface-${runId}`);
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-const frames = [];
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const frames: { file: string; surface: string; name: string; claim: string; hash: string; checks: { label: string; passed: boolean; detail?: string }[]; ok: boolean }[] = [];
 let frameIdx = 0;
 
-async function connectTo(baseUrl) {
+async function connectTo(baseUrl: string) {
   const target = await pickAppTarget(baseUrl);
   const ws = debuggerUrlFor(baseUrl, target);
   const client = await connect(ws);
@@ -56,13 +58,14 @@ async function connectAdmin() {
   const page = targets.find((t) => t.type === "page" && t.title.includes("OpenWork Cloud"))
     ?? targets.find((t) => t.type === "page" && t.url.includes("3005"))
     ?? targets.find((t) => t.type === "page");
+  if (!page) throw new Error("Admin browser target not found");
   const ws = debuggerUrlFor(ADMIN_CDP, page);
   const client = await connect(ws);
   await client.send("Page.enable").catch(() => {});
   return client;
 }
 
-async function shot(client, surface, name, claim, validations = []) {
+async function shot(client: CdpClient, surface: string, name: string, claim: string, validations: { label: string; passed: boolean; detail?: string }[] = []) {
   frameIdx += 1;
   const file = `frame-${String(frameIdx).padStart(2, "0")}-${surface}-${name}.png`;
   const buffer = await captureScreenshot(client);
@@ -81,7 +84,7 @@ async function shot(client, surface, name, claim, validations = []) {
   return file;
 }
 
-async function denApi(token, path, options = {}) {
+async function denApi(token: string, path: string, options: RequestInit = {}) {
   const res = await fetch(`${DEN_API}${path}`, {
     ...options,
     headers: { authorization: `Bearer ${token}`, "content-type": "application/json", ...(options.headers || {}) },
@@ -93,44 +96,46 @@ async function denApi(token, path, options = {}) {
 }
 
 /** Drive the admin web UI: fill logo URL field + click Save. */
-async function adminSetLogoViaUI(admin, logoUrl) {
+async function adminSetLogoViaUI(admin: CdpClient, logoUrl: string) {
   // Set the controlled React input by writing through the native setter AND
   // clearing React's internal value tracker so onChange fires.
-  await evaluate(admin, `(() => {
+  await evaluate(admin, browserScript((logoUrl) => {
     const logo = [...document.querySelectorAll('input')].find(i => (i.placeholder || '').includes('logo'));
     if (!logo) throw new Error('Logo URL input not found');
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
     if (logo._valueTracker) logo._valueTracker.setValue('');
-    setter.call(logo, ${JSON.stringify(logoUrl)});
+    if (!setter) throw new Error("Native form setter missing");
+    setter.call(logo, logoUrl);
     logo.dispatchEvent(new Event('input', { bubbles: true }));
     logo.dispatchEvent(new Event('change', { bubbles: true }));
     logo.scrollIntoView({ block: 'center' });
     return logo.value;
-  })()`);
+  }, [logoUrl]));
 }
 
-async function adminSetAccentViaUI(admin, accentValue) {
-  await evaluate(admin, `(() => {
+async function adminSetAccentViaUI(admin: CdpClient, accentValue: string) {
+  await evaluate(admin, browserScript((accentValue) => {
     const select = document.querySelector('select');
     if (!select) throw new Error('Accent select not found');
-    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
     if (select._valueTracker) select._valueTracker.setValue('');
-    setter.call(select, ${JSON.stringify(accentValue)});
+    if (!setter) throw new Error("Native form setter missing");
+    setter.call(select, accentValue);
     select.dispatchEvent(new Event('input', { bubbles: true }));
     select.dispatchEvent(new Event('change', { bubbles: true }));
     select.scrollIntoView({ block: 'center' });
     return select.value;
-  })()`);
+  }, [accentValue]));
 }
 
-async function adminClickSave(admin) {
-  await evaluate(admin, `(() => {
+async function adminClickSave(admin: CdpClient) {
+  await evaluate(admin, () => {
     const btn = [...document.querySelectorAll('button')].find(b => b.textContent.trim() === 'Save settings');
     if (!btn) throw new Error('Save settings button not found');
     btn.scrollIntoView({ block: 'center' });
     btn.click();
     return true;
-  })()`);
+  });
 }
 
 /**
@@ -138,21 +143,21 @@ async function adminClickSave(admin) {
  * browser session so privileged PATCH /v1/org and policy edits aren't blocked
  * by a 403 fresh_auth_required.
  */
-async function adminEnsureFreshAuth(admin) {
-  const result = await evaluate(admin, `(async () => {
+async function adminEnsureFreshAuth(admin: CdpClient) {
+  const result = await evaluate(admin, browserScript(async (ADMIN_EMAIL, ADMIN_PASSWORD) => {
     const r = await fetch('/api/auth/sign-in/email', {
       method: 'POST', headers: { 'content-type': 'application/json' }, credentials: 'include',
-      body: JSON.stringify({ email: ${JSON.stringify(ADMIN_EMAIL)}, password: ${JSON.stringify(ADMIN_PASSWORD)} }),
+      body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
     });
     return r.status;
-  })()`, { awaitPromise: true });
+  }, [ADMIN_EMAIL, ADMIN_PASSWORD]), { awaitPromise: true });
   if (result !== 200) throw new Error(`Admin fresh re-auth failed: HTTP ${result}`);
 }
 
 /** Trigger the member app to refresh its desktop config and wait for a DOM condition. */
-async function memberRefreshAndWait(member, condition, label, timeoutMs = 25000) {
-  await evaluate(member, `window.dispatchEvent(new CustomEvent('openwork-den-settings-changed', { detail: {} }))`);
-  await evaluate(member, `window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: {} }))`);
+async function memberRefreshAndWait(member: CdpClient, condition: BrowserEvaluation, label: string, timeoutMs = 25000) {
+  await evaluate(member, () => (window.dispatchEvent(new CustomEvent('openwork-den-settings-changed', { detail: {} }))));
+  await evaluate(member, () => (window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: {} }))));
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const ok = await evaluate(member, condition).catch(() => false);
@@ -165,25 +170,25 @@ async function memberRefreshAndWait(member, condition, label, timeoutMs = 25000)
 /** Open the member app's notification center (bell) and wait for the panel.
  *  Assumes we're already on the session route; does NOT re-navigate (that would
  *  re-render and dismiss the panel). Retries the click until the panel opens. */
-async function memberOpenNotifications(member) {
+async function memberOpenNotifications(member: CdpClient) {
   for (let attempt = 0; attempt < 5; attempt += 1) {
-    await evaluate(member, `(() => {
-      const bell = document.querySelector('[title="Notifications"]');
+    await evaluate(member, () => {
+      const bell = document.querySelector<HTMLElement>('[title="Notifications"]');
       if (bell) bell.click();
       return Boolean(bell);
-    })()`);
+    });
     await sleep(700);
-    const open = await evaluate(member, `Boolean([...document.querySelectorAll('div')].find(e => e.innerText && e.innerText.startsWith('Notifications') && e.innerText.includes('Clear all')))`).catch(() => false);
+    const open = await evaluate(member, () => (Boolean([...document.querySelectorAll('div')].find(e => e.innerText && e.innerText.startsWith('Notifications') && e.innerText.includes('Clear all'))))).catch(() => false);
     if (open) return true;
   }
   return false;
 }
 
 /** Count how many distinct accent-colored pixels appear (proves the accent paints). */
-async function memberAccentVisible(member) {
+async function memberAccentVisible(member: CdpClient) {
   // The notification badge + unread dots use the accent. Verify a blue-ish
   // pixel exists by sampling the accent CSS var and an actual painted element.
-  return evaluate(member, `(() => {
+  return evaluate(member, () => {
     const v = getComputedStyle(document.documentElement).getPropertyValue('--dls-accent').trim();
     // Find an element actually painted with the accent (badge, unread dot, primary button).
     const candidates = [...document.querySelectorAll('*')].slice(0, 4000);
@@ -192,14 +197,14 @@ async function memberAccentVisible(member) {
       const s = getComputedStyle(el);
       const bg = s.backgroundColor;
       // Radix blue-9 ≈ rgb(0, 144, 255)
-      const m = bg.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
+      const m = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
       if (m) {
         const [r,g,b] = [+m[1],+m[2],+m[3]];
         if (b > 180 && r < 80 && g > 100 && g < 200) { painted = true; break; }
       }
     }
     return { accentVar: v, painted };
-  })()`);
+  });
 }
 
 async function main() {
@@ -220,7 +225,7 @@ async function main() {
   console.log("Reset: clearing brand + restoring policies");
   await denApi(token, "/v1/org", { method: "PATCH", body: JSON.stringify({ brandLogoUrl: null, brandAccentColor: null }) });
   const list0 = await denApi(token, "/v1/desktop-policies");
-  const def = list0.desktopPolicies.find((p) => p.isDefault);
+  const def = list0.desktopPolicies.find((p: { isDefault?: boolean; name?: string; id: string }) => p.isDefault);
   await denApi(token, `/v1/desktop-policies/${def.id}`, {
     method: "PATCH",
     body: JSON.stringify({ policyName: def.policyName, policy: {
@@ -229,9 +234,9 @@ async function main() {
     } }),
   });
   // Member: light mode + session view + refresh to clear brand.
-  await evaluate(member, `localStorage.setItem('openwork.react.settings.theme-mode','light')`);
-  await evaluate(member, `window.location.hash = '#/session'`);
-  await memberRefreshAndWait(member, "!document.querySelector('[data-testid=\\\"brand-logo\\\"]')", "no logo (clean)").catch(() => {});
+  await evaluate(member, () => (localStorage.setItem('openwork.react.settings.theme-mode','light')));
+  await evaluate(member, () => (window.location.hash = '#/session'));
+  await memberRefreshAndWait(member, () => (!document.querySelector('[data-testid=\"brand-logo\"]')), "no logo (clean)").catch(() => {});
   await sleep(1500);
 
   // Reload admin org-settings so the form reflects the cleared state.
@@ -244,23 +249,23 @@ async function main() {
   // JOURNEY 0: baseline — both surfaces clean
   // =================================================================
   console.log("\nJourney 0: baseline");
-  await evaluate(admin, `(() => { const h=[...document.querySelectorAll('h2')].find(x=>x.textContent.includes('Brand Appearance')); if(h) h.scrollIntoView({block:'center'}); return true; })()`);
+  await evaluate(admin, () => { const h=[...document.querySelectorAll('h2')].find(x=>x.textContent.includes('Brand Appearance')); if(h) h.scrollIntoView({block:'center'}); return true; });
   await shot(admin, "admin", "00-baseline-brand-card",
     "Admin: Brand Appearance card with empty logo + default accent.",
-    [{ label: "Brand Appearance card visible", passed: await evaluate(admin, "document.body.innerText.includes('Brand Appearance')") }]);
+    [{ label: "Brand Appearance card visible", passed: await evaluate(admin, () => (document.body.innerText.includes('Brand Appearance'))) }]);
   await shot(member, "member", "00-baseline-app",
     "Member: clean app, no logo, default accent.",
-    [{ label: "no brand logo", passed: await evaluate(member, "!document.querySelector('[data-testid=\"brand-logo\"]')") }]);
+    [{ label: "no brand logo", passed: await evaluate(member, () => (!document.querySelector('[data-testid="brand-logo"]'))) }]);
 
   // =================================================================
-  // JOURNEY 1: admin sets Genpact logo in the web UI → member sees it
+  // JOURNEY 1: admin sets OpenWork demo logo in the web UI → member sees it
   // =================================================================
   console.log("\nJourney 1: admin sets logo via web UI");
-  await adminSetLogoViaUI(admin, GENPACT_LOGO);
+  await adminSetLogoViaUI(admin, DEMO_LOGO);
   await sleep(500);
   await shot(admin, "admin", "01-logo-typed",
-    "Admin: typed Genpact logo URL into the Logo URL field.",
-    [{ label: "logo URL in field", passed: await evaluate(admin, `[...document.querySelectorAll('input')].some(i => i.value.includes('Genpact'))`) }]);
+    "Admin: typed OpenWork demo logo URL into the Logo URL field.",
+    [{ label: "logo URL in field", passed: await evaluate(admin, () => ([...document.querySelectorAll('input')].some(i => i.value.includes('openworklabs.com')))) }]);
 
   await adminClickSave(admin);
   await sleep(2500); // let the PATCH land
@@ -268,18 +273,18 @@ async function main() {
   const cfg1 = await denApi(token, "/v1/me/desktop-config");
   await shot(admin, "admin", "01-logo-saved",
     "Admin: clicked Save → server persisted brandLogoUrl.",
-    [{ label: "server has brandLogoUrl", passed: cfg1.brandLogoUrl === GENPACT_LOGO, detail: cfg1.brandLogoUrl || "(none)" }]);
+    [{ label: "server has brandLogoUrl", passed: cfg1.brandLogoUrl === DEMO_LOGO, detail: cfg1.brandLogoUrl || "(none)" }]);
 
   // Member app fetches the change on its own and renders the logo.
   await memberRefreshAndWait(member,
-    `(() => { const img = document.querySelector('[data-testid="brand-logo"] img'); return img && img.naturalWidth > 0 && img.complete; })()`,
-    "Genpact logo loaded in member app");
+    () => { const img = document.querySelector<HTMLImageElement>('[data-testid="brand-logo"] img'); return img && img.naturalWidth > 0 && img.complete; },
+    "OpenWork demo logo loaded in member app");
   // Verify the logo renders at a legible size (not a squished icon).
-  const logoDims = await evaluate(member, `(() => { const i = document.querySelector('[data-testid="brand-logo"] img'); const r = i.getBoundingClientRect(); return { w: Math.round(r.width), h: Math.round(r.height) }; })()`);
+  const logoDims = await evaluate(member, () => { const i = document.querySelector<HTMLImageElement>('[data-testid="brand-logo"] img'); if (!i) throw new Error('Brand logo missing'); const r = i.getBoundingClientRect(); return { w: Math.round(r.width), h: Math.round(r.height) }; });
   await shot(member, "member", "01-logo-appeared",
-    "Member: app fetched the change and rendered the Genpact logo at a legible size (no reload).",
+    "Member: app fetched the change and rendered the OpenWork demo logo at a legible size (no reload).",
     [
-      { label: "Genpact logo rendered", passed: await evaluate(member, `Boolean(document.querySelector('[data-testid="brand-logo"] img'))`) },
+      { label: "OpenWork demo logo rendered", passed: await evaluate(member, () => (Boolean(document.querySelector<HTMLImageElement>('[data-testid="brand-logo"] img')))) },
       { label: "logo legible (height ≥ 28px)", passed: logoDims.h >= 28, detail: `${logoDims.w}x${logoDims.h}` },
     ]);
 
@@ -291,7 +296,7 @@ async function main() {
   await sleep(400);
   await shot(admin, "admin", "02-accent-selected",
     "Admin: selected 'Blue' accent in the dropdown.",
-    [{ label: "blue selected", passed: await evaluate(admin, `document.querySelector('select')?.value === 'blue'`) }]);
+    [{ label: "blue selected", passed: await evaluate(admin, () => (document.querySelector('select')?.value === 'blue')) }]);
 
   await adminClickSave(admin);
   await sleep(2500);
@@ -301,16 +306,15 @@ async function main() {
     [{ label: "server has accent=blue", passed: cfg2.brandAccentColor === "blue", detail: cfg2.brandAccentColor || "(none)" }]);
 
   await memberRefreshAndWait(member,
-    `document.documentElement.dataset.brandAccent === 'blue'`,
+    () => (document.documentElement.dataset.brandAccent === 'blue'),
     "blue accent applied in member app");
   // The accent's most prominent painted surface is the notification badge +
   // unread dots. Push a fresh unread notice so the blue accent is guaranteed
   // visible, then open the bell — this single frame shows the blue accent
-  // (badge + unread dot) together with the Genpact logo top-left.
-  await evaluate(member, `window.location.hash = '#/session'`);
+  // (badge + unread dot) together with the OpenWork demo logo top-left.
+  await evaluate(member, () => (window.location.hash = '#/session'));
   await sleep(800);
-  await evaluate(member, `(() => {
-    const store = window.__openwork?.notificationStore;
+  await evaluate(member, () => {
     // Use the public notify path if exposed; otherwise write an unread entry.
     try {
       const raw = localStorage.getItem('openwork:notifications:v1');
@@ -323,21 +327,21 @@ async function main() {
       localStorage.setItem('openwork:notifications:v1', JSON.stringify(data));
     } catch {}
     return true;
-  })()`);
+  });
   // Reload so the store rehydrates the unread entry, then re-apply brand.
-  await evaluate(member, `location.reload()`);
-  await memberRefreshAndWait(member, `document.documentElement.dataset.brandAccent === 'blue'`, "accent re-applied after reload");
+  await evaluate(member, () => (location.reload()));
+  await memberRefreshAndWait(member, () => (document.documentElement.dataset.brandAccent === 'blue'), "accent re-applied after reload");
   await sleep(800);
   await memberOpenNotifications(member);
-  const cssAccent = await evaluate(member, `getComputedStyle(document.documentElement).getPropertyValue('--dls-accent').trim()`);
+  const cssAccent = await evaluate(member, () => (getComputedStyle(document.documentElement).getPropertyValue('--dls-accent').trim()));
   const accentCheck = await memberAccentVisible(member);
   await shot(member, "member", "02-accent-applied",
-    "Member: accent switched to blue — visible on the notification badge + unread dots, with the Genpact logo top-left.",
+    "Member: accent switched to blue — visible on the notification badge + unread dots, with the OpenWork demo logo top-left.",
     [
-      { label: "data-brand-accent=blue", passed: await evaluate(member, `document.documentElement.dataset.brandAccent === 'blue'`) },
+      { label: "data-brand-accent=blue", passed: await evaluate(member, () => (document.documentElement.dataset.brandAccent === 'blue')) },
       { label: "--dls-accent is blue-9", passed: cssAccent === "#0090ff" || cssAccent.includes("blue"), detail: cssAccent },
       { label: "blue accent painted on screen", passed: accentCheck.painted, detail: accentCheck.painted ? "blue pixels found" : "no blue painted" },
-      { label: "Genpact logo still shown", passed: await evaluate(member, `Boolean(document.querySelector('[data-testid="brand-logo"] img'))`) },
+      { label: "OpenWork demo logo still shown", passed: await evaluate(member, () => (Boolean(document.querySelector<HTMLImageElement>('[data-testid="brand-logo"] img')))) },
     ]);
 
   // =================================================================
@@ -350,21 +354,21 @@ async function main() {
   await sleep(3500);
   await shot(admin, "admin", "03-policies-list",
     "Admin: opens the Desktop Policies page.",
-    [{ label: "policies page", passed: await evaluate(admin, "document.body.innerText.toLowerCase().includes('policic') || document.body.innerText.includes('Desktop')") }]);
+    [{ label: "policies page", passed: await evaluate(admin, () => (document.body.innerText.toLowerCase().includes('policic') || document.body.innerText.includes('Desktop'))) }]);
 
   // Open the default policy editor.
-  await evaluate(admin, `(() => {
-    const link = [...document.querySelectorAll('a, button')].find(el => /edit|default/i.test(el.textContent));
+  await evaluate(admin, () => {
+    const link = [...document.querySelectorAll<HTMLElement>('a, button')].find(el => /edit|default/i.test(el.textContent));
     if (link) link.click();
     return Boolean(link);
-  })()`);
+  });
   await sleep(3000);
 
   // Toggle off "Multiple workspaces" checkbox in the editor.
-  const toggled = await evaluate(admin, `(() => {
+  const toggled = await evaluate(admin, () => {
     const labels = [...document.querySelectorAll('label, div')];
     // find checkbox associated with "Multiple workspaces"
-    const checkboxes = [...document.querySelectorAll('input[type="checkbox"], [role="switch"]')];
+    const checkboxes = [...document.querySelectorAll<HTMLElement>('input[type="checkbox"], [role="switch"]')];
     // Heuristic: find the checkbox whose nearby text mentions "workspace".
     for (const cb of checkboxes) {
       const scope = cb.closest('label, div, li, tr');
@@ -375,19 +379,19 @@ async function main() {
       }
     }
     return false;
-  })()`);
+  });
   console.log(`  toggled workspaces checkbox in UI: ${toggled}`);
   await sleep(500);
   await shot(admin, "admin", "03-policy-editor",
     "Admin: in the policy editor, unchecks 'Multiple workspaces'.",
-    [{ label: "editor open", passed: await evaluate(admin, "document.body.innerText.includes('workspace') || document.body.innerText.includes('Workspace')") }]);
+    [{ label: "editor open", passed: await evaluate(admin, () => (document.body.innerText.includes('workspace') || document.body.innerText.includes('Workspace'))) }]);
 
   // Save the policy (button text may be "Save").
-  await evaluate(admin, `(() => {
+  await evaluate(admin, () => {
     const btn = [...document.querySelectorAll('button')].find(b => /save/i.test(b.textContent));
     if (btn) { btn.scrollIntoView({block:'center'}); btn.click(); }
     return Boolean(btn);
-  })()`);
+  });
   await sleep(2500);
 
   // If the UI toggle didn't take (editor markup varies), enforce via API so
@@ -397,7 +401,7 @@ async function main() {
   if (cfg3.allowMultipleWorkspaces !== false) {
     restrictedVia = "api-fallback";
     const list3 = await denApi(token, "/v1/desktop-policies");
-    const d3 = list3.desktopPolicies.find((p) => p.isDefault);
+    const d3 = list3.desktopPolicies.find((p: { isDefault?: boolean; name?: string; id: string }) => p.isDefault);
     await denApi(token, `/v1/desktop-policies/${d3.id}`, {
       method: "PATCH",
       body: JSON.stringify({ policyName: d3.policyName, policy: {
@@ -416,20 +420,20 @@ async function main() {
   // which is the primary surface for org-policy notices. Open it and assert
   // the "Organization policies active" entry is present.
   await memberRefreshAndWait(member,
-    `(() => {
+    () => {
       const raw = localStorage.getItem('openwork:notifications:v1');
       if (!raw) return false;
-      try { return (JSON.parse(raw)?.state?.notifications ?? []).some(n => n.dedupeKey === 'desktop-policy-active'); }
+      try { return (JSON.parse(raw)?.state?.notifications ?? []).some((n: { dedupeKey?: string; readAt?: number | null }) => n.dedupeKey === 'desktop-policy-active'); }
       catch { return false; }
-    })()`,
+    },
     "desktop-policy notification in store");
-  await evaluate(member, `window.location.hash = '#/session'`);
+  await evaluate(member, () => (window.location.hash = '#/session'));
   await sleep(1200);
   await memberOpenNotifications(member);
-  const notifText = await evaluate(member, `(() => {
+  const notifText = await evaluate(member, () => {
     const panel = [...document.querySelectorAll('div')].find(e => e.innerText && e.innerText.startsWith('Notifications') && e.innerText.includes('Organization policies active'));
     return panel ? panel.innerText.slice(0, 400) : '';
-  })()`);
+  });
   await shot(member, "member", "03-notification-center",
     "Member: the notification center (bell) shows the 'Organization policies active' entry after the admin's change.",
     [
@@ -438,11 +442,11 @@ async function main() {
     ]);
 
   // Also capture the in-context settings banner as a secondary surface.
-  await evaluate(member, `window.location.hash = '#/settings/general'`);
+  await evaluate(member, () => (window.location.hash = '#/settings/general'));
   await sleep(1500);
   await shot(member, "member", "03-settings-banner",
     "Member: settings also shows the 'Organization policies active' banner (secondary surface).",
-    [{ label: "policy banner visible", passed: await evaluate(member, `Boolean(document.querySelector('[data-testid="desktop-policy-banner"]'))`) }]);
+    [{ label: "policy banner visible", passed: await evaluate(member, () => (Boolean(document.querySelector('[data-testid="desktop-policy-banner"]')))) }]);
 
   // =================================================================
   // JOURNEY 4: admin clears everything → member returns to default
@@ -452,19 +456,19 @@ async function main() {
   await admin.send("Page.navigate", { url: `${DEN_WEB}/dashboard/org-settings` });
   await sleep(3500);
   // Clear logo field + reset accent to Default, then Save.
-  await evaluate(admin, `(() => {
+  await evaluate(admin, () => {
     const logo = [...document.querySelectorAll('input')].find(i => (i.placeholder||'').includes('logo'));
-    if (logo) { const s=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set; s.call(logo,''); logo.dispatchEvent(new Event('input',{bubbles:true})); logo.dispatchEvent(new Event('change',{bubbles:true})); }
+    if (logo) { const s=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value')?.set; if (!s) throw new Error('Native form setter missing'); s.call(logo,''); logo.dispatchEvent(new Event('input',{bubbles:true})); logo.dispatchEvent(new Event('change',{bubbles:true})); }
     const sel = document.querySelector('select');
-    if (sel) { const s=Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype,'value').set; s.call(sel,''); sel.dispatchEvent(new Event('change',{bubbles:true})); }
+    if (sel) { const s=Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype,'value')?.set; if (!s) throw new Error('Native form setter missing'); s.call(sel,''); sel.dispatchEvent(new Event('change',{bubbles:true})); }
     return true;
-  })()`);
+  });
   await sleep(400);
   await adminClickSave(admin);
   await sleep(2500);
   // Restore the policy too (via API — owner action).
   const list4 = await denApi(token, "/v1/desktop-policies");
-  const d4 = list4.desktopPolicies.find((p) => p.isDefault);
+  const d4 = list4.desktopPolicies.find((p: { isDefault?: boolean; name?: string; id: string }) => p.isDefault);
   await denApi(token, `/v1/desktop-policies/${d4.id}`, {
     method: "PATCH",
     body: JSON.stringify({ policyName: d4.policyName, policy: {
@@ -477,15 +481,15 @@ async function main() {
     "Admin: cleared logo + accent and restored policies. Server clean.",
     [{ label: "server: no brand", passed: !cfg4.brandLogoUrl && !cfg4.brandAccentColor }]);
 
-  await evaluate(member, `window.location.hash = '#/session'`);
+  await evaluate(member, () => (window.location.hash = '#/session'));
   await memberRefreshAndWait(member,
-    `!document.documentElement.dataset.brandAccent && !document.querySelector('[data-testid="brand-logo"]')`,
+    () => (!document.documentElement.dataset.brandAccent && !document.querySelector('[data-testid="brand-logo"]')),
     "member app returned to default");
   await shot(member, "member", "04-back-to-default",
     "Member: app returned to clean default — no logo, no custom accent.",
     [
-      { label: "no brand accent", passed: await evaluate(member, `!document.documentElement.dataset.brandAccent`) },
-      { label: "no brand logo", passed: await evaluate(member, `!document.querySelector('[data-testid="brand-logo"]')`) },
+      { label: "no brand accent", passed: await evaluate(member, () => (!document.documentElement.dataset.brandAccent)) },
+      { label: "no brand logo", passed: await evaluate(member, () => (!document.querySelector('[data-testid="brand-logo"]'))) },
     ]);
 
   admin.close();
@@ -500,9 +504,9 @@ async function main() {
   process.exit(allOk ? 0 : 1);
 }
 
-function renderHtml(frames, allOk) {
-  const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
-  const cards = frames.map((f) => `
+function renderHtml(items: typeof frames, allOk: boolean) {
+  const esc = (s: string) => String(s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c] ?? c));
+  const cards = items.map((f) => `
     <figure class="frame ${f.ok ? "ok" : "fail"} ${f.surface}">
       <div class="tag">${f.surface.toUpperCase()}</div>
       <img src="${f.file}" alt="${esc(f.name)}" />

--- a/evals/package.json
+++ b/evals/package.json
@@ -15,22 +15,24 @@
     "evidence:judge": "node packages/test-evidence/bin/test-evidence-judge.mjs",
     "provision:org-connector-two-members": "node scripts/provision-org-connector-two-members.ts",
     "lint:layers": "depcruise --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json packages specs worlds bin docs-shots runner scripts ../scenarios",
-    "test": "pnpm run lint:layers && node scripts/spec-channel-ratchet.mjs && node scripts/spec-boundary-ratchet.mjs && node --test runner/*.test.ts packages/*/test/*.test.ts bin/*.test.mjs scripts/*.test.mjs",
+    "test": "pnpm run check:browser && pnpm run lint:layers && node scripts/spec-channel-ratchet.mjs && node scripts/spec-boundary-ratchet.mjs && node --test runner/*.test.ts packages/*/test/*.test.ts bin/*.test.mjs scripts/*.test.mjs",
     "typecheck": "tsc -p .",
     "typecheck:spec-layer": "tsc -p tsconfig.primitives.json",
-    "test:core": "vitest run --config vitest.config.ts --project pr specs/thread-approvals-replay.test.ts specs/effective-permissions-attribution.test.ts specs/pdf-attachments-model-routing.test.ts"
+    "test:core": "vitest run --config vitest.config.ts --project pr specs/thread-approvals-replay.test.ts specs/effective-permissions-attribution.test.ts specs/pdf-attachments-model-routing.test.ts",
+    "check:browser": "node scripts/check-browser-code.mjs"
   },
   "dependencies": {
-    "@openwork/sdk": "link:../packages/sdk",
     "@openwork/behaviors": "workspace:*",
     "@openwork/cdp": "workspace:*",
     "@openwork/env": "workspace:*",
-    "@openwork/test-artifacts": "workspace:*",
-    "@openwork/test-evidence": "workspace:*",
     "@openwork/hosts": "workspace:*",
     "@openwork/labs": "workspace:*",
     "@openwork/matchers": "workspace:*",
+    "@openwork/sdk": "link:../packages/sdk",
+    "@openwork/test-artifacts": "workspace:*",
+    "@openwork/test-evidence": "workspace:*",
     "@openwork/testkit": "workspace:*",
+    "@openwork/types": "link:../packages/types",
     "@openwork/world": "link:../packages/world"
   },
   "devDependencies": {

--- a/evals/packages/behaviors/src/browser-handoff.ts
+++ b/evals/packages/behaviors/src/browser-handoff.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -68,42 +69,44 @@ export async function signInInBrowser(
   credentials: { email: string; password: string },
 ): Promise<void> {
   await timed("browser.signIn", async () => {
-    await evalIn(browser, `window.location.href = ${JSON.stringify(url)}`);
-    await waitFor(browser, `(() => {
-      if (document.querySelector('input[type="password"], input[name="password"]')) return true;
-      const email = document.querySelector('input[type="email"], input[name="email"]');
+    await evalIn(browser, browserScript((url) => (window.location.href = url), [url]));
+    await waitFor(browser, browserScript((inputEmail) => {
+      if (document.querySelector<HTMLInputElement>('input[type="password"], input[name="password"]')) return true;
+      const email = document.querySelector<HTMLInputElement>('input[type="email"], input[name="email"]');
       if (!email) return false;
-      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-      setter.call(email, ${JSON.stringify(credentials.email)});
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+      if (!setter) throw new Error("Native input setter is unavailable");
+      setter.call(email, inputEmail);
       email.dispatchEvent(new Event("input", { bubbles: true }));
       const next = [...document.querySelectorAll("button")]
         .find((candidate) => /next|continue|sign ?in/i.test(candidate.textContent ?? "") && !candidate.disabled);
       if (!next) return false;
       next.click();
       return true;
-    })()`, { timeoutMs: 120_000, label: "den email step submitted" });
-    await waitFor(browser, `(() => {
+    }, [credentials.email]), { timeoutMs: 120_000, label: "den email step submitted" });
+    await waitFor(browser, browserScript((inputPassword) => {
       if (/signed in/i.test(document.body?.innerText ?? "")) return true;
-      const password = document.querySelector('input[type="password"], input[name="password"]');
+      const password = document.querySelector<HTMLInputElement>('input[type="password"], input[name="password"]');
       if (!password) return false;
-      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-      setter.call(password, ${JSON.stringify(credentials.password)});
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+      if (!setter) throw new Error("Native input setter is unavailable");
+      setter.call(password, inputPassword);
       password.dispatchEvent(new Event("input", { bubbles: true }));
       const submit = [...document.querySelectorAll("button")]
         .find((candidate) => /sign ?in|continue|log ?in/i.test(candidate.textContent ?? "") && !candidate.disabled);
       if (!submit) return false;
       submit.click();
       return true;
-    })()`, { timeoutMs: 60_000, label: "den password step submitted" });
+    }, [credentials.password]), { timeoutMs: 60_000, label: "den password step submitted" });
     // Signed in means the outcome page, not a submit in flight ("Working...").
-    await waitFor(browser, `(() => {
+    await waitFor(browser, () => {
       const text = document.body?.innerText ?? "";
       // Plain web sign-in redirects into the dashboard; handoff shows "signed in" or the openwork:// code.
       if (location.pathname.startsWith("/dashboard")) return true;
       if (/signed in/i.test(text)) return true;
       return [...document.querySelectorAll("input")]
         .some((input) => (input.value ?? "").startsWith("openwork://"));
-    })()`, { timeoutMs: 60_000, label: "den sign-in outcome" });
+    }, { timeoutMs: 60_000, label: "den sign-in outcome" });
   }, credentials.email);
 }
 
@@ -118,18 +121,18 @@ export async function signInInBrowser(
  * Den issued for this session.
  */
 export async function readHandoffDeepLink(browser: Surface, { timeoutMs = 60_000 } = {}): Promise<string> {
-  const found = await waitFor(browser, `(() => {
+  const found = await waitFor(browser, () => {
     const fromInput = [...document.querySelectorAll("input")]
       .map((input) => input.value)
       .find((value) => typeof value === "string" && value.startsWith("openwork://") && value.includes("grant="));
     if (fromInput) return fromInput;
-    const fromAnchor = [...document.querySelectorAll('a[href^="openwork://"]')]
+    const fromAnchor = [...document.querySelectorAll<HTMLElement>('a[href^="openwork://"]')]
       .map((anchor) => anchor.getAttribute("href"))
       .find((href) => typeof href === "string" && href.includes("grant="));
     if (fromAnchor) return fromAnchor;
-    const inText = (document.body?.innerText ?? "").match(/openwork:\\/\\/[^\\s"']+grant=[^\\s"']+/);
+    const inText = (document.body?.innerText ?? "").match(/openwork:\/\/[^\s"']+grant=[^\s"']+/);
     return inText ? inText[0] : false;
-  })()`, { timeoutMs, label: "handoff deep link in the browser" });
+  }, { timeoutMs, label: "handoff deep link in the browser" });
   if (typeof found !== "string") throw new Error("Could not read a handoff deep link from the browser page.");
   return found;
 }

--- a/evals/packages/behaviors/src/composer.ts
+++ b/evals/packages/behaviors/src/composer.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import { control, evalIn, waitFor } from "./desktop.ts";
 
@@ -37,25 +38,25 @@ function messageText(error: unknown): string {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function readComposerState(app: Surface): Promise<ComposerState> {
-  const value = await evalIn(app, `(() => {
-    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
-      ?? document.querySelector('[contenteditable="true"]');
+  const value = await evalIn(app, () => {
+    const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]')
+      ?? document.querySelector<HTMLElement>('[contenteditable="true"]');
     const run = [...document.querySelectorAll("button")]
       .find((button) => (button.textContent ?? "").trim() === "Run task");
-    const model = document.querySelector('button[aria-label="Change model"]');
+    const model = document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]');
     return {
       composerEditable: Boolean(editor),
       draftText: editor?.innerText ?? "",
       route: location.hash,
       runTaskVisible: Boolean(run),
       runTaskEnabled: Boolean(run && !run.disabled),
-      userMessageCount: document.querySelectorAll('[data-message-role="user"]').length,
-      assistantMessageCount: document.querySelectorAll('[data-message-role="assistant"]').length,
+      userMessageCount: document.querySelectorAll<HTMLElement>('[data-message-role="user"]').length,
+      assistantMessageCount: document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]').length,
       selectedModelLabel: model?.textContent?.trim() ?? "",
       modelUnavailable: document.body.innerText.includes("Model no longer available")
         || document.body.innerText.includes("The model you were using is no longer available"),
     };
-  })()`);
+  });
   if (!isRecord(value)) throw new Error("Composer state was not an object.");
   return {
     composerEditable: value.composerEditable === true,
@@ -79,8 +80,8 @@ async function waitForComposerReady(app: Surface, timeoutMs: number): Promise<Co
       lastState = await readComposerState(app);
       lastError = null;
       if (lastState.composerEditable && (lastState.runTaskVisible
-        || await evalIn(app, `Boolean(window.__openworkControl?.listActions?.()
-          .find((entry) => entry.id === "composer.set_text" && entry.disabled === false))`).catch(() => false))) {
+        || await evalIn(app, () => (Boolean(window.__openworkControl?.listActions?.()
+          .find((entry) => entry.id === "composer.set_text" && entry.disabled === false)))).catch(() => false))) {
         return lastState;
       }
     } catch (error) {
@@ -102,16 +103,16 @@ async function tryWriteComposerText(app: Surface, text: string, readinessTimeout
   // contenteditable paste below stays as a fallback for surfaces that do not
   // register the action.
   let controlError = "composer.set_text was not available";
-  const hasControl = await evalIn(app, `Boolean(window.__openworkControl?.listActions?.()
-    .find((entry) => entry.id === "composer.set_text" && entry.disabled === false))`).catch(() => false);
+  const hasControl = await evalIn(app, () => (Boolean(window.__openworkControl?.listActions?.()
+    .find((entry) => entry.id === "composer.set_text" && entry.disabled === false)))).catch(() => false);
   if (hasControl === true) {
     try {
       await control(app, "composer.set_text", { text }, { timeoutMs: 120_000 });
-      await waitFor(app, `(() => {
-        const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
-          ?? document.querySelector('[contenteditable="true"]');
-        return Boolean(editor && (editor.innerText ?? "").includes(${JSON.stringify(text)}));
-      })()`, { timeoutMs: 30_000, label: "composer draft text via control" });
+      await waitFor(app, browserScript((text) => {
+        const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]')
+          ?? document.querySelector<HTMLElement>('[contenteditable="true"]');
+        return Boolean(editor && (editor.innerText ?? "").includes(text));
+      }, [text]), { timeoutMs: 30_000, label: "composer draft text via control" });
       return;
     } catch (error) {
       controlError = messageText(error);
@@ -121,9 +122,9 @@ async function tryWriteComposerText(app: Surface, text: string, readinessTimeout
   let pasteError = "Could not paste text into the composer contenteditable.";
   try {
     await waitForComposerReady(app, readinessTimeoutMs);
-    const pasted = await evalIn(app, `(() => {
-      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
-        ?? document.querySelector('[contenteditable="true"]');
+    const pasted = await evalIn(app, browserScript((text) => {
+      const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]')
+        ?? document.querySelector<HTMLElement>('[contenteditable="true"]');
       if (!editor) return false;
       editor.focus();
       const selection = window.getSelection();
@@ -132,16 +133,16 @@ async function tryWriteComposerText(app: Surface, text: string, readinessTimeout
       selection?.removeAllRanges();
       selection?.addRange(range);
       const data = new DataTransfer();
-      data.setData("text/plain", ${JSON.stringify(text)});
+      data.setData("text/plain", text);
       editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
       return true;
-    })()`);
+    }, [text]));
     if (pasted !== true) throw new Error(pasteError);
-    await waitFor(app, `(() => {
-      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
-        ?? document.querySelector('[contenteditable="true"]');
-      return Boolean(editor && (editor.innerText ?? "").includes(${JSON.stringify(text)}));
-    })()`, { timeoutMs: 30_000, label: "composer draft text" });
+    await waitFor(app, browserScript((text) => {
+      const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]')
+        ?? document.querySelector<HTMLElement>('[contenteditable="true"]');
+      return Boolean(editor && (editor.innerText ?? "").includes(text));
+    }, [text]), { timeoutMs: 30_000, label: "composer draft text" });
     return;
   } catch (error) {
     pasteError = messageText(error);
@@ -173,12 +174,12 @@ export async function writeComposerText(
 export async function sendComposerMessage(app: Surface, text: string): Promise<ComposerState> {
   const before = await waitForComposerReady(app, 60_000);
   await writeComposerText(app, text);
-  await waitFor(app, `Boolean([...document.querySelectorAll("button")]
-    .find((button) => (button.textContent ?? "").trim() === "Run task" && !button.disabled))`, {
+  await waitFor(app, () => (Boolean([...document.querySelectorAll("button")]
+    .find((button) => (button.textContent ?? "").trim() === "Run task" && !button.disabled))), {
     timeoutMs: 30_000,
     label: "enabled Run task button",
   });
-  const clicked = await evalIn(app, `(() => {
+  const clicked = await evalIn(app, () => {
     const button = [...document.querySelectorAll("button")]
       .find((entry) => (entry.textContent ?? "").trim() === "Run task" && !entry.disabled);
     if (button) {
@@ -186,9 +187,9 @@ export async function sendComposerMessage(app: Surface, text: string): Promise<C
       return true;
     }
     return false;
-  })()`);
+  });
   if (clicked !== true) throw new Error("Run task was no longer clickable; composer.send was not substituted.");
-  await waitFor(app, `document.querySelectorAll('[data-message-role="user"]').length > ${before.userMessageCount}`, {
+  await waitFor(app, browserScript((userMessageCount) => (document.querySelectorAll<HTMLElement>('[data-message-role="user"]').length > userMessageCount), [before.userMessageCount]), {
     timeoutMs: 60_000,
     label: "sent user message",
   });
@@ -199,15 +200,15 @@ export async function waitForAssistantReply(
   app: Surface,
   { timeoutMs }: { timeoutMs: number },
 ): Promise<AssistantReplyFacts> {
-  await waitFor(app, `(() => {
-    const messages = [...document.querySelectorAll('[data-message-role="assistant"]')];
+  await waitFor(app, () => {
+    const messages = [...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')];
     return messages.some((message) => (message.innerText ?? "").trim().length > 0);
-  })()`, { timeoutMs, label: "assistant reply" });
-  const value = await evalIn(app, `(() => {
-    const messages = [...document.querySelectorAll('[data-message-role="assistant"]')];
+  }, { timeoutMs, label: "assistant reply" });
+  const value = await evalIn(app, () => {
+    const messages = [...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')];
     const latest = messages[messages.length - 1];
     return { text: latest?.innerText?.trim() ?? "", assistantMessageCount: messages.length };
-  })()`);
+  });
   if (!isRecord(value)) throw new Error("Assistant reply facts were not an object.");
   return {
     text: stringField(value.text),

--- a/evals/packages/behaviors/src/desktop-boot.ts
+++ b/evals/packages/behaviors/src/desktop-boot.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { dumpScreenState, readActiveWorkspaceId } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import type { DenRef, DenSession } from "./den.ts";
@@ -14,7 +15,7 @@ function messageText(error: unknown): string {
 async function waitForDenState(
   app: Surface,
   den: DenRef,
-  expression: string,
+  expression: import("@openwork/cdp").BrowserEvaluation,
   options: { timeoutMs: number; label: string },
 ): Promise<void> {
   try {
@@ -22,7 +23,7 @@ async function waitForDenState(
   } catch (error) {
     const keys = await evalIn(
       app,
-      "Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(Boolean).sort()",
+      () => (Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(Boolean).sort()),
       { timeoutMs: 5_000 },
     ).catch((keysError: unknown) => [`<unavailable: ${messageText(keysError)}>`]);
     throw new Error(
@@ -37,7 +38,7 @@ export interface SelectedWorkspaceFacts {
 }
 
 export async function signInDesktopAs(app: Surface, den: DenRef, member: DenSession): Promise<void> {
-  await waitFor(app, "Boolean(window.__openworkControl?.listActions?.().some((action) => action.id === 'auth.exchange-grant'))", {
+  await waitFor(app, () => (Boolean(window.__openworkControl?.listActions?.().some((action) => action.id === 'auth.exchange-grant'))), {
     timeoutMs: 60_000,
     label: "auth.exchange-grant action registered",
   });
@@ -47,17 +48,17 @@ export async function signInDesktopAs(app: Surface, den: DenRef, member: DenSess
   } catch (error) {
     if (!messageText(error).includes("Already acting: auth.exchange-grant")) throw error;
   }
-  await waitForDenState(app, den, "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
+  await waitForDenState(app, den, () => (Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())), {
     timeoutMs: 45_000,
     label: "persisted den auth token",
   });
-  await waitForDenState(app, den, "Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
+  await waitForDenState(app, den, () => (Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())), {
     timeoutMs: 60_000,
     label: "active org resolved",
   });
   // A first-time member lands on organization onboarding; a member whose app
   // already has a workspace can come straight back to it.
-  await waitFor(app, `window.location.hash.includes("/onboarding") || /\\/(workspace|session)/.test(window.location.hash)`, {
+  await waitFor(app, () => (window.location.hash.includes("/onboarding") || /\/(workspace|session)/.test(window.location.hash)), {
     timeoutMs: 60_000,
     label: "organization onboarding or workspace route",
   });
@@ -66,13 +67,13 @@ export async function signInDesktopAs(app: Surface, den: DenRef, member: DenSess
 async function completeOrganizationOnboarding(app: Surface): Promise<void> {
   const deadline = Date.now() + 120_000;
   while (Date.now() < deadline && (await currentHash(app)).includes("/onboarding")) {
-    const label = await evalIn(app, `(() => {
+    const label = await evalIn(app, () => {
       const labels = [...document.querySelectorAll("button")]
         .filter((button) => !button.disabled)
         .map((button) => (button.textContent ?? "").trim());
       return ["Continue with organization", "Continue to workspace", "Continue without OpenWork Models", "Continue"]
         .find((candidate) => labels.includes(candidate)) ?? "";
-    })()`);
+    });
     if (typeof label === "string" && label) {
       await clickButton(app, label);
     }
@@ -89,14 +90,14 @@ function workspaceIdFromRoute(route: string): string {
 
 async function waitForTaskUi(app: Surface, workspaceId: string): Promise<string> {
   await go(app, `/workspace/${workspaceId}/session`);
-  await waitFor(app, `(() => {
-    const match = /^#?\\/workspace\\/([^/?#]+)\\/session\\/?$/.exec(window.location.hash);
-    const routeReady = match?.[1] === ${JSON.stringify(workspaceId)};
+  await waitFor(app, browserScript((workspaceId) => {
+    const match = /^#?\/workspace\/([^/?#]+)\/session\/?$/.exec(window.location.hash);
+    const routeReady = match?.[1] === workspaceId;
     const text = document.body.innerText;
     const runTask = [...document.querySelectorAll("button")]
       .some((button) => (button.textContent ?? "").trim() === "Run task");
     return routeReady && (text.includes("What do you need done?") || runTask);
-  })()`, { timeoutMs: 120_000, label: `workspace ${workspaceId} task UI` });
+  }, [workspaceId]), { timeoutMs: 120_000, label: `workspace ${workspaceId} task UI` });
   return currentHash(app);
 }
 
@@ -129,8 +130,8 @@ export async function createAndSelectWorkspace(
     // onboarding steps finish reads an id the app has not adopted yet.
     workspaceId = workspace.id;
     if (!workspaceId) {
-      await waitFor(app, `Boolean(localStorage.getItem("openwork.react.activeWorkspace"))
-        || /\\/workspace\\/[^/?#]+/.test(window.location.hash)`, {
+      await waitFor(app, () => (Boolean(localStorage.getItem("openwork.react.activeWorkspace"))
+        || /\/workspace\/[^/?#]+/.test(window.location.hash)), {
         timeoutMs: 180_000,
         label: "workspace selected after onboarding",
       });
@@ -140,8 +141,8 @@ export async function createAndSelectWorkspace(
     if (route.includes("/onboarding")) await completeOrganizationOnboarding(app);
     workspaceId = await resolveWorkspaceId(app);
     if (!workspaceId || input.create) {
-      await waitFor(app, `window.__openworkControl.listActions()
-        .some((action) => action.id === "workspace.create" && !action.disabled)`, {
+      await waitFor(app, () => (window.__openworkControl.listActions()
+        .some((action) => action.id === "workspace.create" && !action.disabled)), {
         timeoutMs: 60_000,
         label: "workspace.create enabled",
       });
@@ -150,11 +151,11 @@ export async function createAndSelectWorkspace(
       await control(app, "workspace.create", { path: input.path }, { timeoutMs: 60_000 });
       // The app does not always put a new workspace in the hash, so wait for its
       // own active-workspace state to settle instead of matching a route shape.
-      await waitFor(app, `(() => {
+      await waitFor(app, browserScript((workspaceId) => {
         const selected = localStorage.getItem("openwork.react.activeWorkspace")
-          || window.location.hash.match(/\\/workspace\\/([^/?#]+)/)?.[1];
-        return Boolean(selected) && selected !== ${JSON.stringify(workspaceId)};
-      })()`, {
+          || window.location.hash.match(/\/workspace\/([^/?#]+)/)?.[1];
+        return Boolean(selected) && selected !== workspaceId;
+      }, [workspaceId]), {
         timeoutMs: 120_000,
         label: "created workspace selected",
       });

--- a/evals/packages/behaviors/src/desktop.ts
+++ b/evals/packages/behaviors/src/desktop.ts
@@ -1,3 +1,5 @@
+import type { BrowserEvaluation } from "@openwork/cdp";
+import { browserScript } from "@openwork/cdp";
 import { describeAppState, dumpScreenState, evaluateOnSurface, isInteractive, probeAppStateOnSurface } from "@openwork/cdp";
 import type { AppStateProbe, EvaluateOptions, Surface } from "@openwork/cdp";
 
@@ -26,11 +28,11 @@ function jsValue(value: unknown): string {
   return json.replace(/</g, "\\u003c").replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
 }
 
-export async function evalIn(
+export async function evalIn<T>(
   app: Surface,
-  expression: string,
+  expression: BrowserEvaluation<T>,
   opts: EvaluateOptions & { reattachAttempts?: number } = {},
-): Promise<unknown> {
+): Promise<Awaited<T>> {
   // Target healing lives in @openwork/cdp; behaviours just evaluate.
   return evaluateOnSurface(app, expression, {
     ...opts,
@@ -48,11 +50,11 @@ async function timeoutError(app: Surface, message: string): Promise<Error> {
  * evaluation can be caught mid-block; retrying short calls is reliable where one
  * long call is not. Only for IDEMPOTENT reads — never for clicks.
  */
-async function resilientRead(
+async function resilientRead<T>(
   app: Surface,
-  expression: string,
-  { timeoutMs = 60_000, perAttemptMs = DEFAULT_DOM_PROBE_TIMEOUT_MS, label = expression }: { timeoutMs?: number; perAttemptMs?: number; label?: string } = {},
-): Promise<unknown> {
+  expression: BrowserEvaluation<T>,
+  { timeoutMs = 60_000, perAttemptMs = DEFAULT_DOM_PROBE_TIMEOUT_MS, label = "browser callback" }: { timeoutMs?: number; perAttemptMs?: number; label?: string } = {},
+): Promise<Awaited<T>> {
   // A cold profile can block its JS thread for minutes while the workspace
   // runtime boots, so retry to a deadline rather than a fixed attempt count.
   const deadline = Date.now() + timeoutMs;
@@ -75,10 +77,10 @@ async function resilientRead(
   );
 }
 
-export async function waitFor(
+export async function waitFor<T>(
   app: Surface,
-  expression: string,
-  { timeoutMs = DEFAULT_TIMEOUT_MS, label = expression, awaitPromise = false }: { timeoutMs?: number; label?: string; awaitPromise?: boolean } = {},
+  expression: BrowserEvaluation<T>,
+  { timeoutMs = DEFAULT_TIMEOUT_MS, label = "browser callback", awaitPromise = true }: { timeoutMs?: number; label?: string; awaitPromise?: true } = {},
 ): Promise<unknown> {
   const startedAt = Date.now();
   let lastError: unknown = null;
@@ -105,7 +107,7 @@ export async function waitFor(
 }
 
 export async function waitForText(app: Surface, text: string, opts: { timeoutMs?: number } = {}): Promise<void> {
-  await waitFor(app, `document.body.innerText.includes(${jsValue(text)})`, {
+  await waitFor(app, browserScript((text) => (document.body.innerText.includes(text)), [text]), {
     timeoutMs: opts.timeoutMs,
     label: `visible text ${jsValue(text)}`,
   });
@@ -193,11 +195,11 @@ export function parseSessionToolCalls(value: unknown): SessionToolCall[] {
 }
 
 export async function hasText(app: Surface, text: string): Promise<boolean> {
-  return Boolean(await resilientRead(app, `document.body.innerText.includes(${jsValue(text)})`, { label: `text ${jsValue(text)}` }));
+  return Boolean(await resilientRead(app, browserScript((text) => (document.body.innerText.includes(text)), [text]), { label: `text ${jsValue(text)}` }));
 }
 
 export async function visibleText(app: Surface): Promise<string> {
-  const text = await resilientRead(app, "document.body.innerText", { label: "visible text" });
+  const text = await resilientRead(app, () => (document.body.innerText), { label: "visible text" });
   if (typeof text !== "string") throw new Error("CDP did not return document.body.innerText as a string.");
   return text;
 }
@@ -207,61 +209,63 @@ export async function clickText(
   text: string,
   { selector = "button, [role=button], a", timeoutMs = DEFAULT_TIMEOUT_MS }: { selector?: string; timeoutMs?: number } = {},
 ): Promise<unknown> {
-  return waitFor(app, `(() => {
-    const candidates = document.querySelectorAll(${jsValue(selector)});
+  return waitFor(app, browserScript((selector, text) => {
+    const candidates = document.querySelectorAll<HTMLElement>(selector);
     for (const element of candidates) {
       const label = (element.textContent ?? '').trim();
-      if (label.includes(${jsValue(text)})) {
+      if (label.includes(text)) {
         element.scrollIntoView({ block: 'center' });
         element.click();
         return label;
       }
     }
     return null;
-  })()`, { timeoutMs, label: `clickable element with text ${jsValue(text)}` });
+  }, [selector, text]), { timeoutMs, label: `clickable element with text ${jsValue(text)}` });
 }
 
 export async function clickButton(app: Surface, label: string, opts: { timeoutMs?: number } = {}): Promise<void> {
   const timeoutMs = opts.timeoutMs ?? 30_000;
-  await waitFor(app, `Boolean([...document.querySelectorAll('button')]
-    .find((element) => (element.textContent ?? '').trim() === ${jsValue(label)} && !element.disabled))`, {
+  await waitFor(app, browserScript((label) => (Boolean([...document.querySelectorAll('button')]
+    .find((element) => (element.textContent ?? '').trim() === label && !element.disabled))), [label]), {
     timeoutMs,
     label: `enabled button: ${label}`,
   });
-  const clicked = await evalIn(app, `(() => {
+  const clicked = await evalIn(app, browserScript((label) => {
     const button = [...document.querySelectorAll('button')]
-      .find((element) => (element.textContent ?? '').trim() === ${jsValue(label)} && !element.disabled);
+      .find((element) => (element.textContent ?? '').trim() === label && !element.disabled);
     button?.scrollIntoView({ block: 'center' });
     button?.click();
     return Boolean(button);
-  })()`);
+  }, [label]));
   if (clicked !== true) throw new Error(`Could not click ${label}.`);
 }
 
 export async function waitForButtonGone(app: Surface, label: string, opts: { timeoutMs?: number } = {}): Promise<void> {
-  await waitFor(app, `!Boolean([...document.querySelectorAll('button')]
-    .find((element) => (element.textContent ?? '').trim() === ${jsValue(label)}))`, {
+  await waitFor(app, browserScript((label) => (!Boolean([...document.querySelectorAll('button')]
+    .find((element) => (element.textContent ?? '').trim() === label))), [label]), {
     timeoutMs: opts.timeoutMs ?? 60_000,
     label: `button removed: ${label}`,
   });
 }
 
 export async function fill(app: Surface, selector: string, value: string, opts: { timeoutMs?: number } = {}): Promise<void> {
-  await waitFor(app, `Boolean(document.querySelector(${jsValue(selector)}))`, {
+  await waitFor(app, browserScript((selector) => (Boolean(document.querySelector<HTMLElement>(selector))), [selector]), {
     timeoutMs: opts.timeoutMs,
     label: `input ${selector}`,
   });
-  await evalIn(app, `(() => {
-    const input = document.querySelector(${jsValue(selector)});
+  await evalIn(app, browserScript((selector, value) => {
+    const input = document.querySelector<HTMLElement>(selector);
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) throw new Error("Expected an input or textarea");
     const setter = Object.getOwnPropertyDescriptor(
       input instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype,
       'value',
-    ).set;
-    setter.call(input, ${jsValue(value)});
+    )?.set;
+    if (!setter) throw new Error("Native input setter is unavailable");
+    setter.call(input, value);
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
     return true;
-  })()`);
+  }, [selector, value]));
 }
 
 export async function go(app: Surface, hashPath: string, opts: { timeoutMs?: number } = {}): Promise<void> {
@@ -271,7 +275,7 @@ export async function go(app: Surface, hashPath: string, opts: { timeoutMs?: num
   // desktops on one host) makes those bursts routine, and a bare 20s evaluate
   // here was the single most common way a long journey died near its end.
   const timeoutMs = opts.timeoutMs ?? 60_000;
-  await waitFor(app, `(() => { window.location.hash = ${jsValue(hash)}; return true; })()`, {
+  await waitFor(app, browserScript((inputHash) => { window.location.hash = inputHash; return true; }, [hash]), {
     timeoutMs,
     label: `navigate to ${hash}`,
   });
@@ -283,8 +287,8 @@ export async function waitForConnectionCard(app: Surface, name: string, workspac
     // Short per-probe timeout, failure tolerated: two desktops in one sandbox
     // make the renderer freeze in bursts, and a bare 20s evaluate turns one
     // freeze into a failed spec.
-    const found = await evalIn(app, `([...document.querySelectorAll('button')]
-      .some((button) => (button.textContent ?? '').includes(${JSON.stringify(name)})))`, { timeoutMs: 8_000 })
+    const found = await evalIn(app, browserScript((name) => (([...document.querySelectorAll('button')]
+      .some((button) => (button.textContent ?? '').includes(name)))), [name]), { timeoutMs: 8_000 })
       .catch(() => false);
     if (found === true) return;
     // The app opens a freshly created session on its own, which navigates away
@@ -293,29 +297,29 @@ export async function waitForConnectionCard(app: Surface, name: string, workspac
     // becomes /extensions/connections. Checking for the pre-rewrite form made
     // the steer-back below fire every iteration, so navigation fought the
     // rewrite and the surface never settled — which looked like a blank page.
-    const onExtensions = await evalIn(app, `window.location.hash.includes("/extensions")`, { timeoutMs: 8_000 }).catch(() => false);
+    const onExtensions = await evalIn(app, () => (window.location.hash.includes("/extensions")), { timeoutMs: 8_000 }).catch(() => false);
     if (onExtensions !== true) {
       await go(app, `/workspace/${workspaceId}/settings/extensions/connections`);
       await new Promise((resolve) => setTimeout(resolve, 1_500));
       continue;
     }
-    await evalIn(app, "window.__openworkControl.execute('extensions.refresh-marketplace', null)", { awaitPromise: true, timeoutMs: 15_000 })
+    await evalIn(app, () => (window.__openworkControl.execute('extensions.refresh-marketplace', null)), { awaitPromise: true, timeoutMs: 15_000 })
       .catch(() => undefined);
-    await evalIn(app, `(() => {
+    await evalIn(app, () => {
       const button = [...document.querySelectorAll('button')]
         .find((element) => (element.textContent ?? '').trim() === 'Refresh' && !element.disabled);
       button?.click();
       return Boolean(button);
-    })()`).catch(() => undefined);
+    }).catch(() => undefined);
     await new Promise((resolve) => setTimeout(resolve, 2_000));
   }
   // Say what WAS on screen: "card missing" alone cannot distinguish an
   // unmounted surface from a connection den never offered this member.
-  const seen = await evalIn(app, `({
+  const seen = await evalIn(app, () => (({
     hash: window.location.hash,
-    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\\s+/g, ' ').trim()).filter(Boolean).slice(0, 40),
-    text: (document.body.innerText ?? '').replace(/\\s+/g, ' ').slice(0, 600),
-  })`).catch(() => null);
+    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\s+/g, ' ').trim()).filter(Boolean).slice(0, 40),
+    text: (document.body.innerText ?? '').replace(/\s+/g, ' ').slice(0, 600),
+  }))).catch(() => null);
   throw new Error(`The connection card ${name} never appeared. On screen: ${JSON.stringify(seen)}`);
 }
 
@@ -327,19 +331,19 @@ export async function waitForConnectionCard(app: Surface, name: string, workspac
  * signal alone captures a blank panel intermittently.
  */
 export async function revealText(app: Surface, text: string, timeoutMs = 45_000): Promise<void> {
-  await waitFor(app, `(() => {
+  await waitFor(app, browserScript((text) => {
     // innerText, not textContent: innerText is render-aware, so CSS
     // text-transform (a badge styled uppercase) matches what waitForText saw
     // and what a person reads. Comparing raw textContent can never agree.
-    const wanted = ${JSON.stringify(text)}.toLowerCase();
-    const nodes = [...document.querySelectorAll("button, h1, h2, h3, p, span, div")];
+    const wanted = text.toLowerCase();
+    const nodes = [...document.querySelectorAll<HTMLElement>("button, h1, h2, h3, p, span, div")];
     const node = nodes.reverse().find((element) => ((element.innerText ?? element.textContent ?? "")).toLowerCase().includes(wanted));
     if (!node) return false;
     const rect = node.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return false;
     node.scrollIntoView({ block: "center" });
     return true;
-  })()`, { timeoutMs, label: `visible text ${JSON.stringify(text)}` });
+  }, [text]), { timeoutMs, label: `visible text ${JSON.stringify(text)}` });
   // One paint after scrolling, so the frame is not captured mid-scroll.
   await new Promise((resolve) => setTimeout(resolve, 750));
 }
@@ -357,7 +361,7 @@ export async function openConnectionsSurface(app: Surface, workspaceId: string):
   while (Date.now() < deadline) {
     const settled = await evalIn(
       app,
-      `window.location.hash.includes("/extensions") && document.body.innerText.includes("Extensions")`,
+      () => (window.location.hash.includes("/extensions") && document.body.innerText.includes("Extensions")),
       { timeoutMs: 8_000 },
     ).catch(() => false);
     if (settled === true) return;
@@ -366,26 +370,26 @@ export async function openConnectionsSurface(app: Surface, workspaceId: string):
   }
   // Say what WAS on screen: a bare timeout cannot distinguish a route that
   // never rewrote from a shell the app steered somewhere else entirely.
-  const seen = await evalIn(app, `({
+  const seen = await evalIn(app, () => (({
     hash: window.location.hash,
     title: document.title,
-    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\\s+/g, ' ').trim()).filter(Boolean).slice(0, 30),
-    text: (document.body.innerText ?? '').replace(/\\s+/g, ' ').slice(0, 500),
-  })`, { timeoutMs: 10_000 }).catch(() => null);
+    buttons: [...document.querySelectorAll('button')].map((b) => (b.textContent ?? '').replace(/\s+/g, ' ').trim()).filter(Boolean).slice(0, 30),
+    text: (document.body.innerText ?? '').replace(/\s+/g, ' ').slice(0, 500),
+  })), { timeoutMs: 10_000 }).catch(() => null);
   throw new Error(`The extensions connections surface never settled. On screen: ${JSON.stringify(seen)}`);
 }
 
 export async function currentHash(app: Surface): Promise<string> {
-  const hash = await resilientRead(app, "window.location.hash", { label: "location hash" });
+  const hash = await resilientRead(app, () => (window.location.hash), { label: "location hash" });
   if (typeof hash !== "string") throw new Error("CDP did not return window.location.hash as a string.");
   return hash;
 }
 
 export async function enabledButtons(app: Surface): Promise<string[]> {
-  const labels = await resilientRead(app, `[...document.querySelectorAll('button')]
+  const labels = await resilientRead(app, () => ([...document.querySelectorAll('button')]
     .filter((element) => !element.disabled)
     .map((element) => (element.textContent ?? '').trim())
-    .filter(Boolean)`, { label: "enabled buttons" });
+    .filter(Boolean)), { label: "enabled buttons" });
   if (!Array.isArray(labels) || !labels.every((label) => typeof label === "string")) {
     throw new Error("CDP did not return enabled button labels as strings.");
   }
@@ -402,7 +406,7 @@ export async function control(
   // Control actions are non-idempotent; a timeout must surface, not re-fire.
   const result = await evalIn(
     app,
-    `window.__openworkControl.execute(${JSON.stringify(action)}, ${JSON.stringify(args ?? null)})`,
+    browserScript((action, value) => (window.__openworkControl.execute(action, value)), [action, args ?? null]),
     { timeoutMs: 60_000, reattachAttempts: 0, ...opts, awaitPromise: true },
   );
   if (!isRecord(result) || result.ok !== true) {
@@ -446,7 +450,7 @@ export async function waitUntilTextStable(
   let previous = "";
   let stableSince = Date.now();
   while (Date.now() < deadline) {
-    const currentValue = await evalIn(app, "document.body.innerText", {
+    const currentValue = await evalIn(app, () => (document.body.innerText), {
       timeoutMs: Math.min(DEFAULT_DOM_PROBE_TIMEOUT_MS, Math.max(0, deadline - Date.now())),
     }).catch(() => previous);
     const current = typeof currentValue === "string" ? currentValue : previous;

--- a/evals/packages/behaviors/src/engine-session-probe.ts
+++ b/evals/packages/behaviors/src/engine-session-probe.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 
 import { evalIn } from "./desktop.ts";
@@ -162,26 +163,26 @@ async function requestFromSurface(
   if (options.body !== undefined && requestBody === undefined) {
     throw new Error(`Could not serialize engine session probe body for ${path}`);
   }
-  const value = await evalIn(surface, `(async () => {
+  const value = await evalIn(surface, browserScript(async (path, value, inputValue, inputValue2) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
     const baseUrl = String(info.baseUrl);
     let end = baseUrl.length;
     while (end > 0 && baseUrl[end - 1] === "/") end -= 1;
-    const response = await fetch(baseUrl.slice(0, end) + ${JSON.stringify(path)}, {
-      method: ${JSON.stringify(options.method ?? "GET")},
+    const response = await fetch(baseUrl.slice(0, end) + path, {
+      method: value,
       headers: {
         Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
         "Content-Type": "application/json",
       },
-      ${requestBody === undefined ? "" : `body: ${JSON.stringify(requestBody)},`}
-      signal: AbortSignal.timeout(${options.timeoutMs ?? 15_000}),
+      body: inputValue,
+      signal: AbortSignal.timeout(inputValue2),
     });
     const text = await response.text();
     let body = text;
     try { body = text ? JSON.parse(text) : null; } catch {}
     return { status: response.status, body };
-  })()`, { awaitPromise: true, timeoutMs: (options.timeoutMs ?? 15_000) + 5_000 });
+  }, [path, options.method ?? "GET", requestBody ?? null, options.timeoutMs ?? 15_000]), { awaitPromise: true, timeoutMs: (options.timeoutMs ?? 15_000) + 5_000 });
   return parseTransportResult(value);
 }
 

--- a/evals/packages/behaviors/src/models.ts
+++ b/evals/packages/behaviors/src/models.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import type { DenSession } from "./den.ts";
 import { denFetch } from "./den.ts";
@@ -59,15 +60,15 @@ function stringField(value: unknown): string {
 }
 
 async function openModelPicker(app: Surface): Promise<void> {
-  const open = await evalIn(app, `Boolean(document.querySelector(${JSON.stringify(MODEL_SEARCH_INPUT)}))`).catch(() => false);
+  const open = await evalIn(app, browserScript((MODEL_SEARCH_INPUT) => (Boolean(document.querySelector<HTMLElement>(MODEL_SEARCH_INPUT))), [MODEL_SEARCH_INPUT])).catch(() => false);
   if (open !== true) {
-    await waitFor(app, `window.__openworkControl?.listActions().some((entry) => entry.id === "session.model_picker.open" && entry.disabled === false)`, {
+    await waitFor(app, () => (window.__openworkControl?.listActions().some((entry) => entry.id === "session.model_picker.open" && entry.disabled === false)), {
       timeoutMs: 30_000,
       label: "session.model_picker.open enabled",
     });
     await control(app, "session.model_picker.open");
   }
-  await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(MODEL_SEARCH_INPUT)}))`, {
+  await waitFor(app, browserScript((MODEL_SEARCH_INPUT) => (Boolean(document.querySelector<HTMLElement>(MODEL_SEARCH_INPUT))), [MODEL_SEARCH_INPUT]), {
     timeoutMs: 30_000,
     label: "Models dialog search input",
   });
@@ -90,36 +91,36 @@ function parseModels(value: unknown): ModelFacts[] {
 
 export async function readAvailableModels(app: Surface): Promise<ModelFacts[]> {
   await openModelPicker(app);
-  await evalIn(app, `(() => {
-    const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
+  await evalIn(app, browserScript((MODEL_DIALOG) => {
+    const dialog = document.querySelector<HTMLElement>(MODEL_DIALOG);
     if (!dialog) return false;
     const headers = [...dialog.querySelectorAll("button")].filter((button) => {
-      const text = (button.textContent ?? "").replace(/\\s+/g, " ").trim();
-      return /\\d+ models?$/.test(text);
+      const text = (button.textContent ?? "").replace(/\s+/g, " ").trim();
+      return /\d+ models?$/.test(text);
     });
     for (const header of headers) {
       const group = header.parentElement?.parentElement;
-      if (group && !group.querySelector("span.font-mono")) header.click();
+      if (group && !group.querySelector<HTMLElement>("span.font-mono")) header.click();
     }
     return true;
-  })()`);
-  await waitFor(app, `(() => {
-    const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
-    return Boolean(dialog && (dialog.querySelector("span.font-mono") || dialog.innerText.includes("No models")));
-  })()`, { timeoutMs: 30_000, label: "model rows or empty state" });
-  const value = await evalIn(app, `(() => {
-    const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
+  }, [MODEL_DIALOG]));
+  await waitFor(app, browserScript((MODEL_DIALOG) => {
+    const dialog = document.querySelector<HTMLElement>(MODEL_DIALOG);
+    return Boolean(dialog && (dialog.querySelector<HTMLElement>("span.font-mono") || dialog.innerText.includes("No models")));
+  }, [MODEL_DIALOG]), { timeoutMs: 30_000, label: "model rows or empty state" });
+  const value = await evalIn(app, browserScript((MODEL_DIALOG) => {
+    const dialog = document.querySelector<HTMLElement>(MODEL_DIALOG);
     if (!dialog) return [];
     return [...dialog.querySelectorAll("button")].flatMap((button) => {
-      const id = button.querySelector("span.font-mono")?.textContent?.trim();
+      const id = button.querySelector<HTMLElement>("span.font-mono")?.textContent?.trim();
       if (!id) return [];
       const spans = [...button.querySelectorAll("span")];
       const name = spans.find((span) => !span.classList.contains("font-mono"))?.textContent?.trim() ?? id;
       let group = button.parentElement;
-      while (group && !group.querySelector(':scope > div > button')) group = group.parentElement;
-      const providerHeader = group?.querySelector(':scope > div > button');
-      const providerName = providerHeader?.querySelector("span.text-dls-text")?.textContent?.trim()
-        ?? providerHeader?.textContent?.replace(/\\d+ models?.*$/, "").trim()
+      while (group && !group.querySelector<HTMLElement>(':scope > div > button')) group = group.parentElement;
+      const providerHeader = group?.querySelector<HTMLElement>(':scope > div > button');
+      const providerName = providerHeader?.querySelector<HTMLElement>("span.text-dls-text")?.textContent?.trim()
+        ?? providerHeader?.textContent?.replace(/\d+ models?.*$/, "").trim()
         ?? "";
       return [{
         id,
@@ -129,72 +130,72 @@ export async function readAvailableModels(app: Surface): Promise<ModelFacts[]> {
         selectable: !button.disabled,
       }];
     });
-  })()`);
+  }, [MODEL_DIALOG]));
   return parseModels(value);
 }
 
 export async function selectModel(app: Surface, name: string, options?: { provider?: string }): Promise<ModelFacts> {
   await openModelPicker(app);
   await fill(app, MODEL_SEARCH_INPUT, name);
-  await waitFor(app, `(() => {
-    const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
-    const expectedProvider = ${JSON.stringify(options?.provider?.trim())};
+  await waitFor(app, browserScript((MODEL_DIALOG, value, name, inputName) => {
+    const dialog = document.querySelector<HTMLElement>(MODEL_DIALOG);
+    const expectedProvider = value;
     return [...(dialog?.querySelectorAll("button") ?? [])].some((button) => {
-      const id = button.querySelector("span.font-mono")?.textContent?.trim() ?? "";
+      const id = button.querySelector<HTMLElement>("span.font-mono")?.textContent?.trim() ?? "";
       let group = button.parentElement;
-      while (group && !group.querySelector(':scope > div > button')) group = group.parentElement;
-      const providerHeader = group?.querySelector(':scope > div > button');
-      const providerName = providerHeader?.querySelector("span.text-dls-text")?.textContent?.trim()
-        ?? providerHeader?.textContent?.replace(/\\d+ models?.*$/, "").trim()
+      while (group && !group.querySelector<HTMLElement>(':scope > div > button')) group = group.parentElement;
+      const providerHeader = group?.querySelector<HTMLElement>(':scope > div > button');
+      const providerName = providerHeader?.querySelector<HTMLElement>("span.text-dls-text")?.textContent?.trim()
+        ?? providerHeader?.textContent?.replace(/\d+ models?.*$/, "").trim()
         ?? "";
       return !button.disabled
-        && (id === ${JSON.stringify(name)} || (button.textContent ?? "").includes(${JSON.stringify(name)}))
+        && (id === name || (button.textContent ?? "").includes(inputName))
         && (expectedProvider === undefined || providerName === expectedProvider);
     });
-  })()`, { timeoutMs: 30_000, label: `selectable model ${name}` });
-  const selected = await evalIn(app, `(() => {
-    const dialog = document.querySelector(${JSON.stringify(MODEL_DIALOG)});
-    const expectedProvider = ${JSON.stringify(options?.provider?.trim())};
+  }, [MODEL_DIALOG, options?.provider?.trim(), name, name]), { timeoutMs: 30_000, label: `selectable model ${name}` });
+  const selected = await evalIn(app, browserScript((MODEL_DIALOG, value, inputName, inputName2) => {
+    const dialog = document.querySelector<HTMLElement>(MODEL_DIALOG);
+    const expectedProvider = value;
     const button = [...(dialog?.querySelectorAll("button") ?? [])].find((candidate) => {
-      const id = candidate.querySelector("span.font-mono")?.textContent?.trim() ?? "";
+      const id = candidate.querySelector<HTMLElement>("span.font-mono")?.textContent?.trim() ?? "";
       let group = candidate.parentElement;
-      while (group && !group.querySelector(':scope > div > button')) group = group.parentElement;
-      const providerHeader = group?.querySelector(':scope > div > button');
-      const providerName = providerHeader?.querySelector("span.text-dls-text")?.textContent?.trim()
-        ?? providerHeader?.textContent?.replace(/\\d+ models?.*$/, "").trim()
+      while (group && !group.querySelector<HTMLElement>(':scope > div > button')) group = group.parentElement;
+      const providerHeader = group?.querySelector<HTMLElement>(':scope > div > button');
+      const providerName = providerHeader?.querySelector<HTMLElement>("span.text-dls-text")?.textContent?.trim()
+        ?? providerHeader?.textContent?.replace(/\d+ models?.*$/, "").trim()
         ?? "";
       return !candidate.disabled
-        && (id === ${JSON.stringify(name)} || (candidate.textContent ?? "").includes(${JSON.stringify(name)}))
+        && (id === inputName || (candidate.textContent ?? "").includes(inputName2))
         && (expectedProvider === undefined || providerName === expectedProvider);
     });
     if (!button) return null;
-    const id = button.querySelector("span.font-mono")?.textContent?.trim() ?? "";
+    const id = button.querySelector<HTMLElement>("span.font-mono")?.textContent?.trim() ?? "";
     const spans = [...button.querySelectorAll("span")];
     const title = spans.find((span) => !span.classList.contains("font-mono"))?.textContent?.trim() ?? id;
     let group = button.parentElement;
-    while (group && !group.querySelector(':scope > div > button')) group = group.parentElement;
-    const providerHeader = group?.querySelector(':scope > div > button');
-    const providerName = providerHeader?.querySelector("span.text-dls-text")?.textContent?.trim()
-      ?? providerHeader?.textContent?.replace(/\\d+ models?.*$/, "").trim()
+    while (group && !group.querySelector<HTMLElement>(':scope > div > button')) group = group.parentElement;
+    const providerHeader = group?.querySelector<HTMLElement>(':scope > div > button');
+    const providerName = providerHeader?.querySelector<HTMLElement>("span.text-dls-text")?.textContent?.trim()
+      ?? providerHeader?.textContent?.replace(/\d+ models?.*$/, "").trim()
       ?? "";
     button.click();
     return { id, name: title, providerName, selected: true, selectable: true };
-  })()`);
+  }, [MODEL_DIALOG, options?.provider?.trim(), name, name]));
   const models = parseModels(selected ? [selected] : []);
   const model = models[0];
   if (!model) throw new Error(`Could not select model ${name}.`);
-  await waitFor(app, `!Boolean(document.querySelector(${JSON.stringify(MODEL_SEARCH_INPUT)}))`, {
+  await waitFor(app, browserScript((MODEL_SEARCH_INPUT) => (!Boolean(document.querySelector<HTMLElement>(MODEL_SEARCH_INPUT))), [MODEL_SEARCH_INPUT]), {
     timeoutMs: 30_000,
     label: "Models dialog closed after selection",
   });
-  const persisted = await evalIn(app, `(() => {
+  const persisted = await evalIn(app, browserScript((id) => {
     try {
       const preferences = JSON.parse(localStorage.getItem("openwork.preferences") || "{}");
-      return preferences?.defaultModel?.modelID === ${JSON.stringify(model.id)};
+      return preferences?.defaultModel?.modelID === id;
     } catch {
       return false;
     }
-  })()`);
+  }, [model.id]));
   return {
     ...model,
     selected: persisted === true,
@@ -210,37 +211,37 @@ export async function recoverInvalidModelSelection(
     ?? models.find((candidate) => candidate.selectable);
   if (model) {
     const selected = await selectModel(app, model.id);
-    await waitFor(app, `(() => {
+    await waitFor(app, () => {
       const text = document.body.innerText;
       return !text.includes("Model no longer available")
         && !text.includes("The selected provider/model was not found in OpenCode provider catalog");
-    })()`, { timeoutMs: 30_000, label: "invalid selected model cleared" });
+    }, { timeoutMs: 30_000, label: "invalid selected model cleared" });
     return selected;
   }
 
-  await evalIn(app, `(() => {
-    let preferences = {};
+  await evalIn(app, () => {
+    let preferences: Record<string, unknown> = {};
     try { preferences = JSON.parse(localStorage.getItem("openwork.preferences") || "{}"); } catch {}
     delete preferences.defaultModel;
     delete preferences.modelVariant;
     localStorage.setItem("openwork.preferences", JSON.stringify(preferences));
     setTimeout(() => location.reload(), 0);
     return true;
-  })()`);
-  await waitFor(app, "Boolean(window.__openworkControl)", {
+  });
+  await waitFor(app, () => (Boolean(window.__openworkControl)), {
     timeoutMs: 60_000,
     label: "control API after clearing invalid selected model",
   });
-  await waitFor(app, `(() => {
+  await waitFor(app, () => {
     const text = document.body.innerText;
     return !text.includes("Model no longer available")
       && !text.includes("The selected provider/model was not found in OpenCode provider catalog");
-  })()`, { timeoutMs: 30_000, label: "invalid selected model absent after reset" });
+  }, { timeoutMs: 30_000, label: "invalid selected model absent after reset" });
   return null;
 }
 
 export async function readModelRecoveryState(app: Surface): Promise<ModelRecoveryFacts> {
-  const value = await evalIn(app, `(() => {
+  const value = await evalIn(app, browserScript((MODEL_DIALOG) => {
     const text = document.body.innerText;
     const emptyMessage = "Your organization hasn't published any models for you yet.";
     const notice = [...document.querySelectorAll("button")].find((button) =>
@@ -256,12 +257,12 @@ export async function readModelRecoveryState(app: Surface): Promise<ModelRecover
       connectProviderVisible: text.includes("Connect a provider"),
       warningVisible: text.includes("Model no longer available"),
       guidanceVisible: text.includes("The model you were using is no longer available, please select a different model for this session."),
-      pickerOpen: Boolean(document.querySelector(${JSON.stringify(MODEL_DIALOG)})),
+      pickerOpen: Boolean(document.querySelector<HTMLElement>(MODEL_DIALOG)),
       runTaskEnabled: Boolean(run && !run.disabled),
       noticeHeight: notice ? Math.round(notice.getBoundingClientRect().height) : null,
       noticeWhiteSpace: message ? getComputedStyle(message).whiteSpace : null,
     };
-  })()`);
+  }, [MODEL_DIALOG]));
   if (!isRecord(value)) throw new Error("Model recovery state was not an object.");
   return {
     emptyMessageVisible: value.emptyMessageVisible === true,
@@ -278,7 +279,7 @@ export async function readModelRecoveryState(app: Surface): Promise<ModelRecover
 }
 
 export async function retryOrganizationModels(app: Surface): Promise<void> {
-  await waitFor(app, `(() => {
+  await waitFor(app, () => {
     const button = [...document.querySelectorAll("button")].find((entry) => {
       const text = entry.textContent ?? "";
       return text.includes("Your organization hasn't published any models for you yet.") && text.includes("Retry") && !entry.disabled;
@@ -286,11 +287,11 @@ export async function retryOrganizationModels(app: Surface): Promise<void> {
     if (!button) return false;
     button.click();
     return true;
-  })()`, { timeoutMs: 30_000, label: "organization model Retry" });
+  }, { timeoutMs: 30_000, label: "organization model Retry" });
 }
 
 export async function seedUnavailableModel(app: Surface): Promise<UnavailableModelSeed> {
-  await waitFor(app, `window.__openworkControl?.listActions().some((entry) => entry.id === "eval.model_not_available.seed" && entry.disabled === false)`, {
+  await waitFor(app, () => (window.__openworkControl?.listActions().some((entry) => entry.id === "eval.model_not_available.seed" && entry.disabled === false)), {
     timeoutMs: 45_000,
     label: "eval.model_not_available.seed enabled",
   });

--- a/evals/packages/behaviors/src/onboarding.ts
+++ b/evals/packages/behaviors/src/onboarding.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import { clickButton, currentHash, evalIn, fill, waitFor, waitForText } from "./desktop.ts";
 
@@ -37,14 +38,14 @@ export async function createLocalWorkspaceViaUi(
   app: Surface,
   input: { path: string; name?: string },
 ): Promise<LocalWorkspaceFacts> {
-  await waitFor(app, "location.hash.includes('/welcome')", { timeoutMs: 30_000, label: "welcome route" });
-  let manualFolderVisible = await evalIn(app, 'Boolean(document.querySelector(\'input[placeholder="/workspace/my-project"]\'))') === true;
+  await waitFor(app, () => (location.hash.includes('/welcome')), { timeoutMs: 30_000, label: "welcome route" });
+  let manualFolderVisible = await evalIn(app, () => (Boolean(document.querySelector<HTMLInputElement>('input[placeholder="/workspace/my-project"]')))) === true;
   if (!manualFolderVisible) {
-    const useWithoutCloudVisible = await evalIn(app, `Boolean([...document.querySelectorAll("button")]
-      .find((button) => (button.textContent ?? "").trim() === "Use Without Cloud" && !button.disabled))`);
+    const useWithoutCloudVisible = await evalIn(app, () => (Boolean([...document.querySelectorAll("button")]
+      .find((button) => (button.textContent ?? "").trim() === "Use Without Cloud" && !button.disabled))));
     if (useWithoutCloudVisible === true) {
       await clickButton(app, "Use Without Cloud");
-      await waitFor(app, 'Boolean(document.querySelector(\'input[placeholder="/workspace/my-project"]\'))', {
+      await waitFor(app, () => (Boolean(document.querySelector<HTMLInputElement>('input[placeholder="/workspace/my-project"]'))), {
         timeoutMs: 15_000,
         label: "local workspace folder input",
       });
@@ -60,27 +61,27 @@ export async function createLocalWorkspaceViaUi(
     await submitFolder(app, input.path);
   } else {
     entrypoint = "workspace-modal";
-    await waitFor(app, `(() => {
+    await waitFor(app, () => {
       const button = [...document.querySelectorAll("button")]
         .find((candidate) => (candidate.textContent ?? "").trim() === "Get started" && !candidate.disabled);
       if (!button) return false;
       button.click();
       return true;
-    })()`, { timeoutMs: 15_000, label: "Get started" });
+    }, { timeoutMs: 15_000, label: "Get started" });
     await waitForText(app, "Local workspace", { timeoutMs: 15_000 });
-    await waitFor(app, `(() => {
+    await waitFor(app, () => {
       const button = [...document.querySelectorAll("button")]
         .find((candidate) => (candidate.textContent ?? "").trim() === "Local workspace" && !candidate.disabled);
       if (!button) return false;
       button.click();
       return true;
-    })()`, { timeoutMs: 15_000, label: "Local workspace" });
+    }, { timeoutMs: 15_000, label: "Local workspace" });
     await waitForText(app, "No folder selected yet.", { timeoutMs: 15_000 });
-    const injected = await evalIn(app, `(() => {
-      const placeholder = [...document.querySelectorAll("span, div, p")]
+    const injected = await evalIn(app, browserScript((path) => {
+      const placeholder = [...document.querySelectorAll<HTMLElement>("span, div, p")]
         .find((node) => (node.textContent ?? "").includes("No folder selected yet."));
       if (!placeholder) return { ok: false, reason: "folder placeholder not found" };
-      const key = Object.keys(placeholder).find((candidate) => candidate.startsWith("__reactFiber$"));
+      const key = Object.keys(placeholder).find((candidate): candidate is `__reactFiber$${string}` => candidate.startsWith("__reactFiber$"));
       let fiber = key ? placeholder[key] : null;
       while (fiber) {
         const componentName = fiber.elementType?.name || fiber.type?.name || "";
@@ -91,35 +92,35 @@ export async function createLocalWorkspaceViaUi(
       let hook = fiber.memoizedState;
       while (hook) {
         if (hook.queue?.dispatch) {
-          hook.queue.dispatch({ type: "set", key: "selectedFolder", value: ${JSON.stringify(input.path)} });
+          hook.queue.dispatch({ type: "set", key: "selectedFolder", value: path });
           hook.queue.dispatch({ type: "set", key: "pickingFolder", value: false });
           return { ok: true };
         }
         hook = hook.next;
       }
       return { ok: false, reason: "folder reducer dispatch not found" };
-    })()`);
+    }, [input.path]));
     if (!isRecord(injected) || injected.ok !== true) {
       throw new Error(`Could not inject the folder chosen by the native picker: ${JSON.stringify(injected)}`);
     }
     if (input.name) {
-      await evalIn(app, `(() => {
-        const nameInput = document.querySelector('input[placeholder*="name" i], input[placeholder*="workspace" i]');
+      await evalIn(app, browserScript((name) => {
+        const nameInput = document.querySelector<HTMLInputElement>('input[placeholder*="name" i], input[placeholder*="workspace" i]');
         if (!nameInput) return false;
         const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
-        setter?.call(nameInput, ${JSON.stringify(input.name)});
+        setter?.call(nameInput, name);
         nameInput.dispatchEvent(new Event("input", { bubbles: true }));
         nameInput.dispatchEvent(new Event("change", { bubbles: true }));
         return true;
-      })()`);
+      }, [input.name]));
     }
-    await waitFor(app, `(() => {
+    await waitFor(app, () => {
       const button = [...document.querySelectorAll("button")]
         .find((candidate) => (candidate.textContent ?? "").trim() === "Create Workspace" && !candidate.disabled);
       if (!button) return false;
       button.click();
       return true;
-    })()`, { timeoutMs: 15_000, label: "Create Workspace" });
+    }, { timeoutMs: 15_000, label: "Create Workspace" });
   }
 
   await waitForText(app, "Power your first task", { timeoutMs: 120_000 });

--- a/evals/packages/behaviors/src/skills.ts
+++ b/evals/packages/behaviors/src/skills.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
 import { evalIn, waitFor } from "./desktop.ts";
 
@@ -48,29 +49,29 @@ async function openPlugMenu(app: Surface): Promise<void> {
   // workspace engine boots, so a bare click evaluation can eat a 20s CDP
   // timeout and fail the spec. Clicking only while the menu is closed keeps
   // retries from toggling it back shut.
-  await waitFor(app, `(() => {
+  await waitFor(app, browserScript((PLUG_BUTTON) => {
     const labels = [...document.querySelectorAll("button")].map((button) => (button.textContent ?? "").trim());
     if (labels.includes("Skills") && labels.includes("Extensions")) return true;
-    const plug = document.querySelector(${JSON.stringify(PLUG_BUTTON)});
+    const plug = document.querySelector<HTMLElement>(PLUG_BUTTON);
     if (!plug) return false;
     document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     plug.click();
     return false;
-  })()`, { timeoutMs: 60_000, label: "plug menu sections" });
+  }, [PLUG_BUTTON]), { timeoutMs: 60_000, label: "plug menu sections" });
 }
 
 export async function readComposerCapabilities(app: Surface): Promise<ComposerCapabilitiesFacts> {
   await openPlugMenu(app);
-  const value = await evalIn(app, `(() => {
+  const value = await evalIn(app, () => {
     const labels = [...document.querySelectorAll("button")].map((button) => (button.textContent ?? "").trim());
     return ["Agents", "Commands", "Skills", "Extensions"].filter((section) => labels.includes(section));
-  })()`);
+  });
   return { sections: Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [] };
 }
 
 export async function measureLoadedSkills(app: Surface): Promise<SkillsLoadFacts> {
   await openPlugMenu(app);
-  const value = await evalIn(app, `new Promise((resolve) => {
+  const value = await evalIn(app, browserScript((SKILL_MARKERS) => (new Promise((resolve) => {
     const skillsButton = [...document.querySelectorAll("button")]
       .find((button) => (button.textContent ?? "").trim() === "Skills");
     if (!skillsButton) { resolve({ error: "skills section button not found" }); return; }
@@ -78,16 +79,16 @@ export async function measureLoadedSkills(app: Surface): Promise<SkillsLoadFacts
     skillsButton.click();
     const poll = () => {
       const rows = [...document.querySelectorAll("button")]
-        .filter((button) => /^\\/[a-z0-9-]+/i.test((button.textContent ?? "").trim()));
-      const hit = rows.some((button) => ${JSON.stringify(SKILL_MARKERS)}
+        .filter((button) => /^\/[a-z0-9-]+/i.test((button.textContent ?? "").trim()));
+      const hit = rows.some((button) => SKILL_MARKERS
         .some((marker) => (button.textContent ?? "").includes(marker)));
       if (hit) {
         resolve({
           elapsedMs: Math.round(performance.now() - startedAt),
           rowCount: rows.length,
           skills: rows.map((button) => {
-            const label = (button.textContent ?? "").replace(/\\s+/g, " ").trim();
-            return { name: (label.match(/^\\/[a-z0-9-]+/) ?? [label])[0], label, local: label.includes("Local") };
+            const label = (button.textContent ?? "").replace(/\s+/g, " ").trim();
+            return { name: (label.match(/^\/[a-z0-9-]+/) ?? [label])[0], label, local: label.includes("Local") };
           }),
           loadingCommandsVisible: document.body.innerText.includes("Loading commands"),
         });
@@ -100,7 +101,7 @@ export async function measureLoadedSkills(app: Surface): Promise<SkillsLoadFacts
       setTimeout(poll, 20);
     };
     poll();
-  })`, { awaitPromise: true, timeoutMs: 30_000 });
+  })), [SKILL_MARKERS]), { awaitPromise: true, timeoutMs: 30_000 });
   // The in-page poll gives up at 20s; the CDP call must outlive it or the two
   // deadlines race and the spec dies with a raw CDP timeout instead of facts.
   if (isRecord(value) && typeof value.error === "string") throw new Error(`Skills did not render: ${JSON.stringify(value)}`);
@@ -117,30 +118,30 @@ export async function readLoadedSkills(app: Surface): Promise<SkillFacts[]> {
  * cannot show it; reveal it first when a visual claim names it.
  */
 export async function revealMenuRow(app: Surface, marker: string): Promise<void> {
-  await waitFor(app, `(() => {
+  await waitFor(app, browserScript((marker) => {
     const row = [...document.querySelectorAll("button")]
-      .find((button) => (button.textContent ?? "").includes(${JSON.stringify(marker)}));
+      .find((button) => (button.textContent ?? "").includes(marker));
     if (!row) return false;
     row.scrollIntoView({ block: "center" });
     return true;
-  })()`, { timeoutMs: 10_000, label: `menu row ${marker} in view` });
+  }, [marker]), { timeoutMs: 10_000, label: `menu row ${marker} in view` });
 }
 
 export async function readLoadedExtensions(app: Surface): Promise<string[]> {
   await openPlugMenu(app);
-  await waitFor(app, `(() => {
+  await waitFor(app, () => {
     const button = [...document.querySelectorAll("button")]
       .find((candidate) => (candidate.textContent ?? "").trim() === "Extensions");
     if (!button) return false;
     button.click();
     return true;
-  })()`, { label: "Extensions section" });
-  await waitFor(app, 'document.body.innerText.includes("OpenWork Browser")', {
+  }, { label: "Extensions section" });
+  await waitFor(app, () => (document.body.innerText.includes("OpenWork Browser")), {
     timeoutMs: 10_000,
     label: "OpenWork Browser extension",
   });
-  const value = await waitFor(app, `([...document.querySelectorAll("button")]
-    .map((button) => (button.textContent ?? "").replace(/\\s+/g, " ").trim())
-    .filter((label) => label.includes("OpenWork Browser")))`, { timeoutMs: 60_000, label: "OpenWork Browser extension rows" });
+  const value = await waitFor(app, () => (([...document.querySelectorAll("button")]
+    .map((button) => (button.textContent ?? "").replace(/\s+/g, " ").trim())
+    .filter((label) => label.includes("OpenWork Browser")))), { timeoutMs: 60_000, label: "OpenWork Browser extension rows" });
   return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
 }

--- a/evals/packages/behaviors/src/text-observation.ts
+++ b/evals/packages/behaviors/src/text-observation.ts
@@ -3,16 +3,16 @@ import type { Surface } from "@openwork/cdp";
 
 /** Record changes, including empty frames, without modifying the renderer's fetch or event handlers. */
 export async function observeText(surface: Surface, selector: string, options: { ignoreExistingMessages?: boolean } = {}) {
-  const key = `text-observation-${crypto.randomUUID()}`;
-  await callFunctionOnSurface(surface, `(key, selector, ignoreExisting) => {
-    const previous = new Set(ignoreExisting ? [...document.querySelectorAll(selector)].map(node => node.closest('[data-message-id]')?.getAttribute('data-message-id')) : []);
-    const state = { samples: [], frames: 0, expired: false, overflow: false };
-    let frame;
+  const key: `text-observation-${string}` = `text-observation-${crypto.randomUUID()}`;
+  await callFunctionOnSurface(surface, (key: `text-observation-${string}`, selector, ignoreExisting) => {
+    const previous = new Set(ignoreExisting ? [...document.querySelectorAll<HTMLElement>(selector)].map(node => node.closest('[data-message-id]')?.getAttribute('data-message-id')) : []);
+    const state: { samples: string[]; frames: number; expired: boolean; overflow: boolean } = { samples: [], frames: 0, expired: false, overflow: false };
+    let frame = 0;
     const sample = () => {
-      const text = [...document.querySelectorAll(selector)]
+      const text = [...document.querySelectorAll<HTMLElement>(selector)]
         .filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== 'hidden')
         .filter(node => !previous.has(node.closest('[data-message-id]')?.getAttribute('data-message-id')))
-        .map(node => (node.innerText ?? node.textContent ?? '').trim()).join('\\n');
+        .map(node => (node.innerText ?? node.textContent ?? '').trim()).join('\n');
       state.frames++;
       if (state.samples.at(-1) !== text) {
         if (state.samples.length < 2048) state.samples.push(text);
@@ -23,14 +23,14 @@ export async function observeText(surface: Surface, selector: string, options: {
     sample();
     const timer = setTimeout(() => { cancelAnimationFrame(frame); state.expired = true; }, 180000);
     window[key] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
-  }`, [key, selector, options.ignoreExistingMessages === true]);
+  }, [key, selector, options.ignoreExistingMessages === true]);
   return {
     async finish(): Promise<string[]> {
-      const value = await callFunctionOnSurface(surface, `(key) => {
+      const value = await callFunctionOnSurface(surface, (key: `text-observation-${string}`) => {
         const observer = window[key];
         if (!observer) throw new Error('Text observation was lost');
         observer.stop(); delete window[key]; return observer.state;
-      }`, [key]);
+      }, [key]);
       if (!value || typeof value !== "object" || !("samples" in value) || !Array.isArray(value.samples)
         || !value.samples.every((item): item is string => typeof item === "string")
         || !("frames" in value) || typeof value.frames !== "number" || value.frames < 2
@@ -39,7 +39,7 @@ export async function observeText(surface: Surface, selector: string, options: {
       return value.samples;
     },
     async [Symbol.asyncDispose]() {
-      await callFunctionOnSurface(surface, `(key) => { window[key]?.stop(); delete window[key]; }`, [key]);
+      await callFunctionOnSurface(surface, (key: `text-observation-${string}`) => { window[key]?.stop(); delete window[key]; }, [key]);
     },
   };
 }

--- a/evals/packages/behaviors/test/desktop-waits.test.ts
+++ b/evals/packages/behaviors/test/desktop-waits.test.ts
@@ -38,7 +38,7 @@ test("waitFor has a finite default timeout", async (context) => {
     return false;
   });
 
-  await assert.rejects(waitFor(surface, "false"), /Timed out after 30000ms waiting for false/);
+  await assert.rejects(waitFor(surface, () => (false)), /Timed out after 30000ms waiting for browser callback/);
 });
 
 test("waitFor appends a bounded on-screen dump to timeout failures", async () => {
@@ -53,7 +53,7 @@ test("waitFor appends a bounded on-screen dump to timeout failures", async () =>
     : false);
 
   await assert.rejects(
-    waitFor(surface, "false", { timeoutMs: 1, label: "extensions route" }),
+    waitFor(surface, () => (false), { timeoutMs: 1, label: "extensions route" }),
     /On screen: \{"hash":"#\/workspace\/demo\/extensions","route":"\/workspace\/demo\/extensions","title":"OpenWork","buttons":\["Back","Add extension"\],"body":"Extensions Add an extension to this workspace"\}/,
   );
 });
@@ -65,7 +65,7 @@ test("waitFor still reports timeout context when the on-screen dump fails", asyn
   });
 
   await assert.rejects(
-    waitFor(surface, "false", { timeoutMs: 1, label: "extensions route" }),
+    waitFor(surface, () => (false), { timeoutMs: 1, label: "extensions route" }),
     /Timed out after 1ms waiting for extensions route.*On screen: unavailable/,
   );
 });

--- a/evals/packages/cdp/src/app-state.ts
+++ b/evals/packages/cdp/src/app-state.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "./browser-script.ts";
 import { evaluate } from "./cdp.ts";
 import type { CdpClient, EvaluateOptions } from "./cdp.ts";
 
@@ -83,10 +84,10 @@ export function describeAppState(probe: AppStateProbe): string {
   return `route ${probe.route || "<unknown>"}, ${probe.controlReady ? "control ready" : "control missing"}, ${blocker}. Visible text: ${JSON.stringify(probe.text)}`;
 }
 
-const PROBE_EXPRESSION = `(() => {
+const PROBE_EXPRESSION = browserScript((value) => {
   const text = document.body?.innerText ?? "";
   const route = window.location.hash.replace(/^#/, "") || window.location.pathname;
-  const transitional = ${JSON.stringify([...APP_TRANSITIONAL_TEXTS])}
+  const transitional = value
     .find((message) => text.includes(message)) ?? null;
   const buttonLabels = [...document.querySelectorAll("button")].map((button) => (button.textContent ?? "").trim());
   const taskUi = text.includes("What do you need done?") || buttonLabels.includes("Run task");
@@ -95,12 +96,12 @@ const PROBE_EXPRESSION = `(() => {
   // The product's own active-workspace state; the route is only a fallback
   // because a selected workspace does not always appear in the hash.
   const stored = localStorage.getItem("openwork.react.activeWorkspace");
-  const routeMatch = (route.match(/\\/workspace\\/([^/?#]+)/) ?? [])[1] ?? null;
+  const routeMatch = (route.match(/\/workspace\/([^/?#]+)/) ?? [])[1] ?? null;
   const workspaceId = (stored && stored.length > 0 ? stored : null) ?? routeMatch;
   // Any settings/extensions surface inside a workspace is interactive too. The
   // settings shell always offers "Back to app" even when an organization
   // policy hides every tab but Cloud; the /extensions route renders the Library.
-  const settingsSurface = /\\/workspace\\/[^/?#]+\\/(settings|extensions)/.test(route)
+  const settingsSurface = /\/workspace\/[^/?#]+\/(settings|extensions)/.test(route)
     && (text.includes("Back to app") || text.includes("Library") || text.includes("Extensions") || text.includes("Preferences") || text.includes("Permissions"));
   const surface = welcome
     ? "welcome"
@@ -119,7 +120,7 @@ const PROBE_EXPRESSION = `(() => {
     route,
     text: text.slice(0, 300),
   };
-})()`;
+}, [[...APP_TRANSITIONAL_TEXTS]]);
 
 export async function probeAppState(client: CdpClient, opts: EvaluateOptions = {}): Promise<AppStateProbe> {
   return parseAppStateProbe(await evaluate(client, PROBE_EXPRESSION, opts));

--- a/evals/packages/cdp/src/browser-globals.d.ts
+++ b/evals/packages/cdp/src/browser-globals.d.ts
@@ -1,0 +1,88 @@
+import type { DesktopCommandName, DesktopCommandArgs, DesktopCommandResult } from "@openwork/types/desktop-ipc";
+import type { OpenworkContextSnapshot } from "@openwork/types/openwork-context";
+
+/** Test-facing browser protocols. State is installed by the corresponding world before use. */
+declare global {
+  interface Window {
+    __openworkControl: {
+      listActions(): { id: string; disabled: boolean; args?: unknown; [key: string]: unknown }[];
+      execute(action: string, args?: unknown): Promise<{ ok: boolean; error?: string; result?: unknown; value?: unknown }>;
+      context(): OpenworkContextSnapshot;
+      snapshot(): { route: string; narration: string };
+      setEnabled(enabled: boolean): void;
+      command(request: { id: string; args?: unknown; [key: string]: unknown }): Promise<unknown>;
+    };
+    __reauthOriginalOpen?: typeof window.open;
+    __OPENWORK_ELECTRON__: {
+      browserLogins: {
+        testWitnessUrl(): Promise<string>;
+        writeTestStore(request: { path: string; cookies: unknown[] }): Promise<unknown>;
+        signedInSites(): Promise<unknown>;
+        state(): Promise<unknown>;
+        pause(): Promise<unknown>;
+      };
+      invokeDesktop<C extends DesktopCommandName>(command: C, ...args: DesktopCommandArgs<C>): Promise<DesktopCommandResult<C>>;
+      browser: {
+        openUrl(url: string, options?: { sessionId?: string | null }): Promise<{ tabId: string; [key: string]: unknown }>;
+        getState(): Promise<unknown>;
+        [key: string]: unknown;
+      };
+      updater: {
+        getChannel(): Promise<{ channel: "stable" | "alpha"; currentVersion: string }>;
+        setChannel(channel: "stable" | "alpha"): Promise<{ channel: "stable" | "alpha"; currentVersion: string }>;
+      };
+    };
+    __openwork: {
+      slice(name: "route"): {
+        selectedWorkspaceId: string | null;
+        workspaces: { id: string; name?: string; displayName?: string; displayNameResolved?: string; loading?: boolean; error?: string | null }[];
+        sessionsByWorkspaceId: Record<string, { id: string; title?: string }[]>;
+      };
+    };
+    __openworkRecoveryControl: { snapshot(): Promise<unknown>; select(id: string): Promise<unknown> };
+    __openworkApplyDesktopConfig(config: { allowAlphaUpdates?: boolean; brandAppName?: string; brandLogoUrl?: string }): void;
+    __openworkSetDesktopConfigRefreshResult(config: { allowAlphaUpdates?: boolean; brandAppName?: string; brandLogoUrl?: string }): void;
+    __openworkReadDesktopVersionMetadataEval(): { minAppVersion: string; latestAppVersion: string; publishedDesktopVersions: string[] };
+    __openworkUpdaterEvalBridge: {
+      getChannel(): Promise<{ channel: string; currentVersion: string }>;
+      setChannel(channel: "stable" | "alpha"): Promise<{ channel: string; currentVersion: string }>;
+      check(channel?: "stable" | "alpha"): Promise<unknown>;
+      download(): Promise<unknown>;
+      installAndRestart(): Promise<unknown>;
+      onDownloadProgress(callback?: (progress: unknown) => void): () => void;
+    };
+    __backgroundUpdateWitness: { checks: number; downloads: number; installs: number; offset: number; finishDownload: (() => void) | null; intervalCheck: (() => void) | null };
+    __openworkAlphaUpdateEligibilityEvalState: { checks: (string | undefined)[]; currentVersion: string; latestVersion: string };
+    __openworkUpdaterEvalState: { checks: (string | undefined)[]; setChannels: string[]; stableStarted: boolean; finishStable: (() => void) | null };
+    __issue3980NotificationProbe: { observer: MutationObserver; state: { rawSeen: boolean } };
+    __libraryStability: { requests: string[]; denEvents: number; samples: { buttons: number; contentVisible: boolean }[]; sampler?: number };
+    __libraryLifecycleReads: number;
+    __librarySkillReads: number;
+    __opencodeConfigReads: number;
+    __newTaskRequests: string[];
+    __newTaskOpenedAfterMs: number;
+    __sessionSettingsRuntimeErrors: string[];
+    __workspaceStormSettingsGate: { entered: boolean; released: boolean; firstCompleted: boolean; errors: string[]; release(): void };
+    __modelSelectionProof: { changes: number; loops: number; unavailable: boolean };
+    __clicks: number;
+    __handoffProofEvents: string[];
+    mockupExecuted: boolean;
+    [key: `text-observation-${string}`]: { state: { samples: string[]; frames: number; expired: boolean; overflow: boolean }; stop(): void } | undefined;
+    [key: `transcript-observer-${string}`]: { state: { frames: number; seen: boolean[]; violations: { index: number; count: number; atMs: number }[]; stopped: boolean }; stop(): void } | undefined;
+  }
+  interface HTMLElement {
+    _valueTracker?: { setValue(value: string): void };
+    [key: `__reactFiber$${string}`]: BrowserFiber | undefined;
+  }
+  interface BrowserFiber {
+    elementType?: { name?: string };
+    type?: { name?: string };
+    return: BrowserFiber | null;
+    memoizedState: BrowserHook | null;
+  }
+  interface BrowserHook {
+    queue?: { dispatch(action: { type: string; key: string; value: unknown }): void };
+    next: BrowserHook | null;
+  }
+  var __attachmentUploadingSeen: boolean;
+}

--- a/evals/packages/cdp/src/browser-script.ts
+++ b/evals/packages/cdp/src/browser-script.ts
@@ -1,0 +1,46 @@
+/** A checked browser callback and explicit data; it never runs in the test process. */
+export interface BrowserScript<T> {
+  readonly callback: (...args: never) => T;
+  readonly args: readonly unknown[];
+}
+
+export type BrowserEvaluation<T = unknown> = BrowserScript<T> | (() => T);
+
+export function browserScript<Args extends unknown[], T>(callback: (...args: Args) => T, args: [...Args]): BrowserScript<T> {
+  return { callback, args };
+}
+
+/** Serialize data as JavaScript literals, preserving undefined and special numbers.
+ * Functions, accessors, class instances and cycles cannot cross this boundary.
+ */
+export function browserLiteral(value: unknown, ancestors = new Set<object>()): string {
+  if (value === undefined) return "undefined";
+  if (value === null || typeof value === "string" || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "number") return Object.is(value, -0) ? "-0" : String(value);
+  if (typeof value !== "object") throw new TypeError("Browser arguments must be serializable data");
+  if (ancestors.has(value)) throw new TypeError("Browser arguments cannot contain cycles");
+  if (!Array.isArray(value) && Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+    throw new TypeError("Browser arguments must be plain objects or arrays");
+  }
+  if (Object.getOwnPropertySymbols(value).length) throw new TypeError("Browser arguments cannot have symbol keys");
+  ancestors.add(value);
+  const entries = Object.entries(Object.getOwnPropertyDescriptors(value));
+  for (const [, descriptor] of entries) {
+    if (descriptor.get || descriptor.set) throw new TypeError("Browser arguments cannot contain accessors");
+  }
+  const result = Array.isArray(value)
+    ? `[${Array.from({ length: value.length }, (_, index) => {
+      if (!Object.hasOwn(value, index)) throw new TypeError("Browser arguments cannot contain sparse arrays");
+      return browserLiteral(value[index], ancestors);
+    }).join(",")}]`
+    : `{${entries.filter(([, descriptor]) => descriptor.enumerable).map(([key, descriptor]) =>
+      `[${JSON.stringify(key)}]:${browserLiteral(descriptor.value, ancestors)}`).join(",")}}`;
+  ancestors.delete(value);
+  return result;
+}
+
+/** Only this transport helper creates executable source. Callers author TypeScript. */
+export function browserSource<T>(evaluation: BrowserEvaluation<T>): string {
+  const { callback, args } = typeof evaluation === "function" ? { callback: evaluation, args: [] } : evaluation;
+  return `(${callback.toString()})(...${browserLiteral(args)})`;
+}

--- a/evals/packages/cdp/src/cdp.ts
+++ b/evals/packages/cdp/src/cdp.ts
@@ -1,3 +1,5 @@
+import { browserSource, browserLiteral } from "./browser-script.ts";
+import type { BrowserEvaluation } from "./browser-script.ts";
 /**
  * Minimal Chrome DevTools Protocol client for the eval runner.
  *
@@ -30,11 +32,11 @@ export interface CdpConnectOptions {
 }
 
 export interface EvaluateOptions {
-  awaitPromise?: boolean;
+  awaitPromise?: true;
   timeoutMs?: number;
 }
 
-export type CdpFunctionArgument = string | number | boolean | null;
+export type CdpFunctionArgument = string | number | boolean | null | undefined;
 
 /** Cheap DOM/CDP probes should fail quickly enough for their caller to retry. */
 export const DEFAULT_CDP_PROBE_TIMEOUT_MS = 8_000;
@@ -275,21 +277,22 @@ export function connect(
   });
 }
 
-export async function evaluate(
+export async function evaluate<T>(
   client: CdpClient,
-  expression: string,
-  { awaitPromise = false, timeoutMs = DEFAULT_CDP_PROBE_TIMEOUT_MS }: EvaluateOptions = {},
-): Promise<unknown> {
+  expression: BrowserEvaluation<T>,
+  { awaitPromise = true, timeoutMs = DEFAULT_CDP_PROBE_TIMEOUT_MS }: EvaluateOptions = {},
+): Promise<Awaited<T>> {
   const payload = await client.send("Runtime.evaluate", {
-    expression,
+    expression: browserSource(expression),
     awaitPromise,
     returnByValue: true,
   }, { timeoutMs });
-  return runtimeResultValue(payload);
+  // CDP is the one untyped transport boundary; callers infer the callback result.
+  return runtimeResultValue(payload) as Awaited<T>;
 }
 
 function runtimeResultValue(payload: unknown): unknown {
-  if (!isRecord(payload)) return undefined;
+  if (!isRecord(payload)) throw new Error("CDP returned a malformed evaluation result");
   if (isRecord(payload.exceptionDetails)) {
     const exception = payload.exceptionDetails.exception;
     throw new Error(
@@ -299,15 +302,22 @@ function runtimeResultValue(payload: unknown): unknown {
     );
   }
   const result = payload.result;
-  return isRecord(result) ? result.value : undefined;
+  if (!isRecord(result)) throw new Error("CDP evaluation did not return a RemoteObject");
+  if (result.unserializableValue === "NaN") return NaN;
+  if (result.unserializableValue === "Infinity") return Infinity;
+  if (result.unserializableValue === "-Infinity") return -Infinity;
+  if (result.unserializableValue === "-0") return -0;
+  if (typeof result.unserializableValue === "string") throw new Error("Unsupported browser result: " + result.unserializableValue);
+  return result.value;
 }
 
-export async function callFunction(
+export async function callFunction<Args extends CdpFunctionArgument[], T>(
   client: CdpClient,
-  functionDeclaration: string,
-  args: readonly CdpFunctionArgument[] = [],
-  { awaitPromise = false, timeoutMs = DEFAULT_CDP_PROBE_TIMEOUT_MS }: EvaluateOptions = {},
-): Promise<unknown> {
+  callback: (...args: Args) => T,
+  args: [...Args],
+  { awaitPromise = true, timeoutMs = DEFAULT_CDP_PROBE_TIMEOUT_MS }: EvaluateOptions = {},
+): Promise<Awaited<T>> {
+  browserLiteral(args); // Reject functions, accessors and cyclic data before sending anything.
   const receiverPayload = await client.send("Runtime.evaluate", {
     expression: "globalThis",
     returnByValue: false,
@@ -320,13 +330,28 @@ export async function callFunction(
   if (!objectId) throw new Error("CDP did not identify the page global object.");
 
   const payload = await client.send("Runtime.callFunctionOn", {
-    functionDeclaration,
+    functionDeclaration: callback.toString(),
     objectId,
-    arguments: args.map((value) => ({ value })),
+    arguments: args.map((value) => typeof value === "number" && (!Number.isFinite(value) || Object.is(value, -0))
+      ? { unserializableValue: Object.is(value, -0) ? "-0" : String(value) }
+      : { value }),
     awaitPromise,
     returnByValue: true,
   }, { timeoutMs });
-  return runtimeResultValue(payload);
+  return runtimeResultValue(payload) as Awaited<T>;
+}
+
+export async function addInitScript<T>(client: CdpClient, script: BrowserEvaluation<T>): Promise<AsyncDisposable & { dispose(): Promise<void> }> {
+  const result = await client.send("Page.addScriptToEvaluateOnNewDocument", { source: browserSource(script) });
+  if (!isRecord(result) || typeof result.identifier !== "string") throw new Error("CDP did not return an init script identifier");
+  const identifier = result.identifier;
+  let disposed = false;
+  const dispose = async () => {
+    if (disposed) return;
+    await client.send("Page.removeScriptToEvaluateOnNewDocument", { identifier });
+    disposed = true;
+  };
+  return { dispose, [Symbol.asyncDispose]: dispose };
 }
 
 export async function navigate(client: CdpClient, url: string): Promise<void> {

--- a/evals/packages/cdp/src/index.ts
+++ b/evals/packages/cdp/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./browser-script.ts";
 export * from "./app-state.ts";
 export * from "./cdp.ts";
 export * from "./input.ts";

--- a/evals/packages/cdp/src/input.ts
+++ b/evals/packages/cdp/src/input.ts
@@ -135,26 +135,26 @@ export class TargetNotFoundError extends Error {}
 
 export async function locate(surface: Surface, target: Target): Promise<Located> {
   const parsed = JSON.stringify(parseTarget(target));
-  const value = await callFunctionOnSurface(surface, `(serialized) => {
-    const target = JSON.parse(serialized);
-    const matcher = (spec, candidate) => {
+  const value = await callFunctionOnSurface(surface, (serialized) => {
+    const target: ParsedTarget = JSON.parse(serialized);
+    const matcher = (spec: SerializedMatcher | undefined, candidate: unknown) => {
       if (!spec) return true;
       const actual = String(candidate ?? "").trim();
       if (spec.kind === "regexp") return new RegExp(spec.value, spec.flags ?? "").test(actual);
       return actual === spec.value.trim();
     };
-    const startsMatcher = (spec, candidate) => {
+    const startsMatcher = (spec: SerializedMatcher | undefined, candidate: unknown) => {
       if (!spec || spec.kind !== "string") return false;
       return String(candidate ?? "").trim().toLowerCase().startsWith(spec.value.trim().toLowerCase());
     };
-    const implicitRole = (element) => {
+    const implicitRole = (element: Element) => {
       const explicit = element.getAttribute("role");
       if (explicit) return explicit;
       const tag = element.tagName.toLowerCase();
       if (tag === "button") return "button";
-      if (tag === "select") return element.multiple || element.size > 1 ? "listbox" : "combobox";
+      if (tag === "select") return element instanceof HTMLSelectElement && (element.multiple || element.size > 1) ? "listbox" : "combobox";
       if (tag === "a" && element.hasAttribute("href")) return "link";
-      if (tag === "textarea" || element.isContentEditable) return "textbox";
+      if (tag === "textarea" || (element instanceof HTMLElement && element.isContentEditable)) return "textbox";
       if (tag === "input") {
         const type = (element.getAttribute("type") ?? "text").toLowerCase();
         if (type === "checkbox") return "checkbox";
@@ -162,25 +162,25 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
       }
       return "";
     };
-    const associatedLabel = (element) => {
-      if (element.labels?.length) return [...element.labels].map((label) => label.innerText ?? label.textContent ?? "").join(" ").trim();
+    const associatedLabel = (element: Element) => {
+      if ((element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement || element instanceof HTMLButtonElement) && element.labels?.length) return [...element.labels].map((label) => label.innerText ?? label.textContent ?? "").join(" ").trim();
       const parent = element.closest("label");
       return (parent?.innerText ?? parent?.textContent ?? "").trim();
     };
-    const accessibleName = (element) => {
-      const labelledBy = (element.getAttribute("aria-labelledby") ?? "").split(/\\s+/).filter(Boolean)
+    const accessibleName = (element: Element) => {
+      const labelledBy = (element.getAttribute("aria-labelledby") ?? "").split(/\s+/).filter(Boolean)
         .map((id) => document.getElementById(id)?.innerText ?? document.getElementById(id)?.textContent ?? "").join(" ").trim();
       return (element.getAttribute("aria-label") ?? "").trim()
         || labelledBy
         || associatedLabel(element)
         || (element.getAttribute("placeholder") ?? "").trim()
-        || (element.innerText ?? element.textContent ?? "").trim();
+        || ((element instanceof HTMLElement ? element.innerText : null) ?? element.textContent ?? "").trim();
     };
-    const text = (element) => (element.innerText ?? element.textContent ?? "").trim();
-    const rendered = (element) => {
+    const text = (element: Element) => ((element instanceof HTMLElement ? element.innerText : null) ?? element.textContent ?? "").trim();
+    const rendered = (element: Element) => {
       const rect = element.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return false;
-      let current = element;
+      let current: Element | null = element;
       while (current instanceof Element) {
         const style = getComputedStyle(current);
         if (style.display === "none" || style.visibility === "hidden" || Number(style.opacity) === 0) return false;
@@ -193,7 +193,7 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
       : target.text && !target.role && !target.label && !target.placeholder && !target.testId
         ? 'body *'
         : 'button, a[href], input, textarea, select, [role="combobox"], [role="listbox"], [contenteditable="true"], [role="button"], [role="link"], [role="textbox"], [role="checkbox"], [role="menuitem"], [role="tab"], [role="option"], [data-testid]';
-    const candidates = [...document.querySelectorAll(selector)].filter((element) => {
+    const candidates = [...document.querySelectorAll<HTMLElement>(selector)].filter((element: Element) => {
       if (target.role && implicitRole(element) !== target.role) return false;
       if (target.placeholder !== undefined && (element.getAttribute("placeholder") ?? element.getAttribute("aria-placeholder")) !== target.placeholder) return false;
       if (target.testId !== undefined && element.getAttribute("data-testid") !== target.testId) return false;
@@ -202,27 +202,27 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
     });
     let matches = candidates;
     if (target.text) {
-      const exact = candidates.filter((element) => matcher(target.text, text(element)))
-        .filter((element) => ![...element.children].some((child) => matcher(target.text, text(child))));
+      const exact = candidates.filter((element: Element) => matcher(target.text, text(element)))
+        .filter((element: Element) => ![...element.children].some((child) => matcher(target.text, text(child))));
       if (exact.length > 0) matches = exact;
       else {
-        const starts = candidates.filter((element) => rendered(element) && startsMatcher(target.text, text(element)))
-          .filter((element) => ![...element.children].some((child) => startsMatcher(target.text, text(child))));
+        const starts = candidates.filter((element: Element) => rendered(element) && startsMatcher(target.text, text(element)))
+          .filter((element: Element) => ![...element.children].some((child) => startsMatcher(target.text, text(child))));
         matches = starts.length === 1 ? starts : [];
       }
     }
     if (target.bare && !target.composer) {
-      const exact = candidates.filter((element) => matcher(target.bare, accessibleName(element)));
+      const exact = candidates.filter((element: Element) => matcher(target.bare, accessibleName(element)));
       if (exact.length > 0) matches = exact;
       else {
-        const starts = candidates.filter((element) => rendered(element) && startsMatcher(target.bare, text(element)))
-          .filter((element) => ![...element.children].some((child) => startsMatcher(target.bare, text(child))));
+        const starts = candidates.filter((element: Element) => rendered(element) && startsMatcher(target.bare, text(element)))
+          .filter((element: Element) => ![...element.children].some((child) => startsMatcher(target.bare, text(child))));
         matches = starts.length === 1 ? starts : [];
       }
     }
     const element = matches[target.nth];
     if (!element) {
-      const visibleCandidates = [...document.querySelectorAll('button, a[href], [role="button"], [role="link"]')]
+      const visibleCandidates = [...document.querySelectorAll<HTMLElement>('button, a[href], [role="button"], [role="link"]')]
         .filter(rendered)
         .slice(0, 8)
         .map((candidate) => {
@@ -234,7 +234,7 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
     element.scrollIntoView({ block: "center", inline: "center" });
     const rect = element.getBoundingClientRect();
     const center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-    let current = element;
+    let current: Element | null = element;
     let styleVisible = true;
     while (current instanceof Element) {
       const style = getComputedStyle(current);
@@ -251,16 +251,16 @@ export async function locate(surface: Surface, target: Target): Promise<Located>
       name: accessibleName(element),
       visible: styleVisible && rect.width > 0 && rect.height > 0 && inViewport,
       hitTestOk,
-      editable: element instanceof HTMLSelectElement ? !element.matches(":disabled") : element.isContentEditable || !element.readOnly && (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement),
-      value: typeof element.value === "string" ? element.value : element.isContentEditable ? element.innerText : "",
-      text: (element.isContentEditable ? element.innerText : element.innerText ?? element.value ?? element.textContent ?? "").trim(),
+      editable: element instanceof HTMLSelectElement ? !element.matches(":disabled") : (element instanceof HTMLElement && element.isContentEditable) || (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) && !element.readOnly,
+      value: (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) ? element.value : (element instanceof HTMLElement && element.isContentEditable) ? element.innerText : "",
+      text: ((element instanceof HTMLElement && element.isContentEditable) ? element.innerText : element.innerText ?? element.textContent ?? "").trim(),
       covering: hit && !hitTestOk ? {
         tag: hit.tagName.toLowerCase(),
-        text: (hit.innerText ?? hit.textContent ?? "").replace(/\\s+/g, " ").trim().slice(0, 160),
+        text: ((hit instanceof HTMLElement ? hit.innerText : null) ?? hit.textContent ?? "").replace(/\s+/g, " ").trim().slice(0, 160),
         role: implicitRole(hit),
       } : null,
     };
-  }`, [parsed]);
+  }, [parsed]);
   if (isRecord(value) && value.notFound === true) {
     const candidates = Array.isArray(value.candidates)
       ? value.candidates.filter((candidate): candidate is string => typeof candidate === "string").slice(0, 8)
@@ -356,7 +356,7 @@ export async function reload(surface: Surface, options: { timeoutMs?: number } =
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      if (await evaluateOnSurface(surface, "document.readyState === 'complete'", { timeoutMs: Math.min(2_000, Math.max(1, deadline - Date.now())) }) === true) return;
+      if (await evaluateOnSurface(surface, () => (document.readyState === 'complete'), { timeoutMs: Math.min(2_000, Math.max(1, deadline - Date.now())) }) === true) return;
     } catch {
       // Reload briefly destroys the execution context.
     }

--- a/evals/packages/cdp/src/screen-state.ts
+++ b/evals/packages/cdp/src/screen-state.ts
@@ -16,19 +16,19 @@ function stringArrayField(value: Record<string, unknown>, key: string): string[]
   return Array.isArray(entries) ? entries.filter((entry): entry is string => typeof entry === "string").slice(0, 30) : [];
 }
 
-const SCREEN_DUMP_EXPRESSION = `(() => {
+const SCREEN_DUMP_EXPRESSION = () => {
   const hash = window.location.hash;
   return {
     hash,
     route: hash.replace(/^#/, "") || window.location.pathname,
     title: document.title,
     buttons: [...document.querySelectorAll("button")]
-      .map((button) => (button.textContent ?? "").replace(/\\s+/g, " ").trim())
+      .map((button) => (button.textContent ?? "").replace(/\s+/g, " ").trim())
       .filter(Boolean)
       .slice(0, 30),
     body: (document.body?.innerText ?? "").slice(0, 500),
   };
-})()`;
+};
 
 /** A short, best-effort snapshot suitable for appending to timeout errors. */
 export async function dumpScreenState(surface: Surface): Promise<string> {

--- a/evals/packages/cdp/src/screen.ts
+++ b/evals/packages/cdp/src/screen.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "./browser-script.ts";
 import { evaluate } from "./cdp.ts";
 import type { Surface } from "./surface.ts";
 
@@ -21,20 +22,20 @@ export async function emulateFocus(surface: Surface): Promise<void> {
 }
 
 export async function paintBackdrop(surface: Surface, color: string): Promise<void> {
-  await evaluate(surface.client, `(() => {
+  await evaluate(surface.client, browserScript((color) => {
     if (!document.getElementById("docs-shots-backdrop")) {
       const style = document.createElement("style");
       style.id = "docs-shots-backdrop";
-      style.textContent = "html { background-color: ${color} !important; }";
+      style.textContent = `html { background-color: ${color} !important; }`;
       document.head.appendChild(style);
     }
     return true;
-  })()`);
+  }, [color]));
 }
 
 /** Stop CSS motion and text carets so two clean frames can be pixel-identical. */
 export async function freezeMotion(surface: Surface): Promise<void> {
-  await evaluate(surface.client, `(() => {
+  await evaluate(surface.client, () => {
     if (!document.getElementById("docs-shots-freeze")) {
       const style = document.createElement("style");
       style.id = "docs-shots-freeze";
@@ -42,5 +43,5 @@ export async function freezeMotion(surface: Surface): Promise<void> {
       document.head.appendChild(style);
     }
     return true;
-  })()`);
+  });
 }

--- a/evals/packages/cdp/src/surface.ts
+++ b/evals/packages/cdp/src/surface.ts
@@ -1,3 +1,4 @@
+import type { BrowserEvaluation } from "./browser-script.ts";
 import { probeAppState } from "./app-state.ts";
 import { callFunction, DEFAULT_CDP_PROBE_TIMEOUT_MS, connect, debuggerUrlFor, evaluate, pickAppTarget } from "./cdp.ts";
 import { firstPageTarget, targetById, waitForCdp } from "./targets.ts";
@@ -126,11 +127,11 @@ async function readOnSurface<T>(
  * that here means callers — behaviours, specs, the readiness gate — never carry
  * re-attach bookkeeping.
  */
-export async function evaluateOnSurface(
+export async function evaluateOnSurface<T>(
   surface: Surface,
-  expression: string,
+  expression: BrowserEvaluation<T>,
   opts: EvaluateOptions & { reattachAttempts?: number } = {},
-): Promise<unknown> {
+): Promise<Awaited<T>> {
   const { reattachAttempts = 1, timeoutMs = DEFAULT_CDP_PROBE_TIMEOUT_MS, ...evaluateOptions } = opts;
   return readOnSurface(
     surface,
@@ -139,12 +140,12 @@ export async function evaluateOnSurface(
   );
 }
 
-export async function callFunctionOnSurface(
+export async function callFunctionOnSurface<Args extends CdpFunctionArgument[], T>(
   surface: Surface,
-  functionDeclaration: string,
-  args: readonly CdpFunctionArgument[] = [],
+  functionDeclaration: (...args: Args) => T,
+  args: [...Args],
   opts: EvaluateOptions & { reattachAttempts?: number } = {},
-): Promise<unknown> {
+): Promise<Awaited<T>> {
   const { reattachAttempts = 1, timeoutMs = DEFAULT_CDP_PROBE_TIMEOUT_MS, ...callOptions } = opts;
   return readOnSurface(
     surface,

--- a/evals/packages/cdp/test/transport.test.ts
+++ b/evals/packages/cdp/test/transport.test.ts
@@ -1,3 +1,7 @@
+import { runInNewContext } from "node:vm";
+import { browserScript, browserSource, browserLiteral } from "../src/browser-script.ts";
+import { addInitScript } from "../src/cdp.ts";
+import type { CdpClient } from "../src/cdp.ts";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
@@ -138,15 +142,15 @@ test("a stalled websocket can be condemned without awaiting close", async () => 
   const server = await startCdpServer(1);
   try {
     const client = await connect(server.websocketUrl, { connectTimeoutMs: 500, sendTimeoutMs: 500 });
-    await assert.rejects(evaluate(client, "1", { timeoutMs: 30 }), /CDP call Runtime\.evaluate timed out/);
+    await assert.rejects(evaluate(client, () => (1), { timeoutMs: 30 }), /CDP call Runtime\.evaluate timed out/);
 
-    const pending = evaluate(client, "2", { timeoutMs: 500 });
+    const pending = evaluate(client, () => (2), { timeoutMs: 500 });
     if (!client.abort) throw new Error("Connected CDP client did not expose abort().");
     const startedAt = Date.now();
     client.abort(new Error("probe timed out"));
     assert.ok(Date.now() - startedAt < 100, "abort() waited for the peer to complete websocket close");
     await assert.rejects(pending, /CDP transport stalled: probe timed out/);
-    await assert.rejects(evaluate(client, "3", { timeoutMs: 500 }), /CDP socket is not open/);
+    await assert.rejects(evaluate(client, () => (3), { timeoutMs: 500 }), /CDP socket is not open/);
   } finally {
     await server.close();
   }
@@ -157,7 +161,7 @@ test("function calls pass dynamic values as structured CDP arguments", async () 
   const client = await connect(server.websocketUrl, { connectTimeoutMs: 500, sendTimeoutMs: 500 });
   try {
     const dynamicValue = `"); throw new Error("must stay data"); //`;
-    const value = await callFunction(client, "function (value) { return value; }", [dynamicValue]);
+    const value = await callFunction(client, (value) => value, [dynamicValue]);
     assert.equal(value, dynamicValue);
   } finally {
     client.close();
@@ -174,7 +178,7 @@ test("surface evaluation heals after the first websocket consumes its budget", a
       client: firstClient,
     };
 
-    const value = await evaluateOnSurface(surface, "42", { timeoutMs: 30 });
+    const value = await evaluateOnSurface(surface, () => (42), { timeoutMs: 30 });
 
     assert.equal(value, "recovered");
     assert.notEqual(surface.client, firstClient);
@@ -182,4 +186,79 @@ test("surface evaluation heals after the first websocket consumes its budget", a
   } finally {
     await server.close();
   }
+});
+
+
+test("browser callbacks preserve argument values without interpolating executable input", async () => {
+  const input = { text: '\"; throw new Error("injection"); //', nested: [undefined, -0, NaN, Infinity], missing: undefined };
+  const result = await runInNewContext(browserSource(browserScript(async (data) => ({
+    text: data.text,
+    sameUndefined: data.nested[0] === undefined && Object.hasOwn(data, "missing"),
+    negativeZero: Object.is(data.nested[1], -0),
+    nan: Number.isNaN(data.nested[2]),
+    infinity: data.nested[3] === Infinity,
+  }), [input])));
+  assert.equal(result.text, input.text);
+  assert.equal(result.sameUndefined, true);
+  assert.equal(result.negativeZero, true);
+  assert.equal(result.nan, true);
+  assert.equal(result.infinity, true);
+  const dangerousKey = JSON.parse('{"__proto__":{"polluted":true}}');
+  const roundTrip = runInNewContext(browserSource(browserScript(data => data, [dangerousKey])));
+  assert.equal(Object.hasOwn(roundTrip, "__proto__"), true);
+  assert.equal(roundTrip.polluted, undefined);
+});
+
+test("browser serialization rejects functions, cycles, getters and class instances before transport", () => {
+  let getterCalls = 0;
+  const cyclic: { self?: unknown } = {};
+  cyclic.self = cyclic;
+  for (const value of [() => 1, cyclic, new Date(), { get secret() { getterCalls++; return "hidden"; } }]) {
+    assert.throws(() => browserLiteral(value), /Browser arguments/);
+  }
+  assert.equal(getterCalls, 0);
+});
+
+test("typed evaluation awaits promises and surfaces browser exceptions", async () => {
+  const client: CdpClient = {
+    async send(method, params = {}) {
+      assert.equal(method, "Runtime.evaluate");
+      assert.equal(params.awaitPromise, true);
+      if (typeof params.expression !== "string") throw new Error("Expected browser source");
+      try { return { result: { value: await runInNewContext(params.expression) } }; }
+      catch (error) { return { exceptionDetails: { text: String(error) } }; }
+    },
+    close() {},
+  };
+  const result: number = await evaluate(client, browserScript(async (value) => value + 1, [41]));
+  assert.equal(result, 42);
+  await assert.rejects(evaluate(client, () => { throw new Error("browser failure"); }), /browser failure/);
+});
+
+test("init callbacks run in each fresh document and dispose only once", async () => {
+  let source = "";
+  let removals = 0;
+  const client: CdpClient = {
+    async send(method, params = {}) {
+      if (method === "Page.addScriptToEvaluateOnNewDocument") {
+        if (typeof params.source !== "string") throw new Error("Missing init source");
+        source = params.source;
+        return { identifier: "init-1" };
+      }
+      assert.equal(method, "Page.removeScriptToEvaluateOnNewDocument");
+      assert.equal(params.identifier, "init-1");
+      removals++;
+      return {};
+    },
+    close() {},
+  };
+  const script = await addInitScript(client, browserScript((title) => { document.title = title; }, ['quoted " title']));
+  for (let navigation = 0; navigation < 2; navigation++) {
+    const page = { document: { title: "before" } };
+    runInNewContext(source, page);
+    assert.equal(page.document.title, 'quoted " title');
+  }
+  await script.dispose();
+  await script[Symbol.asyncDispose]();
+  assert.equal(removals, 1);
 });

--- a/evals/packages/env/src/desktop-app.ts
+++ b/evals/packages/env/src/desktop-app.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { createAndSelectWorkspace, signInDesktopAs } from "@openwork/behaviors";
 import { attachSurface, evaluateOnSurface, isInteractive, probeAppStateOnSurface } from "@openwork/cdp";
 import type { Surface } from "@openwork/cdp";
@@ -51,11 +52,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function serializedPageValue(value: unknown): string {
-  const serialized = JSON.stringify(value);
-  if (serialized === undefined) throw new Error("Installed production renderer state could not be serialized.");
-  return serialized.replace(/</g, "\\u003c").replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
-}
 
 async function mirrorInstalledProductionRendererState(target: Surface): Promise<AppReadiness> {
   const cdpUrl = process.env.OPENWORK_EVAL_INSTALLED_PRODUCTION_CDP_URL?.trim() || "http://127.0.0.1:9223";
@@ -65,10 +61,10 @@ async function mirrorInstalledProductionRendererState(target: Surface): Promise<
     hostKind: "local",
     cdpUrl,
   });
-  const raw = await evaluateOnSurface(source, `({
+  const raw = await evaluateOnSurface(source, () => (({
     route: location.hash,
     entries: Object.entries(localStorage).filter(([key]) => key.startsWith("openwork.")),
-  })`);
+  })));
   if (!isRecord(raw) || typeof raw.route !== "string" || !Array.isArray(raw.entries)) {
     throw new Error(`Installed production desktop at ${cdpUrl} returned invalid renderer state.`);
   }
@@ -80,13 +76,13 @@ async function mirrorInstalledProductionRendererState(target: Surface): Promise<
     entries.push([entry[0], entry[1]]);
   }
   try {
-    await evaluateOnSurface(target, `(() => {
-      const state = ${serializedPageValue({ route: raw.route, entries })};
+    await evaluateOnSurface(target, browserScript((inputValue) => {
+      const state = inputValue;
       for (const [key, value] of state.entries) localStorage.setItem(key, value);
       location.hash = state.route;
       location.reload();
       return true;
-    })()`);
+    }, [{ route: raw.route, entries }]));
   } catch {
     // The CDP evaluator includes expression prefixes in timeout errors. Never
     // propagate the expression because it contains production localStorage.

--- a/evals/packages/env/src/seed.ts
+++ b/evals/packages/env/src/seed.ts
@@ -1,5 +1,6 @@
+import type { BrowserEvaluation, EvaluateOptions } from "@openwork/cdp";
 import type { DenFetchResult, DenSession, NativeConnectorInput } from "@openwork/behaviors";
-import type { AttachedSurface, CdpFunctionArgument, Surface } from "@openwork/cdp";
+import type { AttachedSurface, Surface } from "@openwork/cdp";
 import type { StartMockMcpOptions } from "@openwork/labs";
 import type { DaytonaExec, DesktopHandle } from "@openwork/hosts";
 import type { App } from "./desktop-app.ts";
@@ -107,5 +108,5 @@ export interface Seed {
   tmpPath(label: string): string;
   composerText(app: Surface, text: string): Promise<void>;
   /** Migration-only raw write escape hatch. New specs must not use it. */
-  evalIn(surface: Surface, expression: string, options?: { args?: readonly CdpFunctionArgument[]; awaitPromise?: boolean; timeoutMs?: number }): Promise<unknown>;
+  evalIn<T>(surface: Surface, expression: BrowserEvaluation<T>, options?: EvaluateOptions): Promise<Awaited<T>>;
 }

--- a/evals/packages/test-evidence/src/screenshot.ts
+++ b/evals/packages/test-evidence/src/screenshot.ts
@@ -18,10 +18,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export async function screenshot(app: Surface): Promise<ScreenshotArtifact> {
   const at = new Date().toISOString();
   const png = await captureScreenshot(app.client);
-  const page = await evaluate(app.client, `({
+  const page = await evaluate(app.client, () => (({
     route: window.location.hash,
     visibleText: document.body.innerText,
-  })`);
+  })));
   if (!isRecord(page) || typeof page.route !== "string" || typeof page.visibleText !== "string") {
     throw new Error("CDP did not return the current route and visible text for the screenshot.");
   }

--- a/evals/packages/testkit/src/index.ts
+++ b/evals/packages/testkit/src/index.ts
@@ -1,3 +1,5 @@
+export { browserScript } from "@openwork/cdp";
+export type { BrowserEvaluation, BrowserScript } from "@openwork/cdp";
 export { control, createDesktopHandoffGrant, evalIn, signInDesktopAs } from "@openwork/behaviors";
 export { requestDenLoopback } from "@openwork/labs";
 export { desktop as relaunchDesktop, electronProfilePaths } from "@openwork/hosts";

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -1,3 +1,5 @@
+import type { BrowserEvaluation, EvaluateOptions } from "@openwork/cdp";
+import { browserScript } from "@openwork/cdp";
 import { typeWithCadence, typingPlan } from "@openwork/behaviors";
 import {
   control,
@@ -215,7 +217,7 @@ async function waitForControlAction(surface: Surface, action: string, timeoutMs 
   await waitForControlRail(surface, action, Math.max(1, deadline - Date.now()));
   while (Date.now() < deadline) {
     try {
-      const actions = await evalIn(surface, "window.__openworkControl?.listActions?.() ?? null", {
+      const actions = await evalIn(surface, () => (window.__openworkControl?.listActions?.() ?? null), {
         timeoutMs: Math.min(2_000, Math.max(1, deadline - Date.now())),
       });
       if (Array.isArray(actions) && actions.some((entry) => isRecord(entry) && entry.id === action && entry.disabled !== true)) return;
@@ -478,7 +480,7 @@ export class SeedChannel implements Seed {
         const denOrigin = new URL(options.den.ref.webUrl).origin;
         let lastHref = "unobserved";
         const waitForDen = () => eventually(async () => {
-          const observation = await evaluateOnSurface(web, `location.origin === ${JSON.stringify(denOrigin)} && document.readyState !== "loading" ? "" : location.href`);
+          const observation = await evaluateOnSurface(web, browserScript((denOrigin) => (location.origin === denOrigin && document.readyState !== "loading" ? "" : location.href), [denOrigin]));
           if (typeof observation === "string") lastHref = observation;
           return observation === "";
         }, { within: 30_000, intervalMs: 250, label: "Den origin document" });
@@ -488,10 +490,10 @@ export class SeedChannel implements Seed {
           await navigate(web.client, options.den.ref.webUrl);
           await waitForDen().catch(() => { throw new Error(`Den origin document did not load; last observed location.href: ${lastHref}`); });
         }
-        await callFunctionOnSurface(web, `(token) => {
+        await callFunctionOnSurface(web, (token) => {
           localStorage.setItem("openwork:web:auth-token", token);
           return true;
-        }`, [session.token]);
+        }, [session.token]);
       }
       const startPath = options.startPath ?? "/";
       await navigate(web.client, new URL(startPath, options.den.ref.webUrl).toString());
@@ -502,10 +504,10 @@ export class SeedChannel implements Seed {
   workspace(app: Surface, path = `/tmp/openwork-spec-${Date.now()}`, options: { create?: boolean } = {}) {
     return this.#runtime.call("seed", "workspace", `workspace(${path})`, app, async () => {
       const result = await import("@openwork/behaviors").then(({ createAndSelectWorkspace }) => createAndSelectWorkspace(app, { path, ...options }));
-      await eventually(() => callFunctionOnSurface(app, `(workspaceId) => {
+      await eventually(() => callFunctionOnSurface(app, (workspaceId) => {
         const workspace = window.__openwork?.slice?.("route")?.workspaces?.find(item => item.id === workspaceId);
         return workspace ? { exists: true, loading: workspace.loading } : { exists: false };
-      }`, [result.workspaceId]), {
+      }, [result.workspaceId]), {
         within: 60000, intervalMs: 250, label: `workspace ${result.workspaceId} initial session load`,
         until: value => isRecord(value) && value.exists === true && value.loading === false,
       });
@@ -594,11 +596,9 @@ export class SeedChannel implements Seed {
     });
   }
 
-  evalIn(surface: Surface, expression: string, options: { args?: readonly import("@openwork/cdp").CdpFunctionArgument[]; awaitPromise?: boolean; timeoutMs?: number } = {}) {
-    const { args, ...evaluateOptions } = options;
-    return this.#runtime.call("seed:raw", "evalIn", "[seed:raw] evalIn(<expression>)", surface, () => args === undefined
-      ? evalIn(surface, expression, evaluateOptions)
-      : callFunctionOnSurface(surface, expression, args, evaluateOptions));
+  evalIn<T>(surface: Surface, expression: BrowserEvaluation<T>, options: EvaluateOptions = {}): Promise<Awaited<T>> {
+    return this.#runtime.call("seed:raw", "evalIn", "[seed:raw] evalIn(<callback>)", surface,
+      () => evalIn(surface, expression, options));
   }
 }
 
@@ -654,7 +654,7 @@ export class UserChannel implements User {
         await clickAt(surface, found.center);
       }
       if (options.sensitive) {
-        const masked = await callFunctionOnSurface(surface, "() => document.activeElement?.tagName === 'INPUT' && document.activeElement.type === 'password'", []);
+        const masked = await callFunctionOnSurface(surface, () => document.activeElement instanceof HTMLInputElement && document.activeElement.type === 'password', []);
         if (masked !== true) throw new Error("Sensitive typing requires a masked password input");
       }
       const mac = surface.handle.hostKind !== "daytona" && process.platform === "darwin";
@@ -777,19 +777,19 @@ export class AgentChannel implements Agent {
   browserRequest(input: { url: string; method?: string; body?: string }): Promise<{ reached: boolean; error?: string }> {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("agent", "browserRequest", `browserRequest(${input.method ?? "GET"} ${input.url})`, surface, async () => {
-      const handle = await callFunctionOnSurface(surface, `async () => window.__OPENWORK_ELECTRON__.browser.openUrl("about:blank")`, [], { awaitPromise: true });
+      const handle = await callFunctionOnSurface(surface, async () => window.__OPENWORK_ELECTRON__.browser.openUrl("about:blank"), [], { awaitPromise: true });
       if (!isRecord(handle) || typeof handle.target_id !== "string") throw new Error("Browser did not return a target");
       const target = (await listTargets(surface.handle.cdpUrl)).find((entry) => entry.id === handle.target_id);
       if (!target) throw new Error("Browser target missing");
       const client = await connect(debuggerUrlFor(surface.handle.cdpUrl, target));
       try {
-        const result = await callFunction(client, `async (encoded) => {
+        const result = await callFunction(client, async (encoded) => {
           const input = JSON.parse(encoded);
           try {
             await fetch(input.url, { method: input.method ?? "GET", body: input.body, mode: "no-cors", cache: "no-store", signal: AbortSignal.timeout(20000) });
             return { reached: true };
           } catch (error) { return { reached: false, error: String(error) }; }
-        }`, [JSON.stringify(input)], { awaitPromise: true, timeoutMs: 25000 });
+        }, [JSON.stringify(input)], { awaitPromise: true, timeoutMs: 25000 });
         if (!isRecord(result) || typeof result.reached !== "boolean") throw new Error("Invalid browser request result");
         return { reached: result.reached, ...(typeof result.error === "string" ? { error: result.error } : {}) };
       } finally { client.close(); }
@@ -800,11 +800,11 @@ export class AgentChannel implements Agent {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("agent", "desktopApi", `desktopApi(${input.method} ${path})`, surface, async () => {
       if (!path.startsWith("/") || path.startsWith("//") || /[\\\s]/.test(path)) throw new Error("A root-relative server path is required.");
-      const value = await callFunctionOnSurface(surface, `async (path, encodedInput) => {
+      const value = await callFunctionOnSurface(surface, async (path, encodedInput) => {
         const input = JSON.parse(encodedInput);
         const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
         if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
-        const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + path, {
+        const response = await fetch(String(info.baseUrl).replace(/\/+$/, "") + path, {
           method: input.method,
           headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""), "Content-Type": "application/json" },
           body: input.body === undefined ? undefined : JSON.stringify(input.body),
@@ -814,7 +814,7 @@ export class AgentChannel implements Agent {
         let body = text;
         try { body = JSON.parse(text); } catch {}
         return { status: response.status, body };
-      }`, [path, JSON.stringify(input)], { awaitPromise: true, timeoutMs: 35_000 });
+      }, [path, JSON.stringify(input)], { awaitPromise: true, timeoutMs: 35_000 });
       if (!isRecord(value) || typeof value.status !== "number") throw new Error("Invalid desktop API result");
       return { status: value.status, body: value.body };
     });
@@ -848,7 +848,7 @@ export class AgentChannel implements Agent {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("agent", "actions", "listActions", surface, async () => {
       await waitForControlRail(surface, "listActions");
-      return evaluateOnSurface(surface, "window.__openworkControl.listActions()");
+      return evaluateOnSurface(surface, () => (window.__openworkControl.listActions()));
     });
   }
 }
@@ -870,7 +870,7 @@ export class ProbeChannel implements Probe {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("probe", "text", "text", surface, async () => {
       if (this.#runtime.adapters.probe?.text) return this.#runtime.adapters.probe.text(surface);
-      const value = await evaluateOnSurface(surface, "document.body.innerText");
+      const value = await evaluateOnSurface(surface, () => (document.body.innerText));
       if (typeof value !== "string") throw new Error("document.body.innerText was not a string.");
       return value;
     });
@@ -879,7 +879,7 @@ export class ProbeChannel implements Probe {
   has(text: string): Promise<boolean> {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("probe", "has", `has(${JSON.stringify(redacted(text))})`, surface, async () => {
-      const value = await callFunctionOnSurface(surface, `(wanted) => document.body.innerText.includes(wanted)`, [text]);
+      const value = await callFunctionOnSurface(surface, (wanted) => document.body.innerText.includes(wanted), [text]);
       if (typeof value !== "boolean") throw new Error("Text presence probe was not a boolean.");
       return value;
     });
@@ -895,7 +895,7 @@ export class ProbeChannel implements Probe {
   async storage<T>(key: string, pick?: (value: unknown) => T): Promise<unknown> {
     const surface = requireSurface(this.#surface);
     const value = await this.#runtime.call("probe", "storage", `storage(${key})`, surface, async () => {
-      const raw = await callFunctionOnSurface(surface, `(storageKey) => localStorage.getItem(storageKey)`, [key]);
+      const raw = await callFunctionOnSurface(surface, (storageKey) => localStorage.getItem(storageKey), [key]);
       if (raw === null || raw === undefined || raw === "") return null;
       if (typeof raw !== "string") throw new Error(`localStorage ${JSON.stringify(key)} was not a string.`);
       try {
@@ -911,27 +911,23 @@ export class ProbeChannel implements Probe {
   hash(): Promise<string> {
     const surface = requireSurface(this.#surface);
     return this.#runtime.call("probe", "hash", "hash", surface, async () => {
-      const value = await evaluateOnSurface(surface, "window.location.hash");
+      const value = await evaluateOnSurface(surface, () => (window.location.hash));
       if (typeof value !== "string") throw new Error("window.location.hash was not a string.");
       return value;
     });
   }
 
-  eval(expression: string, options?: ProbeEvalOptions): Promise<unknown>;
-  eval(surface: Surface, expression: string, options?: ProbeEvalOptions): Promise<unknown>;
-  eval(surfaceOrExpression: Surface | string, expressionOrOptions?: string | ProbeEvalOptions, explicitOptions: ProbeEvalOptions = {}): Promise<unknown> {
-    const surface = typeof surfaceOrExpression === "string" ? requireSurface(this.#surface) : surfaceOrExpression;
-    const source = typeof surfaceOrExpression === "string"
-      ? surfaceOrExpression
-      : typeof expressionOrOptions === "string" ? expressionOrOptions : undefined;
-    const options = typeof surfaceOrExpression === "string"
-      ? typeof expressionOrOptions === "string" ? {} : expressionOrOptions ?? {}
-      : explicitOptions;
-    if (source === undefined) throw new Error("probe.eval requires an expression.");
-    const { args, ...evaluateOptions } = options;
-    return this.#runtime.call("probe:raw", "eval", "[probe:raw] eval(<expression>)", surface, () => args === undefined
-      ? evalIn(surface, source, evaluateOptions)
-      : callFunctionOnSurface(surface, source, args, evaluateOptions));
+  eval<T>(expression: BrowserEvaluation<T>, options?: ProbeEvalOptions): Promise<Awaited<T>>;
+  eval<T>(surface: Surface, expression: BrowserEvaluation<T>, options?: ProbeEvalOptions): Promise<Awaited<T>>;
+  eval<T>(surfaceOrExpression: Surface | BrowserEvaluation<T>, expressionOrOptions?: BrowserEvaluation<T> | ProbeEvalOptions, explicitOptions: ProbeEvalOptions = {}): Promise<Awaited<T>> {
+    const bound = typeof surfaceOrExpression === "function" || "callback" in surfaceOrExpression;
+    const surface = bound ? requireSurface(this.#surface) : surfaceOrExpression;
+    const expression = bound ? surfaceOrExpression : expressionOrOptions;
+    if (!expression || !(typeof expression === "function" || "callback" in expression)) throw new Error("probe.eval requires a browser callback");
+    const options = bound && expressionOrOptions && typeof expressionOrOptions !== "function" && !("callback" in expressionOrOptions)
+      ? expressionOrOptions : explicitOptions;
+    return this.#runtime.call("probe:raw", "eval", "[probe:raw] eval(<callback>)", surface,
+      () => evalIn(surface, expression, options));
   }
 
   connectState(app: Surface) {
@@ -954,10 +950,10 @@ export class ProbeChannel implements Probe {
       if (!path.startsWith("/") || path.startsWith("//") || /[\\\s]/.test(path)) {
         throw new Error("probe.desktopApi requires a root-relative server path.");
       }
-      const value = await callFunctionOnSurface(surface, `async (path) => {
+      const value = await callFunctionOnSurface(surface, async (path) => {
         const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
         if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
-        const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + path, {
+        const response = await fetch(String(info.baseUrl).replace(/\/+$/, "") + path, {
           method: "GET",
           headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
           redirect: "error",
@@ -967,7 +963,7 @@ export class ProbeChannel implements Probe {
         let body = text;
         try { body = text ? JSON.parse(text) : null; } catch {}
         return { status: response.status, body };
-      }`, [path], { awaitPromise: true, timeoutMs: 20_000 });
+      }, [path], { awaitPromise: true, timeoutMs: 20_000 });
       if (!isRecord(value) || typeof value.status !== "number" || !("body" in value)) {
         throw new Error("Invalid desktop API probe response.");
       }

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -1,5 +1,5 @@
 import type { DenSession, DenFetchResult, FieldTypingOptions } from "@openwork/behaviors";
-import type { CdpFunctionArgument, Surface, Target } from "@openwork/cdp";
+import type { BrowserEvaluation, Surface, Target } from "@openwork/cdp";
 import type {
   MockHandle,
   Place,
@@ -30,8 +30,7 @@ export interface TypeOptions extends FieldTypingOptions {
 }
 
 export interface ProbeEvalOptions {
-  args?: readonly CdpFunctionArgument[];
-  awaitPromise?: boolean;
+  awaitPromise?: true;
   timeoutMs?: number;
 }
 
@@ -69,8 +68,8 @@ export interface Probe {
   storage(key: string): Promise<unknown>;
   storage<T>(key: string, pick: (value: unknown) => T): Promise<T>;
   hash(): Promise<string>;
-  eval(expression: string, options?: ProbeEvalOptions): Promise<unknown>;
-  eval(surface: Surface, expression: string, options?: ProbeEvalOptions): Promise<unknown>;
+  eval<T>(expression: BrowserEvaluation<T>, options?: ProbeEvalOptions): Promise<Awaited<T>>;
+  eval<T>(surface: Surface, expression: BrowserEvaluation<T>, options?: ProbeEvalOptions): Promise<Awaited<T>>;
   connectState(app: Surface): ReturnType<typeof import("../state.ts").readConnectState>;
   api(session: DenSession, path: string, init?: RequestInit): Promise<DenFetchResult>;
   /** GET from the bound desktop's local server; authentication stays in the renderer. */

--- a/evals/packages/testkit/src/state.ts
+++ b/evals/packages/testkit/src/state.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { readFile } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { evalIn } from "@openwork/behaviors";
@@ -50,12 +51,12 @@ function errorCode(error: unknown): string | null {
 }
 
 export async function readDenClientState(app: Surface): Promise<DenClientState> {
-  const value = await evalIn(app, `(() => ({
+  const value = await evalIn(app, () => ((() => ({
     authTokenPresent: Boolean((localStorage.getItem("openwork.den.authToken") ?? "").trim()),
     activeOrgId: (localStorage.getItem("openwork.den.activeOrgId") ?? "").trim() || null,
     activeOrgSlug: (localStorage.getItem("openwork.den.activeOrgSlug") ?? "").trim() || null,
     activeOrgName: (localStorage.getItem("openwork.den.activeOrgName") ?? "").trim() || null,
-  }))()`);
+  }))()));
   if (!isRecord(value)) throw new Error("The desktop returned an invalid Den client state.");
   return {
     authTokenPresent: value.authTokenPresent === true,
@@ -66,7 +67,7 @@ export async function readDenClientState(app: Surface): Promise<DenClientState> 
 }
 
 export async function readConnectState(app: Surface): Promise<ConnectState> {
-  const value = await evalIn(app, `(async () => {
+  const value = await evalIn(app, async () => {
     // Resolve the local server the same way the app does: live runtime info
     // from the Electron bridge first (loopback port + token are ephemeral per
     // boot), then the web-mode localStorage overrides as a fallback.
@@ -77,7 +78,7 @@ export async function readConnectState(app: Surface): Promise<ConnectState> {
       if (invokeDesktop) {
         const info = await invokeDesktop("openworkServerInfo");
         if (info && info.running === true) {
-          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\/+$/, "");
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\/+$/, "");
           token = String(info.ownerToken ?? info.clientToken ?? "").trim();
         }
       }
@@ -96,15 +97,15 @@ export async function readConnectState(app: Surface): Promise<ConnectState> {
         { headers: { Authorization: "Bearer " + token } },
       );
       const text = await response.text();
-      let raw = text;
+      let raw: unknown = text;
       try { raw = text ? JSON.parse(text) : null; } catch {}
       return {
         ok: response.ok,
-        status: raw && typeof raw === "object"
+        status: raw && typeof raw === "object" && "status" in raw
           && (raw.status === "available" || raw.status === "missing" || raw.status === "invalid" || raw.status === "unreadable")
           ? raw.status
           : null,
-        connectEnabled: raw && typeof raw === "object" && typeof raw.connectEnabled === "boolean"
+        connectEnabled: raw && typeof raw === "object" && "connectEnabled" in raw && typeof raw.connectEnabled === "boolean"
           ? raw.connectEnabled
           : null,
         raw,
@@ -117,7 +118,7 @@ export async function readConnectState(app: Surface): Promise<ConnectState> {
         raw: { error: error instanceof Error ? error.message : String(error) },
       };
     }
-  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  }, { awaitPromise: true, timeoutMs: 15_000 });
   if (!isRecord(value)) throw new Error("The desktop returned an invalid Connect state.");
   return {
     ok: value.ok === true,
@@ -134,7 +135,7 @@ export async function readCloudMcpHealth(
   workspaceId: string,
   opts?: { probe?: boolean; timeoutMs?: number },
 ): Promise<CloudMcpHealthSummary> {
-  const value = await evalIn(app, `(async () => {
+  const value = await evalIn(app, browserScript(async (workspaceId, value) => {
     // Resolve the local server the same way the app does: live runtime info
     // from the Electron bridge first (loopback port + token are ephemeral per
     // boot), then the web-mode localStorage overrides as a fallback.
@@ -145,7 +146,7 @@ export async function readCloudMcpHealth(
       if (invokeDesktop) {
         const info = await invokeDesktop("openworkServerInfo");
         if (info && info.running === true) {
-          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\/+$/, "");
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\/+$/, "");
           token = String(info.ownerToken ?? info.clientToken ?? "").trim();
         }
       }
@@ -160,11 +161,11 @@ export async function readCloudMcpHealth(
     }
     try {
       const response = await fetch(
-        baseUrl + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/mcp/openwork-cloud/health" + ${JSON.stringify(opts?.probe === true ? "?probe=1" : "")},
+        baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/mcp/openwork-cloud/health" + value,
         { headers: { Authorization: "Bearer " + token } },
       );
       const text = await response.text();
-      let raw = text;
+      let raw: unknown = text;
       try { raw = text ? JSON.parse(text) : null; } catch {}
       return { ok: response.ok, raw };
     } catch (error) {
@@ -173,8 +174,8 @@ export async function readCloudMcpHealth(
         raw: { error: error instanceof Error ? error.message : String(error) },
       };
     }
-  })()`, { awaitPromise: true, timeoutMs: opts?.timeoutMs ?? 15_000 });
-  const result = isRecord(value) ? value : {};
+  }, [workspaceId, opts?.probe === true ? "?probe=1" : ""]), { awaitPromise: true, timeoutMs: opts?.timeoutMs ?? 15_000 });
+  const result: Record<string, unknown> = isRecord(value) ? value : {};
   const raw = result.raw;
   const health = isRecord(raw) ? raw : {};
   const engine = isRecord(health.engine) ? health.engine : {};

--- a/evals/packages/testkit/src/transcript-observer.ts
+++ b/evals/packages/testkit/src/transcript-observer.ts
@@ -1,17 +1,17 @@
+import { browserScript } from "@openwork/cdp";
 import type { Probe } from "./spec/types.ts";
 
 /** Observe rendered transcript text across frames, including gaps between eventual assertions. */
 export async function observeTranscript(probe: Probe, entries: readonly { role: "user" | "assistant"; text: string }[]) {
-  const key = `transcript-observer-${crypto.randomUUID()}`;
-  await probe.eval(`(key, entriesJson) => {
-    const entries = JSON.parse(entriesJson);
-    const state = { frames: 0, seen: entries.map(() => false), violations: [], stopped: false };
-    let frame;
+  const key: `transcript-observer-${string}` = `transcript-observer-${crypto.randomUUID()}`;
+  await probe.eval(browserScript((key: `transcript-observer-${string}`, entries) => {
+    const state: { frames: number; seen: boolean[]; violations: { index: number; count: number; atMs: number }[]; stopped: boolean } = { frames: 0, seen: entries.map(() => false), violations: [], stopped: false };
+    let frame = 0;
     const started = performance.now();
     const sample = () => {
       state.frames++;
       entries.forEach((entry, index) => {
-        const nodes = [...document.querySelectorAll('[data-message-role="' + entry.role + '"]')]
+        const nodes = [...document.querySelectorAll<HTMLElement>('[data-message-role="' + entry.role + '"]')]
           .filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== "hidden");
         const count = nodes.reduce((sum, node) => sum + ((node.innerText ?? "").split(entry.text).length - 1), 0);
         if (count > 0) state.seen[index] = true;
@@ -23,34 +23,34 @@ export async function observeTranscript(probe: Probe, entries: readonly { role: 
     frame = requestAnimationFrame(sample);
     const timer = setTimeout(() => { cancelAnimationFrame(frame); state.stopped = true; }, 180000);
     window[key] = { state, stop() { clearTimeout(timer); cancelAnimationFrame(frame); } };
-  }`, { args: [key, JSON.stringify(entries)] });
+  }, [key, entries]));
   return {
     read() {
-      return probe.eval(`(key) => {
+      return probe.eval(browserScript((key: `transcript-observer-${string}`) => {
         const observer = window[key];
         if (!observer) throw new Error("Transcript observer was lost before verification");
         return observer.state;
-      }`, { args: [key] });
+      }, [key]));
     },
     async finish() {
-      const result = await probe.eval(`(key) => {
+      const result = await probe.eval(browserScript((key: `transcript-observer-${string}`) => {
         const observer = window[key];
         if (!observer) throw new Error("Transcript observer was lost before verification");
         observer.stop(); delete window[key]; return observer.state;
-      }`, { args: [key] });
+      }, [key]));
       return result;
     },
     async [Symbol.asyncDispose]() {
-      await probe.eval(`(key) => { window[key]?.stop(); delete window[key]; }`, { args: [key] });
+      await probe.eval(browserScript((key: `transcript-observer-${string}`) => { window[key]?.stop(); delete window[key]; }, [key]));
     },
   };
 }
 
 /** Read visible messages in display order without depending on engine payloads. */
 export async function readTranscriptMessages(probe: Probe, role: "user" | "assistant" | "system"): Promise<string[]> {
-  const result = await probe.eval(`(role) => [...document.querySelectorAll('[data-message-role="' + role + '"]')]
+  const result = await probe.eval(browserScript((role) => [...document.querySelectorAll<HTMLElement>('[data-message-role="' + role + '"]')]
     .filter(node => node.getClientRects().length && getComputedStyle(node).visibility !== "hidden")
-    .map(node => node.innerText ?? "")`, { args: [role] });
+    .map(node => node.innerText ?? ""), [role]));
   if (!Array.isArray(result) || !result.every((text): text is string => typeof text === "string")) {
     throw new Error("Rendered transcript was unavailable");
   }

--- a/evals/packages/testkit/test/link.test.ts
+++ b/evals/packages/testkit/test/link.test.ts
@@ -168,8 +168,8 @@ test("denLink admin rejects missing and wrong bearer tokens without mutating sta
     assert.match(authorization, /^Bearer [a-f0-9]{64}$/);
     const phaseUrl = adminHealthUrl.replace(/\/health$/, "/phase");
     for (const headers of [
-      { "content-type": "application/json" },
-      { authorization: "Bearer " + "b".repeat(64), "content-type": "application/json" },
+      new Headers({ "content-type": "application/json" }),
+      new Headers({ authorization: "Bearer " + "b".repeat(64), "content-type": "application/json" }),
     ]) {
       const denied = await originalFetch(phaseUrl, {
         method: "POST",

--- a/evals/pnpm-lock.yaml
+++ b/evals/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@openwork/testkit':
         specifier: workspace:*
         version: link:packages/testkit
+      '@openwork/types':
+        specifier: link:../packages/types
+        version: link:../packages/types
       '@openwork/world':
         specifier: link:../packages/world
         version: link:../packages/world

--- a/evals/scripts/check-browser-code.mjs
+++ b/evals/scripts/check-browser-code.mjs
@@ -1,0 +1,134 @@
+import ts from "typescript";
+import { resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Enforce the browser/process boundary using bindings, not regex matches in strings. */
+export function checkBrowserCode(program, root, include) {
+  const checker = program.getTypeChecker();
+  const failures = [];
+  const callbacks = [];
+  const calls = [];
+  const names = new Set(["browserScript", "evaluate", "eval", "evalIn", "rawEvalIn", "evaluateOnSurface", "callFunction", "callFunctionOnSurface", "addInitScript", "inPage", "waitFor", "waitForBehavior", "pollExpression", "resilientRead", "browserSource", "memberRefreshAndWait", "waitForDenState"]);
+  function report(node, message) {
+    const file = node.getSourceFile();
+    const { line, character } = file.getLineAndCharacterOfPosition(node.getStart());
+    failures.push(`${relative(root, file.fileName)}:${line + 1}:${character + 1}: ${message}`);
+  }
+  function unwrap(node) { while (ts.isParenthesizedExpression(node)) node = node.expression; return node; }
+  function callbackFor(node, seen = new Set()) {
+    node = unwrap(node);
+    if (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)) return node;
+    if (!ts.isIdentifier(node)) return;
+    let symbol = checker.getSymbolAtLocation(node);
+    if (symbol?.flags & ts.SymbolFlags.Alias) symbol = checker.getAliasedSymbol(symbol);
+    if (!symbol || seen.has(symbol)) return;
+    seen.add(symbol);
+    for (const declaration of symbol.declarations ?? []) {
+      if (ts.isVariableDeclaration(declaration) && declaration.initializer) return callbackFor(declaration.initializer, seen);
+      if (ts.isFunctionDeclaration(declaration)) return declaration;
+    }
+  }
+  function resultProblem(type, seen = new Set()) {
+    if (seen.has(type)) return;
+    seen.add(type);
+    if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter)) return;
+    if (type.isUnionOrIntersection()) {
+      for (const part of type.types) { const problem = resultProblem(part, seen); if (problem) return problem; }
+      return;
+    }
+    if (type.flags & (ts.TypeFlags.BigIntLike | ts.TypeFlags.ESSymbolLike)) return "bigint/symbol";
+    if (!(type.flags & ts.TypeFlags.Object)) return;
+    if (checker.getSignaturesOfType(type, ts.SignatureKind.Call).length) return "function";
+    if (type.getSymbol()?.declarations?.some(d => /lib\.dom/.test(d.getSourceFile().fileName))) return "DOM object";
+    if (checker.isArrayType(type) || checker.isTupleType(type)) {
+      for (const item of checker.getTypeArguments(type)) { const problem = resultProblem(item, seen); if (problem) return problem; }
+      return;
+    }
+    for (const property of checker.getPropertiesOfType(type)) {
+      const declaration = property.valueDeclaration ?? property.declarations?.[0];
+      if (declaration) { const problem = resultProblem(checker.getTypeOfSymbolAtLocation(property, declaration), seen); if (problem) return problem; }
+    }
+  }
+  function checkCallback(fn) {
+    if (callbacks.includes(fn)) return;
+    callbacks.push(fn);
+    const signature = checker.getSignatureFromDeclaration(fn);
+    if (signature) {
+      const type = checker.getAwaitedType(checker.getReturnTypeOfSignature(signature));
+      const problem = type && resultProblem(type);
+      if (problem) report(fn, `Browser result contains a ${problem}; return a plain data projection instead.`);
+    }
+    if (!fn.body) { report(fn, "Browser callbacks must have an executable body, not a native/bound function."); return; }
+    function walk(node) {
+      if (ts.isTypeNode(node)) return;
+      if (ts.isExpressionStatement(node) && ts.isIdentifier(node.expression)) report(node, "Bare browser expression has no effect; pass data rather than source fragments.");
+      if (ts.isIdentifier(node)) {
+        const parent = node.parent;
+        const propertyName = (ts.isPropertyAccessExpression(parent) && parent.name === node)
+          || ((ts.isPropertyAssignment(parent) || ts.isMethodDeclaration(parent)) && parent.name === node);
+        if (!propertyName) {
+          const symbol = ts.isShorthandPropertyAssignment(parent) ? checker.getShorthandAssignmentValueSymbol(parent) : checker.getSymbolAtLocation(node);
+          const declarations = symbol?.declarations ?? [];
+          const local = declarations.some(d => d.getSourceFile() === fn.getSourceFile() && d.pos >= fn.pos && d.end <= fn.end);
+          const browserGlobal = declarations.length && declarations.some(d => /[\\/]typescript[\\/]lib[\\/]lib\.(dom|es|decorators)/.test(d.getSourceFile().fileName));
+          if (declarations.length && !local && !browserGlobal) report(node, `Browser callback captures '${node.text}'. Pass it through browserScript(callback, [args]) instead.`);
+        }
+      }
+      ts.forEachChild(node, walk);
+    }
+    walk(fn);
+  }
+  for (const file of program.getSourceFiles()) {
+    if (include && !include(file.fileName)) continue;
+    if (!(file.fileName.startsWith(resolve(root, "evals")) || file.fileName.endsWith("/packages/handsfree/test/e2e/browser.ts")) || file.fileName.includes("node_modules") || file.isDeclarationFile) continue;
+    function visit(node) {
+      if (ts.isCallExpression(node)) {
+        let name = ts.isIdentifier(node.expression) ? node.expression.text : ts.isPropertyAccessExpression(node.expression) ? node.expression.name.text : "";
+        const symbol = checker.getSymbolAtLocation(node.expression);
+        if (symbol?.flags & ts.SymbolFlags.Alias) name = checker.getAliasedSymbol(symbol).name;
+        if (names.has(name)) {
+          calls.push(node);
+          if (name === "browserScript" && node.arguments[1]) {
+            const problem = resultProblem(checker.getTypeAtLocation(node.arguments[1]));
+            if (problem) report(node.arguments[1], `Browser arguments contain a ${problem}; pass plain data instead.`);
+          }
+          for (const arg of node.arguments) {
+            const fn = callbackFor(arg);
+            if (fn) checkCallback(fn);
+          }
+          const index = ["browserScript", "browserSource"].includes(name) ? 0 : name === "waitForDenState" ? 2 : name === "eval" ? (node.arguments.length > 1 && checker.typeToString(checker.getTypeAtLocation(node.arguments[0])).includes("Surface") ? 1 : 0) : 1;
+          const arg = node.arguments[index];
+          if (arg && checker.getTypeAtLocation(arg).flags & ts.TypeFlags.StringLike) report(arg, "Raw browser code strings are forbidden; use a typed callback.");
+        }
+        if (name === "send" && node.arguments[0] && ts.isStringLiteral(node.arguments[0])
+          && ["Runtime.evaluate", "Runtime.callFunctionOn", "Page.addScriptToEvaluateOnNewDocument"].includes(node.arguments[0].text)
+          && !file.fileName.endsWith("/cdp/src/cdp.ts")) report(node, "Use the typed CDP evaluation/init-script API.");
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(file);
+  }
+  // Check the browser bodies even when unrelated legacy server imports fail the full eval compiler.
+  for (const diagnostic of ts.getPreEmitDiagnostics(program)) {
+    if (!diagnostic.file || diagnostic.start === undefined) continue;
+    if (calls.some(fn => fn.getSourceFile() === diagnostic.file && diagnostic.start >= fn.getStart() && diagnostic.start < fn.end)
+      || /\/cdp\/src\/(browser-script|browser-globals|cdp|surface)\.(ts|d\.ts)$/.test(diagnostic.file.fileName)) {
+      const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      failures.push(`${relative(root, diagnostic.file.fileName)}:${line + 1}:${character + 1}: TS${diagnostic.code} ${ts.flattenDiagnosticMessageText(diagnostic.messageText, " ")}`);
+    }
+  }
+  return { failures: [...new Set(failures)], count: callbacks.length };
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+  const configPath = resolve(root, "evals/tsconfig.json");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error) throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, " "));
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, resolve(root, "evals"));
+  const program = ts.createProgram(parsed.fileNames, parsed.options);
+  const { failures, count } = checkBrowserCode(program, root);
+  if (failures.length) { console.error(failures.join("\n")); process.exitCode = 1; }
+  else console.log(`Checked ${count} browser callbacks: no raw code strings, captured test variables, or browser type errors.`);
+}

--- a/evals/scripts/spec-channel-ratchet.test.mjs
+++ b/evals/scripts/spec-channel-ratchet.test.mjs
@@ -1,3 +1,7 @@
+import ts from "typescript";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkBrowserCode } from "./check-browser-code.mjs";
 import assert from "node:assert/strict";
 import test from "node:test";
 import { compareBaseline, countRawEscapes } from "./spec-channel-ratchet.mjs";
@@ -49,4 +53,40 @@ test("compareBaseline rejects raw escapes in an unbaselined new-layer spec", () 
       warnings: [],
     },
   );
+});
+
+
+test("browser boundary rejects raw strings, imported aliases, captures and mismatched arguments", () => {
+  const root = fileURLToPath(new URL("../..", import.meta.url));
+  const fixture = resolve(root, "evals/browser-guard-fixture.ts");
+  const source = `
+    import { browserScript as script } from "./packages/cdp/src/browser-script.ts";
+    import { evaluate as run } from "./packages/cdp/src/cdp.ts";
+    import type { CdpClient } from "./packages/cdp/src/cdp.ts";
+    declare const client: CdpClient;
+    const secret = "test-process-only";
+    run(client, "document.title");
+    run(client, () => secret);
+    run(client, () => ({ secret }));
+    run(client, () => process.pid);
+    run(client, () => document.body);
+    run(client, () => () => 1);
+    script((value) => Boolean(value), [new Date()]);
+    script((value: number) => value + 1, ["wrong"]);
+    script((title) => document.title === title, ["safe"]);
+  `;
+  const options = { strict: true, noEmit: true, skipLibCheck: true, target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.NodeNext, moduleResolution: ts.ModuleResolutionKind.NodeNext, allowImportingTsExtensions: true };
+  const host = ts.createCompilerHost(options);
+  const read = host.readFile.bind(host);
+  host.readFile = path => path === fixture ? source : read(path);
+  const program = ts.createProgram([fixture], options, host);
+  const result = checkBrowserCode(program, root, path => path === fixture);
+  assert.ok(result.failures.some(message => message.includes("Raw browser code")));
+  assert.equal(result.failures.filter(message => message.includes("captures 'secret'")).length, 2);
+  assert.ok(result.failures.some(message => message.includes("captures 'process'")));
+  assert.ok(result.failures.some(message => message.includes("not assignable to type 'number'")));
+  assert.equal(result.failures.filter(message => message.includes("Browser result contains")).length, 2);
+  assert.ok(result.failures.some(message => message.includes("Browser arguments contain")));
+  assert.ok(!result.failures.some(message => message.includes("captures 'document'")));
 });

--- a/evals/specs/active-session-workspace-storm.e2e.test.ts
+++ b/evals/specs/active-session-workspace-storm.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { readFile } from "node:fs/promises";
 import { expect } from "vitest";
 import {
@@ -267,10 +268,10 @@ function agentWorkloads(plans: WorkspacePlan[]) {
 }
 
 async function listWorkspaces(desktopApp: App): Promise<WorkspaceListing> {
-  const value = await evalIn(desktopApp, `(async () => {
+  const value = await evalIn(desktopApp, async () => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
-    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + "/workspaces", {
+    const response = await fetch(String(info.baseUrl).replace(/\/+$/, "") + "/workspaces", {
       headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
       signal: AbortSignal.timeout(15000),
     });
@@ -278,10 +279,10 @@ async function listWorkspaces(desktopApp: App): Promise<WorkspaceListing> {
     const items = Array.isArray(body?.items) ? body.items : [];
     return {
       ok: response.ok,
-      ids: items.map((item) => String(item?.id ?? "")).filter(Boolean),
+      ids: items.map((item: { id?: unknown }) => String(item?.id ?? "")).filter(Boolean),
       activeId: typeof body?.activeId === "string" ? body.activeId : null,
     };
-  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  }, { awaitPromise: true, timeoutMs: 20_000 });
   if (!isRecord(value) || value.ok !== true || !Array.isArray(value.ids)) {
     throw new Error(`Listing workspaces failed: ${JSON.stringify(value)}`);
   }
@@ -306,16 +307,16 @@ async function createWorkspace(desktopApp: App, path: string): Promise<string> {
 }
 
 async function configureWorkspaces(desktopApp: App, plans: WorkspacePlan[], baseUrl: string): Promise<void> {
-  const result = await evalIn(desktopApp, `(async () => {
+  const result = await evalIn(desktopApp, browserScript(async (value, providerId, inputValue, modelId, modelName, inputProviderId, inputModelId, inputValue2) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
-    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const root = String(info.baseUrl).replace(/\/+$/, "");
     const headers = {
       Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
       "Content-Type": "application/json",
     };
     const outcomes = [];
-    for (const workspaceId of ${JSON.stringify(plans.map((plan) => plan.workspaceId))}) {
+    for (const workspaceId of value) {
       const config = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
         method: "PATCH",
         headers,
@@ -323,12 +324,12 @@ async function configureWorkspaces(desktopApp: App, plans: WorkspacePlan[], base
           opencode: {
             permission: { edit: "allow", write: "allow", read: "allow", bash: "allow" },
             provider: {
-              [${JSON.stringify(providerId)}]: {
+              [providerId]: {
                 npm: "@ai-sdk/openai-compatible",
                 name: "Active session storm mock",
-                options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-active-session-storm" },
+                options: { baseURL: inputValue, apiKey: "sk-active-session-storm" },
                 models: {
-                  [${JSON.stringify(modelId)}]: { name: ${JSON.stringify(modelName)}, tool_call: true },
+                  [modelId]: { name: modelName, tool_call: true },
                 },
               },
             },
@@ -348,18 +349,18 @@ async function configureWorkspaces(desktopApp: App, plans: WorkspacePlan[], base
       outcomes.push({ workspaceId, stage: "reload", status: reload.status, text: reload.ok ? "ok" : (await reload.text()).slice(0, 300) });
     }
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
       ...preferences,
-      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      defaultModel: { providerID: inputProviderId, modelID: inputModelId },
       modelVariant: null,
       providerStepCompleted: true,
     }));
-    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.setItem("openwork.defaultModel", inputValue2);
     return { outcomes };
-  })()`, { awaitPromise: true, timeoutMs: 240_000 });
+  }, [plans.map((plan) => plan.workspaceId), providerId, `${baseUrl}/v1`, modelId, modelName, providerId, modelId, `${providerId}/${modelId}`]), { awaitPromise: true, timeoutMs: 240_000 });
   if (!isRecord(result) || !Array.isArray(result.outcomes)) {
     throw new Error(`Workspace provider configuration failed: ${JSON.stringify(result)}`);
   }
@@ -370,12 +371,12 @@ async function configureWorkspaces(desktopApp: App, plans: WorkspacePlan[], base
 async function openExactSessionRoute(desktopApp: App, plan: WorkspacePlan): Promise<void> {
   const route = `/workspace/${plan.workspaceId}/session/${plan.sessionId}`;
   await go(desktopApp, route, { timeoutMs: 60_000 });
-  await waitFor(desktopApp, `(() => {
-    const current = window.__openworkControl?.snapshot().route.split("?")[0].replace(/\\/+$/, "") ?? "";
-    return current === ${JSON.stringify(route)}
-      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(plan.workspaceId)}
-      && document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") === ${JSON.stringify(plan.sessionId)};
-  })()`, { timeoutMs: 60_000, label: `exact route ${route}` });
+  await waitFor(desktopApp, browserScript((inputRoute, workspaceId, sessionId) => {
+    const current = window.__openworkControl?.snapshot().route.split("?")[0].replace(/\/+$/, "") ?? "";
+    return current === inputRoute
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId
+      && document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") === sessionId;
+  }, [route, plan.workspaceId, plan.sessionId]), { timeoutMs: 60_000, label: `exact route ${route}` });
 }
 
 async function readSessionFacts(desktopApp: App, workspaceId: string, sessionId: string): Promise<SessionFacts> {
@@ -402,38 +403,38 @@ async function readSessionFacts(desktopApp: App, workspaceId: string, sessionId:
 }
 
 async function readSurfaceFacts(desktopApp: App, marker: string): Promise<SurfaceFacts> {
-  const value = await evalIn(desktopApp, `(() => {
+  const value = await evalIn(desktopApp, browserScript((marker) => {
     const body = document.body.innerText ?? "";
-    const authActions = [...document.querySelectorAll("button, a")]
+    const authActions = [...document.querySelectorAll<HTMLElement>("button, a")]
       .map((element) => (element.textContent ?? "").trim())
       .filter((text) => /^(sign in|reconnect|connect again|log in)$/i.test(text));
     return {
       route: window.__openworkControl?.snapshot().route ?? window.location.hash,
-      sessionId: document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "",
+      sessionId: document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "",
       authActions,
       crash: /aw, snap|renderer process gone|application error|uncaught exception/i.test(body),
-      bodyHasMarker: body.includes(${JSON.stringify(marker)}),
+      bodyHasMarker: body.includes(marker),
       bodyHasToolActivity: body.includes("Hold workspace") || body.includes("sleep "),
     };
-  })()`);
+  }, [marker]));
   return parseSurfaceFacts(value);
 }
 
 async function readEngineRuntimeFacts(desktopApp: App): Promise<EngineRuntimeFacts> {
   return parseEngineRuntimeFacts(await evalIn(
     desktopApp,
-    `window.__OPENWORK_ELECTRON__.invokeDesktop("runtimeStatus")`,
+    () => (window.__OPENWORK_ELECTRON__.invokeDesktop("runtimeStatus")),
     { awaitPromise: true, timeoutMs: 15_000 },
   ));
 }
 
 async function readWorkspaceFileFacts(desktopApp: App, plan: WorkspacePlan): Promise<WorkspaceFileFacts> {
-  const value = await evalIn(desktopApp, `(async () => {
+  const value = await evalIn(desktopApp, browserScript(async (workspaceId, value) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { status: 0, content: "" };
     const response = await fetch(
-      String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(${JSON.stringify(plan.workspaceId)})
-        + "/files/content?path=" + encodeURIComponent(${JSON.stringify(plan.filePath.split("/").pop() ?? "")}),
+      String(info.baseUrl).replace(/\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId)
+        + "/files/content?path=" + encodeURIComponent(value),
       {
         headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
         signal: AbortSignal.timeout(10000),
@@ -441,7 +442,7 @@ async function readWorkspaceFileFacts(desktopApp: App, plan: WorkspacePlan): Pro
     );
     const body = await response.json().catch(() => ({}));
     return { status: response.status, content: typeof body?.content === "string" ? body.content : "" };
-  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  }, [plan.workspaceId, plan.filePath.split("/").pop() ?? ""]), { awaitPromise: true, timeoutMs: 15_000 });
   if (!isRecord(value) || typeof value.status !== "number") {
     throw new Error(`Invalid workspace file facts: ${JSON.stringify(value)}`);
   }
@@ -474,13 +475,13 @@ function sessionCorpus(facts: SessionFacts): string {
 }
 
 async function allowVisibleToolPermission(desktopApp: App): Promise<boolean> {
-  const clicked = await evalIn(desktopApp, `(() => {
+  const clicked = await evalIn(desktopApp, () => {
     const button = [...document.querySelectorAll("button")]
       .find((candidate) => (candidate.textContent ?? "").trim() === "Allow for session" && !candidate.disabled);
     if (!(button instanceof HTMLButtonElement)) return false;
     button.click();
     return true;
-  })()`);
+  });
   if (clicked === true) await sleep(250);
   return clicked === true;
 }
@@ -560,8 +561,8 @@ test.skipIf(!runnable)(
     // The already-mounted model store predates these workspace configs. Reload
     // once, before any session exists, so every workspace sees the same mock
     // provider without perturbing an in-flight engine event subscription.
-    await evalIn(desktopApp, "location.reload(); true");
-    await waitFor(desktopApp, "Boolean(window.__openworkControl)", {
+    await evalIn(desktopApp, () => { location.reload(); return true; });
+    await waitFor(desktopApp, () => (Boolean(window.__openworkControl)), {
       timeoutMs: 60_000,
       label: "desktop reloaded with the storm model preference",
     });
@@ -574,7 +575,7 @@ test.skipIf(!runnable)(
     const workloadStartedAt = new Date().toISOString();
     for (const plan of plans) {
       await go(desktopApp, `/workspace/${plan.workspaceId}/session`);
-      await waitFor(desktopApp, `(localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(plan.workspaceId)}`, {
+      await waitFor(desktopApp, browserScript((workspaceId) => ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId), [plan.workspaceId]), {
         timeoutMs: 60_000,
         label: `workspace ${plan.index} active before task creation`,
       });

--- a/evals/specs/attachment-upload-loading-state.e2e.test.ts
+++ b/evals/specs/attachment-upload-loading-state.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { attachmentUpload } from "../worlds/chat.ts";
@@ -22,7 +23,7 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
 
   await user.type("composer", "Describe the attached image.");
   // TODO(primitive): attach an in-memory file through the composer's file chooser.
-  const attached = await seed.evalIn(world.app, `async (attachmentName) => {
+  const attached = await seed.evalIn(world.app, browserScript(async (attachmentName) => {
       const canvas = document.createElement("canvas");
       canvas.width = 2400;
       canvas.height = 2400;
@@ -36,7 +37,7 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
       const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
       if (!(blob instanceof Blob)) return { error: "no blob" };
       const file = new File([blob], attachmentName, { type: "image/png" });
-      const input = [...document.querySelectorAll('input[type="file"][multiple]')].at(-1);
+      const input = [...document.querySelectorAll<HTMLInputElement>('input[type="file"][multiple]')].at(-1);
       if (!(input instanceof HTMLInputElement)) return { error: "no composer file input" };
       const transfer = new DataTransfer();
       transfer.items.add(file);
@@ -44,17 +45,17 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
       const startedAt = performance.now();
       input.dispatchEvent(new Event("change", { bubbles: true }));
       const deadline = performance.now() + 5000;
-      while (performance.now() < deadline && !document.querySelector("[data-attachment-id]")) {
+      while (performance.now() < deadline && !document.querySelector<HTMLElement>("[data-attachment-id]")) {
         await new Promise((resolve) => requestAnimationFrame(resolve));
       }
-      const chip = document.querySelector("[data-attachment-id]");
+      const chip = document.querySelector<HTMLElement>("[data-attachment-id]");
       return {
         fileBytes: file.size,
         elapsedMs: Math.round(performance.now() - startedAt),
         chipTitle: chip?.getAttribute("title") ?? "",
         chipStatus: chip?.getAttribute("data-attachment-status") ?? "",
       };
-  }`, { args: [attachmentName], awaitPromise: true, timeoutMs: 60_000 });
+  }, [attachmentName]), { awaitPromise: true, timeoutMs: 60_000 });
   if (!isRecord(attached)) throw new Error(`Attachment result was invalid: ${JSON.stringify(attached)}`);
   expect(attached.fileBytes).toEqual(expect.any(Number));
   expect(attached.elapsedMs).toEqual(expect.any(Number));
@@ -65,32 +66,32 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   await user.screenshot();
 
   await step("paste a video alongside the image", async () => {
-    expect(await seed.evalIn(world.app, `(() => {
-      const editor = document.querySelector('[contenteditable="true"]');
+    expect(await seed.evalIn(world.app, () => {
+      const editor = document.querySelector<HTMLElement>('[contenteditable="true"]');
       if (!(editor instanceof HTMLElement)) return false;
       const transfer = new DataTransfer();
       transfer.items.add(new File([new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112])], "pasted-recording.mp4", { type: "video/mp4" }));
       editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: transfer }));
       return true;
-    })()`)).toBe(true);
+    })).toBe(true);
     await user.see({ text: "pasted-recording.mp4" });
   });
 
   // TODO(primitive): observe a transient attachment status during a user send.
-  await seed.evalIn(world.app, `(() => {
+  await seed.evalIn(world.app, () => {
     globalThis.__attachmentUploadingSeen = false;
     const record = () => {
-      if (document.querySelector('[data-attachment-status="uploading"]')) globalThis.__attachmentUploadingSeen = true;
+      if (document.querySelector<HTMLElement>('[data-attachment-status="uploading"]')) globalThis.__attachmentUploadingSeen = true;
     };
     const observer = new MutationObserver(record);
     observer.observe(document.body, { subtree: true, attributes: true, attributeFilter: ["data-attachment-status"], childList: true });
     record();
     return true;
-  })()`);
+  });
   await user.click("Run task");
 
   // TODO(primitive): await a transient attachment-status witness.
-  expect(await probe.eventually(() => probe.eval(`globalThis.__attachmentUploadingSeen === true`), {
+  expect(await probe.eventually(() => probe.eval(() => (globalThis.__attachmentUploadingSeen === true)), {
     within: 30_000,
     intervalMs: 50,
     label: "attachment uploading state observed",
@@ -99,8 +100,8 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   await user.notSee({ text: /1 queued/ });
   expect((await probe.hash()).includes("/session/ses_")).toBe(true);
   // TODO(primitive): inspect attachment cleanup and error-toast state after send.
-  expect(await probe.eval(`!document.querySelector("[data-attachment-id]")
-    && !document.querySelector('[data-sonner-toast][data-type="error"]')`)).toBe(true);
+  expect(await probe.eval(() => (!document.querySelector<HTMLElement>("[data-attachment-id]")
+    && !document.querySelector<HTMLElement>('[data-sonner-toast][data-type="error"]')))).toBe(true);
   await step("sent video remains visible without a binary model error", async () => {
     await user.see({ text: "pasted-recording.mp4" });
     await user.see({ text: "attachment upload loading proof" });
@@ -108,6 +109,6 @@ test("attaching an image shows its chip instantly and sends with a visible uploa
   });
   await user.reload();
   await user.see({ text: "pasted-recording.mp4" });
-  expect(await probe.eval(`document.querySelectorAll('button[title="Open pasted-recording.mp4 in Artifacts"]').length`)).toBe(1);
+  expect(await probe.eval(() => (document.querySelectorAll<HTMLButtonElement>('button[title="Open pasted-recording.mp4 in Artifacts"]').length))).toBe(1);
   await user.screenshot();
 });

--- a/evals/specs/automation-registration-recovery.e2e.test.ts
+++ b/evals/specs/automation-registration-recovery.e2e.test.ts
@@ -42,7 +42,7 @@ test("desktop registration recovers from a transient Den outage without another 
   })
   await proxy.faults.status(registrationPath, 503, { times: 1 })
   const start = (await proxy.requestLog()).length
-  await evalIn(desktop, `window.dispatchEvent(new Event("online"))`)
+  await evalIn(desktop, () => (window.dispatchEvent(new Event("online"))))
   await eventually(async () => {
     const requests = (await proxy.requestLog()).slice(start)
       .filter((request) => request.path === registrationPath)

--- a/evals/specs/bench-openwork-app-v1.e2e.test.ts
+++ b/evals/specs/bench-openwork-app-v1.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { execFile } from "node:child_process";
 import { writeFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { createServer } from "node:http";
@@ -272,7 +273,7 @@ async function writeProviderConfig(workspacePath: string, witnessUrl: string): P
 }
 
 async function readServerInfo(app: Surface): Promise<ServerInfo> {
-  const value = await evalIn(app, `(async () => {
+  const value = await evalIn(app, async () => {
     let baseUrl = "";
     let token = "";
     try {
@@ -280,7 +281,7 @@ async function readServerInfo(app: Surface): Promise<ServerInfo> {
       if (invokeDesktop) {
         const info = await invokeDesktop("openworkServerInfo");
         if (info && info.running === true) {
-          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\\\/+$/, "");
+          baseUrl = String(info.baseUrl ?? info.connectUrl ?? "").trim().replace(/\/+$/, "");
           token = String(info.ownerToken ?? info.clientToken ?? "").trim();
         }
       }
@@ -291,7 +292,7 @@ async function readServerInfo(app: Surface): Promise<ServerInfo> {
       token = token || (localStorage.getItem("openwork.server.token") ?? "").trim();
     }
     return { baseUrl, token };
-  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  }, { awaitPromise: true, timeoutMs: 15_000 });
   if (!isRecord(value) || typeof value.baseUrl !== "string" || !value.baseUrl || typeof value.token !== "string" || !value.token) {
     throw new Error(`Local server credentials are unavailable: ${JSON.stringify(value)}`);
   }
@@ -461,7 +462,7 @@ async function observeExecutionEvents(info: ServerInfo, workspaceId: string, con
 
 async function pollExpression(
   app: Surface,
-  expression: string,
+  expression: import("@openwork/cdp").BrowserEvaluation,
   label: string,
   within = 120_000,
 ): Promise<void> {
@@ -485,52 +486,52 @@ async function waitForComposerReady(app: Surface, label: string): Promise<void> 
 async function selectBenchModel(app: Surface): Promise<void> {
   await pollExpression(
     app,
-    `Boolean(document.querySelector('button[aria-label="Change model"]'))`,
+    () => (Boolean(document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]'))),
     "bench model picker trigger",
   );
-  const opened = await evalIn(app, `(() => {
-    const trigger = document.querySelector('button[aria-label="Change model"]');
+  const opened = await evalIn(app, () => {
+    const trigger = document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]');
     if (!(trigger instanceof HTMLButtonElement)) return false;
     trigger.click();
     return true;
-  })()`);
+  });
   expect(opened).toBe(true);
   await pollExpression(
     app,
-    `Boolean(document.querySelector('[data-slot="popover-content"]'))`,
+    () => (Boolean(document.querySelector<HTMLElement>('[data-slot="popover-content"]'))),
     "open bench model picker",
     30_000,
   );
-  const modelPaneOpened = await evalIn(app, `(() => {
-    const popover = document.querySelector('[data-slot="popover-content"]');
+  const modelPaneOpened = await evalIn(app, browserScript((modelName) => {
+    const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
     if (!(popover instanceof HTMLElement)) return false;
-    if ([...popover.querySelectorAll('[data-slot="command-item"]')]
-      .some((item) => (item.textContent ?? "").includes(${JSON.stringify(modelName)}))) return true;
+    if ([...popover.querySelectorAll<HTMLElement>('[data-slot="command-item"]')]
+      .some((item) => (item.textContent ?? "").includes(modelName))) return true;
     const modelButton = [...popover.querySelectorAll('button')]
       .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
     if (!(modelButton instanceof HTMLButtonElement)) return false;
     modelButton.click();
     return true;
-  })()`);
+  }, [modelName]));
   expect(modelPaneOpened).toBe(true);
-  await pollExpression(app, `(() => {
-    const popover = document.querySelector('[data-slot="popover-content"]');
+  await pollExpression(app, browserScript((modelName) => {
+    const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
     if (!(popover instanceof HTMLElement)) return false;
-    return [...popover.querySelectorAll('[data-slot="command-item"]')]
-      .some((item) => (item.textContent ?? "").includes(${JSON.stringify(modelName)}));
-  })()`, "Bench Model listed in picker");
-  const picked = await evalIn(app, `(() => {
-    const popover = document.querySelector('[data-slot="popover-content"]');
-    const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
-      .find((candidate) => (candidate.textContent ?? "").includes(${JSON.stringify(modelName)}));
+    return [...popover.querySelectorAll<HTMLElement>('[data-slot="command-item"]')]
+      .some((item) => (item.textContent ?? "").includes(modelName));
+  }, [modelName]), "Bench Model listed in picker");
+  const picked = await evalIn(app, browserScript((modelName) => {
+    const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
+    const item = [...(popover?.querySelectorAll<HTMLElement>('[data-slot="command-item"]') ?? [])]
+      .find((candidate) => (candidate.textContent ?? "").includes(modelName));
     if (!(item instanceof HTMLElement)) return false;
     item.click();
     return true;
-  })()`);
+  }, [modelName]));
   expect(picked).toBe(true);
   await pollExpression(
     app,
-    `(document.querySelector('button[aria-label="Change model"]')?.textContent ?? "").includes(${JSON.stringify(modelName)})`,
+    browserScript((modelName) => ((document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]')?.textContent ?? "").includes(modelName)), [modelName]),
     "Bench Model selected",
     30_000,
   );
@@ -557,62 +558,62 @@ async function selectBenchModelV2(app: Surface): Promise<void> {
   const deadline = Date.now() + 60_000;
   await pollExpression(
     app,
-    `Boolean(document.querySelector('button[aria-label="Change model"]'))`,
+    () => (Boolean(document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]'))),
     "v2 bench model picker trigger",
     60_000,
   );
   let lastItems: string[] = [];
   while (Date.now() < deadline) {
-    const opened = await evalIn(app, `(() => {
-      if (document.querySelector('[data-slot="popover-content"]')) return true;
-      const trigger = document.querySelector('button[aria-label="Change model"]');
+    const opened = await evalIn(app, () => {
+      if (document.querySelector<HTMLElement>('[data-slot="popover-content"]')) return true;
+      const trigger = document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]');
       if (!(trigger instanceof HTMLButtonElement)) return false;
       trigger.click();
       return true;
-    })()`);
+    });
     if (opened === true) {
       await sleep(300);
-      await evalIn(app, `(() => {
-        const popover = document.querySelector('[data-slot="popover-content"]');
+      await evalIn(app, browserScript((modelName, modelId) => {
+        const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
         if (!(popover instanceof HTMLElement)) return false;
-        const matches = (text) => text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
-        if ([...popover.querySelectorAll('[data-slot="command-item"]')]
+        const matches = (text: string) => text.includes(modelName) || text.includes(modelId);
+        if ([...popover.querySelectorAll<HTMLElement>('[data-slot="command-item"]')]
           .some((item) => matches(item.textContent ?? ""))) return true;
         const modelButton = [...popover.querySelectorAll('button')]
           .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
         if (!(modelButton instanceof HTMLButtonElement)) return false;
         modelButton.click();
         return true;
-      })()`);
+      }, [modelName, modelId]));
       await sleep(200);
-      const items = await evalIn(app, `(() => {
-        const popover = document.querySelector('[data-slot="popover-content"]');
+      const items = await evalIn(app, () => {
+        const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
         if (!(popover instanceof HTMLElement)) return [];
-        return [...popover.querySelectorAll('[data-slot="command-item"]')]
+        return [...popover.querySelectorAll<HTMLElement>('[data-slot="command-item"]')]
           .map((item) => (item.textContent ?? "").trim());
-      })()`);
+      });
       if (Array.isArray(items) && items.every((item) => typeof item === "string")) {
         lastItems = items;
         if (items.some((item) => item.includes(modelName) || item.includes(modelId))) {
-          const picked = await evalIn(app, `(() => {
-            const popover = document.querySelector('[data-slot="popover-content"]');
-            const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
+          const picked = await evalIn(app, browserScript((modelName, modelId) => {
+            const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
+            const item = [...(popover?.querySelectorAll<HTMLElement>('[data-slot="command-item"]') ?? [])]
               .find((candidate) => {
                 const text = candidate.textContent ?? "";
-                return text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
+                return text.includes(modelName) || text.includes(modelId);
               });
             if (!(item instanceof HTMLElement)) return false;
             item.click();
             return true;
-          })()`);
+          }, [modelName, modelId]));
           expect(picked).toBe(true);
           const remaining = Math.max(1, deadline - Date.now());
           await pollExpression(
             app,
-            `(() => {
-              const text = document.querySelector('button[aria-label="Change model"]')?.textContent ?? "";
-              return text.includes(${JSON.stringify(modelName)}) || text.includes(${JSON.stringify(modelId)});
-            })()`,
+            browserScript((modelName, modelId) => {
+              const text = document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]')?.textContent ?? "";
+              return text.includes(modelName) || text.includes(modelId);
+            }, [modelName, modelId]),
             "v2 Bench Model selected",
             remaining,
           );
@@ -643,34 +644,34 @@ async function ensureBenchModelV2(app: Surface): Promise<boolean> {
 }
 
 async function typeIntoComposer(app: Surface, text: string): Promise<void> {
-  await pollExpression(app, `(() => {
-    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+  await pollExpression(app, () => {
+    const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
     return editor instanceof HTMLElement && (editor.innerText ?? "").trim() === "";
-  })()`, "empty composer ready");
-  const focused = await evalIn(app, `(() => {
-    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+  }, "empty composer ready");
+  const focused = await evalIn(app, () => {
+    const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
     if (!(editor instanceof HTMLElement)) return false;
     editor.focus();
     return true;
-  })()`);
+  });
   expect(focused).toBe(true);
   await app.client.send("Input.insertText", { text });
   const expectedLength = text.length;
   const expectedStart = text.slice(0, 64);
   const expectedEnd = text.slice(-64);
-  await pollExpression(app, `(() => {
-    const value = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "";
-    return value.length === ${expectedLength}
-      && value.startsWith(${JSON.stringify(expectedStart)})
-      && value.endsWith(${JSON.stringify(expectedEnd)});
-  })()`, `composer contains ${expectedLength} inserted characters`);
+  await pollExpression(app, browserScript((expectedLength, expectedStart, expectedEnd) => {
+    const value = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "";
+    return value.length === expectedLength
+      && value.startsWith(expectedStart)
+      && value.endsWith(expectedEnd);
+  }, [expectedLength, expectedStart, expectedEnd]), `composer contains ${expectedLength} inserted characters`);
 }
 
 async function activeSessionId(app: Surface): Promise<string> {
   return eventually(async () => {
     const value = await evalIn(
       app,
-      `document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""`,
+      () => (document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""),
     );
     return typeof value === "string" ? value : "";
   }, {
@@ -687,7 +688,7 @@ async function measurePreparedSend(
   witnessNonce: string,
 ): Promise<SendFacts> {
   const beforeAssistantIds = await evalIn(app,
-    `[...document.querySelectorAll('[data-message-role="assistant"]')].map((message) => message.getAttribute('data-message-id'))`);
+    () => ([...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')].map((message) => message.getAttribute('data-message-id'))));
   if (!Array.isArray(beforeAssistantIds)) throw new Error("Invalid assistant message identities.");
   const startedAt = Date.now();
   await clickButton(app, "Run task", { timeoutMs: 30_000 });
@@ -697,23 +698,23 @@ async function measurePreparedSend(
   // Observe all milestones together. Waiting for the user row first masks
   // tokens that already streamed while that row was still being reconciled.
   await eventually(async () => {
-    const observed = await evalIn(app, `(() => {
-      const users = [...document.querySelectorAll('[data-message-role="user"]')];
-      const assistants = [...document.querySelectorAll('[data-message-role="assistant"]')];
+    const observed = await evalIn(app, browserScript((beforeAssistantIds, expectedUserMarker, witnessNonce) => {
+      const users = [...document.querySelectorAll<HTMLElement>('[data-message-role="user"]')];
+      const assistants = [...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')];
       const text = assistants[assistants.length - 1]?.innerText ?? "";
       const latestAssistant = assistants[assistants.length - 1];
       const newAssistant = Boolean(latestAssistant)
-        && !${JSON.stringify(beforeAssistantIds)}.includes(latestAssistant?.getAttribute('data-message-id'));
-      const sessionId = document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id');
-      const row = [...document.querySelectorAll('[data-sidebar-session-id]')]
+        && !beforeAssistantIds.includes(latestAssistant?.getAttribute('data-message-id'));
+      const sessionId = document.querySelector<HTMLElement>('[data-session-surface-id]')?.getAttribute('data-session-surface-id');
+      const row = [...document.querySelectorAll<HTMLElement>('[data-sidebar-session-id]')]
         .find((item) => item.getAttribute('data-sidebar-session-id') === sessionId);
       return {
-        userRendered: (users[users.length - 1]?.innerText ?? "").includes(${JSON.stringify(expectedUserMarker)}),
+        userRendered: (users[users.length - 1]?.innerText ?? "").includes(expectedUserMarker),
         firstToken: newAssistant && text.includes("token 1 "),
-        complete: newAssistant && Boolean(row) && text.includes("token 20")
-          && text.includes(${JSON.stringify(witnessNonce)}) && !row.querySelector('[data-session-loading-indicator]'),
+        complete: newAssistant && !!row && text.includes("token 20")
+          && text.includes(witnessNonce) && !row.querySelector<HTMLElement>('[data-session-loading-indicator]'),
       };
-    })()`);
+    }, [beforeAssistantIds, expectedUserMarker, witnessNonce]));
     if (!isRecord(observed)) throw new Error("Invalid benchmark milestone observation.");
     const elapsed = Date.now() - startedAt;
     if (observed.userRendered === true) userRendered ??= elapsed;
@@ -730,15 +731,15 @@ async function measurePreparedSend(
     throw new Error("Benchmark render milestones were incomplete.");
   }
   const sessionId = await activeSessionId(app);
-  const facts = await evalIn(app, `(() => {
-    const users = [...document.querySelectorAll('[data-message-role="user"]')];
-    const assistants = [...document.querySelectorAll('[data-message-role="assistant"]')];
+  const facts = await evalIn(app, () => {
+    const users = [...document.querySelectorAll<HTMLElement>('[data-message-role="user"]')];
+    const assistants = [...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')];
     const latestUser = users[users.length - 1];
     return {
-      userLength: latestUser?.querySelector("span.whitespace-pre-wrap")?.textContent?.length ?? 0,
+      userLength: latestUser?.querySelector<HTMLElement>("span.whitespace-pre-wrap")?.textContent?.length ?? 0,
       assistantText: assistants[assistants.length - 1]?.innerText ?? "",
     };
-  })()`);
+  });
   if (!isRecord(facts) || typeof facts.userLength !== "number" || typeof facts.assistantText !== "string") {
     throw new Error(`Could not read completed message facts: ${JSON.stringify(facts)}`);
   }
@@ -758,26 +759,26 @@ async function sendMessage(app: Surface, text: string, witnessNonce: string): Pr
 async function createNewSession(app: Surface): Promise<{ sessionId: string; ms: number }> {
   const previousSessionId = await evalIn(
     app,
-    `document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""`,
+    () => (document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""),
   );
   const previous = typeof previousSessionId === "string" ? previousSessionId : "";
-  await pollExpression(app, `(() => {
-    const button = document.querySelector('[data-sidebar-new-chat]');
+  await pollExpression(app, () => {
+    const button = document.querySelector<HTMLElement>('[data-sidebar-new-chat]');
     return button instanceof HTMLButtonElement && !button.disabled;
-  })()`, "enabled sidebar New task control");
+  }, "enabled sidebar New task control");
   const startedAt = Date.now();
-  const clicked = await evalIn(app, `(() => {
-    const button = document.querySelector("[data-sidebar-new-chat]");
+  const clicked = await evalIn(app, () => {
+    const button = document.querySelector<HTMLElement>("[data-sidebar-new-chat]");
     if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
     button.click();
     return true;
-  })()`);
+  });
   expect(clicked).toBe(true);
   const sessionId = await eventually(async () => {
-    const value = await evalIn(app, `(() => {
-      const match = /\\/session\\/(ses_[^/?#]+)/.exec(window.location.hash);
+    const value = await evalIn(app, () => {
+      const match = /\/session\/(ses_[^/?#]+)/.exec(window.location.hash);
       return match?.[1] ?? "";
-    })()`);
+    });
     return typeof value === "string" ? value : "";
   }, {
     within: 60_000,
@@ -785,10 +786,10 @@ async function createNewSession(app: Surface): Promise<{ sessionId: string; ms: 
     label: "new session route",
     until: (value) => value.startsWith("ses_") && value !== previous,
   });
-  await pollExpression(app, `(() => {
-    const surface = document.querySelector("[data-session-surface-id]");
-    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(sessionId)};
-  })()`, `new session surface ${sessionId}`);
+  await pollExpression(app, browserScript((sessionId) => {
+    const surface = document.querySelector<HTMLElement>("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === sessionId;
+  }, [sessionId]), `new session surface ${sessionId}`);
   await waitForComposerReady(app, `new session ${sessionId} composer and Run task`);
   return { sessionId, ms: Date.now() - startedAt };
 }
@@ -796,36 +797,36 @@ async function createNewSession(app: Surface): Promise<{ sessionId: string; ms: 
 async function createSecondWorkspaceViaUi(app: Surface, firstWorkspaceId: string, workspacePath: string): Promise<string> {
   await pollExpression(
     app,
-    `Boolean(document.querySelector('button[aria-label="Add workspace"]'))`,
+    () => (Boolean(document.querySelector<HTMLButtonElement>('button[aria-label="Add workspace"]'))),
     "Add workspace control",
   );
-  const addClicked = await evalIn(app, `(() => {
-    const button = document.querySelector('button[aria-label="Add workspace"]');
+  const addClicked = await evalIn(app, () => {
+    const button = document.querySelector<HTMLButtonElement>('button[aria-label="Add workspace"]');
     if (!(button instanceof HTMLButtonElement)) return false;
     button.click();
     return true;
-  })()`);
+  });
   expect(addClicked).toBe(true);
-  await pollExpression(app, `(() => [...document.querySelectorAll("button")]
-    .some((button) => (button.textContent ?? "").trim().startsWith("Local workspace") && !button.disabled))()`, "Local workspace option");
-  const localClicked = await evalIn(app, `(() => {
+  await pollExpression(app, () => ((() => [...document.querySelectorAll("button")]
+    .some((button) => (button.textContent ?? "").trim().startsWith("Local workspace") && !button.disabled))()), "Local workspace option");
+  const localClicked = await evalIn(app, () => {
     const button = [...document.querySelectorAll("button")]
       .find((candidate) => (candidate.textContent ?? "").trim().startsWith("Local workspace") && !candidate.disabled);
     if (!(button instanceof HTMLButtonElement)) return false;
     button.click();
     return true;
-  })()`);
+  });
   expect(localClicked).toBe(true);
-  await pollExpression(app, `document.body.innerText.includes("No folder selected yet.")`, "local workspace folder chooser");
+  await pollExpression(app, () => (document.body.innerText.includes("No folder selected yet.")), "local workspace folder chooser");
 
   // CDP cannot operate Electron's native folder dialog. Dispatching the same
   // selected-folder reducer event used after that dialog returns keeps the rest
   // of workspace creation on the visible Add workspace flow.
-  const injected = await evalIn(app, `(() => {
-    const placeholder = [...document.querySelectorAll("span, div, p")]
+  const injected = await evalIn(app, browserScript((workspacePath) => {
+    const placeholder = [...document.querySelectorAll<HTMLElement>("span, div, p")]
       .find((node) => (node.textContent ?? "").includes("No folder selected yet."));
     if (!placeholder) return { ok: false, reason: "folder placeholder not found" };
-    const key = Object.keys(placeholder).find((candidate) => candidate.startsWith("__reactFiber$"));
+    const key = Object.keys(placeholder).find((candidate): candidate is `__reactFiber$${string}` => candidate.startsWith("__reactFiber$"));
     let fiber = key ? placeholder[key] : null;
     while (fiber) {
       const componentName = fiber.elementType?.name || fiber.type?.name || "";
@@ -836,20 +837,20 @@ async function createSecondWorkspaceViaUi(app: Surface, firstWorkspaceId: string
     let hook = fiber.memoizedState;
     while (hook) {
       if (hook.queue?.dispatch) {
-        hook.queue.dispatch({ type: "set", key: "selectedFolder", value: ${JSON.stringify(workspacePath)} });
+        hook.queue.dispatch({ type: "set", key: "selectedFolder", value: workspacePath });
         hook.queue.dispatch({ type: "set", key: "pickingFolder", value: false });
         return { ok: true };
       }
       hook = hook.next;
     }
     return { ok: false, reason: "folder reducer dispatch not found" };
-  })()`);
+  }, [workspacePath]));
   if (!isRecord(injected) || injected.ok !== true) {
     throw new Error(`Could not simulate the native folder selection: ${JSON.stringify(injected)}`);
   }
   await clickButton(app, "Create Workspace", { timeoutMs: 30_000 });
   const workspaceId = await eventually(async () => {
-    const value = await evalIn(app, `localStorage.getItem("openwork.react.activeWorkspace") ?? ""`);
+    const value = await evalIn(app, () => (localStorage.getItem("openwork.react.activeWorkspace") ?? ""));
     return typeof value === "string" ? value : "";
   }, {
     within: 120_000,
@@ -859,7 +860,7 @@ async function createSecondWorkspaceViaUi(app: Surface, firstWorkspaceId: string
   });
   await pollExpression(
     app,
-    `Boolean(document.querySelector(${JSON.stringify(`[data-sidebar-workspace-id="${workspaceId}"]`)}))`,
+    browserScript((value) => (Boolean(document.querySelector<HTMLElement>(value))), [`[data-sidebar-workspace-id="${workspaceId}"]`]),
     "second workspace visible in sidebar",
   );
   await waitForComposerReady(app, "second workspace composer ready");
@@ -867,48 +868,48 @@ async function createSecondWorkspaceViaUi(app: Surface, firstWorkspaceId: string
 }
 
 async function clickSessionRow(app: Surface, chat: Chat): Promise<void> {
-  const clicked = await evalIn(app, `(() => {
-    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${chat.sessionId}"][data-sidebar-session-workspace-id="${chat.workspaceId}"]`)});
-    const control = row?.querySelector(${JSON.stringify(`[data-session-tab-id="${chat.sessionId}"]`)});
+  const clicked = await evalIn(app, browserScript((value, inputValue) => {
+    const row = document.querySelector<HTMLElement>(value);
+    const control = row?.querySelector<HTMLElement>(inputValue);
     if (!(row instanceof HTMLElement) || !(control instanceof HTMLElement)) return false;
     row.scrollIntoView({ block: "center" });
     control.click();
     return true;
-  })()`);
+  }, [`[data-sidebar-session-id="${chat.sessionId}"][data-sidebar-session-workspace-id="${chat.workspaceId}"]`, `[data-session-tab-id="${chat.sessionId}"]`]));
   expect(clicked, `sidebar row for ${chat.title}`).toBe(true);
 }
 
 async function waitForSessionRow(app: Surface, chat: Chat): Promise<void> {
   // Expansion is untimed setup: the metric starts at the target task click.
-  await evalIn(app, `(() => {
-    const group = document.querySelector(${JSON.stringify(`[data-sidebar-workspace-id="${chat.workspaceId}"]`)});
-    const expand = group?.querySelector('button[aria-label="Expand"][aria-expanded="false"]');
+  await evalIn(app, browserScript((value) => {
+    const group = document.querySelector<HTMLElement>(value);
+    const expand = group?.querySelector<HTMLButtonElement>('button[aria-label="Expand"][aria-expanded="false"]');
     if (expand instanceof HTMLElement) expand.click();
-  })()`);
+  }, [`[data-sidebar-workspace-id="${chat.workspaceId}"]`]));
   try {
-    await pollExpression(app, `(() => {
-    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${chat.sessionId}"][data-sidebar-session-workspace-id="${chat.workspaceId}"]`)});
+    await pollExpression(app, browserScript((value, inputValue) => {
+    const row = document.querySelector<HTMLElement>(value);
     return row instanceof HTMLElement
-      && row.querySelector(${JSON.stringify(`[data-session-tab-id="${chat.sessionId}"]`)}) instanceof HTMLElement;
-    })()`, `sidebar row for ${chat.title}`, 10_000);
+      && row.querySelector<HTMLElement>(inputValue) instanceof HTMLElement;
+    }, [`[data-sidebar-session-id="${chat.sessionId}"][data-sidebar-session-workspace-id="${chat.workspaceId}"]`, `[data-session-tab-id="${chat.sessionId}"]`]), `sidebar row for ${chat.title}`, 10_000);
   } catch (error) {
-    const facts = await evalIn(app, `({
+    const facts = await evalIn(app, browserScript((value) => (({
       route: window.location.hash,
-      targetWorkspace: document.querySelector(${JSON.stringify(`[data-sidebar-workspace-id="${chat.workspaceId}"]`)})?.innerText,
-      rows: [...document.querySelectorAll('[data-sidebar-session-id]')].map((row) => ({
+      targetWorkspace: document.querySelector<HTMLElement>(value)?.innerText,
+      rows: [...document.querySelectorAll<HTMLElement>('[data-sidebar-session-id]')].map((row) => ({
         session: row.getAttribute('data-sidebar-session-id'), workspace: row.getAttribute('data-sidebar-session-workspace-id'),
       })),
-    })`);
+    })), [`[data-sidebar-workspace-id="${chat.workspaceId}"]`]));
     throw new Error(`${error instanceof Error ? error.message : String(error)}; sidebar facts: ${JSON.stringify(facts)}`);
   }
 }
 
 async function waitForChatSurface(app: Surface, chat: Chat): Promise<void> {
-  await pollExpression(app, `(() => {
-    const surface = document.querySelector("[data-session-surface-id]");
-    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(chat.sessionId)}
-      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(chat.workspaceId)};
-  })()`, `surface for ${chat.title}`);
+  await pollExpression(app, browserScript((sessionId, workspaceId) => {
+    const surface = document.querySelector<HTMLElement>("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === sessionId
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId;
+  }, [chat.sessionId, chat.workspaceId]), `surface for ${chat.title}`);
 }
 
 async function switchAndMeasure(app: Surface, chat: Chat): Promise<number> {
@@ -923,7 +924,7 @@ async function switchAndMeasure(app: Surface, chat: Chat): Promise<number> {
 async function visibleUserTexts(app: Surface): Promise<string[]> {
   const value = await evalIn(
     app,
-    `[...document.querySelectorAll('[data-message-role="user"]')].map((message) => message.innerText ?? "")`,
+    () => ([...document.querySelectorAll<HTMLElement>('[data-message-role="user"]')].map((message) => message.innerText ?? "")),
   );
   if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
     throw new Error(`Visible user messages were malformed: ${JSON.stringify(value)}`);
@@ -1213,9 +1214,9 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
             expect(aIsolated, `workspace A transcript after switch ${switchIndex}`).toBe(true);
           }
 
-          const compactionProbe = await evalIn(app, `(() => {
-            const root = document.querySelector("[data-session-surface-id]") ?? document;
-            const controls = [...root.querySelectorAll('button, [role="menuitem"], [role="option"], [data-slot="command-item"]')];
+          const compactionProbe = await evalIn(app, () => {
+            const root = document.querySelector<HTMLElement>("[data-session-surface-id]") ?? document;
+            const controls = [...root.querySelectorAll<HTMLElement>('button, [role="menuitem"], [role="option"], [data-slot="command-item"]')];
             return controls.some((control) => {
               const label = [control.textContent, control.getAttribute("aria-label"), control.getAttribute("title")]
                 .filter(Boolean)
@@ -1223,7 +1224,7 @@ test.skipIf(!enabled)(title, { timeout: 900_000 }, async ({ evidence, place }) =
                 .toLowerCase();
               return label.includes("compact") || label.includes("summarize");
             });
-          })()`);
+          });
           uiCompactionAvailable = compactionProbe === true;
         }
 

--- a/evals/specs/chat-loading-shimmer.e2e.test.ts
+++ b/evals/specs/chat-loading-shimmer.e2e.test.ts
@@ -22,12 +22,12 @@ test("chat working and command activity use quiet shimmer without spinners", asy
   const working = await step("the main Working state shimmers without a spinner", async () => {
     await user.see({ text: /Working/ });
     // TODO(primitive): inspect the visual treatment, animation cadence, and backdrop composition of a visible status row.
-    const reading = await probe.eval(`(async () => {
-      const row = document.querySelector('[data-loading-message="working"]');
-      const shimmer = row?.querySelector(".ow-text-shimmer");
-      const pane = document.querySelector("main[data-session-pane]");
+    const reading = await probe.eval(async () => {
+      const row = document.querySelector<HTMLElement>('[data-loading-message="working"]');
+      const shimmer = row?.querySelector<HTMLElement>(".ow-text-shimmer");
+      const pane = document.querySelector<HTMLElement>("main[data-session-pane]");
       const header = pane?.querySelector("header");
-      const filterOf = (element) => getComputedStyle(element).backdropFilter;
+      const filterOf = (element: Element) => getComputedStyle(element).backdropFilter;
       const nestedFilters = [];
       if (row instanceof HTMLElement && pane instanceof HTMLElement) {
         for (let node = row.parentElement; node && node !== pane; node = node.parentElement) {
@@ -40,7 +40,7 @@ test("chat working and command activity use quiet shimmer without spinners", asy
       if (shimmer instanceof HTMLElement) {
         const startedAt = performance.now();
         await new Promise((resolve) => {
-          const sample = (now) => {
+          const sample = (now: number) => {
             positions.add(getComputedStyle(shimmer).backgroundPosition);
             sampledFrames += 1;
             if (now - startedAt >= 1000) resolve(undefined);
@@ -51,7 +51,7 @@ test("chat working and command activity use quiet shimmer without spinners", asy
       }
       return {
         text: row instanceof HTMLElement ? row.innerText.trim() : "",
-        hasSpinner: Boolean(row?.querySelector(".animate-spin")),
+        hasSpinner: Boolean(row?.querySelector<HTMLElement>(".animate-spin")),
         hasShimmer: shimmer instanceof HTMLElement,
         animationName: shimmer instanceof HTMLElement ? getComputedStyle(shimmer).animationName : "",
         sampledFrames,
@@ -61,7 +61,7 @@ test("chat working and command activity use quiet shimmer without spinners", asy
         headerFilter: header instanceof HTMLElement ? filterOf(header) : "",
         nestedFilters,
       };
-    })()`, { awaitPromise: true, timeoutMs: 15_000 });
+    }, { awaitPromise: true, timeoutMs: 15_000 });
     expect(reading).toMatchObject({ text: expect.stringContaining("Working"), hasSpinner: false, hasShimmer: true });
     return reading;
   });
@@ -96,17 +96,17 @@ test("chat working and command activity use quiet shimmer without spinners", asy
     await user.see({ text: /Running command/ });
     await user.see({ text: /Reading brief\.md/ });
     // TODO(primitive): inspect the visual treatment and summary of an aggregate status row.
-    const aggregate = await probe.eval(`(() => {
-      const row = document.querySelector("[data-tool-aggregate-now]");
-      const summary = [...document.querySelectorAll("[data-tool-aggregate] > button")]
+    const aggregate = await probe.eval(() => {
+      const row = document.querySelector<HTMLElement>("[data-tool-aggregate-now]");
+      const summary = [...document.querySelectorAll<HTMLElement>("[data-tool-aggregate] > button")]
         .find((button) => (button.textContent ?? "").includes("Running command"));
       return {
-        text: row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, " ").trim() : "",
-        hasSpinner: Boolean(row?.querySelector(".animate-spin")),
-        hasShimmer: Boolean(row?.querySelector(".ow-text-shimmer")),
-        summary: summary instanceof HTMLElement ? summary.innerText.replace(/\\s+/g, " ").trim() : "",
+        text: row instanceof HTMLElement ? row.innerText.replace(/\s+/g, " ").trim() : "",
+        hasSpinner: Boolean(row?.querySelector<HTMLElement>(".animate-spin")),
+        hasShimmer: Boolean(row?.querySelector<HTMLElement>(".ow-text-shimmer")),
+        summary: summary instanceof HTMLElement ? summary.innerText.replace(/\s+/g, " ").trim() : "",
       };
-    })()`);
+    });
     expect(aggregate).toMatchObject({ text: expect.stringContaining("Reading brief.md"), hasSpinner: false, hasShimmer: true });
     expect(aggregate).not.toMatchObject({ text: expect.stringContaining("Now:") });
     expect(aggregate).toMatchObject({ summary: expect.stringContaining("Running command") });
@@ -117,16 +117,16 @@ test("chat working and command activity use quiet shimmer without spinners", asy
     await user.click({ role: "button", label: /Running command/ });
     await user.see({ text: /git status --short --branch/ });
     // TODO(primitive): count command summaries in a visible aggregate.
-    const command = await probe.eval(`(() => {
-      const block = document.querySelector("[data-tool-aggregate-command]");
+    const command = await probe.eval(() => {
+      const block = document.querySelector<HTMLElement>("[data-tool-aggregate-command]");
       const aggregate = block?.closest("[data-tool-aggregate]");
       return {
-        text: block instanceof HTMLElement ? block.innerText.replace(/\\s+/g, " ").trim() : "",
+        text: block instanceof HTMLElement ? block.innerText.replace(/\s+/g, " ").trim() : "",
         summaryCount: aggregate instanceof HTMLElement
           ? (aggregate.innerText.match(/(?:Ran|Running) command/g) ?? []).length
           : 0,
       };
-    })()`);
+    });
     expect(command).toMatchObject({ text: expect.stringContaining("$"), summaryCount: 1 });
     expect(command).toMatchObject({ text: expect.stringContaining("git status --short --branch") });
   });

--- a/evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts
+++ b/evals/specs/cloud-provider-local-credential-fallback.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect, onTestFinished } from "vitest";
 import { denFetch, evalIn, go, readAvailableModels, waitFor } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
@@ -93,22 +94,22 @@ async function localServerRequest(
   path: string,
   input: { method?: string; body?: Record<string, unknown>; host?: boolean } = {},
 ): Promise<{ status: number; body: unknown }> {
-  const value = await evalIn(surface, `(async () => {
+  const value = await evalIn(surface, browserScript(async (value, path, inputValue, inputValue2) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { status: 0, body: { error: "local_server_unavailable" } };
-    const headers = { "content-type": "application/json" };
-    if (${input.host === true}) headers["x-openwork-host-token"] = String(info.hostToken ?? "");
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (value) headers["x-openwork-host-token"] = String(info.hostToken ?? "");
     else headers.authorization = "Bearer " + String(info.ownerToken ?? info.clientToken ?? "");
-    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + ${JSON.stringify(path)}, {
-      method: ${JSON.stringify(input.method ?? "GET")},
+    const response = await fetch(String(info.baseUrl).replace(/\/+$/, "") + path, {
+      method: inputValue,
       headers,
-      body: ${input.body ? JSON.stringify(JSON.stringify(input.body)) : "undefined"},
+      body: inputValue2,
     });
     const text = await response.text();
     let body = text;
     try { body = text ? JSON.parse(text) : null; } catch {}
     return { status: response.status, body };
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, [input.host === true, path, input.method ?? "GET", input.body ? JSON.stringify(input.body) : undefined]), { awaitPromise: true, timeoutMs: 30_000 });
   if (!isRecord(value) || typeof value.status !== "number") {
     throw new Error(`Invalid local server response for ${path}: ${JSON.stringify(value)}`);
   }
@@ -157,21 +158,21 @@ async function waitForProviderRow(
   const route = `/workspace/${workspaceId}/settings/cloud-providers`;
   await go(surface, `/workspace/${workspaceId}/session`);
   await go(surface, route);
-  await waitFor(surface, `(() => {
+  await waitFor(surface, browserScript((PROVIDER_NAME, statusLabel) => {
     const title = [...document.querySelectorAll("span")]
-      .find((element) => (element.textContent ?? "").trim() === ${JSON.stringify(PROVIDER_NAME)});
+      .find((element) => (element.textContent ?? "").trim() === PROVIDER_NAME);
     const row = title?.parentElement?.parentElement?.parentElement;
-    return Boolean(row && (row.textContent ?? "").includes(${JSON.stringify(statusLabel)}));
-  })()`, { timeoutMs: 120_000, label: `${PROVIDER_NAME} row shows ${statusLabel}` });
+    return Boolean(row && (row.textContent ?? "").includes(statusLabel));
+  }, [PROVIDER_NAME, statusLabel]), { timeoutMs: 120_000, label: `${PROVIDER_NAME} row shows ${statusLabel}` });
 }
 
 async function closeModelPicker(surface: Parameters<typeof evalIn>[0]): Promise<void> {
-  await evalIn(surface, `(() => {
-    const close = document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]');
+  await evalIn(surface, () => {
+    const close = document.querySelector<HTMLElement>('[data-slot="dialog-content"] [data-slot="dialog-close"]');
     if (close instanceof HTMLElement) close.click();
     return true;
-  })()`);
-  await waitFor(surface, `!document.querySelector('[data-slot="dialog-content"]')`, {
+  });
+  await waitFor(surface, () => (!document.querySelector<HTMLElement>('[data-slot="dialog-content"]')), {
     timeoutMs: 15_000,
     label: "model picker closed",
   });

--- a/evals/specs/cloud-provider-sync-contract.e2e.test.ts
+++ b/evals/specs/cloud-provider-sync-contract.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect, onTestFinished } from "vitest";
 import { observeText, textProgressFailures, control, denFetch, evalIn, go, readAvailableModels, selectModel, sendComposerMessage, waitFor } from "@openwork/behaviors";
 import type { DenSession, ModelFacts } from "@openwork/behaviors";
@@ -193,7 +194,7 @@ function parseSyncStatus(payload: Record<string, unknown>): SyncStatusFacts {
 // persisted credentials (localStorage openwork.server.port/openwork.server.token)
 // reach it with a plain Bearer fetch to 127.0.0.1.
 async function readSyncStatusPayload(surface: Parameters<typeof evalIn>[0]): Promise<Record<string, unknown>> {
-  const value = await evalIn(surface, `(async () => {
+  const value = await evalIn(surface, async () => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return { specProbeError: "missing local server credentials" };
@@ -202,7 +203,7 @@ async function readSyncStatusPayload(surface: Parameters<typeof evalIn>[0]): Pro
     });
     if (!response.ok) return { specProbeError: "HTTP " + response.status + " " + (await response.text()).slice(0, 200) };
     return await response.json();
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, { awaitPromise: true, timeoutMs: 30_000 });
   if (!isRecord(value)) {
     throw new Error(`GET /cloud-provider-sync/status returned a non-object: ${JSON.stringify(value)}`);
   }
@@ -213,18 +214,18 @@ async function readSyncStatusPayload(surface: Parameters<typeof evalIn>[0]): Pro
 }
 
 async function engineV2Status(surface: Parameters<typeof evalIn>[0], enabled?: boolean) {
-  const value = await evalIn(surface, `(async () => {
+  const value = await evalIn(surface, browserScript(async (inputEnabled) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return { specProbeError: "missing local server credentials" };
-    const enabled = ${String(enabled)};
+    const enabled = inputEnabled;
     const response = await fetch("http://127.0.0.1:" + port + "/experimental/engine-v2-preview" + (enabled === undefined ? "/status" : ""), {
       ...(enabled === undefined ? {} : { method: "PUT", body: JSON.stringify({ enabled, chatRouting: enabled }) }),
       headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
     });
     if (!response.ok) return { specProbeError: "HTTP " + response.status + " " + (await response.text()).slice(0, 200) };
     return await response.json();
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, [enabled]), { awaitPromise: true, timeoutMs: 30_000 });
   if (!isRecord(value) || typeof value.specProbeError === "string"
     || typeof value.enabled !== "boolean" || typeof value.running !== "boolean") {
     throw new Error(`Engine v2 preview status was invalid: ${JSON.stringify(value)}`);
@@ -421,22 +422,22 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
 
   // readAvailableModels leaves the picker dialog open; close it through its
   // own close control so later claims observe a calm, unobstructed app.
-  await evalIn(desktopApp, `(() => {
-    const close = document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]');
+  await evalIn(desktopApp, () => {
+    const close = document.querySelector<HTMLElement>('[data-slot="dialog-content"] [data-slot="dialog-close"]');
     if (close instanceof HTMLElement) close.click();
     return true;
-  })()`);
-  await waitFor(desktopApp, `!document.querySelector('[data-slot="dialog-content"]')`, {
+  });
+  await waitFor(desktopApp, () => (!document.querySelector<HTMLElement>('[data-slot="dialog-content"]')), {
     timeoutMs: 15_000,
     label: "model picker dialog closed",
   });
 
   await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
   await selectModel(desktopApp, CATALOG_MODEL_ID, { provider: CATALOG_PROVIDER_NAME });
-  const chosenDefault = await evalIn(desktopApp, `localStorage.getItem("openwork.defaultModel")`);
+  const chosenDefault = await evalIn(desktopApp, () => (localStorage.getItem("openwork.defaultModel")));
   expect(typeof chosenDefault).toBe("string");
   expect(String(chosenDefault)).toContain(CATALOG_MODEL_ID);
-  await evalIn(desktopApp, `(() => {
+  await evalIn(desktopApp, () => {
     window.__modelSelectionProof = { changes: 0, loops: 0, unavailable: document.body.innerText.includes("Model no longer available") };
     window.addEventListener("openwork.defaultModelChanged", () => window.__modelSelectionProof.changes++);
     const original = console.error;
@@ -447,9 +448,9 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
     new MutationObserver(() => {
       if (document.body.innerText.includes("Model no longer available")) window.__modelSelectionProof.unavailable = true;
     }).observe(document.body, { childList: true, subtree: true });
-  })()`);
+  });
 
-  expect(await evalIn(desktopApp, `window.__modelSelectionProof.unavailable`)).toBe(false);
+  expect(await evalIn(desktopApp, () => (window.__modelSelectionProof.unavailable))).toBe(false);
 
   // ── Claim 3: loud skips — a dropped provider must name itself ───────────
   // The schema (apps/server/src/cloud-provider-sync.ts:38-69) carries no
@@ -510,13 +511,13 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   // ── Claim 5: the settings surface stands, bug present or fixed ──────────
   const settingsRoute = `/workspace/${desktopApp.workspaceId}/settings/cloud-providers`;
   await go(desktopApp, settingsRoute);
-  await waitFor(desktopApp, `(() => {
+  await waitFor(desktopApp, browserScript((value) => {
     if (!window.location.hash.includes('/settings/cloud-providers')) {
-      window.location.hash = ${JSON.stringify(`#${settingsRoute}`)};
+      window.location.hash = value;
       return false;
     }
     return /provider/i.test(document.body.innerText);
-  })()`, { timeoutMs: 60_000, label: "cloud providers settings surface" });
+  }, [`#${settingsRoute}`]), { timeoutMs: 60_000, label: "cloud providers settings surface" });
   const shot = await screenshot(desktopApp);
   const seen = await validate(shot, [
     "The workspace settings cloud providers surface is visible",
@@ -552,9 +553,9 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
       && status.catalogModelIds.includes(CATALOG_MODEL_ID),
     V2_MIRROR_BUDGET_MS, "custom and native Den providers to appear in the v2 catalog",
   );
-  const catalogPrivacy = await evalIn(desktopApp, `(async () => {
+  const catalogPrivacy = await evalIn(desktopApp, browserScript(async (value, providerId) => {
     const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
-    const paths = ${JSON.stringify([`/workspace/${desktopApp.workspaceId}/opencode2/api/model`, `/workspace/${desktopApp.workspaceId}/opencode2/api/model/default`, `/workspace/${desktopApp.workspaceId}/opencode2/api/provider`, `/workspace/${desktopApp.workspaceId}/opencode2/api/provider/${customRuntime.providerId}`])};
+    const paths = value;
     const results = [];
     let model;
     for (const path of paths) {
@@ -562,11 +563,11 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
         headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") }
       });
       const text = await response.text();
-      if (path === paths[0] && response.ok) model = JSON.parse(text).data.find((entry) => entry.providerID === ${JSON.stringify(customRuntime.providerId)});
+      if (path === paths[0] && response.ok) model = JSON.parse(text).data.find((entry: { providerID?: string }) => entry.providerID === providerId);
       results.push({ status: response.status, leaksKey: text.includes("sk-openwork-sync-contract-eval-only"), ...(response.ok ? {} : { error: text.replaceAll("sk-openwork-sync-contract-eval-only", "[redacted]") }) });
     }
     return { results, model };
-  })()`, { awaitPromise: true });
+  }, [[`/workspace/${desktopApp.workspaceId}/opencode2/api/model`, `/workspace/${desktopApp.workspaceId}/opencode2/api/model/default`, `/workspace/${desktopApp.workspaceId}/opencode2/api/provider`, `/workspace/${desktopApp.workspaceId}/opencode2/api/provider/${customRuntime.providerId}`], customRuntime.providerId]), { awaitPromise: true });
   expect(catalogPrivacy).toMatchObject({
     results: Array.from({ length: 4 }, () => ({ status: 200, leaksKey: false })),
     model: { limit: { context: 1050000, output: 128000 }, capabilities: { tools: true, input: ["text", "image", "pdf"], output: ["text"] } },
@@ -574,8 +575,8 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   evidence.recordAssertionEvidence("custom native OpenAI model limits, tools and modalities survive mirroring", "The fixture uses the native @ai-sdk/openai adapter; its live v2 catalog entry retained 1,050,000 context and 128,000 output limits, tool support, text/image/PDF inputs and text output.", true);
   await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
   await sleep(16_000); // includes the renderer's engine-routing refresh interval
-  expect(await evalIn(desktopApp, `localStorage.getItem("openwork.defaultModel")`)).toBe(chosenDefault);
-  expect(await evalIn(desktopApp, `window.__modelSelectionProof`)).toEqual({ changes: 0, loops: 0, unavailable: false });
+  expect(await evalIn(desktopApp, () => (localStorage.getItem("openwork.defaultModel")))).toBe(chosenDefault);
+  expect(await evalIn(desktopApp, () => (window.__modelSelectionProof))).toEqual({ changes: 0, loops: 0, unavailable: false });
   evidence.recordAssertionEvidence(
     "native organization model selection survives v1 to v2 without false unavailability or a React loop",
     "The selected catalog provider/model stayed unchanged through Settings, cloud refresh, native v2 mirroring and routing refresh; zero default writes, unavailable warnings or maximum-depth errors were observed.", true,
@@ -583,7 +584,7 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   await selectModel(desktopApp, CUSTOM_MODEL_ID, { provider: CUSTOM_PROVIDER_NAME });
   await using responseObservation = await observeText(desktopApp, '[data-message-role="assistant"] .prose');
   await sendComposerMessage(desktopApp, `Reply to the request marked ${promptMarker}.`);
-  await waitFor(desktopApp, `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).some((row) => row.textContent.includes(${JSON.stringify(finalReply)}))`, { timeoutMs: 120_000, label: "native provider reply in the v2 transcript" });
+  await waitFor(desktopApp, browserScript((finalReply) => (Array.from(document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')).some((row) => row.textContent.includes(finalReply))), [finalReply]), { timeoutMs: 120_000, label: "native provider reply in the v2 transcript" });
   await sleep(2_000); // includes the streamed-to-persisted message reconciliation
   const frames = await responseObservation.finish();
   expect(textProgressFailures(frames, finalReply), JSON.stringify(frames)).toEqual([]);
@@ -596,11 +597,11 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
     "native OpenAI inference completes through the selected v2 model",
     "The signed-in desktop rendered the independent reply nonce; the witness required the private model header and saw the selected model on the native Responses endpoint, with no wrong-model or authentication-error requests.", true,
   );
-  const nativeSessionRoute = await evalIn(desktopApp, `location.hash.slice(1)`);
+  const nativeSessionRoute = await evalIn(desktopApp, () => (location.hash.slice(1)));
   if (typeof nativeSessionRoute !== "string") throw new Error("Native session route was unavailable");
   await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
   await selectModel(desktopApp, CATALOG_MODEL_ID, { provider: CATALOG_PROVIDER_NAME });
-  const changesBeforeSync = await evalIn(desktopApp, `window.__modelSelectionProof.changes`);
+  const changesBeforeSync = await evalIn(desktopApp, () => (window.__modelSelectionProof.changes));
   const thirdPublishedAt = Date.now();
   const thirdProviderId = await createProvider(den.admin, orgId, {
     name: "Sync Contract Third Models",
@@ -644,39 +645,40 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
     `baseURL providers ${customRuntime.providerId} and ${thirdRuntime.providerId} mirrored with models ${CUSTOM_MODEL_ID} and ${THIRD_MODEL_ID}; catalog provider ${catalogRuntime.providerId} was ${catalogOutcome}; third-provider latency=${mirrorLatencyMs}ms; sidecar stayed at pid ${pid0}.`,
     hotMirrored,
   );
-  expect(await evalIn(desktopApp, `localStorage.getItem("openwork.defaultModel")`)).toBe(chosenDefault);
-  expect(await evalIn(desktopApp, `window.__modelSelectionProof.changes`)).toBe(changesBeforeSync);
+  expect(await evalIn(desktopApp, () => (localStorage.getItem("openwork.defaultModel")))).toBe(chosenDefault);
+  expect(await evalIn(desktopApp, () => (window.__modelSelectionProof.changes))).toBe(changesBeforeSync);
   // Remove the selected assignment in the fixture organization, then use the
   // real server sync boundary. A missing model must settle into recovery.
   await deleteProvider(den.admin, orgId, catalogProviderId);
-  const syncResult = await evalIn(desktopApp, `(async () => {
+  const syncResult = await evalIn(desktopApp, async () => {
     const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
+    if (!info.hostToken) throw new Error("Missing local server host token");
     const port = localStorage.getItem("openwork.server.port");
     const response = await fetch("http://127.0.0.1:" + port + "/cloud-provider-sync/run", {
       method: "POST", headers: { "x-openwork-host-token": info.hostToken, "Content-Type": "application/json" }, body: "{}"
     });
     return response.status;
-  })()`, { awaitPromise: true, timeoutMs: 90_000 });
+  }, { awaitPromise: true, timeoutMs: 90_000 });
   expect(syncResult).toBe(200);
   await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
   // Opening Models is the user-facing refresh action; server reconciliation
   // alone does not update the renderer's completed catalog snapshot.
   await control(desktopApp, "session.model_picker.open");
-  await waitFor(desktopApp, `document.body.innerText.includes("Model no longer available")`, { timeoutMs: 90_000, label: "revoked model recovery" });
-  const changesAfterRevocation = await evalIn(desktopApp, `window.__modelSelectionProof.changes`);
+  await waitFor(desktopApp, () => (document.body.innerText.includes("Model no longer available")), { timeoutMs: 90_000, label: "revoked model recovery" });
+  const changesAfterRevocation = await evalIn(desktopApp, () => (window.__modelSelectionProof.changes));
   await sleep(5_000);
-  expect(await evalIn(desktopApp, `localStorage.getItem("openwork.defaultModel")`)).toBe(chosenDefault);
-  expect(await evalIn(desktopApp, `window.__modelSelectionProof.changes`)).toBe(changesAfterRevocation);
-  expect(await evalIn(desktopApp, `window.__modelSelectionProof.loops`)).toBe(0);
+  expect(await evalIn(desktopApp, () => (localStorage.getItem("openwork.defaultModel")))).toBe(chosenDefault);
+  expect(await evalIn(desktopApp, () => (window.__modelSelectionProof.changes))).toBe(changesAfterRevocation);
+  expect(await evalIn(desktopApp, () => (window.__modelSelectionProof.loops))).toBe(0);
   await selectModel(desktopApp, CUSTOM_MODEL_ID, { provider: CUSTOM_PROVIDER_NAME });
-  await waitFor(desktopApp, `!document.body.innerText.includes("Model no longer available")`, { timeoutMs: 30_000, label: "explicit model recovery" });
-  const recoveredDefault = await evalIn(desktopApp, `localStorage.getItem("openwork.defaultModel")`);
+  await waitFor(desktopApp, () => (!document.body.innerText.includes("Model no longer available")), { timeoutMs: 30_000, label: "explicit model recovery" });
+  const recoveredDefault = await evalIn(desktopApp, () => (localStorage.getItem("openwork.defaultModel")));
   evidence.recordAssertionEvidence("a genuinely revoked model settles and recovers only after an explicit selection", "Revoking the selected assignment surfaced recovery while preserving its identity for five seconds with no repeated default writes or React loop; selecting an available model cleared the warning.", true);
   // Continue the existing conversation: creating a new task intentionally
   // reconciles the organization credential, which would replace this isolated
   // env-store rotation with the fixture organization's unchanged secret.
   await go(desktopApp, nativeSessionRoute);
-  await waitFor(desktopApp, `Array.from(document.querySelectorAll('[data-message-role="assistant"] .prose')).some((row) => row.textContent.trim() === ${JSON.stringify(finalReply)})`, { timeoutMs: 30_000, label: "original reply restored before continuing the conversation" });
+  await waitFor(desktopApp, browserScript((finalReply) => (Array.from(document.querySelectorAll<HTMLElement>('[data-message-role="assistant"] .prose')).some((row) => row.textContent.trim() === finalReply)), [finalReply]), { timeoutMs: 30_000, label: "original reply restored before continuing the conversation" });
   await using rotationObservation = await observeText(desktopApp, '[data-message-role="assistant"] .prose', { ignoreExistingMessages: true });
   const rotatedMarker = `${promptMarker}-rotated`;
   const rotatedReply = `ROTATED-REPLY-${Date.now()}`;
@@ -688,24 +690,25 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   });
   expect(mockUpdate.ok).toBe(true);
   const rotatedAt = new Date().toISOString();
-  const rotationStatus = await evalIn(desktopApp, `(async () => {
+  const rotationStatus = await evalIn(desktopApp, browserScript(async (providerId, rotatedKey) => {
     const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
+    if (!info.hostToken) throw new Error("Missing local server host token");
     const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
     const headers = { "x-openwork-host-token": info.hostToken, "Content-Type": "application/json" };
     const config = await (await fetch(base + "/runtime-config/providers", { headers })).json();
-    const names = config.provider[${JSON.stringify(customRuntime.providerId)}]?.env;
+    const names = config.provider[providerId]?.env;
     if (!Array.isArray(names) || names.length !== 1) throw new Error("fixture provider must declare one scoped credential");
-    const response = await fetch(base + "/env", { method: "PUT", headers, body: JSON.stringify({ entries: [{ key: names[0], value: ${JSON.stringify(rotatedKey)} }] }) });
+    const response = await fetch(base + "/env", { method: "PUT", headers, body: JSON.stringify({ entries: [{ key: names[0], value: rotatedKey }] }) });
     return response.status;
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, [customRuntime.providerId, rotatedKey]), { awaitPromise: true, timeoutMs: 30_000 });
   expect(rotationStatus).toBe(200);
   await sleep(3_000);
   await sendComposerMessage(desktopApp, `Reply to the request marked ${rotatedMarker}.`);
-  await waitFor(desktopApp, `Array.from(document.querySelectorAll('[data-message-role="assistant"]')).some((row) => row.textContent.includes(${JSON.stringify(rotatedReply)}))`, { timeoutMs: 120_000, label: "reply after credential rotation" });
+  await waitFor(desktopApp, browserScript((rotatedReply) => (Array.from(document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')).some((row) => row.textContent.includes(rotatedReply))), [rotatedReply]), { timeoutMs: 120_000, label: "reply after credential rotation" });
   await sleep(2_000);
   const rotationFrames = await rotationObservation.finish();
   expect(textProgressFailures(rotationFrames, rotatedReply), JSON.stringify(rotationFrames)).toEqual([]);
-  expect(await evalIn(desktopApp, `document.querySelectorAll('[data-message-role="assistant"]').length >= 2 && Array.from(document.querySelectorAll('[data-message-role="assistant"] .prose')).some((row) => row.textContent.trim() === ${JSON.stringify(finalReply)})`)).toBe(true);
+  expect(await evalIn(desktopApp, browserScript((finalReply) => (document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]').length >= 2 && Array.from(document.querySelectorAll<HTMLElement>('[data-message-role="assistant"] .prose')).some((row) => row.textContent.trim() === finalReply)), [finalReply]))).toBe(true);
   evidence.recordAssertionEvidence("a second assistant response never substitutes the previous answer or overwrites it", "Every new response frame matched only the independent second reply; after completion the first answer remained intact in a separate assistant message.", true);
   const rotatedRequests = await den.mocks.agent.agentRequests({ promptMarker: rotatedMarker, sinceIso: rotatedAt, atLeast: 1 });
   expect(rotatedRequests.some((request) => request.kind === "final" && request.model === CUSTOM_MODEL_ID)).toBe(true);
@@ -715,8 +718,8 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 30 * 60_000 }, asy
   await engineV2Status(desktopApp, false);
   await go(desktopApp, `/workspace/${desktopApp.workspaceId}/session`);
   await sleep(16_000);
-  expect(await evalIn(desktopApp, `localStorage.getItem("openwork.defaultModel")`)).toBe(recoveredDefault);
-  expect(await evalIn(desktopApp, `window.__modelSelectionProof.loops`)).toBe(0);
+  expect(await evalIn(desktopApp, () => (localStorage.getItem("openwork.defaultModel")))).toBe(recoveredDefault);
+  expect(await evalIn(desktopApp, () => (window.__modelSelectionProof.loops))).toBe(0);
   evidence.recordAssertionEvidence("selected model survives cloud sync and return to v1", "The exact selected provider/model remained after another Den provider was published, the normal cloud sync completed, and routing returned to v1; no React update loop occurred.", true);
   expect(hotMirrored, `Initial v2 status: ${JSON.stringify(initialV2)}; third v2 status: ${JSON.stringify(thirdV2)}`).toBe(true);
 });

--- a/evals/specs/command-palette-search.e2e.test.ts
+++ b/evals/specs/command-palette-search.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { commandPaletteSearch } from "../worlds/session-shell.ts";
@@ -13,7 +14,7 @@ function stringArray(value: unknown): string[] {
 
 test("command palette searches settings by alias, navigates, records recents, and filters actions", async ({ world, user, probe, step }) => {
   const workspaceId = world.workspace.workspaceId;
-  const macPlatform = await probe.eval(`/Mac|iPhone|iPad|iPod/.test(navigator.platform)`);
+  const macPlatform = await probe.eval(() => (/Mac|iPhone|iPad|iPod/.test(navigator.platform)));
   const paletteShortcut = macPlatform ? "Meta+K" : "Control+K";
   const waitForPaletteClose = () => probe.eventually(() => probe.has("Arrow keys to navigate"), {
     within: 15_000,
@@ -153,12 +154,12 @@ test("command palette searches settings by alias, navigates, records recents, an
       });
       expect(sectionHash).toBe(`#/workspace/${workspaceId}/settings/advanced/${section.id}`);
       await waitForPaletteClose();
-      expect(await probe.eventually(() => probe.eval(`(id) => {
+      expect(await probe.eventually(() => probe.eval(browserScript((id) => {
         const section = document.getElementById(id);
-        const heading = section?.querySelector("h3");
+        const heading = section?.querySelector<HTMLElement>("h3");
         const bounds = heading?.getBoundingClientRect();
         return document.activeElement === section && !!bounds && bounds.top >= 0 && bounds.bottom <= innerHeight;
-      }`, { args: [`advanced-${section.id}`] }), {
+      }, [`advanced-${section.id}`])), {
         within: 15_000,
         label: `${section.title} is focused and in view`,
         until: (value) => value === true,

--- a/evals/specs/compatible-release-picker.e2e.test.ts
+++ b/evals/specs/compatible-release-picker.e2e.test.ts
@@ -38,7 +38,7 @@ test("recovery offers only recent stable releases with exact compatible artifact
   ]);
   await seed.evalIn(
     world.app,
-    `Promise.all([window.__openworkRecoveryControl.select("2.3.0"), window.__openworkRecoveryControl.select("9.9.9")])`,
+    () => (Promise.all([window.__openworkRecoveryControl.select("2.3.0"), window.__openworkRecoveryControl.select("9.9.9")])),
     { awaitPromise: true },
   );
   const afterInvalid = await world.snapshot();

--- a/evals/specs/composer-connections-menu.e2e.test.ts
+++ b/evals/specs/composer-connections-menu.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { connectionsMenu } from "../worlds/chat.ts";
@@ -17,7 +18,7 @@ test("the composer connections menu scrolls through Den inventory and signs in o
 
   await step("the connection inventory has an independently scrolling list", async () => {
     // TODO(primitive): inspect overflow geometry for a visible connection list.
-    const before = await probe.eval(`(targetName) => {
+    const before = await probe.eval(browserScript((targetName) => {
       const title = [...document.querySelectorAll("div")]
         .find((entry) => (entry.textContent ?? "").trim() === targetName && entry.children.length === 0);
       const row = title?.parentElement?.parentElement?.parentElement;
@@ -35,7 +36,7 @@ test("the composer connections menu scrolls through Den inventory and signs in o
         listScrollHeight: list.scrollHeight,
         targetInitiallyBelow: row.getBoundingClientRect().bottom > list.getBoundingClientRect().bottom,
       };
-    }`, { args: [target.name] });
+    }, [target.name]));
     expect(before).toMatchObject({ navigationOverflow: "auto", listOverflow: "auto", targetInitiallyBelow: true });
     if (!isRecord(before)
       || typeof before.panelHeight !== "number"
@@ -45,7 +46,7 @@ test("the composer connections menu scrolls through Den inventory and signs in o
     expect(before.listScrollHeight).toBeGreaterThan(before.listClientHeight);
 
     // TODO(primitive): scroll a named connection row into view.
-    const scrolled = await seed.evalIn(world.app, `(targetName) => {
+    const scrolled = await seed.evalIn(world.app, browserScript((targetName) => {
       const title = [...document.querySelectorAll("div")]
         .find((entry) => (entry.textContent ?? "").trim() === targetName && entry.children.length === 0);
       const row = title?.parentElement?.parentElement?.parentElement;
@@ -53,7 +54,7 @@ test("the composer connections menu scrolls through Den inventory and signs in o
       if (!(row instanceof HTMLElement) || !(list instanceof HTMLElement)) return false;
       list.scrollTop = list.scrollHeight;
       return list.scrollTop > 0;
-    }`, { args: [target.name] });
+    }, [target.name]));
     expect(scrolled).toBe(true);
     await user.see({ text: target.name });
     await user.see({ role: "button", label: "Connect your account", nth: 13 });
@@ -76,7 +77,7 @@ test("the composer connections menu scrolls through Den inventory and signs in o
   });
   expect(connected).toBe(true);
   // TODO(primitive): read one named connection row's status and actions.
-  const readyRow = await probe.eventually(() => probe.eval(`(targetName) => {
+  const readyRow = await probe.eventually(() => probe.eval(browserScript((targetName) => {
     const title = [...document.querySelectorAll("div")]
       .find((entry) => (entry.textContent ?? "").trim() === targetName && entry.children.length === 0);
     const row = title?.parentElement?.parentElement?.parentElement;
@@ -85,7 +86,7 @@ test("the composer connections menu scrolls through Den inventory and signs in o
       hasSignIn: [...(row?.querySelectorAll("button") ?? [])]
         .some((button) => (button.textContent ?? "").trim() === "Connect your account"),
     };
-  }`, { args: [target.name] }), {
+  }, [target.name])), {
     within: 90_000,
     intervalMs: 500,
     label: "target composer connection row becomes ready",

--- a/evals/specs/computer-use-window-scope.e2e.test.ts
+++ b/evals/specs/computer-use-window-scope.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { computerUseWorld, toolState } from "../worlds/computer-use.ts";
@@ -233,14 +234,14 @@ test("Computer Use enables workspace tools from the desktop setup page", async (
   await using app = await world.desktop();
   const { workspaceId } = await createAndSelectWorkspace(app, { path: world.workspacePath });
   await step("Granted macOS access still requires explicit workspace enablement", async () => {
-    await evalIn(app, `location.hash = ${JSON.stringify(`#/workspace/${workspaceId}/extensions/computer-use`)}`);
-    await waitFor(app, `document.body.innerText.includes("Permissions are ready. Enable Computer Use for this workspace.")`, { timeoutMs: 60_000 });
-    expect(await evalIn(app, `[...document.querySelectorAll("button")].some(b => b.textContent.trim() === "Enable Computer Use" && !b.disabled)`)).toBe(true);
+    await evalIn(app, browserScript((value) => (location.hash = value), [`#/workspace/${workspaceId}/extensions/computer-use`]));
+    await waitFor(app, () => (document.body.innerText.includes("Permissions are ready. Enable Computer Use for this workspace.")), { timeoutMs: 60_000 });
+    expect(await evalIn(app, () => ([...document.querySelectorAll("button")].some(b => b.textContent.trim() === "Enable Computer Use" && !b.disabled)))).toBe(true);
   });
   await step("Enable resolves the bundled helper and reaches Ready", async () => {
-    await evalIn(app, `[...document.querySelectorAll("button")].find(b => b.textContent.trim() === "Enable Computer Use").click()`);
-    await waitFor(app, `document.body.innerText.includes("Ready · app access is approved when a session starts")`, { timeoutMs: 60_000 });
-    expect(await evalIn(app, `[...document.querySelectorAll("button")].some(b => /^(Enable|Reconnect) Computer Use$/.test(b.textContent.trim()))`)).toBe(false);
+    await evalIn(app, () => ([...document.querySelectorAll("button")].find(b => b.textContent.trim() === "Enable Computer Use")?.click()));
+    await waitFor(app, () => (document.body.innerText.includes("Ready · app access is approved when a session starts")), { timeoutMs: 60_000 });
+    expect(await evalIn(app, () => ([...document.querySelectorAll("button")].some(b => /^(Enable|Reconnect) Computer Use$/.test(b.textContent.trim()))))).toBe(false);
   });
 });
 

--- a/evals/specs/connect-readiness-preseeded.e2e.test.ts
+++ b/evals/specs/connect-readiness-preseeded.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { readAvailableModels, selectModel } from "@openwork/behaviors";
 import { observeTranscript, spec } from "@openwork/testkit";
@@ -34,7 +35,7 @@ test("bundled engine connects to preseeded organization skills and connections",
 
   const health = await probe.eventually(
     // TODO(primitive): probe.cloudMcpHealth
-    () => probe.eval(cloudHealthExpression, { args: [world.workspaceId] }),
+    () => probe.eval(browserScript(cloudHealthExpression, [world.workspaceId])),
     {
       within: 180_000,
       label: "openwork-cloud engine and agent-tool readiness",

--- a/evals/specs/connection-action-mcp-app.e2e.test.ts
+++ b/evals/specs/connection-action-mcp-app.e2e.test.ts
@@ -28,10 +28,10 @@ test("desktop connects an account directly with the provider and confirms author
   expect(calls.filter(call => call.kind === "tool").every(call => call.toolName?.endsWith("search_capabilities"))).toBe(true);
   expect(calls.filter(call => call.kind === "tool")).toHaveLength(1);
   expect((await world.den.mocks.connector.requests()).filter(request => request.path === "/authorize")).toHaveLength(0);
-  const compact = await probe.eval(`(() => {
-    const card = document.querySelector('[data-testid="desktop-connection-card"]');
-    return { height: card?.getBoundingClientRect().height, width: card?.getBoundingClientRect().width, hasChecklist: Boolean(card?.querySelector('ol')), embeddedApp: Boolean(document.querySelector('[data-mcp-app-resource="ui://openwork/connection-action/v1/view.html"]')) };
-  })()`);
+  const compact = await probe.eval(() => {
+    const card = document.querySelector<HTMLElement>('[data-testid="desktop-connection-card"]');
+    return { height: card?.getBoundingClientRect().height, width: card?.getBoundingClientRect().width, hasChecklist: Boolean(card?.querySelector('ol')), embeddedApp: Boolean(document.querySelector<HTMLElement>('[data-mcp-app-resource="ui://openwork/connection-action/v1/view.html"]')) };
+  });
   expect(compact).toMatchObject({ hasChecklist: false, embeddedApp: false });
   if (!compact || typeof compact !== "object" || !("height" in compact) || typeof compact.height !== "number" || !("width" in compact) || typeof compact.width !== "number") throw new Error("The connection card was not rendered.");
   expect(compact.height).toBeLessThan(88);
@@ -39,14 +39,14 @@ test("desktop connects an account directly with the provider and confirms author
   evidence.recordAssertionEvidence("Search shows one native connection card without a checklist or embedded setup", JSON.stringify(compact), true);
   evidence.recordAssertionEvidence("Authorization does not start before the user clicks Connect", "No provider authorization request before Connect", true);
 
-  await probe.eval(`(() => {
-    const card = document.querySelector('[data-testid="desktop-connection-card"]');
+  await probe.eval(() => {
+    const card = document.querySelector<HTMLElement>('[data-testid="desktop-connection-card"]');
     if (!card) throw new Error("Connection card missing");
-    const sizes = [];
+    const sizes: { width: number; height: number; text: string | null }[] = [];
     const record = () => { const rect = card.getBoundingClientRect(); sizes.push({ width: rect.width, height: rect.height, text: card.textContent }); card.dataset.observedSizes = JSON.stringify(sizes); };
     new MutationObserver(record).observe(card, { childList: true, subtree: true, characterData: true });
     record();
-  })()`);
+  });
   const clickedAt = new Date().toISOString();
   await user.click({ role: "button", label: "Connect Notion" });
   const authorization = await world.den.mocks.connector.authorizeRequestSince(clickedAt, { timeoutMs: 60_000 });
@@ -55,16 +55,16 @@ test("desktop connects an account directly with the provider and confirms author
   await user.see({ text: "Connected" }, { timeoutMs: 120_000 });
   await user.notSee({ role: "button", label: "Connect Notion" });
   await user.notSee({ text: "Your Connections" });
-  const completed = await probe.eval(`(() => {
-    const card = document.querySelector('[data-testid="desktop-connection-card"]');
+  const completed = await probe.eval(() => {
+    const card = document.querySelector<HTMLElement>('[data-testid="desktop-connection-card"]');
     return { height: card?.getBoundingClientRect().height, width: card?.getBoundingClientRect().width, buttons: card?.querySelectorAll('button').length };
-  })()`);
+  });
   expect(completed).toMatchObject({ buttons: 0 });
   if (!completed || typeof completed !== "object" || !("height" in completed) || typeof completed.height !== "number") throw new Error("The connected indicator was not rendered.");
   expect(completed.height).toBe(compact.height);
   expect(completed).toMatchObject({ width: compact.width });
   evidence.recordAssertionEvidence("Connection completion preserves the card dimensions", JSON.stringify({ ready: compact, connected: completed }), true);
-  const transitions = await probe.eval(`JSON.parse(document.querySelector('[data-testid="desktop-connection-card"]')?.getAttribute("data-observed-sizes") ?? "[]")`);
+  const transitions = await probe.eval(() => (JSON.parse(document.querySelector<HTMLElement>('[data-testid="desktop-connection-card"]')?.getAttribute("data-observed-sizes") ?? "[]")));
   if (!Array.isArray(transitions)) throw new Error("No card transition measurements were recorded");
   for (const dimensions of transitions) expect(dimensions).toMatchObject({ width: compact.width, height: compact.height });
   for (const status of ["Opening sign-in…", "Finish sign-in in your browser", "Ready to use"]) {

--- a/evals/specs/connector-catalog.e2e.test.ts
+++ b/evals/specs/connector-catalog.e2e.test.ts
@@ -15,16 +15,16 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.see({ role: "button", label: "Set up Slack" });
   await appUser.see({ text: "Admin setup" });
   await appUser.notSee({ testId: "desktop-connection-card" });
-  const visibleIds = () => appProbe.eval(`Array.from(document.querySelectorAll('[data-connector-preset]'), element => element.getAttribute('data-connector-preset'))`);
+  const visibleIds = () => appProbe.eval(() => (Array.from(document.querySelectorAll<HTMLElement>('[data-connector-preset]'), element => element.getAttribute('data-connector-preset'))));
   expect(await visibleIds()).toEqual(["slack"]);
-  const suggestedWidth = await appProbe.eval(`document.querySelector('[data-testid="connector-catalog"]')?.getBoundingClientRect().width`);
+  const suggestedWidth = await appProbe.eval(() => (document.querySelector<HTMLElement>('[data-testid="connector-catalog"]')?.getBoundingClientRect().width));
   await appUser.screenshot();
   evidence.recordAssertionEvidence("A Slack request offers setup without claiming the service is connected", "Only Slack is suggested with Admin setup; no account connection card is shown", true);
 
   await appUser.click({ role: "button", label: `Browse all ${world.expectedIds.length}` });
   await appUser.see({ role: "textbox", label: "Filter connectors" });
   expect(await visibleIds()).toEqual(world.expectedIds);
-  const expandedWidth = await appProbe.eval(`document.querySelector('[data-testid="connector-catalog"]')?.getBoundingClientRect().width`);
+  const expandedWidth = await appProbe.eval(() => (document.querySelector<HTMLElement>('[data-testid="connector-catalog"]')?.getBoundingClientRect().width));
   expect(expandedWidth).toBe(suggestedWidth);
   evidence.recordAssertionEvidence("Browsing all connectors preserves the suggestion card width", JSON.stringify({ suggestedWidth, expandedWidth }), true);
   await appUser.see({ role: "button", label: "Set up Linear" });
@@ -36,7 +36,7 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.type({ role: "textbox", label: "Filter connectors" }, "slack", { replace: true });
   expect(await visibleIds()).toEqual(["slack"]);
   await probe.eventually(
-    () => appProbe.eval(`document.querySelector('button[aria-label="Set up Slack"]')?.disabled === false`),
+    () => appProbe.eval(() => (document.querySelector<HTMLButtonElement>('button[aria-label="Set up Slack"]')?.disabled === false)),
     { within: 15_000, label: "admin setup action is enabled", until: value => value === true },
   );
   expect(await world.browserUrls.opened()).toEqual([]);
@@ -68,10 +68,10 @@ test("chat suggests Slack setup and lets an admin browse every quick-add connect
   await appUser.see({ text: "Try one of these:" });
   await agent.on(world.app).send(allConnectorsPrompt);
   await appUser.see({ text: allConnectorsReply }, { timeoutMs: 120_000 });
-  const listed = await appProbe.eval(`(() => {
-    const cards = Array.from(document.querySelectorAll('[data-testid="connector-catalog"]'));
-    return Array.from(cards.at(-1)?.querySelectorAll('[data-connector-preset]') ?? [], entry => entry.getAttribute('data-connector-preset'));
-  })()`);
+  const listed = await appProbe.eval(() => {
+    const cards = Array.from(document.querySelectorAll<HTMLElement>('[data-testid="connector-catalog"]'));
+    return Array.from(cards.at(-1)?.querySelectorAll<HTMLElement>('[data-connector-preset]') ?? [], entry => entry.getAttribute('data-connector-preset'));
+  });
   expect(listed).toEqual(world.expectedIds);
   await appUser.screenshot();
   evidence.recordAssertionEvidence("Asking for all quick adds immediately opens the complete catalog", JSON.stringify(listed), true);

--- a/evals/specs/connector-tool-call-branding.e2e.test.ts
+++ b/evals/specs/connector-tool-call-branding.e2e.test.ts
@@ -22,14 +22,14 @@ test("connector-backed tool calls show first-class branding and human-readable l
     expect(await world.den.mocks.connector.toolCalls({ name: "list_channels", sinceIso, atLeast: 1 }))
       .toMatchObject([{ name: "list_channels", args: { limit: 3 } }]);
     // TODO(primitive): probe.connectorBranding
-    const inspect = () => probe.eval(`(() => {
-      const rows = [...document.querySelectorAll('[data-capability-call]')];
+    const inspect = () => probe.eval(() => {
+      const rows = [...document.querySelectorAll<HTMLElement>('[data-capability-call]')];
       const matching = rows.filter(row => row.textContent.includes('Listed channels'));
-      const mark = matching[0]?.querySelector('[data-connector-name="Slack"]');
+      const mark = matching[0]?.querySelector<HTMLElement>('[data-connector-name="Slack"]');
       const image = mark?.querySelector('img');
       return { count: matching.length, connector: mark?.getAttribute('data-connector-name'),
         imageLoaded: image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 };
-    })()`);
+    });
     const branded = await probe.eventually(inspect, { within: 15_000, label: "Slack tool icon and one completed row",
       until: (value) => isRecord(value) && value.imageLoaded === true });
     expect(branded).toMatchObject({ count: 1, connector: "Slack", imageLoaded: true });

--- a/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
+++ b/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
@@ -49,25 +49,25 @@ const title = !e2eTestsEnabled
 const ORG_A = "Handoff Atomic A";
 const ORG_B = "Handoff Atomic B";
 
-const EVENT_RECORDER = `(() => {
+const EVENT_RECORDER = () => {
   if (!window.__handoffProofEvents) {
     window.__handoffProofEvents = [];
     window.addEventListener("openwork-den-session-updated", (event) => {
-      window.__handoffProofEvents.push(String(event?.detail?.status ?? "unknown"));
+      window.__handoffProofEvents.push(String(event instanceof CustomEvent ? event.detail?.status ?? "unknown" : "unknown"));
     });
   }
   return true;
-})()`;
+};
 
 async function readSessionEvents(desktop: Surface): Promise<string[]> {
-  const raw = await evalIn(desktop, "JSON.stringify(window.__handoffProofEvents ?? [])");
+  const raw = await evalIn(desktop, () => (JSON.stringify(window.__handoffProofEvents ?? [])));
   return JSON.parse(String(raw)) as string[];
 }
 
 async function readEnrollmentOrigin(desktop: Surface): Promise<string | null> {
   const raw = await evalIn(
     desktop,
-    "window.localStorage.getItem('openwork.den.sessionOrigin') ?? ''",
+    () => (window.localStorage.getItem('openwork.den.sessionOrigin') ?? ''),
   );
   return String(raw).trim() || null;
 }
@@ -266,7 +266,7 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(
         env: { PORT: rendererPort },
       });
       try {
-        const restartedOrigin = String(await evalIn(restarted, "window.location.origin"));
+        const restartedOrigin = String(await evalIn(restarted, () => (window.location.origin)));
         if (new URL(restartedOrigin).port !== rendererPort) {
           throw new Error(
             `The relaunched renderer did not reuse port ${rendererPort} (origin ${restartedOrigin}); the restart cannot observe the persisted session.`,

--- a/evals/specs/cross-workspace-split-view.e2e.test.ts
+++ b/evals/specs/cross-workspace-split-view.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { evalIn, go, waitFor } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
@@ -80,9 +81,7 @@ function parseSplitFacts(value: unknown): SplitFacts {
 }
 
 async function waitForSessionRow(app: Surface, candidate: SplitCandidate): Promise<void> {
-  await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(
-    `[data-sidebar-session-id="${candidate.sessionId}"][data-sidebar-session-workspace-id="${candidate.workspaceId}"]`,
-  )}))`, {
+  await waitFor(app, browserScript((value) => (Boolean(document.querySelector<HTMLElement>(value))), [`[data-sidebar-session-id="${candidate.sessionId}"][data-sidebar-session-workspace-id="${candidate.workspaceId}"]`]), {
     timeoutMs: 60_000,
     label: `sidebar row for ${candidate.title}`,
   });
@@ -90,23 +89,23 @@ async function waitForSessionRow(app: Surface, candidate: SplitCandidate): Promi
 
 async function openSessionRoute(app: Surface, candidate: SplitCandidate): Promise<void> {
   await go(app, `/workspace/${candidate.workspaceId}/session/${candidate.sessionId}`, { timeoutMs: 60_000 });
-  await waitFor(app, `(() => {
-    const surface = document.querySelector("[data-session-surface-id]");
-    return (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(candidate.workspaceId)}
-      && surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(candidate.sessionId)};
-  })()`, { timeoutMs: 60_000, label: `visible session ${candidate.title}` });
+  await waitFor(app, browserScript((workspaceId, sessionId) => {
+    const surface = document.querySelector<HTMLElement>("[data-session-surface-id]");
+    return (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId
+      && surface?.getAttribute("data-session-surface-id") === sessionId;
+  }, [candidate.workspaceId, candidate.sessionId]), { timeoutMs: 60_000, label: `visible session ${candidate.title}` });
 }
 
 async function openContextMenuForSession(app: Surface, user: User, candidate: SplitCandidate): Promise<void> {
   await user.press("Escape");
   await user.rightClick({ text: candidate.title });
-  await waitFor(app, `Boolean(document.querySelector('[role="menu"]'))`, {
+  await waitFor(app, () => (Boolean(document.querySelector<HTMLElement>('[role="menu"]'))), {
     timeoutMs: 15000, label: `context menu rendered for ${candidate.title}`,
   });
 }
 
 async function splitMenuVisible(app: Surface): Promise<boolean> {
-  return await evalIn(app, `Boolean(document.querySelector("[data-session-menu-open-split]"))`) === true;
+  return await evalIn(app, () => (Boolean(document.querySelector<HTMLElement>("[data-session-menu-open-split]")))) === true;
 }
 
 async function clickOpenSplit(user: User): Promise<void> {
@@ -115,8 +114,8 @@ async function clickOpenSplit(user: User): Promise<void> {
 
 async function closeSecondaryPane(app: Surface, user: User, primary: SplitCandidate): Promise<void> {
   await user.click({ role: "button", label: "Close side chat" });
-  await waitFor(app, `!document.querySelector('[data-workbench-pane="secondary"]')
-    && Boolean(document.querySelector('[data-session-surface-id="${primary.sessionId}"]'))`, {
+  await waitFor(app, browserScript((sessionId) => (!document.querySelector<HTMLElement>('[data-workbench-pane="secondary"]')
+    && Boolean(document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`))), [primary.sessionId]), {
     timeoutMs: 15000, label: "side chat closes and the main conversation remains visible",
   });
 }
@@ -130,13 +129,13 @@ async function openCrossWorkspaceSplitFromPalette(app: Surface, user: User, cand
 }
 
 async function readSplitFacts(app: Surface, primary: SplitCandidate, secondary: SplitCandidate): Promise<SplitFacts> {
-  return parseSplitFacts(await evalIn(app, `(() => {
+  return parseSplitFacts(await evalIn(app, browserScript((inputSessionId, inputSessionId2, inputSessionId3, inputSessionId4) => {
     const context = window.__openworkControl?.context?.();
     const layout = context?.conversations?.layout;
-    const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
-    const secondaryPane = document.querySelector('[data-workbench-pane="secondary"]');
-    const primarySurface = primaryPane?.querySelector('[data-session-surface-id="${primary.sessionId}"]');
-    const secondarySurface = secondaryPane?.querySelector('[data-session-surface-id="${secondary.sessionId}"]');
+    const primaryPane = document.querySelector<HTMLElement>('[data-workbench-pane="primary"]');
+    const secondaryPane = document.querySelector<HTMLElement>('[data-workbench-pane="secondary"]');
+    const primarySurface = primaryPane?.querySelector<HTMLElement>(`[data-session-surface-id="${inputSessionId}"]`);
+    const secondarySurface = secondaryPane?.querySelector<HTMLElement>(`[data-session-surface-id="${inputSessionId2}"]`);
     const resources = Array.isArray(context?.resources) ? context.resources : [];
     const primaryResource = resources.find((resource) => resource?.kind === "session"
       && resource?.state?.pane === "primary" && resource?.state?.visible === true);
@@ -144,30 +143,30 @@ async function readSplitFacts(app: Surface, primary: SplitCandidate, secondary: 
       && resource?.state?.pane === "secondary" && resource?.state?.visible === true);
     return {
       layout: layout?.kind ?? "",
-      primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
-      secondarySessionId: layout?.secondarySessionId ?? "",
-      primaryLayoutWorkspaceId: layout?.primaryWorkspaceId ?? layout?.workspaceId ?? "",
-      secondaryLayoutWorkspaceId: layout?.secondaryWorkspaceId ?? "",
+      primarySessionId: (layout?.kind === "split" ? layout.primarySessionId : undefined) ?? (layout?.kind === "single" ? layout.sessionId : undefined) ?? "",
+      secondarySessionId: (layout?.kind === "split" ? layout.secondarySessionId : undefined) ?? "",
+      primaryLayoutWorkspaceId: (layout?.kind === "split" ? layout.primaryWorkspaceId : undefined) ?? (layout?.kind === "single" ? layout.workspaceId : undefined) ?? "",
+      secondaryLayoutWorkspaceId: (layout?.kind === "split" ? layout.secondaryWorkspaceId : undefined) ?? "",
       primaryPaneWorkspaceId: primaryPane?.getAttribute("data-workbench-workspace-id") ?? "",
       secondaryPaneWorkspaceId: secondaryPane?.getAttribute("data-workbench-workspace-id") ?? "",
       primarySurfaceWorkspaceId: primarySurface?.getAttribute("data-session-surface-workspace-id") ?? "",
       secondarySurfaceWorkspaceId: secondarySurface?.getAttribute("data-session-surface-workspace-id") ?? "",
-      primaryWorkspaceName: primaryPane?.querySelector('[data-workbench-pane-header="primary"]')
+      primaryWorkspaceName: primaryPane?.querySelector<HTMLElement>('[data-workbench-pane-header="primary"]')
         ?.getAttribute("data-workbench-pane-workspace-name") ?? "",
-      secondaryWorkspaceName: secondaryPane?.querySelector('[data-workbench-pane-header="secondary"]')
+      secondaryWorkspaceName: secondaryPane?.querySelector<HTMLElement>('[data-workbench-pane-header="secondary"]')
         ?.getAttribute("data-workbench-pane-workspace-name") ?? "",
       primaryResourceWorkspaceId: primaryResource?.state?.workspaceId ?? "",
       secondaryResourceWorkspaceId: secondaryResource?.state?.workspaceId ?? "",
-      primaryOwnsSecondarySurface: Boolean(primaryPane?.querySelector(
-        '[data-session-surface-id="${secondary.sessionId}"]',
+      primaryOwnsSecondarySurface: Boolean(primaryPane?.querySelector<HTMLElement>(
+        `[data-session-surface-id="${inputSessionId3}"]`,
       )),
-      secondaryOwnsPrimarySurface: Boolean(secondaryPane?.querySelector(
-        '[data-session-surface-id="${primary.sessionId}"]',
+      secondaryOwnsPrimarySurface: Boolean(secondaryPane?.querySelector<HTMLElement>(
+        `[data-session-surface-id="${inputSessionId4}"]`,
       )),
-      primaryUnavailable: Boolean(primaryPane?.querySelector('[data-workbench-pane-unavailable]')),
-      secondaryUnavailable: Boolean(secondaryPane?.querySelector('[data-workbench-pane-unavailable]')),
+      primaryUnavailable: Boolean(primaryPane?.querySelector<HTMLElement>('[data-workbench-pane-unavailable]')),
+      secondaryUnavailable: Boolean(secondaryPane?.querySelector<HTMLElement>('[data-workbench-pane-unavailable]')),
     };
-  })()`));
+  }, [primary.sessionId, secondary.sessionId, secondary.sessionId, primary.sessionId])));
 }
 
 test("same-workspace and cross-workspace split sessions retain visible ownership", async ({ world, user, evidence }) => {
@@ -191,9 +190,9 @@ test("same-workspace and cross-workspace split sessions retain visible ownership
     await openContextMenuForSession(app, user, sameWorkspacePeer);
     expect(await splitMenuVisible(app)).toBe(true);
     await clickOpenSplit(user);
-    await waitFor(app, `Boolean(document.querySelector(
-      '[data-workbench-pane="secondary"][data-workbench-workspace-id="${workspaceA}"] [data-session-surface-id="${sameWorkspacePeer.sessionId}"]'
-    ))`, { timeoutMs: 60_000, label: "same-workspace split renders" });
+    await waitFor(app, browserScript((workspaceA, sessionId) => (Boolean(document.querySelector<HTMLElement>(
+      `[data-workbench-pane="secondary"][data-workbench-workspace-id="${workspaceA}"] [data-session-surface-id="${sessionId}"]`
+    ))), [workspaceA, sameWorkspacePeer.sessionId]), { timeoutMs: 60_000, label: "same-workspace split renders" });
     const sameWorkspaceFacts = await readSplitFacts(app, primary, sameWorkspacePeer);
     expect(sameWorkspaceFacts.primaryPaneWorkspaceId).toBe(workspaceA);
     expect(sameWorkspaceFacts.secondaryPaneWorkspaceId).toBe(workspaceA);
@@ -225,15 +224,15 @@ test("same-workspace and cross-workspace split sessions retain visible ownership
         && !sameWorkspaceFacts.secondaryUnavailable,
     );
     await closeSecondaryPane(app, user, primary);
-    expect(await evalIn(app, `document.querySelector('[data-session-surface-id="${primary.sessionId}"]') !== null`)).toBe(true);
-    expect(await evalIn(app, `document.querySelector('[data-session-surface-id="${sameWorkspacePeer.sessionId}"]') === null`)).toBe(true);
+    expect(await evalIn(app, browserScript((sessionId) => (document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`) !== null), [primary.sessionId]))).toBe(true);
+    expect(await evalIn(app, browserScript((sessionId) => (document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`) === null), [sameWorkspacePeer.sessionId]))).toBe(true);
 
     await openContextMenuForSession(app, user, crossWorkspacePeer);
     expect(await splitMenuVisible(app)).toBe(true);
     await openCrossWorkspaceSplitFromPalette(app, user, crossWorkspacePeer);
-    await waitFor(app, `Boolean(document.querySelector(
-      '[data-workbench-pane="secondary"][data-workbench-workspace-id="${workspaceB}"] [data-session-surface-id="${crossWorkspacePeer.sessionId}"]'
-    ))`, { timeoutMs: 60_000, label: "cross-workspace palette split renders" });
+    await waitFor(app, browserScript((workspaceB, sessionId) => (Boolean(document.querySelector<HTMLElement>(
+      `[data-workbench-pane="secondary"][data-workbench-workspace-id="${workspaceB}"] [data-session-surface-id="${sessionId}"]`
+    ))), [workspaceB, crossWorkspacePeer.sessionId]), { timeoutMs: 60_000, label: "cross-workspace palette split renders" });
 
     const crossWorkspaceFacts = await readSplitFacts(app, primary, crossWorkspacePeer);
     expect(crossWorkspaceFacts.layout).toBe("split");

--- a/evals/specs/engine-v2-preview-flag.e2e.test.ts
+++ b/evals/specs/engine-v2-preview-flag.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -71,21 +72,21 @@ async function serverFetchJson(
   const timeoutMs = init.timeoutMs ?? 15_000;
   const requestBody = init.body === undefined ? undefined : JSON.stringify(init.body);
   if (init.body !== undefined && requestBody === undefined) throw new Error(`Could not serialize request body for ${path}`);
-  const value = await evalIn(app, `(async () => {
+  const value = await evalIn(app, browserScript(async (path, value, inputValue, timeoutMs) => {
     const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
     const token = (localStorage.getItem("openwork.server.token") ?? "").trim();
     if (!port || !token) return { specProbeError: "missing local server credentials" };
-    const response = await fetch("http://127.0.0.1:" + port + ${JSON.stringify(path)}, {
-      method: ${JSON.stringify(init.method ?? "GET")},
+    const response = await fetch("http://127.0.0.1:" + port + path, {
+      method: value,
       headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
-      ${requestBody === undefined ? "" : `body: ${JSON.stringify(requestBody)},`}
-      signal: AbortSignal.timeout(${timeoutMs}),
+      body: inputValue,
+      signal: AbortSignal.timeout(timeoutMs),
     });
     const text = await response.text();
     let json = text;
     try { json = JSON.parse(text); } catch {}
     return { status: response.status, json };
-  })()`, { awaitPromise: true, timeoutMs: timeoutMs + 5_000 });
+  }, [path, init.method ?? "GET", requestBody ?? null, timeoutMs]), { awaitPromise: true, timeoutMs: timeoutMs + 5_000 });
   if (!isRecord(value) || typeof value.status !== "number" || !("json" in value)) {
     throw new Error(`Server request ${path} failed: ${JSON.stringify(value)}`);
   }
@@ -115,8 +116,8 @@ async function untilStatus(
 }
 
 async function clickEngineOption(app: Parameters<typeof evalIn>[0], engine: "v1" | "v2"): Promise<void> {
-  const point = await evalIn(app, `(() => {
-    const control = Array.from(document.querySelectorAll('[aria-label="Chat engine"] [data-engine="${engine}"]'))
+  const point = await evalIn(app, browserScript((engine) => {
+    const control = Array.from(document.querySelectorAll<HTMLElement>(`[aria-label="Chat engine"] [data-engine="${engine}"]`))
       .find((candidate) => {
         const rect = candidate.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0;
@@ -125,7 +126,7 @@ async function clickEngineOption(app: Parameters<typeof evalIn>[0], engine: "v1"
     control.scrollIntoView({ block: "center", behavior: "instant" });
     const rect = control.getBoundingClientRect();
     return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-  })()`);
+  }, [engine]));
   if (
     !isRecord(point)
     || typeof point.x !== "number"
@@ -138,18 +139,18 @@ async function clickEngineOption(app: Parameters<typeof evalIn>[0], engine: "v1"
   await app.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
 }
 
-const engineSelectedExpression = (engine: "v1" | "v2") => `(() => {
-  const group = document.querySelector('[aria-label="Chat engine"]');
-  const control = group?.querySelector('[data-engine="${engine}"]');
+const engineSelectedExpression = (engine: "v1" | "v2") => browserScript((engine) => {
+  const group = document.querySelector<HTMLElement>('[aria-label="Chat engine"]');
+  const control = group?.querySelector<HTMLElement>(`[data-engine="${engine}"]`);
   return control?.getAttribute("aria-pressed") === "true" || control?.getAttribute("data-state") === "on";
-})()`;
+}, [engine]);
 
-const engineReadyExpression = `(() => {
-  const group = document.querySelector('[aria-label="Chat engine"]');
+const engineReadyExpression = () => {
+  const group = document.querySelector<HTMLElement>('[aria-label="Chat engine"]');
   if (!group || group.getAttribute("aria-disabled") === "true" || group.hasAttribute("data-disabled")) return false;
-  const control = group.querySelector('[data-engine="v1"]');
+  const control = group.querySelector<HTMLElement>('[data-engine="v1"]');
   return control?.getAttribute("aria-pressed") === "true" || control?.getAttribute("data-state") === "on";
-})()`;
+};
 
 test.skipIf(!enabled)(title, async ({ evidence, place }) => {
   needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
@@ -205,7 +206,7 @@ test.skipIf(!enabled)(title, async ({ evidence, place }) => {
     const pid0 = runningStatus.pid;
     if (pid0 === undefined) throw new Error("Running OpenCode v2 status did not contain a pid");
     expect(runningStatus.chatRouting).toBe(true);
-    await waitFor(app, `document.body.innerText.includes("Running v")`, {
+    await waitFor(app, () => (document.body.innerText.includes("Running v")), {
       timeoutMs: 30_000,
       label: "OpenCode v2 running status line",
     });

--- a/evals/specs/first-run-cloud-share.e2e.test.ts
+++ b/evals/specs/first-run-cloud-share.e2e.test.ts
@@ -48,11 +48,11 @@ test("first run signs in through the browser, then shares a skill with a colleag
   await step("The browser-issued grant returns to the app", async () => {
     // TODO(primitive): read the browser-issued desktop handoff URL.
     const deepLink = await probe.eventually(
-      () => webProbe.eval(`(() => {
+      () => webProbe.eval(() => {
         const input = [...document.querySelectorAll("input")].find((candidate) => candidate.value.startsWith("openwork://") && candidate.value.includes("grant="));
         if (input) return input.value;
-        return document.querySelector('a[href^="openwork://"]')?.getAttribute("href") ?? "";
-      })()`),
+        return document.querySelector<HTMLElement>('a[href^="openwork://"]')?.getAttribute("href") ?? "";
+      }),
       { within: 120_000, label: "browser-issued desktop handoff URL", until: (value) => typeof value === "string" && value.startsWith("openwork://") },
     );
     if (typeof deepLink !== "string") throw new Error("The browser-issued handoff URL was not a string.");

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -7,7 +7,7 @@ test("visitors see consistent monthly Team and Enterprise pricing", async ({ evi
   needs({ env: ["OPENWORK_EVAL_LANDING_URL"] });
   const origin = process.env.OPENWORK_EVAL_LANDING_URL;
   await using browser = await chrome({ startUrl: `${origin}/pricing`, headless: true });
-  const visible = await eventually(async () => evaluateOnSurface(browser, "document.body.innerText"), {
+  const visible = await eventually(async () => evaluateOnSurface(browser, () => (document.body.innerText)), {
     within: 30_000,
     until: (value) => typeof value === "string" && value.includes("$10") && value.includes("$40"),
   });

--- a/evals/specs/library-add-connector-discovery.e2e.test.ts
+++ b/evals/specs/library-add-connector-discovery.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { denFetch, evalIn, go, waitFor } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
@@ -74,27 +75,27 @@ test(title, async ({ evidence, place }) => {
     mobile: false,
   });
   await go(desktop, `/workspace/${desktop.workspaceId}/extensions`);
-  await waitFor(desktop, `[...document.querySelectorAll("button")]
-    .some((button) => (button.textContent ?? "").trim() === "Add")`, {
+  await waitFor(desktop, () => ([...document.querySelectorAll("button")]
+    .some((button) => (button.textContent ?? "").trim() === "Add")), {
     timeoutMs: 90_000,
     label: "signed-in Library Add control",
   });
-  const voiceModeVisible = await evalIn(desktop, `
+  const voiceModeVisible = await evalIn(desktop, () => (
     [...document.querySelectorAll("button, [role=menuitem], h1, h2, h3")]
       .some((element) => /voice mode/i.test(element.textContent ?? "")
         || /voice mode/i.test(element.getAttribute("aria-label") ?? ""))
-  `);
+  ));
   expect(voiceModeVisible).toBe(false);
-  const libraryText = await evalIn(desktop, `document.body.innerText`);
+  const libraryText = await evalIn(desktop, () => document.body.innerText);
   expect(libraryText).not.toContain("Voice Mode");
 
   const bootstrap = await evalIn(
     desktop,
-    `window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig")
+    () => (window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig")
       .then((config) => ({
         baseUrl: config.baseUrl,
         activeOrgId: localStorage.getItem("openwork.den.activeOrgId"),
-      }))`,
+      }))),
     { awaitPromise: true },
   );
   expect(bootstrap).toMatchObject({
@@ -102,32 +103,32 @@ test(title, async ({ evidence, place }) => {
     activeOrgId: orgId,
   });
 
-  const addOpened = await evalIn(desktop, `(() => {
+  const addOpened = await evalIn(desktop, () => {
     const button = [...document.querySelectorAll("button")]
       .find((entry) => (entry.textContent ?? "").trim() === "Add");
     if (!(button instanceof HTMLButtonElement)) return false;
     button.click();
     return true;
-  })()`);
+  });
   expect(addOpened).toBe(true);
-  await waitFor(desktop, `(() => {
-    const dialog = document.querySelector('[role="dialog"]');
-    return dialog?.querySelectorAll('[data-testid="connection-logo-cues"] [data-connector-cue]').length === 5;
-  })()`, {
+  await waitFor(desktop, () => {
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
+    return dialog?.querySelectorAll<HTMLElement>('[data-testid="connection-logo-cues"] [data-connector-cue]').length === 5;
+  }, {
     timeoutMs: 30_000,
     label: "unified Library picker with representative connector logos",
   });
 
-  const picker = await evalIn(desktop, `(() => {
-    const dialog = document.querySelector('[role="dialog"]');
+  const picker = await evalIn(desktop, () => {
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
     const dialogRect = dialog?.getBoundingClientRect();
     const continueButton = dialog
       ? [...dialog.querySelectorAll('button')]
           .find((button) => (button.textContent ?? '').trim() === 'Continue')
       : null;
     const continueRect = continueButton?.getBoundingClientRect();
-    const cueStrip = dialog?.querySelector('[data-testid="connection-logo-cues"]');
-    const cueTiles = dialog ? [...dialog.querySelectorAll('[data-connector-cue]')] : [];
+    const cueStrip = dialog?.querySelector<HTMLElement>('[data-testid="connection-logo-cues"]');
+    const cueTiles = dialog ? [...dialog.querySelectorAll<HTMLElement>('[data-connector-cue]')] : [];
     const lightTileBackgrounds = cueTiles.map((tile) => getComputedStyle(tile).backgroundColor);
     const previousTheme = document.documentElement.dataset.theme;
     document.documentElement.dataset.theme = 'dark';
@@ -139,16 +140,16 @@ test(title, async ({ evidence, place }) => {
     }
     return {
       choices: dialog
-        ? [...dialog.querySelectorAll('[data-kind-title]')]
+        ? [...dialog.querySelectorAll<HTMLElement>('[data-kind-title]')]
             .map((item) => (item.textContent ?? '').trim())
         : [],
-      radioGroups: dialog?.querySelectorAll('[role="radiogroup"]').length ?? 0,
+      radioGroups: dialog?.querySelectorAll<HTMLElement>('[role="radiogroup"]').length ?? 0,
       oldMakeSection: dialog?.textContent?.includes('WHAT ARE YOU MAKING') ?? false,
       oldConnectSection: dialog?.textContent?.includes('OR CONNECT SOMETHING') ?? false,
       opensDenCopy: dialog?.textContent?.includes('manage setup for this organization in OpenWork Den') ?? false,
       cues: cueTiles.map((item) => item.getAttribute('title')),
       logoLabels: dialog
-        ? [...dialog.querySelectorAll('[data-connector-cue] img, [data-connector-cue] [aria-label]')]
+        ? [...dialog.querySelectorAll<HTMLElement>('[data-connector-cue] img, [data-connector-cue] [aria-label]')]
             .map((item) => item.getAttribute('alt') || item.getAttribute('aria-label'))
         : [],
       cueStripWraps: cueStrip?.classList.contains('flex-wrap') ?? false,
@@ -170,7 +171,7 @@ test(title, async ({ evidence, place }) => {
       ),
       horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
     };
-  })()`);
+  });
   expect(picker).toMatchObject({
     choices: expectedChoices,
     radioGroups: 1,
@@ -202,15 +203,15 @@ test(title, async ({ evidence, place }) => {
       && picker.horizontalOverflow === false,
   );
 
-  await waitFor(desktop, `(() => {
-    const cues = [...document.querySelectorAll('[data-connector-cue]')];
+  await waitFor(desktop, () => {
+    const cues = [...document.querySelectorAll<HTMLElement>('[data-connector-cue]')];
     return cues.length === 5 && cues.every((cue) => {
       const image = cue.querySelector('img');
       return image instanceof HTMLImageElement
         && image.complete
         && image.naturalWidth > 0;
     });
-  })()`, {
+  }, {
     timeoutMs: 30_000,
     label: "all five recognizable connector logos loaded",
   });
@@ -225,35 +226,35 @@ test(title, async ({ evidence, place }) => {
     expect(seen.ok, seen.why).toBe(true);
   }
 
-  const connectionSelected = await evalIn(desktop, `(() => {
-    const connection = document.querySelector('[role="radio"][data-kind="connection"]');
+  const connectionSelected = await evalIn(desktop, () => {
+    const connection = document.querySelector<HTMLElement>('[role="radio"][data-kind="connection"]');
     if (!(connection instanceof HTMLElement)) return false;
     connection.click();
     return true;
-  })()`);
+  });
   expect(connectionSelected).toBe(true);
-  await waitFor(desktop, `document.querySelector('[role="radio"][data-kind="connection"]')
-    ?.getAttribute('aria-checked') === 'true'`, {
+  await waitFor(desktop, () => (document.querySelector<HTMLElement>('[role="radio"][data-kind="connection"]')
+    ?.getAttribute('aria-checked') === 'true'), {
     timeoutMs: 10_000,
     label: "Connection selected in the unified picker",
   });
-  const previousTheme = await evalIn(desktop, `document.documentElement.dataset.theme ?? ''`);
-  await evalIn(desktop, `document.documentElement.dataset.theme = 'dark'`);
+  const previousTheme = await evalIn(desktop, () => (document.documentElement.dataset.theme ?? ''));
+  await evalIn(desktop, () => (document.documentElement.dataset.theme = 'dark'));
   try {
-    await waitFor(desktop, `document.documentElement.dataset.theme === 'dark'`, {
+    await waitFor(desktop, () => (document.documentElement.dataset.theme === 'dark'), {
       timeoutMs: 10_000,
       label: "dark theme applied through the app theme attribute",
     });
-    await evalIn(desktop, `(() => {
-      for (const toast of document.querySelectorAll('[data-sonner-toast]')) {
-        const closeButton = toast.querySelector(
+    await evalIn(desktop, () => {
+      for (const toast of document.querySelectorAll<HTMLElement>('[data-sonner-toast]')) {
+        const closeButton = toast.querySelector<HTMLElement>(
           '[data-close-button], button[aria-label*="close" i]',
         );
         if (closeButton instanceof HTMLButtonElement) closeButton.click();
       }
       return true;
-    })()`);
-    await waitFor(desktop, `document.querySelectorAll('[data-sonner-toast]').length === 0`, {
+    });
+    await waitFor(desktop, () => (document.querySelectorAll<HTMLElement>('[data-sonner-toast]').length === 0), {
       timeoutMs: 10_000,
       label: "unrelated test-world notifications dismissed before dark-theme evidence",
     });
@@ -268,41 +269,42 @@ test(title, async ({ evidence, place }) => {
   } finally {
     await evalIn(
       desktop,
-      previousTheme
-        ? `document.documentElement.dataset.theme = ${JSON.stringify(previousTheme)}`
-        : `delete document.documentElement.dataset.theme`,
+      browserScript((theme) => {
+        if (theme) document.documentElement.dataset.theme = theme;
+        else delete document.documentElement.dataset.theme;
+      }, [previousTheme]),
     );
   }
-  const connectionContinued = await evalIn(desktop, `(() => {
-    const continueButton = [...document.querySelectorAll('[role="dialog"] button')]
+  const connectionContinued = await evalIn(desktop, () => {
+    const continueButton = [...document.querySelectorAll<HTMLElement>('[role="dialog"] button')]
       .find((button) => (button.textContent ?? '').trim() === 'Continue');
     if (!(continueButton instanceof HTMLButtonElement) || continueButton.disabled) return false;
     continueButton.click();
     return true;
-  })()`);
+  });
   expect(connectionContinued).toBe(true);
-  await waitFor(desktop, `!document.querySelector('[role="dialog"]')
+  await waitFor(desktop, () => (!document.querySelector<HTMLElement>('[role="dialog"]')
     && decodeURIComponent(location.hash).endsWith('/extensions')
     && [...document.querySelectorAll('button')]
-      .some((button) => (button.textContent ?? '').trim() === 'Add')`, {
+      .some((button) => (button.textContent ?? '').trim() === 'Add')), {
     timeoutMs: 20_000,
     label: "Connection handoff closes cleanly without entering a native creation flow",
   });
 
-  const reopenedCleanly = await evalIn(desktop, `(() => {
+  const reopenedCleanly = await evalIn(desktop, () => {
     const addButton = [...document.querySelectorAll('button')]
       .find((button) => (button.textContent ?? '').trim() === 'Add');
     if (!(addButton instanceof HTMLButtonElement)) return false;
     addButton.click();
     return true;
-  })()`);
+  });
   expect(reopenedCleanly).toBe(true);
-  await waitFor(desktop, `document.querySelectorAll('[role="dialog"]').length === 1
-    && document.querySelectorAll('[data-testid="library-add-choices"]').length === 1`, {
+  await waitFor(desktop, () => (document.querySelectorAll<HTMLElement>('[role="dialog"]').length === 1
+    && document.querySelectorAll<HTMLElement>('[data-testid="library-add-choices"]').length === 1), {
     timeoutMs: 20_000,
     label: "clean Library picker state after returning from Den handoff",
   });
-  const modalCount = await evalIn(desktop, `document.querySelectorAll('[role="dialog"]').length`);
+  const modalCount = await evalIn(desktop, () => (document.querySelectorAll<HTMLElement>('[role="dialog"]').length));
   expect(modalCount).toBe(1);
   evidence.recordAssertionEvidence(
     "Connection keeps organization context and returns without duplicate modal state",

--- a/evals/specs/library-signed-in-render-stability.e2e.test.ts
+++ b/evals/specs/library-signed-in-render-stability.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { fileURLToPath } from "node:url";
 import { expect } from "vitest";
 import { createAndSelectWorkspace, evalIn, waitFor } from "@openwork/behaviors";
@@ -22,7 +23,7 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
   await using desktopApp = await app({ den, as: "member", place });
   const workspace = await createAndSelectWorkspace(desktopApp, { path: repoRoot });
 
-  const instrumented = await evalIn(desktopApp, `(() => {
+  const instrumented = await evalIn(desktopApp, browserScript((value) => {
     window.__libraryStability = {
       requests: [],
       denEvents: 0,
@@ -30,21 +31,21 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
     };
     const originalFetch = window.fetch;
     window.fetch = function (...args) {
-      const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
+      const target = args[0] instanceof Request ? args[0].url : String(args[0]);
       window.__libraryStability.requests.push(String(target));
       return originalFetch.apply(this, args);
     };
     window.addEventListener("openwork-den-settings-changed", () => {
       window.__libraryStability.denEvents += 1;
     });
-    location.hash = ${JSON.stringify(`#/workspace/${workspace.workspaceId}/extensions`)};
+    location.hash = value;
     return true;
-  })()`);
+  }, [`#/workspace/${workspace.workspaceId}/extensions`]));
   expect(instrumented).toBe(true);
   await waitFor(
     desktopApp,
-    `location.hash.includes("/extensions")
-      && [...document.querySelectorAll("h1, h2")].some((heading) => heading.textContent?.trim() === "Library")`,
+    () => (location.hash.includes("/extensions")
+      && [...document.querySelectorAll<HTMLElement>("h1, h2")].some((heading) => heading.textContent?.trim() === "Library")),
     { timeoutMs: 60_000, label: "signed-in Library" },
   );
 
@@ -53,13 +54,13 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
   // settings echoes retrigger provider sync and remove/re-add inventory cards.
   await waitFor(
     desktopApp,
-    `document.body.innerText.includes("READY TO USE")
-      && document.body.innerText.includes("OpenWork Browser")`,
+    () => (document.body.innerText.includes("READY TO USE")
+      && document.body.innerText.includes("OpenWork Browser")),
     { timeoutMs: 120_000, label: "signed-in Library inventory" },
   );
 
   await new Promise((resolve) => setTimeout(resolve, 10_000));
-  await evalIn(desktopApp, `(() => {
+  await evalIn(desktopApp, () => {
     window.__libraryStability.requests = [];
     window.__libraryStability.denEvents = 0;
     window.__libraryStability.samples = [];
@@ -71,13 +72,13 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
       });
     }, 50);
     return true;
-  })()`);
+  });
   await new Promise((resolve) => setTimeout(resolve, 20_000));
 
-  const result = await evalIn(desktopApp, `(() => {
+  const result = await evalIn(desktopApp, () => {
     window.clearInterval(window.__libraryStability.sampler);
     const requests = window.__libraryStability.requests;
-    const count = (part) => requests.filter((target) => target.includes(part)).length;
+    const count = (part: string) => requests.filter((target) => target.includes(part)).length;
     const buttonCounts = window.__libraryStability.samples.map((sample) => sample.buttons);
     const inventoryStayedVisible = window.__libraryStability.samples.every((sample) => sample.contentVisible);
     const minButtons = Math.min(...buttonCounts);
@@ -100,7 +101,7 @@ test.skipIf(!enabled)(title, { timeout: 10 * 60_000 }, async ({ evidence, place 
         && observed.inventoryStayedVisible
         && observed.minButtons === observed.maxButtons,
     };
-  })()`);
+  });
   const passed = JSON.stringify(result).includes('"stable":true');
   evidence.recordAssertionEvidence(
     "Signed-in Library remains stable after its initial load",

--- a/evals/specs/live-tool-visible-after-session-switch.e2e.test.ts
+++ b/evals/specs/live-tool-visible-after-session-switch.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import {
   control,
@@ -78,15 +79,15 @@ function parseVisibleToolFact(value: unknown): VisibleToolFact {
 }
 
 async function configureWorkspaces(appSurface: App, workspaceIds: string[], baseUrl: string): Promise<void> {
-  const result = await evalIn(appSurface, `(async () => {
+  const result = await evalIn(appSurface, browserScript(async (workspaceIds, providerId, modelName, value, modelId, inputModelName, inputProviderId, inputModelId, inputValue) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return "local_server_unavailable";
-    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const root = String(info.baseUrl).replace(/\/+$/, "");
     const headers = {
       Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
       "Content-Type": "application/json",
     };
-    for (const workspaceId of ${JSON.stringify(workspaceIds)}) {
+    for (const workspaceId of workspaceIds) {
       const configured = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
         method: "PATCH",
         headers,
@@ -94,12 +95,12 @@ async function configureWorkspaces(appSurface: App, workspaceIds: string[], base
           opencode: {
             permission: { bash: "allow" },
             provider: {
-              [${JSON.stringify(providerId)}]: {
+              [providerId]: {
                 npm: "@ai-sdk/openai-compatible",
-                name: ${JSON.stringify(modelName)},
-                options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-live-tool-switch" },
+                name: modelName,
+                options: { baseURL: value, apiKey: "sk-live-tool-switch" },
                 models: {
-                  [${JSON.stringify(modelId)}]: { name: ${JSON.stringify(modelName)}, tool_call: true },
+                  [modelId]: { name: inputModelName, tool_call: true },
                 },
               },
             },
@@ -116,22 +117,22 @@ async function configureWorkspaces(appSurface: App, workspaceIds: string[], base
       if (!reloaded.ok) return "reload:" + reloaded.status + ":" + (await reloaded.text()).slice(0, 300);
     }
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
       ...preferences,
-      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      defaultModel: { providerID: inputProviderId, modelID: inputModelId },
       modelVariant: null,
       providerStepCompleted: true,
     }));
-    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.setItem("openwork.defaultModel", inputValue);
     return "ok";
-  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  }, [workspaceIds, providerId, modelName, `${baseUrl}/v1`, modelId, modelName, providerId, modelId, `${providerId}/${modelId}`]), { awaitPromise: true, timeoutMs: 120_000 });
   expect(result).toBe("ok");
 
-  await evalIn(appSurface, "location.reload(); true");
-  await waitFor(appSurface, "Boolean(window.__openworkControl)", {
+  await evalIn(appSurface, () => { location.reload(); return true; });
+  await waitFor(appSurface, () => (Boolean(window.__openworkControl)), {
     timeoutMs: 60_000,
     label: "desktop restored after mock provider configuration",
   });
@@ -154,20 +155,20 @@ async function createSession(appSurface: App): Promise<string> {
 }
 
 async function clickSessionRow(appSurface: App, workspaceId: string, sessionId: string): Promise<void> {
-  const clicked = await evalIn(appSurface, `(() => {
-    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`)});
-    const control = row?.querySelector(${JSON.stringify(`[data-session-tab-id="${sessionId}"]`)});
+  const clicked = await evalIn(appSurface, browserScript((value, inputValue) => {
+    const row = document.querySelector<HTMLElement>(value);
+    const control = row?.querySelector<HTMLElement>(inputValue);
     if (!(row instanceof HTMLElement) || !(control instanceof HTMLElement)) return false;
     row.scrollIntoView({ block: "center" });
     control.click();
     return true;
-  })()`);
+  }, [`[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`, `[data-session-tab-id="${sessionId}"]`]));
   expect(clicked).toBe(true);
-  await waitFor(appSurface, `(() => {
-    const surface = document.querySelector("[data-session-surface-id]");
-    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(sessionId)}
-      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(workspaceId)};
-  })()`, { timeoutMs: 60_000, label: `workspace ${workspaceId} session ${sessionId} visible after sidebar click` });
+  await waitFor(appSurface, browserScript((sessionId, workspaceId) => {
+    const surface = document.querySelector<HTMLElement>("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === sessionId
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId;
+  }, [sessionId, workspaceId]), { timeoutMs: 60_000, label: `workspace ${workspaceId} session ${sessionId} visible after sidebar click` });
 }
 
 async function readSessionFacts(appSurface: App, workspaceId: string, sessionId: string): Promise<SessionFacts> {
@@ -208,18 +209,18 @@ async function approvePendingPermission(appSurface: App, workspaceId: string, se
 }
 
 async function expectLeftSessionIndicator(appSurface: App, sessionId: string, kind: "loading" | "attention"): Promise<void> {
-  const fact = await eventually(() => evalIn(appSurface, `(() => {
-    const row = document.querySelector('[data-sidebar-session-id="' + CSS.escape(${JSON.stringify(sessionId)}) + '"]');
-    const title = row?.querySelector("[data-session-title-slot]");
-    const indicators = row?.querySelectorAll("[data-session-loading-indicator], [data-session-attention-indicator]");
-    const indicator = row?.querySelector(${JSON.stringify(`[data-session-${kind}-indicator]`)});
+  const fact = await eventually(() => evalIn(appSurface, browserScript((sessionId, value) => {
+    const row = document.querySelector<HTMLElement>('[data-sidebar-session-id="' + CSS.escape(sessionId) + '"]');
+    const title = row?.querySelector<HTMLElement>("[data-session-title-slot]");
+    const indicators = row?.querySelectorAll<HTMLElement>("[data-session-loading-indicator], [data-session-attention-indicator]");
+    const indicator = row?.querySelector<HTMLElement>(value);
     if (!(title instanceof HTMLElement) || !(indicator instanceof HTMLElement)) return false;
     const box = indicator.getBoundingClientRect();
     const style = getComputedStyle(indicator);
     return indicators?.length === 1 && box.width > 0 && box.height > 0
       && box.right <= title.getBoundingClientRect().left
       && style.visibility === "visible" && style.opacity === "1";
-  })()`), {
+  }, [sessionId, `[data-session-${kind}-indicator]`])), {
     within: 15_000,
     intervalMs: 250,
     label: `exactly one visible ${kind} indicator before the session title`,
@@ -233,11 +234,11 @@ async function readVisibleTool(
   sessionId: string,
   toolCallId: string,
 ): Promise<VisibleToolFact> {
-  const value = await evalIn(appSurface, `(() => {
-    const surface = document.querySelector(${JSON.stringify(`[data-session-surface-id="${sessionId}"]`)});
-    const currentSessionId = document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "";
+  const value = await evalIn(appSurface, browserScript((value, toolCallId) => {
+    const surface = document.querySelector<HTMLElement>(value);
+    const currentSessionId = document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "";
     if (!(surface instanceof HTMLElement)) return { currentSessionId, found: false, visible: false, text: "" };
-    const row = surface.querySelector('[data-tool-aggregate="' + CSS.escape(${JSON.stringify(toolCallId)}) + '"]');
+    const row = surface.querySelector<HTMLElement>('[data-tool-aggregate="' + CSS.escape(toolCallId) + '"]');
     if (!(row instanceof HTMLElement)) return { currentSessionId, found: false, visible: false, text: "" };
     const style = getComputedStyle(row);
     const rect = row.getBoundingClientRect();
@@ -253,7 +254,7 @@ async function readVisibleTool(
       && rect.right > Math.max(0, surfaceRect.left)
       && rect.left < Math.min(window.innerWidth, surfaceRect.right);
     return { currentSessionId, found: true, visible, text: row.innerText ?? "" };
-  })()`);
+  }, [`[data-session-surface-id="${sessionId}"]`, toolCallId]));
   return parseVisibleToolFact(value);
 }
 

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { newSplitPrimary } from "../worlds/chat.ts";
@@ -21,7 +22,7 @@ function splitFacts(value: unknown) {
 test("side chats keep questions, replies, and saved splits attached to their own conversation", async ({ world, user, probe, agent, step }) => {
   const primary = world.session.sessionId;
   const workspaceId = world.workspace.workspaceId;
-  const shortcut = await probe.eval(`/Mac|iPhone|iPad|iPod/.test(navigator.platform)`) ? "Meta+K" : "Control+K";
+  const shortcut = await probe.eval(() => (/Mac|iPhone|iPad|iPod/.test(navigator.platform))) ? "Meta+K" : "Control+K";
   const facts = async () => splitFacts(await world.splitFacts());
   const ids = async () => (await agent.list()).map((session) => session.sessionId).sort();
   const waitSplit = (main: string, side?: string) => probe.eventually(facts, {
@@ -37,19 +38,19 @@ test("side chats keep questions, replies, and saved splits attached to their own
   const send = async (pane: "primary" | "secondary", text: string) => {
     await user.type({ placeholder: "Describe your task...", nth: pane === "primary" ? 0 : 1 }, text, { verify: true });
     await user.press("Enter");
-    await probe.eventually(() => probe.eval(`(which, text) => {
-      const root = document.querySelector('[data-workbench-pane="' + which + '"]');
-      return [...(root?.querySelectorAll('[data-message-role="user"]') ?? [])]
+    await probe.eventually(() => probe.eval(browserScript((which, text) => {
+      const root = document.querySelector<HTMLElement>('[data-workbench-pane="' + which + '"]');
+      return [...(root?.querySelectorAll<HTMLElement>('[data-message-role="user"]') ?? [])]
         .some((node) => node.getClientRects().length && node.innerText.includes(text));
-    }`, { args: [pane, text] }), {
+    }, [pane, text])), {
       within: 10_000, label: `${pane} displays the submitted message`, until: (value) => value === true,
     });
   };
-  const pane = (which: "primary" | "secondary") => probe.eval(`(which) => {
-    const root = document.querySelector('[data-workbench-pane="' + which + '"]');
-    const messages = [...(root?.querySelectorAll('[data-message-role="assistant"]') ?? [])];
+  const pane = (which: "primary" | "secondary") => probe.eval(browserScript((which) => {
+    const root = document.querySelector<HTMLElement>('[data-workbench-pane="' + which + '"]');
+    const messages = [...(root?.querySelectorAll<HTMLElement>('[data-message-role="assistant"]') ?? [])];
     return { text: root?.textContent ?? "", answer: messages.at(-1)?.innerText ?? "" };
-  }`, { args: [which] });
+  }, [which]));
   const answer = async (which: "primary" | "secondary", included: string, excluded: string) => {
     await probe.eventually(() => pane(which), { within: 45_000, label: `${which} receives only its own answer`,
       until: (value) => isRecord(value) && typeof value.answer === "string"
@@ -61,22 +62,22 @@ test("side chats keep questions, replies, and saved splits attached to their own
     await user.see(paletteInput);
     await user.type(paletteInput, query, { replace: true });
     await user.click({ role: "option", label });
-    await probe.eventually(() => probe.eval(`(() => {
-      const input = document.querySelector('[data-command-palette-input]');
+    await probe.eventually(() => probe.eval(() => {
+      const input = document.querySelector<HTMLElement>('[data-command-palette-input]');
       return !input || input.getClientRects().length === 0 || getComputedStyle(input).visibility === "hidden";
-    })()`), { within: 10_000, label: "the palette closes after selecting the action", until: (value) => value === true })
+    }), { within: 10_000, label: "the palette closes after selecting the action", until: (value) => value === true })
       .catch(async (error: unknown) => { await user.screenshot(); throw error; });
     await user.notSee(paletteInput);
   };
   const rowTarget = async (sessionId: string): Promise<{ role: "button"; label: string; nth: number }> => {
-    const target = await probe.eventually(() => probe.eval(`(id) => {
-      const row = document.querySelector('[data-session-tab-id="' + id + '"]');
+    const target = await probe.eventually(() => probe.eval(browserScript((id) => {
+      const row = document.querySelector<HTMLElement>('[data-session-tab-id="' + id + '"]');
       const label = row?.getAttribute("aria-label");
-      if (!label) return null;
-      const buttons = [...document.querySelectorAll('button, [role="button"]')]
+      if (!row || !label) return null;
+      const buttons = [...document.querySelectorAll<HTMLElement>('button, [role="button"]')]
         .filter((node) => node.getAttribute("aria-label") === label);
       return { label, nth: buttons.indexOf(row) };
-    }`, { args: [sessionId] }), {
+    }, [sessionId])), {
       within: 15_000, label: "the saved conversation has a sidebar control",
       until: (value) => isRecord(value) && typeof value.label === "string" && typeof value.nth === "number" && value.nth >= 0,
     });
@@ -90,12 +91,12 @@ test("side chats keep questions, replies, and saved splits attached to their own
     });
   };
   const preservedHistory = async (sessionId: string, ...messages: string[]) => {
-    await probe.eventually(() => probe.eval(`(id) => {
-      const surface = document.querySelector('[data-session-surface-id="' + id + '"]');
-      return [...(surface?.querySelectorAll('[data-message-role]') ?? [])]
+    await probe.eventually(() => probe.eval(browserScript((id) => {
+      const surface = document.querySelector<HTMLElement>('[data-session-surface-id="' + id + '"]');
+      return [...(surface?.querySelectorAll<HTMLElement>('[data-message-role]') ?? [])]
         .filter((node) => node.getClientRects().length && getComputedStyle(node).visibility !== "hidden")
-        .map((node) => node.innerText).join("\\n");
-    }`, { args: [sessionId] }), {
+        .map((node) => node.innerText).join("\n");
+    }, [sessionId])), {
       within: 30_000, label: "the reopened conversation renders its earlier messages",
       until: (value) => typeof value === "string" && messages.every((message) => value.includes(message)),
     });
@@ -120,10 +121,10 @@ test("side chats keep questions, replies, and saved splits attached to their own
       await send("primary", world.primaryQuestionPrompt);
       await user.see({ text: "Which format should the main task use?" }, { timeoutMs: 45_000 });
       expect(await pane("secondary")).not.toHaveProperty("text", expect.stringContaining("Which format should the main task use?"));
-      await probe.eventually(() => probe.eval(`(id) => {
-        const row = document.querySelector('[data-sidebar-session-id="' + id + '"]');
-        return Boolean(row?.querySelector('[data-session-side-chat] [data-session-attention-indicator]'));
-      }`, { args: [primary] }), {
+      await probe.eventually(() => probe.eval(browserScript((id) => {
+        const row = document.querySelector<HTMLElement>('[data-sidebar-session-id="' + id + '"]');
+        return Boolean(row?.querySelector<HTMLElement>('[data-session-side-chat] [data-session-attention-indicator]'));
+      }, [primary])), {
         within: 15_000, label: "the attached side chat shows that it needs an answer", until: (value) => value === true,
       });
       await user.screenshot();
@@ -157,18 +158,18 @@ test("side chats keep questions, replies, and saved splits attached to their own
   });
 
   await step("the split belongs to the session row and follows it into Pinned", async () => {
-    const rowLayout = () => probe.eval(`(id) => {
-      const row = document.querySelector('[data-sidebar-session-id="' + id + '"]');
-      const main = row?.querySelector('[data-session-tab-id]')?.getBoundingClientRect();
-      const side = row?.querySelector('[data-session-side-chat]')?.getBoundingClientRect();
-      const headers = [...document.querySelectorAll('[data-workbench-pane-header]')];
+    const rowLayout = () => probe.eval(browserScript((id) => {
+      const row = document.querySelector<HTMLElement>('[data-sidebar-session-id="' + id + '"]');
+      const main = row?.querySelector<HTMLElement>('[data-session-tab-id]')?.getBoundingClientRect();
+      const side = row?.querySelector<HTMLElement>('[data-session-side-chat]')?.getBoundingClientRect();
+      const headers = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane-header]')];
       return {
         attached: Boolean(main && side && side.left >= main.right - 1 && Math.abs(main.top - side.top) < 2),
         pinned: Boolean(row?.closest('[data-global-pinned-sessions]')),
         compactHeaders: headers.length === 2 && headers.every((node) => node.getBoundingClientRect().height <= 44),
-        oldControls: document.querySelectorAll('[data-session-tab-split-pill], [data-sidebar-new-split], [data-second-chat-intro], [data-chat-composer-label]').length,
+        oldControls: document.querySelectorAll<HTMLElement>('[data-session-tab-split-pill], [data-sidebar-new-split], [data-second-chat-intro], [data-chat-composer-label]').length,
       };
-    }`, { args: [primary] });
+    }, [primary]));
     expect(await rowLayout()).toMatchObject({ attached: true, pinned: false, compactHeaders: true, oldControls: 0 });
     await user.rightClick(await rowTarget(primary));
     await user.screenshot();

--- a/evals/specs/opencode-v2-chat-routing.e2e.test.ts
+++ b/evals/specs/opencode-v2-chat-routing.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -94,21 +95,21 @@ async function serverFetchJson(
   const timeoutMs = init.timeoutMs ?? 15_000;
   const requestBody = init.body === undefined ? undefined : JSON.stringify(init.body);
   if (init.body !== undefined && requestBody === undefined) throw new Error(`Could not serialize request body for ${path}`);
-  const value = await evalIn(app, `(async () => {
+  const value = await evalIn(app, browserScript(async (path, value, inputValue, timeoutMs) => {
     const port = (localStorage.getItem("openwork.server.port") ?? "").trim();
     const token = (localStorage.getItem("openwork.server.token") ?? "").trim();
     if (!port || !token) return { specProbeError: "missing local server credentials" };
-    const response = await fetch("http://127.0.0.1:" + port + ${JSON.stringify(path)}, {
-      method: ${JSON.stringify(init.method ?? "GET")},
+    const response = await fetch("http://127.0.0.1:" + port + path, {
+      method: value,
       headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
-      ${requestBody === undefined ? "" : `body: ${JSON.stringify(requestBody)},`}
-      signal: AbortSignal.timeout(${timeoutMs}),
+      body: inputValue,
+      signal: AbortSignal.timeout(timeoutMs),
     });
     const text = await response.text();
     let json = text;
     try { json = JSON.parse(text); } catch {}
     return { status: response.status, json };
-  })()`, { awaitPromise: true, timeoutMs: timeoutMs + 5_000 });
+  }, [path, init.method ?? "GET", requestBody ?? null, timeoutMs]), { awaitPromise: true, timeoutMs: timeoutMs + 5_000 });
   if (!isRecord(value) || typeof value.status !== "number" || !("json" in value)) {
     throw new Error(`Server request ${path} failed: ${JSON.stringify(value)}`);
   }
@@ -154,17 +155,17 @@ async function engineSessionCount(app: Surface, workspaceId: string, lane: "open
   return result.json.data.length;
 }
 
-const engineSelectedExpression = (engine: "v1" | "v2", options: { ready?: boolean } = {}) => `(() => {
-  const group = document.querySelector('[aria-label="Chat engine"]');
+const engineSelectedExpression = (engine: "v1" | "v2", options: { ready?: boolean } = {}) => browserScript((value, engine) => {
+  const group = document.querySelector<HTMLElement>('[aria-label="Chat engine"]');
   if (!group) return false;
-  ${options.ready ? 'if (group.getAttribute("aria-disabled") === "true" || group.hasAttribute("data-disabled")) return false;' : ""}
-  const control = group.querySelector('[data-engine="${engine}"]');
+  if (value && (group.getAttribute("aria-disabled") === "true" || group.hasAttribute("data-disabled"))) return false;
+  const control = group.querySelector<HTMLElement>(`[data-engine="${engine}"]`);
   return control?.getAttribute("aria-pressed") === "true" || control?.getAttribute("data-state") === "on";
-})()`;
+}, [options.ready === true, engine]);
 
 async function clickEngineOption(app: Surface, engine: "v1" | "v2"): Promise<void> {
-  const point = await evalIn(app, `(() => {
-    const control = [...document.querySelectorAll('[aria-label="Chat engine"] [data-engine="${engine}"]')]
+  const point = await evalIn(app, browserScript((engine) => {
+    const control = [...document.querySelectorAll<HTMLElement>(`[aria-label="Chat engine"] [data-engine="${engine}"]`)]
       .find((candidate) => {
         const rect = candidate.getBoundingClientRect();
         return rect.width > 0 && rect.height > 0;
@@ -173,7 +174,7 @@ async function clickEngineOption(app: Surface, engine: "v1" | "v2"): Promise<voi
     control.scrollIntoView({ block: "center", behavior: "instant" });
     const rect = control.getBoundingClientRect();
     return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-  })()`);
+  }, [engine]));
   if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") {
     throw new Error(`Could not resolve the ${engine} chat engine option: ${JSON.stringify(point)}`);
   }
@@ -200,40 +201,40 @@ async function closeModelPicker(app: Surface): Promise<void> {
 }
 
 async function waitForModelInPicker(app: Surface, expected: string, timeoutMs = 45_000): Promise<void> {
-  await waitFor(app, `Boolean(document.querySelector('button[aria-label="Change model"]'))`, {
+  await waitFor(app, () => (Boolean(document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]'))), {
     timeoutMs: 30_000,
     label: "composer model picker",
   });
   const deadline = Date.now() + timeoutMs;
   let lastItems: string[] = [];
   while (Date.now() < deadline) {
-    const opened = await evalIn(app, `(() => {
-      if (document.querySelector('[data-slot="popover-content"]')) return true;
-      const trigger = document.querySelector('button[aria-label="Change model"]');
+    const opened = await evalIn(app, () => {
+      if (document.querySelector<HTMLElement>('[data-slot="popover-content"]')) return true;
+      const trigger = document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]');
       if (!(trigger instanceof HTMLButtonElement)) return false;
       trigger.click();
       return true;
-    })()`);
+    });
     if (opened === true) {
       await sleep(300);
-      await evalIn(app, `(() => {
-        const popover = document.querySelector('[data-slot="popover-content"]');
+      await evalIn(app, browserScript((expected) => {
+        const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
         if (!(popover instanceof HTMLElement)) return false;
-        if ([...popover.querySelectorAll('[data-slot="command-item"]')]
-          .some((item) => (item.textContent ?? "").includes(${JSON.stringify(expected)}))) return true;
+        if ([...popover.querySelectorAll<HTMLElement>('[data-slot="command-item"]')]
+          .some((item) => (item.textContent ?? "").includes(expected))) return true;
         const modelButton = [...popover.querySelectorAll('button')]
           .find((button) => (button.textContent ?? "").trim().startsWith("Model"));
         if (!(modelButton instanceof HTMLButtonElement)) return false;
         modelButton.click();
         return true;
-      })()`);
+      }, [expected]));
       await sleep(200);
-      const items = await evalIn(app, `(() => {
-        const popover = document.querySelector('[data-slot="popover-content"]');
+      const items = await evalIn(app, () => {
+        const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
         if (!(popover instanceof HTMLElement)) return [];
-        return [...popover.querySelectorAll('[data-slot="command-item"]')]
+        return [...popover.querySelectorAll<HTMLElement>('[data-slot="command-item"]')]
           .map((item) => (item.textContent ?? "").trim());
-      })()`);
+      });
       if (Array.isArray(items) && items.every((item) => typeof item === "string")) {
         lastItems = items;
         if (items.some((item) => item.includes(expected))) return;
@@ -247,87 +248,87 @@ async function waitForModelInPicker(app: Surface, expected: string, timeoutMs = 
 
 async function selectModel(app: Surface, modelName: string): Promise<void> {
   await waitForModelInPicker(app, modelName);
-  const picked = await evalIn(app, `(() => {
-    const popover = document.querySelector('[data-slot="popover-content"]');
-    const item = [...(popover?.querySelectorAll('[data-slot="command-item"]') ?? [])]
-      .find((candidate) => (candidate.textContent ?? "").includes(${JSON.stringify(modelName)}));
+  const picked = await evalIn(app, browserScript((modelName) => {
+    const popover = document.querySelector<HTMLElement>('[data-slot="popover-content"]');
+    const item = [...(popover?.querySelectorAll<HTMLElement>('[data-slot="command-item"]') ?? [])]
+      .find((candidate) => (candidate.textContent ?? "").includes(modelName));
     if (!(item instanceof HTMLElement)) return false;
     item.click();
     return true;
-  })()`);
+  }, [modelName]));
   expect(picked).toBe(true);
-  await waitFor(app, `(document.querySelector('button[aria-label="Change model"]')?.textContent ?? "").includes(${JSON.stringify(modelName)})`, {
+  await waitFor(app, browserScript((modelName) => ((document.querySelector<HTMLButtonElement>('button[aria-label="Change model"]')?.textContent ?? "").includes(modelName)), [modelName]), {
     timeoutMs: 15_000,
     label: `${modelName} selected`,
   });
 }
 
 async function typeIntoComposer(app: Surface, text: string): Promise<void> {
-  await waitFor(app, `(() => {
-    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+  await waitFor(app, () => {
+    const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
     return editor instanceof HTMLElement && (editor.innerText ?? "").trim() === "";
-  })()`, { timeoutMs: 30_000, label: "empty composer ready" });
-  const focused = await evalIn(app, `(() => {
-    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+  }, { timeoutMs: 30_000, label: "empty composer ready" });
+  const focused = await evalIn(app, () => {
+    const editor = document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]');
     if (!(editor instanceof HTMLElement)) return false;
     editor.focus();
     return true;
-  })()`);
+  });
   expect(focused).toBe(true);
   await app.client.send("Input.insertText", { text });
-  await waitFor(app, `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === ${JSON.stringify(text)}`, {
+  await waitFor(app, browserScript((text) => ((document.querySelector<HTMLElement>('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? "").trim() === text), [text]), {
     timeoutMs: 10_000,
     label: `composer contains ${text}`,
   });
 }
 
 async function createNewSessionThroughSidebar(app: Surface): Promise<string> {
-  const previousValue = await evalIn(app, `document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""`);
+  const previousValue = await evalIn(app, () => (document.querySelector<HTMLElement>('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""));
   const previous = typeof previousValue === "string" ? previousValue : "";
-  await waitFor(app, `(() => {
-    const button = document.querySelector('[data-sidebar-new-chat]');
+  await waitFor(app, () => {
+    const button = document.querySelector<HTMLElement>('[data-sidebar-new-chat]');
     return button instanceof HTMLButtonElement && !button.disabled;
-  })()`, { timeoutMs: 30_000, label: "enabled sidebar New task control" });
-  const clicked = await evalIn(app, `(() => {
-    const button = document.querySelector('[data-sidebar-new-chat]');
+  }, { timeoutMs: 30_000, label: "enabled sidebar New task control" });
+  const clicked = await evalIn(app, () => {
+    const button = document.querySelector<HTMLElement>('[data-sidebar-new-chat]');
     if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
     button.click();
     return true;
-  })()`);
+  });
   expect(clicked).toBe(true);
-  await waitFor(app, `(() => {
-    const id = document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? "";
-    return id.startsWith("ses_") && id !== ${JSON.stringify(previous)}
+  await waitFor(app, browserScript((previous) => {
+    const id = document.querySelector<HTMLElement>('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? "";
+    return id.startsWith("ses_") && id !== previous
       && window.location.hash.includes("/session/" + id);
-  })()`, { timeoutMs: 60_000, label: "new session created by the active engine client" });
-  const value = await evalIn(app, `document.querySelector('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""`);
+  }, [previous]), { timeoutMs: 60_000, label: "new session created by the active engine client" });
+  const value = await evalIn(app, () => (document.querySelector<HTMLElement>('[data-session-surface-id]')?.getAttribute('data-session-surface-id') ?? ""));
   if (typeof value !== "string" || !value.startsWith("ses_")) throw new Error(`New session id was unavailable: ${String(value)}`);
   return value;
 }
 
 async function clickSessionRow(app: Surface, sessionId: string, workspaceId: string): Promise<void> {
-  const clicked = await evalIn(app, `(() => {
-    const row = document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`)});
-    const control = row?.querySelector(${JSON.stringify(`[data-session-tab-id="${sessionId}"]`)});
+  const clicked = await evalIn(app, browserScript((value, inputValue) => {
+    const row = document.querySelector<HTMLElement>(value);
+    const control = row?.querySelector<HTMLElement>(inputValue);
     if (!(row instanceof HTMLElement) || !(control instanceof HTMLElement)) return false;
     row.scrollIntoView({ block: "center" });
     control.click();
     return true;
-  })()`);
+  }, [`[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`, `[data-session-tab-id="${sessionId}"]`]));
   expect(clicked).toBe(true);
 }
 
 async function waitForChatSurface(app: Surface, sessionId: string, workspaceId: string): Promise<void> {
-  await waitFor(app, `(() => {
-    const surface = document.querySelector("[data-session-surface-id]");
-    return surface?.getAttribute("data-session-surface-id") === ${JSON.stringify(sessionId)}
-      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(workspaceId)};
-  })()`, { timeoutMs: 10_000, label: "v2 session surface after workspace switch" });
+  await waitFor(app, browserScript((sessionId, workspaceId) => {
+    const surface = document.querySelector<HTMLElement>("[data-session-surface-id]");
+    return surface?.getAttribute("data-session-surface-id") === sessionId
+      && (localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId;
+  }, [sessionId, workspaceId]), { timeoutMs: 10_000, label: "v2 session surface after workspace switch" });
 }
 
 async function expectSessionTitle(app: Surface, sessionId: string, workspaceId: string, expected: string): Promise<void> {
   const selector = `[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"] [data-session-title-text]`;
-  await waitFor(app, `(document.querySelector(${JSON.stringify(selector)})?.textContent ?? "").trim() === ${JSON.stringify(expected)}`, {
+  await waitFor(app, browserScript((selector, expected) => ((document.querySelector<HTMLElement>(selector)?.textContent ?? "").trim() === expected), [selector, expected]), {
     timeoutMs: 45_000,
     label: `sidebar title becomes ${expected}`,
   });
@@ -368,8 +369,8 @@ async function sendAndWaitForNonce(
       && candidate.auth === auth && candidate.model === model,
     `${round} streamed witness request`,
   );
-  await waitFor(app, `[...document.querySelectorAll('[data-message-role="assistant"]')]
-    .some((message) => message.textContent?.includes(${JSON.stringify(request.nonce)}))`, {
+  await waitFor(app, browserScript((nonce) => ([...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')]
+    .some((message) => message.textContent?.includes(nonce))), [request.nonce]), {
     timeoutMs: 120_000,
     label: `${round} transcript nonce ${request.nonce}`,
   });
@@ -620,7 +621,7 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
     // New task uses the selected workspace's currently swapped client. This
     // avoids sending a v2 prompt to the pre-toggle v1 session id.
     const v2SessionId = await createNewSessionThroughSidebar(app);
-    await waitFor(app, `(document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${v2SessionId}"] [data-session-title-text]`)})?.textContent ?? "").trim() === "New session"`, {
+    await waitFor(app, browserScript((value) => ((document.querySelector<HTMLElement>(value)?.textContent ?? "").trim() === "New session"), [`[data-sidebar-session-id="${v2SessionId}"] [data-session-title-text]`]), {
       timeoutMs: 15_000,
       label: "an unnamed v2 session is displayed as a new session, not a finished title",
     });
@@ -655,7 +656,7 @@ test.skipIf(!enabled)(title, { timeout: 600_000 }, async ({ evidence, place, ski
     await sleep(1_000);
     // Guards the dev #4364 refetch-on-select interaction: the sidebar must list from the routed engine
     // (`route-workspaces.ts` v2 transport), never drop a v2 session because the refetch listed v1.
-    await waitFor(app, `Boolean(document.querySelector(${JSON.stringify(`[data-sidebar-session-id="${v2SessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`)}))`, {
+    await waitFor(app, browserScript((value) => (Boolean(document.querySelector<HTMLElement>(value))), [`[data-sidebar-session-id="${v2SessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`]), {
       timeoutMs: 10_000,
       label: "v2 session remains in the sidebar after switching workspaces",
     });

--- a/evals/specs/opencode-v2-mcp-hot-reload.e2e.test.ts
+++ b/evals/specs/opencode-v2-mcp-hot-reload.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { createHash } from "node:crypto";
 import { control, evalIn, assertNoLiveSecret, liveOpenAiEnabled, liveOpenAiModel, provisionLiveOpenAi, liveProviderId, liveV2Turn } from "@openwork/behaviors";
@@ -8,25 +9,20 @@ function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function literal(value: unknown): string {
-  const json = JSON.stringify(value);
-  if (json === undefined) throw new Error("Missing probe value");
-  return json.replace(/</g, "\\u003c").replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
-}
 
 async function request(surface: Surface, path: string, method = "GET", body?: unknown) {
-  const result = await evalIn(surface, `(async () => {
+  const result = await evalIn(surface, browserScript(async (path, inputMethod, value) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
-    const response = await fetch("http://127.0.0.1:" + port + ${literal(path)}, {
-      method: ${literal(method)}, headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
-      ${body === undefined ? "" : `body: ${literal(JSON.stringify(body))},`}
+    const response = await fetch("http://127.0.0.1:" + port + path, {
+      method: inputMethod, headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      body: value,
       signal: AbortSignal.timeout(60_000),
     });
     const text = await response.text();
     let json = text; try { json = JSON.parse(text); } catch {}
     return { status: response.status, json };
-  })()`, { awaitPromise: true, timeoutMs: 65_000 });
+  }, [path, method, body === undefined ? null : JSON.stringify(body)]), { awaitPromise: true, timeoutMs: 65_000 });
   if (!record(result) || typeof result.status !== "number") throw new Error("Invalid server response");
   assertNoLiveSecret(result.json);
   return { status: result.status, json: result.json };

--- a/evals/specs/org-team-lifecycle-critical-path.e2e.test.ts
+++ b/evals/specs/org-team-lifecycle-critical-path.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect, onTestFinished } from "vitest";
 import type { Surface } from "@openwork/cdp";
 import {
@@ -225,11 +226,11 @@ async function deleteProvider(admin: DenSession, orgId: string, providerId: stri
 }
 
 async function configureWorkspaceOpenAi(appSurface: Surface, workspaceId: string, apiKey: string): Promise<void> {
-  const providerConfigured = await evalIn(appSurface, `(async () => {
+  const providerConfigured = await evalIn(appSurface, browserScript(async (inputWorkspaceId, inputApiKey) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
-    const request = async (path, init) => {
+    const request = async (path: string, init?: RequestInit) => {
       const response = await fetch("http://127.0.0.1:" + port + path, {
         ...init,
         headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
@@ -237,14 +238,14 @@ async function configureWorkspaceOpenAi(appSurface: Surface, workspaceId: string
       if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 300);
       return "ok";
     };
-    const workspaceId = ${JSON.stringify(workspaceId)};
+    const workspaceId = inputWorkspaceId;
     const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
       method: "PATCH",
-      body: JSON.stringify({ opencode: { provider: { openai: { options: { apiKey: ${JSON.stringify(apiKey)} } } } } }),
+      body: JSON.stringify({ opencode: { provider: { openai: { options: { apiKey: inputApiKey } } } } }),
     });
     if (patched !== "ok") return patched;
     return request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
-  })()`, { awaitPromise: true, timeoutMs: 60_000 });
+  }, [workspaceId, apiKey]), { awaitPromise: true, timeoutMs: 60_000 });
   expect(providerConfigured).toBe("ok");
 }
 
@@ -749,8 +750,8 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
       appMate,
       `This is an automated connectivity check of the newly configured model. Reply with the verification code ${llmMarker} to confirm the model is reachable.`,
     );
-    await waitFor(appMate, `([...document.querySelectorAll('[data-message-role="assistant"]')]
-      .some((message) => (message.innerText ?? "").includes(${JSON.stringify(llmMarker)})))`, {
+    await waitFor(appMate, browserScript((llmMarker) => (([...document.querySelectorAll<HTMLElement>('[data-message-role="assistant"]')]
+      .some((message) => (message.innerText ?? "").includes(llmMarker)))), [llmMarker]), {
       timeoutMs: 300_000,
       label: `complete assistant verification code ${JSON.stringify(llmMarker)}`,
     });
@@ -763,10 +764,10 @@ test.skipIf(missingRequirements.length > 0)(title, { timeout: 45 * 60_000 }, asy
     );
 
     await control(appMate, "session.create_task", undefined, { timeoutMs: 120_000 });
-    await waitFor(appMate, `(() => {
-      const editor = document.querySelector('[contenteditable="true"]');
-      return Boolean(editor && document.querySelectorAll('[data-message-role="user"]').length === 0);
-    })()`, { timeoutMs: 120_000, label: "fresh teammate skill session" });
+    await waitFor(appMate, () => {
+      const editor = document.querySelector<HTMLElement>('[contenteditable="true"]');
+      return Boolean(editor && document.querySelectorAll<HTMLElement>('[data-message-role="user"]').length === 0);
+    }, { timeoutMs: 120_000, label: "fresh teammate skill session" });
     const skillUseSince = new Date().toISOString();
     await sendComposerMessage(
       appMate,

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -14,15 +14,15 @@ test("a parent task surfaces and resolves its child session permission request",
     await user.see("Allow once");
     await user.see("Allow for session");
     // TODO(primitive): read delegated-task permission treatment state.
-    const waiting = await probe.eval(`(() => {
-      const row = document.querySelector('[data-subagent-permission="pending"]');
+    const waiting = await probe.eval(() => {
+      const row = document.querySelector<HTMLElement>('[data-subagent-permission="pending"]');
       return {
         activity: row instanceof HTMLElement ? row.dataset.subagentActivity ?? "" : "",
         childSessionId: row instanceof HTMLElement ? row.dataset.subagentSessionId ?? "" : "",
-        hasPermissionIcon: Boolean(row?.querySelector('[data-subagent-permission-icon]')),
-        hasShimmer: Boolean(row?.querySelector('.ow-text-shimmer')),
+        hasPermissionIcon: Boolean(row?.querySelector<HTMLElement>('[data-subagent-permission-icon]')),
+        hasShimmer: Boolean(row?.querySelector<HTMLElement>('.ow-text-shimmer')),
       };
-    })()`);
+    });
     expect(waiting).toMatchObject({ activity: "waiting-permission", hasPermissionIcon: true, hasShimmer: false });
     expect(waiting).toMatchObject({ childSessionId: expect.stringContaining(":eval-child") });
     await user.screenshot();
@@ -33,11 +33,11 @@ test("a parent task surfaces and resolves its child session permission request",
     await user.notSee({ text: /Requested by Investigate the deployment failure/ }, { timeoutMs: 15_000 });
     await user.notSee({ text: /Needs permission/ });
     // TODO(primitive): read resolved delegated-task running treatment state.
-    expect(await probe.eval(`({
-      permissionPanelVisible: Boolean(document.querySelector('[data-permission-source="child-session"]')),
-      waitingIconVisible: Boolean(document.querySelector('[data-subagent-permission="pending"]')),
-      runningTreatmentVisible: Boolean(document.querySelector('[data-subagent-activity="shimmer"] .ow-text-shimmer')),
-    })`)).toEqual({ permissionPanelVisible: false, waitingIconVisible: false, runningTreatmentVisible: true });
+    expect(await probe.eval(() => (({
+      permissionPanelVisible: Boolean(document.querySelector<HTMLElement>('[data-permission-source="child-session"]')),
+      waitingIconVisible: Boolean(document.querySelector<HTMLElement>('[data-subagent-permission="pending"]')),
+      runningTreatmentVisible: Boolean(document.querySelector<HTMLElement>('[data-subagent-activity="shimmer"] .ow-text-shimmer')),
+    })))).toEqual({ permissionPanelVisible: false, waitingIconVisible: false, runningTreatmentVisible: true });
   });
 });
 

--- a/evals/specs/preview-world.e2e.test.ts
+++ b/evals/specs/preview-world.e2e.test.ts
@@ -92,7 +92,7 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
       if (record(definition) && typeof definition.id === "string" && typeof definition.restrictedValue === "boolean") assert.equal(policy.policy[definition.id], definition.restrictedValue);
     }
     await using surface = await attachSurface({ name: "preview-proof", kind: "electron", hostKind: "daytona", cdpUrl: desktop.outputs.cdp });
-    const before = await evaluateOnSurface(surface, "({ route: location.hash, marker: localStorage.setItem('preview-proof', 'preserved') })");
+    const before = await evaluateOnSurface(surface, () => (({ route: location.hash, marker: localStorage.setItem('preview-proof', 'preserved') })));
     assert.ok(record(before) && typeof before.route === "string" && before.route.includes("workspace"));
     await screenshot(surface);
     evidence.recordAssertionEvidence("Desktop preview reaches real Electron through noVNC", "The viewer returns 200, its WebSocket speaks RFB, and the Electron renderer is on a workspace route. Restricted policy matches Den definitions; two team connectors use unconnected individual accounts.", true);
@@ -109,7 +109,7 @@ test("preview worlds expose Den and real Electron, preserve progress on frontend
     const after = await denFetch(ref, "/v1/mcp-connections?scope=manageable", { headers });
     assert.ok(record(after.body) && Array.isArray(after.body.connections));
     assert.deepEqual(after.body.connections, savedConnections);
-    assert.equal(await evaluateOnSurface(surface, "localStorage.getItem('preview-proof')"), "preserved");
+    assert.equal(await evaluateOnSurface(surface, () => (localStorage.getItem('preview-proof'))), "preserved");
     assert.equal((await snapshot("preview-desktop")).pid, desktop.pid);
     evidence.recordAssertionEvidence("Frontend update preserves the preview", "The live HTTP response contains the new Next build ID, which differs from the previous build; the existing session still reads the same connectors, Electron retains its localStorage marker, and world ownership stays unchanged.", true);
     await surface[Symbol.asyncDispose]();

--- a/evals/specs/reauth-popup.e2e.test.ts
+++ b/evals/specs/reauth-popup.e2e.test.ts
@@ -73,11 +73,11 @@ test("workspace SSO verifies through a real popup and safely recovers from inter
   await step("Cancel closes the real popup and does not retry", async () => {
     await user.click({ role: "button", label: "Continue with SSO" });
     const popup = await waiting();
-    const nonce = await probe.eval("document.querySelector('[data-reauth-nonce]').dataset.reauthNonce");
+    const nonce = await probe.eval(() => (document.querySelector<HTMLElement>('[data-reauth-nonce]')?.dataset.reauthNonce));
     if (typeof nonce !== "string") throw new Error("Expected the current dialog nonce");
     await user.click({ role: "button", label: "Cancel" });
     await world.sendCompletion("stale", nonce);
-    expect(await probe.eval("document.querySelector('[role=dialog]') === null")).toBe(true);
+    expect(await probe.eval(() => (document.querySelector<HTMLElement>('[role=dialog]') === null))).toBe(true);
     await probe.eventually(() => world.popupCount(), { within: 10_000, label: "cancel closes popup", until: (count) => count === 0 });
     expect(await world.storedName()).toBe(world.originalName);
     popup.client.close();
@@ -103,7 +103,7 @@ test("workspace SSO verifies through a real popup and safely recovers from inter
     await user.on(popup).screenshot();
     await user.on(popup).click({ role: "button", label: "Approve sign-in" });
     await user.see({ text: "Workspace settings updated." }, { timeoutMs: 60_000 });
-    expect(await probe.eval("document.querySelector('[role=dialog]') === null")).toBe(true);
+    expect(await probe.eval(() => (document.querySelector<HTMLElement>('[role=dialog]') === null))).toBe(true);
     expect(await world.storedName()).toBe(changedName);
     await probe.eventually(() => world.popupCount(), { within: 10_000, label: "successful popup closes", until: (count) => count === 0 });
     await user.reload();

--- a/evals/specs/reliable-app-recovery.e2e.test.ts
+++ b/evals/specs/reliable-app-recovery.e2e.test.ts
@@ -19,7 +19,7 @@ test("a fatal desktop bootstrap failure offers one-click verified recovery witho
     .toEqual(["1.8.2"]);
 
   // TODO(primitive): negatively exercise an unverified recovery candidate.
-  await seed.evalIn(world.app, `window.__openworkRecoveryControl.select("1.8.1")`, { awaitPromise: true });
+  await seed.evalIn(world.app, () => (window.__openworkRecoveryControl.select("1.8.1")), { awaitPromise: true });
   const afterInvalid = await world.snapshot();
   expect(typeof afterInvalid === "object" && afterInvalid !== null ? Reflect.get(afterInvalid, "installRequests") : null).toEqual([]);
   expect(typeof afterInvalid === "object" && afterInvalid !== null ? Reflect.get(afterInvalid, "quitRequested") : null).toBe(false);

--- a/evals/specs/responsive-session-layout.e2e.test.ts
+++ b/evals/specs/responsive-session-layout.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { control, evalIn, go, listSessions, seedSessions, waitFor } from "@openwork/behaviors";
 import type { Surface } from "@openwork/cdp";
@@ -33,19 +34,19 @@ const sessionTitles = ["Responsive primary chat", "Responsive split chat"];
 
 async function openSessionRoute(app: Surface, workspaceId: string, sessionId: string) {
   await go(app, `/workspace/${workspaceId}/session/${sessionId}`);
-  await waitFor(app, `Boolean(document.querySelector(
-    '[data-session-surface-id="${sessionId}"]'
-  ))`, { timeoutMs: 60_000, label: "primary session route" });
+  await waitFor(app, browserScript((sessionId) => (Boolean(document.querySelector<HTMLElement>(
+    `[data-session-surface-id="${sessionId}"]`
+  ))), [sessionId]), { timeoutMs: 60_000, label: "primary session route" });
 }
 
 async function openSessionInSplit(app: Surface, workspaceId: string, sessionId: string) {
-  const opened = await evalIn(app, `(() => {
-    const row = document.querySelector(
-      '[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]'
+  const opened = await evalIn(app, browserScript((sessionId, workspaceId, inputSessionId) => {
+    const row = document.querySelector<HTMLElement>(
+      `[data-sidebar-session-id="${sessionId}"][data-sidebar-session-workspace-id="${workspaceId}"]`
     );
     if (!(row instanceof HTMLElement)) return false;
     row.scrollIntoView({ block: "center" });
-    const target = row.querySelector('[data-session-tab-id="${sessionId}"]') ?? row;
+    const target = row.querySelector<HTMLElement>(`[data-session-tab-id="${inputSessionId}"]`) ?? row;
     if (!(target instanceof HTMLElement)) return false;
     const rect = target.getBoundingClientRect();
     target.dispatchEvent(new MouseEvent("contextmenu", {
@@ -57,52 +58,52 @@ async function openSessionInSplit(app: Surface, workspaceId: string, sessionId: 
       clientY: rect.top + Math.min(12, Math.max(1, rect.height / 2)),
     }));
     return true;
-  })()`);
+  }, [sessionId, workspaceId, sessionId]));
   expect(opened).toBe(true);
-  await waitFor(app, `Boolean(document.querySelector('[data-session-menu-open-split]'))`, {
+  await waitFor(app, () => (Boolean(document.querySelector<HTMLElement>('[data-session-menu-open-split]'))), {
     timeoutMs: 15_000,
     label: "Open in split view menu item",
   });
-  const clicked = await evalIn(app, `(() => {
-    const item = document.querySelector('[data-session-menu-open-split]');
+  const clicked = await evalIn(app, () => {
+    const item = document.querySelector<HTMLElement>('[data-session-menu-open-split]');
     if (!(item instanceof HTMLElement)) return false;
     item.click();
     return true;
-  })()`);
+  });
   expect(clicked).toBe(true);
 }
 
 async function pressPaneKey(app: Surface, pane: "chat" | "split" | "panel", key: string) {
-  const pressed = await evalIn(app, `(() => {
-    const tab = document.querySelector('[data-narrow-pane="${pane}"]');
+  const pressed = await evalIn(app, browserScript((pane, inputKey) => {
+    const tab = document.querySelector<HTMLElement>(`[data-narrow-pane="${pane}"]`);
     if (!(tab instanceof HTMLElement)) return false;
     tab.focus();
-    tab.dispatchEvent(new KeyboardEvent("keydown", { key: ${JSON.stringify(key)}, bubbles: true }));
+    tab.dispatchEvent(new KeyboardEvent("keydown", { key: inputKey, bubbles: true }));
     return true;
-  })()`);
+  }, [pane, key]));
   expect(pressed).toBe(true);
 }
 
 async function openFilesPanel(app: Surface) {
-  const openedMenu = await evalIn(app, `(() => {
-    const button = document.querySelector('button[aria-label="More actions"]');
+  const openedMenu = await evalIn(app, () => {
+    const button = document.querySelector<HTMLButtonElement>('button[aria-label="More actions"]');
     if (!(button instanceof HTMLButtonElement)) return false;
     button.click();
     return true;
-  })()`);
+  });
   expect(openedMenu).toBe(true);
-  await waitFor(app, `Boolean([...document.querySelectorAll('[role="menuitem"]')]
-    .find((item) => (item.textContent ?? '').trim().startsWith('Files')))`, {
+  await waitFor(app, () => (Boolean([...document.querySelectorAll<HTMLElement>('[role="menuitem"]')]
+    .find((item) => (item.textContent ?? '').trim().startsWith('Files')))), {
     timeoutMs: 15_000,
     label: "Files menu item",
   });
-  const openedPanel = await evalIn(app, `(() => {
-    const item = [...document.querySelectorAll('[role="menuitem"]')]
+  const openedPanel = await evalIn(app, () => {
+    const item = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')]
       .find((candidate) => (candidate.textContent ?? '').trim().startsWith('Files'));
     if (!(item instanceof HTMLElement)) return false;
     item.click();
     return true;
-  })()`);
+  });
   expect(openedPanel).toBe(true);
 }
 
@@ -130,15 +131,15 @@ test.skipIf(!runnable)(
 
     await openSessionRoute(app, workspaceId, primary.sessionId);
     await openSessionInSplit(app, workspaceId, secondary.sessionId);
-    await waitFor(app, `Boolean(document.querySelector(
-      '[data-workbench-pane="secondary"] [data-session-surface-id="${secondary.sessionId}"]'
-    ))`, { timeoutMs: 60_000, label: "desktop split session" });
+    await waitFor(app, browserScript((sessionId) => (Boolean(document.querySelector<HTMLElement>(
+      `[data-workbench-pane="secondary"] [data-session-surface-id="${sessionId}"]`
+    ))), [secondary.sessionId]), { timeoutMs: 60_000, label: "desktop split session" });
 
     // Exercise desktop split panes as well as the single-pane mobile layout.
     for (const width of [1440, 1100, 390, 320]) {
       await setViewport(app, { width, height: 844, deviceScaleFactor: 1 });
-      await waitFor(app, `(() => {
-        const toolbars = [...document.querySelectorAll('[data-composer-toolbar]')]
+      await waitFor(app, () => {
+        const toolbars = [...document.querySelectorAll<HTMLElement>('[data-composer-toolbar]')]
           .filter((toolbar) => toolbar.getBoundingClientRect().width > 0);
         return toolbars.length > 0 && toolbars.every((toolbar) => {
           const bounds = toolbar.getBoundingClientRect();
@@ -152,7 +153,7 @@ test.skipIf(!runnable)(
               rect.right <= other.left + 1 || other.right <= rect.left + 1
               || rect.bottom <= other.top + 1 || other.bottom <= rect.top + 1));
         });
-      })()`, { timeoutMs: 30_000, label: `composer controls fit without overlap at ${width}px` });
+      }, { timeoutMs: 30_000, label: `composer controls fit without overlap at ${width}px` });
       await screenshot(app);
       evidence.recordAssertionEvidence(
         `Composer controls remain contained and do not overlap at ${width}px`,
@@ -162,20 +163,20 @@ test.skipIf(!runnable)(
     }
 
     await setViewport(app, { width: 390, height: 844, deviceScaleFactor: 1 });
-    await waitFor(app, `(() => {
-      const selected = document.querySelector('[data-narrow-pane][aria-selected="true"]');
-      const secondary = document.querySelector('[data-session-surface-id="${secondary.sessionId}"]');
-      const primary = document.querySelector('[data-session-surface-id="${primary.sessionId}"]');
+    await waitFor(app, browserScript((sessionId, inputSessionId) => {
+      const selected = document.querySelector<HTMLElement>('[data-narrow-pane][aria-selected="true"]');
+      const secondary = document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`);
+      const primary = document.querySelector<HTMLElement>(`[data-session-surface-id="${inputSessionId}"]`);
       return selected?.getAttribute('data-narrow-pane') === 'split' && Boolean(secondary) && !primary;
-    })()`, { timeoutMs: 30_000, label: "focused split becomes the narrow visible pane" });
+    }, [secondary.sessionId, primary.sessionId]), { timeoutMs: 30_000, label: "focused split becomes the narrow visible pane" });
 
-    const initialNarrowFacts = await evalIn(app, `(() => {
-      const tabs = [...document.querySelectorAll('[data-narrow-pane]')];
+    const initialNarrowFacts = await evalIn(app, () => {
+      const tabs = [...document.querySelectorAll<HTMLElement>('[data-narrow-pane]')];
       const active = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true');
       const activePanel = active
         ? document.getElementById(active.getAttribute('aria-controls') ?? '')
         : null;
-      const switcher = document.querySelector('[data-narrow-pane-switcher]');
+      const switcher = document.querySelector<HTMLElement>('[data-narrow-pane-switcher]');
       const switcherRect = switcher?.getBoundingClientRect();
       const panelRect = activePanel?.getBoundingClientRect();
       return {
@@ -199,7 +200,7 @@ test.skipIf(!runnable)(
         documentWidth: document.documentElement.scrollWidth,
         viewportWidth: window.innerWidth,
       };
-    })()`);
+    });
     expect(initialNarrowFacts).toMatchObject({
       selected: "split",
       tabStops: 1,
@@ -224,42 +225,42 @@ test.skipIf(!runnable)(
     );
 
     await pressPaneKey(app, "split", "ArrowLeft");
-    await waitFor(app, `(() => {
-      const selected = document.querySelector('[data-narrow-pane][aria-selected="true"]');
+    await waitFor(app, browserScript((sessionId, inputSessionId) => {
+      const selected = document.querySelector<HTMLElement>('[data-narrow-pane][aria-selected="true"]');
       return selected?.getAttribute('data-narrow-pane') === 'chat'
-        && Boolean(document.querySelector('[data-session-surface-id="${primary.sessionId}"]'))
-        && !document.querySelector('[data-session-surface-id="${secondary.sessionId}"]');
-    })()`, { timeoutMs: 30_000, label: "ArrowLeft selects primary chat" });
+        && Boolean(document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`))
+        && !document.querySelector<HTMLElement>(`[data-session-surface-id="${inputSessionId}"]`);
+    }, [primary.sessionId, secondary.sessionId]), { timeoutMs: 30_000, label: "ArrowLeft selects primary chat" });
 
     const draft = "Keep this narrow-screen draft";
-    const focusedComposer = await evalIn(app, `(() => {
-      const editor = document.querySelector(
-        '[data-session-surface-id="${primary.sessionId}"] [contenteditable="true"][data-lexical-editor="true"]'
+    const focusedComposer = await evalIn(app, browserScript((sessionId) => {
+      const editor = document.querySelector<HTMLElement>(
+        `[data-session-surface-id="${sessionId}"] [contenteditable="true"][data-lexical-editor="true"]`
       );
       if (!(editor instanceof HTMLElement)) return false;
       editor.focus();
       return document.activeElement === editor;
-    })()`);
+    }, [primary.sessionId]));
     expect(focusedComposer).toBe(true);
     await app.client.send("Input.insertText", { text: draft });
-    await waitFor(app, `(document.querySelector(
-      '[data-session-surface-id="${primary.sessionId}"] [contenteditable="true"][data-lexical-editor="true"]'
-    )?.textContent ?? '').includes(${JSON.stringify(draft)})`, {
+    await waitFor(app, browserScript((sessionId, draft) => ((document.querySelector<HTMLElement>(
+      `[data-session-surface-id="${sessionId}"] [contenteditable="true"][data-lexical-editor="true"]`
+    )?.textContent ?? '').includes(draft)), [primary.sessionId, draft]), {
       timeoutMs: 15_000,
       label: "narrow primary draft",
     });
 
     const focusSecondaryResult = await control(app, "session.open", { sessionId: secondary.sessionId });
     expect(focusSecondaryResult).toMatchObject({ ok: true, reused: "secondary-pane" });
-    await waitFor(app, `document.querySelector('[data-narrow-pane="split"]')?.getAttribute('aria-selected') === 'true'
-      && Boolean(document.querySelector('[data-session-surface-id="${secondary.sessionId}"]'))`, {
+    await waitFor(app, browserScript((sessionId) => (document.querySelector<HTMLElement>('[data-narrow-pane="split"]')?.getAttribute('aria-selected') === 'true'
+      && Boolean(document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`))), [secondary.sessionId]), {
       timeoutMs: 30_000,
       label: "session.open reveals narrow split",
     });
     await pressPaneKey(app, "split", "ArrowLeft");
-    await waitFor(app, `(document.querySelector(
-      '[data-session-surface-id="${primary.sessionId}"] [contenteditable="true"][data-lexical-editor="true"]'
-    )?.textContent ?? '').includes(${JSON.stringify(draft)})`, {
+    await waitFor(app, browserScript((sessionId, draft) => ((document.querySelector<HTMLElement>(
+      `[data-session-surface-id="${sessionId}"] [contenteditable="true"][data-lexical-editor="true"]`
+    )?.textContent ?? '').includes(draft)), [primary.sessionId, draft]), {
       timeoutMs: 30_000,
       label: "draft survives narrow pane remount",
     });
@@ -270,12 +271,12 @@ test.skipIf(!runnable)(
     );
 
     await openFilesPanel(app);
-    await waitFor(app, `document.querySelector('[data-narrow-pane="panel"]')?.getAttribute('aria-selected') === 'true'
-      && Boolean(document.getElementById('narrow-session-pane-panel'))`, {
+    await waitFor(app, () => (document.querySelector<HTMLElement>('[data-narrow-pane="panel"]')?.getAttribute('aria-selected') === 'true'
+      && Boolean(document.getElementById('narrow-session-pane-panel'))), {
       timeoutMs: 30_000,
       label: "tools panel becomes the narrow visible pane",
     });
-    const panelFacts = await evalIn(app, `(() => {
+    const panelFacts = await evalIn(app, () => {
       const panel = document.getElementById('narrow-session-pane-panel');
       const rect = panel?.getBoundingClientRect();
       return {
@@ -289,7 +290,7 @@ test.skipIf(!runnable)(
         documentWidth: document.documentElement.scrollWidth,
         viewportWidth: window.innerWidth,
       };
-    })()`);
+    });
     expect(panelFacts).toEqual({
       panelInsideViewport: true,
       chatHidden: true,
@@ -298,16 +299,16 @@ test.skipIf(!runnable)(
       viewportWidth: 390,
     });
 
-    const closedPanel = await evalIn(app, `(() => {
-      const close = document.querySelector('#narrow-session-pane-panel button[aria-label="Close panel"]');
+    const closedPanel = await evalIn(app, () => {
+      const close = document.querySelector<HTMLElement>('#narrow-session-pane-panel button[aria-label="Close panel"]');
       if (!(close instanceof HTMLButtonElement)) return false;
       close.click();
       return true;
-    })()`);
+    });
     expect(closedPanel).toBe(true);
-    await waitFor(app, `!document.querySelector('[data-narrow-pane="panel"]')
-      && document.querySelector('[data-narrow-pane="chat"]')?.getAttribute('aria-selected') === 'true'
-      && Boolean(document.querySelector('[data-session-surface-id="${primary.sessionId}"]'))`, {
+    await waitFor(app, browserScript((sessionId) => (!document.querySelector<HTMLElement>('[data-narrow-pane="panel"]')
+      && document.querySelector<HTMLElement>('[data-narrow-pane="chat"]')?.getAttribute('aria-selected') === 'true'
+      && Boolean(document.querySelector<HTMLElement>(`[data-session-surface-id="${sessionId}"]`))), [primary.sessionId]), {
       timeoutMs: 30_000,
       label: "closing selected panel falls back to chat",
     });

--- a/evals/specs/saved-app-creation.e2e.test.ts
+++ b/evals/specs/saved-app-creation.e2e.test.ts
@@ -118,14 +118,15 @@ test("create, preview, save and reopen an app without changing already-open resu
   evidence.recordAssertionEvidence("Drafts stay off the dashboard until saved, and Cancel does not save them", "Draft list was empty; Cancel retained a null active revision; Save persisted the exact revision, workflow link, and personal dashboard placement without executing or scheduling a run.", true);
 
   await step("saved app header stays readable in a narrow preview", async () => {
-    await seed.evalIn(world.app, `document.querySelector('[data-app-header]').parentElement.style.width = '320px'`);
-    const header = await probe.eval(world.app, `(() => {
-      const header = document.querySelector('[data-app-header]');
-      const title = header.querySelector('h2');
+    await seed.evalIn(world.app, () => { const parent = document.querySelector<HTMLElement>('[data-app-header]')?.parentElement; if (!parent) throw new Error('Missing app header parent'); parent.style.width = '320px'; });
+    const header = await probe.eval(world.app, () => {
+      const header = document.querySelector<HTMLElement>('[data-app-header]');
+      const title = header?.querySelector<HTMLElement>('h2');
+      if (!header || !title) throw new Error('Missing app header or title');
       return { width: header.getBoundingClientRect().width, height: header.getBoundingClientRect().height,
         titleWidth: title.getBoundingClientRect().width, titleFits: title.scrollWidth <= title.clientWidth,
         buttonLabels: [...header.querySelectorAll('button')].map(button => button.textContent.trim()) };
-    })()`);
+    });
     expect(record(header).width).toBe(320);
     expect(record(header).height).toBeLessThan(72);
     expect(record(header).titleWidth).toBeGreaterThan(180);
@@ -137,7 +138,7 @@ test("create, preview, save and reopen an app without changing already-open resu
     await user.see("Delete Team briefing");
     await user.screenshot();
     await user.click("App options for Team briefing");
-    await seed.evalIn(world.app, `document.querySelector('[data-app-header]').parentElement.style.removeProperty('width')`);
+    await seed.evalIn(world.app, () => (document.querySelector<HTMLElement>('[data-app-header]')?.parentElement?.style.removeProperty('width')));
   });
   evidence.recordAssertionEvidence("The saved app header preserves the title at a 320px panel width", "The real preview header remains under 72px tall with over 180px for the fully visible title. Saved is status text and Delete remains reachable in the options menu.", true);
 

--- a/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
+++ b/evals/specs/sidebar-title-overflow-fade.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec, type Probe } from "@openwork/testkit";
 import { sidebarOverflow } from "../worlds/session-shell.ts";
@@ -30,9 +31,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function rowStates(probe: Probe): Promise<RowState[]> {
   // TODO(primitive): probe.geometry should read the boxes of a row's title and actions.
-  const value = await probe.eval(`(() => [...document.querySelectorAll("[data-sidebar-session-id]")].map((row) => {
-    const title = row.querySelector("[data-session-title-slot]");
-    const actions = row.querySelector("[data-session-hover-actions]");
+  const value = await probe.eval(() => ((() => [...document.querySelectorAll<HTMLElement>("[data-sidebar-session-id]")].map((row) => {
+    const title = row.querySelector<HTMLElement>("[data-session-title-slot]");
+    const actions = row.querySelector<HTMLElement>("[data-session-hover-actions]");
     if (!(title instanceof HTMLElement) || !(actions instanceof HTMLElement)) return null;
     return {
       title: (title.textContent ?? "").trim(),
@@ -40,7 +41,7 @@ async function rowStates(probe: Probe): Promise<RowState[]> {
       actionsLeft: actions.getBoundingClientRect().left,
       actionsOpacity: getComputedStyle(actions).opacity,
     };
-  }))()`);
+  }))()));
   if (!Array.isArray(value)) throw new Error(`Unexpected sidebar rows: ${JSON.stringify(value)}`);
   return value.map((row) => {
     if (!isRecord(row)
@@ -54,11 +55,11 @@ async function rowStates(probe: Probe): Promise<RowState[]> {
 
 async function listState(probe: Probe): Promise<ListState> {
   // TODO(primitive): probe.geometry should read the scroll extents of a visible target.
-  const value = await probe.eval(`(() => {
-    const list = document.querySelector('[data-sidebar="content"]');
+  const value = await probe.eval(() => {
+    const list = document.querySelector<HTMLElement>('[data-sidebar="content"]');
     if (!(list instanceof HTMLElement)) return null;
     return { clientWidth: list.clientWidth, scrollLeft: list.scrollLeft, scrollWidth: list.scrollWidth };
-  })()`);
+  });
   if (!isRecord(value)
     || typeof value.clientWidth !== "number"
     || typeof value.scrollLeft !== "number"
@@ -75,8 +76,8 @@ async function expectListFits(probe: Probe): Promise<void> {
 
 async function titleState(probe: Probe, title: string): Promise<TitleState> {
   // TODO(primitive): probe.computedStyle should read overflow geometry and computed masks for a visible target.
-  const value = await probe.eval(`(title) => {
-    const text = [...document.querySelectorAll("[data-session-title-text]")]
+  const value = await probe.eval(browserScript((title) => {
+    const text = [...document.querySelectorAll<HTMLElement>("[data-session-title-text]")]
       .find((node) => (node.textContent ?? "").trim() === title);
     if (!(text instanceof HTMLElement) || !(text.parentElement instanceof HTMLElement)) return null;
     const viewport = text.parentElement;
@@ -86,7 +87,7 @@ async function titleState(probe: Probe, title: string): Promise<TitleState> {
       maskImage: getComputedStyle(viewport).maskImage,
       scrollWidth: text.scrollWidth,
     };
-  }`, { args: [title] });
+  }, [title]));
   if (!isRecord(value)
     || typeof value.clientWidth !== "number"
     || typeof value.hiddenEdges !== "string"
@@ -112,19 +113,19 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
   await step("collapsing the macOS sidebar aligns the pane with the window controls, and reopening restores its inset", async () => {
     await user.see({ text: world.longTitle });
     // Exercise the macOS titlebar layout even when the desktop host is Linux.
-    const platformClasses = await seed.evalIn(world.app, `document.documentElement.className`);
+    const platformClasses = await seed.evalIn(world.app, () => (document.documentElement.className));
     if (typeof platformClasses !== "string") throw new Error("Desktop platform classes were not readable.");
-    await seed.evalIn(world.app, `(() => {
+    await seed.evalIn(world.app, () => {
       document.documentElement.classList.remove('openwork-platform-linux', 'openwork-platform-windows');
       document.documentElement.classList.add('openwork-electron', 'openwork-platform-mac');
-    })()`);
+    });
     // TODO(primitive): probe.geometry should compare a pane and its visible titlebar trigger.
-    const geometry = () => probe.eval(`(() => {
-      const pane = document.querySelector('[data-session-pane]');
+    const geometry = () => probe.eval(() => {
+      const pane = document.querySelector<HTMLElement>('[data-session-pane]');
       const header = pane?.querySelector('header');
-      const trigger = [...document.querySelectorAll('[data-sidebar="trigger"]')]
+      const trigger = [...document.querySelectorAll<HTMLElement>('[data-sidebar="trigger"]')]
         .find((element) => element.getBoundingClientRect().width > 0);
-      const sidebar = document.querySelector('[data-slot="sidebar"][data-state]');
+      const sidebar = document.querySelector<HTMLElement>('[data-slot="sidebar"][data-state]');
       if (!pane || !header || !trigger || !sidebar) return null;
       const box = pane.getBoundingClientRect();
       const headerBox = header.getBoundingClientRect();
@@ -136,7 +137,7 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
         left: box.left,
         centerOffset: Math.abs(headerBox.top + headerBox.height / 2 - triggerBox.top - triggerBox.height / 2),
       };
-    })()`);
+    });
     const expanded = await geometry();
     expect(expanded).toMatchObject({ state: "expanded", top: 8 });
     if (!isRecord(expanded) || typeof expanded.isMac !== "boolean") throw new Error("Pane geometry was not readable.");
@@ -159,7 +160,7 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
       until: (value) => isRecord(value) && value.state === "expanded" && value.left === expanded.left,
     });
     expect(await geometry()).toMatchObject({ top: expanded.top, left: expanded.left });
-    await seed.evalIn(world.app, `(classes) => { document.documentElement.className = classes; }`, { args: [platformClasses] });
+    await seed.evalIn(world.app, browserScript((classes) => { document.documentElement.className = classes; }, [platformClasses]));
   });
 
   await step("the list fits the sidebar and does not scroll sideways", async () => {
@@ -203,12 +204,12 @@ test("the sidebar title fade follows only the edges with hidden text", async ({ 
   await step("widening the sidebar removes the fade", async () => {
     // TODO(primitive): user.drag should resize a visible rail using trusted pointer input.
     // TODO(primitive): probe.geometry should resolve the center of a visible target.
-    const point = await probe.eval(`(() => {
-      const rail = document.querySelector('[data-sidebar="rail"]');
+    const point = await probe.eval(() => {
+      const rail = document.querySelector<HTMLElement>('[data-sidebar="rail"]');
       if (!(rail instanceof HTMLElement)) return null;
       const rect = rail.getBoundingClientRect();
       return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-    })()`);
+    });
     if (!isRecord(point) || typeof point.x !== "number" || typeof point.y !== "number") throw new Error("Sidebar rail was not measurable.");
     await world.app.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
     await world.app.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x + 340, y: point.y, button: "left" });

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -12,14 +12,14 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.see({ testId: "den-onboarding-shell" });
     await user.notSee({ testId: "den-org-sidebar" });
     await user.notSee({ role: "button", label: "Open menu" });
-    expect(await probe.eval(`(() => {
-      const frame = document.querySelector('[data-testid="setup-frame"]');
+    expect(await probe.eval(() => {
+      const frame = document.querySelector<HTMLElement>('[data-testid="setup-frame"]');
       const frameBounds = frame?.getBoundingClientRect();
       const footer = frame?.querySelector('footer')?.getBoundingClientRect();
       const story = frame?.querySelector('aside')?.getBoundingClientRect();
       const panel = frame?.querySelector('aside')?.nextElementSibling?.getBoundingClientRect();
-      const brand = frame?.querySelector('header > div')?.getBoundingClientRect();
-      const progress = frame?.querySelector('nav[aria-label="Setup progress"]')?.getBoundingClientRect();
+      const brand = frame?.querySelector<HTMLElement>('header > div')?.getBoundingClientRect();
+      const progress = frame?.querySelector<HTMLElement>('nav[aria-label="Setup progress"]')?.getBoundingClientRect();
       return Boolean(frameBounds && footer && story && panel && brand && progress
         && Math.abs(frameBounds.left) < 2
         && Math.abs(frameBounds.right - document.documentElement.clientWidth) < 2
@@ -30,8 +30,8 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
         && Math.abs(brand.left - story.left) < 2
         && Math.abs(progress.left - panel.left) < 2
         && Math.abs(progress.right - panel.right) < 2);
-    })()`)).toBe(true);
-    expect(await probe.eval("document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
+    })).toBe(true);
+    expect(await probe.eval(() => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
   };
   const orgs = async () => {
     const result = await probe.api(world.den.admin, "/v1/me/orgs");
@@ -76,7 +76,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.notSee({ role: "textbox", label: "Team name" });
     await user.see({ testId: "auth-landing-visual" });
     await user.see({ text: "Your choice of model. One place to work." });
-    await probe.eventually(() => probe.eval("Boolean(document.querySelector('[data-testid=auth-landing-visual] canvas'))"), { within: 15000, label: "Paper shader canvas", until: (visible) => visible === true });
+    await probe.eventually(() => probe.eval(() => (Boolean(document.querySelector<HTMLElement>('[data-testid=auth-landing-visual] canvas')))), { within: 15000, label: "Paper shader canvas", until: (visible) => visible === true });
     await user.looks(["The signup landing shows Good work starts here alongside a clear email entry form within a restrained black-and-white setup frame, with a compact black-and-white dithered texture band above the form. The product example clearly shows a chat conversation, an inline dashboard result, and a composer with provider choice"]);
     await user.type({ role: "textbox", label: "Email" }, world.owner.email);
     await user.click({ role: "button", label: "Next" });
@@ -158,7 +158,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.see({ text: "macOS" });
     await user.see({ text: "Windows" });
     await user.see({ text: "Linux" });
-    expect(await probe.eval("document.querySelectorAll('[data-testid=download-openwork-card] details a[href]').length")).toBe(8);
+    expect(await probe.eval(() => (document.querySelectorAll<HTMLElement>('[data-testid=download-openwork-card] details a[href]').length))).toBe(8);
     await user.click({ text: "Other platforms and versions" });
     await user.looks(["The final setup screen shows a clear desktop download and model setup path in the same restrained black-and-white design"]);
     expect(await invitationsFor(personalId)).toEqual([]);
@@ -379,7 +379,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.see({ text: "Already added" });
     await mobileUser.notSee({ role: "button", label: "Open menu" });
     await mobileUser.notSee({ testId: "den-org-sidebar" });
-    expect(await probe.eval(mobile, "document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
+    expect(await probe.eval(mobile, () => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
     await mobileUser.press("Control+Home");
     await mobileUser.looks(["The top of the narrow Tools screen shows legible setup progress and the Give your team a head start heading without horizontal clipping"]);
     await mobileUser.hover({ role: "button", label: "Continue" });
@@ -389,7 +389,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.notSee({ testId: "download-openwork-card" });
     await mobileUser.see({ role: "button", label: "Email me the download link" });
     await mobileUser.see({ role: "link", label: "Try OpenWork Web" });
-    expect(await probe.eval(mobile, "document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
+    expect(await probe.eval(mobile, () => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
     expect(await connectionsFor(flexibleId)).toEqual(toolsBefore);
     await mobileUser.hover({ role: "button", label: "Email me the download link" });
     await mobileUser.looks(["The mobile OpenWork Desktop card shows its complete heading, OpenWork mark, explanatory copy, and Email me the download link button in a restrained neutral card"]);
@@ -411,12 +411,12 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
       within: 30_000, label: "the real download email is captured for the signed-in owner", until: (emails) => emails.length === before.length + 1,
     });
     expect(sent.filter((email) => email.to === world.owner.email)).toHaveLength(before.filter((email) => email.to === world.owner.email).length + 1);
-    expect(await probe.eval(mobile, `Array.from(document.querySelectorAll('[data-testid="onboarding-mobile-options"] button')).find((button) => button.textContent.trim() === "Download link sent")?.disabled`)).toBe(true);
+    expect(await probe.eval(mobile, () => (Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="onboarding-mobile-options"] button')).find((button) => button.textContent.trim() === "Download link sent")?.disabled))).toBe(true);
     await mobileUser.click({ role: "button", label: "Download link sent" });
     expect(await downloadEmails()).toEqual(sent);
-    expect(await probe.eval(mobile, `Array.from(document.querySelectorAll('[data-testid="onboarding-mobile-options"] a')).find((link) => link.textContent.trim() === "Try OpenWork Web")?.getAttribute("href")`)).toBe("/dashboard/web");
+    expect(await probe.eval(mobile, () => (Array.from(document.querySelectorAll<HTMLElement>('[data-testid="onboarding-mobile-options"] a')).find((link) => link.textContent.trim() === "Try OpenWork Web")?.getAttribute("href")))).toBe("/dashboard/web");
     await mobileUser.click({ role: "link", label: "Try OpenWork Web" });
-    await probe.eventually(() => probe.eval(mobile, "window.location.pathname"), {
+    await probe.eventually(() => probe.eval(mobile, () => (window.location.pathname)), {
       within: 30_000, label: "mobile web option opens the existing access and plans page", until: (path) => path === "/dashboard/web",
     });
     evidence.recordAssertionEvidence("Mobile setup preserves configured tools, sends one real download email to the signed-in owner, disables repeat sends, and links to web access without starting checkout", JSON.stringify({ recipient: world.owner.email, newDownloadEmails: 1, repeatSendDisabled: true, webRoute: "/dashboard/web", configuredToolsUnchanged: true }), true);
@@ -427,7 +427,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.see({ text: "Good work starts here." }, { timeoutMs: 90_000 });
     await mobileUser.see({ role: "textbox", label: "Email" });
     await mobileUser.see({ text: "Your choice of model. One place to work." });
-    expect(await probe.eval(mobile, "document.documentElement.scrollWidth <= window.innerWidth")).toBe(true);
+    expect(await probe.eval(mobile, () => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
     await mobileUser.looks(["The narrow signup screen has legible progress steps, heading, email form, and model-provider choice without horizontal clipping"]);
   });
 

--- a/evals/specs/spec-primitives.test.ts
+++ b/evals/specs/spec-primitives.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect } from "vitest";
@@ -94,9 +95,9 @@ primitiveTest("worlds and capability channels preserve provenance and ordering",
   await user.click("Run task");
   expect(seed.tmpPath("mid-flow")).toBe("/fake/mid-flow");
   expect(clickCount).toBe(1);
-  expect(await seed.evalIn(fakeSurface, "Promise.resolve('seed')", { awaitPromise: true, timeoutMs: 1_000 })).toBe("evaluated");
-  expect(await probe.eval("Promise.resolve('probe')", { awaitPromise: true, timeoutMs: 1_000 })).toBe("evaluated");
-  await probe.eval("(value) => value", { args: ["argument value"], awaitPromise: true, timeoutMs: 1_000 });
+  expect(await seed.evalIn(fakeSurface, () => (Promise.resolve('seed')), { awaitPromise: true, timeoutMs: 1_000 })).toBe("evaluated");
+  expect(await probe.eval(() => (Promise.resolve('probe')), { awaitPromise: true, timeoutMs: 1_000 })).toBe("evaluated");
+  await probe.eval(browserScript((value) => value, ["argument value"]), { awaitPromise: true, timeoutMs: 1_000 });
   await user.see({ text: /Running 1 command, reading 1 file/ });
   await user.see("composer", { editable: true, text: /Keep this draft/ });
   await user.see({ text: "alice@example.com Bearer abc accessToken=token-value secret='secret-value' password=password-value" });
@@ -119,7 +120,7 @@ primitiveTest("worlds and capability channels preserve provenance and ordering",
     expect.objectContaining({ stage: "body", channel: "user", verb: "type", detail: "type(composer, \"Replacement text\", replace)" }),
   ]));
   expect(trace.some((entry) => entry.verb === "tmpPath")).toBe(false);
-  expect(cdpCalls.filter((call) => call.method === "Runtime.evaluate" && call.params.awaitPromise === true)).toHaveLength(2);
+  expect(cdpCalls.filter((call) => call.method === "Runtime.evaluate" && call.params.awaitPromise === true)).toHaveLength(3);
   expect(cdpCalls).toEqual(expect.arrayContaining([
     expect.objectContaining({
       method: "Input.dispatchKeyEvent",
@@ -127,10 +128,9 @@ primitiveTest("worlds and capability channels preserve provenance and ordering",
     }),
     expect.objectContaining({ method: "Input.insertText", params: { text: "Replacement text" } }),
     expect.objectContaining({
-      method: "Runtime.callFunctionOn",
+      method: "Runtime.evaluate",
       params: expect.objectContaining({
-        functionDeclaration: "(value) => value",
-        arguments: [{ value: "argument value" }],
+        expression: expect.stringContaining('"argument value"'),
         awaitPromise: true,
       }),
     }),

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -98,8 +98,9 @@ test("a streaming answer renders as markdown block by block and settles to the s
     expect(ready).toMatchObject({ controls: true, autoplay: false, paused: true, error: null });
     await world.videoState(true);
     const playing = await eventually(() => world.videoState(), {
-      within: 5_000, until: (state) => state?.time > 0,
+      within: 5_000, until: (state) => (state?.time ?? 0) > 0,
     });
+    if (!playing) throw new Error("Video disappeared during playback");
     expect(playing.time).toBeGreaterThan(0);
     expect(playing.error).toBeNull();
   });

--- a/evals/specs/task-activity-shimmer.e2e.test.ts
+++ b/evals/specs/task-activity-shimmer.e2e.test.ts
@@ -7,14 +7,14 @@ const test = spec.world(taskActivity);
 test("running delegated-task activity uses a quiet shimmer without a spinner", async ({ user, probe }) => {
   await user.see({ role: "button", label: /Build isolated Azure repro/ });
   // TODO(primitive): inspect the visual treatment classes on a delegated-task status row.
-  const rendered = await probe.eval(`(() => {
-    const row = document.querySelector('[data-subagent-activity="shimmer"]');
+  const rendered = await probe.eval(() => {
+    const row = document.querySelector<HTMLElement>('[data-subagent-activity="shimmer"]');
     return {
-      text: row instanceof HTMLElement ? row.innerText.replace(/\\s+/g, " ").trim() : "",
-      hasSpinner: Boolean(row?.querySelector(".animate-spin")),
-      hasShimmer: Boolean(row?.querySelector(".ow-text-shimmer")),
+      text: row instanceof HTMLElement ? row.innerText.replace(/\s+/g, " ").trim() : "",
+      hasSpinner: Boolean(row?.querySelector<HTMLElement>(".animate-spin")),
+      hasShimmer: Boolean(row?.querySelector<HTMLElement>(".ow-text-shimmer")),
     };
-  })()`);
+  });
   expect(rendered).toMatchObject({
     text: expect.stringMatching(/Build isolated Azure repro.*Working/),
     hasSpinner: false,

--- a/evals/specs/todo-progress-persists-during-run.e2e.test.ts
+++ b/evals/specs/todo-progress-persists-during-run.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import {
   control,
@@ -92,27 +93,27 @@ function parseSessionFacts(value: unknown): SessionFacts {
 }
 
 async function configureWorkspace(appSurface: App, workspaceId: string, baseUrl: string): Promise<void> {
-  const result = await evalIn(appSurface, `(async () => {
+  const result = await evalIn(appSurface, browserScript(async (workspaceId, providerId, modelName, value, modelId, inputModelName, inputWorkspaceId, inputProviderId, inputModelId, inputValue) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return "local_server_unavailable";
-    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const root = String(info.baseUrl).replace(/\/+$/, "");
     const headers = {
       Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
       "Content-Type": "application/json",
     };
-    const configured = await fetch(root + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/config", {
+    const configured = await fetch(root + "/workspace/" + encodeURIComponent(workspaceId) + "/config", {
       method: "PATCH",
       headers,
       body: JSON.stringify({
         opencode: {
           permission: { bash: "allow", todowrite: "allow" },
           provider: {
-            [${JSON.stringify(providerId)}]: {
+            [providerId]: {
               npm: "@ai-sdk/openai-compatible",
-              name: ${JSON.stringify(modelName)},
-              options: { baseURL: ${JSON.stringify(`${baseUrl}/v1`)}, apiKey: "sk-todo-progress" },
+              name: modelName,
+              options: { baseURL: value, apiKey: "sk-todo-progress" },
               models: {
-                [${JSON.stringify(modelId)}]: { name: ${JSON.stringify(modelName)}, tool_call: true },
+                [modelId]: { name: inputModelName, tool_call: true },
               },
             },
           },
@@ -121,29 +122,29 @@ async function configureWorkspace(appSurface: App, workspaceId: string, baseUrl:
       signal: AbortSignal.timeout(30000),
     });
     if (!configured.ok) return "config:" + configured.status + ":" + (await configured.text()).slice(0, 300);
-    const reloaded = await fetch(root + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/engine/reload", {
+    const reloaded = await fetch(root + "/workspace/" + encodeURIComponent(inputWorkspaceId) + "/engine/reload", {
       method: "POST",
       headers,
       signal: AbortSignal.timeout(60000),
     });
     if (!reloaded.ok) return "reload:" + reloaded.status + ":" + (await reloaded.text()).slice(0, 300);
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
       ...preferences,
-      defaultModel: { providerID: ${JSON.stringify(providerId)}, modelID: ${JSON.stringify(modelId)} },
+      defaultModel: { providerID: inputProviderId, modelID: inputModelId },
       modelVariant: null,
       providerStepCompleted: true,
     }));
-    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${providerId}/${modelId}`)});
+    localStorage.setItem("openwork.defaultModel", inputValue);
     return "ok";
-  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  }, [workspaceId, providerId, modelName, `${baseUrl}/v1`, modelId, modelName, workspaceId, providerId, modelId, `${providerId}/${modelId}`]), { awaitPromise: true, timeoutMs: 120_000 });
   expect(result).toBe("ok");
 
-  await evalIn(appSurface, "location.reload(); true");
-  await waitFor(appSurface, "Boolean(window.__openworkControl)", {
+  await evalIn(appSurface, () => { location.reload(); return true; });
+  await waitFor(appSurface, () => (Boolean(window.__openworkControl)), {
     timeoutMs: 60_000,
     label: "desktop restored after mock provider configuration",
   });
@@ -166,16 +167,16 @@ async function createSession(appSurface: App): Promise<string> {
 }
 
 async function approvePendingPermission(appSurface: App, workspaceId: string, sessionId: string): Promise<number> {
-  const value = await evalIn(appSurface, `(async () => {
+  const value = await evalIn(appSurface, browserScript(async (workspaceId, inputSessionId) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return [];
-    const root = String(info.baseUrl).replace(/\\/+$/, "")
-      + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)}) + "/opencode";
+    const root = String(info.baseUrl).replace(/\/+$/, "")
+      + "/workspace/" + encodeURIComponent(workspaceId) + "/opencode";
     const headers = {
       Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
       "Content-Type": "application/json",
     };
-    const sessionId = ${JSON.stringify(sessionId)};
+    const sessionId = inputSessionId;
     const pending = await fetch(root + "/api/session/" + encodeURIComponent(sessionId) + "/permission", {
       headers,
       signal: AbortSignal.timeout(10000),
@@ -192,7 +193,7 @@ async function approvePendingPermission(appSurface: App, workspaceId: string, se
       statuses.push(response.status);
     }
     return statuses;
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, [workspaceId, sessionId]), { awaitPromise: true, timeoutMs: 30_000 });
   if (!Array.isArray(value) || value.some((status) => typeof status !== "number" || status < 200 || status >= 300)) {
     throw new Error(`Permission approval failed: ${JSON.stringify(value)}`);
   }
@@ -206,13 +207,13 @@ async function readSessionFacts(
   command: string,
   completionMarker: string,
 ): Promise<SessionFacts> {
-  const value = await evalIn(appSurface, `(async () => {
+  const value = await evalIn(appSurface, browserScript(async (workspaceId, inputSessionId, inputCommand, completionMarker, inputSessionId2, inputSessionId3) => {
     const empty = { sessionId: "", runningBash: false, todoCount: 0, finalReplyVisible: false, idle: false };
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return empty;
-    const root = String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(${JSON.stringify(workspaceId)})
+    const root = String(info.baseUrl).replace(/\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId)
       + "/opencode/session";
-    const base = root + "/" + encodeURIComponent(${JSON.stringify(sessionId)});
+    const base = root + "/" + encodeURIComponent(inputSessionId);
     const options = {
       headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
       signal: AbortSignal.timeout(15000),
@@ -228,44 +229,44 @@ async function readSessionFacts(
     const parts = list.flatMap((message) => Array.isArray(message?.parts) ? message.parts : []);
     const runningBash = parts.some((part) => part?.tool === "bash"
       && part?.state?.status === "running"
-      && part?.state?.input?.command === ${JSON.stringify(command)});
+      && part?.state?.input?.command === inputCommand);
     const finalReplyVisible = list.some((message) => message?.info?.role === "assistant"
-      && (Array.isArray(message.parts) ? message.parts : []).some((part) => part?.type === "text"
-        && typeof part.text === "string" && part.text.includes(${JSON.stringify(completionMarker)})));
-    const status = statuses?.[${JSON.stringify(sessionId)}];
+      && (Array.isArray(message.parts) ? message.parts : []).some((part: { type?: string; text?: string }) => part?.type === "text"
+        && typeof part.text === "string" && part.text.includes(completionMarker)));
+    const status = statuses?.[inputSessionId2];
     return {
-      sessionId: ${JSON.stringify(sessionId)},
+      sessionId: inputSessionId3,
       runningBash,
       todoCount: Array.isArray(todos) ? todos.length : 0,
       finalReplyVisible,
       idle: !status || status.type === "idle",
     };
-  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  }, [workspaceId, sessionId, command, completionMarker, sessionId, sessionId]), { awaitPromise: true, timeoutMs: 20_000 });
   return parseSessionFacts(value);
 }
 
 async function expandTodoPanel(appSurface: App, sessionId: string, expectedItems: string[]): Promise<void> {
-  const clicked = await evalIn(appSurface, `(() => {
-    const surface = document.querySelector(${JSON.stringify(`[data-session-surface-id="${sessionId}"]`)});
-    const button = surface?.querySelector("[data-todo-progress-panel] button");
+  const clicked = await evalIn(appSurface, browserScript((value) => {
+    const surface = document.querySelector<HTMLElement>(value);
+    const button = surface?.querySelector<HTMLElement>("[data-todo-progress-panel] button");
     if (!(button instanceof HTMLElement)) return false;
     button.click();
     return true;
-  })()`);
+  }, [`[data-session-surface-id="${sessionId}"]`]));
   expect(clicked, "todo panel toggle button present").toBe(true);
-  await waitFor(appSurface, `(() => {
-    const panel = document.querySelector(${JSON.stringify(`[data-session-surface-id="${sessionId}"] [data-todo-progress-panel]`)});
+  await waitFor(appSurface, browserScript((value, expectedItems) => {
+    const panel = document.querySelector<HTMLElement>(value);
     const text = panel instanceof HTMLElement ? panel.innerText : "";
-    return ${JSON.stringify(expectedItems)}.every((item) => text.includes(item));
-  })()`, { timeoutMs: 10_000, label: "todo panel expanded with every item listed" });
+    return expectedItems.every((item) => text.includes(item));
+  }, [`[data-session-surface-id="${sessionId}"] [data-todo-progress-panel]`, expectedItems]), { timeoutMs: 10_000, label: "todo panel expanded with every item listed" });
 }
 
 async function readTodoPanel(appSurface: App, sessionId: string): Promise<PanelFact> {
-  const value = await evalIn(appSurface, `(() => {
-    const currentSessionId = document.querySelector("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "";
-    const surface = document.querySelector(${JSON.stringify(`[data-session-surface-id="${sessionId}"]`)});
+  const value = await evalIn(appSurface, browserScript((value) => {
+    const currentSessionId = document.querySelector<HTMLElement>("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? "";
+    const surface = document.querySelector<HTMLElement>(value);
     if (!(surface instanceof HTMLElement)) return { currentSessionId, found: false, visible: false, completed: -1, total: -1, label: "" };
-    const panel = surface.querySelector("[data-todo-progress-panel]");
+    const panel = surface.querySelector<HTMLElement>("[data-todo-progress-panel]");
     if (!(panel instanceof HTMLElement)) return { currentSessionId, found: false, visible: false, completed: -1, total: -1, label: "" };
     const style = getComputedStyle(panel);
     const rect = panel.getBoundingClientRect();
@@ -283,7 +284,7 @@ async function readTodoPanel(appSurface: App, sessionId: string): Promise<PanelF
       total: Number(panel.getAttribute("data-todo-progress-total")),
       label: panel.querySelector("button")?.innerText ?? "",
     };
-  })()`);
+  }, [`[data-session-surface-id="${sessionId}"]`]));
   return parsePanelFact(value);
 }
 
@@ -407,10 +408,10 @@ test.skipIf(!runnable)(
     expect(completed.panel.found, "todo panel remains after the run finishes").toBe(true);
     expect(completed.panel.visible).toBe(true);
     expect(completed.panel.total).toBe(todos.length);
-    await waitFor(desktopApp, `(() => {
-      const surface = document.querySelector(${JSON.stringify(`[data-session-surface-id="${chat}"]`)});
+    await waitFor(desktopApp, browserScript((value) => {
+      const surface = document.querySelector<HTMLElement>(value);
       return surface instanceof HTMLElement && !surface.innerText.includes("Running command");
-    })()`, { timeoutMs: 30_000, label: "no tool still rendered as running after the final reply" });
+    }, [`[data-session-surface-id="${chat}"]`]), { timeoutMs: 30_000, label: "no tool still rendered as running after the final reply" });
     const afterRunShot = await screenshot(desktopApp);
     const afterRunValidation = await validate(afterRunShot, [
       "A Progress panel above the composer still lists three todo items after the agent finished",

--- a/evals/specs/welcome-one-field.e2e.test.ts
+++ b/evals/specs/welcome-one-field.e2e.test.ts
@@ -8,7 +8,7 @@ const inviteUrl = "http://localhost:59991/join-org?invite=inv_demo123";
 test("the welcome join field takes a server URL or web invite and points the app at that organization", async ({ world, user, probe, step }) => {
   // TODO(primitive): read the persisted desktop bootstrap configuration.
   const readBootstrapBaseUrl = () => probe.eval(
-    `window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig").then((config) => config.baseUrl)`,
+    () => (window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig").then((config) => config.baseUrl)),
     { awaitPromise: true },
   );
   await step("Welcome offers three doors", async () => {

--- a/evals/specs/workflow-run-previews.e2e.test.ts
+++ b/evals/specs/workflow-run-previews.e2e.test.ts
@@ -101,10 +101,10 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     }
     // The old URL redirects into Analytics and receives the same gate.
     await user.see({ text: "Workflow Runs is part of the Enterprise plan." }, { timeoutMs: 90_000 });
-    expect(await probe.eval(world.web, "location.pathname")).toBe("/dashboard/analytics/workflow-runs");
+    expect(await probe.eval(world.web, () => location.pathname)).toBe("/dashboard/analytics/workflow-runs");
     await user.navigate(`${world.den.ref.webUrl}/dashboard/script-runs`);
     await user.see({ text: "Workflow Runs is part of the Enterprise plan." });
-    expect(await probe.eval(world.web, "location.pathname")).toBe("/dashboard/analytics/workflow-runs");
+    expect(await probe.eval(world.web, () => location.pathname)).toBe("/dashboard/analytics/workflow-runs");
     await user.see({ role: "link", label: /^Usage & adoption$/ });
     await user.see({ role: "link", label: "Models & usage" });
     await user.notSee({ testId: "nav-workflow-runs" });
@@ -174,7 +174,7 @@ test("workflow activity shows linked version diagrams and keeps one-off and inac
     expect(await readRuns()).toEqual(before);
     await user.navigate(`${world.den.ref.webUrl}/dashboard/workflow-runs`);
     await user.see({ text: "Workflow Runs" });
-    expect(await probe.eval(world.web, "location.pathname")).toBe("/dashboard/analytics/workflow-runs");
+    expect(await probe.eval(world.web, () => location.pathname)).toBe("/dashboard/analytics/workflow-runs");
     await user.click({ testId: `workflow-run-details-${world.receiptId}` });
     await user.see({ text: `plugin:${world.pluginId}:${world.configObjectId}` });
 

--- a/evals/specs/workspace-engine-upgrade.e2e.test.ts
+++ b/evals/specs/workspace-engine-upgrade.e2e.test.ts
@@ -32,7 +32,7 @@ async function greet(user: User, probe: Probe) {
 }
 
 test("existing workspaces create usable sessions after changing chat engines", async ({ world, user, probe, step }) => {
-  const macPlatform = await probe.eval(`/Mac|iPhone|iPad|iPod/.test(navigator.platform)`);
+  const macPlatform = await probe.eval(() => (/Mac|iPhone|iPad|iPod/.test(navigator.platform)));
   const paletteShortcut = macPlatform ? "Meta+K" : "Control+K";
   const createPaletteChat = async () => {
     const previousRoute = await probe.hash();

--- a/evals/specs/workspace-new-task-hit-target.e2e.test.ts
+++ b/evals/specs/workspace-new-task-hit-target.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { workspaceNewTask } from "../worlds/session-shell.ts";
@@ -14,18 +15,18 @@ test("workspace New task opens an editable composer immediately and creates one 
 
   await step("the plus remains the topmost hit target", async () => {
     // TODO(primitive): probe.hitTarget should identify the painted element at a visible control's center.
-    const hit = await probe.eval(`(() => {
-      const plus = document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]');
+    const hit = await probe.eval(browserScript((workspaceId) => {
+      const plus = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`);
       if (!(plus instanceof HTMLElement)) return { hitPlus: false, hitTitle: false, tag: "" };
       const rect = plus.getBoundingClientRect();
       const node = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
-      const title = plus.closest("[data-workspace-actions]")?.parentElement?.querySelector(".ow-fade-truncate");
+      const title = plus.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>(".ow-fade-truncate");
       return {
         hitPlus: plus.contains(node),
         hitTitle: Boolean(title && node instanceof Node && title.contains(node)),
         tag: node instanceof Element ? node.tagName.toLowerCase() : "",
       };
-    })()`);
+    }, [world.workspace.workspaceId]));
     if (!isRecord(hit)) throw new Error(`New task plus returned malformed hit facts: ${JSON.stringify(hit)}`);
     expect(hit.hitPlus).toBe(true);
     expect(hit.hitTitle).toBe(false);
@@ -36,17 +37,18 @@ test("workspace New task opens an editable composer immediately and creates one 
   });
 
   const before = (await agent.list()).map((session) => session.sessionId).sort();
-  const requests = () => probe.eval(`window.__newTaskRequests`);
+  const requests = () => probe.eval(() => (window.__newTaskRequests));
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
-  const expandedBefore = await probe.eval(`document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]')
-    ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
+  const expandedBefore = await probe.eval(browserScript((workspaceId) => (document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`)
+    ?.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>("[aria-expanded]")?.getAttribute("aria-expanded")), [world.workspace.workspaceId]));
   // TODO(primitive): probe.paintTiming should measure input-to-visible-content in the renderer.
-  await probe.eval(`(() => {
-    const button = document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]');
+  await probe.eval(browserScript((workspaceId) => {
+    const button = document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`);
+    if (!button) throw new Error("Missing new task button");
     button.addEventListener("click", () => {
       const started = performance.now();
       const observer = new MutationObserver(() => {
-        const heading = [...document.querySelectorAll("h2")]
+        const heading = [...document.querySelectorAll<HTMLElement>("h2")]
           .find((node) => node.textContent === "What do you need done?" && node.getClientRects().length);
         if (!heading) return;
         window.__newTaskOpenedAfterMs = performance.now() - started;
@@ -54,10 +56,10 @@ test("workspace New task opens an editable composer immediately and creates one 
       });
       observer.observe(document.body, { subtree: true, childList: true });
     }, { once: true, capture: true });
-  })()`);
+  }, [world.workspace.workspaceId]));
   await user.click({ role: "button", label: `New session · ${workspaceName}` });
   await user.see({ text: "What do you need done?" });
-  const openedAfterMs = await probe.eval(`window.__newTaskOpenedAfterMs`);
+  const openedAfterMs = await probe.eval(() => (window.__newTaskOpenedAfterMs));
   expect(openedAfterMs).toBeLessThan(1000);
   expect(await probe.hash()).not.toContain("/session/ses_");
   expect(await requests()).toEqual([]);
@@ -71,7 +73,7 @@ test("workspace New task opens an editable composer immediately and creates one 
     await user.type({ placeholder: "Describe your task..." }, world.prompt, { verify: true });
     await user.hover({ role: "button", label: workspaceName });
     await user.click({ role: "button", label: `New session · ${workspaceName}` });
-    expect(await probe.eval(`document.querySelector('[contenteditable="true"]')?.textContent`)).toBe(world.prompt);
+    expect(await probe.eval(() => (document.querySelector<HTMLElement>('[contenteditable="true"]')?.textContent))).toBe(world.prompt);
     expect(await requests()).toEqual([]);
     evidence.recordAssertionEvidence(
       "The empty composer accepts a draft and preserves it on another New task click",
@@ -95,8 +97,8 @@ test("workspace New task opens an editable composer immediately and creates one 
   expect(after.length).toBe(before.length + 1);
   expect(after).toEqual(expect.arrayContaining(before));
   // TODO(primitive): probe.attribute should read the accessible control's aria-expanded value.
-  const expandedAfter = await probe.eval(`document.querySelector('[data-sidebar-workspace-id="${world.workspace.workspaceId}"] [data-workspace-new-task]')
-    ?.closest("[data-workspace-actions]")?.parentElement?.querySelector("[aria-expanded]")?.getAttribute("aria-expanded")`);
+  const expandedAfter = await probe.eval(browserScript((workspaceId) => (document.querySelector<HTMLElement>(`[data-sidebar-workspace-id="${workspaceId}"] [data-workspace-new-task]`)
+    ?.closest("[data-workspace-actions]")?.parentElement?.querySelector<HTMLElement>("[aria-expanded]")?.getAttribute("aria-expanded")), [world.workspace.workspaceId]));
   expect(expandedAfter).toBe(expandedBefore);
   evidence.recordAssertionEvidence(
     "Submitting creates exactly one task in the intended workspace and receives the mock reply",

--- a/evals/specs/workspace-storm-auth-coherence.e2e.test.ts
+++ b/evals/specs/workspace-storm-auth-coherence.e2e.test.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/testkit";
 /**
  * Repro attempts for the field report "failed authorization / asks me to
  * reconnect even though the tools/MCPs are connected": a member with many
@@ -63,20 +64,20 @@ interface WorkspaceListing {
 
 /** The local server's own workspace registry, read the way the app reads it. */
 async function listWorkspaces(desktopApp: App): Promise<WorkspaceListing> {
-  const value = await evalIn(desktopApp, `(async () => {
+  const value = await evalIn(desktopApp, async () => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
-    const response = await fetch(String(info.baseUrl).replace(/\\/+$/, "") + "/workspaces", {
+    const response = await fetch(String(info.baseUrl).replace(/\/+$/, "") + "/workspaces", {
       headers: { authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
     });
     if (!response.ok) return { error: "workspaces_http_" + response.status };
     const body = await response.json();
     const items = Array.isArray(body?.items) ? body.items : [];
     return {
-      ids: items.map((item) => String(item?.id ?? "")).filter(Boolean),
+      ids: items.map((item: { id?: unknown }) => String(item?.id ?? "")).filter(Boolean),
       activeId: typeof body?.activeId === "string" ? body.activeId : null,
     };
-  })()`, { awaitPromise: true, timeoutMs: 20_000 });
+  }, { awaitPromise: true, timeoutMs: 20_000 });
   if (!isRecord(value) || !Array.isArray(value.ids)) {
     throw new Error(`Listing workspaces failed: ${JSON.stringify(value)}`);
   }
@@ -110,31 +111,31 @@ async function switchToWorkspace(desktopApp: App, workspaceId: string, dwellMs: 
 
 /** Ask the real Den auth provider to re-read its session; exercises injected identity failures. */
 async function refreshDenSession(desktopApp: App, times: number): Promise<void> {
-  await evalIn(desktopApp, `(async () => {
-    for (let index = 0; index < ${times}; index += 1) {
+  await evalIn(desktopApp, browserScript(async (times) => {
+    for (let index = 0; index < times; index += 1) {
       window.dispatchEvent(new Event("openwork-den-session-updated"));
       await new Promise((resolve) => window.setTimeout(resolve, 100));
     }
-  })()`, { awaitPromise: true, timeoutMs: 10_000 });
+  }, [times]), { awaitPromise: true, timeoutMs: 10_000 });
 }
 
 async function probeDenPath(desktopApp: App, apiUrl: string, path: string, times: number): Promise<void> {
-  await evalIn(desktopApp, `(async () => {
+  await evalIn(desktopApp, browserScript(async (times, apiUrl, path) => {
     const token = localStorage.getItem("openwork.den.authToken") ?? "";
-    for (let index = 0; index < ${times}; index += 1) {
+    for (let index = 0; index < times; index += 1) {
       try {
-        await fetch(${JSON.stringify(apiUrl)} + ${JSON.stringify(path)}, {
+        await fetch(apiUrl + path, {
           headers: { Authorization: "Bearer " + token },
         });
       } catch {}
     }
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, [times, apiUrl, path]), { awaitPromise: true, timeoutMs: 30_000 });
 }
 
 /** Wait until the app itself has adopted the workspace as active. */
 async function waitForAdoptedWorkspace(desktopApp: App, workspaceId: string): Promise<void> {
-  await waitFor(desktopApp, `(localStorage.getItem("openwork.react.activeWorkspace") ?? "") === ${JSON.stringify(workspaceId)}
-    && window.location.hash.includes(${JSON.stringify(`/workspace/${workspaceId}`)})`, {
+  await waitFor(desktopApp, browserScript((workspaceId, value) => ((localStorage.getItem("openwork.react.activeWorkspace") ?? "") === workspaceId
+    && window.location.hash.includes(value)), [workspaceId, `/workspace/${workspaceId}`]), {
     timeoutMs: 60_000,
     label: `workspace ${workspaceId} adopted as active`,
   });
@@ -503,11 +504,11 @@ test.skipIf(!runnable)(
       true,
     );
 
-    const gateInstalled = await evalIn(desktopApp, `(() => {
+    const gateInstalled = await evalIn(desktopApp, () => {
       const originalFetch = window.fetch.bind(window);
       let releaseGate = () => {};
-      const gate = new Promise((resolve) => { releaseGate = resolve; });
-      const state = {
+      const gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+      const state: Window["__workspaceStormSettingsGate"] = {
         entered: false,
         released: false,
         firstCompleted: false,
@@ -537,24 +538,24 @@ test.skipIf(!runnable)(
         return originalFetch(input, init);
       };
       return true;
-    })()`);
+    });
     expect(gateInstalled).toBe(true);
     await go(desktopApp, `/workspace/${encodeURIComponent(first)}/settings/general`);
-    await waitFor(desktopApp, "window.__workspaceStormSettingsGate?.entered === true", {
+    await waitFor(desktopApp, () => (window.__workspaceStormSettingsGate?.entered === true), {
       timeoutMs: 30_000,
       label: "first Settings workspace refresh held in flight",
     });
     await go(desktopApp, `/workspace/${encodeURIComponent(finalWorkspaceId)}/settings/general`);
-    await waitFor(desktopApp, `window.location.hash.includes(${JSON.stringify(`/workspace/${encodeURIComponent(finalWorkspaceId)}/settings/general`)})
-      && document.body.innerText.includes("Overview of all settings")`, {
+    await waitFor(desktopApp, browserScript((value) => (window.location.hash.includes(value)
+      && document.body.innerText.includes("Overview of all settings")), [`/workspace/${encodeURIComponent(finalWorkspaceId)}/settings/general`]), {
       timeoutMs: 90_000,
       label: "final Settings route rendered while the stale refresh is held",
     });
     const coherentBeforeRelease = await eventually(
-      () => evalIn(desktopApp, `(async () => {
+      () => evalIn(desktopApp, async () => {
         const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
         const desktopState = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("workspaceBootstrap");
-        const response = await fetch(String(info?.baseUrl ?? "").replace(/\\/+$/, "") + "/workspaces", {
+        const response = await fetch(String(info?.baseUrl ?? "").replace(/\/+$/, "") + "/workspaces", {
           headers: { authorization: "Bearer " + String(info?.ownerToken ?? info?.clientToken ?? "") },
         });
         const body = await response.json();
@@ -565,7 +566,7 @@ test.skipIf(!runnable)(
           desktop: String(desktopState?.activeId ?? ""),
           server: String(body?.activeId ?? ""),
         };
-      })()`, { awaitPromise: true, timeoutMs: 20_000 }),
+      }, { awaitPromise: true, timeoutMs: 20_000 }),
       {
         within: 90_000,
         intervalMs: 500,
@@ -581,17 +582,17 @@ test.skipIf(!runnable)(
       true,
     );
 
-    await evalIn(desktopApp, "window.__workspaceStormSettingsGate?.release(); true");
-    await waitFor(desktopApp, "window.__workspaceStormSettingsGate?.firstCompleted === true", {
+    await evalIn(desktopApp, () => { window.__workspaceStormSettingsGate?.release(); return true; });
+    await waitFor(desktopApp, () => (window.__workspaceStormSettingsGate?.firstCompleted === true), {
       timeoutMs: 30_000,
       label: "held workspace response completed",
     });
     await sleep(2_000);
-    const afterRelease = await evalIn(desktopApp, `(() => ({
+    const afterRelease = await evalIn(desktopApp, () => ((() => ({
       active: localStorage.getItem("openwork.react.activeWorkspace") ?? "",
       errors: [...(window.__workspaceStormSettingsGate?.errors ?? [])],
       visibleError: /Failed to fetch|OpenCode base URL is missing|Workspace configuration failed|Runtime error/.test(document.body.innerText),
-    }))()`);
+    }))()));
     expect(afterRelease).toMatchObject({ active: finalWorkspaceId, errors: [], visibleError: false });
     await switchToWorkspace(desktopApp, finalWorkspaceId, 0);
 
@@ -608,7 +609,7 @@ test.skipIf(!runnable)(
       attempt: "Attempt 3",
     });
 
-    const adopted = await evalIn(desktopApp, `localStorage.getItem("openwork.react.activeWorkspace") ?? ""`);
+    const adopted = await evalIn(desktopApp, () => (localStorage.getItem("openwork.react.activeWorkspace") ?? ""));
     evidence.recordAssertionEvidence(
       "Attempt 3: no lost update — the adopted workspace is the last one requested",
       `openwork.react.activeWorkspace=${JSON.stringify(adopted)} after ${toggles} toggles (expected ${finalWorkspaceId}).`,

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -5,13 +5,13 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "target": "es2023",
-    "lib": ["es2023", "esnext.disposable"],
+    "lib": ["es2023", "dom", "dom.iterable", "esnext.disposable"],
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["docs-shots/**/*.ts", "runner/**/*.ts", "packages/**/*.ts", "scripts/**/*.ts", "specs/**/*.ts", "worlds/**/*.ts", "vitest.config.ts"],
+  "include": ["docs-shots/**/*.ts", "drivers/**/*.mts", "../packages/handsfree/test/e2e/browser.ts", "runner/**/*.ts", "packages/**/*.ts", "scripts/**/*.ts", "specs/**/*.ts", "worlds/**/*.ts", "vitest.config.ts"],
   "exclude": ["results"]
 }

--- a/evals/worlds/browser-panel.ts
+++ b/evals/worlds/browser-panel.ts
@@ -1,3 +1,4 @@
+import { browserScript, browserSource } from "@openwork/cdp";
 import { control } from "@openwork/behaviors";
 import { captureScreenshot, connect, debuggerUrlFor, evaluate, listTargets, navigate } from "@openwork/cdp";
 import type { AttachedSurface, CdpClient, Surface } from "@openwork/cdp";
@@ -55,7 +56,12 @@ export const INPUT_PROBE_PAGE = `data:text/html;charset=utf-8,${encodeURICompone
   '<!doctype html><title>input-probe</title>'
   + '<body style="margin:0"><button id="hit" style="position:fixed;inset:0 0 50% 0;font-size:24px">hit</button>'
   + '<input id="field" style="position:fixed;top:60%;left:10px;width:300px;font-size:24px">'
-  + '<script>window.__clicks=0;document.getElementById("hit").addEventListener("click",()=>{window.__clicks+=1});</script>',
+  + `<script>${browserSource(() => {
+    window.__clicks = 0;
+    const button = document.getElementById("hit");
+    if (!button) throw new Error("Input probe button missing");
+    button.addEventListener("click", () => { window.__clicks += 1; });
+  })}</script>`,
 )}`;
 
 function pngSize(png: Buffer): Viewport {
@@ -113,7 +119,7 @@ function stringField(value: unknown): string {
  * browser; the response body is irrelevant to the viewport journey.
  */
 async function embeddedServerUrl(seed: Seed, app: Surface): Promise<string> {
-  const info = await seed.evalIn(app, `window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo")`, { awaitPromise: true });
+  const info = await seed.evalIn(app, () => (window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo")), { awaitPromise: true });
   if (!isRecord(info) || info.running !== true) throw new Error("The embedded OpenWork server is not running.");
   return stringField(info.baseUrl).replace(/\/+$/, "");
 }
@@ -121,7 +127,7 @@ async function embeddedServerUrl(seed: Seed, app: Surface): Promise<string> {
 async function loginWitnessUrl(seed: Seed, app: Surface): Promise<string> {
   return stringField(await seed.evalIn(
     app,
-    "window.__OPENWORK_ELECTRON__.browserLogins.testWitnessUrl()",
+    () => (window.__OPENWORK_ELECTRON__.browserLogins.testWitnessUrl()),
     { awaitPromise: true },
   ));
 }
@@ -173,9 +179,10 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const url = `${origin}/?viewport-probe=transcript-link&source=chat%20link#working-page`;
       const artifactName = "browser-handoff.md";
       const artifactText = "Keep these notes open while following the research link.";
-      await seed.evalIn(app, `async (workspaceId, sessionId, url, artifactName, artifactText, fileUrl) => {
+      await seed.evalIn(app, browserScript(async (workspaceId, sessionId, url, artifactName, artifactText, fileUrl) => {
         const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
-        const base = info.baseUrl.replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId);
+        if (!info.baseUrl) throw new Error("Missing local server URL");
+        const base = info.baseUrl.replace(/\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId);
         const headers = { Authorization: "Bearer " + (info.ownerToken ?? info.clientToken), "Content-Type": "application/json" };
         const file = await fetch(base + "/files/content", {
           method: "POST", headers, signal: AbortSignal.timeout(15000),
@@ -192,14 +199,10 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
         });
         if (!message.ok) throw new Error("Could not seed the transcript link: " + message.status);
         const saved = await message.json();
-        if (!Array.isArray(saved.parts) || !saved.parts.some(part => part.type === "text" && part.text.includes(url))) {
+        if (!Array.isArray(saved.parts) || !saved.parts.some((part: { type?: string; text?: string }) => part.type === "text" && part.text?.includes(url))) {
           throw new Error("Transcript seed did not persist the requested link.");
         }
-      }`, {
-        args: [workspace.workspaceId, sessionId, url, artifactName, artifactText, new URL(`file://${workspacePath}/${artifactName}`).href],
-        awaitPromise: true,
-        timeoutMs: 50_000,
-      });
+      }, [workspace.workspaceId, sessionId, url, artifactName, artifactText, new URL(`file://${workspacePath}/${artifactName}`).href]), { awaitPromise: true, timeoutMs: 50_000 });
       return { url, artifactName, artifactText };
     },
 
@@ -223,7 +226,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const deadline = Date.now() + 30_000;
       let routed = false;
       while (Date.now() < deadline) {
-        const actions = await seed.evalIn(app, "window.__openworkControl.listActions().map((action) => action.id)");
+        const actions = await seed.evalIn(app, () => (window.__openworkControl.listActions().map((action) => action.id)));
         if (Array.isArray(actions) && actions.includes("session.open")) {
           await control(app, "session.open", { sessionId });
           return;
@@ -242,7 +245,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const url = `${origin}/?viewport-probe=${encodeURIComponent(name)}`;
       const result = await seed.evalIn(
         app,
-        `window.__OPENWORK_ELECTRON__.browser.openUrl(${JSON.stringify(url)})`,
+        browserScript((url) => (window.__OPENWORK_ELECTRON__.browser.openUrl(url)), [url]),
         { awaitPromise: true, timeoutMs: 30_000 },
       );
       if (!isRecord(result)) throw new Error("browser.openUrl returned no handle.");
@@ -258,7 +261,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const url = `${await loginWitnessUrl(seed, app)}/?login-probe=${encodeURIComponent(name)}`;
       const result = await seed.evalIn(
         app,
-        `window.__OPENWORK_ELECTRON__.browser.openUrl(${JSON.stringify(url)})`,
+        browserScript((url) => (window.__OPENWORK_ELECTRON__.browser.openUrl(url)), [url]),
         { awaitPromise: true, timeoutMs: 30_000 },
       );
       if (!isRecord(result)) throw new Error("browser.openUrl returned no login witness handle.");
@@ -270,11 +273,11 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const url = `${await loginWitnessUrl(seed, app)}/?login-probe=${encodeURIComponent(name)}`;
       const result = await seed.evalIn(
         app,
-        `window.__openworkControl.command(${JSON.stringify({
+        browserScript((value) => (window.__openworkControl.command(value)), [{
           id: "browser.open_url",
           args: { url, provider: "builtin" },
           origin: { sessionId: ownerSessionId },
-        })})`,
+        }]),
         { awaitPromise: true, timeoutMs: 30_000 },
       );
       if (!isRecord(result) || result.ok !== true || !isRecord(result.result)) {
@@ -299,11 +302,11 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const url = `${origin}/?viewport-probe=${encodeURIComponent(name)}`;
       const result = await seed.evalIn(
         app,
-        `window.__openworkControl.command(${JSON.stringify({
+        browserScript((value) => (window.__openworkControl.command(value)), [{
           id: "browser.open_url",
           args: { url, provider: "builtin" },
           origin: { sessionId: ownerSessionId },
-        })})`,
+        }]),
         { awaitPromise: true, timeoutMs: 30_000 },
       );
       if (!isRecord(result) || result.ok !== true || !isRecord(result.result)) {
@@ -331,7 +334,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       const storePath = `${directory}/cookies.sqlite`;
       const result = await seed.evalIn(
         app,
-        `window.__OPENWORK_ELECTRON__.browserLogins.writeTestStore(${JSON.stringify({ path: storePath, cookies })})`,
+        browserScript((value) => (window.__OPENWORK_ELECTRON__.browserLogins.writeTestStore(value)), [{ path: storePath, cookies }]),
         { awaitPromise: true, timeoutMs: 30_000 },
       );
       if (!isRecord(result)) throw new Error("The eval seam did not register a login store.");
@@ -342,7 +345,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     async updateLoginStore(storePath: string, cookies: Array<Record<string, unknown>>): Promise<void> {
       const result = await seed.evalIn(
         app,
-        `window.__OPENWORK_ELECTRON__.browserLogins.writeTestStore(${JSON.stringify({ path: storePath, cookies })})`,
+        browserScript((value) => (window.__OPENWORK_ELECTRON__.browserLogins.writeTestStore(value)), [{ path: storePath, cookies }]),
         { awaitPromise: true, timeoutMs: 30_000 },
       );
       if (!isRecord(result)) throw new Error("The eval seam did not update the login store.");
@@ -357,9 +360,9 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     async readCheckedSyncSites(): Promise<string[]> {
       const result = await seed.evalIn(
         app,
-        `[...document.querySelectorAll('[data-testid^="login-sync-site-"]')]
+        () => ([...document.querySelectorAll<HTMLElement>('[data-testid^="login-sync-site-"]')]
           .filter((element) => element.getAttribute("aria-checked") === "true" || element.hasAttribute("data-checked"))
-          .map((element) => element.getAttribute("data-testid").slice("login-sync-site-".length))`,
+          .map((element) => (element.getAttribute("data-testid") ?? "").slice("login-sync-site-".length))),
       );
       if (!Array.isArray(result)) throw new Error("The sync dialog did not report its checked sites.");
       return result.map(String);
@@ -367,30 +370,30 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
 
     /** Sites the built-in browser is signed in to, as Settings shows them. */
     async signedInSites(): Promise<string[]> {
-      const result = await seed.evalIn(app, "window.__OPENWORK_ELECTRON__.browserLogins.signedInSites()", { awaitPromise: true });
+      const result = await seed.evalIn(app, () => (window.__OPENWORK_ELECTRON__.browserLogins.signedInSites()), { awaitPromise: true });
       if (!Array.isArray(result)) throw new Error("The desktop bridge did not list signed-in sites.");
       return result.map((site) => (isRecord(site) ? stringField(site.site) : "")).filter(Boolean);
     },
 
     /** Renderer-safe sync metadata, never cookie values. */
     async loginSyncState(): Promise<Record<string, unknown>> {
-      const result = await seed.evalIn(app, "window.__OPENWORK_ELECTRON__.browserLogins.state()", { awaitPromise: true });
+      const result = await seed.evalIn(app, () => (window.__OPENWORK_ELECTRON__.browserLogins.state()), { awaitPromise: true });
       if (!isRecord(result)) throw new Error("The desktop bridge did not report browser login sync state.");
       return result;
     },
 
     async pauseLoginSync(): Promise<void> {
-      await seed.evalIn(app, "window.__OPENWORK_ELECTRON__.browserLogins.pause()", { awaitPromise: true });
+      await seed.evalIn(app, () => (window.__OPENWORK_ELECTRON__.browserLogins.pause()), { awaitPromise: true });
     },
 
     /** What the witness page observes without exposing an HttpOnly cookie value. */
     async readLoginWitness(tab: BuiltinBrowserTab): Promise<string> {
-      return withTabClient(app, tab.targetId, async (client) => String(await evaluate(client, "document.body.dataset.loginState")));
+      return withTabClient(app, tab.targetId, async (client) => String(await evaluate(client, () => (document.body.dataset.loginState))));
     },
 
     /** What the page inside a tab can read from `document.cookie`. */
     async readDocumentCookie(tab: BuiltinBrowserTab): Promise<string> {
-      return withTabClient(app, tab.targetId, async (client) => String(await evaluate(client, "document.cookie")));
+      return withTabClient(app, tab.targetId, async (client) => String(await evaluate(client, () => (document.cookie))));
     },
 
     /** Navigate the existing CDP page without opening a replacement tab. */
@@ -404,7 +407,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
         await client.send("Page.reload");
         const deadline = Date.now() + 15_000;
         while (Date.now() < deadline) {
-          if ((await evaluate(client, "document.readyState")) === "complete") return;
+          if ((await evaluate(client, () => (document.readyState))) === "complete") return;
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
       });
@@ -414,7 +417,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     async readBrowserState(): Promise<BrowserState> {
       return parseBrowserState(await seed.evalIn(
         app,
-        "window.__OPENWORK_ELECTRON__.browser.getState()",
+        () => (window.__OPENWORK_ELECTRON__.browser.getState()),
         { awaitPromise: true },
       ));
     },
@@ -429,7 +432,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     /** The viewport a tab lays out for and whether its page believes it has focus. */
     async readPageProbe(tab: BuiltinBrowserTab): Promise<PageProbe> {
       return withTabClient(app, tab.targetId, async (client) => parsePageProbe(
-        await evaluate(client, "({ width: window.innerWidth, height: window.innerHeight, hasFocus: document.hasFocus() })"),
+        await evaluate(client, () => (({ width: window.innerWidth, height: window.innerHeight, hasFocus: document.hasFocus() }))),
       ));
     },
 
@@ -444,7 +447,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
         await navigate(client, INPUT_PROBE_PAGE);
         const deadline = Date.now() + 15_000;
         while (Date.now() < deadline) {
-          if ((await evaluate(client, "document.title")) === "input-probe") return;
+          if ((await evaluate(client, () => (document.title))) === "input-probe") return;
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
         throw new Error("The input probe page did not load in the built-in browser tab.");
@@ -456,12 +459,12 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
       return withTabClient(app, tab.targetId, async (client) => {
         await client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: 100, y: 100, button: "left", clickCount: 1 });
         await client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: 100, y: 100, button: "left", clickCount: 1 });
-        await evaluate(client, "document.getElementById('field').focus()");
+        await evaluate(client, () => (document.getElementById('field')?.focus()));
         for (const char of text) {
           await client.send("Input.dispatchKeyEvent", { type: "keyDown", text: char });
           await client.send("Input.dispatchKeyEvent", { type: "keyUp", text: char });
         }
-        const result = await evaluate(client, "({ clicks: window.__clicks, value: document.getElementById('field').value })");
+        const result = await evaluate(client, () => (({ clicks: window.__clicks, value: document.querySelector<HTMLInputElement>('#field')?.value })));
         if (!isRecord(result) || typeof result.clicks !== "number" || typeof result.value !== "string") {
           throw new Error("The input probe page did not report clicks and typed text.");
         }
@@ -472,7 +475,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     /** Observe the existing document without focusing its hidden native view. */
     async readInputProbe(tab: BuiltinBrowserTab): Promise<unknown> {
       return withTabClient(app, tab.targetId, (client) => evaluate(client,
-        "({ clicks: window.__clicks, value: document.getElementById('field').value })"));
+        () => (({ clicks: window.__clicks, value: document.querySelector<HTMLInputElement>('#field')?.value }))));
     },
 
     /**
@@ -493,7 +496,7 @@ async function createBuiltinBrowserWorld(seed: Seed, env?: Record<string, string
     /** The viewport the page inside a tab is laying out for right now. */
     async readViewport(tab: BuiltinBrowserTab): Promise<Viewport> {
       return withTabClient(app, tab.targetId, async (client) => parseViewport(
-        await evaluate(client, "({ width: window.innerWidth, height: window.innerHeight })"),
+        await evaluate(client, () => (({ width: window.innerWidth, height: window.innerHeight }))),
       ));
     },
   };
@@ -523,9 +526,9 @@ export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<
   const origin = await embeddedServerUrl(seed, app);
   const linkUrl = `${origin}/?link-context=alpha%20beta&encoded=%2Fkeep%3Fyes%3D1#thread-link`;
   const note = "Keep this note in its own conversation.";
-  await seed.evalIn(app, `async (workspaceId, sessionId, note, url) => {
+  await seed.evalIn(app, browserScript(async (workspaceId, sessionId, note, url) => {
     const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
-    const response = await fetch(info.baseUrl.replace(/\\/+$/, "")
+    const response = await fetch(String(info.baseUrl).replace(/\/+$/, "")
       + "/workspace/" + encodeURIComponent(workspaceId)
       + "/opencode/session/" + encodeURIComponent(sessionId) + "/message", {
       method: "POST",
@@ -538,7 +541,7 @@ export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<
     });
     if (!response.ok) throw new Error("Transcript message seed failed: " + response.status);
     return true;
-  }`, { args: [workspace.workspaceId, reading.sessionId, note, linkUrl], awaitPromise: true, timeoutMs: 35_000 });
+  }, [workspace.workspaceId, reading.sessionId, note, linkUrl]), { awaitPromise: true, timeoutMs: 35_000 });
   await world.showSession(reading.sessionId);
 
   return {
@@ -550,19 +553,19 @@ export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<
     note,
 
     async readLink() {
-      return evaluate(app.client, `(() => {
-        const link = [...document.querySelectorAll('[data-message-role="user"] a[href]')]
-          .find(node => node.getAttribute("href") === ${JSON.stringify(linkUrl)});
-        return link ? { href: link.href, sessionId: link.closest("[data-session-surface-id]")?.dataset.sessionSurfaceId } : null;
-      })()`);
+      return evaluate(app.client, browserScript((linkUrl) => {
+        const link = [...document.querySelectorAll<HTMLAnchorElement>('[data-message-role="user"] a[href]')]
+          .find(node => node.getAttribute("href") === linkUrl);
+        return link ? { href: link.href, sessionId: link.closest<HTMLElement>("[data-session-surface-id]")?.dataset.sessionSurfaceId } : null;
+      }, [linkUrl]));
     },
 
     async readMainUrl() {
-      return evaluate(app.client, "location.href");
+      return evaluate(app.client, () => (location.href));
     },
 
     async readClipboard() {
-      return evaluate(app.client, "navigator.clipboard.readText()", { awaitPromise: true });
+      return evaluate(app.client, () => (navigator.clipboard.readText()), { awaitPromise: true });
     },
 
     /** Exclude the menu document, but include popups and all built-in pages. */
@@ -588,14 +591,14 @@ export async function transcriptLinkWorld(seed: Seed, world: Awaited<ReturnType<
     },
 
     async menuLabels(surface: Surface) {
-      return evaluate(surface.client, `Array.from(document.querySelectorAll('[role="menu"]'),
-        menu => menu.getAttribute("aria-label"))`);
+      return evaluate(surface.client, () => (Array.from(document.querySelectorAll<HTMLElement>('[role="menu"]'),
+        menu => menu.getAttribute("aria-label"))));
     },
 
     async menuShown(surface: Surface) {
       // Chromium can retain document.hasFocus() on a detached native view. The
       // renderer clears its menu on dismissal, so stale choices cannot persist.
-      return await evaluate(surface.client, 'Boolean(document.querySelector(\'[role="menu"]\'))') === true;
+      return await evaluate(surface.client, () => (Boolean(document.querySelector<HTMLElement>('[role="menu"]')))) === true;
     },
 
     async closePopup(targetId: string) {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
@@ -88,12 +89,12 @@ export async function configureProvider(
   engine = resolveEvalEngine(),
 ): Promise<void> {
   // TODO(primitive): configure a workspace provider and select its model.
-  const result = await seed.evalIn(app, `async (workspaceId, providerId, modelId, defaultModel, opencodeJson) => {
+  const result = await seed.evalIn(app, browserScript(async (workspaceId, providerId, modelId, defaultModel, opencodeJson) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
     const opencode = JSON.parse(opencodeJson);
-    const request = async (path, init) => {
+    const request = async (path: string, init?: RequestInit) => {
       const response = await fetch("http://127.0.0.1:" + port + path, {
         ...init,
         headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
@@ -112,7 +113,7 @@ export async function configureProvider(
     const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
     if (reloaded !== "ok") return reloaded;
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
@@ -124,14 +125,10 @@ export async function configureProvider(
     localStorage.setItem("openwork.defaultModel", defaultModel);
     localStorage.removeItem("openwork.sessionModels." + workspaceId);
     return "ok";
-  }`, {
-    args: [workspaceId, providerId, modelId, `${providerId}/${modelId}`, JSON.stringify(opencode)],
-    awaitPromise: true,
-    timeoutMs: 120_000,
-  });
+  }, [workspaceId, providerId, modelId, `${providerId}/${modelId}`, JSON.stringify(opencode)]), { awaitPromise: true, timeoutMs: 120_000 });
   if (result !== "ok") throw new Error(`Provider configuration failed: ${String(result)}`);
-  await seed.evalIn(app, "location.reload(); true");
-  const ready = await seed.evalIn(app, `async (workspaceId, engine, providerId, modelId) => {
+  await seed.evalIn(app, () => { location.reload(); return true; });
+  const ready = await seed.evalIn(app, browserScript(async (workspaceId, engine, providerId, modelId) => {
     const deadline = Date.now() + 60000;
     while (Date.now() < deadline) {
       const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
@@ -155,7 +152,7 @@ export async function configureProvider(
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
     return false;
-  }`, { args: [workspaceId, engine, providerId, modelId], awaitPromise: true, timeoutMs: 120_000 });
+  }, [workspaceId, engine, providerId, modelId]), { awaitPromise: true, timeoutMs: 120_000 });
   if (ready !== true) throw new Error(`Selected ${engine} engine did not become ready after provider configuration.`);
 }
 
@@ -174,7 +171,7 @@ export async function arrangeControl(
   args?: unknown,
 ): Promise<unknown> {
   // TODO(primitive): invoke a named renderer fixture control and await its result.
-  return seed.evalIn(app, `async (action, argsJson) => {
+  return seed.evalIn(app, browserScript(async (action, argsJson) => {
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
       const available = window.__openworkControl?.listActions().find((candidate) => candidate.id === action && !candidate.disabled);
@@ -184,7 +181,7 @@ export async function arrangeControl(
     const result = await window.__openworkControl.execute(action, JSON.parse(argsJson));
     if (!result?.ok) throw new Error(String(result?.error ?? "control action failed"));
     return result.value;
-  }`, { args: [action, JSON.stringify(args ?? null)], awaitPromise: true, timeoutMs: 120_000 });
+  }, [action, JSON.stringify(args ?? null)]), { awaitPromise: true, timeoutMs: 120_000 });
 }
 
 async function seedSessionRetry(
@@ -233,7 +230,7 @@ async function splitPaneQuestions(
   const workspace = await seed.workspace(app, seed.tmpPath(name));
   // Arrange an allowed native question tool independently of custom-agent defaults.
   // TODO(primitive): write workspace fixture files through a first-class seed API.
-  const questionPolicyWritten = await seed.evalIn(app, `async (workspaceId, content) => {
+  const questionPolicyWritten = await seed.evalIn(app, browserScript(async (workspaceId, content) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/files/content", {
@@ -242,7 +239,7 @@ async function splitPaneQuestions(
       body: JSON.stringify({ path: "opencode.json", content }),
     });
     return response.ok;
-  }`, { args: [workspace.workspaceId, JSON.stringify(policy)], awaitPromise: true });
+  }, [workspace.workspaceId, JSON.stringify(policy)]), { awaitPromise: true });
   if (questionPolicyWritten !== true) throw new Error("Could not arrange the question-tool policy.");
   await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
     provider: {
@@ -327,32 +324,32 @@ export async function newSplitPrimary(seed: Seed) {
   ]);
   const switchSession = await seedSessionRetry(seed, app, { title: "Split switch target" });
   const session = await seedSessionRetry(seed, app, { title: "New split primary" });
-  const splitFacts = () => evalIn(app, `(() => {
+  const splitFacts = () => evalIn(app, () => {
     const context = window.__openworkControl?.context?.();
     const layout = context?.conversations?.layout;
-    const primaryPane = document.querySelector('[data-workbench-pane="primary"]');
-    const secondaryPanes = [...document.querySelectorAll('[data-workbench-pane="secondary"]')];
+    const primaryPane = document.querySelector<HTMLElement>('[data-workbench-pane="primary"]');
+    const secondaryPanes = [...document.querySelectorAll<HTMLElement>('[data-workbench-pane="secondary"]')];
     const secondaryPane = secondaryPanes[0];
     return {
       layoutKind: layout?.kind ?? "",
-      focusedPane: layout?.focused ?? "",
+      focusedPane: (layout?.kind === "split" ? layout.focused : undefined) ?? "",
       focusedComposerSessionId: document.activeElement?.matches('[contenteditable="true"]')
         ? document.activeElement.closest("[data-session-surface-id]")?.getAttribute("data-session-surface-id") ?? ""
         : "",
-      primarySessionId: layout?.primarySessionId ?? layout?.sessionId ?? "",
-      secondarySessionId: layout?.secondarySessionId ?? "",
-      primaryWorkspaceId: layout?.primaryWorkspaceId ?? "",
-      secondaryWorkspaceId: layout?.secondaryWorkspaceId ?? "",
-      primarySurfaceSessionId: primaryPane?.querySelector('[data-session-surface-id]')
+      primarySessionId: (layout?.kind === "split" ? layout.primarySessionId : undefined) ?? (layout?.kind === "single" ? layout.sessionId : undefined) ?? "",
+      secondarySessionId: (layout?.kind === "split" ? layout.secondarySessionId : undefined) ?? "",
+      primaryWorkspaceId: (layout?.kind === "split" ? layout.primaryWorkspaceId : undefined) ?? "",
+      secondaryWorkspaceId: (layout?.kind === "split" ? layout.secondaryWorkspaceId : undefined) ?? "",
+      primarySurfaceSessionId: primaryPane?.querySelector<HTMLElement>('[data-session-surface-id]')
         ?.getAttribute('data-session-surface-id') ?? "",
-      secondarySurfaceSessionId: secondaryPane?.querySelector('[data-session-surface-id]')
+      secondarySurfaceSessionId: secondaryPane?.querySelector<HTMLElement>('[data-session-surface-id]')
         ?.getAttribute('data-session-surface-id') ?? "",
       secondaryPaneWorkspaceId: secondaryPane?.getAttribute('data-workbench-workspace-id') ?? "",
       secondaryPaneCount: secondaryPanes.length,
       locationHash: window.location.hash,
     };
-  })()`);
-  const agentContextViaServer = () => evalIn(app, `(async () => {
+  });
+  const agentContextViaServer = () => evalIn(app, async () => {
     const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port") + "/experimental/ui-control/request", {
       method: "POST",
       headers: {
@@ -362,7 +359,7 @@ export async function newSplitPrimary(seed: Seed) {
       body: JSON.stringify({ kind: "context" }),
     });
     return response.json();
-  })()`, { awaitPromise: true, timeoutMs: 15_000 });
+  }, { awaitPromise: true, timeoutMs: 15_000 });
   return { app, workspace, session, splitFacts, agentContextViaServer, primaryPrompt, secondaryPrompt, switchSession, switchPrompt, primaryQuestionPrompt, secondaryQuestionPrompt, contextPrompt };
 }
 
@@ -402,12 +399,12 @@ export async function connectionsMenu(seed: Seed) {
   const app = await seed.desktop({ den, as: "admin" });
   const session = await seedSessionRetry(seed, app);
   // TODO(primitive): click a button by its title when it has no accessible name.
-  const opened = await seed.evalIn(app, `(() => {
-    const trigger = document.querySelector('button[title="Agents, commands, skills, plugins, and connections"]');
+  const opened = await seed.evalIn(app, () => {
+    const trigger = document.querySelector<HTMLButtonElement>('button[title="Agents, commands, skills, plugins, and connections"]');
     if (!(trigger instanceof HTMLButtonElement)) return false;
     trigger.click();
     return true;
-  })()`);
+  });
   if (opened !== true) throw new Error("Composer capability menu did not open.");
   return { app, den, session, connections };
 }
@@ -580,25 +577,25 @@ export async function renderCycle(seed: Seed) {
       },
     });
     // TODO(primitive): enable the renderer profiler before desktop launch.
-    await seed.evalIn(app, `(() => {
+    await seed.evalIn(app, () => {
       localStorage.setItem("openwork.debug.profiler", "1");
       localStorage.removeItem("openwork.debug.profilerOverlay");
       location.reload();
       return true;
-    })()`);
-    const controlsReady = await seed.evalIn(app, `(async () => {
+    });
+    const controlsReady = await seed.evalIn(app, async () => {
       const deadline = Date.now() + 30000;
       while (Date.now() < deadline) {
         if (window.__openworkControl?.listActions().some((action) => action.id === "session.create_task" && !action.disabled)) return true;
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
       return false;
-    })()`, { awaitPromise: true, timeoutMs: 120_000 });
+    }, { awaitPromise: true, timeoutMs: 120_000 });
     if (controlsReady !== true) throw new Error("Session controls did not return after enabling the profiler.");
     const session = await seedSessionRetry(seed, app);
     await seed.composerText(app, `Reply with exactly: ${renderCycleFirstReply}`);
     // TODO(primitive): send an arranged historical turn and await its completion.
-    const historical = await seed.evalIn(app, `async (expectedReply) => {
+    const historical = await seed.evalIn(app, browserScript(async (expectedReply) => {
       const sent = await window.__openworkControl.execute("composer.send", null);
       if (!sent?.ok) throw new Error(String(sent?.error ?? "composer.send failed"));
       const deadline = Date.now() + 30000;
@@ -607,7 +604,7 @@ export async function renderCycle(seed: Seed) {
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
       return false;
-    }`, { args: [renderCycleFirstReply], awaitPromise: true, timeoutMs: 120_000 });
+    }, [renderCycleFirstReply]), { awaitPromise: true, timeoutMs: 120_000 });
     if (historical !== true) throw new Error(`Historical turn did not complete. Requests: ${requests.join("; ")}`);
     return {
       app,
@@ -677,7 +674,7 @@ export async function streamedMarkdown(seed: Seed) {
     },
   });
   // A tiny H.264 clip, served through the same authenticated file endpoint as user files.
-  await seed.evalIn(app, `async (workspaceId, dataBase64) => {
+  await seed.evalIn(app, browserScript(async (workspaceId, dataBase64) => {
     const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
     const response = await fetch(base + "/workspace/" + encodeURIComponent(workspaceId) + "/files/raw", {
       method: "POST",
@@ -685,9 +682,9 @@ export async function streamedMarkdown(seed: Seed) {
       body: JSON.stringify({ path: "clip.mp4", dataBase64 }),
     });
     if (!response.ok) throw new Error("Video fixture write failed: " + response.status);
-  }`, { args: [workspace.workspaceId, (await readFile(new URL("../fixtures/assistant-video.mp4", import.meta.url))).toString("base64")], awaitPromise: true });
+  }, [workspace.workspaceId, (await readFile(new URL("../fixtures/assistant-video.mp4", import.meta.url))).toString("base64")]), { awaitPromise: true });
   const engine = resolveEvalEngine();
-  const ready = await seed.evalIn(app, `async (workspaceId, engine, providerId, modelId) => {
+  const ready = await seed.evalIn(app, browserScript(async (workspaceId, engine, providerId, modelId) => {
     const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
     const headers = { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") };
     const deadline = Date.now() + 60000;
@@ -704,18 +701,18 @@ export async function streamedMarkdown(seed: Seed) {
       await new Promise(resolve => setTimeout(resolve, 250));
     }
     return false;
-  }`, { args: [workspace.workspaceId, engine, providerId, modelId], awaitPromise: true, timeoutMs: 65000 });
+  }, [workspace.workspaceId, engine, providerId, modelId]), { awaitPromise: true, timeoutMs: 65000 });
   if (ready !== true) throw new Error(`Selected ${engine} engine was not ready for the streaming journey`);
   const session = await seedSessionRetry(seed, app);
   return { app, den, workspace, session,
     async videoState(play = false) {
-      return seed.evalIn(app, `async (play) => {
-        const video = document.querySelector('video[data-openwork-video-path="clip.mp4"]');
+      return seed.evalIn(app, browserScript(async (play) => {
+        const video = document.querySelector<HTMLVideoElement>('video[data-openwork-video-path="clip.mp4"]');
         if (!video) return null;
         if (play) await video.play();
         return { controls: video.controls, autoplay: video.autoplay, ready: video.readyState >= 2,
           paused: video.paused, time: video.currentTime, error: video.error?.message ?? null };
-      }`, { args: [play], awaitPromise: true });
+      }, [play]), { awaitPromise: true });
     },
   };
 }
@@ -878,26 +875,26 @@ async function writeProviderConfig(path: string, providerId: string, modelId: st
 
 async function selectModelInWorld(seed: Seed, app: Awaited<ReturnType<Seed["desktop"]>>, modelName: string): Promise<void> {
   // TODO(primitive): select a model as arranged state.
-  const selected = await seed.evalIn(app, `async (modelName) => {
+  const selected = await seed.evalIn(app, browserScript(async (modelName) => {
     const deadline = Date.now() + 60000;
-    if (!document.querySelector('input[placeholder="Search providers and models..."]')) {
+    if (!document.querySelector<HTMLInputElement>('input[placeholder="Search providers and models..."]')) {
       const result = await window.__openworkControl.execute("session.model_picker.open", null);
       if (!result?.ok) return false;
     }
     while (Date.now() < deadline) {
-      const input = document.querySelector('input[placeholder="Search providers and models..."]');
+      const input = document.querySelector<HTMLInputElement>('input[placeholder="Search providers and models..."]');
       if (input instanceof HTMLInputElement && input.value !== modelName) {
         const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
         setter?.call(input, modelName);
         input.dispatchEvent(new Event("input", { bubbles: true }));
       }
-      const dialog = document.querySelector('[data-slot="dialog-content"]');
+      const dialog = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
       const item = [...(dialog?.querySelectorAll("button") ?? [])]
         .find((candidate) => !candidate.disabled && (candidate.textContent ?? "").includes(modelName));
       if (item instanceof HTMLElement) {
         item.click();
         while (Date.now() < deadline) {
-          if (!document.querySelector('input[placeholder="Search providers and models..."]')) return true;
+          if (!document.querySelector<HTMLInputElement>('input[placeholder="Search providers and models..."]')) return true;
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
         return false;
@@ -905,7 +902,7 @@ async function selectModelInWorld(seed: Seed, app: Awaited<ReturnType<Seed["desk
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
     return false;
-  }`, { args: [modelName], awaitPromise: true, timeoutMs: 120_000 });
+  }, [modelName]), { awaitPromise: true, timeoutMs: 120_000 });
   if (selected !== true) throw new Error(`Model ${modelName} was not selectable.`);
 }
 
@@ -1089,7 +1086,7 @@ async function configureCrossWorkspaces(
   baseUrl: string,
 ): Promise<void> {
   // TODO(primitive): configure one provider across several workspaces and select its model.
-  const configured = await seed.evalIn(app, `async (workspaceIdsJson, providerBaseUrl) => {
+  const configured = await seed.evalIn(app, browserScript(async (workspaceIdsJson, providerBaseUrl) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
@@ -1119,7 +1116,7 @@ async function configureCrossWorkspaces(
       if (!reload.ok && reload.status !== 504) return "reload:" + reload.status + ":" + (await reload.text()).slice(0, 300);
     }
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
@@ -1130,9 +1127,9 @@ async function configureCrossWorkspaces(
     }));
     localStorage.setItem("openwork.defaultModel", "composer-switch-mock/composer-switch-model");
     return "ok";
-  }`, { args: [JSON.stringify(workspaceIds), `${baseUrl}/v1`], awaitPromise: true, timeoutMs: 180_000 });
+  }, [JSON.stringify(workspaceIds), `${baseUrl}/v1`]), { awaitPromise: true, timeoutMs: 180_000 });
   if (configured !== "ok") throw new Error(`Cross-workspace provider configuration failed: ${String(configured)}`);
-  await seed.evalIn(app, "location.reload(); true");
+  await seed.evalIn(app, () => { location.reload(); return true; });
 }
 
 export async function crossWorkspace(seed: Seed) {
@@ -1300,7 +1297,7 @@ export async function snapshotFailure(seed: Seed) {
   const workspace = await seed.workspace(app, seed.tmpPath("composer-snapshot-failure"));
   const session = await seedSessionRetry(seed, app, { title: "Composer snapshot failure proof" });
   await arrangeControl(seed, app, "eval.chat_transcript.seed");
-  const failureJson = await seed.evalIn(app, `async () => {
+  const failureJson = await seed.evalIn(app, browserScript(async () => {
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
       const available = window.__openworkControl?.listActions()
@@ -1311,7 +1308,7 @@ export async function snapshotFailure(seed: Seed) {
     const result = await window.__openworkControl.execute("eval.session_snapshot.fail", null);
     if (!result?.ok) throw new Error(String(result?.error ?? "control action failed"));
     return JSON.stringify(result.result);
-  }`, { args: [], awaitPromise: true, timeoutMs: 120_000 });
+  }, []), { awaitPromise: true, timeoutMs: 120_000 });
   const failure: unknown = typeof failureJson === "string" ? JSON.parse(failureJson) : failureJson;
   if (!isRecord(failure) || failure.isError !== true) {
     throw new Error(`Session snapshot failure was not established: ${JSON.stringify(failure)}`);
@@ -1398,7 +1395,7 @@ export async function computerMentions(seed: Seed) {
     den, app, workspace, session,
     async submittedParts() {
       // TODO(primitive): inspect submitted engine parts, including synthetic routing instructions.
-      return seed.evalIn(app, `async (workspaceId) => {
+      return seed.evalIn(app, browserScript(async (workspaceId) => {
         const port = localStorage.getItem("openwork.server.port");
         const token = localStorage.getItem("openwork.server.token");
         const base = "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/opencode/session";
@@ -1414,10 +1411,10 @@ export async function computerMentions(seed: Seed) {
         }
         messages.sort((a, b) => a.info.time.created - b.info.time.created);
         return messages.filter((message) => message.info.role === "user").map((message) => ({
-          visible: message.parts.filter((part) => part.type === "text" && !part.synthetic).map((part) => part.text).join("").trim(),
-          routing: message.parts.filter((part) => part.type === "text" && part.synthetic).map((part) => part.text),
+          visible: message.parts.filter((part: { type: string; synthetic?: boolean; text: string }) => part.type === "text" && !part.synthetic).map((part: { text: string }) => part.text).join("").trim(),
+          routing: message.parts.filter((part: { type: string; synthetic?: boolean; text: string }) => part.type === "text" && part.synthetic).map((part: { text: string }) => part.text),
         }));
-      }`, { args: [workspace.workspaceId], awaitPromise: true });
+      }, [workspace.workspaceId]), { awaitPromise: true });
     },
   };
 }
@@ -1457,12 +1454,12 @@ export async function visualization(seed: Seed) {
   return {
     den, app, workspace, session,
     preview: async () => {
-      const result = await evalIn(app, `(() => {
-      const preview = document.querySelector('[data-testid="visualization-preview"]');
+      const result = await evalIn(app, () => {
+      const preview = document.querySelector<HTMLElement>('[data-testid="visualization-preview"]');
       return { viewport: preview?.getAttribute('data-viewport'), width: preview?.getBoundingClientRect().width,
         scripts: preview?.querySelectorAll('script').length, executed: window.mockupExecuted === true,
-        cards: document.querySelectorAll('[data-testid="visualization-card"]').length };
-    })()`);
+        cards: document.querySelectorAll<HTMLElement>('[data-testid="visualization-card"]').length };
+    });
       if (!isRecord(result) || typeof result.width !== "number") throw new Error("Visualization preview missing");
       return { ...result, width: result.width };
     },
@@ -1511,13 +1508,13 @@ export async function skillLifecycle(seed: Seed) {
     const app = await seed.desktop({ den, as: "admin" });
     const workspace = await seed.workspace(app, seed.tmpPath("skill-lifecycle"));
     const request = async (path: string) => {
-      const response = await seed.evalIn(app, `async (path) => {
+      const response = await seed.evalIn(app, browserScript(async (path) => {
         const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port") + path, {
           headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token") },
           signal: AbortSignal.timeout(10000),
         });
         return { status: response.status, json: await response.json() };
-      }`, { args: [path], awaitPromise: true });
+      }, [path]), { awaitPromise: true });
       if (!isRecord(response) || typeof response.status !== "number") throw new Error("Missing desktop response");
       assertNoLiveSecret(response);
       return { status: response.status, json: response.json };
@@ -1526,14 +1523,14 @@ export async function skillLifecycle(seed: Seed) {
     const modelId = live ? liveOpenAiModel() : "skill-lifecycle-model";
     // This world arranges an opted-in native v2 conversation, including when
     // invoked by the standard E2E command without an engine override.
-    await seed.evalIn(app, `async () => {
+    await seed.evalIn(app, async () => {
       const response = await fetch("http://127.0.0.1:" + localStorage.getItem("openwork.server.port") + "/experimental/engine-v2-preview", {
         method: "PUT", headers: { Authorization: "Bearer " + localStorage.getItem("openwork.server.token"), "Content-Type": "application/json" },
         body: JSON.stringify({ enabled: true, chatRouting: true }), signal: AbortSignal.timeout(180000),
       });
       if (!response.ok) throw new Error("Could not enable the native engine");
       return true;
-    }`, { awaitPromise: true, timeoutMs: 185_000 });
+    }, { awaitPromise: true, timeoutMs: 185_000 });
     await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
       permission: { skill: "allow" },
       ...(!live ? { provider: { [providerId]: {

--- a/evals/worlds/dashboard-launch-input.ts
+++ b/evals/worlds/dashboard-launch-input.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Den, Seed } from "@openwork/env";
 import { evalIn as rawEvalIn } from "@openwork/behaviors";
 import type { DenSession } from "@openwork/behaviors";
@@ -155,28 +156,28 @@ export async function atlassianDashboardTiles(seed: Seed) {
   // product writes: the central Cloud MCP entry plus the private App-host
   // authorization. This is the documented reconcile surface, not a stub.
   // TODO(primitive): seed.connectMcp
-  const reconciled = await rawEvalIn(app, `(async () => {
+  const reconciled = await rawEvalIn(app, browserScript(async (workspaceId, value, inputValue, inputValue2) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
-    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(${JSON.stringify(workspace.workspaceId)}) + "/mcp/openwork-cloud/reconcile", {
+    const response = await fetch("http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/mcp/openwork-cloud/reconcile", {
       method: "POST",
       headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
       body: JSON.stringify({
         config: {
           type: "remote",
-          url: ${JSON.stringify(`${den.ref.apiUrl}/mcp/agent`)},
+          url: value,
           enabled: true,
-          headers: { Authorization: ${JSON.stringify(`Bearer ${mcpToken}`)} },
+          headers: { Authorization: inputValue },
           oauth: false,
         },
-        appHostAuthorization: ${JSON.stringify(`Bearer ${appHostToken}`)},
+        appHostAuthorization: inputValue2,
         trigger: "dashboard-launch-input-world",
       }),
     });
     const text = await response.text();
     return response.ok ? "ok" : "HTTP " + response.status + " " + text.slice(0, 1_000);
-  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  }, [workspace.workspaceId, `${den.ref.apiUrl}/mcp/agent`, `Bearer ${mcpToken}`, `Bearer ${appHostToken}`]), { awaitPromise: true, timeoutMs: 120_000 });
   if (reconciled !== "ok") throw new Error(`Reconciling Connect MCP for the desktop failed: ${String(reconciled)}`);
 
   const section = `[data-granted-dashboard="${dashboardId}"]`;
@@ -193,7 +194,7 @@ export async function atlassianDashboardTiles(seed: Seed) {
      */
     // TODO(primitive): user.click({ role: "button", text: "Dashboard" }) should locate the sidebar rail entry and open a collapsed sidebar.
     async openDashboard(): Promise<boolean> {
-      const opened = await rawEvalIn(app, `(() => {
+      const opened = await rawEvalIn(app, () => {
         const button = [...document.querySelectorAll("button")]
           .find((entry) => entry.textContent?.trim() === "Dashboard");
         if (button instanceof HTMLButtonElement && !button.disabled) {
@@ -213,42 +214,42 @@ export async function atlassianDashboardTiles(seed: Seed) {
           if (toggle instanceof HTMLButtonElement) toggle.click();
         }
         return false;
-      })()`);
+      });
       return opened === true;
     },
     /** True once both granted tiles render with their Run buttons. */
     // TODO(primitive): probe.dashboardTiles should expose granted tiles and their launch controls.
     async tilesReady(): Promise<boolean> {
-      const ready = await rawEvalIn(app, `(() => {
-        const section = document.querySelector(${JSON.stringify(section)});
+      const ready = await rawEvalIn(app, browserScript((inputSection, confluenceTileTitle, jiraTileTitle, inputConfluenceTileTitle, inputJiraTileTitle) => {
+        const section = document.querySelector<HTMLElement>(inputSection);
         return section instanceof HTMLElement
-          && section.innerText.includes(${JSON.stringify(confluenceTileTitle)})
-          && section.innerText.includes(${JSON.stringify(jiraTileTitle)})
-          && Boolean(section.querySelector('button[aria-label="Run ${confluenceTileTitle}"]'))
-          && Boolean(section.querySelector('button[aria-label="Run ${jiraTileTitle}"]'));
-      })()`);
+          && section.innerText.includes(confluenceTileTitle)
+          && section.innerText.includes(jiraTileTitle)
+          && Boolean(section.querySelector<HTMLElement>(`button[aria-label="Run ${inputConfluenceTileTitle}"]`))
+          && Boolean(section.querySelector<HTMLElement>(`button[aria-label="Run ${inputJiraTileTitle}"]`));
+      }, [section, confluenceTileTitle, jiraTileTitle, confluenceTileTitle, jiraTileTitle]));
       return ready === true;
     },
     /** The member-visible state of both tiles. */
     // TODO(primitive): probe.dashboardTiles
     async tiles(): Promise<DashboardTilesFacts> {
-      const value = await rawEvalIn(app, `(() => {
-        const section = document.querySelector(${JSON.stringify(section)});
+      const value = await rawEvalIn(app, browserScript((inputSection, confluenceTileTitle, jiraTileTitle) => {
+        const section = document.querySelector<HTMLElement>(inputSection);
         if (!(section instanceof HTMLElement)) return null;
-        const tiles = [...section.querySelectorAll("[data-dashboard-entry]")];
-        const read = (title) => {
+        const tiles = [...section.querySelectorAll<HTMLElement>("[data-dashboard-entry]")];
+        const read = (title: string) => {
           const tile = tiles.find((entry) => entry.textContent?.includes(title));
           if (!(tile instanceof HTMLElement)) return null;
           return {
-            text: tile.innerText.replace(/\\s+/g, " ").trim(),
+            text: tile.innerText.replace(/\s+/g, " ").trim(),
             badgeFailed: tile.innerText.includes("Refresh failed"),
             opaque: tile.innerText.includes("Unexpected server error"),
             namesCloudId: tile.innerText.includes("cloudId"),
           };
         };
-        return { confluence: read(${JSON.stringify(confluenceTileTitle)}), jql: read(${JSON.stringify(jiraTileTitle)}) };
-      })()`);
-      const facts = isRecord(value) ? value : {};
+        return { confluence: read(confluenceTileTitle), jql: read(jiraTileTitle) };
+      }, [section, confluenceTileTitle, jiraTileTitle]));
+      const facts: Record<string, unknown> = isRecord(value) ? value : {};
       return { confluence: parseTileFacts(facts.confluence), jql: parseTileFacts(facts.jql) };
     },
   };

--- a/evals/worlds/den-admin-navigation.ts
+++ b/evals/worlds/den-admin-navigation.ts
@@ -21,19 +21,19 @@ export async function adminDashboardWeb(seed: Seed) {
     /** The current web location's pathname and search. */
     // TODO(primitive): probe.location should expose pathname+search on web surfaces; probe.hash only covers the hash.
     async location(): Promise<string> {
-      const value = await seed.evalIn(web, "window.location.pathname + window.location.search");
+      const value = await seed.evalIn(web, () => (window.location.pathname + window.location.search));
       if (typeof value !== "string") throw new Error("Expected the web location to be a string.");
       return value;
     },
     /** The accessible link names in the organization sidebar. */
     // TODO(primitive): probe should list accessible link names inside a container by testId.
     async sidebarLinks(): Promise<string[]> {
-      return strings(await seed.evalIn(web, "Array.from(document.querySelectorAll('[data-testid=\"den-org-sidebar\"] a')).map((a) => (a.textContent ?? '').trim())"));
+      return strings(await seed.evalIn(web, () => (Array.from(document.querySelectorAll<HTMLElement>('[data-testid="den-org-sidebar"] a')).map((a) => (a.textContent ?? '').trim()))));
     },
     /** The direct text labels of selected tabs. */
     // TODO(primitive): user.see({ role: "tab" }) cannot assert aria-selected today.
     async selectedTabs(): Promise<string[]> {
-      return strings(await seed.evalIn(web, "Array.from(document.querySelectorAll('[role=\"tab\"][aria-selected=\"true\"]')).map((tab) => Array.from(tab.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE).map((node) => node.textContent ?? '').join('').trim())"));
+      return strings(await seed.evalIn(web, () => (Array.from(document.querySelectorAll<HTMLElement>('[role="tab"][aria-selected="true"]')).map((tab) => Array.from(tab.childNodes).filter((node) => node.nodeType === Node.TEXT_NODE).map((node) => node.textContent ?? '').join('').trim()))));
     },
   };
 }

--- a/evals/worlds/den.ts
+++ b/evals/worlds/den.ts
@@ -1,3 +1,4 @@
+import { addInitScript, browserScript } from "@openwork/cdp";
 import { localMysqlIsRunning, SkipError } from "@openwork/env";
 import type { Seed } from "@openwork/env";
 import { waitFor } from "@openwork/behaviors";
@@ -98,22 +99,19 @@ export async function ssoInvite(seed: Seed) {
       httpOnly: true,
     });
     if (!booleanField(configurationCookie, "success")) throw new Error("Could not apply the admin session to the SSO configuration test browser.");
-    await configurationWeb.client.send("Page.addScriptToEvaluateOnNewDocument", {
-      source: `(() => {
-        const apiOrigin = ${JSON.stringify(den.ref.apiUrl)};
-        const originalFetch = window.fetch.bind(window);
-        window.fetch = (input, init) => {
-          const rawUrl = typeof input === "string" || input instanceof URL ? input.toString() : input.url;
-          const url = new URL(rawUrl, window.location.href);
-          if (url.pathname.startsWith("/v1/sso/test/") && url.origin !== apiOrigin) {
-            return originalFetch(new URL(url.pathname + url.search, apiOrigin), init);
-          }
-          return originalFetch(input, init);
-        };
-      })();`,
-    });
+    await addInitScript(configurationWeb.client, browserScript((apiOrigin) => {
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = (input, init) => {
+        const rawUrl = input instanceof Request ? input.url : String(input);
+        const url = new URL(rawUrl, window.location.href);
+        if (url.pathname.startsWith("/v1/sso/test/") && url.origin !== apiOrigin) {
+          return originalFetch(new URL(url.pathname + url.search, apiOrigin), init);
+        }
+        return originalFetch(input, init);
+      };
+    }, [den.ref.apiUrl]));
     await navigate(configurationWeb.client, testUrl);
-    await waitFor(configurationWeb, `/authentication test finished/i.test(document.body?.innerText ?? "")`, {
+    await waitFor(configurationWeb, () => (/authentication test finished/i.test(document.body?.innerText ?? "")), {
       timeoutMs: 90_000,
       label: "successful SSO configuration test",
     });

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { spawn } from "node:child_process";
 import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -77,7 +78,7 @@ export async function appSmokeWorld(seed: Seed) {
   return {
     app, workspace, packaged,
     async packagedRuntime() {
-      return evalIn(app, `(async () => {
+      return evalIn(app, async () => {
         const bridge = window.__OPENWORK_ELECTRON__;
         if (typeof bridge?.invokeDesktop !== "function") return { bridge: false };
         const info = await bridge.invokeDesktop("openworkServerInfo");
@@ -86,16 +87,16 @@ export async function appSmokeWorld(seed: Seed) {
           welcome: location.hash === "#/welcome" && [...document.querySelectorAll("button")]
             .some(button => button.textContent.trim() === "Use Without Cloud" && !button.disabled),
           crash: /Something went wrong|Cannot find module|Maximum update depth exceeded/.test(document.body.innerText) };
-      })()`, { awaitPromise: true });
+      }, { awaitPromise: true });
     },
     async packagedToolIds() {
-      return evalIn(app, `(async () => {
-        await window.__OPENWORK_ELECTRON__.invokeDesktop("engineStart", ${JSON.stringify(seed.tmpPath("packaged-plugin-smoke"))}, { runtime: "direct" });
+      return evalIn(app, browserScript(async (value, inputValue) => {
+        await window.__OPENWORK_ELECTRON__.invokeDesktop("engineStart", value, { runtime: "direct" });
         const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
         const headers = { Authorization: "Bearer " + info.ownerToken, "Content-Type": "application/json" };
         const created = await fetch(info.baseUrl + "/workspaces/local", {
           method: "POST", headers, signal: AbortSignal.timeout(15000),
-          body: JSON.stringify({ folderPath: ${JSON.stringify(seed.tmpPath("packaged-plugin-smoke"))} }),
+          body: JSON.stringify({ folderPath: inputValue }),
         });
         if (created.status !== 201) throw new Error("Workspace creation failed: " + created.status);
         const workspace = await created.json();
@@ -104,7 +105,7 @@ export async function appSmokeWorld(seed: Seed) {
         });
         if (!tools.ok) throw new Error("Engine tool discovery failed: " + tools.status);
         return tools.json();
-      })()`, { awaitPromise: true, timeoutMs: 60_000 });
+      }, [seed.tmpPath("packaged-plugin-smoke"), seed.tmpPath("packaged-plugin-smoke")]), { awaitPromise: true, timeoutMs: 60_000 });
     },
     async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
   };
@@ -139,14 +140,14 @@ export async function sessionWorld(seed: Seed) {
 export async function parentChildPermissionWorld(seed: Seed) {
   const base = await sessionWorld(seed);
   // TODO(primitive): seed a child-session permission request and parent activity row.
-  const seeded = await seed.evalIn(base.app, `(async () => {
+  const seeded = await seed.evalIn(base.app, async () => {
     const child = await window.__openworkControl.execute("eval.child_permission.seed", null);
-    if (!child?.ok || typeof child.result?.childSessionId !== "string") return child;
+    if (!child?.ok || !child.result || typeof child.result !== "object" || !("childSessionId" in child.result) || typeof child.result.childSessionId !== "string") return { child, activity: null };
     const activity = await window.__openworkControl.execute("eval.task_activity.seed", {
       childSessionId: child.result.childSessionId,
     });
     return { child, activity };
-  })()`, { awaitPromise: true });
+  }, { awaitPromise: true });
   if (!isRecord(seeded) || !isRecord(seeded.child) || seeded.child.ok !== true
     || !isRecord(seeded.activity) || seeded.activity.ok !== true) {
     throw new Error(`Child permission seed failed: ${JSON.stringify(seeded)}`);
@@ -160,11 +161,11 @@ export async function artifactCodeBrowserWorld(seed: Seed) {
   if (!session) throw new Error("Could not seed the artifact code browser session.");
   await go(base.app, `/workspace/${base.workspace.workspaceId}/session/${session.sessionId}`);
   // TODO(primitive): write workspace files through the local server fixture.
-  const wrote = await seed.evalIn(base.app, `async (workspaceId) => {
+  const wrote = await seed.evalIn(base.app, browserScript(async (workspaceId) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return false;
-    const write = (path, content) => fetch(
+    const write = (path: string, content: string) => fetch(
       "http://127.0.0.1:" + port + "/workspace/" + encodeURIComponent(workspaceId) + "/files/content",
       {
         method: "POST",
@@ -174,34 +175,34 @@ export async function artifactCodeBrowserWorld(seed: Seed) {
     );
     const responses = await Promise.all([
       write("restricted/hidden-proof.ts", "export const restricted = true;"),
-      write("src/openwork-artifact-proof.ts", "export const artifactEditor = true;\\n"),
-      write("config/openwork-artifact-settings.json", "{\\"artifactEditor\\":true}\\n"),
+      write("src/openwork-artifact-proof.ts", "export const artifactEditor = true;\n"),
+      write("config/openwork-artifact-settings.json", "{\"artifactEditor\":true}\n"),
     ]);
     return responses.every((response) => response.ok);
-  }`, { args: [base.workspace.workspaceId], awaitPromise: true });
+  }, [base.workspace.workspaceId]), { awaitPromise: true });
   if (wrote !== true) throw new Error("Could not seed artifact code files.");
   // TODO(primitive): open an initial built-in browser artifact tab.
-  await seed.evalIn(base.app, `window.__openworkControl.execute("browser.open_url", { url: "about:blank" })`, { awaitPromise: true });
+  await seed.evalIn(base.app, () => (window.__openworkControl.execute("browser.open_url", { url: "about:blank" })), { awaitPromise: true });
   await waitForBehavior(
     base.app,
-    `window.__openworkControl.listActions().some((action) => action.id === "eval.artifact_tabs.seed_overflow" && !action.disabled)`,
+    () => (window.__openworkControl.listActions().some((action) => action.id === "eval.artifact_tabs.seed_overflow" && !action.disabled)),
     { timeoutMs: 30_000, label: "artifact seed action enabled" },
   );
   // TODO(primitive): seed artifact tabs through a first-class artifact fixture.
-  const tabs = await seed.evalIn(base.app, `window.__openworkControl.execute("eval.artifact_tabs.seed_overflow", { count: 12 })`, { awaitPromise: true });
+  const tabs = await seed.evalIn(base.app, () => (window.__openworkControl.execute("eval.artifact_tabs.seed_overflow", { count: 12 })), { awaitPromise: true });
   if (!isRecord(tabs) || tabs.ok !== true) throw new Error(`Could not seed artifact tabs: ${JSON.stringify(tabs)}`);
   return {
     ...base,
     async visibleArtifactCode() {
-      return seed.evalIn(base.app, `(() => {
-        const root = document.querySelector("[data-artifact-code-view]");
+      return seed.evalIn(base.app, () => {
+        const root = document.querySelector<HTMLElement>("[data-artifact-code-view]");
         if (!root || root.getBoundingClientRect().height === 0) return "";
-        const text = (node) => [...node.childNodes].map((child) =>
+        const text = (node: Node): string => [...node.childNodes].map((child) =>
           child.nodeType === Node.TEXT_NODE ? child.textContent :
           child instanceof Element ? text(child.shadowRoot || child) : ""
         ).join("");
         return text(root);
-      })()`);
+      });
     },
     async setCatalogFolderRestricted(restricted: boolean) {
       const path = join(base.workspacePath, "restricted");
@@ -324,20 +325,20 @@ export async function unconfiguredNotificationWorld(seed: Seed) {
   });
   const engineError: unknown = await engineResponse.json();
   // TODO(primitive): point a desktop at a caller-owned local server and observe transient notification text.
-  const switched = await evalIn(app, `(async () => {
+  const switched = await evalIn(app, browserScript(async (port, serverToken) => {
     const state = { rawSeen: document.body.innerText.includes('{"code":') };
     const observer = new MutationObserver(() => {
       if (document.body.innerText.includes('{"code":')) state.rawSeen = true;
     });
     observer.observe(document.body, { subtree: true, childList: true, characterData: true });
     window.__issue3980NotificationProbe = { observer, state };
-    localStorage.setItem("openwork.server.urlOverride", "http://127.0.0.1.nip.io:${port}");
-    localStorage.setItem("openwork.server.token", ${JSON.stringify(serverToken)});
+    localStorage.setItem("openwork.server.urlOverride", `http://127.0.0.1.nip.io:${port}`);
+    localStorage.setItem("openwork.server.token", serverToken);
     localStorage.removeItem("openwork.server.hostToken");
     await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("engineStop");
     window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
     return true;
-  })()`, { awaitPromise: true, timeoutMs: 30_000 });
+  }, [port, serverToken]), { awaitPromise: true, timeoutMs: 30_000 });
   if (switched !== true) throw new Error("Could not switch the desktop to the unconfigured server.");
   return {
     app,
@@ -357,10 +358,10 @@ export async function unconfiguredNotificationWorld(seed: Seed) {
 }
 
 async function installAlphaUpdateBridge(app: Awaited<ReturnType<typeof desktop>>) {
-  const installed = await evalIn(app, `(() => {
+  const installed = await evalIn(app, () => {
     const nativeUpdater = window.__OPENWORK_ELECTRON__?.updater;
     if (!nativeUpdater?.getChannel || !nativeUpdater.setChannel) return false;
-    const state = { checks: [], currentVersion: "0.18.37-alpha.2491+64d2d37", latestVersion: "0.18.37-alpha.2492+4921a02" };
+    const state: Window["__openworkAlphaUpdateEligibilityEvalState"] = { checks: [], currentVersion: "0.18.37-alpha.2491+64d2d37", latestVersion: "0.18.37-alpha.2492+4921a02" };
     window.__openworkAlphaUpdateEligibilityEvalState = state;
     localStorage.setItem("openwork.react.settings.update-auto-check", "0");
     window.__openworkApplyDesktopConfig?.({ allowAlphaUpdates: true });
@@ -382,7 +383,7 @@ async function installAlphaUpdateBridge(app: Awaited<ReturnType<typeof desktop>>
       onDownloadProgress: () => () => {},
     };
     return true;
-  })()`);
+  });
   if (installed !== true) throw new Error("Could not install the controlled updater bridge.");
 }
 
@@ -426,7 +427,7 @@ export async function compatibleReleaseWorld(_seed: Seed, { place }: { place: Pl
       ]),
     },
   });
-  const snapshot = () => evalIn(app, `window.__openworkRecoveryControl.snapshot()`, { awaitPromise: true });
+  const snapshot = () => evalIn(app, () => (window.__openworkRecoveryControl.snapshot()), { awaitPromise: true });
   return { app, snapshot, async [Symbol.asyncDispose]() { await app.stop(); } };
 }
 
@@ -442,9 +443,9 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
     : null;
   const host = provisioned ? daytonaSandbox(provisioned.sandbox) : localHost();
   const seeded = await desktop({ name: "recovery-profile-seed", host, profileDir });
-  const names = await evalIn(seeded, `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
-    folderPath: ${JSON.stringify(`${profileDir}/continuity-workspace`)}, name: "reliable-recovery-profile-marker"
-  }).then((state) => state.workspaces.map((workspace) => workspace.displayName))`, { awaitPromise: true });
+  const names = await evalIn(seeded, browserScript((value) => (window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
+    folderPath: value, name: "reliable-recovery-profile-marker"
+  }).then((state) => state.workspaces.map((workspace) => workspace.displayName))), [`${profileDir}/continuity-workspace`]), { awaitPromise: true });
   if (!Array.isArray(names) || !names.includes("reliable-recovery-profile-marker")) throw new Error("Could not seed recovery profile.");
   await seeded.stop();
   const app = await desktop({
@@ -460,10 +461,10 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
       ]),
     },
   });
-  const snapshot = () => evalIn(app, `window.__openworkRecoveryControl.snapshot()`, { awaitPromise: true });
+  const snapshot = () => evalIn(app, () => (window.__openworkRecoveryControl.snapshot()), { awaitPromise: true });
   const workspaceNames = () => evalIn(
     app,
-    `window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceBootstrap").then((state) => state.workspaces.map((entry) => entry.displayName))`,
+    () => (window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceBootstrap").then((state) => state.workspaces.map((entry) => entry.displayName))),
     { awaitPromise: true },
   );
   return {
@@ -489,10 +490,10 @@ export async function reliableRecoveryWorld(_seed: Seed, { place }: { place: Pla
 }
 
 async function installUpdaterRaceBridge(app: Awaited<ReturnType<typeof desktop>>, delayStable: boolean) {
-  const installed = await evalIn(app, `(() => {
+  const installed = await evalIn(app, browserScript((delayStable) => {
     const nativeUpdater = window.__OPENWORK_ELECTRON__?.updater;
     if (!nativeUpdater?.getChannel || !nativeUpdater.setChannel) return false;
-    const state = { checks: [], setChannels: [], stableStarted: false, finishStable: null };
+    const state: Window["__openworkUpdaterEvalState"] = { checks: [], setChannels: [], stableStarted: false, finishStable: null };
     window.__openworkUpdaterEvalState = state;
     window.__openworkApplyDesktopConfig?.({ allowAlphaUpdates: true });
     window.__openworkSetDesktopConfigRefreshResult?.({ allowAlphaUpdates: true });
@@ -501,7 +502,7 @@ async function installUpdaterRaceBridge(app: Awaited<ReturnType<typeof desktop>>
       setChannel: async (channel) => { state.setChannels.push(channel); return nativeUpdater.setChannel(channel); },
       check: async (channel) => {
         state.checks.push(channel);
-        if (${JSON.stringify(delayStable)} && channel === "stable") {
+        if (delayStable && channel === "stable") {
           state.stableStarted = true;
           return new Promise((resolve) => { state.finishStable = () => resolve({ available: true, channel: "stable", currentVersion: "0.18.0", latestVersion: "9.9.9" }); });
         }
@@ -512,7 +513,7 @@ async function installUpdaterRaceBridge(app: Awaited<ReturnType<typeof desktop>>
       onDownloadProgress: () => () => {},
     };
     return true;
-  })()`);
+  }, [delayStable]));
   if (installed !== true) throw new Error("Could not install updater race bridge.");
 }
 
@@ -544,7 +545,7 @@ export async function updaterChannelWorld(_seed: Seed) {
     await go(active, "/session");
     await installUpdaterRaceBridge(active, false);
     await go(active, `/workspace/${workspace.workspaceId}/settings/updates`);
-    await waitForBehavior(active, `window.location.hash.includes("/settings/updates") && Boolean(document.querySelector('[aria-label="Release channel"]'))`, {
+    await waitForBehavior(active, () => (window.location.hash.includes("/settings/updates") && Boolean(document.querySelector<HTMLElement>('[aria-label="Release channel"]'))), {
       timeoutMs: 60_000,
       label: "relaunched Updates page",
     });
@@ -629,18 +630,18 @@ export async function enterpriseTlsWorld(seed: Seed, { place }: { place: Place }
     // TODO(primitive): seed a named workspace in a caller-owned desktop profile.
     const seededWorkspaceNames = await seed.evalIn(
       rawApp,
-      `(folderPath) => window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
+      browserScript((folderPath) => window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceCreate", {
         folderPath,
         name: "enterprise-tls-profile-continuity"
-      }).then((state) => state.workspaces.map((workspace) => workspace.displayName))`,
-      { args: [`${profileDir}/continuity-workspace`], awaitPromise: true },
+      }).then((state) => state.workspaces.map((workspace) => workspace.displayName)), [`${profileDir}/continuity-workspace`]),
+      { awaitPromise: true },
     );
     if (!Array.isArray(seededWorkspaceNames) || !seededWorkspaceNames.includes("enterprise-tls-profile-continuity")) {
       throw new Error("Could not seed the enterprise TLS continuity workspace.");
     }
     await waitForBehavior(
       rawApp,
-      `window.__openworkControl?.listActions?.().some((action) => action.id === "auth.exchange-grant")`,
+      () => (window.__openworkControl?.listActions?.().some((action) => action.id === "auth.exchange-grant")),
       { timeoutMs: 60_000, label: "pre-trust sign-in reachability action" },
     );
     const grant = await createDesktopHandoffGrant(den.admin);
@@ -842,16 +843,14 @@ export async function toolTesterWorld(seed: Seed) {
     /** The Tool Tester link destination for this connection. */
     // TODO(primitive): read a visible link destination by test id.
     async testToolsHref(): Promise<string> {
-      const value = await seed.evalIn(web, `(connectionId) => document.querySelector('[data-testid="test-mcp-tools-' + connectionId + '"]')?.getAttribute("href") ?? ""`, {
-        args: [connection.id],
-      });
+      const value = await seed.evalIn(web, browserScript((connectionId) => document.querySelector<HTMLElement>('[data-testid="test-mcp-tools-' + connectionId + '"]')?.getAttribute("href") ?? "", [connection.id]));
       return typeof value === "string" ? value : "";
     },
     /** Whether Tool Tester appears in Manage rather than Settings. */
     // TODO(primitive): identify a nav item's containing sidebar group.
     async toolTesterSidebarPlacement(): Promise<{ inManage: boolean; inSettings: boolean }> {
-      const value = await seed.evalIn(web, `(() => {
-        const sidebar = document.querySelector('[data-testid="den-org-sidebar"]');
+      const value = await seed.evalIn(web, () => {
+        const sidebar = document.querySelector<HTMLElement>('[data-testid="den-org-sidebar"]');
         const links = sidebar ? [...sidebar.querySelectorAll('a')] : [];
         const toolTester = links.find((link) => link.textContent?.trim() === "Tool Tester");
         const settings = links.find((link) => link.textContent?.trim() === "Settings");
@@ -859,7 +858,7 @@ export async function toolTesterWorld(seed: Seed) {
           inManage: toolTester?.closest('[data-sidebar-section="manage"]') != null,
           inSettings: settings?.parentElement?.contains(toolTester ?? null) ?? false,
         };
-      })()`);
+      });
       if (!isRecord(value) || typeof value.inManage !== "boolean" || typeof value.inSettings !== "boolean") {
         throw new Error(`Expected Tool Tester sidebar placement booleans, received ${JSON.stringify(value)}.`);
       }
@@ -867,18 +866,18 @@ export async function toolTesterWorld(seed: Seed) {
     },
     /** The current web location. */
     async location(): Promise<string> {
-      const value = await seed.evalIn(web, `location.href`);
+      const value = await seed.evalIn(web, () => (location.href));
       if (typeof value !== "string") throw new Error("Expected the web location to be a string.");
       return value;
     },
     /** The checked states of the arguments editor modes by label. */
     // TODO(primitive): assert selected and unselected radio state.
     async argumentsEditorModes(): Promise<Record<string, string | null>> {
-      const value = await seed.evalIn(web, `(() => {
-        const editor = document.querySelector('[role="radiogroup"][aria-label="Arguments editor mode"]');
-        const radios = editor ? [...editor.querySelectorAll('[role="radio"]')] : [];
+      const value = await seed.evalIn(web, () => {
+        const editor = document.querySelector<HTMLElement>('[role="radiogroup"][aria-label="Arguments editor mode"]');
+        const radios = editor ? [...editor.querySelectorAll<HTMLElement>('[role="radio"]')] : [];
         return Object.fromEntries(radios.map((radio) => [(radio.textContent ?? "").trim(), radio.getAttribute("aria-checked")]));
-      })()`);
+      });
       if (!isRecord(value) || !Object.values(value).every((entry) => typeof entry === "string" || entry === null)) {
         throw new Error(`Expected arguments editor modes, received ${JSON.stringify(value)}.`);
       }
@@ -891,25 +890,25 @@ export async function toolTesterWorld(seed: Seed) {
     /** The selected Tool call inspection tab's label. */
     // TODO(primitive): assert the selected result tab state.
     async selectedInspectionTab(): Promise<string> {
-      const value = await seed.evalIn(web, `document.querySelector('[aria-label="Tool call inspection"] [role="tab"][aria-selected="true"]')?.textContent?.trim() ?? ""`);
+      const value = await seed.evalIn(web, () => (document.querySelector<HTMLElement>('[aria-label="Tool call inspection"] [role="tab"][aria-selected="true"]')?.textContent?.trim() ?? ""));
       return typeof value === "string" ? value : "";
     },
     /** The organization tools switch's checked state. */
     // TODO(primitive): assert a visible switch's checked state.
     async orgToolsSwitchChecked(): Promise<string | null> {
-      const value = await seed.evalIn(web, `document.querySelector('[role="switch"][aria-label="Tools enabled for your organization"]')?.getAttribute("aria-checked")`);
+      const value = await seed.evalIn(web, () => (document.querySelector<HTMLElement>('[role="switch"][aria-label="Tools enabled for your organization"]')?.getAttribute("aria-checked")));
       return typeof value === "string" ? value : null;
     },
     /** The arguments editor's nested-schema fallback state. */
     // TODO(primitive): assert disabled and selected radio state.
     async argumentsEditorFallback(): Promise<{ formDisabled: boolean; jsonChecked: string }> {
-      const value = await seed.evalIn(web, `(() => {
-        const editor = document.querySelector('[role="radiogroup"][aria-label="Arguments editor mode"]');
-        const radios = editor ? [...editor.querySelectorAll('[role="radio"]')] : [];
+      const value = await seed.evalIn(web, () => {
+        const editor = document.querySelector<HTMLElement>('[role="radiogroup"][aria-label="Arguments editor mode"]');
+        const radios = editor ? [...editor.querySelectorAll<HTMLElement>('[role="radio"]')] : [];
         const form = radios.find((radio) => (radio.textContent ?? "").trim() === "Form");
         const json = radios.find((radio) => (radio.textContent ?? "").trim() === "JSON");
         return { formDisabled: form?.hasAttribute("disabled") ?? false, jsonChecked: json?.getAttribute("aria-checked") ?? "" };
-      })()`);
+      });
       if (!isRecord(value) || typeof value.formDisabled !== "boolean" || typeof value.jsonChecked !== "string") {
         throw new Error(`Expected arguments editor fallback state, received ${JSON.stringify(value)}.`);
       }
@@ -918,7 +917,7 @@ export async function toolTesterWorld(seed: Seed) {
     /** Whether the Run tool button is disabled. */
     // TODO(primitive): assert a visible button's disabled state.
     async runToolDisabled(): Promise<boolean> {
-      return await seed.evalIn(web, `[...document.querySelectorAll("button")].some((button) => button.textContent?.trim() === "Run tool" && button.disabled)`) === true;
+      return await seed.evalIn(web, () => ([...document.querySelectorAll("button")].some((button) => button.textContent?.trim() === "Run tool" && button.disabled))) === true;
     },
   };
 }
@@ -938,7 +937,7 @@ export async function managedVaultWorld(_seed: Seed, { place }: { place: Place }
   const serverTarget = async (surface = app) => {
     const deadline = Date.now() + 120_000;
     while (Date.now() < deadline) {
-      const info = await evalIn(surface, `window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo")`, {
+      const info = await evalIn(surface, () => (window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo")), {
         awaitPromise: true,
         timeoutMs: 15_000,
       }).catch(() => null);
@@ -1049,14 +1048,16 @@ export async function managedVaultWorld(_seed: Seed, { place }: { place: Place }
 export async function backgroundUpdateWorld(seed: Seed) {
   const app = await seed.desktop({ name: "background-update", signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("background-update"));
-  await evalIn(app, `(async () => {
+  await evalIn(app, async () => {
     const currentVersion = "0.18.0";
     const now = Date.now.bind(Date);
-    const state = { checks: 0, downloads: 0, installs: 0, offset: 0, finishDownload: null, intervalCheck: null };
+    const state: Window["__backgroundUpdateWitness"] = { checks: 0, downloads: 0, installs: 0, offset: 0, finishDownload: null, intervalCheck: null };
     window.__backgroundUpdateWitness = state;
     const schedule = window.setInterval.bind(window);
-    window.setInterval = (callback, delay, ...args) => {
-      if (delay === 15 * 60 * 1000) state.intervalCheck = callback;
+    // The browser timer returns a numeric handle; Node's merged ambient overload does not apply here.
+    const browserWindow: Window = window;
+    browserWindow.setInterval = (callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+      if (delay === 15 * 60 * 1000 && typeof callback === "function") state.intervalCheck = () => callback(...args);
       return schedule(callback, delay, ...args);
     };
     Date.now = () => now() + state.offset;
@@ -1081,35 +1082,35 @@ export async function backgroundUpdateWorld(seed: Seed) {
     };
     state.offset += 16 * 60 * 1000;
     window.dispatchEvent(new Event("focus"));
-  })()`, { awaitPromise: true });
+  }, { awaitPromise: true });
   return {
     app,
-    snapshot: () => evalIn(app, `(() => {
+    snapshot: () => evalIn(app, () => {
       const { checks, downloads, installs } = window.__backgroundUpdateWitness;
       return {
         checks, downloads, installs, route: location.hash,
-        updateInTitlebar: Boolean(document.querySelector('header [data-update-button]')),
-        updateInSidebar: Boolean(document.querySelector('[data-sidebar="footer"] [data-update-button]')),
-        sidebarName: document.querySelector('[data-sidebar-brand]')?.textContent?.trim() ?? null,
-        customLogoLoaded: Boolean(document.querySelector('[data-testid="brand-logo"] img')?.naturalWidth),
+        updateInTitlebar: Boolean(document.querySelector<HTMLElement>('header [data-update-button]')),
+        updateInSidebar: Boolean(document.querySelector<HTMLElement>('[data-sidebar="footer"] [data-update-button]')),
+        sidebarName: document.querySelector<HTMLElement>('[data-sidebar-brand]')?.textContent?.trim() ?? null,
+        customLogoLoaded: Boolean(document.querySelector<HTMLImageElement>('[data-testid="brand-logo"] img')?.naturalWidth),
       };
-    })()`),
-    setCustomBranding: () => evalIn(app, `(() => {
+    }),
+    setCustomBranding: () => evalIn(app, () => {
       const logo = 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="120" height="32"><rect width="120" height="32" rx="5" fill="#25262b"/><text x="12" y="22" font-family="sans-serif" font-size="18" fill="white">Studio</text></svg>');
       window.__openworkApplyDesktopConfig({ brandAppName: "Studio", brandLogoUrl: logo });
-    })()`),
-    tickUpdateInterval: () => evalIn(app, `(() => {
+    }),
+    tickUpdateInterval: () => evalIn(app, () => {
       const state = window.__backgroundUpdateWitness;
       if (!state.intervalCheck) throw new Error("Update interval was not registered");
       state.offset += 15 * 60 * 1000;
       state.intervalCheck();
-    })()`),
-    finishDownload: () => evalIn(app, `window.__backgroundUpdateWitness.finishDownload()`),
-    returnToApp: () => evalIn(app, `(() => {
+    }),
+    finishDownload: () => evalIn(app, () => (window.__backgroundUpdateWitness.finishDownload?.())),
+    returnToApp: () => evalIn(app, () => {
       window.__backgroundUpdateWitness.offset += 16 * 60 * 1000;
       window.dispatchEvent(new Event("focus"));
       window.dispatchEvent(new Event("online"));
-    })()`),
+    }),
     openSettings: () => go(app, `/workspace/${workspace.workspaceId}/settings/updates`),
     openWorkspace: () => go(app, `/workspace/${workspace.workspaceId}/session`),
   };

--- a/evals/worlds/library.ts
+++ b/evals/worlds/library.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -159,7 +160,7 @@ export function mcpCallBody(id: number, name: string, args: Record<string, unkno
   });
 }
 
-export const connectStateExpression = `(() => {
+export const connectStateExpression = () => {
   const port = localStorage.getItem("openwork.server.port") ?? "";
   const baseUrl = port ? "http://127.0.0.1:" + port : "";
   const token = localStorage.getItem("openwork.server.token") ?? "";
@@ -170,9 +171,9 @@ export const connectStateExpression = `(() => {
   request.send();
   const raw = JSON.parse(request.responseText || "{}");
   return { ok: request.status >= 200 && request.status < 300, status: raw?.status ?? null, connectEnabled: raw?.connectEnabled ?? null };
-})()`;
+};
 
-export const runtimeGenerationExpression = `(async () => {
+export const runtimeGenerationExpression = async () => {
   const invokeDesktop = window.__OPENWORK_ELECTRON__?.invokeDesktop;
   if (!invokeDesktop) return { running: false, baseUrl: "", generation: null };
   const info = await invokeDesktop("openworkServerInfo");
@@ -181,9 +182,9 @@ export const runtimeGenerationExpression = `(async () => {
     baseUrl: String(info?.baseUrl ?? ""),
     generation: typeof info?.generation === "number" ? info.generation : null,
   };
-})()`;
+};
 
-export const cloudHealthExpression = `(workspaceId) => {
+export const cloudHealthExpression = (workspaceId: string) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return { error: "missing local server credentials" };
@@ -192,7 +193,7 @@ export const cloudHealthExpression = `(workspaceId) => {
     request.setRequestHeader("Authorization", "Bearer " + token);
     request.send();
     return JSON.parse(request.responseText || "{}");
-  }`;
+  };
 
 export async function connectPolicyRuntimeRestart(seed: Seed, { place }: { place: import("@openwork/env").Place }) {
   const stamp = Date.now();
@@ -205,9 +206,7 @@ export async function connectPolicyRuntimeRestart(seed: Seed, { place }: { place
   });
   const app = await startApp({ den, as: "fresh", place, localServerDelayMs: 5_000 });
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [app.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [app.workspaceId]));
   return withDispose({ app }, async () => app.stop());
 }
 
@@ -234,9 +233,7 @@ export async function connectStateProvenance(seed: Seed) {
   const app = await seed.desktop({ den, signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("connect-state-provenance"));
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
   return { app, member: den.members.fresh };
 }
 
@@ -297,9 +294,7 @@ export async function preseededConnect(seed: Seed) {
   const app = await seed.desktop({ den, signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("preseeded-connect"));
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
   return {
     app, den, prompt, proofPhrase, providerName, modelId,
     admin: den.admin,
@@ -400,9 +395,7 @@ export async function libraryConnectorDiscovery(seed: Seed) {
     mobile: false,
   });
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
   return { app, organizationId, denWebUrl: den.ref.webUrl };
 }
 
@@ -417,7 +410,7 @@ export async function librarySessionRestore(seed: Seed) {
   const workspace = await seed.workspace(app, seed.tmpPath("library-session-restore"));
   const skillsRoute = `/workspace/${workspace.workspaceId}/extensions/skills`;
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(route) => { location.hash = route; return true; }`, { args: [`#${skillsRoute}`] });
+  await seed.evalIn(app, browserScript((route) => { location.hash = route; return true; }, [`#${skillsRoute}`]));
   return {
     app,
     proxy,
@@ -436,9 +429,7 @@ export async function libraryAdvancedRefresh(seed: Seed) {
   const app = await seed.desktop({ den: { ...den, ref: proxy.ref }, as: "admin" });
   const workspace = await seed.workspace(app, seed.tmpPath("library-advanced-refresh"));
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
   return { app, proxy, admin: den.admin, connector: den.mocks.connector };
 }
 
@@ -465,9 +456,7 @@ export async function libraryAuthoringRoutes(seed: Seed) {
   const app = await seed.desktop({ den: { ...den, ref: proxy.ref }, signIn: false });
   const workspace = await seed.workspace(app, seed.tmpPath("library-authoring-routes"));
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/extensions"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/extensions"; return true; }, [workspace.workspaceId]));
   const web = await seed.web({ den, signedInAs: den.admin, startPath: "/dashboard/library", headless: true });
   return {
     app,
@@ -489,13 +478,13 @@ export async function libraryConfigReadBudget(seed: Seed) {
   const app = await seed.desktop({ name: "library-config-read-budget" });
   await seed.workspace(app, repoRoot);
   // TODO(primitive): seed.networkObserver
-  await seed.evalIn(app, `(() => {
+  await seed.evalIn(app, () => {
     window.__opencodeConfigReads = 0;
     window.__librarySkillReads = 0;
     window.__libraryLifecycleReads = 0;
     const originalFetch = window.fetch;
     window.fetch = function (...args) {
-      const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
+      const target = args[0] instanceof Request ? args[0].url : String(args[0]);
       if (typeof target === "string" && target.includes("/opencode-config")) window.__opencodeConfigReads += 1;
       if (typeof target === "string" && target.includes("/skills/browser-automation")) window.__librarySkillReads += 1;
       if (typeof target === "string" && (target.includes("/cloud-provider-sync/status") || target.includes("/opencode/config?") || target.endsWith("/mcp") || target.endsWith("/den-session"))) window.__libraryLifecycleReads += 1;
@@ -511,7 +500,7 @@ export async function libraryConfigReadBudget(seed: Seed) {
     }
     location.hash = "#/settings/general";
     return true;
-  })()`);
+  });
   return { app };
 }
 
@@ -524,9 +513,7 @@ export async function libraryMcpConnectError(seed: Seed) {
   const app = await seed.desktop({ den, as: "admin" });
   const workspace = await seed.workspace(app, seed.tmpPath("library-mcp-connect-error"));
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
   return {
     app,
     connector: den.mocks.connector,
@@ -543,18 +530,18 @@ export async function librarySignedInStability(seed: Seed) {
   const app = await seed.desktop({ den, as: "member" });
   const workspace = await seed.workspace(app, repoRoot);
   // TODO(primitive): seed.networkObserver
-  await seed.evalIn(app, `(workspaceId) => {
+  await seed.evalIn(app, browserScript((workspaceId) => {
     window.__libraryStability = { requests: [], denEvents: 0, samples: [] };
     const originalFetch = window.fetch;
     window.fetch = function (...args) {
-      const target = typeof args[0] === "string" ? args[0] : args[0]?.url;
+      const target = args[0] instanceof Request ? args[0].url : String(args[0]);
       window.__libraryStability.requests.push(String(target));
       return originalFetch.apply(this, args);
     };
     window.addEventListener("openwork-den-settings-changed", () => { window.__libraryStability.denEvents += 1; });
     location.hash = "#/workspace/" + workspaceId + "/settings/general";
     return true;
-  }`, { args: [workspace.workspaceId] });
+  }, [workspace.workspaceId]));
   return { app };
 }
 
@@ -562,7 +549,7 @@ export async function libraryStateTabs(seed: Seed) {
   const app = await seed.desktop({ name: "library-state-tabs" });
   await seed.workspace(app, repoRoot);
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `location.hash = "#/settings/general"; true`);
+  await seed.evalIn(app, () => { location.hash = "#/settings/general"; return true; });
   return { app };
 }
 
@@ -575,9 +562,7 @@ export async function localManagedMcp(seed: Seed) {
   const app = await seed.desktop({ den, as: "admin" });
   const workspace = await seed.workspace(app, seed.tmpPath("local-managed-mcp"));
   // TODO(primitive): seed.route
-  await seed.evalIn(app, `(workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }`, {
-    args: [workspace.workspaceId],
-  });
+  await seed.evalIn(app, browserScript((workspaceId) => { location.hash = "#/workspace/" + workspaceId + "/settings/general"; return true; }, [workspace.workspaceId]));
   return { app, connector: den.mocks.connector, name: `local-managed-${stamp}`, workspaceId: workspace.workspaceId };
 }
 
@@ -882,11 +867,11 @@ async function configureWorkspaceModel(seed: Seed, input: {
   directMcp?: { name: string; url: string };
 }): Promise<void> {
   // TODO(primitive): seed.workspaceRuntimeConfig
-  const result = await rawEvalIn(input.app, `(async () => {
+  const result = await rawEvalIn(input.app, browserScript(async (inputWorkspaceId, providerId, value, modelId, inputValue, inputValue2, inputProviderId, inputModelId, inputValue3) => {
     const port = localStorage.getItem("openwork.server.port");
     const token = localStorage.getItem("openwork.server.token");
     if (!port || !token) return "missing local server credentials";
-    const request = async (path, init) => {
+    const request = async (path: string, init?: RequestInit) => {
       const response = await fetch("http://127.0.0.1:" + port + path, {
         ...init,
         headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
@@ -894,68 +879,62 @@ async function configureWorkspaceModel(seed: Seed, input: {
       if (!response.ok) return path + " failed: " + response.status + " " + (await response.text()).slice(0, 500);
       return "ok";
     };
-    const workspaceId = ${JSON.stringify(input.workspaceId)};
+    const workspaceId = inputWorkspaceId;
     const patched = await request("/workspace/" + encodeURIComponent(workspaceId) + "/config", {
       method: "PATCH",
       body: JSON.stringify({ opencode: {
         provider: {
-          [${JSON.stringify(input.providerId)}]: {
+          [providerId]: {
             npm: "@ai-sdk/openai-compatible",
             name: "E2E MCP App model",
-            options: { baseURL: ${JSON.stringify(`${input.fixtureUrl}/v1`)}, apiKey: "sk-e2e-fixture" },
-            models: { [${JSON.stringify(input.modelId)}]: { name: "E2E MCP App model", tool_call: true } },
+            options: { baseURL: value, apiKey: "sk-e2e-fixture" },
+            models: { [modelId]: { name: "E2E MCP App model", tool_call: true } },
           },
         },
-        mcp: ${JSON.stringify(input.directMcp ? {
-          [input.directMcp.name]: { type: "remote", url: input.directMcp.url, enabled: true, oauth: false },
-        } : {})},
+        mcp: inputValue,
       } }),
     });
     if (patched !== "ok") return patched;
     const reloaded = await request("/workspace/" + encodeURIComponent(workspaceId) + "/engine/reload", { method: "POST" });
     if (reloaded !== "ok" && !reloaded.includes("opencode_reload_timeout")) return reloaded;
-    ${input.denApiUrl && input.mcpToken ? `
+    if (inputValue2) {
       const reconcile = await request("/workspace/" + encodeURIComponent(workspaceId) + "/mcp/openwork-cloud/reconcile", {
-        method: "POST",
-        body: JSON.stringify({
-          config: {
-            type: "remote",
-            url: ${JSON.stringify(`${input.denApiUrl}/mcp/agent`)},
-            enabled: true,
-            headers: { Authorization: ${JSON.stringify(`Bearer ${input.mcpToken}`)} },
-            oauth: false,
-          },
-          appHostAuthorization: ${JSON.stringify(input.appHostToken ? `Bearer ${input.appHostToken}` : undefined)},
-          provider: ${JSON.stringify(input.providerId)},
-          model: ${JSON.stringify(input.modelId)},
-          trigger: "spec-primitives-migration",
-        }),
+        method: "POST", body: JSON.stringify(inputValue2),
       });
       if (reconcile !== "ok") return reconcile;
-    ` : ""}
+    }
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch {}
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
       ...preferences,
-      defaultModel: { providerID: ${JSON.stringify(input.providerId)}, modelID: ${JSON.stringify(input.modelId)} },
+      defaultModel: { providerID: inputProviderId, modelID: inputModelId },
       modelVariant: null,
       providerStepCompleted: true,
     }));
-    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${input.providerId}/${input.modelId}`)});
+    localStorage.setItem("openwork.defaultModel", inputValue3);
     localStorage.removeItem("openwork.sessionModels." + workspaceId);
     return "ok";
-  })()`, { awaitPromise: true, timeoutMs: 120_000 });
+  }, [input.workspaceId, input.providerId, `${input.fixtureUrl}/v1`, input.modelId, input.directMcp ? {
+          [input.directMcp.name]: { type: "remote", url: input.directMcp.url, enabled: true, oauth: false },
+        } : {}, input.denApiUrl && input.mcpToken ? {
+      config: {
+        type: "remote", url: `${input.denApiUrl}/mcp/agent`, enabled: true,
+        headers: { Authorization: `Bearer ${input.mcpToken}` }, oauth: false,
+      },
+      appHostAuthorization: input.appHostToken ? `Bearer ${input.appHostToken}` : undefined,
+      provider: input.providerId, model: input.modelId, trigger: "spec-primitives-migration",
+    } : null, input.providerId, input.modelId, `${input.providerId}/${input.modelId}`]), { awaitPromise: true, timeoutMs: 120_000 });
   if (result !== "ok") throw new Error(`Configuring the fixture model failed: ${String(result)}`);
 }
 
 async function reloadConfiguredApp(app: import("@openwork/cdp").Surface): Promise<void> {
   // TODO(primitive): seed.reloadConfiguredDesktop
-  await rawEvalIn(app, "location.reload(); true").catch(() => undefined);
+  await rawEvalIn(app, () => { location.reload(); return true; }).catch(() => undefined);
   const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
-    if (await rawEvalIn(app, "Boolean(window.__openworkControl)").catch(() => false) === true) return;
+    if (await rawEvalIn(app, () => (Boolean(window.__openworkControl))).catch(() => false) === true) return;
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   throw new Error("The configured desktop control did not return after reload.");

--- a/evals/worlds/reauth-popup.ts
+++ b/evals/worlds/reauth-popup.ts
@@ -1,3 +1,4 @@
+import { evaluate, browserScript } from "@openwork/cdp";
 import type { Seed } from "@openwork/env";
 import { connect, debuggerUrlFor, listTargets, setViewport, type Surface } from "@openwork/cdp";
 import { chrome, daytonaSandbox, defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
@@ -92,12 +93,27 @@ PY`);
     },
     async blockPopups(blocked: boolean) {
       // Browser fault injection only; no authentication response or application state is mocked.
-      await web.client.send("Runtime.evaluate", { expression: blocked
-        ? "window.__reauthOriginalOpen = window.open; window.open = () => null"
-        : "window.open = window.__reauthOriginalOpen; delete window.__reauthOriginalOpen" });
+      await evaluate(web.client, browserScript((blocked) => {
+        if (blocked) {
+          window.__reauthOriginalOpen = window.open;
+          window.open = () => null;
+        } else if (window.__reauthOriginalOpen) {
+          window.open = window.__reauthOriginalOpen;
+          delete window.__reauthOriginalOpen;
+        }
+      }, [blocked]));
     },
     async sendCompletion(kind: "wrong-nonce" | "foreign-origin" | "stale", nonce?: string) {
-      await web.client.send("Runtime.evaluate", { expression: `window.dispatchEvent(new MessageEvent("message", { origin: ${kind === "foreign-origin" ? '"https://foreign.example.test"' : 'location.origin'}, data: { type: "openwork:reauth-complete", nonce: ${nonce !== undefined ? JSON.stringify(nonce) : kind === "wrong-nonce" ? '"unrelated"' : 'document.querySelector("[data-reauth-nonce]").dataset.reauthNonce'}, error: null } }))` });
+      await evaluate(web.client, browserScript((kind, nonce) => {
+        window.dispatchEvent(new MessageEvent("message", {
+          origin: kind === "foreign-origin" ? "https://foreign.example.test" : location.origin,
+          data: {
+            type: "openwork:reauth-complete",
+            nonce: nonce ?? (kind === "wrong-nonce" ? "unrelated" : document.querySelector<HTMLElement>("[data-reauth-nonce]")?.dataset.reauthNonce),
+            error: null,
+          },
+        }));
+      }, [kind, nonce ?? null]));
     },
   };
 }

--- a/evals/worlds/saved-apps.ts
+++ b/evals/worlds/saved-apps.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import type { Seed } from "@openwork/env";
 import { go, runWorkflow, saveWorkflow } from "@openwork/behaviors";
 import { connect, debuggerUrlFor, evaluate, listTargets } from "@openwork/cdp";
@@ -118,20 +119,25 @@ export async function savedAppCreation(seed: Seed) {
     } },
     mcp: { "openwork-cloud": { type: "remote", url: `${den.ref.apiUrl}/mcp/agent`, enabled: true, oauth: false, headers: { Authorization: `Bearer ${token}` } } },
   });
-  const inPreview = async (expression: string) => {
-    // The opaque sandbox is an out-of-process frame; the parent's DOM snapshot excludes it.
+  const inPreview = async (action: "read" | "details") => {
     const targets = await listTargets(app.handle.cdpUrl);
     const target = targets.find((entry) => entry.type === "iframe" && (entry.url === "about:srcdoc" || entry.url.includes("/mcp-apps/sandbox.html")));
     if (!target) return "";
     const client = await connect(debuggerUrlFor(app.handle.cdpUrl, target));
-    try { return await evaluate(client, `(() => { const appDocument = document.querySelector("iframe")?.contentDocument ?? document; return (() => { ${expression} })(); })()`); }
-    finally { client.close(); }
+    try {
+      return await evaluate(client, browserScript((action) => {
+        const appDocument = document.querySelector("iframe")?.contentDocument ?? document;
+        if (action === "read") return appDocument.body.innerText;
+        appDocument.querySelector("button")?.click();
+        return "";
+      }, [action]));
+    } finally { client.close(); }
   };
   return {
     app, den, proxy, resetProxy, workspace, configObjectId, dashboardId, rpc, run,
     open: (path: string) => go(app, path),
-    previewText: async () => String(await inPreview("return appDocument.body.innerText")),
-    showDetails: () => inPreview('appDocument.querySelector("button")?.click()'),
+    previewText: async () => String(await inPreview("read")),
+    showDetails: () => inPreview("details"),
     receiptId: field(firstRun, "receiptId"),
     render: () => rpc("render_workflow_artifact", { configObjectId }),
     async revise(appId: string) {

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -1,3 +1,4 @@
+import { browserScript } from "@openwork/cdp";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { mkdir, rm } from "node:fs/promises";
 import { engineSessionProbe, readAvailableModels, selectModel, waitFor } from "@openwork/behaviors";
@@ -67,21 +68,17 @@ async function additionalWorkspace(
   app: Awaited<ReturnType<Seed["desktop"]>>,
   path: string,
 ): Promise<ShellWorkspace> {
-  const previous = await seed.evalIn(app, `localStorage.getItem("openwork.react.activeWorkspace") ?? ""`);
+  const previous = await seed.evalIn(app, () => (localStorage.getItem("openwork.react.activeWorkspace") ?? ""));
   // TODO(primitive): seed.workspace should always create the requested additional workspace.
-  const result = await seed.evalIn(app, `(path) => window.__openworkControl.execute("workspace.create", { path })`, {
-    args: [path],
-    awaitPromise: true,
-    timeoutMs: 120_000,
-  });
+  const result = await seed.evalIn(app, browserScript((path) => window.__openworkControl.execute("workspace.create", { path }), [path]), { awaitPromise: true, timeoutMs: 120_000 });
   if (!isRecord(result) || result.ok !== true) throw new Error(`Could not create workspace ${path}: ${JSON.stringify(result)}`);
   const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
-    const state = await seed.evalIn(app, `({
+    const state = await seed.evalIn(app, () => (({
       workspaceId: localStorage.getItem("openwork.react.activeWorkspace") ?? "",
       route: window.location.hash,
       ready: Boolean(window.__openworkControl),
-    })`);
+    })));
     if (isRecord(state)
       && typeof state.workspaceId === "string"
       && state.workspaceId
@@ -109,18 +106,18 @@ async function configureWorkspaceProvider(
   },
 ): Promise<void> {
   // TODO(primitive): seed.configureWorkspaceProvider should configure and reload a workspace model without raw renderer evaluation.
-  const result = await seed.evalIn(app, `async (workspaceIdsJson, smallModel, allowTools, providerId, modelId, modelName, baseUrl, defaultModel) => {
+  const result = await seed.evalIn(app, browserScript(async (workspaceIdsJson, smallModel, allowTools, providerId, modelId, modelName, baseUrl, defaultModel) => {
     const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
     if (!info?.running || !info.baseUrl) return { error: "local_server_unavailable" };
     const workspaceIds = JSON.parse(workspaceIdsJson);
-    const root = String(info.baseUrl).replace(/\\/+$/, "");
+    const root = String(info.baseUrl).replace(/\/+$/, "");
     const headers = {
       Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? ""),
       "Content-Type": "application/json",
     };
     const outcomes = [];
     for (const workspaceId of workspaceIds) {
-      const opencode = {
+      const opencode: { provider: Record<string, unknown>; small_model?: string; permission?: unknown } = {
         provider: {
           [providerId]: {
             npm: "@ai-sdk/openai-compatible",
@@ -150,7 +147,7 @@ async function configureWorkspaceProvider(
       outcomes.push({ workspaceId, stage: "reload", status: reload.status, text: reload.ok ? "ok" : (await reload.text()).slice(0, 300) });
     }
     const raw = localStorage.getItem("openwork.preferences");
-    let preferences = {};
+    let preferences: Record<string, unknown> = {};
     try { preferences = raw ? JSON.parse(raw) : {}; } catch { preferences = {}; }
     if (!preferences || typeof preferences !== "object" || Array.isArray(preferences)) preferences = {};
     localStorage.setItem("openwork.preferences", JSON.stringify({
@@ -162,8 +159,7 @@ async function configureWorkspaceProvider(
     localStorage.setItem("openwork.defaultModel", defaultModel);
     for (const workspaceId of workspaceIds) localStorage.removeItem("openwork.sessionModels." + workspaceId);
     return { outcomes };
-  }`, {
-    args: [
+  }, [
       JSON.stringify(workspaceIds),
       options.smallModel ?? null,
       options.allowTools ?? false,
@@ -172,10 +168,7 @@ async function configureWorkspaceProvider(
       options.modelName,
       options.baseUrl,
       `${options.providerId}/${options.modelId}`,
-    ],
-    awaitPromise: true,
-    timeoutMs: 240_000,
-  });
+    ]), { awaitPromise: true, timeoutMs: 240_000 });
   if (typeof result !== "object" || result === null || !("outcomes" in result) || !Array.isArray(result.outcomes)) {
     throw new Error(`Workspace provider configuration failed: ${JSON.stringify(result)}`);
   }
@@ -234,20 +227,20 @@ export async function workspaceNewTask(seed: Seed) {
   // TODO(primitive): seed.networkFault should delay and observe renderer requests.
   // Keep real session creation behind a slow transport boundary. Opening the
   // composer must not reach this boundary; submitting must reach it only once.
-  await seed.evalIn(app, `(() => {
+  await seed.evalIn(app, () => {
     window.__newTaskRequests = [];
     const originalFetch = window.fetch;
     window.fetch = async function (...args) {
       const request = args[0];
-      const url = typeof request === "string" ? request : request.url;
-      const method = args[1]?.method ?? request.method ?? "GET";
+      const url = request instanceof Request ? request.url : String(request);
+      const method = args[1]?.method ?? (request instanceof Request ? request.method : "GET");
       if (method.toUpperCase() === "POST" && new URL(url, location.href).pathname.endsWith("/session")) {
         window.__newTaskRequests.push(url);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
       return originalFetch.apply(this, args);
     };
-  })()`);
+  });
   return { app, workspace, workspacePath, sessions, prompt, reply };
 }
 
@@ -260,7 +253,7 @@ export async function pinnedSessions(seed: Seed) {
 
   // TODO(primitive): probe.context should expose the OpenWork context snapshot.
   async function context(): Promise<{ pinnedSessionIds: string[]; pinnedResourceRefs: string[] }> {
-    const value = await seed.evalIn(app, `(() => {
+    const value = await seed.evalIn(app, () => {
       const c = window.__openworkControl?.context?.();
       return {
         pinnedSessionIds: c?.conversations?.pinnedSessionIds ?? null,
@@ -268,7 +261,7 @@ export async function pinnedSessions(seed: Seed) {
           .filter((r) => r.kind === "session" && r.state?.pinned === true)
           .map((r) => r.ref),
       };
-    })()`);
+    });
     if (!isRecord(value)
       || !Array.isArray(value.pinnedSessionIds)
       || !value.pinnedSessionIds.every((id) => typeof id === "string")
@@ -284,12 +277,12 @@ export async function pinnedSessions(seed: Seed) {
 
   // TODO(primitive): probe.sidebar complements user.see({ text: "Pinned" }) by exposing which rows the section contains.
   async function pinnedSidebarRows(): Promise<string[] | null> {
-    const value = await seed.evalIn(app, `(() => {
-      const section = document.querySelector("[data-global-pinned-sessions]");
+    const value = await seed.evalIn(app, () => {
+      const section = document.querySelector<HTMLElement>("[data-global-pinned-sessions]");
       if (!section) return null;
-      return [...section.querySelectorAll("[data-sidebar-session-id]")]
+      return [...section.querySelectorAll<HTMLElement>("[data-sidebar-session-id]")]
         .map((row) => row.getAttribute("data-sidebar-session-id"));
-    })()`);
+    });
     if (value === null) return null;
     if (!Array.isArray(value) || !value.every((sessionId) => typeof sessionId === "string")) {
       throw new Error(`Global pinned sidebar rows were malformed: ${JSON.stringify(value)}`);
@@ -318,11 +311,11 @@ export async function archiveSessions(seed: Seed) {
    */
   // TODO(primitive): probe.sessions should expose the workspace's native session list.
   async function archivedAt(): Promise<Record<string, number>> {
-    const value = await seed.evalIn(app, `async (workspaceId, engine) => {
+    const value = await seed.evalIn(app, browserScript(async (workspaceId, engine) => {
       const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
       if (!info?.running || !info.baseUrl) throw new Error("OpenWork server is unavailable");
       const response = await fetch(
-        String(info.baseUrl).replace(/\\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId) + (engine === "v2" ? "/opencode2/api/session?limit=200" : "/opencode/session?limit=200"),
+        String(info.baseUrl).replace(/\/+$/, "") + "/workspace/" + encodeURIComponent(workspaceId) + (engine === "v2" ? "/opencode2/api/session?limit=200" : "/opencode/session?limit=200"),
         {
           headers: { Authorization: "Bearer " + String(info.ownerToken ?? info.clientToken ?? "") },
           signal: AbortSignal.timeout(15000),
@@ -335,7 +328,7 @@ export async function archiveSessions(seed: Seed) {
       return Object.fromEntries(sessions
         .filter((session) => typeof session?.id === "string")
         .map((session) => [session.id, typeof session?.time?.archived === "number" ? session.time.archived : 0]));
-    }`, { args: [workspace.workspaceId, engine], awaitPromise: true, timeoutMs: 20_000 });
+    }, [workspace.workspaceId, engine]), { awaitPromise: true, timeoutMs: 20_000 });
     if (!isRecord(value)) throw new Error(`Workspace archived state was malformed: ${JSON.stringify(value)}`);
     const stamps: Record<string, number> = {};
     for (const [sessionId, stamp] of Object.entries(value)) {
@@ -348,16 +341,16 @@ export async function archiveSessions(seed: Seed) {
   /** Which rows the workspace's own session tree shows, and whether the global Archived section exists. */
   // TODO(primitive): probe.sidebar should expose the workspace tree and the Archived section.
   async function sidebar(): Promise<{ active: string[]; archivedSection: boolean; archiveMenuDisabled: boolean }> {
-    const value = await seed.evalIn(app, `(workspaceId) => {
-      const tree = document.querySelector('[data-sidebar-workspace-id="' + workspaceId + '"]');
+    const value = await seed.evalIn(app, browserScript((workspaceId) => {
+      const tree = document.querySelector<HTMLElement>('[data-sidebar-workspace-id="' + workspaceId + '"]');
       return {
-        active: [...(tree?.querySelectorAll("[data-sidebar-session-id]") ?? [])]
+        active: [...(tree?.querySelectorAll<HTMLElement>("[data-sidebar-session-id]") ?? [])]
           .map((row) => row.getAttribute("data-sidebar-session-id")),
-        archivedSection: Boolean(document.querySelector("[data-global-archived-sessions]")),
-        archiveMenuDisabled: [...document.querySelectorAll('[role="menuitem"][aria-disabled="true"]')]
+        archivedSection: Boolean(document.querySelector<HTMLElement>("[data-global-archived-sessions]")),
+        archiveMenuDisabled: [...document.querySelectorAll<HTMLElement>('[role="menuitem"][aria-disabled="true"]')]
           .some((item) => item.textContent?.trim() === "Archive session"),
       };
-    }`, { args: [workspace.workspaceId] });
+    }, [workspace.workspaceId]));
     if (!isRecord(value)
       || !Array.isArray(value.active)
       || !value.active.every((sessionId) => typeof sessionId === "string")
@@ -371,13 +364,13 @@ export async function archiveSessions(seed: Seed) {
   /** True once the undo pill is on screen and its slide-in has finished, i.e. when a person would reach for it. */
   // TODO(primitive): user.click should wait for a target's entrance animation to settle.
   async function undoToastSettled(): Promise<boolean> {
-    const value = await seed.evalIn(app, `(() => {
-      const pill = document.querySelector("[data-undo-toast]");
+    const value = await seed.evalIn(app, () => {
+      const pill = document.querySelector<HTMLElement>("[data-undo-toast]");
       const toast = pill?.closest("[data-sonner-toast]");
       if (!(toast instanceof HTMLElement)) return false;
       return toast.dataset.mounted === "true"
         && toast.getAnimations({ subtree: true }).every((animation) => animation.playState !== "running");
-    })()`);
+    });
     return value === true;
   }
 
@@ -467,16 +460,16 @@ export async function externalSessionVisibility(seed: Seed) {
   // and explicitly close its picker before testing sidebar clicks: the missing
   // default-model prompt can otherwise appear between hit-testing and clicking.
   await readAvailableModels(app);
-  await seed.evalIn(app, `(() => {
-    const close = document.querySelector('[data-slot="dialog-content"] [data-slot="dialog-close"]');
+  await seed.evalIn(app, () => {
+    const close = document.querySelector<HTMLElement>('[data-slot="dialog-content"] [data-slot="dialog-close"]');
     if (!(close instanceof HTMLElement)) throw new Error("Model picker close control unavailable");
     close.click();
-  })()`);
-  await waitFor(app, `!document.querySelector('[data-slot="dialog-overlay"]')`, {
+  });
+  await waitFor(app, () => (!document.querySelector<HTMLElement>('[data-slot="dialog-overlay"]')), {
     timeoutMs: 30_000,
     label: "model picker backdrop dismissed before sidebar interaction",
   });
-  const rawServerInfo = await seed.evalIn(app, `window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo")`, {
+  const rawServerInfo = await seed.evalIn(app, () => (window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo")), {
     awaitPromise: true,
     timeoutMs: 30_000,
   });
@@ -632,7 +625,7 @@ export async function externalSessionVisibility(seed: Seed) {
     /** The sidebar's own per-workspace session lists and load state. */
     // TODO(primitive): probe.route should expose the sidebar's per-workspace session lists.
     async route(): Promise<SidebarRouteFacts> {
-      return parseSidebarRouteFacts(await seed.evalIn(app, `(() => {
+      return parseSidebarRouteFacts(await seed.evalIn(app, () => {
         const route = window.__openwork?.slice?.("route");
         if (!route) return null;
         return {
@@ -648,7 +641,7 @@ export async function externalSessionVisibility(seed: Seed) {
             (sessions ?? []).map((session) => ({ id: String(session?.id ?? ""), title: String(session?.title ?? "") })),
           ])),
         };
-      })()`));
+      }));
     },
     /**
      * Creates a session the way another client would: straight against the
@@ -724,12 +717,12 @@ export async function settingsRuntime(seed: Seed) {
   const firstWorkspace = await seed.workspace(app, `/tmp/${firstName}`);
   const secondWorkspace = await additionalWorkspace(seed, app, `/tmp/${secondName}`);
   // TODO(primitive): seed.runtimeErrorCapture should install a scoped renderer error witness.
-  await seed.evalIn(app, `(() => {
+  await seed.evalIn(app, () => {
     window.__sessionSettingsRuntimeErrors = [];
     window.addEventListener("error", (event) => window.__sessionSettingsRuntimeErrors.push(String(event.error?.message ?? event.message ?? "window error")));
     window.addEventListener("unhandledrejection", (event) => window.__sessionSettingsRuntimeErrors.push(String(event.reason?.message ?? event.reason ?? "unhandled rejection")));
     return true;
-  })()`);
+  });
   return { app, firstWorkspace, secondWorkspace, firstName, secondName };
 }
 
@@ -753,11 +746,11 @@ export async function renderCycle(seed: Seed, { place }: { place: import("@openw
   const workspacePath = seed.tmpPath("desktop-render-cycle");
   await mkdir(workspacePath, { recursive: true });
   // TODO(primitive): seed.storage should arrange persisted renderer preferences without raw evaluation.
-  await seed.evalIn(app, `(() => {
+  await seed.evalIn(app, () => {
     localStorage.setItem("openwork.debug.profilerOverlay", "1");
     location.reload();
     return true;
-  })()`).catch(() => undefined);
+  }).catch(() => undefined);
   return {
     app,
     workspacePath,
@@ -943,11 +936,11 @@ export async function activeSessionStorm(seed: Seed) {
     baseUrl: `${den.mocks.agent.url}/v1`,
     allowTools: true,
   });
-  await seed.evalIn(app, "location.reload(); true").catch(() => undefined);
+  await seed.evalIn(app, () => { location.reload(); return true; }).catch(() => undefined);
   const reloadDeadline = Date.now() + 60_000;
   while (Date.now() < reloadDeadline) {
-    const ready = await seed.evalIn(app, `Boolean(window.__openworkControl)
-      && Boolean((localStorage.getItem("openwork.den.authToken") ?? "").trim())`)
+    const ready = await seed.evalIn(app, () => (Boolean(window.__openworkControl)
+      && Boolean((localStorage.getItem("openwork.den.authToken") ?? "").trim())))
       .catch(() => false);
     if (ready === true) break;
     await new Promise((resolve) => setTimeout(resolve, 250));

--- a/evals/worlds/signup-workspace.ts
+++ b/evals/worlds/signup-workspace.ts
@@ -27,7 +27,7 @@ export async function signupWorkspace(seed: Seed, options: { filmDirectory?: str
       den.admin = await signIn(den.ref, owner);
     },
     async pathname() {
-      const path = await seed.evalIn(web, "window.location.pathname");
+      const path = await seed.evalIn(web, () => (window.location.pathname));
       if (typeof path !== "string") throw new Error("Expected browser path");
       return path;
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "release:cut": "node scripts/release/cut.mjs",
     "release:cut:watch": "node scripts/release/cut.mjs --watch",
     "test:core": "pnpm --filter @openwork/app test:core && pnpm --filter openwork-server test:core && pnpm --filter @openwork-ee/den-api test && pnpm --filter @openwork/desktop test:core && pnpm --dir evals run test:core",
-    "test:extended": "pnpm --filter @openwork/app test && pnpm --filter openwork-server test && pnpm --filter @openwork-ee/den-api test && pnpm --filter @openwork/desktop test && node --test scripts/release/*.test.mjs && pnpm test:eval-runner && pnpm evals:pr && pnpm test:e2e"
+    "test:extended": "pnpm --filter @openwork/app test && pnpm --filter openwork-server test && pnpm --filter @openwork-ee/den-api test && pnpm --filter @openwork/desktop test && node --test scripts/release/*.test.mjs && pnpm test:eval-runner && pnpm evals:pr && pnpm test:e2e",
+    "evals:check-browser": "pnpm --dir evals check:browser"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/handsfree/test/e2e/browser.ts
+++ b/packages/handsfree/test/e2e/browser.ts
@@ -1,0 +1,36 @@
+import { evaluate } from "../../../../evals/packages/cdp/src/cdp.ts";
+import type { CdpClient } from "../../../../evals/packages/cdp/src/cdp.ts";
+
+declare global {
+  interface Window {
+    __events: Array<{ t: number } & ({ type: "click"; id: string } | { type: "check"; checked: boolean })>;
+  }
+}
+
+/** Independent, type-checked browser observations for the computer-use benchmark. */
+export function groundTruth(client: CdpClient) {
+  return {
+    resetEvents: () => evaluate(client, () => { window.__events = []; }),
+    eventCount: () => evaluate(client, () => window.__events.length),
+    lastClickedId: () => evaluate(client, () => {
+      const event = window.__events.at(-1);
+      return event?.type === "click" ? event.id : undefined;
+    }),
+    resetField: () => evaluate(client, () => {
+      const field = document.querySelector<HTMLInputElement>("#field");
+      if (!field) throw new Error("Benchmark field is missing");
+      field.value = "";
+      field.focus();
+    }),
+    fieldValue: () => evaluate(client, () => {
+      const field = document.querySelector<HTMLInputElement>("#field");
+      if (!field) throw new Error("Benchmark field is missing");
+      return field.value;
+    }),
+    focusField: () => evaluate(client, () => {
+      const field = document.querySelector<HTMLInputElement>("#field");
+      if (!field) throw new Error("Benchmark field is missing");
+      field.focus();
+    }),
+  };
+}

--- a/packages/handsfree/test/e2e/run.mjs
+++ b/packages/handsfree/test/e2e/run.mjs
@@ -15,6 +15,9 @@
 //
 // Usage: node packages/handsfree/test/e2e/run.mjs
 
+import { connect } from "../../../../evals/packages/cdp/src/cdp.ts";
+import { groundTruth } from "./browser.ts";
+
 import { spawn, execSync } from "node:child_process";
 import { createReadStream, createWriteStream, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -108,20 +111,8 @@ mcpIn.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized"
 const targets = await cdpTargets();
 const tab = targets.find((t) => t.type === "page" && t.url.includes("bench.html"));
 if (!tab) throw new Error("bench.html tab not found in disposable Chrome");
-const ws = new WebSocket(tab.webSocketDebuggerUrl);
-await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
-let wsId = 0;
-const wsPending = new Map();
-ws.onmessage = (ev) => {
-  const m = JSON.parse(ev.data);
-  if (m.id && wsPending.has(m.id)) { wsPending.get(m.id)(m); wsPending.delete(m.id); }
-};
-const evaljs = (expression) => new Promise((res, rej) => {
-  const i = ++wsId;
-  const t = setTimeout(() => rej(new Error("cdp timeout")), 15000);
-  wsPending.set(i, (m) => { clearTimeout(t); res(m.result?.result?.value); });
-  ws.send(JSON.stringify({ id: i, method: "Runtime.evaluate", params: { expression, returnByValue: true } }));
-});
+const client = await connect(tab.webSocketDebuggerUrl);
+const browser = groundTruth(client);
 
 await sleep(2000);
 const findEl = (snap, pred) => snap.elements?.find(pred);
@@ -143,15 +134,15 @@ record("element_recall", found.length, expected.length, `missing: ${expected.fil
 // 2. click accuracy across all three addressing modes, CDP-verified
 async function clickRound(key, makeArgs) {
   let ok = 0;
-  await evaljs("window.__events = []");
+  await browser.resetEvents();
   for (const name of buttons) {
     const el = findEl(snap, (e) => e.role === "Button" && (e.label ?? "").includes(name));
     if (!el) continue;
-    const before = (await evaljs("window.__events.length")) ?? 0;
+    const before = (await browser.eventCount()) ?? 0;
     await cu("click", { app: CHROME_APP, ...makeArgs(el) });
     await sleep(150);
-    const last = await evaljs("window.__events[window.__events.length-1]?.id");
-    const after = await evaljs("window.__events.length");
+    const last = await browser.lastClickedId();
+    const after = await browser.eventCount();
     if (after === before + 1 && last === name) ok++;
     else console.log(`${key} MISS: ${name} -> ${last}`);
   }
@@ -176,11 +167,11 @@ const strings = [
 ];
 let typeOk = 0;
 for (const text of strings) {
-  await evaljs("document.getElementById('field').value=''; document.getElementById('field').focus()");
+  await browser.resetField();
   await sleep(100);
   await cu("type_text", { app: CHROME_APP, text });
   await sleep(300);
-  if ((await evaljs("document.getElementById('field').value")) === text) typeOk++;
+  if ((await browser.fieldValue()) === text) typeOk++;
 }
 record("type_text", typeOk, strings.length);
 
@@ -189,16 +180,16 @@ snap = await cu("snapshot", { app: CHROME_APP });
 const field = findEl(snap, (e) => (e.label ?? "").includes("bench-field"));
 await cu("set_value", { app: CHROME_APP, ref: field.ref, value: "set-value-test-42" });
 await sleep(300);
-record("set_value", (await evaljs("document.getElementById('field').value")) === "set-value-test-42" ? 1 : 0, 1);
+record("set_value", (await browser.fieldValue()) === "set-value-test-42" ? 1 : 0, 1);
 
 // 6. background modifier combo: cmd+a + retype
 await cu("snapshot", { app: CHROME_APP });
-await evaljs("document.getElementById('field').focus()");
+await browser.focusField();
 await cu("press_key", { app: CHROME_APP, combo: "command+a" });
 await sleep(100);
 await cu("type_text", { app: CHROME_APP, text: "replaced" });
 await sleep(300);
-record("select_all_replace", (await evaljs("document.getElementById('field').value")) === "replaced" ? 1 : 0, 1);
+record("select_all_replace", (await browser.fieldValue()) === "replaced" ? 1 : 0, 1);
 
 // --- report ---
 console.log("\n========== RESULTS ==========");
@@ -214,6 +205,7 @@ console.log("\n-- Execution paths --");
 for (const [k, v] of Object.entries(results.paths)) console.log(`${k.padEnd(24)} ${v.length}x`);
 
 // --- cleanup ---
+client.close();
 try { execSync(`pkill -f "user-data-dir=${profileDir}"`); } catch {}
 try { execSync(`pkill -f 'OpenWork Computer Use.app'`); } catch {}
 await sleep(1000);


### PR DESCRIPTION
## Summary
Browser test code now uses checked TypeScript callbacks with inferred argument and result types instead of executable strings. `browserScript(callback, [args])` carries explicit data across the browser boundary; `addInitScript` supports pre-navigation setup and disposal.

## Why
Code inside a string bypassed TypeScript, hid invalid DOM access and accidental source interpolation, and left test results untyped. This makes those mistakes visible before a browser is provisioned.

## Issue
Follow-up to the testing approach discussed in #4594. This PR targets `dev`; that open PR’s new reload witness will need the same callback API when integrated.

## Scope
- Migrate browser execution across specs, worlds, behavior helpers, testkit, screenshots, and standalone test drivers.
- Keep source serialization inside the CDP transport, validate arguments, await async results, and propagate browser exceptions.
- Add browser DOM/protocol types and a binding-aware TypeScript guard against source strings, captured process variables, invalid arguments/results, and raw CDP bypasses. It checks 631 callbacks and runs in the test-framework CI command.
- Cover serialization, hostile input, async failures, init-script disposal, and the guard in existing test files.
- Resolve the merge with `dev` by retaining both typed browser exports and `quitDesktop`; fix CodeQL’s loose URL substring assertion by comparing the full expected logo URL.

## Out of scope
Product behavior and existing test-layer/boundary baseline debt.

## Testing
### Ran
- `pnpm evals:check-browser`: passed, 631 callbacks.
- Node 24 framework suite (`node --test evals/runner/*.test.ts evals/packages/*/test/*.test.ts evals/bin/*.test.mjs evals/scripts/*.test.mjs`): 268 passed, 0 failed, 0 skipped on the PR head.
- `pnpm evals:e2e signup-workspace-intent` selected `daytona (daytona CLI authenticated)`. On the final head it reached the final screenshot with 15 passed assertion artifacts, then exceeded the default 600-second aggregate deadline while cold-booting three browser environments.
- The same-head Daytona rerun passed: 1 passed, 0 failed, 0 skipped in 587.8 seconds. All 10 deferred visual validations also passed; there are 0 failed or pending judgments.
  Reproduce the same-head Daytona rerun with `OPENWORK_EVAL_DAYTONA=1 OPENWORK_EVAL_E2E_TESTS=1 OPENWORK_EVAL_VISION=defer pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e --testTimeout 900000 specs/signup-workspace-intent.e2e.test.ts`. Individual assertion timeouts and world-setup limits are unchanged.
- Supplemental `pnpm evals:pr specs/spec-primitives.test.ts`: 3 passed, 1 intentionally skipped (`needs: OPENWORK_SPEC_PRIMITIVES_MISSING_OPT_IN=1`); this supplemental run is Incomplete and is not counted as passing proof.

### Historical baseline comparison before the merge update
Clean control: `71b774c2a` (`dev`), same Node 24/pnpm and frozen installs.
- `pnpm evals:typecheck`: exit 2 on both; 327 diagnostics here versus 346 on clean dev. First shared failure: `apps/server/src/agent-context-cloud-probe.ts:216` TS1294, syntax incompatible with `erasableSyntaxOnly`. No new file/error-code counts remain.
- `pnpm --dir evals lint:layers`: exit 26 on both, identical 26 dependency violations. Example: `specs/workspace-engine-upgrade.e2e.test.ts → @openwork/behaviors`.
- Channel and boundary ratchets: exit 1 on both with identical output. Their baselines were not expanded.

## CI status
All build, core, SDK, deployment, and CodeQL checks are green on the final head. Warden approved the final head, and the PR was squash-merged after all checks completed. The pre-existing full typecheck/layer/ratchet failures above were reproduced locally against clean dev; the browser guard and all 268 framework tests pass.

## Manual verification
Use ordinary user/locator helpers for interaction. For a browser probe, pass a callback such as `probe.eval(() => document.title)`; use `browserScript` for external arguments. Run `pnpm evals:check-browser` before the journey.

## Evidence
Final-head signup journey: **Passed**, including 15 assertion artifacts and 10 visual validations. [Published test evidence](https://github.com/different-ai/openwork/pull/4596#issuecomment-5564358227) includes the source run, 11 screenshots, all 25 passed expectations, and 0 failed/pending judgments. Use the reproduction command above for the full cold-boot journey.

## Risk
This changes the internal eval API across 100 files. Callbacks must be self-contained and return plain data. Dynamic API JSON remains unknown and still requires validation. The macOS computer-use benchmark was migrated and its browser code checked, but the full native benchmark was not run.

## Rollback
Revert this PR as a unit; callers and the transport API migrate together.
