### PR TITLE
Streamline first launch and complete onboarding before desktop return

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1578,7 +1578,8 @@ export function writeDenSettings(
     (previous.authToken ?? "") === authToken &&
     (previous.activeOrgId ?? "") === activeOrgId &&
     (previous.activeOrgSlug ?? "") === activeOrgSlug &&
-    (previous.activeOrgName ?? "") === activeOrgName
+    (previous.activeOrgName ?? "") === activeOrgName &&
+    (isDesktopRuntime() || window.localStorage.getItem(STORAGE_BASE_URL) === baseUrl)
   ) {
     return;
   }

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -16,6 +16,7 @@ import {
   denSessionUpdatedEvent,
 } from "../../app/lib/den-session-events";
 import { evalRelaunchDesktopApp } from "../../app/lib/desktop";
+import { isDesktopRuntime } from "../../app/lib/runtime-env";
 import { Button } from "../../components/ui/button";
 import { t } from "../../i18n";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
@@ -412,7 +413,7 @@ export function AppRoot() {
                 path="/welcome"
                 element={
                   <DevProfiler id="WelcomeRoute">
-                    <WelcomeRoute />
+                    {isDesktopRuntime() ? <Navigate to="/session" replace /> : <WelcomeRoute />}
                   </DevProfiler>
                 }
               />

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -26,7 +26,6 @@ import { createClient, unwrap } from "@/app/lib/opencode";
 import { createClientV2 } from "@/app/lib/opencode-v2-adapter";
 import { getNativeSession } from "@/app/lib/opencode-session-native";
 import { createOpenworkServerClient, OpenworkServerError, type OpenworkServerClient } from "@/app/lib/openwork-server";
-import { readDenBootstrapConfig } from "@/app/lib/den";
 import { isDesktopRuntime } from "@/app/lib/runtime-env";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
 import type { WorkspaceConnectionState } from "@/app/types";
@@ -950,18 +949,15 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     workspaces,
   ]);
 
-  // Redirect to /welcome when no workspaces exist and the user hasn't
-  // completed onboarding. Desktop only does this for the default hosted
-  // bootstrap; org-bound desktops should keep their sign-in gate instead.
+  // Desktop starts in the normal task UI; deployment sign-in and activation
+  // gates are owned by the app root. Keep the non-desktop welcome path.
   useEffect(() => {
+    if (isDesktopRuntime()) return;
     if (loading) return;
     if (workspaces.length > 0) return;
     if (local.prefs.hasCompletedOnboarding) return;
     if (denAuth.status === "checking") return;
     if (denAuth.isSignedIn) return;
-    if (isDesktopRuntime()) {
-      if (readDenBootstrapConfig().source !== "default") return;
-    }
     navigate("/welcome", { replace: true });
   }, [denAuth.isSignedIn, denAuth.status, loading, local.prefs.hasCompletedOnboarding, navigate, workspaces.length]);
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2853,6 +2853,14 @@ or use: pnpm dev:worktree`);
     // Electron see the same workspace list. Import the short-lived
     // Electron-only filename only when the shared file is missing.
     await workspaceStore.migrateLegacyElectronWorkspaceStateIfNeeded();
+    // Public first launch uses the same folder as the chat-first composer.
+    // Provision it before the renderer and runtime read the workspace list.
+    const firstLaunchWorkspaceFailure = DESKTOP_DISTRIBUTION.flavor === "public" && !bootstrapConfig.fromFile && !bootstrapConfig.requireSignin
+      ? await workspaceStore.bootstrapFirstLaunchWorkspace()
+      : null;
+    if (firstLaunchWorkspaceFailure) {
+      console.warn("[workspace] default folder unavailable; continuing without a workspace", firstLaunchWorkspaceFailure);
+    }
     // The UI-control bridge evaluates arbitrary JavaScript in the renderer, so
     // it stays down until the installation is activated. Otherwise it is a
     // local bypass of the pre-activation restriction.
@@ -2870,6 +2878,14 @@ or use: pnpm dev:worktree`);
 
     queueDeepLinks(forwardedDeepLinks(process.argv));
     const win = await createMainWindow();
