### PR TITLE
fix(browser): repair macOS login sync and in-flight sign-out

### DIFF
--- a/apps/desktop/electron/browser-login-sync.mjs
+++ b/apps/desktop/electron/browser-login-sync.mjs
@@ -47,7 +47,7 @@ function defaultOpenDatabase(filePath) {
 
 function defaultReadKeychainPassword(service) {
   return new Promise((resolve, reject) => {
-    execFile("/usr/bin/security", ["find-generic-password", "-wa", service], { timeout: 120_000 }, (error, stdout, stderr) => {
+    execFile("/usr/bin/security", ["find-generic-password", "-w", "-s", service], { timeout: 120_000 }, (error, stdout, stderr) => {
       if (error) {
         const detail = String(stderr || error.message || "");
         if (/could not be found/i.test(detail)) {
@@ -444,13 +444,11 @@ export function createBrowserLoginSync({
         throw new Error("sync-cancelled");
       }
     };
-    const selected = new Set(state.selectedSites);
     const sourceCookies = cookiesForSites(cookies, state.selectedSites)
       .filter((cookie) => cookie.httpOnly === true)
       .filter((cookie) => cookie.expiresAt === null || cookie.expiresAt * 1000 >= now());
     const sourceByIdentity = new Map(sourceCookies.map((cookie) => [cookieIdentity(cookie), cookie]));
-    const previousByIdentity = new Map(state.managedCookies.map((cookie) => [managedCookieIdentity(cookie), cookie]));
-    const nextManaged = new Map();
+    const managedByIdentity = new Map(state.managedCookies.map((cookie) => [managedCookieIdentity(cookie), cookie]));
     const tallies = new Map(state.selectedSites.map((site) => [site, { site, synced: 0, failed: 0, removed: 0 }]));
     let writeFailed = false;
 
@@ -461,39 +459,37 @@ export function createBrowserLoginSync({
       tallies.set(site, tally);
       try {
         await getSession().cookies.set(toElectronCookie(cookie));
+        // Revocation waits for this write; record what it installed even if cancelled.
+        managedByIdentity.set(identity, managedCookie(cookie));
+        state.managedCookies = [...managedByIdentity.values()];
         assertCurrent();
-        nextManaged.set(identity, managedCookie(cookie));
         tally.synced += 1;
       } catch (error) {
         if (isSyncCancelled(error)) throw error;
         writeFailed = true;
         tally.failed += 1;
-        const previous = previousByIdentity.get(identity);
-        if (previous) nextManaged.set(identity, previous);
       }
     }
 
     if (complete && !writeFailed) {
-      for (const [identity, cookie] of previousByIdentity) {
-        if (nextManaged.has(identity)) continue;
+      for (const [identity, cookie] of managedByIdentity) {
+        if (sourceByIdentity.has(identity)) continue;
         assertCurrent();
         const tally = tallies.get(cookie.site) ?? { site: cookie.site, synced: 0, failed: 0, removed: 0 };
         tallies.set(cookie.site, tally);
         try {
           await removeManagedCookie(cookie);
+          managedByIdentity.delete(identity);
+          state.managedCookies = [...managedByIdentity.values()];
           assertCurrent();
           tally.removed += 1;
         } catch (error) {
           if (isSyncCancelled(error)) throw error;
           tally.failed += 1;
-          nextManaged.set(identity, cookie);
         }
       }
-    } else {
-      for (const [identity, cookie] of previousByIdentity) if (!nextManaged.has(identity) && selected.has(cookie.site)) nextManaged.set(identity, cookie);
     }
 
-    state.managedCookies = [...nextManaged.values()].filter((cookie) => selected.has(cookie.site));
     await getSession().cookies.flushStore?.();
     return { sites: [...tallies.values()].filter((tally) => tally.synced > 0 || tally.failed > 0 || tally.removed > 0) };
   }

--- a/apps/desktop/electron/browser-login-sync.test.mjs
+++ b/apps/desktop/electron/browser-login-sync.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { register } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,15 +8,19 @@ import test from "node:test";
 const hooks = `
 export function resolve(specifier, context, next) {
   if (specifier === "electron") return { url: "electron-stub:login-sync", shortCircuit: true };
+  if (specifier === "node:child_process") return { url: "keychain-stub:login-sync", shortCircuit: true };
   return next(specifier, context);
 }
 export function load(url, context, next) {
   if (url === "electron-stub:login-sync") return { format: "module", source: "export const session = { fromPartition() { throw new Error('unused'); } };", shortCircuit: true };
+  if (url === "keychain-stub:login-sync") return { format: "module", source: "export const calls = []; export function execFile(file, args, options, callback) { calls.push({ file, args, options }); callback(null, 'synthetic-keychain-password', ''); }", shortCircuit: true };
   return next(url, context);
 }
 `;
 register(`data:text/javascript,${encodeURIComponent(hooks)}`);
 const { createBrowserLoginSync } = await import("./browser-login-sync.mjs");
+// @ts-expect-error The registered test-only child-process stub exports its witness.
+const { calls: keychainCalls } = await import("node:child_process");
 
 const NOW = Date.UTC(2026, 8, 4);
 const nowSeconds = Math.trunc(NOW / 1000);
@@ -110,6 +114,7 @@ function setup({ pollIntervalMs = 0, watchSource = null } = {}) {
     });
   const logins = createService();
   return {
+    home,
     logins,
     browserSession,
     cookiesPath,
@@ -208,6 +213,101 @@ test("setup exposes no values, keeps sensitive sites unchecked, and reads values
   assert.equal(persisted.includes("bank-secret"), false);
   logins.shutdown();
 });
+
+test("Chrome setup looks up the Keychain service rather than its account name", async (t) => {
+  const home = mkdtempSync(join(tmpdir(), "openwork-login-sync-chrome-"));
+  t.after(() => rmSync(home, { recursive: true, force: true }));
+  const profile = join(home, "Library", "Application Support", "Google", "Chrome", "Default");
+  mkdirSync(profile, { recursive: true });
+  writeFileSync(join(profile, "Cookies"), "synthetic Chrome source");
+  const row = {
+    host_key: ".example.com", name: "sid", value: "chrome-fixture", encrypted_value: Buffer.alloc(0),
+    path: "/", is_secure: 1, is_httponly: 1, samesite: 1, has_expires: 0, is_persistent: 0,
+    expires_utc: 0, last_access_utc: 0,
+  };
+  const browserSession = fakeSession();
+  const logins = createBrowserLoginSync({
+    platform: "darwin", home, env: {}, initialPolicyAllowed: true,
+    pollIntervalMs: 0, watchSource: null, getSession: () => browserSession,
+    openDatabase: () => ({
+      prepare(sql) {
+        return { all() {
+          if (sql.startsWith("PRAGMA table_info")) return Object.keys(row).map((name) => ({ name }));
+          if (sql.includes("FROM meta")) return [{ value: "23" }];
+          return [row];
+        } };
+      },
+      close() {},
+    }),
+  });
+  t.after(() => logins.shutdown());
+  keychainCalls.length = 0;
+  const source = (await logins.listSources()).profiles.find((entry) => entry.browser === "chrome");
+  assert.ok(source);
+  const preview = await logins.preview({ sourceId: source.id });
+  assert.deepEqual(keychainCalls, [], "metadata preview never requests a password");
+  await logins.configure({ previewId: preview.previewId, sites: ["example.com"] });
+  assert.deepEqual(keychainCalls, [{
+    file: "/usr/bin/security",
+    args: ["find-generic-password", "-w", "-s", "Chrome Safe Storage"],
+    options: { timeout: 120_000 },
+  }]);
+  assert.equal((await browserSession.cookies.get())[0].value, "chrome-fixture");
+});
+
+for (const revocation of ["disconnect", "stopSite", "pause"]) {
+  for (const writeSucceeds of [true, false]) {
+    test(`${revocation} retains all installed cookies for forgetting when a pending write ${writeSucceeds ? "succeeds" : "fails"}`, { timeout: 5_000 }, async (t) => {
+      const fixture = setup();
+      t.after(() => { fixture.logins.shutdown(); rmSync(fixture.home, { recursive: true, force: true }); });
+      await configureExample(fixture.logins);
+      const cookies = fixture.browserSession.cookies;
+      for (const [host, name] of [["bank.example", "sid"], ["example.com", "direct"], ["example.com", "pending"], ["example.com", "unattempted"]]) {
+        await cookies.set({ url: `https://${host}/`, domain: `.${host}`, path: "/", name, value: "direct-fixture" });
+      }
+      const unrelated = (await cookies.get()).filter((cookie) => cookie.value === "direct-fixture"
+        && (!writeSucceeds || cookie.name !== "pending"));
+      const source = fixture.rows()[0];
+      fixture.setRows(["early", "pending", "unattempted"].map((name) => ({ ...source, name })));
+      let signalEntered;
+      let releaseWrite;
+      const entered = new Promise((resolve) => { signalEntered = resolve; });
+      const release = new Promise((resolve) => { releaseWrite = resolve; });
+      t.after(() => releaseWrite());
+      const set = cookies.set;
+      const attempts = [];
+      cookies.set = async (details) => {
+        attempts.push(details.name);
+        if (details.name === "pending") {
+          signalEntered();
+          await release;
+          if (!writeSucceeds) throw new Error("target-write-failed");
+        }
+        await set(details);
+      };
+      const syncing = assert.rejects(fixture.logins.syncNow(), /Browser login sync failed/);
+      await entered;
+      let revoked = false;
+      const revoke = (revocation === "disconnect" ? fixture.logins.disconnect({ forgetSynced: true })
+        : revocation === "stopSite" ? fixture.logins.stopSite("example.com") : fixture.logins.pause())
+        .then((result) => { revoked = true; return result; });
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(revoked, false, "revocation waits for the native write to settle");
+      releaseWrite();
+      await Promise.all([syncing, revoke]);
+      assert.deepEqual(attempts, ["early", "pending"], "cancellation prevents later writes");
+      if (revocation === "pause") {
+        const installed = writeSucceeds ? 3 : 2;
+        assert.equal((await fixture.logins.getState()).managedCookieCount, installed);
+        assert.equal(JSON.parse(readFileSync(fixture.statePath, "utf8")).managedCookies.length, installed);
+        await fixture.logins.disconnect({ forgetSynced: true });
+      }
+      assert.deepEqual(await cookies.get(), unrelated, "forgetting removes only successfully installed owned cookies");
+      assert.equal((await fixture.logins.getState()).managedCookieCount, 0);
+      assert.deepEqual(fixture.browserSession.cleared, [], "revocation never clears unrelated storage");
+    });
+  }
+}
 
 test("sync updates and removes managed source cookies without touching unselected sites", async () => {
   const fixture = setup();

--- a/apps/desktop/electron/browser-login-sync.test.mjs
+++ b/apps/desktop/electron/browser-login-sync.test.mjs
@@ -270,6 +270,7 @@ for (const revocation of ["disconnect", "stopSite", "pause"]) {
       const source = fixture.rows()[0];
       fixture.setRows(["early", "pending", "unattempted"].map((name) => ({ ...source, name })));
       let signalEntered;
+      /** @type {(value?: unknown) => void} */
       let releaseWrite;
       const entered = new Promise((resolve) => { signalEntered = resolve; });
       const release = new Promise((resolve) => { releaseWrite = resolve; });

--- a/evals/specs/browser-login-sync.e2e.test.ts
+++ b/evals/specs/browser-login-sync.e2e.test.ts
@@ -6,7 +6,7 @@ const test = spec.world(browserLoginSyncWorld, {
   needs: { optIn: ["OPENWORK_EVAL_BROWSER_LOGIN_SYNC"] },
 });
 
-test("selected browser logins stay synced until the user pauses them", async ({ world, user, step }) => {
+test("selected browser logins stay synced until the user pauses or forgets them", async ({ world, user, step }) => {
   const nowSeconds = Math.trunc(Date.now() / 1000);
   const sourceCookies = (value: string | null) => [
     ...(value === null ? [] : [{
@@ -125,5 +125,45 @@ test("selected browser logins stay synced until the user pauses them", async ({ 
     expect(await world.readLoginWitness(tab)).toBe("signed-out");
     expect(state.active).toBe(false);
     expect(state.status).toBe("paused");
+  });
+
+  await step("Disconnect and forget signs out the page and source changes cannot restore its login", async () => {
+    await world.openSettingsPanel("permissions");
+    await user.click({ testId: "login-sync-resume" });
+    await world.showSession(world.session.sessionId);
+    await eventually(async () => {
+      await world.reloadTab(tab);
+      return world.readLoginWitness(tab);
+    }, {
+      within: 15_000,
+      until: (value) => value === "signed-in-v1",
+      label: "resuming restores the selected login before it is forgotten",
+    });
+    await world.openSettingsPanel("permissions");
+    await user.click({ testId: "login-sync-disconnect" });
+    await user.see({ testId: "login-sync-setup" });
+    expect(await world.loginSyncState()).toMatchObject({ configured: false, active: false, managedCookieCount: 0 });
+    await world.showSession(world.session.sessionId);
+    await eventually(async () => {
+      await world.reloadTab(tab);
+      return world.readLoginWitness(tab);
+    }, {
+      within: 15_000,
+      until: (value) => value === "signed-out",
+      label: "forgetting removes the login from the actual browser page",
+    });
+    await world.updateLoginStore(store.path, sourceCookies("login-v2-fixture"));
+    const changedAt = Date.now();
+    await eventually(async () => {
+      expect(await world.loginSyncState()).toMatchObject({ configured: false, active: false, managedCookieCount: 0 });
+      await world.reloadTab(tab);
+      expect(await world.readLoginWitness(tab)).toBe("signed-out");
+      expect(await world.signedInSites()).toEqual([]);
+      return Date.now() - changedAt;
+    }, {
+      within: 10_000,
+      until: (elapsed) => elapsed >= 6_000,
+      label: "the forgotten login stays absent beyond watcher and poll intervals",
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fix two regressions introduced by #4452:

- Chrome-family login sync supplied a Keychain service name to the account-name filter. Use `security find-generic-password -w -s <service>` so normal macOS Safe Storage entries resolve. Preview still never requests a password.
- Disconnect/forget, Stop Site, or Pause during a pending cookie write could lose track of newly installed cookies. Record each successful native write before checking cancellation, so subsequent forgetting removes those cookies while leaving unrelated cookies untouched. Failed and unattempted writes do not become owned.
- Rebase onto current `dev` and explicitly type the deferred write resolver in the existing regression test. This fixes the Electron typecheck failure without changing runtime behavior or weakening the cancellation assertions.

## Verification: Incomplete

Current head: `3dd7a41b7b020d8fce4a9bce177a3f9220e90a55`.
Rebased onto `dev`: `3f9bced07f93104afa8fbb8928c645708a603bac`.
Both feature commits have verified signatures.

### Passed On The Current Head

Environment: Node `24.11.1`, repository-pinned pnpm `11.4.0`.

- `pnpm --filter @openwork/desktop typecheck:electron`: exit 0. Before the resolver annotation, the same command reproduced TS2722 at the deferred callback invocation.
- `node --test apps/desktop/electron/browser-login-sync.test.mjs`: exit 0; 16 passed, 0 failed, 0 skipped. Includes successful and failed pending writes during disconnect, Stop Site, and pause; cancellation prevents later writes, forgetting removes installed cookies, and unrelated cookies remain unchanged.
- `git diff --check origin/dev...HEAD`: exit 0.

### Historical Journey Evidence

The [published browser-login-sync journey](https://github.com/different-ai/openwork/pull/4597#issuecomment-5564875963) passed on `f395ff1db291b41e2440d796d46d11e9ca420dfa`: 1 passed, 0 failed, 0 skipped; `placement: daytona (daytona CLI authenticated)`.
It covered synchronization, pause/resume, actual page sign-out after disconnect/forget, and no login restoration after later source changes. That evidence is historical after this rebase and does not establish a passing verdict for the current head.

### Missing / Deferred

- No exact-head cold-boot journey was rerun. The colocated tests and typecheck above are supporting checks, not replacement journey evidence.
- Real macOS Keychain prompts and Chrome encrypted-cookie integration remain unverified. Tests use synthetic profiles and a stubbed Keychain; no real browser profile or Keychain was read.
- Broader cross-platform verification remains deferred.

Owning journey to rerun on the current head:

```sh
OPENWORK_EVAL_REF=$(git rev-parse HEAD) pnpm evals:e2e browser-login-sync
```

For manual macOS verification, use a disposable Chrome profile and a non-sensitive test site. Confirm sign-in, disconnect and forget, then confirm sign-out persists after source changes and unselected-site cookies remain unchanged.

No release, deployment, or merge is included.
