### PR TITLE
Fix desktop sign-in for users without an organization

### DIFF
--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -9,7 +9,7 @@ import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/exte
 import { jsonValidator, publicRoute, userSessionRoute } from "../../middleware/index.js"
 import { db } from "../../db.js"
 import { env, type DenOrgMode } from "../../env.js"
-import { resolveUserOrganizations } from "../../orgs.js"
+import { ensurePersonalOrganizationForUser, resolveUserOrganizations } from "../../orgs.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { enforceRateLimit } from "../../utils/rate-limit.js"
@@ -594,10 +594,20 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
     let organization: { id: string; slug: string; name: string } | null = null
     let organizationMetadata: string | null = null
     try {
-      const resolved = await resolveUserOrganizations({
-        userId: normalizeDenTypeId("user", exchange.user.id),
+      const userId = normalizeDenTypeId("user", exchange.user.id)
+      let resolved = await resolveUserOrganizations({
+        userId,
         activeOrganizationId: exchange.activeOrganizationId,
       })
+      // Bootstrap only an authenticated desktop handoff, not browser onboarding
+      // or membership in a managed single-org deployment.
+      if (env.orgMode === "multi_org" && resolved.orgs.length === 0) {
+        const organizationId = await ensurePersonalOrganizationForUser(userId)
+        resolved = await resolveUserOrganizations({
+          userId,
+          activeOrganizationId: organizationId,
+        })
+      }
       const activeOrg = resolved.orgs.find((org) => org.id === resolved.activeOrgId) ?? null
       organization = activeOrg ? { id: activeOrg.id, slug: activeOrg.slug, name: activeOrg.name } : null
       organizationMetadata = activeOrg?.metadata ?? null

--- a/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
+++ b/evals/specs/cross-server-handoff-atomic-commit.e2e.test.ts
@@ -3,6 +3,7 @@ import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, onTestFinished } from "vitest";
+import { denFetch, signIn } from "@openwork/behaviors";
 import {
   app,
   control,
@@ -287,6 +288,85 @@ test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(
         evidence.recordAssertionEvidence(
           "Restart restored the complete B enrollment",
           `After a relaunch, the app came back signed in to ${ORG_B} with the B credential and enrollment origin.`,
+          true,
+        );
+
+        const anonymous = await denFetch(denB.ref, "/v1/auth/desktop-handoff", {
+          method: "POST", body: JSON.stringify({}),
+        });
+        expect(anonymous.response.status).toBe(401);
+        const credentials = {
+          email: `handoff-no-org-${Date.now()}@openwork.test`,
+          name: "Personal Handoff",
+          password: "OpenWorkEval123!",
+        };
+        const signup = await denFetch(denB.ref, "/api/auth/sign-up/email", {
+          method: "POST",
+          body: JSON.stringify(credentials),
+        });
+        expect(signup.response.ok).toBe(true);
+        const newcomer = await signIn(denB.ref, credentials);
+        const headers = { authorization: `Bearer ${newcomer.token}` };
+        const before = await denFetch(newcomer, "/v1/me/orgs", { headers });
+        expect(before.response.ok).toBe(true);
+        expect(before.body).toMatchObject({ orgs: [], activeOrgId: null });
+        const invitation = await denFetch(denB.admin, "/v1/invitations", {
+          method: "POST",
+          headers: { authorization: `Bearer ${denB.admin.token}` },
+          body: JSON.stringify({ email: credentials.email, role: "member" }),
+        });
+        expect(invitation.response.ok).toBe(true);
+        const orgBefore = await denFetch(denB.admin, "/v1/org", {
+          headers: { authorization: `Bearer ${denB.admin.token}` },
+        });
+        expect(orgBefore.response.ok).toBe(true);
+        const adminBefore = await denFetch(denB.admin, "/v1/me/orgs", {
+          headers: { authorization: `Bearer ${denB.admin.token}` },
+        });
+        expect(adminBefore.response.ok).toBe(true);
+
+        let personalOrgId = "";
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const grant = await createDesktopHandoffGrant(newcomer);
+          await control(restarted, "auth.exchange-grant", {
+            grant, baseUrl: denB.ref.webUrl,
+          }, { timeoutMs: 60_000 });
+          const state = await eventually(() => readDenClientState(restarted), {
+            within: 60_000,
+            label: "org-less user enrolled with a personal organization",
+            until: (value) => value.authTokenPresent && Boolean(value.activeOrgId) && value.activeOrgId !== stateB.activeOrgId,
+          });
+          expect(state.activeOrgId).toBeTruthy();
+          if (attempt === 0) personalOrgId = state.activeOrgId ?? "";
+          expect(state.activeOrgId).toBe(personalOrgId);
+          const directory = await denFetch(newcomer, "/v1/me/orgs", { headers });
+          expect(directory.response.ok).toBe(true);
+          expect(directory.body).toMatchObject({
+            orgs: [{ id: personalOrgId, role: "owner", memberCount: 1 }],
+            activeOrgId: personalOrgId,
+          });
+          const replay = await denFetch(newcomer, "/v1/auth/desktop-handoff/exchange", {
+            method: "POST", body: JSON.stringify({ grant }),
+          });
+          expect(replay.response.status).toBe(404);
+        }
+        const adminAfter = await denFetch(denB.admin, "/v1/me/orgs", {
+          headers: { authorization: `Bearer ${denB.admin.token}` },
+        });
+        expect(adminAfter.response.ok).toBe(true);
+        expect(adminAfter.body).toEqual(adminBefore.body);
+        const orgAfter = await denFetch(denB.admin, "/v1/org", {
+          headers: { authorization: `Bearer ${denB.admin.token}` },
+        });
+        expect(orgAfter.response.ok).toBe(true);
+        expect(orgAfter.body).toEqual(orgBefore.body);
+        const denied = await denFetch(newcomer, "/v1/org", {
+          headers: { ...headers, "x-openwork-org-id": stateB.activeOrgId ?? "" },
+        });
+        expect(denied.response.status).toBe(404);
+        evidence.recordAssertionEvidence(
+          "An authenticated desktop handoff supplies a default owned organization only when membership is missing",
+          "The fresh account had no organizations before handoff; desktop sign-in resolved one owned organization, a second handoff reused it, consumed grants remained unusable, and the existing organization's memberships and pending invitation were unchanged. The newcomer could not access the invited organization without accepting.",
           true,
         );
       } finally {


### PR DESCRIPTION
## Summary
Authenticated desktop sign-in should not fail solely because the account has no organization. After validating the handoff grant, reuse the personal-organization bootstrap helper for multi-org accounts with zero memberships and return the resulting organization to the desktop.

Browser onboarding, existing organization selection, single-org deployments, and SSO/invite acceptance rules are unchanged. Extend the existing handoff journey with assertions for default ownership, repeat handoff reuse, anonymous rejection, grant replay rejection, and isolation from a pending invitation and existing memberships.

## Verification
**Verdict: Incomplete** at `f859fe78e6eaa0e7e89510b74a6af971ca0b73ef`.

- `bun test --conditions development ./ee/apps/den-api/test/desktop-handoff-public-url.test.ts`: 17 passed, 0 failed; exit 0.
- `bun test --conditions development ./ee/apps/den-api/test/handoff-exchange-cors.test.ts`: 3 passed, 0 failed; exit 0.
- `git diff --check origin/dev...HEAD`: passed.
- Commit signature verified as `G`; branch is based on refreshed `dev` at `5afbfcb49`.

<!-- test-evidence -->
### cross-server-handoff-atomic-commit: Incomplete
Command: `pnpm evals:e2e cross-server-handoff-atomic-commit`

Placement: `daytona (daytona CLI authenticated)`.
Result: 0 passed, 0 failed, 1 skipped; exit 2.
Skip reason: `needs local placement without OPENWORK_EVAL_DEN_API_URL`.

The journey skipped before provisioning resources. No local override or new infrastructure was used. The CLI receipt is `cli-run-1788817167596.json`; no completed ambient assertion evidence was produced for publication. The new runtime assertions remain unexecuted, and the focused checks above do not substitute for journey proof.

## Remaining Risk
Simultaneous first handoffs remain unverified. The reused bootstrap helper uses a check-then-create sequence without concurrency serialization, so concurrent requests may create duplicate default organizations. This change does not add concurrency hardening.