### PR TITLE
fix(analytics): prevent refresh from dropping paginated tasks

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/models-analytics-panel.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/models-analytics-panel.tsx
@@ -116,7 +116,6 @@ export function ModelsAnalyticsPanel() {
   const [tab, setTab] = useState<Tab>("Activity");
   const [days, setDays] = useState(30);
   const [selected, setSelected] = useState<Activity | null>(null);
-  const [extra, setExtra] = useState<Activity | null>(null);
   const [mutating, setMutating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [groupBy, setGroupBy] = useState("model");
@@ -129,6 +128,10 @@ export function ModelsAnalyticsPanel() {
     },
   });
   const activity = dataQuery.data?.activity;
+  const [pagination, setPagination] = useState<{ firstPage: Activity | undefined; extra: Activity | null }>({ firstPage: activity, extra: null });
+  // Reset before committing a new first page, never mixing old and new cursors.
+  if (pagination.firstPage !== activity) setPagination({ firstPage: activity, extra: null });
+  const extra = pagination.firstPage === activity ? pagination.extra : null;
   const consumption = dataQuery.data?.consumption;
   const busy = mutating || dataQuery.isFetching;
   const loading = !dataQuery.data && dataQuery.isPending;
@@ -144,7 +147,7 @@ export function ModelsAnalyticsPanel() {
         await queryClient.cancelQueries({ queryKey: [...key, "data"] });
         queryClient.removeQueries({ queryKey: [...key, "data"] });
         queryClient.setQueryData(settingsKey, updated);
-        setSelected(null); setExtra(null);
+        setSelected(null); setPagination({ firstPage: undefined, extra: null });
       });
     } catch (error) { setError(error instanceof Error ? error.message : "Could not save your choice."); }
     finally { setMutating(false); }
@@ -164,7 +167,10 @@ export function ModelsAnalyticsPanel() {
       const query = new URLSearchParams({ days: String(days), ...cursor, ...(first ? { memberId: first.memberId, sessionId: first.sessionId, taskId: first.taskId } : {}) });
       const next = modelsAnalyticsActivitySchema.parse(await request(`activity?${query}`));
       if (selected) setSelected({ events: [...selected.events, ...next.events], next: next.next });
-      else setExtra({ events: [...(extra?.events ?? []), ...next.events], next: next.next });
+      // A poll may have replaced the pagination state while this request waited.
+      else setPagination((current) => current === pagination ? {
+        ...current, extra: { events: [...(extra?.events ?? []), ...next.events], next: next.next },
+      } : current);
     } catch (error) { setError(error instanceof Error ? error.message : "Could not load more activity."); }
     finally { setMutating(false); }
   }
