### PR TITLE
fix(app): prevent fork discovery from pausing live conversations

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1108,74 +1108,143 @@ export function translateV2Event(
   return null;
 }
 
-async function* translateV2Events(
+function translateV2Events(
   response: Response,
   signal: AbortSignal | undefined,
   fetchSession: (sessionID: string, signal: AbortSignal) => Promise<Session | null>,
   directory?: string,
 ): AsyncGenerator<OpencodeEvent> {
-  if (!response.body) return;
-  const reader = response.body.getReader();
+  const reader = response.body?.getReader();
   const decoder = new TextDecoder();
   const state = createV2EventTranslationState();
   const discoveredForks = new Set<string>();
-  let buffer = "";
-  try {
-    while (!signal?.aborted) {
-      const chunk = await reader.read();
-      if (chunk.done) break;
-      buffer += decoder.decode(chunk.value, { stream: true });
-      const lines = buffer.split(/\r?\n/);
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        if (!line.startsWith("data:")) continue;
-        const text = line.slice("data:".length).trim();
-        if (!text) continue;
-        let event: unknown;
-        try {
-          event = JSON.parse(text);
-          if (typeof event === "string") event = JSON.parse(event);
-        } catch {
-          continue;
-        }
-        const eventDirectory = isRecord(event) ? readString(readRecord(event, "location") ?? {}, "directory") : undefined;
-        if (directory && (!eventDirectory || normalizeDirectoryPath(directory) !== normalizeDirectoryPath(eventDirectory))) continue;
-        if (isRecord(event) && event.type === "session.forked") {
-          const sessionID = readSessionID(eventProperties(event));
-          if (!sessionID || discoveredForks.has(sessionID)) continue;
-          // Fork events contain ancestry, not a session. In particular their
-          // parentID must not turn the new root conversation into a task child.
-          const timeout = AbortSignal.timeout(2_000);
-          const lookupSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
-          let onAbort = () => {};
-          const aborted = new Promise<null>((resolve) => {
-            onAbort = () => resolve(null);
-            lookupSignal.addEventListener("abort", onAbort, { once: true });
-            if (lookupSignal.aborted) onAbort();
-          });
-          try {
-            // Desktop IPC may not cancel its transport; still bound SSE delay.
-            const info = await Promise.race([fetchSession(sessionID, lookupSignal), aborted]);
-            if (lookupSignal.aborted || !info || info.id !== sessionID || !info.directory) continue;
-            if (eventDirectory && normalizeDirectoryPath(info.directory) !== normalizeDirectoryPath(eventDirectory)) continue;
-            discoveredForks.add(sessionID);
-            yield { type: "session.created", properties: { info } };
-          } catch {
-            // Deleted sessions and unavailable lookups must not end the SSE
-            // stream. A replay or the normal list refresh can discover it later.
-          } finally {
-            lookupSignal.removeEventListener("abort", onAbort);
-          }
-          continue;
-        }
-        const translated = translateV2Event(event, state);
-        if (!translated) continue;
-        for (const item of translated) yield item;
-      }
+  const lookups = new Map<string, AbortController>();
+  const discoveries: Session[] = [];
+  const reads: ({ chunk: ReadableStreamReadResult<Uint8Array> } | { error: unknown })[] = [];
+  let reading = false;
+  let ended = !reader;
+  let stopped = false;
+  let wake: (() => void) | undefined;
+  const notify = () => { wake?.(); wake = undefined; };
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    signal?.removeEventListener("abort", stop);
+    for (const lookup of lookups.values()) lookup.abort();
+    lookups.clear();
+    discoveries.length = 0;
+    reads.length = 0;
+    void reader?.cancel().catch(() => {});
+    reader?.releaseLock();
+    notify();
+  };
+  signal?.addEventListener("abort", stop, { once: true });
+  if (signal?.aborted) stop();
+
+  const discover = async (sessionID: string, eventDirectory: string | undefined) => {
+    const lookup = new AbortController();
+    lookups.set(sessionID, lookup);
+    const timeout = setTimeout(() => lookup.abort(), 2_000);
+    let onAbort = () => {};
+    const aborted = new Promise<null>((resolve) => {
+      onAbort = () => resolve(null);
+      lookup.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      // IPC may ignore cancellation; bound discovery without holding up SSE.
+      const info = await Promise.race([fetchSession(sessionID, lookup.signal), aborted]);
+      if (lookup.signal.aborted || !info || info.id !== sessionID || !info.directory) return;
+      if (eventDirectory && normalizeDirectoryPath(info.directory) !== normalizeDirectoryPath(eventDirectory)) return;
+      discoveredForks.add(sessionID);
+      discoveries.push(info);
+    } catch {
+      // A later replay can retry deleted sessions and unavailable lookups.
+    } finally {
+      clearTimeout(timeout);
+      lookup.signal.removeEventListener("abort", onAbort);
+      lookups.delete(sessionID);
+      notify();
     }
-  } finally {
-    reader.releaseLock();
-  }
+  };
+
+  let buffer = "";
+  const stream = (async function* (): AsyncGenerator<OpencodeEvent> {
+    try {
+      while (!stopped) {
+        const discovery = discoveries.shift();
+        if (discovery) { yield { type: "session.created", properties: { info: discovery } }; continue; }
+        const read = reads.shift();
+        if (!read) {
+          if (ended && lookups.size === 0) break;
+          if (!ended && !reading && reader) {
+            reading = true;
+            // One handler per read and one replaceable waiter, not a race that
+            // keeps attaching listeners to a held lookup on every SSE chunk.
+            void reader.read().then(
+              (chunk) => { if (!stopped) reads.push({ chunk }); notify(); },
+              (error: unknown) => { if (!stopped) reads.push({ error }); notify(); },
+            );
+          }
+          await new Promise<void>((resolve) => { wake = resolve; });
+          continue;
+        }
+        reading = false;
+        if ("error" in read) throw read.error;
+        const { chunk } = read;
+        if (chunk.done) { ended = true; continue; }
+        buffer += decoder.decode(chunk.value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (stopped) return;
+          if (!line.startsWith("data:")) continue;
+          const text = line.slice("data:".length).trim();
+          if (!text) continue;
+          let event: unknown;
+          try {
+            event = JSON.parse(text);
+            if (typeof event === "string") event = JSON.parse(event);
+          } catch {
+            continue;
+          }
+          const eventDirectory = isRecord(event) ? readString(readRecord(event, "location") ?? {}, "directory") : undefined;
+          if (directory && (!eventDirectory || normalizeDirectoryPath(directory) !== normalizeDirectoryPath(eventDirectory))) continue;
+          if (isRecord(event) && event.type === "session.forked") {
+            const sessionID = readSessionID(eventProperties(event));
+            if (!sessionID || discoveredForks.has(sessionID) || lookups.has(sessionID)) continue;
+            // Fork events contain ancestry, not a session. In particular their
+            // parentID must not turn the new root conversation into a task child.
+            void discover(sessionID, eventDirectory);
+            continue;
+          }
+          const translated = translateV2Event(event, state);
+          if (!translated) continue;
+          for (const item of translated) {
+            if (stopped) return;
+            if (item.type === "session.deleted") {
+              const sessionID = readString(item.properties, "sessionID");
+              if (sessionID) {
+                lookups.get(sessionID)?.abort();
+                // Neither a completed lookup nor a stale fork replay may
+                // recreate a session after its deletion has been emitted.
+                discoveredForks.add(sessionID);
+                const index = discoveries.findIndex((info) => info.id === sessionID);
+                if (index !== -1) discoveries.splice(index, 1);
+              }
+            }
+            yield item;
+          }
+        }
+      }
+    } finally {
+      stop();
+    }
+  })();
+  // Async-generator return normally queues behind next(), which may be waiting
+  // on a quiet SSE connection. Cancel first so it can enter its finally block.
+  const returnStream = stream.return.bind(stream);
+  stream.return = (value) => { stop(); return returnStream(value); };
+  return stream;
 }
 
 function createWebFetch(auth: { token?: string }): typeof globalThis.fetch {

--- a/apps/app/tests/opencode-v2-adapter.test.ts
+++ b/apps/app/tests/opencode-v2-adapter.test.ts
@@ -160,6 +160,22 @@ function jsonResponse(value: unknown, status = 200): Response {
   });
 }
 
