### PR TITLE
fix(den-web): simplify SSO handoff and add manual redirect

### DIFF
--- a/ee/apps/den-web/app/sso/[orgSlug]/page.tsx
+++ b/ee/apps/den-web/app/sso/[orgSlug]/page.tsx
@@ -10,6 +10,8 @@ export default function OrganizationSsoSignInPage() {
   const params = useParams<{ orgSlug: string }>();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
+  const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
   const orgSlug = typeof params?.orgSlug === "string" ? params.orgSlug : "";
 
   const callbackURL = useMemo(() => searchParams.get("callbackURL") || getSocialCallbackUrl(), [searchParams]);
@@ -18,6 +20,8 @@ export default function OrganizationSsoSignInPage() {
 
   useEffect(() => {
     let cancelled = false;
+    setError(null);
+    setRedirectUrl(null);
 
     void (async () => {
       try {
@@ -49,6 +53,7 @@ export default function OrganizationSsoSignInPage() {
         }
 
         if (!cancelled) {
+          setRedirectUrl(nextUrl);
           window.location.assign(nextUrl);
         }
       } catch (nextError) {
@@ -61,19 +66,29 @@ export default function OrganizationSsoSignInPage() {
     return () => {
       cancelled = true;
     };
-  }, [callbackURL, errorCallbackURL, loginHint, orgSlug]);
+  }, [callbackURL, errorCallbackURL, loginHint, orgSlug, attempt]);
 
   return (
     <DenStatusScreen
       title={error ? "We couldn’t sign you in" : "Signing you in"}
-      description={error ? "Return to sign in and try again, or contact your organization’s administrator." : "Taking you to your organization’s sign-in page."}
+      description={error ? "Try again, return to sign in, or contact your organization’s administrator." : "Redirecting you to your organisation’s identity provider"}
       status="Connecting to your identity provider…"
       error={error}
     >
+      {redirectUrl ? (
+        <p className="mt-6 text-[13px] text-[var(--dls-text-secondary)]">
+          If the page did not open, <a href={redirectUrl} className="font-medium text-[var(--dls-text-primary)] underline underline-offset-4">click here</a>.
+        </p>
+      ) : null}
       {error ? (
-        <Link href="/" className="mt-6 inline-flex h-10 items-center justify-center rounded-full border border-[var(--dls-border)] px-4 text-[13px] font-medium transition-colors hover:bg-[var(--dls-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dls-accent)]">
-          Back to sign in
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <button type="button" className="den-button-secondary mt-6" onClick={() => setAttempt((value) => value + 1)}>
+            Try again
+          </button>
+          <Link href="/" className="mt-6 inline-flex h-10 items-center justify-center rounded-full border border-[var(--dls-border)] px-4 text-[13px] font-medium transition-colors hover:bg-[var(--dls-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dls-accent)]">
+            Back to sign in
+          </Link>
+        </div>
       ) : null}
     </DenStatusScreen>
   );

--- a/ee/apps/den-web/app/sso/[orgSlug]/page.tsx
+++ b/ee/apps/den-web/app/sso/[orgSlug]/page.tsx
@@ -70,9 +70,8 @@ export default function OrganizationSsoSignInPage() {
 
   return (
     <DenStatusScreen
-      title={error ? "We couldn’t sign you in" : "Signing you in"}
-      description={error ? "Try again, return to sign in, or contact your organization’s administrator." : "Redirecting you to your organisation’s identity provider"}
-      status="Connecting to your identity provider…"
+      title={error ? "We couldn’t sign you in" : "Redirecting you to your organisation’s identity provider"}
+      description={error ? "Try again, return to sign in, or contact your organization’s administrator." : ""}
       error={error}
     >
       {redirectUrl ? (

--- a/evals/specs/sso-redirect-screen.e2e.test.ts
+++ b/evals/specs/sso-redirect-screen.e2e.test.ts
@@ -1,0 +1,146 @@
+import { expect } from "vitest";
+import { browserScript, server, test } from "@openwork/testkit";
+import { addInitScript, setViewport } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import { evalIn, waitFor } from "@openwork/behaviors";
+
+declare global {
+  interface Window {
+    ssoRequests: Array<{
+      url: string;
+      method: string;
+      credentials: RequestCredentials;
+      headers: Record<string, string>;
+      body: unknown;
+      reply(status: number, body: unknown): void;
+      fail(): void;
+    }>;
+  }
+}
+
+test("SSO handoff keeps the shared status screen and supports manual navigation and retry", { timeout: 600_000 }, async ({ place, evidence }) => {
+  await using den = await server({ place, provision: false });
+  await using browser = await chrome({ host: place.host(), startUrl: "about:blank", headless: true });
+  // Only the SSO endpoint is controlled. Next routing, runtime config, requestJson,
+  // page effects and the shared status component all run in the real Den app.
+  await using witness = await addInitScript(browser.client, () => {
+    window.ssoRequests = [];
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const request = new Request(input, init);
+      if (new URL(request.url).pathname !== "/api/auth/sign-in/sso") return originalFetch(input, init);
+      const body: unknown = JSON.parse(await request.text());
+      return new Promise<Response>((resolve, reject) => {
+        window.ssoRequests.push({
+          url: request.url, method: request.method, credentials: request.credentials,
+          headers: Object.fromEntries(request.headers), body,
+          reply: (status, payload) => resolve(new Response(typeof payload === "string" ? payload : JSON.stringify(payload), { status })),
+          fail: () => reject(new TypeError("Network unavailable")),
+        });
+        request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
+      });
+    };
+  });
+  const navigate = async (path: string) => {
+    await browser.client.send("Page.navigate", { url: new URL(path, den.ref.webUrl).toString() });
+  };
+  const pending = async () => {
+    await waitFor(browser, () => (window.ssoRequests?.length > 0 && Boolean(document.querySelector('[role="status"]'))), { timeoutMs: 90_000 });
+    expect(await evalIn(browser, () => (document.querySelector('main a, main button, [role="alert"]') === null))).toBe(true);
+    expect(await evalIn(browser, () => (document.querySelector("main")?.textContent))).toContain("Redirecting you to your organisation\u2019s identity provider");
+  };
+  const requestBody = (index: number) => evalIn(browser, browserScript((index) => (window.ssoRequests[index].body), [index]));
+  const reply = (index: number, status: number, body: unknown) => evalIn(browser, browserScript((index, status, body) => {
+    window.ssoRequests[index].reply(status, body);
+  }, [index, status, body]));
+  const expectError = async (message: string) => {
+    await waitFor(browser, () => Boolean(document.querySelector('[role="alert"]')), { timeoutMs: 10_000 });
+    expect(await evalIn(browser, () => (document.querySelector('[role="alert"]')?.textContent))).toBe(message);
+    expect(await evalIn(browser, () => (document.querySelector('[role="status"]') === null))).toBe(true);
+    expect(await evalIn(browser, () => ([...document.querySelectorAll("main a")].map((link) => link.textContent?.trim())))).toEqual(["Back to sign in"]);
+    expect(await evalIn(browser, () => (document.querySelector("main button")?.textContent?.trim()))).toBe("Try again");
+    expect(await evalIn(browser, () => location.hash)).toBe("");
+  };
+
+  await navigate("/sso/synthetic-team");
+  await pending();
+  const origin = new URL(den.ref.webUrl).origin;
+  expect(await requestBody(0)).toEqual({ organizationSlug: "synthetic-team", callbackURL: `${origin}/` });
+  expect(await evalIn(browser, () => {
+    const { url, method, credentials, headers } = window.ssoRequests[0];
+    return { url, method, credentials, headers };
+  })).toEqual({ url: `${origin}/api/auth/sign-in/sso`, method: "POST", credentials: "include", headers: { accept: "application/json", "content-type": "application/json" } });
+  expect(await evalIn(browser, () => (document.querySelector("main")?.textContent))).not.toMatch(/synthetic-team|org_/);
+  // Same-document navigation lets us exercise real location.assign and the real
+  // anchor default action while observing the fallback on the interim screen.
+  const destination = `${origin}/sso/synthetic-team#identity-provider`;
+  await reply(0, 200, { url: destination });
+  await waitFor(browser, () => (location.hash === "#identity-provider" && Boolean(document.querySelector("main a"))));
+  expect(await evalIn(browser, () => (document.querySelector<HTMLAnchorElement>("main a")?.href))).toBe(destination);
+  expect(await evalIn(browser, () => (document.querySelector("main a")?.parentElement?.textContent))).toBe("If the page did not open, click here.");
+  await evalIn(browser, () => {
+    history.replaceState(null, "", location.pathname);
+    document.querySelector<HTMLAnchorElement>("main a")?.click();
+  });
+  await waitFor(browser, () => location.hash === "#identity-provider");
+  expect(await evalIn(browser, () => window.ssoRequests.length)).toBe(1);
+  evidence.recordAssertionEvidence("Automatic and manual handoff", "The real page sends a credentialed SSO POST, never exposes internal organization identifiers, has no premature fallback, and both location.assign and the fallback anchor reach the returned URL without another request.", true);
+
+  const context = {
+    callbackURL: `${origin}/join-org?invite=synthetic-invite&desktopAuth=1`,
+    errorCallbackURL: `${origin}/?error=sso&webAuth=1`,
+    loginHint: "person+hint@openwork.test",
+  };
+  await navigate(`/sso/synthetic-team?${new URLSearchParams(context)}`);
+  await pending();
+  expect(await requestBody(0)).toEqual({ organizationSlug: "synthetic-team", ...context });
+  await reply(0, 403, { message: "Provider unavailable" });
+  await expectError("Provider unavailable");
+  await evalIn(browser, () => document.querySelector<HTMLButtonElement>("main button")?.click());
+  await waitFor(browser, () => (window.ssoRequests.length === 2 && !document.querySelector('[role="alert"]')));
+  await pending();
+  expect(await requestBody(1)).toEqual(await requestBody(0));
+  await reply(1, 200, { url: "#recovered" });
+  await waitFor(browser, () => (location.hash === "#recovered" && Boolean(document.querySelector("main a"))));
+  expect(await evalIn(browser, () => (document.querySelector('[role="alert"]') === null))).toBe(true);
+  expect(await evalIn(browser, () => document.querySelector("main a")?.getAttribute("href"))).toBe("#recovered");
+  evidence.recordAssertionEvidence("Retry preserves request context", "A provider error exposes retry and the existing sign-in link; retry removes the error and actions while pending, retains callbackURL/errorCallbackURL/loginHint exactly, and navigates to the new response URL.", true);
+
+  for (const failure of [
+    { status: 200, body: {}, message: "SSO sign-in started without a redirect URL." },
+    { status: 200, body: { url: 42 }, message: "SSO sign-in started without a redirect URL." },
+    { status: 502, body: "not json", message: "Failed to start SSO sign-in (502)." },
+  ]) {
+    await navigate("/sso/synthetic-team");
+    await pending();
+    await reply(0, failure.status, failure.body);
+    await expectError(failure.message);
+  }
+  await navigate("/sso/synthetic-team?desktopAuth=1&desktopScheme=openwork&webAuth=1&webAuthReturn=%2Fweb&invite=token&intent=models&mode=sign-in&unrelated=drop");
+  await pending();
+  expect(await requestBody(0)).toEqual({ organizationSlug: "synthetic-team", callbackURL: `${origin}/?mode=sign-in&desktopAuth=1&desktopScheme=openwork&webAuth=1&webAuthReturn=%2Fweb&invite=token&intent=models` });
+  await evalIn(browser, () => window.ssoRequests[0].fail());
+  await expectError("Network unavailable");
+  evidence.recordAssertionEvidence("Failure handling stays intact", "Missing/non-string redirect URLs, non-JSON error responses and network failures expose retry but no identity-provider link or navigation; the default callback retains supported handoff parameters only.", true);
+
+  const frame = () => evalIn(browser, () => {
+    const main = document.querySelector("main");
+    const card = main?.lastElementChild;
+    if (!main || !card) throw new Error("Status frame missing");
+    const bounds = card.getBoundingClientRect();
+    return { main: main.className, card: card.className, width: bounds.width, left: bounds.left, background: getComputedStyle(main).backgroundColor };
+  });
+  for (const width of [390, 1280]) {
+    await setViewport(browser, { width, height: 900, deviceScaleFactor: 1 });
+    await navigate("/sso/test/complete");
+    await waitFor(browser, () => document.querySelector("h1")?.textContent === "Authentication test finished", { timeoutMs: 90_000 });
+    const sharedFrame = await frame();
+    await navigate("/sso/synthetic-team");
+    await pending();
+    expect(await frame()).toEqual(sharedFrame);
+    await waitFor(browser, () => Boolean(document.querySelector<HTMLImageElement>('main img[src="/openwork-mark.svg"]')?.naturalWidth));
+    expect(await evalIn(browser, () => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    expect(await evalIn(browser, () => (document.querySelector('[data-testid="setup-frame"]') === null))).toBe(true);
+  }
+  evidence.recordAssertionEvidence("Current shared status frame", "At 390px and 1280px the real SSO page matches the existing SSO completion page's frame classes, width, position and background, loads the brand image and has no horizontal overflow. The login setup frame is not substituted.", true);
+});

--- a/evals/specs/sso-redirect-screen.e2e.test.ts
+++ b/evals/specs/sso-redirect-screen.e2e.test.ts
@@ -45,7 +45,7 @@ test("SSO handoff keeps the shared status screen and supports manual navigation 
     await browser.client.send("Page.navigate", { url: new URL(path, den.ref.webUrl).toString() });
   };
   const pending = async () => {
-    await waitFor(browser, () => (window.ssoRequests?.length > 0 && Boolean(document.querySelector('[role="status"]'))), { timeoutMs: 90_000 });
+    await waitFor(browser, () => (window.ssoRequests?.length > 0 && document.querySelector("h1")?.textContent === "Redirecting you to your organisation’s identity provider"), { timeoutMs: 90_000 });
     expect(await evalIn(browser, () => (document.querySelector('main a, main button, [role="alert"]') === null))).toBe(true);
     expect(await evalIn(browser, () => (document.querySelector("main")?.textContent))).toContain("Redirecting you to your organisation\u2019s identity provider");
   };
@@ -70,7 +70,7 @@ test("SSO handoff keeps the shared status screen and supports manual navigation 
     const { url, method, credentials, headers } = window.ssoRequests[0];
     return { url, method, credentials, headers };
   })).toEqual({ url: `${origin}/api/auth/sign-in/sso`, method: "POST", credentials: "include", headers: { accept: "application/json", "content-type": "application/json" } });
-  expect(await evalIn(browser, () => (document.querySelector("main")?.textContent))).not.toMatch(/synthetic-team|org_/);
+  expect(await evalIn(browser, () => (document.querySelector("main")?.textContent))).not.toMatch(/synthetic-team|org_|Enterprise SSO|Signing you in|Connecting to your identity provider/);
   // Same-document navigation lets us exercise real location.assign and the real
   // anchor default action while observing the fallback on the interim screen.
   const destination = `${origin}/sso/synthetic-team#identity-provider`;

--- a/evals/specs/sso-redirect-screen.e2e.test.ts
+++ b/evals/specs/sso-redirect-screen.e2e.test.ts
@@ -2,7 +2,7 @@ import { expect } from "vitest";
 import { browserScript, server, test } from "@openwork/testkit";
 import { addInitScript, setViewport } from "@openwork/cdp";
 import { chrome } from "@openwork/hosts";
-import { evalIn, waitFor } from "@openwork/behaviors";
+import { clickText, evalIn, waitFor } from "@openwork/behaviors";
 
 declare global {
   interface Window {
@@ -79,9 +79,10 @@ test("SSO handoff keeps the shared status screen and supports manual navigation 
   expect(await evalIn(browser, () => (document.querySelector<HTMLAnchorElement>("main a")?.href))).toBe(destination);
   expect(await evalIn(browser, () => (document.querySelector("main a")?.parentElement?.textContent))).toBe("If the page did not open, click here.");
   await evalIn(browser, () => {
-    history.replaceState(null, "", location.pathname);
-    document.querySelector<HTMLAnchorElement>("main a")?.click();
+    location.hash = "";
   });
+  await waitFor(browser, () => location.hash === "");
+  await clickText(browser, "click here");
   await waitFor(browser, () => location.hash === "#identity-provider");
   expect(await evalIn(browser, () => window.ssoRequests.length)).toBe(1);
   evidence.recordAssertionEvidence("Automatic and manual handoff", "The real page sends a credentialed SSO POST, never exposes internal organization identifiers, has no premature fallback, and both location.assign and the fallback anchor reach the returned URL without another request.", true);
@@ -96,7 +97,7 @@ test("SSO handoff keeps the shared status screen and supports manual navigation 
   expect(await requestBody(0)).toEqual({ organizationSlug: "synthetic-team", ...context });
   await reply(0, 403, { message: "Provider unavailable" });
   await expectError("Provider unavailable");
-  await evalIn(browser, () => document.querySelector<HTMLButtonElement>("main button")?.click());
+  await clickText(browser, "Try again");
   await waitFor(browser, () => (window.ssoRequests.length === 2 && !document.querySelector('[role="alert"]')));
   await pending();
   expect(await requestBody(1)).toEqual(await requestBody(0));


### PR DESCRIPTION
## Summary
- Use the current shared branded SSO status screen with only the requested redirect message.
- Add a direct identity-provider fallback link once the SSO endpoint returns its URL.
- Add retry after a failed request, retaining the existing Back to sign in link.
- Preserve current requestJson handling, callbackURL, errorCallbackURL, loginHint, automatic redirect, and all login/session behaviour. No backend changes.
- Rebased onto current dev; no unrelated older feature-branch commits included.

## Verification
Focused journey: **Passed**, on final head e78ddec9c942fe6c9fbf4106d95430a83f876836.
- Fresh cold-boot Daytona server and browser; 1 test passed, 0 failed, 0 skipped; all four assertion-evidence groups passed.
- Reproduce after push: pnpm evals:e2e sso-redirect-screen --daytona (unset server/sandbox reuse overrides).
- Covers automatic and manual navigation, error retry, retained sign-in parameters, failure handling, exact simplified copy, and shared responsive frame at 390px and 1280px.
- Uses a controlled SSO endpoint response in the real Den app; not an external IdP round trip.
- git diff origin/dev...HEAD --check: exit 0.

## Remaining validation
Overall verdict: **Incomplete**. Draft pending resolution/classification of broader eval browser/boundary/type checks that reported diagnostics outside the changed files. No clean-base control has established those as pre-existing. Focused journey evidence will be published in the PR comment.

## Functional impact
Only manual continuation and retry are new. Authentication policy, credential/session handling, callback destinations and successful automatic handoff are unchanged.