@@ -224,7 +230,7 @@ export function ModelsAnalyticsPanel() {
       {tab !== "Integrations" ? <>
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-wrap items-center gap-3">
-            <DenSelect aria-label="Analytics period" className="h-9 w-40" value={String(days)} onChange={(event) => { setDays(Number(event.target.value)); setExtra(null); setSelected(null); }}>
+            <DenSelect aria-label="Analytics period" className="h-9 w-40" value={String(days)} onChange={(event) => { setDays(Number(event.target.value)); setPagination({ firstPage: undefined, extra: null }); setSelected(null); }}>
               <option value="7">Last 7 days</option><option value="30">Last 30 days</option><option value="90">Last 90 days</option>
             </DenSelect>
             {tab === "Consumption" ? <DenSelect aria-label="Group consumption by" className="h-9 w-40" value={groupBy} onChange={(event) => setGroupBy(event.target.value)}>
@@ -232,7 +238,7 @@ export function ModelsAnalyticsPanel() {
             </DenSelect> : null}
           </div>
           <div className="flex items-center gap-3"><span className="text-xs text-[#637291]">Updates automatically</span>
-            <DenButton variant="secondary" size="sm" disabled={busy} onClick={() => { setExtra(null); void dataQuery.refetch(); }}><RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${dataQuery.isFetching ? "animate-spin" : ""}`} aria-hidden="true" />Refresh analytics</DenButton>
+            <DenButton variant="secondary" size="sm" disabled={busy} onClick={() => void dataQuery.refetch()}><RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${dataQuery.isFetching ? "animate-spin" : ""}`} aria-hidden="true" />Refresh analytics</DenButton>
           </div>
         </div>
         {!dataQuery.isError || dataQuery.data ? <div className="grid gap-3.5 sm:grid-cols-2 lg:grid-cols-4">

--- a/evals/packages/env/src/den.ts
+++ b/evals/packages/env/src/den.ts
@@ -765,7 +765,7 @@ export async function server(options: ServerOptions): Promise<Den> {
     throw new Error("Local Den requires MySQL on 127.0.0.1:3306. Run: pnpm dev:den:mysql");
   }
   if (!await localRedisIsRunning()) {
-    throw new Error("Local Den requires Redis on 127.0.0.1:6379. Run: redis-server --port 6379 --daemonize yes --save '' --appendonly no");
+    throw new Error("Local Den requires Redis at DATABASE_REDIS_URL or redis://127.0.0.1:6379. Start an isolated Redis and configure DATABASE_REDIS_URL.");
   }
 
   const bootedMocks = await bootLocalMocks(options.place, options.mocks ?? {});

--- a/evals/packages/env/src/place.ts
+++ b/evals/packages/env/src/place.ts
@@ -101,7 +101,8 @@ export async function localMysqlIsRunning(): Promise<boolean> {
  * sign-in instead of failing, so local lanes gate on it the way they gate MySQL.
  */
 export async function localRedisIsRunning(): Promise<boolean> {
-  return canConnect(6379, "127.0.0.1");
+  const url = new URL(process.env.DATABASE_REDIS_URL?.trim() || "redis://127.0.0.1:6379");
+  return canConnect(url.port ? Number(url.port) : 6379, url.hostname);
 }
 
 class LocalPlace implements Place {

--- a/evals/packages/labs/src/models-analytics-fixture.mjs
+++ b/evals/packages/labs/src/models-analytics-fixture.mjs
@@ -35,6 +35,23 @@ async function arrange(command, orgId, inferenceUrl) {
     else if (command === "resume-analytics") {
         await db.execute(sql.raw("RENAME TABLE models_analytics_event_unavailable TO models_analytics_event"));
     }
+    else if (command === "pagination" || command === "pagination-newest") {
+        const [settings] = await db.select().from(schema.ModelsAnalyticsSettingsTable).where(eq(schema.ModelsAnalyticsSettingsTable.org_id, id));
+        if (!settings?.enabled || !settings.consented_by) throw new Error("Pagination needs an opted-in fixture member");
+        const now = Date.now();
+        await db.insert(schema.ModelsAnalyticsEventTable).values(Array.from({ length: command === "pagination" ? 400 : 1 }, (_, index) => {
+            const suffix = command === "pagination" ? String(index + 1) : "newest";
+            const eventId = `pagination-${suffix}`;
+            const timestamp = new Date(now - index);
+            const event = { id: eventId, type: "model.call", timestamp: timestamp.toISOString(), sessionId: "pagination",
+                taskId: eventId, model: `pagination-model-${suffix}`, status: "completed", usageComplete: false };
+            return {
+                id: createHash("sha256").update(JSON.stringify([id, settings.consented_by, "inference", eventId])).digest("hex"),
+                event_id: eventId, org_id: id, member_id: settings.consented_by, source: "inference", type: event.type,
+                timestamp, session_id: event.sessionId, task_id: event.taskId, model: event.model, usage_complete: false, payload: event,
+            };
+        }));
+    }
     else if (command === "subscription") {
         await db.insert(schema.OrgSubscriptionTable).values({
             id: createDenTypeId("orgSubscription"), organization_id: id, type: "inference", status: "active",

--- a/evals/specs/models-analytics-upgrade.e2e.test.ts
+++ b/evals/specs/models-analytics-upgrade.e2e.test.ts
@@ -293,6 +293,53 @@ test("an existing Models subscriber can decline, enable and disable task analyti
   expect(afterOptOut.some((request) => request.method === "POST" && request.path.endsWith("/inference/analytics/events"))).toBe(false);
   await user.on(app).see({ text: "Keep working after turning off task analytics." });
   evidence.recordAssertionEvidence("Turning analytics off leaves the existing desktop conversation and selected model usable", "A new assistant reply arrived from the same selected model after disable; the independent HTTP witness observed no task-event uploads across opt-out, re-enable and 40 seconds of background reporting, the disabled-period task was absent, and the earlier conversation was still visible", true);
+  await world.seedPagination();
+  await webUser.reload();
+  await webUser.see({ text: "pagination-model-200" }, { timeoutMs: 60_000 });
+  {
+  const firstPage = record((await probe.api(world.den.admin, "/v1/inference/analytics/activity?days=30")).body);
+  expect(list(firstPage.events).at(-1)).toMatchObject({ id: "pagination-200" });
+  const oldCursor = record(firstPage.next).beforeId;
+  if (typeof oldCursor !== "string") throw new Error("Expected the first activity cursor");
+  await using latePage = await world.holdActivityPage(oldCursor);
+  await webUser.click({ role: "button", label: "Load more activity" });
+  expect(await probe.eventually(() => latePage.read(), {
+    within: 10_000, label: "the old activity page body is held", until: (state) => state.held,
+  })).toMatchObject({ cursors: [oldCursor], status: 200, delivered: false, expired: false });
+
+  await world.seedPagination(true);
+  // Refresh while Load more is still pending, not after its old page has rendered.
+  await webUser.see({ text: "pagination-model-newest" }, { timeoutMs: 45_000 });
+  const refreshed = record((await probe.api(world.den.admin, "/v1/inference/analytics/activity?days=30")).body);
+  expect(list(refreshed.events).at(-1)).toMatchObject({ id: "pagination-199" });
+  const freshCursor = record(refreshed.next).beforeId;
+  expect(freshCursor).not.toBe(oldCursor);
+  expect(await latePage.read()).toMatchObject({ held: true, delivered: false, expired: false });
+  await latePage.release();
+  // The enabled refresh button witnesses more() finishing and React committing its result.
+  await probe.eventually(() => probe.on(world.web).dom('[data-testid="models-task-analytics"] button:not(:disabled)'), {
+    within: 10_000, label: "the late page finishes in the refreshed view",
+    until: (snapshot) => snapshot.elements.some((element) => element.text === "Refresh analytics"),
+  });
+  expect(await latePage.read()).toMatchObject({ delivered: true, expired: false });
+  await webUser.see({ text: "pagination-model-newest" });
+  await webUser.see({ text: "pagination-model-199" });
+  await webUser.notSee({ text: "pagination-model-200" });
+  await webUser.notSee({ text: "pagination-model-400" });
+  expect((await probe.on(world.web).text()).match(/\bpagination-model-(?:\d+|newest)\b/g)).toHaveLength(200);
+  await webUser.click({ role: "button", label: "Load more activity" });
+  await webUser.see({ text: "pagination-model-200" });
+  await webUser.see({ text: "pagination-model-399" });
+  await webUser.notSee({ text: "pagination-model-400" });
+  expect((await latePage.read()).cursors).toEqual([oldCursor, freshCursor]);
+  await webUser.click({ role: "button", label: "Load more activity" });
+  await webUser.see({ text: "pagination-model-400" });
+  await webUser.notSee({ role: "button", label: "Load more activity" });
+  const seenModels = (await probe.on(world.web).text()).match(/\bpagination-model-(?:\d+|newest)\b/g);
+  expect(seenModels).toHaveLength(401);
+  expect(new Set(seenModels).size).toBe(401);
+  evidence.recordAssertionEvidence("Refreshing model activity rejects a late old page and preserves a complete traversal", "The real page after task 200 was held while a newer event triggered automatic refresh. After releasing the old body and observing completion, only the refreshed 200 rows remained, with no stale tasks 200 or 400. The next UI request used the refreshed cursor, recovered task 200 through 399, and the final page reached 400. All 401 fixture tasks appeared exactly once, with no further page available.", true);
+  }
   expect((await api("/v1/org", { method: "DELETE" })).response.status).toBe(200);
   await world.verifyErasure();
   evidence.recordAssertionEvidence("Deleting a workspace erases its task analytics and stored export credentials", "Workspace deletion returned 200; an independent data-store witness found no retained history or analytics configuration", true);

--- a/evals/worlds/models-analytics.ts
+++ b/evals/worlds/models-analytics.ts
@@ -2,10 +2,20 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { allocateFreePort } from "@openwork/cdp";
+import { allocateFreePort, browserScript, evaluate } from "@openwork/cdp";
 import { provisionOrg } from "@openwork/behaviors";
 import { createDaytonaHost, defaultDaytonaExec, execInSandbox } from "@openwork/hosts";
 import type { Seed } from "@openwork/env";
+
+declare global {
+  interface Window {
+    __analyticsPageGate?: {
+      cursors: string[]; held: boolean; delivered: boolean; expired: boolean; status: number;
+      release(): void; restore(): void;
+    };
+  }
+}
+
 function modelsFixtureKey(memberId: string) { return `ow_inf_models-analytics-fixture-${memberId}`; }
 
 const root = fileURLToPath(new URL("../../", import.meta.url));
@@ -100,6 +110,7 @@ async function createModelsWorld(seed: Seed, analyticsUpgrade: boolean, usageSet
     fixtureKey: modelsFixtureKey,
     async upgradeAnalytics() { await arrange("migrate"); },
     async analyticsStoreUnavailable(unavailable: boolean) { await arrange(unavailable ? "pause-analytics" : "resume-analytics"); },
+    async seedPagination(newest = false) { await arrange(newest ? "pagination-newest" : "pagination"); },
     async anotherOrganization() { return provisionOrg(den.ref, {}); },
     async verifyErasure() { await arrange("assert-erased"); },
     async anotherSubscriber() {
@@ -172,7 +183,55 @@ async function createModelsWorld(seed: Seed, analyticsUpgrade: boolean, usageSet
 export async function modelsAnalyticsWorld(seed: Seed) {
   const world = await createModelsWorld(seed, true);
   const web = await seed.web({ den: world.den, signedInAs: world.den.admin, startPath: "/dashboard/inference", headless: true, viewport: { width: 1440, height: 1100 } });
-  return { ...world, web };
+  return { ...world, web,
+    async holdActivityPage(beforeId: string) {
+      await seed.evalIn(web, browserScript((beforeId) => {
+        if (window.__analyticsPageGate) throw new Error("An analytics page gate is already active");
+        const original = window.fetch;
+        const state: NonNullable<Window["__analyticsPageGate"]> = {
+          cursors: [], held: false, delivered: false, expired: false, status: 0,
+          release() {},
+          restore() { state.release(); window.fetch = original; delete window.__analyticsPageGate; },
+        };
+        window.__analyticsPageGate = state;
+        window.fetch = async (input, init) => {
+          const url = new URL(input instanceof Request ? input.url : String(input), location.href);
+          const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+          const cursor = method === "GET" && url.pathname.endsWith("/v1/inference/analytics/activity") ? url.searchParams.get("beforeId") : null;
+          if (cursor) state.cursors.push(cursor);
+          const response = await original.call(window, input, init);
+          if (cursor === beforeId && !state.held) {
+            const readText = response.text.bind(response);
+            // Deliver real headers, but hold the real body across the automatic refresh.
+            response.text = async () => {
+              const text = await readText();
+              state.status = response.status;
+              state.held = true;
+              await new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(() => { state.expired = true; reject(new Error("Analytics page gate timed out")); }, 60_000);
+                state.release = () => { clearTimeout(timer); resolve(); };
+              });
+              state.delivered = true;
+              return text;
+            };
+          }
+          return response;
+        };
+      }, [beforeId]));
+      return {
+        read: () => evaluate(web.client, () => {
+          if (!window.__analyticsPageGate) throw new Error("Analytics page gate lost its document");
+          const { cursors, held, delivered, expired, status } = window.__analyticsPageGate;
+          return { cursors, held, delivered, expired, status };
+        }),
+        release: () => seed.evalIn(web, () => {
+          if (!window.__analyticsPageGate?.held) throw new Error("No analytics page is held");
+          window.__analyticsPageGate.release();
+        }),
+        async [Symbol.asyncDispose]() { await seed.evalIn(web, () => window.__analyticsPageGate?.restore()); },
+      };
+    },
+  };
 }
 
 export async function modelsInferenceWorld(seed: Seed) {


### PR DESCRIPTION
## Summary

Fix a pagination regression introduced by #4580. A background refresh could replace the first page while retaining appended pages and a cursor from the old snapshot, hiding a boundary task.

- Bind appended pages to their first-page snapshot; reset stale pages and ignore late Load more responses from the previous state.
- Extend the existing analytics journey to hold a real page response across automatic refresh, release it, and check that it cannot append stale rows or replace the refreshed cursor. The subsequent traversal must contain all 401 fixture tasks exactly once.
- Make local Redis readiness honor the configured `DATABASE_REDIS_URL`, matching the service the isolated test actually uses rather than probing an unrelated default-port service.

Consent, filters, detail views, HTTPS-only export configuration, and private-address export protection remain unchanged.

## Verification — Incomplete

Current head: `35fadc0a6ac71042b23403475ba201eb6b05ddf6`.
Base: `8de555a5ab5efe7332f3589deed9e68f1124cdea`.
Both feature commits have verified signatures. No merge, release, or deployment is included.

### Current-head review

`pnpm warden:check` — exit 0 on the clean committed branch. Expected and completed: `diff-security-review`, `confidentiality-review`, and `spec-provenance-review`; all reported no findings. `desktop-den-sync-review` was not applicable to the changed paths. Six changed files and thirteen chunks were reviewed. HEAD and `origin/dev` matched the values above before and after review.

Review run: `143ad96f-2026-09-09T23-36-20-049Z`. No new finding IDs were emitted. Local review does not substitute for GitHub approval or runtime proof.

Existing finding **UWL-4QH**: the missing concurrent-response witness is implemented, but its runtime claim is not cleared. Clear when the exact-head journey reaches and passes the overlap and complete-traversal assertions.

### Local journey attempt — Failed before pagination

`pnpm evals:e2e models-analytics-upgrade --local`

Printed placement: `placement: local (--local)`.
Exit 1: **0 tests passed, 1 failed, 0 skipped**, with 13 assertion expectations passed before failure.

Tested source: `d73a56a42f632d3380171d6f6b785c1461f5fe54`, before the latest base-only rebase. This is a historical failed run, not current-head passing evidence.

The journey timed out waiting for `Connection verified.` at the Langfuse export step. Both requests returned HTTP 400: the local fixture supplies HTTP loopback while production intentionally requires HTTPS and rejects private destinations. The pagination assertions were not reached. No clean-control run was performed, so this is not classified as a proven pre-existing failure.

The run used disposable, separate-port MySQL and Redis with isolated state. Test processes, database, and containers were cleaned up. No production service or real model provider was used.

### Supporting checks and historical evidence

- Browser callback validation passed on the repair candidate: 800 callbacks, exit 0. This is static feedback, not runtime proof.
- Configured Redis readiness passed a dynamic-port reachable/unreachable check without probing the default port.
- Current-head whitespace and signature checks passed.
- The [earlier published journey](https://github.com/different-ai/openwork/pull/4598#issuecomment-5564876006) passed on `9e0a650b244b32814f8442693c941eca866fc185`, before these changes. It did not exercise the late in-flight response; it remains historical only.

### Remaining work

Repair the local HTTPS export witness without weakening HTTPS/SSRF protections, then rerun the covering journey on the final head and publish its complete assertion evidence. Warden approval, resolved review threads, and passing required checks must be rechecked on that same head. This PR is not claimed merge-ready.