+function eventStream() {
+  let send = (..._events: unknown[]) => {};
+  let close = () => {};
+  let fail = (_error: Error) => {};
+  let cancelled = false;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      send = (...events) => controller.enqueue(new TextEncoder().encode(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")));
+      close = () => controller.close();
+      fail = (error) => controller.error(error);
+    },
+    cancel() { cancelled = true; },
+  });
+  return { response: new Response(body), send, close, fail, body, get cancelled() { return cancelled; } };
+}
+
 describe("OpenCode v2 event translation", () => {
   test("renders an admitted user message before execution using its persisted identity", () => {
     const state = createV2EventTranslationState();
@@ -1149,11 +1165,11 @@ describe("OpenCode v2 client compatibility", () => {
       const received = [];
       for await (const event of subscription.stream) received.push(event);
       expect(received).toHaveLength(2);
-      expect(received[0]).toEqual({ type: "session.created", properties: { info: {
+      expect(received.find((event) => event.type === "session.created")).toEqual({ type: "session.created", properties: { info: {
         id: info.id, title: info.title, slug: info.slug, projectID: info.projectID,
         directory: info.location.directory, version: info.version, time: info.time,
       } } });
-      expect(received[1]?.type).toBe("permission.asked");
+      expect(received[0]?.type).toBe("permission.asked");
       expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
         ["GET", "/workspace/owned/opencode2/api/event"], ["GET", "/workspace/owned/opencode2/api/session/ses_fork"],
       ]);
@@ -1163,17 +1179,130 @@ describe("OpenCode v2 client compatibility", () => {
     } finally { globalThis.fetch = originalFetch; }
   });
 
+  test("held fork discovery does not block permission or text, wakes a waiting reader, and deduplicates replays", async () => {
+    const originalFetch = globalThis.fetch;
+    const source = eventStream();
+    const controller = new AbortController();
+    const lookup = Promise.withResolvers<Response>();
+    const requests: Request[] = [];
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.endsWith("/api/event")) return source.response;
+      requests.push(request);
+      return lookup.promise;
+    };
+    try {
+      const subscription = await createClientV2("http://opencode.test/opencode2", "/workspace", {}).event.subscribe({}, { signal: controller.signal });
+      source.send(nativeForkEvent);
+      source.send(nativeForkEvent);
+      source.send(capturedPermissionAsked);
+      const started = Date.now();
+      expect((await subscription.stream.next()).value?.type).toBe("permission.asked");
+      const data = { sessionID: "ses_other", assistantMessageID: "msg_other", ordinal: 0 };
+      source.send({ type: "session.text.started", location: { directory: "/workspace" }, data });
+      expect((await subscription.stream.next()).value?.type).toBe("message.updated");
+      expect((await subscription.stream.next()).value?.type).toBe("message.part.updated");
+      for (let index = 0; index < 100; index += 1) {
+        source.send({ type: "session.text.delta", location: { directory: "/workspace" }, data: { ...data, delta: "text" } });
+        expect((await subscription.stream.next()).value).toMatchObject({
+          type: "message.part.delta", properties: { sessionID: "ses_other", delta: "text" },
+        });
+      }
+      expect(Date.now() - started).toBeLessThan(1_000);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.signal.aborted).toBe(false);
+
+      const pending = subscription.stream.next();
+      await delay(0);
+      lookup.resolve(jsonResponse({ data: { id: "ses_fork", title: "Late fork", location: { directory: "/workspace" } } }));
+      expect((await pending).value).toMatchObject({
+        type: "session.created", properties: { info: { id: "ses_fork", title: "Late fork" } },
+      });
+      // Discovery must not discard the outstanding SSE read or refetch success.
+      source.send(nativeForkEvent);
+      source.send(capturedPermissionReplied);
+      expect((await subscription.stream.next()).value?.type).toBe("permission.replied");
+      expect(requests).toHaveLength(1);
+      await subscription.stream.return(undefined);
+      expect(source.cancelled).toBe(true);
+      expect(source.body.locked).toBe(false);
+    } finally {
+      controller.abort();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each(["pending", "queued"])("deletion discards %s fork discovery without affecting another lookup", async (phase) => {
+    const originalFetch = globalThis.fetch;
+    const source = eventStream();
+    const controller = new AbortController();
+    const lookup = Promise.withResolvers<Response>();
+    const otherLookup = Promise.withResolvers<Response>();
+    const requests: Request[] = [];
+    const info = { id: "ses_fork", title: "Deleted fork", location: { directory: "/workspace" } };
+    const deleted = {
+      type: "session.deleted", location: { directory: "/workspace" },
+      data: phase === "pending" ? { sessionID: "ses_fork" } : { info: { id: "ses_fork" } },
+    };
+    globalThis.fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.endsWith("/api/event")) return source.response;
+      requests.push(request);
+      if (request.url.endsWith("/api/session/ses_fork")) return lookup.promise;
+      if (request.url.endsWith("/api/session/ses_other")) return otherLookup.promise;
+      throw new Error(`Unexpected request: ${request.url}`);
+    };
+    try {
+      const subscription = await createClientV2("http://opencode.test/opencode2", "/workspace", {}).event.subscribe({}, { signal: controller.signal });
+      // One SSE chunk lets lookup completion queue while parsing is paused at
+      // the permission yield, before the matching deletion is translated.
+      source.send(
+        nativeForkEvent,
+        { ...nativeForkEvent, data: { ...nativeForkEvent.data, sessionID: "ses_other" } },
+        { ...deleted, location: { directory: "/other" } },
+        { ...deleted, location: undefined },
+        capturedPermissionAsked, deleted, capturedPermissionReplied,
+      );
+      expect((await subscription.stream.next()).value?.type).toBe("permission.asked");
+      expect(requests).toHaveLength(2);
+      expect(requests.every((request) => !request.signal.aborted)).toBe(true);
+      if (phase === "queued") {
+        lookup.resolve(jsonResponse({ data: info }));
+        await delay(0);
+      }
+      expect((await subscription.stream.next()).value).toMatchObject({
+        type: "session.deleted", properties: { sessionID: "ses_fork" },
+      });
+      if (phase === "pending") expect(requests[0]?.signal.aborted).toBe(true);
+      expect(requests[1]?.signal.aborted).toBe(false);
+      expect((await subscription.stream.next()).value?.type).toBe("permission.replied");
+      // The deleted lookup's transport ignores cancellation and returns stale
+      // metadata; only the unrelated fork may still be discovered.
+      lookup.resolve(jsonResponse({ data: info }));
+      otherLookup.resolve(jsonResponse({ data: { ...info, id: "ses_other", title: "Kept fork" } }));
+      expect((await subscription.stream.next()).value).toMatchObject({
+        type: "session.created", properties: { info: { id: "ses_other", title: "Kept fork" } },
+      });
+      source.send(nativeForkEvent, capturedPermissionAsked);
+      expect((await subscription.stream.next()).value?.type).toBe("permission.asked");
+      expect(requests).toHaveLength(2);
+      source.close();
+      expect(await subscription.stream.next()).toEqual({ done: true, value: undefined });
+      expect(source.body.locked).toBe(false);
+    } finally { controller.abort(); globalThis.fetch = originalFetch; }
+  });
+
   test.each(["deleted", "unavailable", "network", "missing", "wrong-id", "foreign", "unscoped", "timeout"])(
     "skips a %s fork lookup, continues the stream, and allows recovery on replay", async (failure) => {
       const originalFetch = globalThis.fetch;
+      const source = eventStream();
+      const controller = new AbortController();
       let lookups = 0;
       let lookupSignal: AbortSignal | undefined;
       const info = { id: "ses_fork", title: "Recovered fork", location: { directory: "/workspace" }, time: { created: 100, updated: 200 } };
       globalThis.fetch = async (input, init) => {
         const request = input instanceof Request ? input : new Request(input, init);
-        if (request.url.endsWith("/api/event")) return new Response(
-          [nativeForkEvent, capturedPermissionAsked, nativeForkEvent].map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
-        );
+        if (request.url.endsWith("/api/event")) return source.response;
         lookups += 1;
         if (lookups > 1) return jsonResponse({ data: info });
         lookupSignal = request.signal;
@@ -1189,39 +1318,63 @@ describe("OpenCode v2 client compatibility", () => {
       };
       try {
         const client = createClientV2("http://opencode.test/opencode2", "/workspace", {});
-        const subscription = await client.event.subscribe();
+        const subscription = await client.event.subscribe({}, { signal: controller.signal });
+        source.send(nativeForkEvent);
+        source.send(capturedPermissionAsked);
         const started = Date.now();
         expect((await subscription.stream.next()).value?.type).toBe("permission.asked");
-        expect(Date.now() - started).toBeLessThan(3_000);
-        if (failure === "timeout") expect(lookupSignal?.aborted).toBe(true);
+        expect(Date.now() - started).toBeLessThan(1_000);
+        if (failure === "timeout") {
+          expect(lookupSignal?.aborted).toBe(false);
+          await new Promise<void>((resolve) => lookupSignal?.addEventListener("abort", () => resolve(), { once: true }));
+          expect(Date.now() - started).toBeLessThan(3_000);
+        }
+        // Replay after failure has settled, not while the first lookup is live.
+        await delay(0);
+        source.send(nativeForkEvent);
         expect((await subscription.stream.next()).value).toMatchObject({
           type: "session.created", properties: { info: { id: info.id, title: info.title } },
         });
+        source.close();
         expect(await subscription.stream.next()).toEqual({ done: true, value: undefined });
+        expect(source.body.locked).toBe(false);
         expect(lookups).toBe(2);
-      } finally { globalThis.fetch = originalFetch; }
+      } finally { controller.abort(); globalThis.fetch = originalFetch; }
     },
   );
 
-  test("aborting a subscription cancels its fork lookup without emitting a session", async () => {
+  test.each(["abort", "return", "read error"])("%s cleans up a waiting subscription and its fork lookup without emitting a session", async (action) => {
     const originalFetch = globalThis.fetch;
     const controller = new AbortController();
+    const source = eventStream();
     const dispatched = Promise.withResolvers<Request>();
+    const lookup = Promise.withResolvers<Response>();
     globalThis.fetch = async (input, init) => {
       const request = input instanceof Request ? input : new Request(input, init);
-      if (request.url.endsWith("/api/event")) return new Response(`data: ${JSON.stringify(nativeForkEvent)}\n\n`);
+      if (request.url.endsWith("/api/event")) return source.response;
       dispatched.resolve(request);
-      return new Promise<Response>((_resolve, reject) => {
-        request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
-      });
+      return lookup.promise;
     };
     try {
       const subscription = await createClientV2("http://opencode.test/opencode2", "/workspace", {}).event.subscribe({}, { signal: controller.signal });
+      source.send(nativeForkEvent);
       const pending = subscription.stream.next();
       const request = await dispatched.promise;
-      controller.abort();
-      expect(await pending).toEqual({ done: true, value: undefined });
+      await delay(0);
+      if (action === "read error") {
+        const error = new Error("SSE read failed");
+        source.fail(error);
+        await expect(pending).rejects.toBe(error);
+      } else {
+        if (action === "abort") controller.abort();
+        else expect(await subscription.stream.return(undefined)).toEqual({ done: true, value: undefined });
+        expect(await pending).toEqual({ done: true, value: undefined });
+      }
       expect(request.signal.aborted).toBe(true);
+      expect(source.cancelled).toBe(action !== "read error");
+      expect(source.body.locked).toBe(false);
+      lookup.resolve(jsonResponse({ data: { id: "ses_fork", location: { directory: "/workspace" } } }));
+      expect(await subscription.stream.next()).toEqual({ done: true, value: undefined });
     } finally { controller.abort(); globalThis.fetch = originalFetch; }
   });
 

--- a/evals/specs/sidebar-external-session-visibility.e2e.test.ts
+++ b/evals/specs/sidebar-external-session-visibility.e2e.test.ts
@@ -156,7 +156,7 @@ test("sessions created outside the window appear in a non-selected workspace's s
   if (world.engine === "v2") {
     await step("an external native fork appears live without refetching or changing its source", async () => {
       await sleep(EMPTY_LIST_RETRY_SETTLE_MS);
-      await using requests = await world.observeSessionRequests(otherId);
+      await using requests = await world.observeSessionRequests(otherId, sessionIds(await world.route(), otherId));
       // Positive control: prove the witness sees the real desktop list transport.
       await agent.run("workspace.reload_sessions", { workspaceId: otherId });
       await probe.eventually(() => requests.snapshot().lists, {
@@ -169,7 +169,31 @@ test("sessions created outside the window appear in a non-selected workspace's s
       });
       const listsBeforeFork = requests.snapshot().lists;
       await using events = await world.observeWorkspaceEvents(otherId);
-      const fork = await world.forkSessionOutsideWindow(otherId, selectedId);
+      const unrelatedTitle = "External session while fork metadata is pending";
+      // Do not spend the hold window waiting for the source-history checks.
+      const [fork, unrelatedId] = await Promise.all([
+        world.forkSessionOutsideWindow(otherId, selectedId),
+        (async () => {
+          const held = await probe.eventually(() => requests.snapshot().held, {
+            within: 30_000, intervalMs: 10, label: "fork metadata GET held before creating an unrelated session",
+            until: (held) => held !== null,
+          });
+          expect(held?.pending).toBe(true);
+          const unrelatedId = await world.createSessionOutsideWindow(otherId, unrelatedTitle);
+          await user.see({ text: unrelatedTitle }, { timeoutMs: 1_500 });
+          const duringHold = await world.route();
+          const pending = requests.snapshot().held;
+          expect(pending?.pending).toBe(true);
+          expect(pending?.elapsedMs).toBeLessThan(1_500);
+          expect(sessionIds(duringHold, otherId)).toContain(unrelatedId);
+          expect(sessionIds(duringHold, otherId)).not.toContain(held?.sessionId);
+          expect(sessionIds(duringHold, homeId)).toEqual(homeSessionsBefore);
+          expect(duringHold.selectedWorkspaceId).toBe(otherId);
+          await requests.releaseMetadata();
+          return unrelatedId;
+        })(),
+      ]);
+      expect(requests.snapshot().held?.sessionId).toBe(fork.id);
       expect(fork.title).toBe(`${selectedTitle} (fork #1)`);
       expect(fork.sourceAfter).toEqual(fork.sourceBefore);
       const afterFork = await probe.eventually(() => world.route(), {
@@ -185,22 +209,31 @@ test("sessions created outside the window appear in a non-selected workspace's s
       await user.see({ text: selectedTitle });
       const nativeEvents = await probe.eventually(() => events.snapshot(), {
         within: 15_000, intervalMs: 250, label: "native fork event observed",
-        until: (text) => text.includes(fork.id),
+        until: (text) => text.includes(fork.id) && text.includes(unrelatedId),
       });
       const payloads = nativeEvents.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) => JSON.parse(line.slice(5)));
       expect(payloads).toEqual(expect.arrayContaining([expect.objectContaining({
         type: "session.forked", data: expect.objectContaining({ sessionID: fork.id, parentID: selectedId }),
       })]));
-      expect(payloads).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "session.created" })]));
+      // The only native creation is the unrelated session, never the fork.
+      expect(payloads.filter((event) => event.type === "session.created")).toEqual([
+        expect.objectContaining({ data: expect.objectContaining({ sessionID: unrelatedId }) }),
+      ]);
       await probe.eventually(() => requests.snapshot().reads, {
         within: 15_000, intervalMs: 250, label: "desktop fetches the fork session directly",
         until: (paths) => paths.some((path) => path.endsWith(`/api/session/${fork.id}`)),
       });
       await sleep(STALE_OBSERVATION_MS);
       expect(requests.snapshot().lists).toBe(listsBeforeFork);
+      expect(sessionIds(await world.route(), otherId).filter((id) => id === fork.id)).toHaveLength(1);
+      evidence.recordAssertionEvidence(
+        "an unrelated native session event reaches the sidebar before fork metadata completes",
+        "The unrelated session was created after CDP paused the fork's exact metadata GET. Its sidebar row became visible within 1500ms of that GET while it remained held, with no Network response, completion, or failure event; the fork was still absent. Releasing the lookup then surfaced the fork exactly once.",
+        true,
+      );
       evidence.recordAssertionEvidence(
         "external v2 forks appear once with the authoritative title, without refetching or changing the source or another workspace",
-        "A CDP request witness detected the deliberate session-list reload before the fork, then the direct GET for the fork with no additional list requests through visibility and a quiet window. The native stream emitted session.forked, not session.created. Its new identity appeared as a visible root conversation while the source metadata, exported history, source title, workspace selection, and other workspace list remained unchanged.",
+        "A CDP request witness detected the deliberate session-list reload before the fork, then the direct GET for the fork with no additional list requests through visibility and a quiet window. The native stream emitted session.forked for the fork and session.created only for the unrelated session. The fork's new identity appeared as a visible root conversation while the source metadata, exported history, source title, workspace selection, and other workspace list remained unchanged.",
         true,
       );
     });

--- a/evals/worlds/session-shell.ts
+++ b/evals/worlds/session-shell.ts
@@ -497,19 +497,45 @@ export async function externalSessionVisibility(seed: Seed) {
     other,
     homePath,
     engine: resolveEvalEngine(),
-    async observeSessionRequests(workspaceId: string) {
+    async observeSessionRequests(workspaceId: string, holdMetadataExcept?: readonly string[]) {
       const debuggerUrl = app.client.webSocketDebuggerUrl;
       if (!debuggerUrl) throw new Error("Session request witness needs a desktop CDP endpoint");
       const socket = new WebSocket(debuggerUrl);
       const ready = Promise.withResolvers<void>();
-      const requests: { method: string; path: string }[] = [];
+      const requests: { method: string; path: string; requestId: string; startedAt: number }[] = [];
       const prefixes = ["workspace", "w"].map((mount) => `/${mount}/${encodeURIComponent(workspaceId)}/opencode2/api/session`);
+      const ended = new Set<string>();
+      const commands = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>();
+      let nextCommandId = 2;
+      let held: { requestId: string; networkId: string; sessionId: string; startedAt: number } | undefined;
+      let released = false;
+      let holdTimeout: ReturnType<typeof setTimeout> | undefined;
       let failure: Error | undefined;
       let disposed = false;
+      const command = async (method: string, params = {}) => {
+        const id = nextCommandId++;
+        const result = Promise.withResolvers<void>();
+        commands.set(id, result);
+        const timeout = setTimeout(() => result.reject(new Error(`Session request witness timed out: ${method}`)), 15_000);
+        try {
+          socket.send(JSON.stringify({ id, method, params }));
+          await result.promise;
+        } finally {
+          clearTimeout(timeout);
+          commands.delete(id);
+        }
+      };
+      const releaseMetadata = async () => {
+        if (!held || released) return;
+        released = true;
+        clearTimeout(holdTimeout);
+        await command("Fetch.continueRequest", { requestId: held.requestId });
+      };
       const fail = () => {
         if (disposed) return;
         failure = new Error("Session request witness lost its CDP connection");
         ready.reject(failure);
+        for (const result of commands.values()) result.reject(failure);
       };
       const timeout = setTimeout(() => ready.reject(new Error("Session request witness did not become ready")), 15_000);
       socket.addEventListener("open", () => socket.send(JSON.stringify({ id: 1, method: "Network.enable" })));
@@ -522,17 +548,47 @@ export async function externalSessionVisibility(seed: Seed) {
           if (message.error) ready.reject(new Error("Session request witness could not enable Network events"));
           else ready.resolve();
         }
-        if (message.method !== "Network.requestWillBeSent" || !isRecord(message.params)) return;
+        const result = typeof message.id === "number" ? commands.get(message.id) : undefined;
+        if (result) {
+          if (message.error) result.reject(new Error(`Session request witness CDP command ${message.id} failed`));
+          else result.resolve();
+        }
+        if (!isRecord(message.params)) return;
+        if (["Network.responseReceived", "Network.loadingFinished", "Network.loadingFailed"].includes(String(message.method))
+          && typeof message.params.requestId === "string") ended.add(message.params.requestId);
+        if (message.method === "Fetch.requestPaused" && typeof message.params.requestId === "string") {
+          const request = message.params.request;
+          const networkId = message.params.networkId;
+          const network = requests.find((item) => item.requestId === networkId);
+          const prefix = network && prefixes.find((prefix) => network.path.startsWith(`${prefix}/`));
+          const sessionId = prefix && network?.path.slice(prefix.length + 1);
+          // One-shot hold; source reads and non-metadata traffic pass through.
+          if (!held && holdMetadataExcept && isRecord(request) && request.method === "GET"
+            && network && sessionId && !sessionId.includes("/") && !holdMetadataExcept.includes(decodeURIComponent(sessionId))) {
+            held = { requestId: message.params.requestId, networkId: network.requestId, sessionId: decodeURIComponent(sessionId), startedAt: network.startedAt };
+            // Fail closed at 1.5s, leaving headroom below the adapter's 2s abort.
+            holdTimeout = setTimeout(() => void releaseMetadata().catch((error: Error) => { failure = error; }),
+              Math.max(0, 1_500 - (performance.now() - held.startedAt)));
+          } else {
+            void command("Fetch.continueRequest", { requestId: message.params.requestId }).catch((error: Error) => { failure = error; });
+          }
+          return;
+        }
+        if (message.method !== "Network.requestWillBeSent") return;
         const request = message.params.request;
         if (!isRecord(request) || typeof request.url !== "string" || typeof request.method !== "string") return;
         const url = new URL(request.url);
         const path = url.pathname.replace(/\/+$/, "");
         if (url.origin !== serverUrl.origin || !prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))) return;
-        // Retain only method/path: headers and request bodies may contain secrets.
-        requests.push({ method: request.method, path });
+        if (typeof message.params.requestId !== "string") return;
+        // Retain only identity/timing/method/path, never headers or bodies.
+        requests.push({ method: request.method, path, requestId: message.params.requestId, startedAt: performance.now() });
       });
       try {
         await ready.promise;
+        if (holdMetadataExcept) await command("Fetch.enable", {
+          patterns: prefixes.map((prefix) => ({ urlPattern: `${serverUrl.origin}${prefix}/*`, requestStage: "Request" })),
+        });
       } catch (error) {
         disposed = true;
         socket.close();
@@ -546,11 +602,22 @@ export async function externalSessionVisibility(seed: Seed) {
           return {
             lists: requests.filter((request) => request.method === "GET" && prefixes.includes(request.path)).length,
             reads: requests.filter((request) => request.method === "GET").map((request) => request.path),
+            held: held ? {
+              sessionId: held.sessionId,
+              elapsedMs: performance.now() - held.startedAt,
+              pending: !released && !ended.has(held.networkId),
+            } : null,
           };
         },
+        releaseMetadata,
         async [Symbol.asyncDispose]() {
-          disposed = true;
-          socket.close();
+          clearTimeout(holdTimeout);
+          try {
+            if (holdMetadataExcept) await command("Fetch.disable");
+          } finally {
+            disposed = true;
+            socket.close();
+          }
         },
       };
     },


### PR DESCRIPTION
## Problem
The v2 external-fork discovery added in #4586 awaits session metadata inside the shared SSE parsing loop. A slow or unavailable lookup can pause unrelated text, permission prompts, and session events for up to two seconds per lookup.

## Change
- Resolve fork metadata outside the stream parser, retaining the two-second bound and workspace validation.
- Deduplicate pending/successful discoveries and deliver late metadata without waiting for another SSE chunk.
- Cancel on subscription shutdown and deletion; never resurrect a deleted session from a late response.
- Extend the existing external-session sidebar journey rather than add a new spec. It holds the real metadata request, observes an unrelated session appear while the fork is still pending, then releases the request and verifies exactly-once discovery and workspace isolation.

## Verification
Verdict: **Passed** for the focused runtime journey on `4244898a949d77ce8fd11d7919205575a7d7f152`.

- `pnpm_config_verify_deps_before_run=error pnpm exec bun test apps/app/tests/opencode-v2-adapter.test.ts`: exit 0; 64 passed, 0 failed; 468 assertions.
- `OPENWORK_EVAL_ENGINE=v2 OPENWORK_EVAL_REF=4244898a949d77ce8fd11d7919205575a7d7f152 pnpm evals:e2e sidebar-external-session-visibility`: exit 0; 1 passed, 0 failed, 0 skipped. Cold-booted the exact head. `placement: daytona (daytona CLI authenticated)`.
- Six recorded journey assertions passed; no pending judgments. Exact-head evidence is published separately below.
- `git diff --check`: passed.

Earlier validation attempts did not verify the change: an unpinned run hit the shell timeout, and an abbreviated-ref run failed the checkout gate. The full-SHA run above supersedes both.

Broader eval typecheck/channel-ratchet checks did not pass during authoring (including configured-library support for Promise.withResolvers and diagnostics outside the changed files); they are not claimed green or classified as pre-existing. Full cross-platform and v1 suites are deferred; v1 behavior is untouched.

## Scope
This fixes one concrete v2 event-delivery stall, not every possible cause of desktop slowness. Browser-policy request amplification and eager video loading remain separate investigations. No permission-policy changes.