### PR TITLE
fix(app): render the enterprise activation gate instead of a white screen

### DIFF
--- a/apps/app/src/react-app/shell/providers.test.tsx
+++ b/apps/app/src/react-app/shell/providers.test.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource react */
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toContain: (expected: string) => void;
+  toEqual: (expected: unknown) => void;
+  not: { toThrow: () => void };
+};
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DenAuthProvider } from "@/react-app/domains/cloud/den-auth-provider";
+import { DesktopUpdaterProvider } from "@/react-app/domains/settings/state/desktop-updater-provider";
+import { EnterpriseAwareAppProviders } from "./providers";
+
+// Mirrors ENTERPRISE_DESKTOP_DISTRIBUTION from the desktop shell: the flavor
+// that gates every feature behind Den activation.
+const ENTERPRISE_DISTRIBUTION = {
+  flavor: "enterprise",
+  appName: "OpenWork Enterprise",
+  appIdentifier: "com.differentai.openwork",
+  protocolScheme: "openwork",
+  requireSignin: true,
+  requireActivation: true,
+} as const;
+
+// Minimal browser stand-in: the renderer reads distribution from the preload
+// bridge and persists local prefs through localStorage. No gateway marker is
+// installed, so readDenBootstrapConfig falls back to its module default
+// (no enterpriseActivation) — exactly the pre-activation state.
+// Returns a restore function so the stub never leaks into other test files
+// sharing this bun test process.
+function installFakeWindow() {
+  const globals = globalThis as Record<string, unknown>;
+  const previousWindow = globals.window;
+  const storage = new Map<string, string>();
+  globals.window = {
+    __OPENWORK_ELECTRON__: { meta: { distribution: ENTERPRISE_DISTRIBUTION } },
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    location: { origin: "http://localhost:5173" },
+  };
+  return () => {
+    if (previousWindow === undefined) delete globals.window;
+    else globals.window = previousWindow;
+  };
+}
+
+// The real AppRoot-level consumer that renders before activation completes
+// (added in #4482). Its useUpdater() hook pulls in the full context chain the
+// pre-activation branch must provide.
+function UpdaterProbe() {
+  return (
+    <DesktopUpdaterProvider>
+      <div data-testid="updater-probe">updater-context-ok</div>
+    </DesktopUpdaterProvider>
+  );
+}
+
+describe("EnterpriseAwareAppProviders pre-activation branch", () => {
+  test("supports AppRoot-level updater consumers before enterprise activation", () => {
+    const restoreWindow = installFakeWindow();
+    try {
+      let markup = "";
+      expect(() => {
+        markup = renderToStaticMarkup(
+          // DenAuthProvider sits outside EnterpriseAwareAppProviders in the
+          // production AppProviders tree; mirror that nesting here.
+          <DenAuthProvider>
+            <EnterpriseAwareAppProviders>
+              <UpdaterProbe />
+            </EnterpriseAwareAppProviders>
+          </DenAuthProvider>,
+        );
+      }).not.toThrow();
+      expect(markup).toContain("updater-context-ok");
+    } finally {
+      restoreWindow();
+    }
+  });
+});

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -50,10 +50,19 @@ type AppProvidersProps = {
   children: ReactNode;
 };
 
-function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
+export function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
   const activationRequired = useEnterpriseActivationRequired();
   if (activationRequired) {
-    return <ConnectLinkProvider>{children}</ConnectLinkProvider>;
+    // Pre-activation children still include AppRoot-level consumers
+    // (DesktopUpdaterProvider since #4482) whose hooks read the local and
+    // desktop-config contexts, so those providers must stay mounted here too.
+    return (
+      <ConnectLinkProvider>
+        <DesktopConfigProvider>
+          <LocalProvider>{children}</LocalProvider>
+        </DesktopConfigProvider>
+      </ConnectLinkProvider>
+    );
   }
   return (
     <>

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -107,9 +107,17 @@ describe("enterprise desktop activation", () => {
   });
 
   test("keeps the branded connect-link activation consumer mounted before activation", () => {
-    expect(providersSource).toContain(
-      "return <ConnectLinkProvider>{children}</ConnectLinkProvider>;",
+    // The pre-activation branch keeps ConnectLinkProvider mounted (the branded
+    // connect-link consumer) and also provides the contexts AppRoot-level
+    // consumers need — DesktopUpdaterProvider's useUpdater() reads Local and
+    // DesktopConfig contexts before activation completes (#4482).
+    const activationBranch = providersSource.slice(
+      providersSource.indexOf("if (activationRequired)"),
+      providersSource.indexOf("<DesktopRuntimeBoot"),
     );
+    expect(activationBranch).toContain("<ConnectLinkProvider>");
+    expect(activationBranch).toContain("<DesktopConfigProvider>");
+    expect(activationBranch).toContain("<LocalProvider>");
     expect(connectConfirmDialogSource).toContain(
       "const trustedBrandUrl = transport ? claims?.brand.iconUrl ?? claims?.brand.logoUrl : null;",
     );


### PR DESCRIPTION
## Problem

Since #4482 mounted `DesktopUpdaterProvider` at the outermost AppRoot layer, its `useUpdater()` hook reads the `Local` and `DesktopConfig` contexts during render. The pre-activation branch of `EnterpriseAwareAppProviders` (#3185) mounts neither, so an enterprise build crashes with `Local context is missing` (then `useDesktopConfig must be used within a DesktopConfigProvider`) before the activation gate can render.

Result: **a blank white window on first launch of an unactivated enterprise install** — the activation page ("Link this app to your organization") never appears, with no ErrorBoundary to recover. Reproduced in dev via `OPENWORK_DESKTOP_DISTRIBUTION=enterprise pnpm dev`: `#root` stays empty and the CDP console shows the crash stack `useLocal → useUpdater → DesktopUpdaterProvider`.

## Fix

Mount `DesktopConfigProvider` and `LocalProvider` in the pre-activation branch of `EnterpriseAwareAppProviders` (`apps/app/src/react-app/shell/providers.tsx`), so AppRoot-level consumers keep working before activation. `ConnectLinkProvider` stays outermost, preserving the branded connect-link activation consumer from #3185.

## Testing

- New behaviour test `apps/app/src/react-app/shell/providers.test.tsx`: renders the **real** `DesktopUpdaterProvider` inside the pre-activation branch (TDD — watched it fail with both crash messages before the fix, pass after). The fake window stub is restored in `finally` so it never leaks into other test files.
- Updated the providers source-shape assertion in `apps/app/tests/enterprise-activation.test.ts` to the new contract (`ConnectLinkProvider` + `DesktopConfigProvider` + `LocalProvider` in the pre-activation branch); the branded connect-confirm-dialog assertion is unchanged.
- Full `apps/app` suite: **1345 pass / 8 fail, identical failure set to the pre-change baseline** (verified by stashing the change and diffing the failure lists — the 8 are pre-existing).
- `pnpm --filter @openwork/app typecheck`: clean.
- Runtime-verified in dev: the enterprise activation gate now renders fully (workspace-address input + Continue), instead of the white screen.
