### PR TITLE
fix(landing): tidy footer wrapping and SOC 2 badge

### DIFF
--- a/ee/apps/landing/components/site-footer.tsx
+++ b/ee/apps/landing/components/site-footer.tsx
@@ -6,7 +6,7 @@ export function SiteFooter() {
   return (
     <footer className="pt-10 text-sm text-gray-500">
       <div className="flex flex-col items-start justify-between gap-6 border-t border-[var(--lp-border)] pt-10 md:flex-row md:items-center">
-        <div className="flex flex-col gap-2">
+        <div className="flex shrink-0 flex-col items-start gap-2">
           <div className="font-medium text-gray-800">Powered by</div>
           <a
             href="https://opencode.ai"
@@ -19,14 +19,14 @@ export function SiteFooter() {
           <Link
             href="/trust"
             aria-label="SOC 2 Type I — view Trust Center"
-            className="inline-flex items-center gap-1.5 rounded-full border border-[var(--lp-border)] px-2.5 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-800"
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[var(--lp-border)] px-2.5 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-800"
           >
-            <ShieldCheck className="h-3.5 w-3.5" />
+            <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
             SOC 2 Type I
           </Link>
         </div>
 
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-3 md:gap-x-8">
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-3 md:justify-end md:gap-x-8">
           <Link href="/docs" target="_blank" className="whitespace-nowrap transition-colors hover:text-gray-800">
             Docs
           </Link>

--- a/ee/apps/landing/components/site-footer.tsx
+++ b/ee/apps/landing/components/site-footer.tsx
@@ -5,28 +5,8 @@ import { OpenCodeLogo } from "./opencode-logo";
 export function SiteFooter() {
   return (
     <footer className="pt-10 text-sm text-gray-500">
-      <div className="flex flex-col items-start justify-between gap-6 border-t border-[var(--lp-border)] pt-10 md:flex-row md:items-center">
-        <div className="flex shrink-0 flex-col items-start gap-2">
-          <div className="font-medium text-gray-800">Powered by</div>
-          <a
-            href="https://opencode.ai"
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-3 text-gray-500 transition-colors hover:text-gray-800"
-          >
-            <OpenCodeLogo className="h-3 w-auto" />
-          </a>
-          <Link
-            href="/trust"
-            aria-label="SOC 2 Type I — view Trust Center"
-            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[var(--lp-border)] px-2.5 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-800"
-          >
-            <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
-            SOC 2 Type I
-          </Link>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-3 md:justify-end md:gap-x-8">
+      <div className="flex flex-col items-start gap-6 border-t border-[var(--lp-border)] pt-10">
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-3 md:gap-x-8">
           <Link href="/docs" target="_blank" className="whitespace-nowrap transition-colors hover:text-gray-800">
             Docs
           </Link>
@@ -66,6 +46,28 @@ export function SiteFooter() {
             Terms
           </Link>
           <div className="whitespace-nowrap">© 2026 Different AI</div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+          <div className="flex items-center gap-2 whitespace-nowrap text-xs">
+            <span>Powered by</span>
+            <a
+              href="https://opencode.ai"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center text-gray-500 transition-colors hover:text-gray-800"
+            >
+              <OpenCodeLogo className="h-3 w-auto" />
+            </a>
+          </div>
+          <Link
+            href="/trust"
+            aria-label="SOC 2 Type I — view Trust Center"
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[var(--lp-border)] px-2.5 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-800"
+          >
+            <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
+            SOC 2 Type I
+          </Link>
         </div>
       </div>
     </footer>

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -70,12 +70,26 @@ test("visitors can read the trust badge and access every footer link at responsi
       const bounds = footer.getBoundingClientRect();
       const iconBounds = icon.getBoundingClientRect();
       const links = [...footer.querySelectorAll("a")];
+      const brand = footer.querySelector('a[href="https://opencode.ai"]');
+      const poweredBy = brand?.parentElement?.querySelector("span");
+      if (!brand || !poweredBy) throw new Error("Powered by OpenCode missing");
+      const brandBounds = brand.getBoundingClientRect();
+      const poweredByBounds = poweredBy.getBoundingClientRect();
+      const badgeBounds = badge.getBoundingClientRect();
+      const linksBottom = Math.max(...links.filter((link) => link !== brand && link !== badge)
+        .map((link) => link.getBoundingClientRect().bottom));
       return {
         viewport: window.innerWidth,
         lines: lines.length,
         textVisible: lines.every((rect) => rect.width > 0 && rect.height > 0),
         iconWidth: iconBounds.width,
         iconHeight: iconBounds.height,
+        poweredBy: poweredBy.textContent,
+        brandInline: poweredByBounds.right <= brandBounds.left
+          && poweredByBounds.top < brandBounds.bottom && brandBounds.top < poweredByBounds.bottom,
+        brandRowBelowLinks: Math.min(poweredByBounds.top, brandBounds.top, badgeBounds.top) >= linksBottom,
+        badgeBesideBrand: badgeBounds.left >= brandBounds.right
+          && badgeBounds.top < brandBounds.bottom && brandBounds.top < badgeBounds.bottom,
         footerFits: bounds.left >= 0 && bounds.right <= window.innerWidth && footer.scrollWidth <= footer.clientWidth,
         contentFits: [...footer.querySelectorAll("*")].every((element) => {
           const rect = element.getBoundingClientRect();
@@ -91,13 +105,15 @@ test("visitors can read the trust badge and access every footer link at responsi
     expect(facts, `footer at ${width}px`).toMatchObject({
       viewport: width, lines: 1, textVisible: true, iconWidth: 14, iconHeight: 14,
       footerFits: true, contentFits: true, linksVisible: true,
+      poweredBy: "Powered by", brandInline: true, brandRowBelowLinks: true,
     });
+    if (width >= 768) expect(facts.badgeBesideBrand, `trust badge beside brand at ${width}px`).toBe(true);
     expect(facts.links).toEqual([
-      ["https://opencode.ai", ""], ["/trust", "SOC 2 Type I — view Trust Center"],
       ["/docs", "Docs"], ["/pricing", "Pricing"], ["/roadmap", "Roadmap"],
       ["/download", "Desktop"], ["https://app.openworklabs.com", "Cloud"],
       ["/dashboard", "Dashboard"], ["/enterprise", "Enterprise"], ["/contact", "Contact"],
       ["/trust", "Trust Center"], ["/privacy", "Privacy"], ["/terms", "Terms"],
+      ["https://opencode.ai", ""], ["/trust", "SOC 2 Type I — view Trust Center"],
     ]);
     evidence.recordAssertionEvidence(`Footer remains readable and complete at ${width}px`, JSON.stringify(facts), true);
   }

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { chrome } from "@openwork/hosts";
-import { evaluateOnSurface } from "@openwork/cdp";
+import { evaluateOnSurface, setViewport } from "@openwork/cdp";
 import { eventually, needs, test } from "@openwork/testkit";
 
 test("visitors see consistent monthly Team and Enterprise pricing", async ({ evidence }) => {
@@ -42,4 +42,63 @@ test("visitors see consistent monthly Team and Enterprise pricing", async ({ evi
   expect(guide).not.toContain("Team Starter");
   expect(guide).not.toContain("Enterprise — custom");
   evidence.recordAssertionEvidence("The public agent guide agrees with pricing", "Team $10/seat/month and Enterprise $40/user/month", true);
+});
+
+test("visitors can read the trust badge and access every footer link at responsive widths", async ({ evidence }) => {
+  needs({ env: ["OPENWORK_EVAL_LANDING_URL"] });
+  const origin = process.env.OPENWORK_EVAL_LANDING_URL;
+  await using browser = await chrome({ startUrl: `${origin}/pricing`, headless: true });
+  await eventually(() => evaluateOnSurface(browser, () => Boolean(document.querySelector("footer svg"))), {
+    within: 30_000,
+    until: Boolean,
+  });
+
+  for (const width of [320, 768, 1024, 1440]) {
+    await setViewport(browser, { width, height: 900, deviceScaleFactor: 1 });
+    const facts = await evaluateOnSurface(browser, async () => {
+      await document.fonts.ready;
+      const footer = document.querySelector("footer");
+      const badge = footer?.querySelector('a[aria-label^="SOC 2 Type I"]');
+      const icon = badge?.querySelector("svg");
+      if (!footer || !badge || !icon) throw new Error("Footer trust badge or shield missing");
+      const text = [...badge.childNodes].find((node) => node.nodeType === Node.TEXT_NODE && node.textContent?.includes("SOC 2 Type I"));
+      if (!text || !text.textContent) throw new Error("Trust badge text missing");
+      const range = document.createRange();
+      range.setStart(text, text.textContent.indexOf("SOC 2 Type I"));
+      range.setEnd(text, text.textContent.indexOf("SOC 2 Type I") + "SOC 2 Type I".length);
+      const lines = [...range.getClientRects()];
+      const bounds = footer.getBoundingClientRect();
+      const iconBounds = icon.getBoundingClientRect();
+      const links = [...footer.querySelectorAll("a")];
+      return {
+        viewport: window.innerWidth,
+        lines: lines.length,
+        textVisible: lines.every((rect) => rect.width > 0 && rect.height > 0),
+        iconWidth: iconBounds.width,
+        iconHeight: iconBounds.height,
+        footerFits: bounds.left >= 0 && bounds.right <= window.innerWidth && footer.scrollWidth <= footer.clientWidth,
+        contentFits: [...footer.querySelectorAll("*")].every((element) => {
+          const rect = element.getBoundingClientRect();
+          return rect.left >= bounds.left - 1 && rect.right <= bounds.right + 1;
+        }),
+        links: links.map((link) => [link.getAttribute("href"), link.getAttribute("aria-label") ?? link.textContent.trim()]),
+        linksVisible: links.every((link) => {
+          const rect = link.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0 && getComputedStyle(link).visibility === "visible";
+        }),
+      };
+    });
+    expect(facts, `footer at ${width}px`).toMatchObject({
+      viewport: width, lines: 1, textVisible: true, iconWidth: 14, iconHeight: 14,
+      footerFits: true, contentFits: true, linksVisible: true,
+    });
+    expect(facts.links).toEqual([
+      ["https://opencode.ai", ""], ["/trust", "SOC 2 Type I — view Trust Center"],
+      ["/docs", "Docs"], ["/pricing", "Pricing"], ["/roadmap", "Roadmap"],
+      ["/download", "Desktop"], ["https://app.openworklabs.com", "Cloud"],
+      ["/dashboard", "Dashboard"], ["/enterprise", "Enterprise"], ["/contact", "Contact"],
+      ["/trust", "Trust Center"], ["/privacy", "Privacy"], ["/terms", "Terms"],
+    ]);
+    evidence.recordAssertionEvidence(`Footer remains readable and complete at ${width}px`, JSON.stringify(facts), true);
+  }
 });


### PR DESCRIPTION
## Summary
- Put navigation links first, with a compact Powered by OpenCode row underneath.
- Place the SOC 2 Type I badge beside the branding, allowing natural wrapping on narrow screens.
- Keep the trust label on one line and shield full-sized; preserve all links and copy.

## Verification
Overall verdict: Incomplete (broader browser type-check and cold-start server verification remain unresolved).

Passed:
- Footer unit test: 1 passed.
- Exact-head browser journey at 252215a35: 2 passed, 0 failed, 0 skipped; exit 0.
- Command: OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:3107 pnpm evals:pr specs/landing-pricing.test.ts
- Fresh local Chrome instances; no placement line emitted, no --local override. Candidate Next server already running.
- Published footer evidence covers 320, 768, 1024, and 1440px: branding below links, inline Powered by OpenCode, adjacent badge at tablet/desktop widths, single-line trust label, full-size shield, no footer overflow, and all 13 links intact.
- git diff --check.

Incomplete / deferred:
- Broader browser checker reported implicit-any errors in cross-workspace-split-view.e2e.test.ts and worlds/session-shell.ts. Not reproduced on a clean control; not classified as pre-existing.
- Cold-start candidate server verification was not run.
- The sticky evidence comment contains the footer test; separate pricing assertion evidence is not retained there.
- No merge or production deployment performed.