+    if (firstLaunchWorkspaceFailure) {
+      runDetachedTask("show default workspace warning", () => dialog.showMessageBox(win, {
+        type: "warning",
+        message: "OpenWork could not prepare its default folder",
+        detail: `OpenWork is open without a workspace. Use Add workspace in the sidebar to choose another folder.\n\n${firstLaunchWorkspaceFailure.error}`,
+        buttons: ["Continue"],
+      }));
+    }
     if (process.platform === "linux" && !BLANK_SLATE_LAUNCH.enabled) {
       await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl);
     }

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -920,6 +920,29 @@ export function createWorkspaceStore({
     return writeWorkspaceState(next);
   }
 
+  async function bootstrapFirstLaunchWorkspace() {
+    const state = await readWorkspaceState();
+    // Recovery and an explicitly saved empty list both take precedence.
+    if (state.workspaces.length > 0 || existsSync(workspaceStatePath())) return null;
+    const home = process.env.OPENWORK_DEV_MODE === "1" && process.env.OPENWORK_DEV_SHARED_STATE !== "1"
+      ? path.join(app.getPath("userData"), "openwork-dev-data", "home")
+      : os.homedir();
+    const folderPath = await normalizeLocalWorkspacePath(path.join(home, "OpenWork Chat"));
+    try {
+      await createWorkspace({ folderPath });
+      return null;
+    } catch (error) {
+      // A blocked default folder is recoverable by choosing another folder.
+      // Never hide registry writes or unexpected initialization failures.
+      if (
+        !["EEXIST", "ENOTDIR", "EACCES", "EPERM", "EROFS"].includes(error?.code)
+        || typeof error.path !== "string"
+        || (error.path !== folderPath && !error.path.startsWith(`${folderPath}${path.sep}`))
+      ) throw error;
+      return { folderPath, error: error.message };
+    }
+  }
+
   async function listLocalWorkspacePaths() {
     return (await readWorkspaceState())
       .workspaces
@@ -977,7 +1000,9 @@ export function createWorkspaceStore({
       workspaceType: "local",
     });
     await mkdir(path.join(folderPath, ".opencode"), { recursive: true });
-    await writeWorkspaceOpenworkConfig(folderPath, defaultWorkspaceOpenworkConfig(folderPath, preset));
+    if (!(await pathExists(path.join(folderPath, ".opencode", "openwork.json")))) {
+      await writeWorkspaceOpenworkConfig(folderPath, defaultWorkspaceOpenworkConfig(folderPath, preset));
+    }
 
     return mutateWorkspaceState((state) => {
       const key = workspacePathKey(workspace);
@@ -1224,6 +1249,7 @@ export function createWorkspaceStore({
 
   return {
     addAuthorizedRoot,
+    bootstrapFirstLaunchWorkspace,
     createRemoteWorkspace,
     createWorkspace,
     clearDesktopBootstrapConfig,

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, realpath, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, realpath, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -93,6 +93,9 @@ test("recovers missing desktop workspace state from token store paths", async ()
     assert.equal(state.selectedId, state.workspaces[0].id);
     assert.equal(state.watchedId, state.workspaces[0].id);
 
+    await store.bootstrapFirstLaunchWorkspace();
+    assert.deepEqual((await store.readWorkspaceState()).workspaces, state.workspaces);
+
     const persisted = JSON.parse(await readFile(path.join(userData, "openwork-workspaces.json"), "utf8"));
     assert.equal(persisted.workspaces.length, 1);
     assert.equal(persisted.selectedWorkspaceId, state.workspaces[0].id);
@@ -170,6 +173,8 @@ test("keeps persisted empty desktop workspace state authoritative", async () => 
     const state = await store.readWorkspaceState();
     assert.deepEqual(state.workspaces, []);
     assert.equal(state.selectedId, "");
+    await store.bootstrapFirstLaunchWorkspace();
+    assert.deepEqual((await store.readWorkspaceState()).workspaces, []);
   } finally {
     restoreEnv("OPENWORK_SERVER_CONFIG", previous);
   }
@@ -215,7 +220,7 @@ test("prefers server config workspaces when desktop state is missing", async () 
   }
 });
 
-test("does not create a default workspace when desktop state is absent", async () => {
+test("first-launch bootstrap creates and selects the chat folder, but ordinary reads do not", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "openwork-workspace-store-"));
   const userData = path.join(root, "userData");
   const previousDevMode = process.env.OPENWORK_DEV_MODE;
@@ -232,11 +237,88 @@ test("does not create a default workspace when desktop state is absent", async (
 
     const state = await store.readWorkspaceState();
     assert.equal(state.workspaces.length, 0);
-    await assert.rejects(readFile(path.join(userData, "openwork-dev-data", "home", "OpenWork", ".opencode", "openwork.json"), "utf8"));
+    await assert.rejects(readFile(path.join(userData, "openwork-dev-data", "home", "OpenWork Chat", ".opencode", "openwork.json"), "utf8"));
+
+    await store.bootstrapFirstLaunchWorkspace();
+    const created = await store.readWorkspaceState();
+    const folder = path.join(userData, "openwork-dev-data", "home", "OpenWork Chat");
+    assert.equal(created.workspaces.length, 1);
+    assert.equal(created.workspaces[0].path, folder);
+    assert.equal(created.workspaces[0].workspaceType, "local");
+    assert.equal(created.selectedId, created.workspaces[0].id);
+    assert.equal(created.watchedId, created.selectedId);
+    assert.equal(created.activeId, created.selectedId);
+    const config = await store.readWorkspaceOpenworkConfig(folder);
+    assert.deepEqual(config.authorizedRoots, [folder]);
+    assert.equal(config.workspace.preset, "starter");
+    await store.bootstrapFirstLaunchWorkspace();
+    assert.deepEqual(await store.readWorkspaceState(), created);
   } finally {
     restoreEnv("OPENWORK_DEV_MODE", previousDevMode);
     restoreEnv("OPENWORK_SERVER_CONFIG", previousServerConfig);
   }
+});
+
+test("first-launch bootstrap preserves existing folders and their model configuration", async () => {
+  await withIsolatedBootstrapStore(async ({ store, root }) => {
+    const folder = path.join(root, "home", "OpenWork Chat");
+    const config = { version: 1, authorizedRoots: [folder], workspace: { name: "Existing chat" } };
+    await store.writeWorkspaceOpenworkConfig(folder, config);
+    const modelConfigPath = path.join(folder, "opencode.json");
+    const modelConfig = JSON.stringify({ model: "existing-provider/existing-model" });
+    await writeFile(modelConfigPath, modelConfig, "utf8");
+
+    await store.bootstrapFirstLaunchWorkspace();
+    assert.equal((await store.readWorkspaceState()).workspaces[0].path, await realpath(folder));
+    assert.deepEqual(await store.readWorkspaceOpenworkConfig(folder), config);
+    assert.equal(await readFile(modelConfigPath, "utf8"), modelConfig);
+  });
+});
+
+test("a blocked default folder reports the error and allows a different authorized workspace", async () => {
+  await withIsolatedBootstrapStore(async ({ store, root }) => {
+    const folder = path.join(root, "home", "OpenWork Chat");
+    await mkdir(path.dirname(folder), { recursive: true });
+    await writeFile(folder, "keep this file", "utf8");
+
+    const failure = await store.bootstrapFirstLaunchWorkspace();
+    assert.equal(failure.folderPath, await realpath(folder));
+    assert.match(failure.error, /EEXIST|ENOTDIR/);
+    assert.deepEqual((await store.readWorkspaceState()).workspaces, []);
+    assert.equal(await readFile(folder, "utf8"), "keep this file");
+
+    const alternate = path.join(root, "another-folder");
+    const created = await store.createWorkspace({ folderPath: alternate });
+    assert.equal(created.workspaces.length, 1);
+    assert.equal(created.selectedId, created.workspaces[0].id);
+    assert.deepEqual((await store.readWorkspaceOpenworkConfig(alternate)).authorizedRoots, [alternate]);
+  });
+});
+
+test("a non-writable default folder reports a recoverable permission error", {
+  skip: process.platform === "win32" || process.getuid?.() === 0,
+}, async () => {
+  await withIsolatedBootstrapStore(async ({ store, root }) => {
+    const folder = path.join(root, "home", "OpenWork Chat");
+    await mkdir(folder, { recursive: true });
+    await chmod(folder, 0o500);
+    try {
+      const failure = await store.bootstrapFirstLaunchWorkspace();
+      assert.equal(failure.folderPath, await realpath(folder));
+      assert.match(failure.error, /EACCES|EPERM/);
+      assert.deepEqual((await store.readWorkspaceState()).workspaces, []);
+    } finally {
+      await chmod(folder, 0o700);
+    }
+  });
+});
+
+test("first-launch bootstrap does not hide workspace registry failures", async () => {
+  await withIsolatedBootstrapStore(async ({ store, userDataPath }) => {
+    await writeFile(userDataPath, "not a registry directory", "utf8");
+    await assert.rejects(store.bootstrapFirstLaunchWorkspace(), { code: "EEXIST" });
+    assert.equal(await readFile(userDataPath, "utf8"), "not a registry directory");
+  });
 });
 
 test("normalizes recovered remote OpenWork entries before persisting", async () => {

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -17,7 +17,7 @@ import { CLOUD_INSTANCE_BACKEND } from "../../workers/cloud-constants.js"
 
 const createGrantSchema = z.object({
   next: z.string().trim().max(128).optional().describe("Optional continuation hint for handoff clients."),
-  desktopScheme: z.string().trim().max(32).optional().describe("Optional desktop URL scheme to use when building the OpenWork deep link."),
+  desktopScheme: z.literal("openwork").optional().describe("The registered OpenWork desktop URL scheme."),
   returnUrl: z.string().trim().max(2048).optional().describe("Optional HTTPS OpenWork Cloud web return URL. Accepted only for multi-organization Cloud instances after server-side origin validation."),
 }).meta({ ref: "DesktopHandoffGrantCreateBody" })
 
@@ -186,15 +186,10 @@ export function resolveDesktopDenBaseUrl(request: Request) {
 }
 
 function buildOpenworkDeepLink(input: {
-  scheme?: string | null
   grant: string
   denBaseUrl: string
 }) {
-  const requestedScheme = input.scheme?.trim() || "openwork"
-  const scheme = /^[a-z][a-z0-9+.-]*$/i.test(requestedScheme)
-    ? requestedScheme
-    : "openwork"
-  const url = new URL(`${scheme}://den-auth`)
+  const url = new URL("openwork://den-auth")
   url.searchParams.set("grant", input.grant)
   url.searchParams.set("denBaseUrl", input.denBaseUrl)
   return url.toString()
@@ -449,7 +444,6 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
       grant,
       expiresAt: expiresAt.toISOString(),
       openworkUrl: buildOpenworkDeepLink({
-        scheme: input.desktopScheme || "openwork",
         grant,
         denBaseUrl,
       }),

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -137,7 +137,7 @@ function DesktopHandoffCopyLink({
   );
 }
 
-function DesktopHandoffAction({
+export function DesktopHandoffAction({
   openworkUrl,
   grant,
   organizationName,
@@ -275,8 +275,10 @@ export function AuthPanel({
     signupPasswordFeedback,
     user,
     desktopAuthRequested,
+    setupPending,
     desktopRedirectUrl,
     desktopRedirectBusy,
+    retryDesktopAuthHandoff,
     showAuthFeedback,
     submitAuth,
     submitVerificationCode,
@@ -621,7 +623,7 @@ export function AuthPanel({
   // Gate on the session user (not authInfo feedback). Otherwise a hydrated
   // desktop session still renders the email-first form underneath the Open
   // OpenWork button.
-  const isSignedInWithDesktopHandoff = Boolean(desktopAuthRequested && user && !authError);
+  const isSignedInWithDesktopHandoff = Boolean(desktopAuthRequested && user && !setupPending);
   const signedInEmail = user?.email?.trim() || "";
   const emailFirstPanelActive = emailFirstFlow && !isSingleOrgSsoMode && !verificationRequired && !isPasswordResetRequest;
   const emailFirstFormBusy = loginOptionBusy || authBusy || desktopRedirectBusy;
@@ -653,9 +655,14 @@ export function AuthPanel({
             organizationName={isSingleOrgMode ? singleOrgName : null}
             showCopyLinkByDefault
           />
+        ) : authError ? (
+          <div className="grid gap-3">
+            <p role="alert" className="text-sm text-rose-600">{authError}</p>
+            <button type="button" className="den-button-primary w-full" disabled={desktopRedirectBusy} onClick={retryDesktopAuthHandoff}>Retry opening OpenWork</button>
+          </div>
         ) : (
           <div className="den-frame-inset rounded-[1.5rem] px-4 py-3 text-center text-sm text-[var(--dls-text-secondary)]" aria-live="polite">
-            Preparing your OpenWork sign-in link...
+            Checking your workspace...
           </div>
         )}
 
@@ -801,12 +808,24 @@ export function AuthPanel({
 
         {!waitingForPrefilledLoginOption && emailFirstStep === "new_account" ? (
           <form
+            data-testid="signup-new-account"
             className="grid gap-4"
             onSubmit={async (event) => {
               const next = await submitAuth(event);
               await handleAuthNavigation(next);
             }}
           >
+            <label className="grid gap-2">
+              <span className="den-label">Name</span>
+              <input
+                className="den-input"
+                type="text"
+                value={authName}
+                onChange={(event) => setAuthName(event.target.value)}
+                autoComplete="name"
+                required
+              />
+            </label>
             {!hideEmailField ? (
               <label className="grid gap-2">
                 <span className="den-label">Email</span>
@@ -821,31 +840,6 @@ export function AuthPanel({
                   required
                 />
               </label>
-            ) : null}
-            <label className="grid gap-2">
-              <span className="den-label">Name</span>
-              <input
-                className="den-input"
-                type="text"
-                value={authName}
-                onChange={(event) => setAuthName(event.target.value)}
-                autoComplete="name"
-                required
-              />
-            </label>
-            {!hideSocialAuth ? (
-              <>
-                <div className="den-divider" aria-hidden="true">
-                  <span>or</span>
-                </div>
-                <SocialButton
-                  onClick={() => void beginSocialAuth("google")}
-                  disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
-                >
-                  <GoogleLogo />
-                  <span>Sign up with Google</span>
-                </SocialButton>
-              </>
             ) : null}
             <label className="grid gap-2">
               <span className="den-label">Password</span>
@@ -864,6 +858,20 @@ export function AuthPanel({
               {formBusy ? "Working..." : activeContent.submitLabel}
               {!formBusy ? <ArrowRight className="h-4 w-4" /> : null}
             </button>
+            {!hideSocialAuth ? (
+              <>
+                <div className="den-divider" aria-hidden="true">
+                  <span>or</span>
+                </div>
+                <SocialButton
+                  onClick={() => void beginSocialAuth("google")}
+                  disabled={!runtimeConfigLoaded || authBusy || desktopRedirectBusy}
+                >
+                  <GoogleLogo />
+                  <span>Sign up with Google</span>
+                </SocialButton>
+              </>
+            ) : null}
           </form>
         ) : null}
 

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -49,8 +49,8 @@ export function AuthScreen() {
   const router = useRouter();
   const pathname = usePathname();
   const routingRef = useRef(false);
-  const { user, sessionHydrated, desktopAuthRequested, webAuthRequested, resolveUserLandingRoute } = useDenFlow();
-  const hasResolvedSession = sessionHydrated && Boolean(user) && !desktopAuthRequested && !webAuthRequested;
+  const { user, runtimeConfigLoaded, sessionHydrated, desktopAuthRequested, setupPending, authError, webAuthRequested, resolveUserLandingRoute } = useDenFlow();
+  const hasResolvedSession = runtimeConfigLoaded && sessionHydrated && Boolean(user) && !authError && (!desktopAuthRequested || setupPending) && !webAuthRequested;
 
   useEffect(() => {
     if (!hasResolvedSession || routingRef.current) {
@@ -84,7 +84,7 @@ export function AuthScreen() {
     >
       <div data-testid="auth-landing-frame">
         <div data-testid="auth-landing-form">
-          {!sessionHydrated ? (
+          {!runtimeConfigLoaded || !sessionHydrated ? (
             <SessionStatusPanel mode="checking" />
           ) : hasResolvedSession ? (
             <SessionStatusPanel mode="redirecting" />

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -16,7 +16,7 @@ type SettingsTab = "profile" | "organizations";
 
 export function OrganizationScreen() {
   const router = useRouter();
-  const { user, sessionHydrated, signOut, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const { user, sessionHydrated, signOut, runtimeConfig, runtimeConfigLoaded, continueSetup } = useDenFlow();
   const [orgs, setOrgs] = useState<DenOrgSummary[]>([]);
   const [busy, setBusy] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -46,7 +46,7 @@ export function OrganizationScreen() {
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
   const singleOrgName = runtimeConfig.singleOrgName || "OpenWork";
   const singleOrgSlug = runtimeConfig.singleOrgSlug.trim();
-  const showDirectCreateFlow = !isSingleOrgMode && orgs.length === 0;
+  const showDirectCreateFlow = !isSingleOrgMode && !error && orgs.length === 0;
   const {
     query: orgQuery,
     setQuery: setOrgQuery,
@@ -74,7 +74,11 @@ export function OrganizationScreen() {
         }
 
         if (isMounted) {
+          if (typeof payload !== "object" || payload === null || !("orgs" in payload) || !Array.isArray(payload.orgs)) {
+            throw new Error("Organization lookup returned incomplete details.");
+          }
           const parsed = parseOrgListPayload(payload);
+          if (parsed.orgs.length !== payload.orgs.length) throw new Error("Organization lookup returned incomplete details.");
           const nextOrgs = parsed.orgs.map((org) => ({ ...org, isActive: org.slug === parsed.activeOrgSlug }));
           const targetOrg = nextOrgs.find((org) => org.isActive) ?? nextOrgs[0] ?? null;
           if (isSingleOrgMode && targetOrg) {
@@ -82,6 +86,7 @@ export function OrganizationScreen() {
             return;
           }
           setOrgs(nextOrgs);
+          if (!isSingleOrgMode && nextOrgs.length === 0) continueSetup(null, "/organization");
           setShowCreate(!isSingleOrgMode && nextOrgs.length === 0);
           setBusy(false);
         }
@@ -151,6 +156,7 @@ export function OrganizationScreen() {
       if (intent === "team" && desktopSetup === "restricted") {
         await applyRestrictedSetup(nextOrg.id);
       }
+      continueSetup(nextOrg.id, getOnboardingPeopleRoute(nextOrg.slug));
       router.push(getOnboardingPeopleRoute(nextOrg.slug));
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : "Failed to create organization.");

--- a/ee/apps/den-web/app/(den)/_lib/setup-continuation.ts
+++ b/ee/apps/den-web/app/(den)/_lib/setup-continuation.ts
@@ -13,7 +13,7 @@ export function parseSetupContinuation(raw: string | null): SetupContinuation | 
     const value: unknown = JSON.parse(raw);
     if (typeof value !== "object" || value === null
       || !("userId" in value) || !(value.userId === null || typeof value.userId === "string")
-      || !("desktopScheme" in value) || !(value.desktopScheme === null || (typeof value.desktopScheme === "string" && /^[a-z][a-z0-9+.-]*$/i.test(value.desktopScheme)))
+      || !("desktopScheme" in value) || !(value.desktopScheme === null || value.desktopScheme === "openwork")
       || !("at" in value) || typeof value.at !== "number" || !Number.isFinite(value.at)
       || value.at > Date.now() || Date.now() - value.at > 24 * 60 * 60 * 1000
       || !("setup" in value)) return null;

--- a/ee/apps/den-web/app/(den)/_lib/setup-continuation.ts
+++ b/ee/apps/den-web/app/(den)/_lib/setup-continuation.ts
@@ -1,0 +1,34 @@
+// Tab-scoped navigation intent, never a credential or a persisted membership flag.
+export const SETUP_CONTINUATION_KEY = "openwork.den.setup-continuation";
+export type SetupContinuation = {
+  userId: string | null;
+  desktopScheme: string | null;
+  setup: { organizationId: string | null; route: string } | null;
+  at: number;
+};
+
+export function parseSetupContinuation(raw: string | null): SetupContinuation | null {
+  if (!raw) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (typeof value !== "object" || value === null
+      || !("userId" in value) || !(value.userId === null || typeof value.userId === "string")
+      || !("desktopScheme" in value) || !(value.desktopScheme === null || (typeof value.desktopScheme === "string" && /^[a-z][a-z0-9+.-]*$/i.test(value.desktopScheme)))
+      || !("at" in value) || typeof value.at !== "number" || !Number.isFinite(value.at)
+      || value.at > Date.now() || Date.now() - value.at > 24 * 60 * 60 * 1000
+      || !("setup" in value)) return null;
+    const setup = value.setup;
+    let pending: SetupContinuation["setup"] = null;
+    if (setup !== null) {
+      if (typeof setup !== "object"
+      || !("organizationId" in setup) || !(setup.organizationId === null || typeof setup.organizationId === "string")
+      || !("route" in setup) || typeof setup.route !== "string"
+      || !["/organization", "/dashboard/onboarding/people", "/dashboard/onboarding/tools", "/dashboard/onboarding"].includes(setup.route)
+      || !value.userId) return null;
+      pending = { organizationId: setup.organizationId, route: setup.route };
+    }
+    return { userId: value.userId, desktopScheme: value.desktopScheme, at: value.at, setup: pending };
+  } catch {
+    return null;
+  }
+}

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -1992,10 +1992,9 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     const stored = parseSetupContinuation(window.sessionStorage.getItem(SETUP_CONTINUATION_KEY));
-    const requestedScheme = params.get("desktopScheme")?.trim() ?? "";
     persistContinuation(params.get("desktopAuth") === "1"
       ? { userId: stored?.userId ?? null, setup: stored?.setup ?? null, at: Date.now(),
-          desktopScheme: /^[a-z][a-z0-9+.-]*$/i.test(requestedScheme) ? requestedScheme : "openwork" }
+          desktopScheme: "openwork" }
       : stored);
     setWebAuthRequested(params.get("webAuth") === "1");
     const requestedWebReturnUrl = params.get("webAuthReturn")?.trim() ?? "";

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { createContext, createElement, useContext, useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { SETUP_CONTINUATION_KEY, parseSetupContinuation, type SetupContinuation } from "../_lib/setup-continuation";
 import {
   AUTH_TOKEN_STORAGE_KEY,
   DEFAULT_AUTH_NAME,
@@ -131,9 +133,14 @@ type DenFlowContextValue = {
   sessionHydrated: boolean;
   desktopAuthRequested: boolean;
   desktopAuthScheme: string;
+  setupPending: boolean;
+  setupOrganizationId: string | null;
+  continueSetup: (organizationId: string | null, route: string) => void;
+  completeSetup: (organizationId: string) => Promise<boolean>;
   webAuthRequested: boolean;
   desktopRedirectUrl: string | null;
   desktopRedirectBusy: boolean;
+  retryDesktopAuthHandoff: () => void;
   showAuthFeedback: boolean;
   submitAuth: (event: FormEvent<HTMLFormElement>) => Promise<AuthNavigationResult>;
   submitVerificationCode: (event: FormEvent<HTMLFormElement>) => Promise<AuthNavigationResult>;
@@ -234,6 +241,12 @@ function clearPendingAuthIntent() {
 }
 
 export function DenFlowProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [continuation, setContinuation] = useState<SetupContinuation | null>(null);
+  const continuationRef = useRef<SetupContinuation | null>(null);
+  const handoffBusyRef = useRef(false);
+  const sessionEpochRef = useRef(0);
   const [authMode, setAuthModeState] = useState<AuthMode>("sign-up");
   const [email, setEmail] = useState("");
   const [authName, setAuthName] = useState("");
@@ -257,13 +270,15 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     return token;
   });
-  const [sessionHydrated, setSessionHydrated] = useState(false);
-  const [desktopAuthRequested, setDesktopAuthRequested] = useState(false);
-  const [desktopAuthScheme, setDesktopAuthScheme] = useState("openwork");
+  const [hydratedSession, setHydratedSession] = useState<{ token: string | null } | null>(null);
+  const sessionHydrated = hydratedSession !== null && hydratedSession.token === authToken;
+  const desktopAuthScheme = continuation?.desktopScheme ?? "openwork";
+  const setupPending = Boolean(user && continuation?.userId === user.id && continuation.setup);
   const [webAuthRequested, setWebAuthRequested] = useState(false);
   const [webAuthReturnUrl, setWebAuthReturnUrl] = useState<string | null>(null);
   const [desktopRedirectBusy, setDesktopRedirectBusy] = useState(false);
   const [desktopRedirectUrl, setDesktopRedirectUrl] = useState<string | null>(null);
+  const desktopAuthRequested = Boolean(continuation?.desktopScheme || desktopRedirectUrl);
   const [desktopRedirectAttempted, setDesktopRedirectAttempted] = useState(false);
   const [webRedirectBusy, setWebRedirectBusy] = useState(false);
   const [webRedirectAttempted, setWebRedirectAttempted] = useState(false);
@@ -373,6 +388,20 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     window.localStorage.setItem(ONBOARDING_INTENT_STORAGE_KEY, JSON.stringify(next));
+  }
+
+  function persistContinuation(next: SetupContinuation | null) {
+    continuationRef.current = next;
+    setContinuation(next);
+    if (next) window.sessionStorage.setItem(SETUP_CONTINUATION_KEY, JSON.stringify(next));
+    else window.sessionStorage.removeItem(SETUP_CONTINUATION_KEY);
+  }
+
+  function continueSetup(organizationId: string | null, route: string) {
+    if (!runtimeConfigLoaded || !sessionHydrated || !user || isSingleOrgMode) return;
+    const current = continuationRef.current;
+    persistContinuation({ userId: user.id, desktopScheme: current?.userId === user.id ? current.desktopScheme : null,
+      setup: { organizationId, route }, at: Date.now() });
   }
 
   function appendEvent(level: LaunchEvent["level"], label: string, detail: string) {
@@ -530,18 +559,13 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       }
     }
 
-    if (desktopAuthRequested) {
-      setAuthInfo("Signed in. Returning to OpenWork...");
-      return null;
-    }
-
-    if (webAuthRequested) {
-      setAuthInfo("Signed in. Returning to OpenWork...");
-      return null;
-    }
-
     if (authenticatedUser && (getPendingWorkspaceClaimToken() || getPendingOrgInvitationId())) {
       return "join-org";
+    }
+
+    if (desktopAuthRequested || webAuthRequested) {
+      setAuthInfo("Signed in. Returning to OpenWork...");
+      return null;
     }
 
     if (authenticatedUser && nextMode === "sign-up") {
@@ -976,13 +1000,15 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }, 1800);
   }
 
-  async function refreshSession(quiet = false) {
+  async function refreshSession(quiet = false, isCurrent = () => true) {
+    const epoch = sessionEpochRef.current;
     const headers = new Headers();
     if (authToken) {
       headers.set("Authorization", `Bearer ${authToken}`);
     }
 
     const { response, payload } = await requestJson("/v1/me", { method: "GET", headers }, 12000);
+    if (!isCurrent() || epoch !== sessionEpochRef.current) return null;
 
     if (!response.ok) {
       setUser(null);
@@ -1016,29 +1042,23 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     const { response, payload } = await requestJson("/v1/me/orgs", { method: "GET", headers }, 12000);
     if (!response.ok) {
-      return {
-        orgs: [],
-        activeOrgId: null,
-        activeOrgSlug: null,
-      };
+      throw new Error(getErrorMessage(payload, "Could not load your organizations. Refresh to try again."));
     }
-
-    return parseOrgListPayload(payload);
+    if (!isRecord(payload) || !Array.isArray(payload.orgs)) throw new Error("Organization lookup returned incomplete details.");
+    const directory = parseOrgListPayload(payload);
+    if (directory.orgs.length !== payload.orgs.length) throw new Error("Organization lookup returned incomplete details.");
+    return directory;
   }
 
-  async function resolveDashboardRoute() {
-    const orgDirectory = await loadOrgDirectory();
-    requestOrgSelectionOnNextLoad(orgDirectory.orgs);
-
-    const activeOrgSlug = orgDirectory.activeOrgSlug ?? orgDirectory.orgs[0]?.slug ?? null;
-    return activeOrgSlug ? getOrgDashboardRoute(activeOrgSlug) : null;
-  }
-
-  async function completeDesktopAuthHandoff() {
-    if (!desktopAuthRequested || desktopRedirectBusy) {
-      return;
+  async function completeDesktopAuthHandoff(organizationId?: string) {
+    const current = continuationRef.current;
+    const epoch = sessionEpochRef.current;
+    if (!runtimeConfigLoaded || !sessionHydrated || authBusy || !current?.desktopScheme || current.userId !== user?.id || handoffBusyRef.current
+      || (current.setup && current.setup.organizationId !== organizationId)) {
+      return false;
     }
 
+    handoffBusyRef.current = true;
     setDesktopRedirectBusy(true);
     setDesktopRedirectAttempted(true);
     setAuthError(null);
@@ -1049,31 +1069,60 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         headers.set("Authorization", `Bearer ${authToken}`);
       }
 
+      if (organizationId) {
+        const selected = await requestJson("/v1/me/active-organization", {
+          method: "POST", headers, body: JSON.stringify({ organizationId }),
+        });
+        if (!selected.response.ok) throw new Error(getErrorMessage(selected.payload, "Could not select your workspace."));
+      }
+      if (continuationRef.current !== current || epoch !== sessionEpochRef.current) return false;
+
       const { response, payload } = await requestJson("/api/auth/desktop-handoff", {
         method: "POST",
         headers,
         body: JSON.stringify({ desktopScheme: desktopAuthScheme })
       });
+      if (continuationRef.current !== current || epoch !== sessionEpochRef.current) return false;
 
       if (!response.ok) {
         setAuthError(getErrorMessage(payload, `Desktop handoff failed with ${response.status}.`));
-        return;
+        return false;
       }
 
       const openworkUrl = getDesktopHandoffOpenworkUrl(payload) ?? "";
       if (!openworkUrl) {
         setAuthError("Desktop handoff succeeded, but no OpenWork redirect URL was returned.");
-        return;
+        return false;
       }
 
       rememberDesktopHandoffGrant(getDesktopHandoffGrant(payload, openworkUrl));
       setDesktopRedirectUrl(openworkUrl);
+      persistContinuation(null);
+      clearPendingAuthIntent();
       window.location.assign(openworkUrl);
+      return true;
     } catch (error) {
-      setAuthError(error instanceof Error ? error.message : "Failed to open OpenWork.");
+      if (continuationRef.current === current && epoch === sessionEpochRef.current) setAuthError(error instanceof Error ? error.message : "Failed to open OpenWork.");
+      return false;
     } finally {
+      handoffBusyRef.current = false;
       setDesktopRedirectBusy(false);
     }
+  }
+
+  async function completeSetup(organizationId: string) {
+    const current = continuationRef.current;
+    if (!runtimeConfigLoaded || !sessionHydrated) return false;
+    if (!user || (current && current.userId !== user.id)
+      || (current?.setup && current.setup.organizationId !== organizationId)) {
+      setAuthError("Return to the workspace where you started setup before completing it.");
+      return false;
+    }
+    if (getPendingOrgInvitationId() || getPendingWorkspaceClaimToken()) return false;
+    if (current?.desktopScheme) return completeDesktopAuthHandoff(organizationId);
+    persistContinuation(null);
+    clearPendingAuthIntent();
+    return true;
   }
 
   function getWebHandoffReturnUrl(payload: unknown) {
@@ -1147,7 +1196,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     // (auth-screen) gate on it themselves, while explicit actions — the
     // "Go to dashboard" button on the signed-in handoff card — must resolve
     // a destination even mid desktop handoff.
-    if (!user) {
+    if (!runtimeConfigLoaded || !sessionHydrated || !user) {
       return null;
     }
 
@@ -1161,23 +1210,40 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       return getJoinOrgRoute(pendingInvitationId);
     }
 
-    const dashboardRoute = await resolveDashboardRoute();
-
-    if (dashboardRoute) {
-      if (getPendingAuthIntent() === "models") {
-        clearPendingAuthIntent();
-        return getInferenceRoute();
-      }
-
-      return dashboardRoute;
+    if (continuationRef.current?.userId === user.id && continuationRef.current.setup) {
+      return continuationRef.current.setup.route;
+    }
+    if (runtimeConfig === EMPTY_RUNTIME_CONFIG) {
+      setAuthError("Could not load workspace configuration. Refresh to try again.");
+      return null;
     }
 
-    return "/organization";
+    const epoch = sessionEpochRef.current;
+    let directory: Awaited<ReturnType<typeof loadOrgDirectory>>;
+    try {
+      directory = await loadOrgDirectory();
+    } catch (error) {
+      if (epoch === sessionEpochRef.current) setAuthError(error instanceof Error ? error.message : "Could not load your organizations.");
+      return null;
+    }
+    if (epoch !== sessionEpochRef.current) return null;
+    requestOrgSelectionOnNextLoad(directory.orgs);
+    if (directory.orgs.length === 0) {
+      if (!isSingleOrgMode) continueSetup(null, "/organization");
+      return "/organization";
+    }
+
+    if (getPendingAuthIntent() === "models") {
+      clearPendingAuthIntent();
+      return getInferenceRoute();
+    }
+    return getOrgDashboardRoute();
   }
 
   async function submitAuth(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
+    sessionEpochRef.current += 1;
     setAuthBusy(true);
     setAuthError(null);
     setSignupPasswordFeedback([]);
@@ -1348,6 +1414,10 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    sessionEpochRef.current += 1;
+    persistContinuation(null);
+    clearPendingAuthIntent();
+    setDesktopRedirectUrl(null);
     setAuthBusy(true);
     setAuthError(null);
 
@@ -1365,6 +1435,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     setUser(null);
     setAuthToken(null);
+    setHydratedSession({ token: null });
     setWorker(null);
     setWorkers([]);
     setWorkerLookupId("");
@@ -1920,11 +1991,12 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       setAuthMode(requestedMode);
     }
 
-    setDesktopAuthRequested(params.get("desktopAuth") === "1");
+    const stored = parseSetupContinuation(window.sessionStorage.getItem(SETUP_CONTINUATION_KEY));
     const requestedScheme = params.get("desktopScheme")?.trim() ?? "";
-    if (/^[a-z][a-z0-9+.-]*$/i.test(requestedScheme)) {
-      setDesktopAuthScheme(requestedScheme);
-    }
+    persistContinuation(params.get("desktopAuth") === "1"
+      ? { userId: stored?.userId ?? null, setup: stored?.setup ?? null, at: Date.now(),
+          desktopScheme: /^[a-z][a-z0-9+.-]*$/i.test(requestedScheme) ? requestedScheme : "openwork" }
+      : stored);
     setWebAuthRequested(params.get("webAuth") === "1");
     const requestedWebReturnUrl = params.get("webAuthReturn")?.trim() ?? "";
     setWebAuthReturnUrl(requestedWebReturnUrl || null);
@@ -1956,11 +2028,12 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     const hydrateSession = async () => {
+      const epoch = sessionEpochRef.current;
       try {
-        await refreshSession(true);
+        await refreshSession(true, () => !cancelled);
       } finally {
-        if (!cancelled) {
-          setSessionHydrated(true);
+        if (!cancelled && epoch === sessionEpochRef.current) {
+          setHydratedSession({ token: authToken });
         }
       }
     };
@@ -2170,20 +2243,78 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   }, [activeWorker?.workerId, selectedWorker?.workerId, runtimeSnapshot?.upgrade.status]);
 
   useEffect(() => {
-    if (!desktopAuthRequested || !user || desktopRedirectUrl || desktopRedirectBusy || desktopRedirectAttempted) {
-      return;
+    if (!runtimeConfigLoaded || !sessionHydrated || !user || !continuation) return;
+    if (continuation.userId && continuation.userId !== user.id) {
+      persistContinuation(null);
+      setDesktopRedirectUrl(null);
+      setDesktopRedirectAttempted(false);
+      clearPendingAuthIntent();
+    } else if (!continuation.userId) {
+      persistContinuation({ ...continuation, userId: user.id });
     }
-
-    void completeDesktopAuthHandoff();
-  }, [desktopAuthRequested, user?.id, authToken, desktopRedirectUrl, desktopRedirectBusy, desktopRedirectAttempted, desktopAuthScheme]);
+  }, [runtimeConfigLoaded, sessionHydrated, user?.id, continuation]);
 
   useEffect(() => {
-    if (!webAuthRequested || !user || webRedirectBusy || webRedirectAttempted) {
+    const current = continuationRef.current;
+    if (!runtimeConfigLoaded || !sessionHydrated || !user || current?.userId !== user.id || !current.setup) return;
+    if (["/dashboard/onboarding/people", "/dashboard/onboarding/tools", "/dashboard/onboarding"].includes(pathname)
+      && current.setup.route !== pathname) {
+      persistContinuation({ ...current, setup: { ...current.setup, route: pathname } });
+    }
+  }, [pathname, user?.id, runtimeConfigLoaded, sessionHydrated]);
+
+  useEffect(() => {
+    if (!runtimeConfigLoaded || !sessionHydrated || authBusy || !desktopAuthRequested || !user || continuation?.userId !== user.id
+      || setupPending || desktopRedirectUrl || desktopRedirectBusy || desktopRedirectAttempted) return;
+    // Invitation acceptance and workspace claims own their explicit handoffs.
+    if (pathname === "/join-org" || pathname === "/workspace-claim") return;
+    const pendingClaim = getPendingWorkspaceClaimToken();
+    const pendingInvitation = getPendingOrgInvitationId();
+    if (pendingClaim) {
+      router.replace(getWorkspaceClaimRoute(pendingClaim));
+      return;
+    }
+    if (pendingInvitation) {
+      router.replace(getJoinOrgRoute(pendingInvitation));
+      return;
+    }
+    // Failed config fetches return the single-org fallback, not a deployment decision.
+    if (runtimeConfig === EMPTY_RUNTIME_CONFIG) {
+      setAuthError("Could not load workspace configuration. Refresh to try again.");
+      setDesktopRedirectAttempted(true);
+      return;
+    }
+    let cancelled = false;
+    const current = continuationRef.current;
+    const epoch = sessionEpochRef.current;
+    void loadOrgDirectory().then((directory) => {
+      if (cancelled || epoch !== sessionEpochRef.current || continuationRef.current !== current || getPendingOrgInvitationId() || getPendingWorkspaceClaimToken()) return;
+      if (directory.orgs.length === 0) {
+        if (!isSingleOrgMode) {
+          persistContinuation({ userId: user.id, desktopScheme: desktopAuthScheme, setup: { organizationId: null, route: "/organization" }, at: Date.now() });
+        }
+        router.replace("/organization");
+        return;
+      }
+      void completeDesktopAuthHandoff();
+    }).catch((error: unknown) => {
+      if (!cancelled && epoch === sessionEpochRef.current) {
+        setAuthError(error instanceof Error ? error.message : "Could not load your organizations.");
+        setDesktopRedirectAttempted(true);
+      }
+    });
+    return () => { cancelled = true; };
+  }, [runtimeConfig, runtimeConfigLoaded, isSingleOrgMode, sessionHydrated, authBusy, desktopAuthRequested, user?.id, authToken, continuation?.userId, setupPending, pathname, desktopRedirectUrl, desktopRedirectBusy, desktopRedirectAttempted, desktopAuthScheme]);
+
+  useEffect(() => {
+    if (!runtimeConfigLoaded || !sessionHydrated || !webAuthRequested || !user || webRedirectBusy || webRedirectAttempted
+      || pathname === "/join-org" || pathname === "/workspace-claim"
+      || getPendingOrgInvitationId() || getPendingWorkspaceClaimToken()) {
       return;
     }
 
     void completeWebAuthHandoff();
-  }, [webAuthRequested, webAuthReturnUrl, user?.id, authToken, webRedirectBusy, webRedirectAttempted]);
+  }, [runtimeConfigLoaded, sessionHydrated, webAuthRequested, webAuthReturnUrl, user?.id, authToken, webRedirectBusy, webRedirectAttempted, pathname]);
 
   useEffect(() => {
     if (!user || !onboardingPending) {
@@ -2255,9 +2386,18 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     sessionHydrated,
     desktopAuthRequested,
     desktopAuthScheme,
+    setupPending,
+    setupOrganizationId: setupPending ? continuation?.setup?.organizationId ?? null : null,
+    continueSetup,
+    completeSetup,
     webAuthRequested,
     desktopRedirectUrl,
     desktopRedirectBusy,
+    retryDesktopAuthHandoff: () => {
+      if (handoffBusyRef.current || setupPending) return;
+      setAuthError(null);
+      setDesktopRedirectAttempted(false);
+    },
     showAuthFeedback,
     submitAuth,
     submitVerificationCode,

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/onboarding/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/onboarding/page.tsx
@@ -1,7 +1,5 @@
 import { MarketplaceOnboardingScreen } from "../../_components/marketplace-onboarding-screen";
-import { getPublicInstallers } from "../../../_lib/public-installers";
 
-export default async function MarketplaceOnboardingPage() {
-  const { installers, releaseTag } = await getPublicInstallers();
-  return <MarketplaceOnboardingScreen installers={installers} releaseTag={releaseTag} />;
+export default function MarketplaceOnboardingPage() {
+  return <MarketplaceOnboardingScreen />;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -1,241 +1,102 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Check, KeyRound, ArrowUpRight, Mail, ArrowRight } from "lucide-react";
-import { DownloadOpenWorkCard, type DownloadCardInstallers } from "@openwork/ui/react";
+import { Check, KeyRound, ArrowUpRight, ArrowRight } from "lucide-react";
 import { DenBadge } from "../../_components/ui/badge";
+import { DesktopHandoffAction } from "../../_components/auth-panel";
 import { SetupFrame } from "../../_components/setup-frame";
-import {
-  getCustomLlmProvidersRoute,
-  getInferenceRoute,
-  getOrgDashboardRoute,
-  getOnboardingToolsRoute,
-  getYourConnectionsRoute,
-  getWebRoute,
-} from "../../_lib/den-org";
-import { getErrorMessage, requestJson } from "../../_lib/den-flow";
+import { getCustomLlmProvidersRoute, getInferenceRoute, getOrgDashboardRoute } from "../../_lib/den-org";
+import { getErrorMessage, normalizeAuthIntentParam, PENDING_AUTH_INTENT_STORAGE_KEY, requestJson } from "../../_lib/den-flow";
+import { getDesktopGrant } from "../../_lib/desktop-handoff";
+import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
-import { isMobileUserAgent } from "../../_lib/platform";
-
-const APP_INSTALLED_KEY = "openwork:onboarding:app-installed";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function useLocalStorageFlag(key: string) {
-  const [value, setValue] = useState(false);
-
+export function MarketplaceOnboardingScreen() {
+  const router = useRouter();
+  const { orgId, orgSlug, activeOrg } = useOrgDashboard();
+  const { desktopAuthRequested, desktopRedirectUrl, authError, completeSetup } = useDenFlow();
+  const [completing, setCompleting] = useState(false);
+  const modelsHeading = useRef<HTMLHeadingElement>(null);
   useEffect(() => {
-    try {
-      setValue(localStorage.getItem(key) === "1");
-    } catch {
-      // localStorage unavailable
+    if (desktopAuthRequested && normalizeAuthIntentParam(window.sessionStorage.getItem(PENDING_AUTH_INTENT_STORAGE_KEY)) === "models") {
+      modelsHeading.current?.focus();
     }
-  }, [key]);
-
-  function toggle(next: boolean) {
-    setValue(next);
-    try {
-      if (next) localStorage.setItem(key, "1");
-      else localStorage.removeItem(key);
-    } catch {
-      // localStorage unavailable
-    }
-  }
-
-  return [value, toggle] as const;
-}
-
-function useInferenceEnabled() {
-  return useQuery({
-    queryKey: ["onboarding", "inference"] as const,
-    queryFn: async (): Promise<boolean> => {
-      const { response, payload } = await requestJson("/v1/inference", { method: "GET" }, 12000);
-      if (!response.ok) return false;
-      const inference = isRecord(payload) && isRecord(payload.inference) ? payload.inference : null;
-      return inference?.enabled === true;
+  }, [desktopAuthRequested]);
+  const { data: modelsEnabled, isPending: modelsLoading, error: modelsError } = useQuery({
+    queryKey: ["onboarding", "inference", orgId],
+    enabled: Boolean(orgId),
+    queryFn: async () => {
+      if (!orgId) throw new Error("Choose a workspace to check OpenWork Models.");
+      const { response, payload } = await requestJson("/v1/inference", { method: "GET", headers: { "x-openwork-org-id": orgId } }, 12000);
+      if (!response.ok) throw new Error(getErrorMessage(payload, "Could not check OpenWork Models."));
+      return typeof payload === "object" && payload !== null && "inference" in payload
+        && typeof payload.inference === "object" && payload.inference !== null
+        && "enabled" in payload.inference && payload.inference.enabled === true;
     },
-    staleTime: 30_000,
+    staleTime: 0,
   });
-}
 
-function OpenWorkMark({ className = "h-5 w-5" }: { className?: string }) {
-  return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img src="/openwork-mark.svg" alt="" aria-hidden className={className} />
-  );
-}
-
-function MobileOpenWorkOptions({ orgSlug, webAvailable }: { orgSlug: string | null; webAvailable: boolean }) {
-  const [sending, setSending] = useState(false);
-  const [sent, setSent] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function emailDownload() {
-    if (sending || sent) return;
-    setSending(true);
-    setError(null);
+  async function finish() {
+    if (!orgId || completing) return;
+    setCompleting(true);
     try {
-      const { response, payload } = await requestJson("/v1/me/send-download-link", { method: "POST" }, 12000);
-      if (!response.ok) {
-        setError(response.status >= 500
-          ? "Could not send your link right now. Please try again."
-          : getErrorMessage(payload, "Could not send your link. Please try again."));
-        return;
-      }
-      setSent(true);
-    } catch {
-      setError("Could not send your link. Check your connection and try again.");
+      if (await completeSetup(orgId) && !desktopAuthRequested) router.push(getOrgDashboardRoute(orgSlug));
     } finally {
-      setSending(false);
+      setCompleting(false);
     }
   }
 
   return (
-    <div className="grid gap-3" data-testid="onboarding-mobile-options">
-      <div className="rounded-2xl bg-neutral-50 p-5">
-        <div className="flex items-center gap-3">
-          <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-white"><OpenWorkMark className="size-6" /></span>
-          <div><h3 className="text-sm font-semibold text-neutral-950">OpenWork Desktop</h3><p className="mt-1 text-xs text-neutral-500">For when you’re back at your desk.</p></div>
-        </div>
-        <p className="mt-4 text-sm leading-6 text-neutral-600">Work with your files and team tools on your computer. Send a download link to your account’s email.</p>
-        <button type="button" onClick={() => void emailDownload()} disabled={sending || sent} className="mt-4 inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-xl bg-neutral-950 px-3 py-3 text-sm font-medium text-white transition-colors hover:bg-neutral-800 disabled:cursor-default disabled:bg-neutral-200 disabled:text-neutral-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950">
-          {sent ? <Check className="size-4" aria-hidden /> : <Mail className="size-4" aria-hidden />}
-          {sending ? "Sending…" : sent ? "Download link sent" : "Email me the download link"}
-        </button>
-        {sent ? <p role="status" className="mt-3 text-xs leading-5 text-neutral-600">Check your inbox. Open the link on your computer when you’re ready.</p> : null}
-        {error ? <p role="alert" className="mt-3 text-sm leading-5 text-red-700">{error}</p> : null}
-      </div>
-      {webAvailable ? <div className="rounded-2xl bg-neutral-50 p-5">
-        <div className="flex items-center gap-3">
-          <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-white"><OpenWorkMark className="size-6" /></span>
-          <div><h3 className="text-sm font-semibold text-neutral-950">OpenWork Web</h3><p className="mt-1 text-xs text-neutral-500">Your cloud workspace, in the browser.</p></div>
-        </div>
-        <p className="mt-4 text-sm leading-6 text-neutral-600">Keep going from here. Explore cloud access and plans without installing the desktop app.</p>
-        <Link href={getWebRoute(orgSlug)} className="mt-3 flex min-h-12 items-center justify-between gap-2 rounded-xl bg-white px-4 py-3 text-sm font-medium text-neutral-950 hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950">Try OpenWork Web<ArrowRight className="size-4" aria-hidden /></Link>
-      </div> : null}
-    </div>
-  );
-}
-
-export function MarketplaceOnboardingScreen({
-  installers,
-  releaseTag,
-}: {
-  installers?: DownloadCardInstallers | null;
-  releaseTag?: string;
-}) {
-  const { activeOrg, orgSlug, orgContext } = useOrgDashboard();
-  const { data: modelsEnabled = false, isLoading: modelsLoading } = useInferenceEnabled();
-  const [appInstalled, setAppInstalled] = useLocalStorageFlag(APP_INSTALLED_KEY);
-
-  const [mobileDevice, setMobileDevice] = useState(false);
-  useEffect(() => {
-    setMobileDevice(isMobileUserAgent() || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
-  }, []);
-
-  const orgName = activeOrg?.name ?? "your team";
-
-  return (
-    <SetupFrame
-      step="ready"
-      title="Put your tools to work."
-      description={`Start a chat. Build dashboards, run workflows, and use ${orgName}’s tools—with the model you choose.`}
-    >
-      <div className="grid gap-8" data-testid="marketplace-onboarding">
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl bg-neutral-50 px-4 py-3 text-xs text-neutral-500">
-          <span>More useful with your team’s tools.</span>
-          <Link href={getOnboardingToolsRoute(orgSlug)} className="font-medium text-neutral-900 underline-offset-4 hover:underline">Choose team tools →</Link>
-        </div>
-        <section aria-labelledby="setup-download-heading" className="grid gap-4">
-          <div className="flex items-start gap-3">
-            <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-[var(--dls-border)] text-xs font-medium text-[var(--dls-text-secondary)]">1</span>
-            <div>
-              <h2 id="setup-download-heading" className="text-base font-semibold tracking-tight text-[var(--dls-text-primary)]">Choose where to start</h2>
-              <p className="mt-1 text-sm leading-6 text-[var(--dls-text-secondary)]">Chat with your files and team tools, in one place.</p>
-            </div>
-          </div>
-          <div className={mobileDevice ? "block" : "sm:hidden"}>
-            <MobileOpenWorkOptions orgSlug={orgSlug} webAvailable={orgContext?.capabilities.openworkWeb === true} />
-          </div>
-          <div className={mobileDevice ? "hidden" : "hidden sm:grid sm:gap-4"}>
-            <DownloadOpenWorkCard installers={installers} releaseTag={releaseTag} compact appIcon={<OpenWorkMark className="size-6" />} />
-            <div className="flex items-center justify-between gap-3 text-xs text-[var(--dls-text-secondary)]">
-              {appInstalled ? (
-                <span className="inline-flex items-center gap-2" role="status">
-                  <Check className="size-3.5" aria-hidden /> Installation marked complete
-                </span>
-              ) : (
-                <button
-                  type="button"
-                  data-testid="onboarding-app-installed"
-                  onClick={() => setAppInstalled(true)}
-                  className="rounded-sm text-sm font-medium underline-offset-4 hover:text-[var(--dls-text-primary)] hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--dls-text-primary)]"
-                >
-                  I&apos;ve already installed it →
-                </button>
-              )}
-              <span>Sign in with the same account.</span>
-            </div>
-          </div>
-        </section>
-
-        <section aria-labelledby="setup-models-heading" className="grid gap-4 border-t border-[var(--dls-border)] pt-7">
-          <div className="flex items-start gap-3">
-            <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-[var(--dls-border)] text-xs font-medium text-[var(--dls-text-secondary)]">2</span>
-            <div className="min-w-0 flex-1">
-              <h2 id="setup-models-heading" className="text-base font-semibold tracking-tight text-[var(--dls-text-primary)]">Choose what powers your work</h2>
-              <p className="mt-1 text-sm leading-6 text-[var(--dls-text-secondary)]" role="status">
-                {modelsLoading
-                  ? "Checking OpenWork Models…"
-                  : modelsEnabled
-                    ? "OpenWork Models are on for this workspace."
-                    : "Choose your model and provider. Use OpenWork Models or bring your own account—you can set this up later."}
-              </p>
-            </div>
+    <SetupFrame step="ready" title="Choose what powers your work." description="Use OpenWork Models or bring your own provider. You can decide now or set this up later.">
+      <div className="grid gap-6" data-testid="marketplace-onboarding">
+        <section aria-labelledby="setup-models-heading" className="grid gap-4">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-400">Optional · Models</p>
+            <h2 id="setup-models-heading" ref={modelsHeading} tabIndex={-1} className="mt-2 text-xl font-semibold tracking-[-0.03em]">Your choice of model.</h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--dls-text-secondary)]" role="status">
+              {modelsLoading ? "Checking OpenWork Models..." : modelsError ? "Model status is unavailable. You can still complete setup." : modelsEnabled ? "OpenWork Models are on for this workspace." : "Signing in does not enable models. Keep your existing provider, or choose one when you are ready."}
+            </p>
             {modelsEnabled ? <DenBadge icon={Check}>Models on</DenBadge> : null}
           </div>
           <div className="divide-y divide-[var(--dls-border)] overflow-hidden rounded-2xl border border-[var(--dls-border)]">
             <div className="flex items-start gap-3 p-4 sm:p-5" data-testid="onboarding-choice-openwork-models">
-              <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-[var(--dls-hover)]"><OpenWorkMark /></div>
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-[var(--dls-hover)]">
+                <img src="/openwork-mark.svg" alt="" aria-hidden className="h-5 w-5" />
+              </div>
               <div className="min-w-0 flex-1">
-                <h3 className="text-sm font-semibold text-[var(--dls-text-primary)]">OpenWork Models</h3>
+                <h3 className="text-sm font-semibold">OpenWork Models</h3>
                 <p className="mt-1 text-[13px] leading-5 text-[var(--dls-text-secondary)]">Managed models, billed per member. No API keys to look after.</p>
-                <Link href={getInferenceRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-[var(--dls-text-primary)] underline-offset-4 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--dls-text-primary)]">
-                  {modelsEnabled ? "Manage models" : "Turn on models"}<ArrowUpRight className="size-3.5" aria-hidden />
+                <Link href={getInferenceRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-neutral-950">
+                  {modelsEnabled ? "Manage models" : "Explore models"}<ArrowUpRight className="size-3.5" aria-hidden />
                 </Link>
               </div>
             </div>
             <div className="flex items-start gap-3 p-4 sm:p-5" data-testid="onboarding-choice-byok">
               <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-[var(--dls-hover)]"><KeyRound className="size-[18px] text-[var(--dls-text-secondary)]" aria-hidden /></div>
               <div className="min-w-0 flex-1">
-                <h3 className="text-sm font-semibold text-[var(--dls-text-primary)]">Bring your Own Keys</h3>
+                <h3 className="text-sm font-semibold">Bring your Own Keys</h3>
                 <p className="mt-1 text-[13px] leading-5 text-[var(--dls-text-secondary)]">Connect your provider or gateway. Keep your own billing and model choices.</p>
-                <Link href={getCustomLlmProvidersRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium text-[var(--dls-text-primary)] underline-offset-4 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-[var(--dls-text-primary)]">
+                <Link href={getCustomLlmProvidersRoute(orgSlug)} className="mt-3 inline-flex items-center gap-1.5 rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-neutral-950">
                   Add a provider<ArrowUpRight className="size-3.5" aria-hidden />
                 </Link>
               </div>
             </div>
           </div>
         </section>
-
-        <div className="rounded-2xl bg-neutral-50 p-5 text-sm leading-6 text-neutral-600">
-          <h3 className="font-medium text-neutral-950">One connection. Your team’s tools.</h3>
-          <p className="mt-1 text-[13px]">OpenWork’s MCP gateway brings shared tools into compatible AI apps. Each person uses their own connected accounts and team permissions.</p>
-          <Link href={getYourConnectionsRoute(orgSlug)} className="mt-3 inline-block font-medium text-neutral-900 underline-offset-4 hover:underline">Connect your accounts →</Link>
-        </div>
-        <section aria-labelledby="setup-finish-heading" className="grid gap-4 border-t border-[var(--dls-border)] pt-7" data-testid="onboarding-finish">
+        <section aria-labelledby="setup-finish-heading" className="grid gap-4 border-t border-[var(--dls-border)] pt-6" data-testid="onboarding-finish">
           <div>
-            <h2 id="setup-finish-heading" className="text-base font-semibold tracking-tight text-[var(--dls-text-primary)]">Your workspace is ready</h2>
-            <p className="mt-2 text-sm leading-6 text-[var(--dls-text-secondary)]">Finish setup to open your dashboard. You can download the app, connect accounts, and choose models whenever you’re ready.</p>
+            <h2 id="setup-finish-heading" className="text-base font-semibold tracking-tight">Your workspace is ready</h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--dls-text-secondary)]">No model selection is required to complete setup.</p>
           </div>
-          <Link href={getOrgDashboardRoute(orgSlug)} className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-neutral-950 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-neutral-800">
-            Finish setup<ArrowRight className="size-4" aria-hidden />
-          </Link>
+          {authError ? <p role="alert" className="text-sm text-rose-600">{authError}</p> : null}
+          {desktopRedirectUrl ? <DesktopHandoffAction openworkUrl={desktopRedirectUrl} grant={getDesktopGrant(desktopRedirectUrl)} organizationName={activeOrg?.name ?? null} showCopyLinkByDefault /> : (
+            <button type="button" onClick={() => void finish()} disabled={!orgId || completing} className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-neutral-950 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-neutral-800 disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2">
+              {completing ? "Completing..." : desktopAuthRequested ? "Complete and open the app" : "Complete setup"}<ArrowRight className="size-4" aria-hidden />
+            </button>
+          )}
         </section>
       </div>
     </SetupFrame>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/onboarding-tools-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/onboarding-tools-screen.tsx
@@ -30,6 +30,7 @@ export function OnboardingToolsScreen() {
 function ToolsForm() {
   const router = useRouter();
   const { orgSlug } = useOrgDashboard();
+  const { desktopAuthRequested } = useDenFlow();
   const presetsQuery = useMcpConnectionPresets();
   const connectionsQuery = useMcpConnections("manageable");
   const createConnection = useCreateMcpConnection();
@@ -96,7 +97,7 @@ function ToolsForm() {
   function continueSetup() {
     if (addingRef.current) return;
     const intent = normalizeAuthIntentParam(window.sessionStorage.getItem(PENDING_AUTH_INTENT_STORAGE_KEY));
-    if (intent === "models") {
+    if (intent === "models" && !desktopAuthRequested) {
       window.sessionStorage.removeItem(PENDING_AUTH_INTENT_STORAGE_KEY);
       router.push(getInferenceRoute(orgSlug));
       return;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -299,7 +299,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const onboardingRoute = getMarketplaceOnboardingRoute();
   const isOnboarding = pathname === onboardingRoute || pathname.startsWith(`${onboardingRoute}/`);
-  const { user, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const { user, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded, setupPending, setupOrganizationId } = useDenFlow();
   const {
     activeOrg,
     orgDirectory,
@@ -793,7 +793,14 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           </div>
         </header>
 
-        <main className="flex-1 overflow-y-auto bg-[#fafafa]">{children}</main>
+        <main className="flex-1 overflow-y-auto bg-[#fafafa]">
+          {setupPending && setupOrganizationId === activeOrg?.id ? (
+            <div className="border-b border-gray-100 px-4 py-3 text-sm md:px-6">
+              <Link href={onboardingRoute} className="font-medium text-gray-900 underline underline-offset-4">Back to setup</Link>
+            </div>
+          ) : null}
+          {children}
+        </main>
       </div>
 
       <DenCommandPalette

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -22,7 +22,7 @@ import {
   roleIncludesCanonicalRole,
 } from "../../_lib/den-org";
 import { shouldOpenOrgSelection } from "../../_lib/org-selection";
-import { ORG_SCOPE_HEADER, OrganizationNotFoundError, setRequestOrgScope } from "../../_lib/org-scope";
+import { ORG_SCOPE_HEADER, OrganizationNotFoundError, getRequestOrgScope, setRequestOrgScope } from "../../_lib/org-scope";
 
 type OrgDashboardContextValue = {
   orgSlug: string | null;
@@ -79,7 +79,7 @@ export function OrgDashboardProvider({
 }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { user, sessionHydrated, signOut, refreshWorkers, workersLoadedOnce, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const { user, sessionHydrated, signOut, refreshWorkers, workersLoadedOnce, runtimeConfig, runtimeConfigLoaded, setupOrganizationId } = useDenFlow();
   const [orgDirectory, setOrgDirectory] = useState<DenOrgSummary[]>([]);
   const [orgContext, setOrgContext] = useState<DenOrgContext | null>(null);
   const [orgSelectionOpen, setOrgSelectionOpen] = useState(false);
@@ -221,10 +221,14 @@ export function OrgDashboardProvider({
 
     try {
       let directoryPayload = await loadOrgDirectory();
-      const displayedOrgId = orgContext?.organization.id ?? null;
+      // A tab's unfinished setup owns its org even when another tab switches the session.
+      const displayedOrgId = setupOrganizationId ?? orgContext?.organization.id ?? null;
       const displayedOrg = displayedOrgId
         ? directoryPayload.orgs.find((entry) => entry.id === displayedOrgId) ?? null
         : null;
+      if (setupOrganizationId && !displayedOrg) {
+        throw new Error("Your setup workspace is unavailable. Restore access before continuing setup.");
+      }
 
       if (displayedOrg && !displayedOrg.isActive) {
         setRequestOrgScope(displayedOrg.id);
@@ -258,7 +262,7 @@ export function OrgDashboardProvider({
       // Single-org deployments never surface the picker; otherwise the
       // org-selection module decides from the directory plus any pending
       // sign-in request.
-      if (!isSingleOrgMode && shouldOpenOrgSelection(directoryPayload.orgs)) {
+      if (!setupOrganizationId && !isSingleOrgMode && shouldOpenOrgSelection(directoryPayload.orgs)) {
         setRequestOrgScope(null);
         setOrgDirectory(directoryPayload.orgs);
         setOrgContext(null);
@@ -277,6 +281,12 @@ export function OrgDashboardProvider({
       setOrgContext(context);
       await refreshWorkers({ keepSelection: false, quiet: workersLoadedOnce });
     } catch (error) {
+      if (setupOrganizationId) {
+        setRequestOrgScope(null);
+        setOrgContext(null);
+        setOrgError(error instanceof Error ? error.message : "Could not restore your setup workspace.");
+        return;
+      }
       if (error instanceof OrganizationNotFoundError) {
         try {
           await recoverFromOrganizationNotFound();
@@ -895,7 +905,7 @@ export function OrgDashboardProvider({
     }
 
     void refreshOrgData();
-  }, [router, sessionHydrated, user?.id, isSingleOrgMode]);
+  }, [router, sessionHydrated, user?.id, isSingleOrgMode, setupOrganizationId]);
 
   const value: OrgDashboardContextValue = {
     orgSlug: activeOrg?.slug ?? null,
@@ -932,7 +942,13 @@ export function OrgDashboardProvider({
 
   return (
     <OrgDashboardContext.Provider value={value}>
-      {children}
+      {setupOrganizationId && (orgContext?.organization.id !== setupOrganizationId
+        || activeOrgId !== setupOrganizationId || getRequestOrgScope() !== setupOrganizationId) ? (
+        <div className="grid min-h-[420px] place-content-center gap-3 px-6 text-sm text-gray-600" data-testid="setup-workspace-restoring">
+          <p role={orgError ? "alert" : "status"}>{orgError ?? "Restoring your setup workspace..."}</p>
+          {!orgBusy ? <button type="button" onClick={() => void refreshOrgData()} className="font-medium text-gray-900 underline underline-offset-4">Retry setup workspace</button> : null}
+        </div>
+      ) : children}
       <ReauthDialog
         open={reauthDialogOpen}
         user={user}

--- a/ee/apps/den-web/tests/auth-landing-contract.test.ts
+++ b/ee/apps/den-web/tests/auth-landing-contract.test.ts
@@ -23,7 +23,9 @@ describe("Den auth landing contract", () => {
     expect(source).toContain("Logged in as");
     expect(source).toContain("showCopyLinkByDefault");
     expect(source).toContain('data-testid="desktop-handoff-copy-link"');
-    expect(source).toContain("desktopAuthRequested && user && !authError");
+    expect(source).toContain("desktopAuthRequested && user && !setupPending");
+    expect(source).toContain("Retry opening OpenWork");
+    expect(source).toContain("onClick={retryDesktopAuthHandoff}");
     expect(source).not.toContain("showAuthFeedback && authInfo && !authError");
   });
 });

--- a/ee/apps/den-web/tests/desktop-handoff.test.ts
+++ b/ee/apps/den-web/tests/desktop-handoff.test.ts
@@ -49,6 +49,7 @@ test("restores only fresh tab-scoped setup with a user and a known route", () =>
     { ...pending, at: Date.now() + 60_000 },
     { ...pending, setup: { organizationId: "org-1", route: "https://outside.test" } },
     { ...pending, desktopScheme: "openwork://" },
+    { ...pending, desktopScheme: "untrusted-app" },
     { ...pending, setup: { route: "/dashboard/onboarding" } },
   ]) expect(parseSetupContinuation(JSON.stringify(invalid))).toBeNull();
   expect(parseSetupContinuation("not json")).toBeNull();

--- a/ee/apps/den-web/tests/desktop-handoff.test.ts
+++ b/ee/apps/den-web/tests/desktop-handoff.test.ts
@@ -1,9 +1,17 @@
-import { expect, test } from "bun:test";
+import { expect, mock, spyOn, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import * as navigation from "next/navigation";
+import * as requests from "../app/(den)/_lib/den-flow";
+import * as runtime from "../app/(den)/_lib/runtime-config";
+import { DenFlowProvider, useDenFlow } from "../app/(den)/_providers/den-flow-provider";
 import {
   getDesktopGrant,
   getDesktopHandoffGrant,
   getDesktopHandoffOpenworkUrl,
 } from "../app/(den)/_lib/desktop-handoff";
+import { SETUP_CONTINUATION_KEY, parseSetupContinuation, type SetupContinuation } from "../app/(den)/_lib/setup-continuation";
 
 test("preserves the complete OpenWork desktop handoff URL", () => {
   const openworkUrl = "openwork://den-auth?grant=one-time-code&denBaseUrl=https%3A%2F%2Fapi.example.test";
@@ -29,4 +37,190 @@ test("rejects missing and malformed desktop handoffs", () => {
   ).toBeNull();
   expect(getDesktopGrant("not a url")).toBeNull();
   expect(getDesktopGrant(null)).toBeNull();
+});
+
+test("restores only fresh tab-scoped setup with a user and a known route", () => {
+  const pending = { userId: "user-1", desktopScheme: "openwork", setup: { organizationId: "org-1", route: "/dashboard/onboarding/tools" }, at: Date.now() };
+  expect(parseSetupContinuation(JSON.stringify(pending))).toEqual(pending);
+  expect(parseSetupContinuation(JSON.stringify({ ...pending, setup: null, userId: null }))).toMatchObject({ userId: null, setup: null });
+  for (const invalid of [
+    { ...pending, userId: null },
+    { ...pending, at: Date.now() - 25 * 60 * 60 * 1000 },
+    { ...pending, at: Date.now() + 60_000 },
+    { ...pending, setup: { organizationId: "org-1", route: "https://outside.test" } },
+    { ...pending, desktopScheme: "openwork://" },
+    { ...pending, setup: { route: "/dashboard/onboarding" } },
+  ]) expect(parseSetupContinuation(JSON.stringify(invalid))).toBeNull();
+  expect(parseSetupContinuation("not json")).toBeNull();
+});
+
+const account = { id: "user-1", email: "member@openwork.test", name: "Member" };
+const directory = { orgs: [{ id: "org-1", name: "Team", slug: "team", role: "owner", orgMemberId: "member-1", membershipId: "membership-1" }] };
+function deferred<T>() {
+  let resolve: (value: T) => void = () => { throw new Error("Deferred result not initialized"); };
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function withFlow(options: {
+  config?: Promise<runtime.DenWebRuntimeConfig>;
+  stored?: SetupContinuation;
+  desktop?: boolean;
+  reply?: (path: string) => Promise<{ status?: number; payload: unknown }>;
+}, check: (fixture: { state: () => ReturnType<typeof useDenFlow>; paths: string[]; opened: string[]; submit: () => void }) => Promise<void>) {
+  GlobalRegistrator.register({ url: `https://app.example.test/${options.desktop === false ? "" : "?desktopAuth=1"}` });
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  if (options.stored) sessionStorage.setItem(SETUP_CONTINUATION_KEY, JSON.stringify(options.stored));
+  const paths: string[] = [];
+  const opened: string[] = [];
+  spyOn(navigation, "usePathname").mockReturnValue("/");
+  spyOn(navigation, "useRouter").mockReturnValue({ push() {}, replace() {}, refresh() {}, back() {}, forward() {}, prefetch: async () => {} });
+  spyOn(runtime, "getRuntimeConfig").mockImplementation(() => options.config ?? Promise.resolve({ ...runtime.EMPTY_RUNTIME_CONFIG, orgMode: "multi_org" }));
+  spyOn(window.location, "assign").mockImplementation((url) => { opened.push(String(url)); });
+  spyOn(requests, "requestJson").mockImplementation(async (path) => {
+    paths.push(path);
+    const reply = options.reply ? await options.reply(path) : { payload: path === "/v1/me" ? { user: account } : path === "/v1/me/orgs" ? directory : {} };
+    return { response: Response.json(reply.payload, { status: reply.status ?? 200 }), payload: reply.payload };
+  });
+  let current: ReturnType<typeof useDenFlow> | null = null;
+  function Capture() {
+    const flow = useDenFlow();
+    current = flow;
+    return createElement("form", { onSubmit: (event) => { void flow.submitAuth(event); } });
+  }
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  try {
+    await act(async () => { root.render(createElement(DenFlowProvider, null, createElement(Capture))); });
+    await check({
+      state: () => { if (!current) throw new Error("Flow not mounted"); return current; }, paths, opened,
+      submit: () => { container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })); },
+    });
+  } finally {
+    await act(async () => root.unmount());
+    mock.restore();
+    await GlobalRegistrator.unregister();
+  }
+}
+
+test.each(["multi_org", "single_org"] satisfies runtime.DenWebRuntimeConfig["orgMode"][])("%s waits for runtime and the authenticated session before classifying an empty directory", async (orgMode) => {
+  const config = deferred<runtime.DenWebRuntimeConfig>();
+  const me = deferred<{ user: typeof account }>();
+  await withFlow({ config: config.promise, reply: async (path) => ({ payload: path === "/v1/me" ? await me.promise : path === "/v1/me/orgs" ? { orgs: [] } : {} }) }, async ({ state, paths }) => {
+    expect(await state().resolveUserLandingRoute()).toBeNull();
+    expect(paths).not.toContain("/v1/me/orgs");
+    await act(async () => config.resolve({ ...runtime.EMPTY_RUNTIME_CONFIG, orgMode }));
+    expect(state().runtimeConfigLoaded).toBe(true);
+    expect(state().sessionHydrated).toBe(false);
+    expect(await state().resolveUserLandingRoute()).toBeNull();
+    expect(paths).not.toContain("/v1/me/orgs");
+    await act(async () => me.resolve({ user: account }));
+    expect(state().sessionHydrated).toBe(true);
+    expect(state().setupPending).toBe(orgMode === "multi_org");
+    expect(paths).not.toContain("/api/auth/desktop-handoff");
+  });
+});
+
+test("sign-out invalidates an in-flight session response and clears the tab continuation", async () => {
+  const me = deferred<{ user: typeof account }>();
+  await withFlow({ reply: async (path) => ({ payload: path === "/v1/me" ? await me.promise : {} }) }, async ({ state, paths }) => {
+    await act(async () => state().signOut());
+    await act(async () => me.resolve({ user: account }));
+    expect(state().user).toBeNull();
+    expect(state().sessionHydrated).toBe(true);
+    expect(sessionStorage.getItem(SETUP_CONTINUATION_KEY)).toBeNull();
+    expect(paths).not.toContain("/api/auth/desktop-handoff");
+  });
+});
+
+test("a different authenticated user cannot inherit an earlier user's setup or desktop return", async () => {
+  await withFlow({ stored: { userId: "old-user", desktopScheme: "openwork", setup: { organizationId: "old-org", route: "/dashboard/onboarding/tools" }, at: Date.now() } }, async ({ state, paths }) => {
+    expect(state().user?.id).toBe(account.id);
+    expect(state().setupPending).toBe(false);
+    expect(state().desktopAuthRequested).toBe(false);
+    expect(sessionStorage.getItem(SETUP_CONTINUATION_KEY)).toBeNull();
+    expect(paths).not.toContain("/api/auth/desktop-handoff");
+  });
+});
+
+test("an organization lookup failure neither starts setup nor issues a handoff", async () => {
+  await withFlow({ reply: async (path) => path === "/v1/me/orgs"
+    ? { status: 503, payload: { message: "Directory unavailable" } }
+    : { payload: path === "/v1/me" ? { user: account } : {} } }, async ({ state, paths }) => {
+    expect(state().authError).toBeTruthy();
+    expect(state().setupPending).toBe(false);
+    expect(paths).not.toContain("/api/auth/desktop-handoff");
+  });
+});
+
+test.each([runtime.EMPTY_RUNTIME_CONFIG, { ...runtime.EMPTY_RUNTIME_CONFIG }])("fallback or single-org config never discards unfinished setup", async (config) => {
+  const setup = { organizationId: "org-1", route: "/dashboard/onboarding/people" };
+  await withFlow({ config: Promise.resolve(config), stored: { userId: account.id, desktopScheme: "openwork", setup, at: Date.now() } }, async ({ state, paths }) => {
+    expect(state().setupPending).toBe(true);
+    expect(await state().resolveUserLandingRoute()).toBe(setup.route);
+    expect(parseSetupContinuation(sessionStorage.getItem(SETUP_CONTINUATION_KEY))?.setup).toEqual(setup);
+    expect(paths).not.toContain("/api/auth/desktop-handoff");
+  });
+});
+
+test("failed runtime config cannot classify a new account or hand off a returning account", async () => {
+  await withFlow({ config: Promise.resolve(runtime.EMPTY_RUNTIME_CONFIG) }, async ({ state, paths }) => {
+    expect(state().authError).toContain("workspace configuration");
+    let route: string | null = null;
+    await act(async () => { route = await state().resolveUserLandingRoute(); });
+    expect(route).toBeNull();
+    expect(paths).not.toContain("/v1/me/orgs");
+    expect(paths).not.toContain("/api/auth/desktop-handoff");
+  });
+});
+
+test("sign-out discards a late handoff result without opening the app", async () => {
+  const handoff = deferred<{ payload: unknown }>();
+  await withFlow({ reply: async (path) => path === "/api/auth/desktop-handoff" ? handoff.promise
+    : { payload: path === "/v1/me" ? { user: account } : path === "/v1/me/orgs" ? directory : {} } }, async ({ state, paths, opened }) => {
+    expect(paths).toContain("/api/auth/desktop-handoff");
+    await act(async () => state().signOut());
+    await act(async () => handoff.resolve({ payload: { grant: "stale-test-grant", openworkUrl: "openwork://den-auth?grant=stale-test-grant" } }));
+    expect(opened).toEqual([]);
+    expect(state().desktopRedirectUrl).toBeNull();
+    expect(state().user).toBeNull();
+  });
+});
+
+test("changing the auth token requires the new session to hydrate before landing decisions", async () => {
+  const signedIn = deferred<{ user: typeof account }>();
+  let signingIn = false;
+  await withFlow({ desktop: false, reply: async (path) => {
+    if (path === "/api/auth/sign-in/email") { signingIn = true; return { payload: { token: "replacement-test-token", user: account } }; }
+    return { payload: path === "/v1/me" ? signingIn ? await signedIn.promise : { user: account } : {} };
+  } }, async ({ state, paths, submit }) => {
+    expect(state().sessionHydrated).toBe(true);
+    await act(async () => { state().setAuthMode("sign-in"); state().setEmail(account.email); state().setPassword("test-password"); });
+    await act(async () => submit());
+    expect(state().sessionHydrated).toBe(false);
+    expect(await state().resolveUserLandingRoute()).toBeNull();
+    expect(paths).not.toContain("/v1/me/orgs");
+    await act(async () => signedIn.resolve({ user: account }));
+    expect(state().sessionHydrated).toBe(true);
+  });
+});
+
+test("a returning user's failed handoff can retry without signing in again", async () => {
+  let attempts = 0;
+  await withFlow({ reply: async (path) => {
+    if (path === "/api/auth/desktop-handoff") {
+      attempts += 1;
+      return attempts === 1 ? { status: 503, payload: { message: "Try again" } } : { payload: { grant: "test-grant", openworkUrl: "openwork://den-auth?grant=test-grant" } };
+    }
+    return { payload: path === "/v1/me" ? { user: account } : path === "/v1/me/orgs" ? directory : {} };
+  } }, async ({ state, opened }) => {
+    expect(state().authError).toBeTruthy();
+    expect(attempts).toBe(1);
+    await act(async () => state().retryDesktopAuthHandoff());
+    expect(state().authError).toBeNull();
+    expect(attempts).toBe(2);
+    expect(opened).toEqual(["openwork://den-auth?grant=test-grant"]);
+    expect(sessionStorage.getItem(SETUP_CONTINUATION_KEY)).toBeNull();
+  });
 });

--- a/ee/apps/den-web/tests/onboarding-page.test.ts
+++ b/ee/apps/den-web/tests/onboarding-page.test.ts
@@ -10,28 +10,39 @@ function read(...segments: string[]) {
 
 const screen = read("dashboard", "_components", "marketplace-onboarding-screen.tsx");
 const page = read("dashboard", "(admin)", "onboarding", "page.tsx");
-const publicInstallers = read("_lib", "public-installers.ts");
 
 describe("Marketplace onboarding page", () => {
-  test("keeps real platform downloads and release assets", () => {
-    expect(screen).toContain("DownloadOpenWorkCard");
+  test("finishes setup without downloads or an installation checklist", () => {
+    expect(screen).not.toContain("DownloadOpenWorkCard");
+    expect(screen).not.toContain("send-download-link");
+    expect(screen).not.toContain("app-installed");
     expect(screen).toContain("DenBadge");
-    expect(page).toContain("getPublicInstallers");
-    expect(publicInstallers).toContain('name.startsWith("openwork-cloud-")');
-    expect(publicInstallers).toContain('name.startsWith("openwork-enterprise-")');
+    expect(page).not.toContain("getPublicInstallers");
+    expect(screen).toContain("Complete and open the app");
+    expect(screen).toContain("completeSetup(orgId)");
   });
 
   test("offers OpenWork Models and Bring your Own Keys as the model path", () => {
     expect(screen).toContain("onboarding-choice-openwork-models");
     expect(screen).toContain("onboarding-choice-byok");
-    expect(screen).toContain("Turn on models");
+    expect(screen).toContain("Explore models");
     expect(screen).toContain("Bring your Own Keys");
     expect(screen).toContain("/openwork-mark.svg");
   });
 
-  test("keeps the installed flag and inference check", () => {
-    expect(screen).toContain("openwork:onboarding:app-installed");
+  test("checks model status without enabling models", () => {
     expect(screen).toContain("/v1/inference");
-    expect(screen).toContain("onboarding-app-installed");
+    expect(screen).toContain('headers: { "x-openwork-org-id": orgId }');
+    expect(screen).not.toContain('method: "POST"');
+    expect(screen).toContain("Signing in does not enable models.");
+    expect(screen).toContain("No model selection is required");
+  });
+
+  test("retains the web Models route and focuses Models before desktop completion", () => {
+    const tools = read("dashboard", "_components", "onboarding-tools-screen.tsx");
+    expect(tools).toContain('intent === "models" && !desktopAuthRequested');
+    expect(tools).toContain("router.push(getInferenceRoute(orgSlug))");
+    expect(screen).toContain("modelsHeading.current?.focus()");
+    expect(screen).not.toContain("removeItem(PENDING_AUTH_INTENT_STORAGE_KEY)");
   });
 });

--- a/ee/apps/landing/app/cloud/page.tsx
+++ b/ee/apps/landing/app/cloud/page.tsx
@@ -46,7 +46,6 @@ export default async function CloudPage() {
       <div className="relative z-10">
         <SiteNav
           stars={github.stars}
-          downloadHref={github.downloads.macos}
           callUrl={callHref}
           mobilePrimaryHref={CLOUD_SIGNUP_URL}
           mobilePrimaryLabel="Get started for free"

--- a/ee/apps/landing/app/connect/page.tsx
+++ b/ee/apps/landing/app/connect/page.tsx
@@ -46,7 +46,6 @@ export default async function ConnectPage() {
       <div className="relative z-10">
         <SiteNav
           stars={github.stars}
-          downloadHref={github.downloads.macos}
           callUrl={callHref}
           mobilePrimaryHref={CLOUD_SIGNUP_URL}
           mobilePrimaryLabel="Get started for free"

--- a/ee/apps/landing/app/dashboard/page.tsx
+++ b/ee/apps/landing/app/dashboard/page.tsx
@@ -64,7 +64,6 @@ export default async function DashboardPage() {
       <div className="relative z-10">
         <SiteNav
           stars={github.stars}
-          downloadHref={github.downloads.macos}
           callUrl={callHref}
           mobilePrimaryHref={CLOUD_SIGNUP_URL}
           mobilePrimaryLabel="Open OpenWork Cloud"

--- a/ee/apps/landing/app/download/page.tsx
+++ b/ee/apps/landing/app/download/page.tsx
@@ -48,7 +48,6 @@ export default async function Download() {
       <StructuredData data={downloadSchema} />
       <SiteNav
         stars={github.stars}
-        downloadHref={github.downloads.macos}
         mobilePrimaryHref="/download"
         mobilePrimaryLabel="Download now"
         active="download"

--- a/ee/apps/landing/app/enterprise/page.tsx
+++ b/ee/apps/landing/app/enterprise/page.tsx
@@ -22,7 +22,6 @@ export default async function Enterprise() {
   return (
     <LandingEnterprise
       stars={github.stars}
-      downloadHref={github.downloads.macos}
       calUrl={cal}
     />
   );

--- a/ee/apps/landing/app/glm-5.2/page.tsx
+++ b/ee/apps/landing/app/glm-5.2/page.tsx
@@ -82,7 +82,6 @@ export default async function GlmLanding() {
       <StructuredData data={glmSchema} />
       <SiteNav
         stars={github.stars}
-        downloadHref={github.downloads.macos}
       />
 
       <main className="pb-24 pt-20">

--- a/ee/apps/landing/app/layout.tsx
+++ b/ee/apps/landing/app/layout.tsx
@@ -1,10 +1,13 @@
 import "./globals.css";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script";
+import type { ReactNode } from "react";
 import { BotIdClient } from "botid/client";
 import { WebMcpProvider } from "../components/webmcp-provider";
 import { StructuredData } from "../components/structured-data";
 import { POSTHOG_PROJECT_KEY } from "../lib/posthog-client";
+import { getGithubData } from "../lib/github";
+import { DownloadProvider } from "../components/download-link";
 
 // Matches the server-side gate in lib/posthog-server.ts.
 // Local pnpm dev, local prod builds, and Vercel previews load no PostHog at all (no autocapture/pageviews), so only real production traffic reaches analytics.
@@ -62,11 +65,12 @@ const protectedRoutes = [
   { path: "/api/app-feedback", method: "POST" as const },
 ];
 
-export default function RootLayout({
+export default async function RootLayout({
   children
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
+  const github = await getGithubData();
   return (
     <html lang="en" className={`${inter.variable} ${jetbrains.variable}`}>
       <head>
@@ -89,7 +93,7 @@ export default function RootLayout({
       </head>
       <body className="overflow-x-hidden antialiased">
         <WebMcpProvider />
-        {children}
+        <DownloadProvider installers={github.installers}>{children}</DownloadProvider>
       </body>
     </html>
   );

--- a/ee/apps/landing/app/layout.tsx
+++ b/ee/apps/landing/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script";
-import type { ReactNode } from "react";
 import { BotIdClient } from "botid/client";
 import { WebMcpProvider } from "../components/webmcp-provider";
 import { StructuredData } from "../components/structured-data";
@@ -68,7 +67,7 @@ const protectedRoutes = [
 export default async function RootLayout({
   children
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
 }) {
   const github = await getGithubData();
   return (
@@ -93,7 +92,7 @@ export default async function RootLayout({
       </head>
       <body className="overflow-x-hidden antialiased">
         <WebMcpProvider />
-        <DownloadProvider installers={github.installers}>{children}</DownloadProvider>
+        <DownloadProvider installers={github.installers}><>{children}</></DownloadProvider>
       </body>
     </html>
   );

--- a/ee/apps/landing/app/pricing/page.tsx
+++ b/ee/apps/landing/app/pricing/page.tsx
@@ -83,7 +83,6 @@ export default async function PricingPage() {
           <SiteNav
             stars={github.stars}
             callUrl={callUrl}
-            downloadHref={github.downloads.macos}
             active="pricing"
           />
         </div>

--- a/ee/apps/landing/app/starter-success/page.tsx
+++ b/ee/apps/landing/app/starter-success/page.tsx
@@ -32,7 +32,7 @@ export default async function StarterSuccessPage() {
 
   return (
     <div className="min-h-screen">
-      <SiteNav stars={github.stars} downloadHref={github.downloads.macos} />
+      <SiteNav stars={github.stars} />
 
       <main className="pb-24 pt-20">
         <div className="content-max-width px-6">

--- a/ee/apps/landing/app/trust/page.tsx
+++ b/ee/apps/landing/app/trust/page.tsx
@@ -22,7 +22,6 @@ export default async function TrustPage() {
   return (
     <LandingTrustOverview
       stars={github.stars}
-      downloadHref={github.downloads.macos}
       calUrl={cal}
     />
   );

--- a/ee/apps/landing/components/download-link.tsx
+++ b/ee/apps/landing/components/download-link.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { detectPlatform, type DownloadCardInstallers } from "@openwork/ui/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import { automaticDownloadHref } from "../lib/automatic-download";
+import { capturePosthogEvent } from "../lib/posthog-client";
+
+const DownloadContext = createContext<(sourcePath: string) => void>(() => {});
+
+export function DownloadProvider({ installers, children }: {
+  installers: DownloadCardInstallers;
+  children: ReactNode;
+}) {
+  const detection = useRef<ReturnType<typeof detectPlatform> | null>(null);
+  const [download, setDownload] = useState<{ href: string; attempt: number } | null>(null);
+
+  useEffect(() => {
+    detection.current = detectPlatform();
+  }, []);
+
+  async function startDownload(sourcePath: string) {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const detected = await Promise.race([
+        detection.current ?? detectPlatform(),
+        new Promise<null>((resolve) => { timeout = setTimeout(() => resolve(null), 1500); })
+      ]);
+      const href = automaticDownloadHref(installers, detected, navigator.userAgent, navigator.maxTouchPoints);
+      capturePosthogEvent("desktop_download_clicked", {
+        source_path: sourcePath,
+        download_url: href,
+        os: detected?.os,
+        architecture: detected?.arch
+      });
+      if (href) setDownload((previous) => ({ href, attempt: (previous?.attempt ?? 0) + 1 }));
+    } catch {
+      // Detection failure leaves the visitor on /download with manual choices.
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return (
+    <DownloadContext.Provider value={startDownload}>
+      {children}
+      {/* Keep the transfer alive across client navigation to the fallback page. */}
+      {download ? <iframe key={download.attempt} src={download.href} title="OpenWork installer download" hidden /> : null}
+    </DownloadContext.Provider>
+  );
+}
+
+export function DownloadLink({ children, className }: { children: ReactNode; className?: string }) {
+  const startDownload = useContext(DownloadContext);
+  const router = useRouter();
+
+  return (
+    <Link
+      href="/download"
+      className={className}
+      onClick={(event) => {
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        event.preventDefault();
+        // Preserve campaign attribution without putting replayable download intent
+        // in the URL or storage. A visit, prefetch, reload, or Back never starts it.
+        void startDownload(window.location.pathname);
+        router.push(`/download${window.location.search}`);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/ee/apps/landing/components/landing-enterprise.tsx
+++ b/ee/apps/landing/components/landing-enterprise.tsx
@@ -22,7 +22,6 @@ import { SiteNav } from "./site-nav";
 
 type Props = {
   stars: string;
-  downloadHref: string;
   calUrl: string;
 };
 
@@ -118,7 +117,6 @@ export function LandingEnterprise(props: Props) {
         <SiteNav
           stars={props.stars}
           callUrl={props.calUrl}
-          downloadHref={props.downloadHref}
           active="enterprise"
         />
 

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -2,7 +2,6 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowRight, Globe, Monitor, SquareTerminal } from "lucide-react";
-import Link from "next/link";
 import { useMemo, useState } from "react";
 
 import { BrandLogo } from "./lp-brand-logos";
@@ -27,6 +26,7 @@ import {
 } from "./lp-primitives";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
+import { DownloadLink } from "./download-link";
 
 type Props = {
   stars: string;
@@ -64,7 +64,7 @@ export function LandingHome(props: Props) {
     () => landingDemoFlows.find((flow) => flow.id === activeDemoId) ?? landingDemoFlows[0],
     [activeDemoId]
   );
-  const primaryHref = props.isMobileVisitor ? CLOUD_SIGNUP_URL : props.downloadHref;
+  const primaryHref = props.isMobileVisitor ? CLOUD_SIGNUP_URL : "/download";
   const callExternal = /^https?:\/\//.test(props.callHref);
 
   return (
@@ -74,7 +74,6 @@ export function LandingHome(props: Props) {
       <div className="relative z-10">
         <SiteNav
           stars={props.stars}
-          downloadHref={props.downloadHref}
           callUrl={props.callHref}
           mobilePrimaryHref={CLOUD_SIGNUP_URL}
           mobilePrimaryLabel="Get started for free"
@@ -109,12 +108,11 @@ export function LandingHome(props: Props) {
                     Get Started for Free <ArrowRight size={18} />
                   </a>
                 ) : (
-                  <Link
-                    href="/download"
+                  <DownloadLink
                     className="doc-button inline-flex items-center gap-2"
                   >
                     Download for free <ArrowRight size={18} />
-                  </Link>
+                  </DownloadLink>
                 )}
                 <a
                   href={props.callHref}

--- a/ee/apps/landing/components/landing-trust.tsx
+++ b/ee/apps/landing/components/landing-trust.tsx
@@ -10,7 +10,6 @@ import {
 
 type SharedProps = {
   stars: string;
-  downloadHref: string;
   calUrl: string;
 };
 
@@ -58,7 +57,6 @@ export function LandingTrustOverview(props: SharedProps) {
           <SiteNav
             stars={props.stars}
             callUrl={callHref}
-            downloadHref={props.downloadHref}
           />
         </div>
 

--- a/ee/apps/landing/components/legal-page.tsx
+++ b/ee/apps/landing/components/legal-page.tsx
@@ -30,7 +30,6 @@ export async function LegalPage({ file }: LegalPageProps) {
           <SiteNav
             stars={github.stars}
             callUrl={callUrl}
-            downloadHref={github.downloads.macos}
           />
         </div>
 

--- a/ee/apps/landing/components/lp-cta.tsx
+++ b/ee/apps/landing/components/lp-cta.tsx
@@ -1,3 +1,5 @@
+import { DownloadLink } from "./download-link";
+
 type CtaLink = {
   label: string;
   href: string;
@@ -30,9 +32,11 @@ export function LpCta({
       </div>
       <div className="flex shrink-0 flex-col items-start gap-3 md:items-end">
         <div className="flex flex-col gap-3 sm:flex-row">
-          <a href={primary.href} className="lp-pill-primary">
-            {primary.label}
-          </a>
+          {primary.href === "/download" ? (
+            <DownloadLink className="lp-pill-primary">{primary.label}</DownloadLink>
+          ) : (
+            <a href={primary.href} className="lp-pill-primary">{primary.label}</a>
+          )}
           <a href={secondary.href} className="lp-pill-secondary">
             {secondary.label}
           </a>

--- a/ee/apps/landing/components/lp-primitives.tsx
+++ b/ee/apps/landing/components/lp-primitives.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { DownloadLink } from "./download-link";
 
 type LpSectionHeaderProps = {
   label: string;
@@ -73,8 +74,9 @@ type LpArrowLinkProps = {
 };
 
 export function LpArrowLink({ href, children }: LpArrowLinkProps) {
+  const Component = href === "/download" ? DownloadLink : "a";
   return (
-    <a
+    <Component
       href={href}
       className="group inline-flex items-center gap-1.5 text-[14px] font-medium text-[var(--lp-ink)]"
     >
@@ -85,6 +87,6 @@ export function LpArrowLink({ href, children }: LpArrowLinkProps) {
       >
         →
       </span>
-    </a>
+    </Component>
   );
 }

--- a/ee/apps/landing/components/migration-guide-page.tsx
+++ b/ee/apps/landing/components/migration-guide-page.tsx
@@ -29,7 +29,7 @@ const checklist = [
 export function MigrationGuidePage({ stars, downloadHref }: Props) {
   return (
     <div className="min-h-screen overflow-x-hidden bg-[var(--lp-page)] text-[var(--lp-ink)]">
-      <SiteNav stars={stars} downloadHref={downloadHref} active="docs" />
+      <SiteNav stars={stars} active="docs" />
 
       <main className="mx-auto w-full max-w-[1040px] px-6 pb-8">
         <header className="border-b border-[var(--lp-border)] pb-14 pt-16 md:pb-20 md:pt-[88px]">

--- a/ee/apps/landing/components/site-nav.tsx
+++ b/ee/apps/landing/components/site-nav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Menu, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { OpenWorkMark } from "./openwork-mark";
+import { DownloadLink } from "./download-link";
 
 type ActivePage =
   | "home"
@@ -19,7 +20,6 @@ type ActivePage =
 type Props = {
   stars: string;
   callUrl?: string;
-  downloadHref?: string;
   mobilePrimaryHref?: string;
   mobilePrimaryLabel?: string;
   active?: ActivePage;
@@ -48,8 +48,6 @@ export function SiteNav(props: Props) {
   const mobilePrimaryLabel = props.mobilePrimaryLabel || "Get Started for free";
   const callExternal = /^https?:\/\//.test(callHref);
   const mobilePrimaryExternal = /^https?:\/\//.test(mobilePrimaryHref);
-  const downloadHref = props.downloadHref || "/download";
-  const downloadExternal = /^https?:\/\//.test(downloadHref);
   const navItems: NavItem[] = [
     { href: "/#product", label: "Product", key: "home" },
     { href: "/connect", label: "Connect", key: "connect" },
@@ -113,14 +111,11 @@ export function SiteNav(props: Props) {
               </svg>
               {props.stars}
             </a>
-            <a
-              href={downloadHref}
-              target={downloadExternal ? "_blank" : undefined}
-              rel={downloadExternal ? "noreferrer" : undefined}
+            <DownloadLink
               className="lp-pill-primary lp-pill-sm !hidden lg:!inline-flex"
             >
               Download
-            </a>
+            </DownloadLink>
             <button
               type="button"
               className="rounded-full p-2 text-[#011627] transition-colors hover:bg-white/70 lg:hidden"

--- a/ee/apps/landing/lib/automatic-download.ts
+++ b/ee/apps/landing/lib/automatic-download.ts
@@ -1,0 +1,29 @@
+import type { DetectedPlatform, DownloadCardInstallers } from "@openwork/ui/react";
+
+export function automaticDownloadHref(
+  installers: DownloadCardInstallers,
+  detected: DetectedPlatform | null,
+  userAgent: string,
+  maxTouchPoints: number
+): string | null {
+  // The shared card detector defaults unknown devices to macOS. That is not
+  // safe for starting a download, including iPads using a desktop user agent.
+  if (/android|iphone|ipad|ipod|mobile|cros/i.test(userAgent)) return null;
+  if (/macintosh/i.test(userAgent) && maxTouchPoints > 1) return null;
+  const os = /windows nt/i.test(userAgent) ? "windows"
+    : /macintosh|mac os x/i.test(userAgent) ? "macos"
+    : /linux/i.test(userAgent) ? "linux" : null;
+  if (!os || detected?.os !== os || !detected.arch) return null;
+
+  const arm = detected.arch === "arm64";
+  const candidates = os === "macos"
+    ? [arm ? installers.macos.appleSilicon : installers.macos.intel]
+    : os === "windows"
+      ? [installers.windows[detected.arch]]
+      : arm
+        ? [installers.linux.appImageArm64, installers.linux.tarArm64]
+        : [installers.linux.appImageX64, installers.linux.tarX64];
+
+  // Release-page fallbacks must stay visible choices, never hidden navigations.
+  return candidates.find((href) => /\.(dmg|exe|appimage|tar\.gz)$/i.test(href)) ?? null;
+}

--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -150,8 +150,8 @@ export const getGithubData = async () => {
   const exe = selectAsset(windowsAssets, [".exe"], ["openwork-win-"]);
   const macosApple = selectAsset(assets, [".dmg"], ["mac-arm64"]);
   const macosIntel = selectAsset(assets, [".dmg"], ["mac-x64"]);
-  const windowsX64 =
-    selectAsset(windowsAssets, [".exe"], ["win-x64"]) || exe;
+  const macosUniversal = selectAsset(assets, [".dmg"], ["mac-universal"]);
+  const windowsX64 = selectAsset(windowsAssets, [".exe"], ["win-x64"]);
   const windowsArm64 = selectAsset(windowsAssets, [".exe"], ["win-arm64"]);
 
   const linuxAppImageX64 =
@@ -175,8 +175,8 @@ export const getGithubData = async () => {
     },
     installers: {
       macos: {
-        appleSilicon: macosApple?.browser_download_url || dmg?.browser_download_url || releaseUrl,
-        intel: macosIntel?.browser_download_url || dmg?.browser_download_url || releaseUrl
+        appleSilicon: macosApple?.browser_download_url || macosUniversal?.browser_download_url || releaseUrl,
+        intel: macosIntel?.browser_download_url || macosUniversal?.browser_download_url || releaseUrl
       },
       windows: {
         x64: windowsX64?.browser_download_url || windowsReleaseUrl,

--- a/ee/apps/landing/test/github.test.ts
+++ b/ee/apps/landing/test/github.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { getGithubData } from "../lib/github";
+import { automaticDownloadHref } from "../lib/automatic-download";
+import type { DetectedPlatform } from "@openwork/ui/react";
 
 type GithubFixtureAsset = {
   name: string;
@@ -79,6 +81,58 @@ afterEach(() => {
 });
 
 describe("getGithubData", () => {
+  test("never substitutes another architecture when a public installer is missing", async () => {
+    const release = releaseWithAssets([
+      asset("openwork-mac-arm64-0.17.38.dmg"),
+      asset("openwork-win-arm64-0.17.38.exe")
+    ]);
+    installGithubFetch({ latestRelease: release, releases: [release] });
+    const data = await getGithubData();
+    expect(data.installers.macos.intel).toBe(releasePageUrl);
+    expect(data.installers.windows.x64).toBe(releasePageUrl);
+    expect(automaticDownloadHref(data.installers, { os: "macos", arch: "x64", osVersion: null, source: "ua-ch" }, "Macintosh", 0)).toBeNull();
+
+    const universal = asset("openwork-mac-universal-0.17.38.dmg");
+    const universalRelease = releaseWithAssets([universal]);
+    installGithubFetch({ latestRelease: universalRelease, releases: [universalRelease] });
+    const universalData = await getGithubData();
+    expect(universalData.installers.macos.appleSilicon).toBe(universal.browser_download_url);
+    expect(universalData.installers.macos.intel).toBe(universal.browser_download_url);
+  });
+
+  test("one-click selection uses the detected architecture, with safe manual fallbacks", async () => {
+    const release = releaseWithAssets([
+      asset("openwork-mac-arm64-0.17.38.dmg"),
+      asset("openwork-mac-x64-0.17.38.dmg"),
+      asset("openwork-win-arm64-0.17.38.exe"),
+      asset("openwork-win-x64-0.17.38.exe"),
+      asset("openwork-linux-x86_64-0.17.38.AppImage"),
+      asset("openwork-linux-arm64-0.17.38.tar.gz")
+    ]);
+    installGithubFetch({ latestRelease: release, releases: [release] });
+    const { installers } = await getGithubData();
+    const devices: { os: DetectedPlatform["os"]; ua: string; hrefs: string[] }[] = [
+      { os: "macos", ua: "Macintosh", hrefs: [installers.macos.appleSilicon, installers.macos.intel] },
+      { os: "windows", ua: "Windows NT 10.0; Win64; x64", hrefs: [installers.windows.arm64, installers.windows.x64] },
+      { os: "linux", ua: "X11; Linux x86_64", hrefs: [installers.linux.tarArm64, installers.linux.appImageX64] }
+    ];
+    const architectures: DetectedPlatform["arch"][] = ["arm64", "x64"];
+    for (const device of devices) {
+      for (const [index, arch] of architectures.entries()) {
+        const detected: DetectedPlatform = { os: device.os, arch, osVersion: null, source: "ua-ch" };
+        expect(automaticDownloadHref(installers, detected, device.ua, 0)).toBe(device.hrefs[index]);
+        expect(automaticDownloadHref(installers, { ...detected, arch: null }, device.ua, 0)).toBeNull();
+      }
+    }
+    const mac: DetectedPlatform = { os: "macos", arch: "arm64", osVersion: null, source: "webgl" };
+    for (const ua of ["", "Unknown", "iPhone", "iPad", "Linux; Android", "X11; CrOS x86_64"]) {
+      expect(automaticDownloadHref(installers, mac, ua, 0)).toBeNull();
+    }
+    expect(automaticDownloadHref(installers, mac, "Macintosh", 5)).toBeNull();
+    expect(automaticDownloadHref(installers, mac, "Windows NT 10.0", 0)).toBeNull();
+    expect(automaticDownloadHref(installers, null, "Macintosh", 0)).toBeNull();
+  });
+
   test("selects only public desktop assets when installer assets are listed first", async () => {
     const macArm64 = asset("openwork-mac-arm64-0.17.38.dmg");
     const macX64 = asset("openwork-mac-x64-0.17.38.dmg");

--- a/evals/README.md
+++ b/evals/README.md
@@ -207,6 +207,11 @@ and accepts a string or regular expression. Clicks require center-point hit
 testing; `{ hitTest: false }` is a last resort for an intentionally covered
 target and still performs a trusted CDP click at that element's center.
 
+`probe.dom(selector)` reads a fixed DOM snapshot: matching elements in document
+order with text, focus and rectangles, plus viewport/document widths. It never
+returns input values or accepts executable callbacks. Use it for geometry and
+focus assertions after trusted `user.press("Tab")` actions, rather than raw eval.
+
 Worlds can arrange a shaped Den connection with `seed.denLink(den, options)`;
 the returned link is fixture-owned. `probe.connectState(app)` reads the
 testkit's normalized desktop Connect state without exposing the raw helper to a

--- a/evals/packages/cdp/src/input.ts
+++ b/evals/packages/cdp/src/input.ts
@@ -31,6 +31,30 @@ export interface Located {
   covering: { tag: string; text: string; role: string } | null;
 }
 
+/** Read-only DOM geometry and focus; deliberately excludes input values and attributes. */
+export async function readDom(surface: Surface, selector: string) {
+  const snapshot = await callFunctionOnSurface(surface, (selector) => ({
+    viewportWidth: document.documentElement.clientWidth,
+    documentWidth: document.documentElement.scrollWidth,
+    elements: Array.from(document.querySelectorAll(selector), (element) => {
+      const { left, right, top, bottom, width, height } = element.getBoundingClientRect();
+      return {
+        tag: element.tagName.toLowerCase(),
+        text: element.textContent?.trim() ?? "",
+        focused: element === document.activeElement,
+        rect: { left, right, top, bottom, width, height },
+      };
+    }),
+  }), [selector]);
+  if (!snapshot || !Number.isFinite(snapshot.viewportWidth) || !Number.isFinite(snapshot.documentWidth)
+    || !Array.isArray(snapshot.elements) || !snapshot.elements.every((element) => element
+      && typeof element.tag === "string" && typeof element.text === "string" && typeof element.focused === "boolean"
+      && element.rect && [element.rect.left, element.rect.right, element.rect.top, element.rect.bottom, element.rect.width, element.rect.height].every(Number.isFinite))) {
+    throw new Error("DOM inspection returned an invalid snapshot.");
+  }
+  return snapshot;
+}
+
 interface SerializedMatcher {
   kind: "string" | "regexp";
   value: string;

--- a/evals/packages/cdp/test/input.test.ts
+++ b/evals/packages/cdp/test/input.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { assertAbsent, locate, TargetNotFoundError, mapKey, parseTarget, waitForLocated } from "../src/input.ts";
+import { runInNewContext } from "node:vm";
+import { assertAbsent, locate, TargetNotFoundError, mapKey, parseTarget, readDom, waitForLocated } from "../src/input.ts";
 import type { Surface } from "../src/surface.ts";
 
 function surfaceReturning(value: unknown): Surface {
@@ -114,4 +115,28 @@ test("absence distinguishes a hidden target from a visible target", async () => 
   const target = { center: { x: 1, y: 1 }, rect: { x: 0, y: 0, width: 2, height: 2 }, tag: "div", name: "Error", visible: false, hitTestOk: false, editable: false, value: "", text: "Error", covering: null };
   await assertAbsent(surfaceReturning(target), "Error", 10);
   await assert.rejects(assertAbsent(surfaceReturning({ ...target, visible: true }), "Error", 10), /remained visible/);
+});
+
+test("DOM inspection projects geometry and focus without exposing input values", async () => {
+  const input = { tagName: "INPUT", textContent: "", value: "private-password", getBoundingClientRect: () => ({ left: 1, right: 101, top: 2, bottom: 22, width: 100, height: 20 }) };
+  const surface = surfaceReturning(null);
+  surface.client.send = async (method, params) => {
+    if (method === "Runtime.evaluate") return { result: { objectId: "global" } };
+    assert.equal(method, "Runtime.callFunctionOn");
+    assert.ok(params && typeof params.functionDeclaration === "string");
+    assert.deepEqual(params.arguments, [{ value: "input" }]);
+    const value = runInNewContext(`(${params.functionDeclaration})("input")`, {
+      document: { documentElement: { clientWidth: 390, scrollWidth: 400 }, activeElement: input,
+        querySelectorAll(selector: string) { assert.equal(selector, "input"); return [input]; } },
+    });
+    return { result: { value } };
+  };
+  const result = await readDom(surface, "input");
+  assert.equal(result.elements[0]?.focused, true);
+  assert.equal(result.elements[0]?.rect.width, 100);
+  assert.equal(result.documentWidth > result.viewportWidth, true);
+  assert.equal(JSON.stringify(result).includes("private-password"), false);
+  assert.equal(input.value, "private-password");
+  await assert.rejects(readDom(surfaceReturning(null), "input"), /invalid snapshot/);
+  await assert.rejects(readDom(surfaceReturning({ viewportWidth: 390, documentWidth: 390, elements: [{}] }), "input"), /invalid snapshot/);
 });

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "@openwork/behaviors";
 import {
   callFunctionOnSurface,
+  addInitScript,
   callFunction, connect, debuggerUrlFor, listTargets,
   clickAt,
   dumpScreenState,
@@ -469,7 +470,7 @@ export class SeedChannel implements Seed {
       const web = this.#runtime.stack.use(await chrome({
         name: "spec-web",
         host: this.#runtime.place.host(),
-        startUrl: options.den.ref.webUrl,
+        startUrl: options.signedInAs === undefined ? options.den.ref.webUrl : "about:blank",
         headless: options.headless,
       }));
       if (options.viewport) await setViewport(web, {
@@ -479,22 +480,15 @@ export class SeedChannel implements Seed {
       if (options.signedInAs !== undefined) {
         const session = sessionFromWebOptions(options);
         const denOrigin = new URL(options.den.ref.webUrl).origin;
-        let lastHref = "unobserved";
-        const waitForDen = () => eventually(async () => {
-          const observation = await evaluateOnSurface(web, browserScript((denOrigin) => (location.origin === denOrigin && document.readyState !== "loading" ? "" : location.href), [denOrigin]));
-          if (typeof observation === "string") lastHref = observation;
-          return observation === "";
-        }, { within: 30_000, intervalMs: 250, label: "Den origin document" });
-        try {
-          await waitForDen();
-        } catch {
-          await navigate(web.client, options.den.ref.webUrl);
-          await waitForDen().catch(() => { throw new Error(`Den origin document did not load; last observed location.href: ${lastHref}`); });
-        }
-        await callFunctionOnSurface(web, (token) => {
-          localStorage.setItem("openwork:web:auth-token", token);
-          return true;
-        }, [session.token]);
+        // Seed before hydration: a running anonymous page can otherwise clear the token.
+        await using initialSession = await addInitScript(web.client, browserScript((origin, token) => {
+          if (location.origin === origin) localStorage.setItem("openwork:web:auth-token", token);
+        }, [denOrigin, session.token]));
+        await navigate(web.client, new URL(options.startPath ?? "/", options.den.ref.webUrl).toString());
+        await eventually(() => evaluateOnSurface(web, browserScript((origin) =>
+          location.origin === origin && document.readyState !== "loading", [denOrigin])),
+        { within: 30_000, intervalMs: 250, label: "Seeded Den origin document" });
+        return web;
       }
       const startPath = options.startPath ?? "/";
       await navigate(web.client, new URL(startPath, options.den.ref.webUrl).toString());

--- a/evals/packages/testkit/src/spec/runtime.ts
+++ b/evals/packages/testkit/src/spec/runtime.ts
@@ -21,6 +21,7 @@ import {
   evaluateOnSurface,
   hoverAt,
   locate,
+  readDom,
   assertAbsent,
   navigate,
   pressKey,
@@ -864,6 +865,11 @@ export class ProbeChannel implements Probe {
 
   on(surface: Surface): Probe {
     return new ProbeChannel(this.#runtime, surface);
+  }
+
+  dom(selector: string) {
+    const surface = requireSurface(this.#surface);
+    return this.#runtime.call("probe", "dom", `dom(${JSON.stringify(redacted(selector))})`, surface, () => readDom(surface, selector));
   }
 
   text(): Promise<string> {

--- a/evals/packages/testkit/src/spec/types.ts
+++ b/evals/packages/testkit/src/spec/types.ts
@@ -63,6 +63,8 @@ export interface Agent {
 
 export interface Probe {
   text(): Promise<string>;
+  /** Fixed, read-only DOM projection for layout, focus and element presence assertions. */
+  dom(selector: string): ReturnType<typeof import("@openwork/cdp").readDom>;
   has(text: string): Promise<boolean>;
   composer(): ReturnType<typeof import("@openwork/behaviors").readComposerState>;
   storage(key: string): Promise<unknown>;

--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -9,18 +9,25 @@ test("app boots with a control route and meaningful visible content", async ({ w
   expect((await probe.text()).trim().length).toBeGreaterThan(40);
   if (world.packaged) {
     expect(await world.packagedRuntime()).toEqual({
-      bridge: true, protocol: "file:", health: 200, welcome: true, crash: false,
+      bridge: true, protocol: "file:", health: 200, emptySession: true, signedOut: true, onboarding: false, crash: false,
     });
+    await user.see("composer", { editable: true, text: "" });
+    await user.see("Run task");
+    const workspaceId = /^#\/workspace\/([^/]+)\/session$/.exec(await probe.hash())?.[1];
+    if (!workspaceId) throw new Error("The packaged app did not open its empty workspace route.");
+    const sessions = await probe.desktopApi(`/workspace/${workspaceId}/opencode/session`);
+    expect(sessions.status).toBe(200);
+    expect(sessions.body).toEqual([]);
     const tools = await world.packagedToolIds();
     expect(tools).toEqual(expect.arrayContaining(["openwork_docs_search", "openwork_query"]));
     evidence.recordAssertionEvidence(
       "The packaged engine loads OpenWork Connect canary tools",
-      "A workspace created through the packaged embedded server exposes openwork_docs_search and openwork_query through the real engine tool registry. The engine resolves the shipped plugins outside app.asar without repository dependencies.",
+      "The automatically selected default workspace exposes openwork_docs_search and openwork_query through the real engine tool registry without test-driven workspace creation or engine startup. The engine resolves the shipped plugins outside app.asar without repository dependencies.",
       true,
     );
     evidence.recordAssertionEvidence(
       "The packaged desktop loads its renderer, preload bridge, and embedded server without a development server",
-      "The installed-layout binary reached an interactive welcome screen through file: assets; a preload IPC round trip returned its embedded server endpoint and HTTP health returned 200. No crash screen was present. The host used a fresh isolated profile.",
+      "The installed-layout binary opened an empty editable session through file: assets, signed out and without onboarding gates or a blank session. A preload IPC round trip returned its embedded server endpoint and HTTP health returned 200. No crash screen was present. The host used a fresh isolated profile.",
       true,
     );
   } else {

--- a/evals/specs/app-smoke.e2e.test.ts
+++ b/evals/specs/app-smoke.e2e.test.ts
@@ -8,10 +8,10 @@ test("app boots with a control route and meaningful visible content", async ({ w
   expect(await probe.hash()).toBeTruthy();
   expect((await probe.text()).trim().length).toBeGreaterThan(40);
   if (world.packaged) {
+    await user.see("composer", { editable: true, text: "" });
     expect(await world.packagedRuntime()).toEqual({
       bridge: true, protocol: "file:", health: 200, emptySession: true, signedOut: true, onboarding: false, crash: false,
     });
-    await user.see("composer", { editable: true, text: "" });
     await user.see("Run task");
     const workspaceId = /^#\/workspace\/([^/]+)\/session$/.exec(await probe.hash())?.[1];
     if (!workspaceId) throw new Error("The packaged app did not open its empty workspace route.");

--- a/evals/specs/first-run-local.e2e.test.ts
+++ b/evals/specs/first-run-local.e2e.test.ts
@@ -1,63 +1,66 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { bareFirstRunWorld } from "../worlds/first-run.ts";
+import { localFirstRunWorld } from "../worlds/first-run.ts";
 
-const test = spec.world(bareFirstRunWorld);
-const prompt = "Create a short welcome checklist for this OpenWork workspace. Use exactly three bullets and mention one thing I can do next.";
+const test = spec.world(localFirstRunWorld);
 
-test("first use without an invite or cloud reaches local task UI with honest model setup", async ({ world, user, probe, step }) => {
-  await step("Welcome", async () => {
-    await user.see({ text: "Welcome to OpenWork" });
-    await user.see("Use Without Cloud");
-    await user.notSee({ text: /Something went wrong/ });
-  });
-
-  await step("Choose a local folder", async () => {
-    await user.click("Use Without Cloud");
-    await user.type({ placeholder: "/workspace/my-project" }, world.workspacePath);
-    await user.click("Use this folder");
-    await user.see({ text: "Power your first task" }, { timeoutMs: 120_000 });
-  });
-
-  await step("Finish onboarding", async () => {
-    await user.click("Skip and use the free model");
-    await user.see({ text: "How did you hear about OpenWork?" }, { timeoutMs: 90_000 });
-    await user.click("Skip");
+test("first launch opens an empty signed-out workspace and runs the first prompt without onboarding", async ({ world, user, probe, step }) => {
+  await step("Start directly in the normal empty app", async () => {
     await user.see({ text: /What do you need done\?/ }, { timeoutMs: 180_000 });
+    await user.see("composer", { editable: true, text: "" });
     await user.see("Run task");
+    await user.see({ testId: "account-status-menu" }, { text: /Sign in/ });
+    await user.notSee({ text: "Welcome to OpenWork" });
+    await user.notSee("Use Without Cloud");
+    await user.notSee({ text: /Choose (a )?folder|Choose (a )?model/ });
+    await user.notSee({ text: "Power your first task" });
+    await user.notSee({ text: "How did you hear about OpenWork?" });
+    await user.notSee({ text: /Something went wrong/ });
+    expect(await probe.storage("openwork.den.authToken")).toBeNull();
+    expect(await probe.storage("openwork.den.activeOrgId")).toBeNull();
   });
 
   const composer = await probe.composer();
-  expect(composer.route).toContain("/workspace/");
-  expect(composer.route).toContain("/session");
-  expect(composer.runTaskVisible).toBe(true);
-  await user.notSee({ text: /Something went wrong/ });
-  await user.see({ text: /Using the free starter model/ });
-  await user.type("composer", prompt);
+  const workspaceId = /^#\/workspace\/([^/]+)\/session$/.exec(composer.route)?.[1];
+  if (!workspaceId) throw new Error(`Expected the empty workspace route, received ${composer.route}`);
 
-  if (!(await probe.composer()).runTaskEnabled) {
-    await user.see("Connect a model provider");
-    return;
-  }
+  await step("The default folder is provisioned without creating a blank session", async () => {
+    expect(composer.userMessageCount).toBe(0);
+    expect(composer.assistantMessageCount).toBe(0);
+    expect(composer.runTaskVisible).toBe(true);
+    const workspaces = await probe.desktopApi("/workspaces");
+    expect(workspaces.status).toBe(200);
+    expect(workspaces.body).toMatchObject({
+      activeId: workspaceId,
+      items: [{ id: workspaceId, workspaceType: "local", path: expect.stringMatching(/[/\\]OpenWork Chat$/) }],
+    });
+    const sessions = await probe.desktopApi(`/workspace/${workspaceId}/opencode/session`);
+    expect(sessions.status).toBe(200);
+    expect(sessions.body).toEqual([]);
+    await user.see({ text: /Using the free starter model/ });
+    expect(await probe.storage("openwork.defaultModel")).toBe("opencode/big-pickle");
+  });
 
-  await step("Run the first task or hear honestly why the free model can't", async () => {
+  await step("The first prompt runs on the default provider without setup", async () => {
+    await user.type("composer", world.prompt);
+    await probe.eventually(async () => (await probe.composer()).runTaskEnabled, {
+      within: 30_000,
+      label: "first task ready without choosing a model",
+      until: (enabled) => enabled,
+    });
+    expect(await probe.hash()).toBe(composer.route);
+    expect(await world.mock.agentRequests({ promptMarker: world.prompt })).toEqual([]);
     await user.click("Run task");
-    await user.see({ text: prompt }, { timeoutMs: 30_000 });
-    const outcome = await probe.eventually(
-      async () => {
-        const composer = await probe.composer();
-        if (composer.assistantMessageCount > 0) return "replied";
-        const busy = await probe.has("The free starter model is busy right now");
-        return busy ? "free-model-busy" : null;
-      },
-      { within: 180_000, label: "assistant reply or honest free-model notice", until: (value) => value !== null },
-    );
-    expect(outcome === "replied" || outcome === "free-model-busy").toBe(true);
-    if (outcome === "free-model-busy") {
-      await user.see({ text: "The free starter model is busy right now" });
-    }
+    await user.see({ text: world.prompt }, { timeoutMs: 30_000 });
+    await user.see({ text: world.reply }, { timeoutMs: 180_000 });
+    const requests = await world.mock.agentRequests({ promptMarker: world.prompt, atLeast: 1, timeoutMs: 10_000 });
+    expect(requests.some((request) => request.kind === "final" && request.model === "big-pickle")).toBe(true);
+    expect((await probe.composer()).assistantMessageCount).toBeGreaterThan(0);
+    await user.notSee({ text: "The free starter model is busy right now" });
     await user.notSee({ text: /subscribe to Go/i });
     await user.notSee({ text: /Error from provider/ });
     await user.notSee({ text: /Something went wrong/ });
+    await user.notSee({ text: "Power your first task" });
+    await user.notSee({ text: "How did you hear about OpenWork?" });
   });
 });

--- a/evals/specs/landing-pricing.test.ts
+++ b/evals/specs/landing-pricing.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import { chrome } from "@openwork/hosts";
-import { evaluateOnSurface, setViewport } from "@openwork/cdp";
+import { clickAt, evaluateOnSurface, locate, navigate, reload, setViewport } from "@openwork/cdp";
 import { eventually, needs, test } from "@openwork/testkit";
 
 test("visitors see consistent monthly Team and Enterprise pricing", async ({ evidence }) => {
@@ -116,5 +116,158 @@ test("visitors can read the trust badge and access every footer link at responsi
       ["https://opencode.ai", ""], ["/trust", "SOC 2 Type I — view Trust Center"],
     ]);
     evidence.recordAssertionEvidence(`Footer remains readable and complete at ${width}px`, JSON.stringify(facts), true);
+  }
+});
+
+test("download CTAs request the detected installer once and retain the alternative downloads", async ({ evidence }) => {
+  needs({ env: ["OPENWORK_EVAL_LANDING_URL"] });
+  const origin = process.env.OPENWORK_EVAL_LANDING_URL;
+  await using browser = await chrome({ startUrl: "about:blank", headless: true });
+  const version = await (await fetch(`${browser.handle.cdpUrl}/json/version`, { signal: AbortSignal.timeout(10_000) })).json();
+  const socketUrl = new URL(version.webSocketDebuggerUrl);
+  const cdpBase = new URL(browser.handle.cdpUrl);
+  socketUrl.protocol = cdpBase.protocol === "https:" ? "wss:" : "ws:";
+  socketUrl.host = cdpBase.host;
+  const socket = new WebSocket(socketUrl);
+  const requests: string[] = [];
+  const errors: string[] = [];
+  let ready = false;
+  let commandId = 1;
+  const enabling = new Map<number, { sessionId: string; primary: boolean }>();
+  socket.onopen = () => socket.send(JSON.stringify({
+    id: commandId,
+    method: "Target.setAutoAttach",
+    params: { autoAttach: true, waitForDebuggerOnStart: true, flatten: true }
+  }));
+  socket.onerror = () => errors.push("Download witness socket failed");
+  socket.onmessage = ({ data }) => {
+    const message = JSON.parse(String(data));
+    if (message.error) errors.push(JSON.stringify(message.error));
+    if (message.method === "Target.attachedToTarget") {
+      const { sessionId, targetInfo } = message.params;
+      const id = ++commandId;
+      enabling.set(id, { sessionId, primary: targetInfo.targetId === browser.client.targetId });
+      // Include cross-origin frames and alternate links opened in a new tab.
+      socket.send(JSON.stringify({ id, sessionId, method: "Fetch.enable", params: {
+        patterns: [{ urlPattern: "https://github.com/different-ai/openwork/releases*", requestStage: "Request" }]
+      } }));
+      return;
+    }
+    const enabled = enabling.get(message.id);
+    if (enabled) {
+      enabling.delete(message.id);
+      socket.send(JSON.stringify({ id: ++commandId, sessionId: enabled.sessionId, method: "Target.setAutoAttach",
+        params: { autoAttach: true, waitForDebuggerOnStart: true, flatten: true } }));
+      socket.send(JSON.stringify({ id: ++commandId, sessionId: enabled.sessionId, method: "Runtime.runIfWaitingForDebugger" }));
+      if (enabled.primary && !message.error) ready = true;
+    }
+    if (message.method !== "Fetch.requestPaused") return;
+    requests.push(message.params.request.url);
+    // Witness the real browser request without downloading a release binary or
+    // contacting GitHub. Release-page mistakes are captured by the same pattern.
+    socket.send(JSON.stringify({
+      id: ++commandId,
+      sessionId: message.sessionId,
+      method: "Fetch.fulfillRequest",
+      params: {
+        requestId: message.params.requestId,
+        responseCode: 200,
+        responseHeaders: [
+          { name: "Content-Type", value: "application/octet-stream" },
+          { name: "Content-Disposition", value: "attachment; filename=installer-fixture" }
+        ],
+        body: ""
+      }
+    }));
+  };
+
+  try {
+    await eventually(() => ready, { within: 10_000, until: Boolean });
+    await browser.client.send("Browser.setDownloadBehavior", { behavior: "deny" });
+    await browser.client.send("Emulation.setDeviceMetricsOverride", { width: 1440, height: 900, deviceScaleFactor: 1, mobile: false });
+    const devices = [
+      { platform: "macOS", ua: "Macintosh; Intel Mac OS X 10_15_7", architecture: "arm", asset: /mac-(arm64|universal).*\.dmg$/i },
+      { platform: "macOS", ua: "Macintosh; Intel Mac OS X 10_15_7", architecture: "x86", asset: /mac-(x64|universal).*\.dmg$/i },
+      { platform: "Windows", ua: "Windows NT 10.0; Win64; x64", architecture: "x86", asset: /win-x64.*\.exe$/i },
+      { platform: "Windows", ua: "Windows NT 10.0; Win64; x64", architecture: "arm", asset: /win-arm64.*\.exe$/i },
+      { platform: "Linux", ua: "X11; Linux x86_64", architecture: "x86", asset: /linux-(x86_64|x64).*\.(AppImage|tar\.gz)$/i },
+      { platform: "Linux", ua: "X11; Linux aarch64", architecture: "arm", asset: /linux-arm64.*\.(AppImage|tar\.gz)$/i },
+      { platform: "Unknown", ua: "Unknown desktop", architecture: "x86", asset: null },
+      { platform: "Chrome OS", ua: "X11; CrOS x86_64", architecture: "x86", asset: null },
+      { platform: "Android", ua: "Linux; Android 14; Mobile", architecture: "arm", asset: null }
+    ];
+    const attribution = "?utm_source=download-journey&utm_campaign=onboarding";
+    let supportedDownloads = 0;
+    for (const device of devices) {
+      await browser.client.send("Emulation.setUserAgentOverride", {
+        userAgent: `Mozilla/5.0 (${device.ua}) AppleWebKit/537.36 Chrome/130.0.0.0 Safari/537.36`,
+        userAgentMetadata: {
+          brands: [{ brand: "Chromium", version: "130" }],
+          fullVersionList: [{ brand: "Chromium", version: "130.0.0.0" }],
+          platform: device.platform, platformVersion: "15.0.0", architecture: device.architecture,
+          bitness: "64", model: "", mobile: device.platform === "Android"
+        }
+      });
+      const before = requests.length;
+      await navigate(browser.client, `${origin}/download${attribution}`);
+      await eventually(() => evaluateOnSurface(browser, () => Boolean(document.querySelector('[data-testid="download-openwork-card"][data-detection-source]'))), {
+        within: 30_000, until: Boolean
+      });
+      const alternatives = await evaluateOnSurface(browser, () => Array.from(document.querySelectorAll<HTMLAnchorElement>('[data-download-openwork-link]'), (link) => ({
+        label: link.textContent?.trim(), href: link.href, target: link.target
+      })));
+      expect(alternatives).toHaveLength(8);
+      expect(alternatives.every((link) => link.target === "_blank")).toBe(true);
+      const expected = device.asset ? alternatives.find((link) => device.asset?.test(link.href))?.href : undefined;
+      // Observe beyond the bounded detection wait, not just the first render.
+      await new Promise((resolve) => setTimeout(resolve, 1700));
+      expect(requests).toHaveLength(before);
+
+      // Carry a campaign through the actual homepage CTA (not a crafted intent URL).
+      await navigate(browser.client, `${origin}/${attribution}`);
+      await eventually(() => evaluateOnSurface(browser, () => document.body.innerText.includes("Contact sales")), { within: 30_000, until: Boolean });
+      expect(requests).toHaveLength(before);
+      await clickAt(browser, (await locate(browser, { role: "link", text: device.platform === "Android" ? /^Download$/ : /^Download for free/ })).center);
+      await eventually(() => evaluateOnSurface(browser, () => location.pathname + location.search), {
+        within: 30_000, until: (path) => path === `/download${attribution}`
+      });
+      if (expected) {
+        await eventually(() => requests.length, { within: 10_000, until: (count) => count > before });
+        expect(requests.slice(before)).toEqual([expected]);
+        supportedDownloads += 1;
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 1700));
+        expect(requests).toHaveLength(before);
+      }
+      const afterClick = requests.length;
+      await reload(browser);
+      await eventually(() => evaluateOnSurface(browser, () => Boolean(document.querySelector('[data-testid="download-openwork-card"][data-detection-source]'))), {
+        within: 30_000, until: Boolean
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1700));
+      expect(requests).toHaveLength(afterClick);
+      expect(await evaluateOnSurface(browser, () => Array.from(document.querySelectorAll<HTMLAnchorElement>('[data-download-openwork-link]'), (link) => ({
+        label: link.textContent?.trim(), href: link.href, target: link.target
+      })))).toEqual(alternatives);
+      if (device.platform === "Windows" && device.architecture === "x86" && expected) {
+        await clickAt(browser, (await locate(browser, { role: "link", text: /^Download$/ })).center);
+        await eventually(() => requests.length, { within: 10_000, until: (count) => count > afterClick });
+        expect(requests.slice(afterClick)).toEqual([expected]);
+        const alternate = alternatives.find((link) => /mac-(arm64|universal).*\.dmg$/i.test(link.href));
+        expect(alternate).toBeDefined();
+        const beforeAlternate = requests.length;
+        await clickAt(browser, (await locate(browser, { role: "link", text: /^Apple Silicon/ })).center);
+        await eventually(() => requests.length, { within: 10_000, until: (count) => count > beforeAlternate });
+        expect(requests.slice(beforeAlternate)).toEqual([alternate?.href]);
+        expect(await evaluateOnSurface(browser, () => location.pathname)).toBe("/download");
+      }
+      evidence.recordAssertionEvidence(`${device.platform} ${device.architecture}: click-only download with manual alternatives`,
+        expected ? "Exactly the matching installer requested; attribution and 8 alternatives retained; visiting and reloading do not download"
+          : "Unknown platform or missing installer requests nothing; all 8 manual alternatives retained", true);
+    }
+    expect(supportedDownloads).toBeGreaterThan(0);
+    expect(errors).toEqual([]);
+  } finally {
+    socket.close();
   }
 });

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -392,6 +392,8 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.looks(["The lower part of the narrow Tools screen shows readable tool cards and a clear Continue button without horizontal clipping"]);
     await mobileUser.click({ role: "button", label: "Continue" });
     await mobileUser.see({ testId: "marketplace-onboarding" }, { timeoutMs: 90_000 });
+    await mobileUser.reload();
+    await mobileUser.see({ testId: "marketplace-onboarding" }, { timeoutMs: 90_000 });
     await mobileUser.notSee({ testId: "download-openwork-card" });
     await mobileUser.notSee({ role: "button", label: "Email me the download link" });
     await mobileUser.see({ testId: "onboarding-choice-openwork-models" });
@@ -430,7 +432,7 @@ desktopTest("desktop-origin signup completes the questions before issuing a fres
     if (!isRecord(result.body) || !isRecord(result.body.inference)) throw new Error("Expected inference state");
     expect(result.body.inference.enabled).toBe(false);
   };
-  const desktopUrl = new URL("/?mode=sign-up&desktopAuth=1&desktopScheme=openwork&intent=models", world.den.ref.webUrl).toString();
+  const desktopUrl = new URL("/?mode=sign-up&desktopAuth=1&desktopScheme=untrusted-app&intent=models", world.den.ref.webUrl).toString();
   let orgId = "";
 
   await step("desktop signup starts full setup rather than returning immediately", async () => {
@@ -459,6 +461,15 @@ desktopTest("desktop-origin signup completes the questions before issuing a fres
     if (!isRecord(org) || typeof org.id !== "string") throw new Error("Expected created org");
     orgId = org.id;
     noHandoff();
+    for (const desktopScheme of ["untrusted-app", "https", "openwork-untrusted"]) {
+      const rejected = await seed.api(world.den.admin, "/v1/auth/desktop-handoff", {
+        method: "POST", body: JSON.stringify({ desktopScheme }),
+      });
+      expect(rejected.response.status).toBe(400);
+      expect(rejected.body).not.toHaveProperty("grant");
+      expect(rejected.body).not.toHaveProperty("openworkUrl");
+    }
+    evidence.recordAssertionEvidence("Untrusted desktop schemes cannot obtain a grant or return URL", "Direct authenticated grant requests for an arbitrary app, HTTPS, and an OpenWork lookalike scheme all returned 400 without a grant or URL. The browser also began with an untrusted scheme query parameter; normal completion below must still dispatch only to openwork.", true);
   });
 
   await step("resuming People and reloading Tools restore the setup org after a shared-session switch", async () => {

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -1,37 +1,41 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { signupWorkspace } from "../worlds/signup-workspace.ts";
+import { desktopOnboardingWorld } from "../../scenarios/onboarding/world.ts";
 
 // New journey: an account with no organization makes its first personal/team
 // choice, optionally invites people, then reviews the ready workspace.
-const test = spec.world(signupWorkspace, { timeout: 600_000 });
+const test = spec.world((seed) => signupWorkspace(seed), { timeout: 600_000 });
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 test("signup distinguishes joining, personal work, and restricted team setup without changing another organization", async ({ world, user, probe, seed, evidence, step }) => {
+  const expectNoHorizontalOverflow = async (surfaceProbe = probe) => {
+    const snapshot = await surfaceProbe.dom("html");
+    expect(snapshot.documentWidth).toBeLessThanOrEqual(snapshot.viewportWidth);
+  };
   const expectFocusedSetup = async () => {
     await user.see({ testId: "den-onboarding-shell" });
     await user.notSee({ testId: "den-org-sidebar" });
     await user.notSee({ role: "button", label: "Open menu" });
-    expect(await probe.eval(() => {
-      const frame = document.querySelector<HTMLElement>('[data-testid="setup-frame"]');
-      const frameBounds = frame?.getBoundingClientRect();
-      const footer = frame?.querySelector('footer')?.getBoundingClientRect();
-      const story = frame?.querySelector('aside')?.getBoundingClientRect();
-      const panel = frame?.querySelector('aside')?.nextElementSibling?.getBoundingClientRect();
-      const brand = frame?.querySelector<HTMLElement>('header > div')?.getBoundingClientRect();
-      const progress = frame?.querySelector<HTMLElement>('nav[aria-label="Setup progress"]')?.getBoundingClientRect();
-      return Boolean(frameBounds && footer && story && panel && brand && progress
-        && Math.abs(frameBounds.left) < 2
-        && Math.abs(frameBounds.right - document.documentElement.clientWidth) < 2
+    const [frameBounds, footer, story, panel, brand, progress] = await Promise.all([
+      '[data-testid="setup-frame"]', '[data-testid="setup-frame"] footer', '[data-testid="setup-frame"] aside',
+      '[data-testid="setup-frame"] aside + div', '[data-testid="setup-frame"] header > div', 'nav[aria-label="Setup progress"]',
+    ].map(async (selector) => {
+      const snapshot = await probe.dom(selector);
+      expect(snapshot.elements).toHaveLength(1);
+      return snapshot.elements[0].rect;
+    }));
+    const { viewportWidth } = await probe.dom("html");
+    expect(Math.abs(frameBounds.left) < 2
+        && Math.abs(frameBounds.right - viewportWidth) < 2
         && Math.abs(panel.right - story.left - 1130) < 2
         && Math.abs(footer.left - story.left) < 2
         && Math.abs(footer.right - panel.right) < 2
         && story.right <= panel.left && Math.abs(story.top - panel.top) < 2
         && Math.abs(brand.left - story.left) < 2
         && Math.abs(progress.left - panel.left) < 2
-        && Math.abs(progress.right - panel.right) < 2);
-    })).toBe(true);
-    expect(await probe.eval(() => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
+        && Math.abs(progress.right - panel.right) < 2).toBe(true);
+    await expectNoHorizontalOverflow();
   };
   const orgs = async () => {
     const result = await probe.api(world.den.admin, "/v1/me/orgs");
@@ -76,10 +80,18 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await user.notSee({ role: "textbox", label: "Team name" });
     await user.see({ testId: "auth-landing-visual" });
     await user.see({ text: "Your choice of model. One place to work." });
-    await probe.eventually(() => probe.eval(() => (Boolean(document.querySelector<HTMLElement>('[data-testid=auth-landing-visual] canvas')))), { within: 15000, label: "Paper shader canvas", until: (visible) => visible === true });
+    await probe.eventually(async () => (await probe.dom('[data-testid="auth-landing-visual"] canvas')).elements.length > 0, { within: 15000, label: "Paper shader canvas", until: (visible) => visible === true });
     await user.looks(["The signup landing shows Good work starts here alongside a clear email entry form within a restrained black-and-white setup frame, with a compact black-and-white dithered texture band above the form. The product example clearly shows a chat conversation, an inline dashboard result, and a composer with provider choice"]);
     await user.type({ role: "textbox", label: "Email" }, world.owner.email);
     await user.click({ role: "button", label: "Next" });
+    await user.see({ testId: "signup-new-account" });
+    await user.click({ role: "textbox", label: "Name" });
+    expect((await probe.dom('[data-testid="signup-new-account"] input[autocomplete="name"]')).elements[0]?.focused).toBe(true);
+    for (const selector of ['input[autocomplete="email"]', 'input[autocomplete="new-password"]', 'button[type="submit"]', 'button[type="button"]']) {
+      await user.press("Tab");
+      expect((await probe.dom(`[data-testid="signup-new-account"] ${selector}`)).elements[0]?.focused).toBe(true);
+    }
+    expect((await probe.dom('[data-testid="signup-new-account"] > button, [data-testid="signup-new-account"] > .den-divider')).elements.map(({ text }) => text)).toEqual(["Sign up", "or", "Sign up with Google"]);
     await user.type({ role: "textbox", label: "Name" }, world.owner.name);
     await user.type({ role: "textbox", label: "Password" }, world.owner.password);
     await user.click({ role: "button", label: "Sign up" });
@@ -154,13 +166,11 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await expectFocusedSetup();
     expect(await connectionsFor(personalId)).toEqual(connectionsBeforeSkip);
     evidence.recordAssertionEvidence("Skipping optional tools does not save even a selected connection", "Notion was selected, then Do this later continued to Ready; the personal organization's connection inventory stayed empty.", true);
-    await user.click({ text: "Other platforms and versions" });
-    await user.see({ text: "macOS" });
-    await user.see({ text: "Windows" });
-    await user.see({ text: "Linux" });
-    expect(await probe.eval(() => (document.querySelectorAll<HTMLElement>('[data-testid=download-openwork-card] details a[href]').length))).toBe(8);
-    await user.click({ text: "Other platforms and versions" });
-    await user.looks(["The final setup screen shows a clear desktop download and model setup path in the same restrained black-and-white design"]);
+    await user.notSee({ testId: "download-openwork-card" });
+    await user.notSee({ text: "Other platforms and versions" });
+    await user.see({ testId: "onboarding-choice-openwork-models" });
+    await user.see({ testId: "onboarding-choice-byok" });
+    await user.looks(["The final setup screen focuses on optional model choices and a clear completion button, without a download or installation checklist"]);
     expect(await invitationsFor(personalId)).toEqual([]);
     expect(await inviteEmails()).toEqual(outboxBeforeSkip);
     evidence.recordAssertionEvidence("Personal setup preserves desktop defaults and explicit skip never submits a typed invitation", JSON.stringify({ memberships: memberships.length, personalPolicy, invitations: [], emailsUnchanged: true }), true);
@@ -175,7 +185,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
       await user.notSee({ testId: "den-org-sidebar" });
       await user.press(shortcut);
       await user.notSee({ testId: "den-command-palette" });
-      await user.click({ role: "link", label: "Finish setup" });
+      await user.click({ role: "button", label: "Complete setup" });
       await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
       await user.notSee({ testId: "den-onboarding-shell" });
       expect(await world.pathname()).toBe("/dashboard");
@@ -185,13 +195,13 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
       await user.see({ testId: "den-command-palette" });
       await user.press("Escape");
       await user.notSee({ testId: "den-command-palette" });
-      evidence.recordAssertionEvidence(`${shortcut} is suppressed during onboarding and restored on the dashboard`, "Pressing the shortcut during setup leaves the palette closed both before and after Finish setup, without reloading; pressing it on the dashboard opens the palette, and Escape closes it.", true);
+      evidence.recordAssertionEvidence(`${shortcut} is suppressed during onboarding and restored on the dashboard`, "Pressing the shortcut during setup leaves the palette closed both before and after completion, without reloading; pressing it on the dashboard opens the palette, and Escape closes it.", true);
     }
     await user.reload();
     await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 30_000 });
     expect(await connectionsFor(personalId)).toEqual([]);
     expect(await invitationsFor(personalId)).toEqual([]);
-    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until Finish setup", "People, Tools and Ready fill the viewport with a 1130px desktop content area and matching footer edges, with the logo aligned to the story and the stepper aligned to both panel edges, without the sidebar or menu; Finish setup opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
+    evidence.recordAssertionEvidence("Setup keeps two panes and hides dashboard navigation until completion", "People, Tools and Ready fill the viewport with a 1130px desktop content area and matching footer edges, with the logo aligned to the story and the stepper aligned to both panel edges, without the sidebar or menu; completion opens /dashboard and restores navigation, including after reload, with no tools or invitations required.", true);
   });
 
   let flexibleId = "";
@@ -358,7 +368,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     expect(await invitationsFor(flexibleId)).toHaveLength(2);
     evidence.recordAssertionEvidence("Restricted setup saves the real desktop policy before opening People, survives reload, and leaves other organizations unchanged", JSON.stringify({ saved, retainedAfterReload: true, legacySetupContinuesToPeople: true, personalPolicy, orgCount: 3, restrictedInvitations: 0, flexibleInvitations: 2 }), true);
   });
-  await step("mobile setup offers a download email or web access after reviewing team tools", async () => {
+  await step("mobile setup completes after optional model choices without a download", async () => {
     const selected = await seed.api(world.den.admin, "/v1/me/active-organization", {
       method: "POST", body: JSON.stringify({ organizationId: flexibleId }),
     });
@@ -368,58 +378,33 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
       headless: true, viewport: { width: 390, height: 844 },
     });
     const mobileUser = user.on(mobile);
-    const downloadEmails = async () => {
-      const result = await probe.api(world.den.admin, "/v1/dev/emails?template=downloadLink");
-      expect(result.response.ok).toBe(true);
-      if (!isRecord(result.body) || !Array.isArray(result.body.emails)) throw new Error("Expected download email outbox");
-      return result.body.emails.filter(isRecord).map(({ template, to, subject, at }) => ({ template, to, subject, at }));
-    };
     const toolsBefore = await connectionsFor(flexibleId);
     await mobileUser.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
     await mobileUser.see({ text: "Already added" });
     await mobileUser.notSee({ role: "button", label: "Open menu" });
     await mobileUser.notSee({ testId: "den-org-sidebar" });
-    expect(await probe.eval(mobile, () => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
+    await expectNoHorizontalOverflow(probe.on(mobile));
     await mobileUser.press("Control+Home");
     await mobileUser.looks(["The top of the narrow Tools screen shows legible setup progress and the Give your team a head start heading without horizontal clipping"]);
     await mobileUser.hover({ role: "button", label: "Continue" });
     await mobileUser.looks(["The lower part of the narrow Tools screen shows readable tool cards and a clear Continue button without horizontal clipping"]);
     await mobileUser.click({ role: "button", label: "Continue" });
-    await mobileUser.see({ testId: "onboarding-mobile-options" }, { timeoutMs: 90_000 });
+    await mobileUser.see({ testId: "marketplace-onboarding" }, { timeoutMs: 90_000 });
     await mobileUser.notSee({ testId: "download-openwork-card" });
-    await mobileUser.see({ role: "button", label: "Email me the download link" });
-    await mobileUser.see({ role: "link", label: "Try OpenWork Web" });
-    expect(await probe.eval(mobile, () => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
+    await mobileUser.notSee({ role: "button", label: "Email me the download link" });
+    await mobileUser.see({ testId: "onboarding-choice-openwork-models" });
+    await mobileUser.see({ testId: "onboarding-choice-byok" });
+    await expectNoHorizontalOverflow(probe.on(mobile));
     expect(await connectionsFor(flexibleId)).toEqual(toolsBefore);
-    await mobileUser.hover({ role: "button", label: "Email me the download link" });
-    await mobileUser.looks(["The mobile OpenWork Desktop card shows its complete heading, OpenWork mark, explanatory copy, and Email me the download link button in a restrained neutral card"]);
-    await mobileUser.hover({ role: "link", label: "Try OpenWork Web" });
-    await mobileUser.looks(["The mobile OpenWork Web card shows its complete heading, OpenWork mark, access-and-plans explanation, and Try OpenWork Web link without horizontal clipping"]);
+    await mobileUser.hover({ role: "button", label: "Complete setup" });
+    await mobileUser.looks(["The mobile final setup screen shows optional model choices and a legible Complete setup action, without downloads or horizontal clipping"]);
     await mobileUser.notSee({ role: "button", label: "Open menu" });
-    await mobileUser.click({ role: "link", label: "Finish setup" });
+    await mobileUser.click({ role: "button", label: "Complete setup" });
     await mobileUser.see({ role: "button", label: "Open menu" }, { timeoutMs: 30_000 });
     await mobileUser.notSee({ testId: "den-onboarding-shell" });
     await mobileUser.click({ role: "button", label: "Open menu" });
     await mobileUser.see({ testId: "den-org-sidebar", nth: 1 });
-    evidence.recordAssertionEvidence("Mobile onboarding finishes without downloading and reveals working dashboard navigation", "Tools and Ready omit the menu; Finish setup restores it and opening the menu reveals the sidebar.", true);
-    await mobileUser.navigate(new URL("/dashboard/onboarding", world.den.ref.webUrl).toString());
-    await mobileUser.see({ role: "button", label: "Email me the download link" }, { timeoutMs: 90_000 });
-    const before = await downloadEmails();
-    await mobileUser.click({ role: "button", label: "Email me the download link" });
-    await mobileUser.see({ role: "button", label: "Download link sent" }, { timeoutMs: 30_000 });
-    const sent = await probe.eventually(downloadEmails, {
-      within: 30_000, label: "the real download email is captured for the signed-in owner", until: (emails) => emails.length === before.length + 1,
-    });
-    expect(sent.filter((email) => email.to === world.owner.email)).toHaveLength(before.filter((email) => email.to === world.owner.email).length + 1);
-    expect(await probe.eval(mobile, () => (Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="onboarding-mobile-options"] button')).find((button) => button.textContent.trim() === "Download link sent")?.disabled))).toBe(true);
-    await mobileUser.click({ role: "button", label: "Download link sent" });
-    expect(await downloadEmails()).toEqual(sent);
-    expect(await probe.eval(mobile, () => (Array.from(document.querySelectorAll<HTMLElement>('[data-testid="onboarding-mobile-options"] a')).find((link) => link.textContent.trim() === "Try OpenWork Web")?.getAttribute("href")))).toBe("/dashboard/web");
-    await mobileUser.click({ role: "link", label: "Try OpenWork Web" });
-    await probe.eventually(() => probe.eval(mobile, () => (window.location.pathname)), {
-      within: 30_000, label: "mobile web option opens the existing access and plans page", until: (path) => path === "/dashboard/web",
-    });
-    evidence.recordAssertionEvidence("Mobile setup preserves configured tools, sends one real download email to the signed-in owner, disables repeat sends, and links to web access without starting checkout", JSON.stringify({ recipient: world.owner.email, newDownloadEmails: 1, repeatSendDisabled: true, webRoute: "/dashboard/web", configuredToolsUnchanged: true }), true);
+    evidence.recordAssertionEvidence("Mobile onboarding finishes without downloading and reveals working dashboard navigation", "Tools and Ready omit the menu; completion restores it and opening the menu reveals the sidebar. Configured tools are unchanged.", true);
   });
   await step("the public signup also fits a narrow screen", async () => {
     const mobile = await seed.web({ den: world.den, startPath: "/", headless: true, viewport: { width: 390, height: 844 } });
@@ -427,8 +412,166 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.see({ text: "Good work starts here." }, { timeoutMs: 90_000 });
     await mobileUser.see({ role: "textbox", label: "Email" });
     await mobileUser.see({ text: "Your choice of model. One place to work." });
-    expect(await probe.eval(mobile, () => (document.documentElement.scrollWidth <= window.innerWidth))).toBe(true);
+    await expectNoHorizontalOverflow(probe.on(mobile));
     await mobileUser.looks(["The narrow signup screen has legible progress steps, heading, email form, and model-provider choice without horizontal clipping"]);
   });
 
+});
+
+const desktopTest = spec.world(desktopOnboardingWorld, { timeout: 600_000 });
+
+desktopTest("desktop-origin signup completes the questions before issuing a fresh grant, while returning members skip them", async ({ world, user, probe, seed, step, evidence }) => {
+  const noHandoff = () => expect(world.handoff()).toEqual({ grants: 0, modelWrites: 0, returns: [] });
+  const modelsOff = async () => {
+    const result = await probe.api(world.den.admin, "/v1/inference", { headers: { "x-openwork-org-id": orgId } });
+    expect(result.response.ok).toBe(true);
+    if (!isRecord(result.body) || !isRecord(result.body.inference)) throw new Error("Expected inference state");
+    expect(result.body.inference.enabled).toBe(false);
+  };
+  const desktopUrl = new URL("/?mode=sign-up&desktopAuth=1&desktopScheme=openwork&intent=models", world.den.ref.webUrl).toString();
+  let orgId = "";
+
+  await step("desktop signup starts full setup rather than returning immediately", async () => {
+    await user.navigate(desktopUrl);
+    await user.see({ role: "textbox", label: "Email" }, { timeoutMs: 90_000 });
+    await user.type({ role: "textbox", label: "Email" }, world.owner.email);
+    await user.click({ role: "button", label: "Next" });
+    await user.type({ role: "textbox", label: "Name" }, world.owner.name);
+    await user.type({ role: "textbox", label: "Password" }, world.owner.password);
+    await user.click({ role: "button", label: "Sign up" });
+    await user.see({ text: "Make it yours." }, { timeoutMs: 90_000 });
+    await world.adoptSignedInOwner();
+    noHandoff();
+    await user.reload();
+    await user.see({ text: "Make it yours." }, { timeoutMs: 90_000 });
+    noHandoff();
+    await user.click({ text: "On my own" });
+    await user.type({ role: "textbox", label: "Organization name" }, "Desktop workspace");
+    await user.click({ role: "button", label: "Continue" });
+    await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    const result = await probe.api(world.den.admin, "/v1/me/orgs");
+    expect(result.response.ok).toBe(true);
+    if (!isRecord(result.body) || !Array.isArray(result.body.orgs)) throw new Error("Expected org directory");
+    expect(result.body.orgs).toHaveLength(1);
+    const org = result.body.orgs[0];
+    if (!isRecord(org) || typeof org.id !== "string") throw new Error("Expected created org");
+    orgId = org.id;
+    noHandoff();
+  });
+
+  await step("resuming People and reloading Tools restore the setup org after a shared-session switch", async () => {
+    const created = await seed.api(world.den.admin, "/v1/org", { method: "POST", body: JSON.stringify({ name: "Other workspace" }) });
+    expect(created.response.ok).toBe(true);
+    if (!isRecord(created.body) || !isRecord(created.body.organization) || typeof created.body.organization.id !== "string") throw new Error("Expected second workspace");
+    const otherOrgId = created.body.organization.id;
+    const token = await probe.storage("openwork:web:auth-token");
+    if (typeof token !== "string" || !token) throw new Error("Expected the browser's authenticated session");
+    // Use the same session as the browser, not the separate API witness login.
+    const browserSession = { ...world.den.admin, token };
+    const setupWrites = async (id: string) => {
+      const headers = { "x-openwork-org-id": id };
+      const [org, connections] = await Promise.all([
+        probe.api(world.den.admin, "/v1/org", { headers }),
+        probe.api(world.den.admin, "/v1/mcp-connections?scope=manageable", { headers }),
+      ]);
+      expect(org.response.ok).toBe(true);
+      expect(connections.response.ok).toBe(true);
+      if (!isRecord(org.body) || !Array.isArray(org.body.invitations) || !isRecord(connections.body) || !Array.isArray(connections.body.connections)) throw new Error("Expected setup write witnesses");
+      return { invitations: org.body.invitations.filter(isRecord), connections: connections.body.connections.filter(isRecord) };
+    };
+    const expectActiveOrg = async (id: string) => {
+      const active = await probe.api(browserSession, "/v1/me/orgs");
+      expect(active.response.ok).toBe(true);
+      if (!isRecord(active.body)) throw new Error("Expected active organization");
+      expect(active.body.activeOrgId).toBe(id);
+    };
+    const switchElsewhere = async () => {
+      const switched = await seed.api(browserSession, "/v1/me/active-organization", { method: "POST", body: JSON.stringify({ organizationId: otherOrgId }) });
+      expect(switched.response.ok).toBe(true);
+      await expectActiveOrg(otherOrgId);
+    };
+    const otherBefore = await setupWrites(otherOrgId);
+    await switchElsewhere();
+    await user.navigate(new URL("/", world.den.ref.webUrl).toString());
+    await user.see({ role: "textbox", label: "Teammate email 1" }, { timeoutMs: 90_000 });
+    await user.see({ text: "Desktop workspace" });
+    await expectActiveOrg(orgId);
+    await user.reload();
+    await user.see({ text: "Bring your people." }, { timeoutMs: 90_000 });
+    noHandoff();
+    await user.type({ role: "textbox", label: "Teammate email 1" }, "resumed-teammate@openwork.test");
+    await user.click({ role: "button", label: "Send invitations" });
+    await user.see({ text: "Invitation sent" }, { timeoutMs: 30_000 });
+    expect((await setupWrites(orgId)).invitations).toContainEqual(expect.objectContaining({ email: "resumed-teammate@openwork.test", role: "member", status: "pending" }));
+    expect(await setupWrites(otherOrgId)).toEqual(otherBefore);
+    await user.click({ role: "button", label: "Continue" });
+    await user.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
+    await user.see({ role: "checkbox", label: "Add Notion" });
+    await switchElsewhere();
+    await user.reload();
+    await user.see({ text: "Give your team a head start." }, { timeoutMs: 90_000 });
+    await user.see({ role: "checkbox", label: "Add Notion" });
+    await expectActiveOrg(orgId);
+    noHandoff();
+    await user.click({ role: "checkbox", label: "Add Notion" });
+    await user.click({ role: "button", label: "Add to team" });
+    await user.see({ text: "Added to team" }, { timeoutMs: 90_000 });
+    expect((await setupWrites(orgId)).connections).toContainEqual(expect.objectContaining({ name: "Notion", connectedForMe: false }));
+    expect(await setupWrites(otherOrgId)).toEqual(otherBefore);
+    await user.click({ role: "button", label: "Continue" });
+    await user.see({ text: "Your workspace is ready" }, { timeoutMs: 90_000 });
+    expect((await probe.dom("#setup-models-heading")).elements[0]?.focused).toBe(true);
+    await user.notSee({ testId: "download-openwork-card" });
+    await user.notSee({ role: "button", label: "Email me the download link" });
+    await user.see({ role: "button", label: "Complete and open the app" });
+    noHandoff();
+    await modelsOff();
+    // Model/provider settings stay usable; returning to Ready does not complete setup.
+    await user.click({ role: "link", label: "Add a provider" });
+    await user.see({ role: "link", label: "Back to setup" }, { timeoutMs: 90_000 });
+    expect(await world.pathname()).toBe("/dashboard/custom-llm-providers");
+    await user.reload();
+    await user.see({ role: "link", label: "Back to setup" }, { timeoutMs: 90_000 });
+    expect(await world.pathname()).toBe("/dashboard/custom-llm-providers");
+    noHandoff();
+    await user.click({ role: "link", label: "Back to setup" });
+    await user.see({ role: "button", label: "Complete and open the app" }, { timeoutMs: 90_000 });
+    await user.reload();
+    await user.see({ role: "button", label: "Complete and open the app" }, { timeoutMs: 90_000 });
+    expect((await probe.dom("#setup-models-heading")).elements[0]?.focused).toBe(true);
+    noHandoff();
+    evidence.recordAssertionEvidence("Desktop signup retains all setup steps across reloads without a grant", "Make it yours, People, Tools, Ready and an optional provider-settings detour survived reloads. Browser request witness recorded zero grants, model writes and desktop returns before completion.", true);
+    evidence.recordAssertionEvidence("A shared-session org switch cannot retarget unfinished setup", "The browser's exact session was switched to another org before resuming People from / and before reloading Tools. Both restored the saved setup org; the invitation and Notion configuration were written only there, while the other org remained unchanged.", true);
+  });
+
+  await step("completion issues the real one-time grant for the intended organization without enabling models", async () => {
+    await user.click({ role: "button", label: "Complete and open the app" });
+    const handoff = await probe.eventually(() => world.handoff(), { within: 30_000, label: "browser requests OS return", until: (value) => value.returns.length === 1 });
+    expect(handoff.grants).toBe(1);
+    expect(handoff.modelWrites).toBe(0);
+    const link = new URL(handoff.returns[0]);
+    expect(link.protocol).toBe("openwork:");
+    expect(link.hostname).toBe("den-auth");
+    const grant = link.searchParams.get("grant");
+    expect(grant).toBeTruthy();
+    // Stand in for the OS recipient; consume only the grant the browser actually issued.
+    const exchange = await seed.api(world.den.admin, "/v1/auth/desktop-handoff/exchange", { method: "POST", body: JSON.stringify({ grant }) });
+    expect(exchange.response.ok).toBe(true);
+    if (!isRecord(exchange.body)) throw new Error("Expected handoff exchange");
+    expect(exchange.body.organization).toMatchObject({ id: orgId, name: "Desktop workspace" });
+    expect(exchange.body.user).toMatchObject({ email: world.owner.email });
+    await modelsOff();
+    evidence.recordAssertionEvidence("Completion returns a fresh browser-issued grant for the new workspace with models off", "The browser requested the OpenWork protocol URL once; the mock OS recipient exchanged that exact grant for the intended user and organization. No model writes occurred and inference remained disabled.", true);
+  });
+
+  await step("an existing member returns directly even when the URL says sign-up", async () => {
+    await user.navigate(desktopUrl);
+    await user.see({ testId: "desktop-signed-in-handoff" }, { timeoutMs: 90_000 });
+    await user.notSee({ text: "Make it yours." });
+    const returning = await probe.eventually(() => world.handoff(), { within: 30_000, label: "returning member handoff", until: (value) => value.returns.length === 2 });
+    expect(returning.grants).toBe(2);
+    expect(returning.returns[1]).not.toBe(returning.returns[0]);
+    expect(returning.modelWrites).toBe(0);
+    await modelsOff();
+  });
 });

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -5,7 +5,9 @@ import { desktopOnboardingWorld } from "../../scenarios/onboarding/world.ts";
 
 // New journey: an account with no organization makes its first personal/team
 // choice, optionally invites people, then reviews the ready workspace.
-const test = spec.world((seed) => signupWorkspace(seed), { timeout: 600_000 });
+// This journey cold-boots Den and three browser surfaces; each individual
+// interaction remains bounded below, including the final signed-out mobile view.
+const test = spec.world((seed) => signupWorkspace(seed), { timeout: 900_000 });
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 test("signup distinguishes joining, personal work, and restricted team setup without changing another organization", async ({ world, user, probe, seed, evidence, step }) => {

--- a/evals/specs/signup-workspace-intent.e2e.test.ts
+++ b/evals/specs/signup-workspace-intent.e2e.test.ts
@@ -386,7 +386,7 @@ test("signup distinguishes joining, personal work, and restricted team setup wit
     await mobileUser.notSee({ role: "button", label: "Open menu" });
     await mobileUser.notSee({ testId: "den-org-sidebar" });
     await expectNoHorizontalOverflow(probe.on(mobile));
-    await mobileUser.press("Control+Home");
+    await mobileUser.hover({ text: "Give your team a head start." });
     await mobileUser.looks(["The top of the narrow Tools screen shows legible setup progress and the Give your team a head start heading without horizontal clipping"]);
     await mobileUser.hover({ role: "button", label: "Continue" });
     await mobileUser.looks(["The lower part of the narrow Tools screen shows readable tool cards and a clear Continue button without horizontal clipping"]);

--- a/evals/specs/welcome-one-field.e2e.test.ts
+++ b/evals/specs/welcome-one-field.e2e.test.ts
@@ -5,13 +5,25 @@ import { bareFirstRunWorld } from "../worlds/first-run.ts";
 const test = spec.world(bareFirstRunWorld);
 const inviteUrl = "http://localhost:59991/join-org?invite=inv_demo123";
 
-test("the welcome join field takes a server URL or web invite and points the app at that organization", async ({ world, user, probe, step }) => {
-  // TODO(primitive): read the persisted desktop bootstrap configuration.
-  const readBootstrapBaseUrl = () => probe.eval(
-    () => (window.__OPENWORK_ELECTRON__.invokeDesktop("getDesktopBootstrapConfig").then((config) => config.baseUrl)),
-    { awaitPromise: true },
+test("desktop opens directly while the non-desktop welcome join field accepts a server URL or web invite", async ({ world, user: desktopUser, probe, step }) => {
+  await step("Desktop starts without welcome or setup gates", async () => {
+    await desktopUser.see("composer", { editable: true, text: "" });
+    await desktopUser.see("Run task");
+    expect(await probe.hash()).toMatch(/^#\/workspace\/[^/]+\/session$/);
+    await desktopUser.notSee({ text: "Welcome to OpenWork" });
+    await desktopUser.notSee("Use Without Cloud");
+    await desktopUser.notSee({ text: "Power your first task" });
+    await desktopUser.notSee({ text: "How did you hear about OpenWork?" });
+    await desktopUser.click({ testId: "account-status-menu" });
+    await desktopUser.see("Sign in to OpenWork Cloud");
+    await desktopUser.press("Escape");
+  });
+
+  const user = desktopUser.on(world.web);
+  const readBootstrapBaseUrl = () => probe.on(world.web).eval(
+    () => localStorage.getItem("openwork.den.baseUrl"),
   );
-  await step("Welcome offers three doors", async () => {
+  await step("Non-desktop welcome keeps its optional entry paths", async () => {
     await user.see({ text: "Welcome to OpenWork" });
     await user.see("Sign in to OpenWork Cloud");
     await user.see("Use Without Cloud");
@@ -45,10 +57,17 @@ test("the welcome join field takes a server URL or web invite and points the app
     await user.click("Connect");
     await user.see({ text: /Trust this organization server\?/ }, { timeoutMs: 20_000 });
     expect(await readBootstrapBaseUrl()).toBe("https://openwork.acme.test");
+    expect(await world.openedUrls()).not.toContain(inviteUrl);
     await user.click("Trust and open invite");
     await user.see({ text: /Your invite opened in the browser/ }, { timeoutMs: 20_000 });
     expect(await readBootstrapBaseUrl()).toBe("http://localhost:59991");
-    if (world.capture) expect(await world.capture.waitForUrl((url) => url === inviteUrl, { timeoutMs: 20_000 })).toBe(inviteUrl);
+    await probe.eventually(() => world.openedUrls(), {
+      within: 20_000,
+      label: "confirmed invite opens a browser tab",
+      until: (urls) => urls.includes(inviteUrl),
+    });
     await user.looks(["The dialog says the invite opened in the browser and to finish joining there"]);
+    expect(await probe.hash()).toMatch(/^#\/workspace\/[^/]+\/session$/);
+    expect(await probe.storage("openwork.den.baseUrl")).not.toBe("http://localhost:59991");
   });
 });

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -1,4 +1,4 @@
-import { browserScript } from "@openwork/cdp";
+import { browserScript, listTargets } from "@openwork/cdp";
 import { spawn } from "node:child_process";
 import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -24,7 +24,6 @@ import { diagnoseEgressLabProduct } from "@openwork/behaviors";
 import { matchVerdictExpectations } from "@openwork/matchers";
 import {
   assignPluginToMarketplace,
-  captureOpenedUrls,
   completeDesktopHandoff,
   createDesktopHandoffGrant,
   createMarketplace,
@@ -84,44 +83,88 @@ export async function appSmokeWorld(seed: Seed) {
         const info = await bridge.invokeDesktop("openworkServerInfo");
         const health = await fetch(info.baseUrl + "/health", { signal: AbortSignal.timeout(5000) });
         return { bridge: true, protocol: location.protocol, health: health.status,
-          welcome: location.hash === "#/welcome" && [...document.querySelectorAll("button")]
-            .some(button => button.textContent.trim() === "Use Without Cloud" && !button.disabled),
+          emptySession: /^#\/workspace\/[^/]+\/session$/.test(location.hash)
+            && Boolean(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')),
+          signedOut: !localStorage.getItem("openwork.den.authToken") && !localStorage.getItem("openwork.den.activeOrgId"),
+          onboarding: /Welcome to OpenWork|Power your first task|How did you hear about OpenWork\?/.test(document.body.innerText),
           crash: /Something went wrong|Cannot find module|Maximum update depth exceeded/.test(document.body.innerText) };
       }, { awaitPromise: true });
     },
     async packagedToolIds() {
-      return evalIn(app, browserScript(async (value, inputValue) => {
-        await window.__OPENWORK_ELECTRON__.invokeDesktop("engineStart", value, { runtime: "direct" });
+      return evalIn(app, async () => {
+        const workspaces = await window.__OPENWORK_ELECTRON__.invokeDesktop("workspaceBootstrap");
+        const workspace = workspaces.workspaces.find((entry) => entry.id === workspaces.selectedId);
+        if (workspaces.workspaces.length !== 1 || !workspace?.path?.endsWith("OpenWork Chat")) {
+          throw new Error("Packaged startup did not select its default chat workspace.");
+        }
         const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
         const headers = { Authorization: "Bearer " + info.ownerToken, "Content-Type": "application/json" };
-        const created = await fetch(info.baseUrl + "/workspaces/local", {
-          method: "POST", headers, signal: AbortSignal.timeout(15000),
-          body: JSON.stringify({ folderPath: inputValue }),
-        });
-        if (created.status !== 201) throw new Error("Workspace creation failed: " + created.status);
-        const workspace = await created.json();
-        const tools = await fetch(info.baseUrl + "/workspace/" + workspace.activeId + "/opencode/experimental/tool/ids", {
+        const tools = await fetch(info.baseUrl + "/workspace/" + workspace.id + "/opencode/experimental/tool/ids", {
           headers, signal: AbortSignal.timeout(30000),
         });
         if (!tools.ok) throw new Error("Engine tool discovery failed: " + tools.status);
         return tools.json();
-      }, [seed.tmpPath("packaged-plugin-smoke"), seed.tmpPath("packaged-plugin-smoke")]), { awaitPromise: true, timeoutMs: 60_000 });
+      }, { awaitPromise: true, timeoutMs: 60_000 });
     },
     async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
   };
 }
 
 export async function bareFirstRunWorld(seed: Seed, { place }: { place: Place }) {
-  const capture = process.platform === "linux" && place.kind === "local" ? await captureOpenedUrls() : null;
-  const app = capture
-    ? await desktop({ name: "first-run", host: place.host(), env: { PATH: `${capture.binDir}:${process.env.PATH ?? ""}` } })
-    : await seed.desktop({ name: "first-run", signIn: false });
+  const app = await seed.desktop({ name: "first-run", signIn: false });
+  const url = new URL(await evalIn(app, () => location.href));
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("The non-desktop welcome journey requires the source app's HTTP surface.");
+  }
+  url.hash = "/welcome";
+  const web = await chrome({ name: "first-run-welcome", host: place.host(), startUrl: url.href, headless: true });
   return {
     app,
-    capture,
-    workspacePath: seed.tmpPath("first-run-workspace"),
-    async [Symbol.asyncDispose]() { await app[Symbol.asyncDispose](); },
+    web,
+    async openedUrls() { return (await listTargets(web.handle.cdpUrl)).map((target) => target.url); },
+    async [Symbol.asyncDispose]() { await web[Symbol.asyncDispose](); },
   };
+}
+
+export async function localFirstRunWorld(seed: Seed) {
+  const prompt = "Create a short welcome checklist for this OpenWork workspace. Use exactly three bullets and mention one thing I can do next.";
+  const reply = "Your workspace is ready. You can draft a document next.";
+  const den = await seed.den({
+    provision: false,
+    mocks: { starter: seed.mock({ agentWorkloads: [{ promptMarker: prompt, finalReply: reply, steps: [] }] }) },
+  });
+  const mock = den.mocks.starter;
+  // Only replace the provider transport. Do not seed a workspace, session,
+  // sign-in, onboarding preference, or selected model: the app must supply them.
+  const app = await seed.desktop({
+    name: "first-run-local",
+    signIn: false,
+    env: {
+      DAYTONA_SECRETS_ENV: "/tmp/openwork-first-run-no-secrets",
+      OPENWORK_DESKTOP_DISTRIBUTION: "public",
+      OPENWORK_EVAL_MODEL: "",
+      VITE_DISABLE_OPENWORK_MODELS: "0",
+      OPENCODE_CONFIG: "",
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        enabled_providers: ["opencode"],
+        small_model: "opencode/big-pickle",
+        provider: {
+          opencode: {
+            npm: "@ai-sdk/openai-compatible",
+            options: { baseURL: `${mock.url}/v1`, apiKey: "sk-eval-fixture" },
+            whitelist: ["big-pickle"],
+            models: {
+              "big-pickle": {
+                name: "Big Pickle",
+                provider: { npm: "@ai-sdk/openai-compatible", api: `${mock.url}/v1` },
+              },
+            },
+          },
+        },
+      }),
+    },
+  });
+  return { app, mock, prompt, reply };
 }
 
 export async function workspaceWorld(seed: Seed) {

--- a/packages/sdk/src/gen/types.gen.ts
+++ b/packages/sdk/src/gen/types.gen.ts
@@ -191,9 +191,9 @@ export type DesktopHandoffGrantCreateBody = {
    */
   next?: string;
   /**
-   * Optional desktop URL scheme to use when building the OpenWork deep link.
+   * The registered OpenWork desktop URL scheme.
    */
-  desktopScheme?: string;
+  desktopScheme?: "openwork";
   /**
    * Optional HTTPS OpenWork Cloud web return URL. Accepted only for multi-organization Cloud instances after server-side origin validation.
    */

--- a/scenarios/onboarding/e2e.test.ts
+++ b/scenarios/onboarding/e2e.test.ts
@@ -2,11 +2,11 @@ import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
 import { onboardingWorld } from "./world.ts";
 import { onboarding } from "./workflow.ts";
-import { downloadScreenshot } from "./screenshots.ts";
+import { completionScreenshot } from "./screenshots.ts";
 
 const test = spec.world(onboardingWorld, { timeout: 600_000 });
 
-test("signup, invite two teammates, add tools, and download the desktop app", async (ctx) => {
+test("signup, invite two teammates, add tools, and complete setup without a download", async (ctx) => {
   const result = await onboarding(ctx);
   const { recordAssertionEvidence: record } = ctx.evidence;
 
@@ -60,29 +60,19 @@ test("signup, invite two teammates, add tools, and download the desktop app", as
     true,
   );
 
-  const begun = result.downloads.find(
-    (event) => event.event === "Browser.downloadWillBegin",
-  );
-  expect(begun?.suggestedFilename).toMatch(
-    /^openwork-linux-x86_64-.*\.AppImage$/,
-  );
-  expect(result.completed?.guid).toBe(begun?.guid);
-  expect(result.completed?.receivedBytes).toBeGreaterThan(1_000_000);
-  expect(result.completed?.receivedBytes).toBe(result.completed?.totalBytes);
-  expect(result.downloads.some((event) => event.state === "canceled")).toBe(
-    false,
-  );
+  expect(result.downloads).toEqual([]);
+  expect(result.completedPath).toBe("/dashboard");
   record(
-    "Desktop installer downloaded completely",
-    JSON.stringify(result.completed),
+    "Setup opens the dashboard without downloading or requiring models",
+    JSON.stringify({ path: result.completedPath, downloads: result.downloads }),
     true,
   );
 
   await ctx.world.film?.stop();
-  const screenshot = await downloadScreenshot(ctx.world);
+  const screenshot = await completionScreenshot(ctx.world);
   expect(screenshot.bytes).toBeGreaterThan(1_000);
   record(
-    "DocShot captures the settled download page",
+    "DocShot captures the completed setup dashboard",
     JSON.stringify(screenshot),
     true,
   );

--- a/scenarios/onboarding/empty-chat.tsx
+++ b/scenarios/onboarding/empty-chat.tsx
@@ -1,6 +1,6 @@
 import { Icon, Mark, mix } from "@openwork/presentation";
 
-/** Illustrated app opening; the recording proves the download, not desktop installation. */
+/** Standalone illustration, not evidence of desktop installation or launch. */
 export function EmptyChat({ f }: { f: number }) {
   const show = mix(f, 0, 32);
   return (

--- a/scenarios/onboarding/remotion.tsx
+++ b/scenarios/onboarding/remotion.tsx
@@ -18,7 +18,7 @@ registerRoot(() => (
           "Use onboarding/render.mjs with a completed capture directory",
         );
       return {
-        durationInFrames: Math.ceil((props.recording.durationSeconds + 8) * 30),
+        durationInFrames: Math.ceil((props.recording.durationSeconds + 2) * 30),
       };
     }}
   />

--- a/scenarios/onboarding/render.mjs
+++ b/scenarios/onboarding/render.mjs
@@ -20,17 +20,9 @@ const captureDirectory = resolve(directory);
 const recording = recordingFromCapture(
   JSON.parse(await readFile(join(captureDirectory, "capture.json"), "utf8")),
 );
-const completed = recording.downloads.find(
-  (event) => event.state === "completed",
-);
-if (
-  !completed ||
-  completed.receivedBytes <= 0 ||
-  completed.receivedBytes !== completed.totalBytes ||
-  recording.downloads.some((event) => event.state === "canceled")
-) {
+if (recording.downloads.length > 0) {
   throw new Error(
-    "Onboarding needs a completed installer download before animating the app opening",
+    "Use an onboarding capture that completes setup without downloading an installer",
   );
 }
 const temporary = await mkdtemp(join(tmpdir(), "openwork-onboarding-render-"));

--- a/scenarios/onboarding/screenshots.ts
+++ b/scenarios/onboarding/screenshots.ts
@@ -5,18 +5,18 @@ import { captureUntil } from "../../evals/docs-shots/loop.ts";
 import type { onboardingWorld } from "./world.ts";
 
 /** Capture an already-open scenario using the existing DocShot readiness loop. */
-export async function downloadScreenshot(
+export async function completionScreenshot(
   world: Awaited<ReturnType<typeof onboardingWorld>>,
 ) {
   const png = await captureUntil(
     world.web,
     gate({
-      expect: ["Download for Linux"],
-      never: ["2 invitations sent.", "Give your team a head start."],
+      expect: ["Studio"],
+      never: ["2 invitations sent.", "Give your team a head start.", "Complete setup"],
     }),
   );
   const directory = join(world.directory, "screenshots");
   await mkdir(directory, { recursive: true });
-  await writeFile(join(directory, "download.png"), png);
-  return { file: "screenshots/download.png", bytes: png.byteLength };
+  await writeFile(join(directory, "completed-setup.png"), png);
+  return { file: "screenshots/completed-setup.png", bytes: png.byteLength };
 }

--- a/scenarios/onboarding/video.tsx
+++ b/scenarios/onboarding/video.tsx
@@ -1,12 +1,9 @@
 import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
 import {
   BrowserFrame,
-  DownloadToast,
   RecordedBrowser,
-  mix,
 } from "@openwork/presentation";
 import type { BrowserRecording } from "@openwork/presentation";
-import { EmptyChat } from "./empty-chat.tsx";
 
 export type OnboardingVideoProps = { recording: BrowserRecording };
 
@@ -14,16 +11,6 @@ export function OnboardingVideo({ recording }: OnboardingVideoProps) {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
   const seconds = Math.min(frame / fps, recording.durationSeconds);
-  const openingFrame = Math.ceil((recording.durationSeconds + 2) * fps);
-  const opening = frame >= openingFrame;
-  const download = recording.downloads.findLast(
-    (event) => event.seconds <= seconds,
-  );
-  const complete = download?.state === "completed";
-  const progress =
-    download && download.totalBytes > 0
-      ? download.receivedBytes / download.totalBytes
-      : 0;
 
   return (
     <AbsoluteFill
@@ -43,35 +30,9 @@ export function OnboardingVideo({ recording }: OnboardingVideoProps) {
           transformOrigin: "0 0",
         }}
       >
-        <div
-          style={{
-            opacity: opening
-              ? mix(frame, openingFrame, openingFrame + 24, 1, 0)
-              : 1,
-          }}
-        >
-          <BrowserFrame
-            section="Get started"
-            address="OpenWork"
-            download={
-              download && (
-                <DownloadToast
-                  f={30}
-                  progress={progress}
-                  complete={complete}
-                  bytes={download.totalBytes}
-                />
-              )
-            }
-          >
-            <RecordedBrowser recording={recording} seconds={seconds} />
-          </BrowserFrame>
-        </div>
-        {opening && (
-          <div style={{ position: "absolute", inset: 0 }}>
-            <EmptyChat f={frame - openingFrame} />
-          </div>
-        )}
+        <BrowserFrame section="Get started" address="OpenWork">
+          <RecordedBrowser recording={recording} seconds={seconds} />
+        </BrowserFrame>
       </div>
     </AbsoluteFill>
   );

--- a/scenarios/onboarding/workflow.ts
+++ b/scenarios/onboarding/workflow.ts
@@ -114,33 +114,27 @@ export async function onboarding(ctx: OnboardingContext) {
     await read("/v1/mcp-connections?scope=manageable", orgId),
     "connections",
   );
-  await step("Continue to download", async () => {
+  await step("Review optional models", async () => {
     await user.click({ role: "button", label: "Continue" });
     await user.see(
-      { role: "link", text: "Download for Linux" },
+      { text: "Your workspace is ready" },
       { timeoutMs: 90_000 },
     );
   });
 
-  const film = world.film;
-  if (!film)
-    throw new Error("The onboarding world must capture browser downloads");
-  await step("Download OpenWork", () =>
-    user.click({ role: "link", text: "Download for Linux" }),
-  );
-  const completed = await step("Download completes", () =>
-    probe.eventually(
-      () => film.downloads.find((event) => event.state === "completed"),
-      { within: 180_000, label: "installer completed", until: Boolean },
-    ),
-  );
+  await user.notSee({ testId: "download-openwork-card" });
+  await step("Complete setup", async () => {
+    await user.click({ role: "button", label: "Complete setup" });
+    await user.see({ testId: "den-org-sidebar" }, { timeoutMs: 90_000 });
+    await user.notSee({ testId: "den-onboarding-shell" });
+  });
   return {
     organizationsBefore,
     organizations,
     invitations,
     emails,
     connections,
-    completed,
-    downloads: film.downloads,
+    completedPath: await world.pathname(),
+    downloads: world.film?.downloads ?? [],
   };
 }

--- a/scenarios/onboarding/world.ts
+++ b/scenarios/onboarding/world.ts
@@ -13,3 +13,75 @@ export async function onboardingWorld(seed: Seed) {
   world.owner.password = "OpenWork-demo-9274!";
   return { ...world, directory };
 }
+
+export async function desktopOnboardingWorld(seed: Seed) {
+  const world = await signupWorkspace(seed);
+  const endpoint = world.web.client.webSocketDebuggerUrl;
+  if (!endpoint) throw new Error("Desktop return witness requires browser CDP");
+  const socket = new WebSocket(endpoint);
+  let resolveReady: () => void = () => {};
+  let rejectReady: (error: Error) => void = () => {};
+  const ready = new Promise<void>((resolve, reject) => { resolveReady = resolve; rejectReady = reject; });
+  let failure: Error | null = null;
+  let disposed = false;
+  const requests: { method: string; path: string }[] = [];
+  const returns: string[] = [];
+  const record = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+  const fail = () => {
+    if (disposed) return;
+    failure = new Error("Desktop return witness lost browser CDP");
+    rejectReady(failure);
+  };
+  const timeout = setTimeout(() => rejectReady(new Error("Desktop return witness timed out")), 15_000);
+  socket.addEventListener("error", fail);
+  socket.addEventListener("close", fail);
+  socket.addEventListener("open", () => {
+    socket.send(JSON.stringify({ id: 1, method: "Network.enable" }));
+    socket.send(JSON.stringify({ id: 2, method: "Page.enable" }));
+  });
+  socket.addEventListener("message", (event) => {
+    const message: unknown = JSON.parse(String(event.data));
+    if (!record(message)) return;
+    if (message.error) { fail(); return; }
+    if (message.id === 2) resolveReady();
+    if (!record(message.params)) return;
+    const params = message.params;
+    if (message.method === "Network.requestWillBeSent" && record(params.request)) {
+      const request = params.request;
+      if (typeof request.url === "string" && typeof request.method === "string") {
+        const url = new URL(request.url);
+        if (url.origin === new URL(world.den.ref.webUrl).origin) requests.push({ method: request.method, path: url.pathname });
+      }
+    }
+    if (message.method === "Page.frameRequestedNavigation" && typeof params.url === "string" && params.url.startsWith("openwork://")) {
+      // Mock only OS dispatch: retain the browser-issued URL, never mint a test grant.
+      returns.push(params.url);
+      socket.send(JSON.stringify({ id: 3, method: "Page.stopLoading" }));
+    }
+  });
+  try {
+    await ready;
+  } catch (error) {
+    disposed = true;
+    socket.close();
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+  return {
+    ...world,
+    handoff() {
+      if (failure) throw failure;
+      return {
+        grants: requests.filter(({ method, path }) => method === "POST" && path.endsWith("/auth/desktop-handoff")).length,
+        modelWrites: requests.filter(({ method, path }) => method !== "GET" && /\/v1\/inference(?:\/|$)/.test(path)).length,
+        returns: [...returns],
+      };
+    },
+    async [Symbol.asyncDispose]() {
+      disposed = true;
+      socket.close();
+      await world[Symbol.asyncDispose]();
+    },
+  };
+}

--- a/scenarios/tsconfig.json
+++ b/scenarios/tsconfig.json
@@ -12,6 +12,7 @@
     ]
   },
   "include": [
+    "../evals/packages/cdp/src/browser-globals.d.ts",
     "**/*.ts",
     "**/*.tsx"
   ],

--- a/scripts/check-connect-installer-parity.mjs
+++ b/scripts/check-connect-installer-parity.mjs
@@ -13,10 +13,6 @@ const cloudDocs = await readFile(
   new URL("../packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx", import.meta.url),
   "utf8",
 );
-const onboardingScreen = await readFile(
-  new URL("../ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx", import.meta.url),
-  "utf8",
-);
 
 function sourceHasLiteral(sourceText, literal) {
   return sourceText.split(literal).length > 1;
@@ -141,16 +137,5 @@ assert.ok(cloudDocs.includes("search_capabilities") && cloudDocs.includes("execu
 assert.ok(!cloudDocs.includes("openwork-ui-mcp"), "Cloud MCP docs must not reference the local UI MCP package");
 assert.ok(!cloudDocs.includes("opaque bearer tokens") && !cloudDocs.includes("Access tokens are opaque"), "Cloud MCP docs must not claim opaque public access tokens");
 assert.ok(!cloudDocs.includes("JWKS"), "Cloud MCP docs must not expose JWKS implementation details");
-
-assert.ok(onboardingScreen.includes(serverUrl), "Cloud onboarding must copy the public /mcp/agent endpoint");
-assert.ok(!onboardingScreen.includes("openwork-ui-mcp"), "Cloud onboarding must not copy the local UI MCP package");
-assert.ok(
-  sourceHasLiteral(onboardingScreen, "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp"),
-  "Cloud onboarding must link to the Cloud MCP docs",
-);
-assert.ok(onboardingScreen.includes("OpenCode is verified"), "Cloud onboarding must state verified clients");
-assert.ok(onboardingScreen.includes("setup guides"), "Cloud onboarding must state setup-only client coverage");
-assert.ok(onboardingScreen.includes("break-all") && onboardingScreen.includes("whitespace-normal"), "Cloud onboarding endpoint text must wrap on narrow screens");
-assert.ok(onboardingScreen.includes("aria-live=\"polite\"") && onboardingScreen.includes("Copy OpenWork MCP endpoint"), "Cloud onboarding must expose accessible copy feedback");
 
 console.log("OpenWork Connect landing and docs installers are in parity.");


### PR DESCRIPTION
## Summary

OpenWork should be usable immediately after installation, and optional account setup should finish before sending a new user back to desktop.

- Download CTAs start the detected installer while retaining the download page and alternative versions. Plain visits and reloads do not start downloads.
- Public desktop first launch selects the existing default chat folder and opens the empty task screen without folder, model, or acquisition-survey gates. Existing workspaces, provider settings, and enterprise activation requirements remain intact.
- The new-account form is ordered **Name, Email, Password, Sign up, or, Google**. Email-first discovery remains unchanged.
- First-time desktop sign-in stays in **Make it yours, optional People, optional Tools, optional Models/BYOK, Complete and open the app**, with no download button or installation checklist.
- Generate the one-time desktop grant only at completion. Reloads retain the tab's pending setup, and resumed questions remain pinned to the organization where setup began. Returning members keep the short sign-in path.
- Desktop grants accept only the registered `openwork` scheme. Invalid protocols are rejected server-side without issuing a grant or URL.

Sign-in remains optional. This does not replace OpenCode models, enable paid models, add a free-credit offer, or change pricing. GitHub sign-in remains separate.

## Interface And Flow

**[View the five onboarding screenshots](https://github.com/different-ai/openwork/pull/4608#issuecomment-5589270568)**: Account, Your space, People, Tools, and Models/completion.

These existing screenshots show the real local UI with synthetic data at `888cb59b9745731b487c011fd10634b60dd34e6d`. They are supplementary, not exact-head journey proof. No grant, sign-in code, or private identity is shown.

## Synchronization

- Final PR head: `f32eb0de078f22b01e970e775c513c3db922da51`.
- Rebased onto canonical `dev` at `ca0a4bd6f93ed7e54f02a546959753197ed2b544`, retaining the newer footer assertions and packaged-startup correction. All seven feature commits have verified signatures; no merge commit was added to the feature branch.
- Merged by Jalil on September 8 at 19:48 UTC as `51c0ab92f51c13f758dbfdfe1e589fd55b639ee2`, which is contained in observed `dev` at `fc8c9852bb3f21691597a470e6692d097b74c094`.
- #4619 is untouched; its branch and evidence need refreshing independently after this parent rewrite.

## Verification

**[Exact-head test evidence](https://github.com/different-ai/openwork/pull/4608#issuecomment-5590711518)**: latest selected results are **8 passed, 0 failed, 0 skipped**. Every result below belongs to the final PR head above, not the later squash commit or subsequent `dev` changes.

| Command | Exit | Passed / Failed / Skipped |
| --- | --- | --- |
| `pnpm evals:e2e signup-workspace-intent --local` | 0 | 2 / 0 / 0 |
| `pnpm evals:e2e first-run-local --local` | 0 | 1 / 0 / 0 |
| `pnpm evals:e2e welcome-one-field --local` | 0 | 1 / 0 / 0 |
| `OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:13006 pnpm evals:pr specs/landing-pricing.test.ts` | 0 | 3 / 0 / 0 |
| `OPENWORK_EVAL_ELECTRON_BINARY=<freshly-built-macOS-arm64-binary> OPENWORK_EVAL_ELECTRON_RESOURCES_PREPARED=1 OPENWORK_EVAL_ENGINE=v1 pnpm evals:e2e app-smoke --local` | 0 | 1 / 0 / 0 |

E2E runs printed `placement: local (--local)` and used fresh owned resources. The landing PR-lane command used local Chromium against the local landing server. Packaged proof used a fresh unsigned macOS arm64 build and isolated profile, checking the renderer, preload bridge, embedded server, empty signed-out workspace, and shipped tool registry.

The mobile Tools-to-Ready transition, reload, and completion now pass. Negative scheme-routing assertions pass. First launch passed two consecutive cold reruns after one earlier input-discrepancy failure; that failed attempt remains documented in the evidence comment and is not classified as pre-existing or fixed.

Also passed: `pnpm sdk:check`, app and Den Web typechecks, Electron build/package, and `git diff --check`. GitHub checks completed without failures and review was approved.

Overall proof status: **Incomplete** for 16 deferred visual judgments; no skipped test is counted as passed.

## Review Notes

- All three review threads are resolved. The trusted-scheme fix is covered by authenticated negative requests and the successful browser-issued handoff.
- The organization name is rendered only in the authorized user's consumed-grant confirmation, not in the handoff URL or grant.
- The calendar-link review location was inspected; this PR only replaces the download link on that page and does not introduce the calendar parameters.
- This supersedes the welcome-screen portion of #4497; that PR is untouched. Existing auth loading presentation is preserved.
- Tab-scoped continuation is navigation state, not a membership-completion database flag. It expires after 24 hours and is not shared across tabs/devices.
