### PR TITLE
fix(app): stop sweeping unrelated permissions when switching threads

### DIFF
--- a/apps/app/src/app/lib/opencode-v2-adapter.ts
+++ b/apps/app/src/app/lib/opencode-v2-adapter.ts
@@ -1313,6 +1313,12 @@ export function isOpencodeV2BaseUrl(baseUrl: string): boolean {
   }
 }
 
+const v2Clients = new WeakSet<ReturnType<typeof createClient>>();
+
+export function isOpencodeV2Client(client: ReturnType<typeof createClient>): boolean {
+  return v2Clients.has(client);
+}
+
 export function createClientV2(
   opencode2BaseUrl: string,
   directory: string | undefined,
@@ -1794,6 +1800,7 @@ export function createClientV2(
   Object.assign(compatibilityClient.find, adapter.find);
   Object.assign(compatibilityClient.mcp, adapter.mcp);
   Object.assign(compatibilityClient.event, adapter.event);
+  v2Clients.add(compatibilityClient);
   return compatibilityClient;
 }
 

--- a/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
+++ b/apps/app/src/react-app/domains/session/sync/use-session-interactions.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { unwrap } from "@/app/lib/opencode";
+import { isOpencodeV2Client } from "@/app/lib/opencode-v2-adapter";
 import type { Client, PendingPermission, PendingQuestion, TodoItem } from "@/app/types";
 import { t } from "@/i18n";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
@@ -77,24 +78,29 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
 
   useEffect(() => {
     if (!client || !workspaceId || interactionSessionIds.length === 0) return;
-    let cancelled = false;
+    const controller = new AbortController();
     const directory = workspaceRoot || undefined;
     void (async () => {
       const snapshotStartedAt = Date.now();
       try {
         let legacyPermissions: Parameters<typeof seedPermissionState>[2] = [];
         let legacyReadSucceeded = false;
-        try {
-          legacyPermissions = unwrap(await client.permission.list({ directory }));
-          legacyReadSucceeded = true;
-        } catch {
-          // Older/newer OpenCode permission APIs can fail independently.
+        // The v2 compatibility list sweeps every session; the scoped reads below
+        // already return its native requests. V1 still needs both protocols.
+        if (!isOpencodeV2Client(client)) {
+          try {
+            legacyPermissions = unwrap(await client.permission.list({ directory }, { signal: controller.signal }));
+            legacyReadSucceeded = true;
+          } catch {
+            // Older/newer OpenCode permission APIs can fail independently.
+          }
         }
+        if (controller.signal.aborted) return;
 
         const v2Reads = await Promise.all(interactionSessionIds.map(async (permissionSessionId) => {
           try {
             const permissions = unwrap(
-              await client.v2.session.permission.list({ sessionID: permissionSessionId }),
+              await client.v2.session.permission.list({ sessionID: permissionSessionId }, { signal: controller.signal }),
             ).data;
             return { permissionSessionId, permissions, succeeded: true };
           } catch {
@@ -102,7 +108,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
           }
         }));
 
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
         for (const read of v2Reads) {
           if (!legacyReadSucceeded && !read.succeeded) continue;
           seedPermissionState(
@@ -118,19 +124,19 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
       }
     })();
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [client, interactionSessionIds, workspaceId, workspaceRoot]);
 
   useEffect(() => {
     if (!client || !workspaceId || interactionSessionIds.length === 0) return;
-    let cancelled = false;
+    const controller = new AbortController();
     const directory = workspaceRoot || undefined;
     void (async () => {
       const snapshotStartedAt = Date.now();
       try {
-        const list = unwrap(await client.question.list({ directory }));
-        if (cancelled) return;
+        const list = unwrap(await client.question.list({ directory }, { signal: controller.signal }));
+        if (controller.signal.aborted) return;
         for (const questionSessionId of interactionSessionIds) {
           seedQuestionState(workspaceId, questionSessionId, list, { snapshotStartedAt });
         }
@@ -140,7 +146,7 @@ export function useSessionInteractions(input: UseSessionInteractionsInput) {
       }
     })();
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [client, interactionSessionIds, workspaceId, workspaceRoot]);
 

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
 import type { PermissionRequest, PermissionV2Request, QuestionRequest } from "@opencode-ai/sdk/v2/client";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 
+import { createClient } from "../src/app/lib/opencode";
+import { createClientV2 } from "../src/app/lib/opencode-v2-adapter";
+import { useSessionInteractions, type UseSessionInteractionsInput } from "../src/react-app/domains/session/sync/use-session-interactions";
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import { useSessionActivityStore } from "../src/react-app/domains/session/status/session-activity-store";
@@ -113,6 +119,85 @@ afterEach(() => {
 });
 
 describe("session permission sync", () => {
+  for (const engine of ["v1", "v2"]) {
+    test(`${engine} hydration reads only its required protocols and cancels obsolete reads`, async () => {
+      GlobalRegistrator.register({ url: "http://localhost/" });
+      Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+      const originalFetch = globalThis.fetch;
+      const calls: Request[] = [];
+      const delayed = Promise.withResolvers<Response>();
+      const delayedQuestion = Promise.withResolvers<Response>();
+      const v2 = engine === "v2";
+      let hold = false;
+      const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init);
+        calls.push(request);
+        const path = new URL(request.url).pathname;
+        if (path.endsWith("/api/session")) throw new Error("Unrelated session sweep must not run");
+        if (path.endsWith("/api/session/session-a/permission") && hold) return delayed.promise;
+        if ((path.endsWith("/form/request") || path.endsWith("/question")) && hold) return delayedQuestion.promise;
+        if (path.endsWith("/api/session/session-child/permission")) {
+          return Response.json({ data: [v2Permission("perm-child", "session-child")] });
+        }
+        if (path.endsWith("/api/session/session-a/permission")) return Response.json({ data: [] });
+        if (!v2 && path.endsWith("/permission")) {
+          return Response.json([permission("perm-legacy", "session-a"), permission("perm-other", "session-b")]);
+        }
+        return Response.json(v2 ? { data: [] } : []);
+      };
+      Object.defineProperty(globalThis, "fetch", { configurable: true, writable: true, value: fetchStub });
+      const client = v2 ? createClientV2("http://localhost/opencode2", "/project", {}) : createClient("http://localhost/opencode", "/project");
+      function Interactions(props: UseSessionInteractionsInput) {
+        const interactions = useSessionInteractions(props);
+        return createElement("div", null, interactions.activePermission?.id);
+      }
+      const container = document.createElement("div");
+      const root = createRoot(container);
+      const render = (sessionId: string, interactionSessionIds: string[] = []) => root.render(createElement(Interactions, {
+        client, workspaceId: "workspace-a", workspaceRoot: "/project", sessionId, interactionSessionIds,
+      }));
+      const cached = (id: string) => getReactQueryClient().getQueryData(permissionKey("workspace-a", id));
+      try {
+        await act(async () => render("session-a", ["session-child", "session-a", "session-child"]));
+        expect(calls.filter((request) => new URL(request.url).pathname.endsWith("/permission")).map((request) => new URL(request.url).pathname))
+          .toEqual([
+            ...(!v2 ? ["/opencode/permission"] : []),
+            `/${v2 ? "opencode2" : "opencode"}/api/session/session-a/permission`,
+            `/${v2 ? "opencode2" : "opencode"}/api/session/session-child/permission`,
+          ]);
+        expect(cached("session-child")).toMatchObject([{ id: "perm-child", sessionID: "session-child", protocol: "v2" }]);
+        expect(cached("session-a")).toEqual(v2 ? [] : expect.arrayContaining([expect.objectContaining({ id: "perm-legacy" })]));
+        expect(cached("session-b")).toBeUndefined();
+
+        // A request finishing after navigation must not overwrite newer live state,
+        // even when its transport ignores cancellation and returns a stale body.
+        hold = true;
+        await act(async () => render("session-a"));
+        const oldPermission = calls.findLast((request) => new URL(request.url).pathname.endsWith("/session-a/permission"));
+        const oldQuestion = calls.findLast((request) => /\/(question|form\/request)$/.test(new URL(request.url).pathname));
+        expect(oldPermission?.signal.aborted).toBe(false);
+        expect(oldQuestion?.signal.aborted).toBe(false);
+        await act(async () => render("session-b"));
+        // V1's shared timeout transport replaces Request signals. The hook still
+        // suppresses its late result; v2's native web transport also aborts I/O.
+        if (v2) {
+          expect(oldPermission?.signal.aborted).toBe(true);
+          expect(oldQuestion?.signal.aborted).toBe(true);
+        }
+        await act(async () => {
+          seedPermissionState("workspace-a", "session-a", [v2Permission("perm-live", "session-a")]);
+          delayed.resolve(Response.json({ data: [] }));
+          delayedQuestion.resolve(Response.json(v2 ? { data: [] } : []));
+        });
+        expect(cached("session-a")).toMatchObject([{ id: "perm-live" }]);
+      } finally {
+        await act(async () => root.unmount());
+        Object.defineProperty(globalThis, "fetch", { configurable: true, writable: true, value: originalFetch });
+        await GlobalRegistrator.unregister();
+      }
+    });
+  }
+
   test("seeds only permissions for the selected session", () => {
     seedPermissionState("workspace-a", "session-a", [
       permission("perm-a", "session-a"),

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -1,9 +1,41 @@
 import { expect } from "vitest";
 import { spec } from "@openwork/testkit";
-import { parentChildPermissionWorld } from "../worlds/first-run.ts";
+import { parentChildPermissionWorld, scopedPermissionRefreshWorld } from "../worlds/first-run.ts";
 import { delegatedQuestionHandoff } from "../worlds/chat.ts";
 
 const test = spec.world(parentChildPermissionWorld);
+
+const scopeTest = spec.world(scopedPermissionRefreshWorld, { timeout: 600_000 });
+
+scopeTest("switching and creating threads hydrate permissions without waiting for unrelated roots", async ({ world, user, agent, probe, step }) => {
+  await probe.eventually(() => world.permissionReads(), {
+    within: 15_000, label: "the unrelated permission endpoint is held open",
+    until: (reads) => reads.some((read) => read.calibration && read.held && !read.completed),
+  });
+  const assertScoped = async (sessionId: string, before: number) => {
+    const reads = await probe.eventually(() => world.permissionReads().slice(before), {
+      within: 15_000, label: "the selected thread finishes its scoped permission read while the unrelated request is held",
+      until: (reads) => reads.some((read) => read.sessionId === sessionId && read.completed),
+    });
+    expect(reads.filter((read) => !read.calibration).map((read) => read.sessionId)).toEqual([sessionId]);
+    expect(world.permissionReads().filter((read) => read.sessionId === world.unrelated.sessionId))
+      .toEqual([{ sessionId: world.unrelated.sessionId, calibration: true, held: true, completed: false }]);
+    expect(await probe.hash()).toContain(`/session/${sessionId}`);
+    await user.see("composer", { editable: true });
+    console.info(`[permission-scope] ${world.engine}: 1 scoped read, 0 unrelated reads, calibration still held`);
+  };
+  await step("switching reads only the selected root, not the other seven roots", async () => {
+    const before = world.permissionReads().length;
+    await user.click({ text: world.selected.title });
+    await assertScoped(world.selected.sessionId, before);
+  });
+  await step("a newly created thread hydrates without sweeping existing roots", async () => {
+    const before = world.permissionReads().length;
+    const sessionId = await agent.createSession("Fresh permission scope");
+    await assertScoped(sessionId, before);
+    await user.screenshot();
+  });
+});
 
 test("a parent task surfaces and resolves its child session permission request", async ({ user, probe, step }) => {
   await step("The parent exposes the child request", async () => {

--- a/evals/specs/parent-child-permission-approval.e2e.test.ts
+++ b/evals/specs/parent-child-permission-approval.e2e.test.ts
@@ -8,6 +8,9 @@ const test = spec.world(parentChildPermissionWorld);
 const scopeTest = spec.world(scopedPermissionRefreshWorld, { timeout: 600_000 });
 
 scopeTest("switching and creating threads hydrate permissions without waiting for unrelated roots", async ({ world, user, agent, probe, step }) => {
+  user = user.on(world.app);
+  agent = agent.on(world.app);
+  probe = probe.on(world.app);
   await probe.eventually(() => world.permissionReads(), {
     within: 15_000, label: "the unrelated permission endpoint is held open",
     until: (reads) => reads.some((read) => read.calibration && read.held && !read.completed),
@@ -26,7 +29,7 @@ scopeTest("switching and creating threads hydrate permissions without waiting fo
   };
   await step("switching reads only the selected root, not the other seven roots", async () => {
     const before = world.permissionReads().length;
-    await user.click({ text: world.selected.title });
+    await agent.run("session.open", { sessionId: world.selected.sessionId });
     await assertScoped(world.selected.sessionId, before);
   });
   await step("a newly created thread hydrates without sweeping existing roots", async () => {

--- a/evals/worlds/first-run.ts
+++ b/evals/worlds/first-run.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { app as startApp, server as startServer } from "@openwork/env";
+import { app as startApp, server as startServer, resolveEvalEngine } from "@openwork/env";
 import { SkipError } from "@openwork/env";
 import type { Place, Seed } from "@openwork/env";
 import { createAndSelectWorkspace, evalIn, go, waitFor as waitForBehavior } from "@openwork/behaviors";
@@ -153,6 +153,97 @@ export async function parentChildPermissionWorld(seed: Seed) {
     throw new Error(`Child permission seed failed: ${JSON.stringify(seeded)}`);
   }
   return base;
+}
+
+export async function scopedPermissionRefreshWorld(seed: Seed) {
+  const base = await workspaceWorld(seed);
+  const sessions = await seed.sessions(base.app, Array.from({ length: 8 }, (_, index) => `Permission scope ${index}`));
+  const [unrelated, selected] = sessions;
+  if (!unrelated || !selected) throw new Error("Permission scope sessions were not created");
+  const engine = resolveEvalEngine();
+  const prefix = `/workspace/${encodeURIComponent(base.workspace.workspaceId)}/${engine === "v2" ? "opencode2" : "opencode"}`;
+  const debuggerUrl = base.app.client.webSocketDebuggerUrl;
+  if (!debuggerUrl) throw new Error("Permission witness needs a desktop CDP endpoint");
+  const socket = new WebSocket(debuggerUrl);
+  const ready = Promise.withResolvers<void>();
+  const commands = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>();
+  const reads: { sessionId: string; networkId: string; calibration: boolean; held: boolean }[] = [];
+  const finished = new Set<string>();
+  let nextId = 1;
+  let failure: Error | undefined;
+  const command = async (method: string, params = {}) => {
+    const id = nextId++;
+    const result = Promise.withResolvers<void>();
+    commands.set(id, result);
+    const timeout = setTimeout(() => result.reject(new Error(`Permission witness timed out: ${method}`)), 15_000);
+    try {
+      socket.send(JSON.stringify({ id, method, params }));
+      await result.promise;
+    } finally {
+      clearTimeout(timeout);
+      commands.delete(id);
+    }
+  };
+  const readyTimeout = setTimeout(() => ready.reject(new Error("Permission witness did not connect")), 15_000);
+  socket.addEventListener("open", () => ready.resolve());
+  socket.addEventListener("error", () => {
+    failure = new Error("Permission witness connection failed");
+    ready.reject(failure);
+  });
+  socket.addEventListener("message", (event) => {
+    const message: unknown = JSON.parse(String(event.data));
+    if (!isRecord(message)) return;
+    if (typeof message.id === "number") {
+      const pending = commands.get(message.id);
+      if (message.error) pending?.reject(new Error("Permission witness command failed"));
+      else pending?.resolve();
+    }
+    const params = message.params;
+    if (!isRecord(params)) return;
+    if (message.method === "Network.loadingFinished" && typeof params.requestId === "string") finished.add(params.requestId);
+    if (message.method !== "Fetch.requestPaused" || typeof params.requestId !== "string") return;
+    const request = params.request;
+    if (!isRecord(request) || typeof request.url !== "string") return;
+    const url = new URL(request.url);
+    const match = url.pathname.slice(prefix.length).match(/^\/api\/session\/([^/]+)\/permission$/);
+    const sessionId = match?.[1] ? decodeURIComponent(match[1]) : "";
+    if (request.method === "GET" && sessionId && typeof params.networkId === "string") {
+      // Hold every read of one unrelated root, not just a single lucky request.
+      // The calibration proves the fault is active without relying on timing.
+      const held = sessionId === unrelated.sessionId;
+      reads.push({ sessionId, networkId: params.networkId, calibration: url.searchParams.has("scope-calibration"), held });
+      if (held) return;
+    }
+    void command("Fetch.continueRequest", { requestId: params.requestId }).catch((error: Error) => { failure = error; });
+  });
+  const dispose = async () => {
+    clearTimeout(readyTimeout);
+    try { if (socket.readyState === WebSocket.OPEN) await command("Fetch.disable"); }
+    finally { socket.close(); }
+  };
+  try {
+    await ready.promise;
+    clearTimeout(readyTimeout);
+    await command("Network.enable");
+    await command("Fetch.enable", { patterns: [{ urlPattern: `*${prefix}/api/session/*/permission*`, requestStage: "Request" }] });
+    await seed.evalIn(base.app, browserScript(async (path) => {
+      const info = await window.__OPENWORK_ELECTRON__.invokeDesktop("openworkServerInfo");
+      void fetch(info.baseUrl + path, {
+        headers: { Authorization: `Bearer ${info.ownerToken}` }, signal: AbortSignal.timeout(120_000),
+      }).catch(() => undefined);
+    }, [`${prefix}/api/session/${encodeURIComponent(unrelated.sessionId)}/permission?scope-calibration=1`]), { awaitPromise: true });
+    return {
+      ...base, selected, unrelated, engine,
+      permissionReads() {
+        if (failure) throw failure;
+        return reads.map((read) => ({ sessionId: read.sessionId, calibration: read.calibration, held: read.held, completed: finished.has(read.networkId) }));
+      },
+      async [Symbol.asyncDispose]() { await dispose(); },
+    };
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
 }
 
 export async function artifactCodeBrowserWorld(seed: Seed) {


### PR DESCRIPTION
## Problem
Opening or creating a v2 thread called the compatibility permission list, which fetched the session index and read every session permission endpoint serially. The selected thread and its descendants were then read again. Large workspaces and rapid switching accumulated unrelated requests before the visible approval could hydrate.

## Change
- Identify native v2 clients without changing the shared client API.
- Hydrate v2 permissions only for the selected conversation and descendants.
- Preserve both permission protocols for v1, session ownership, reply behavior, and newer live-event state.
- Abort obsolete permission/question hydration and suppress late results. Transport cancellation remains best-effort where existing desktop/v1 wrappers replace signals.

## Verification — Passed (focused v2 journey)
Head: `f416b96e21486417261042dd1b878924814c996a`.

`OPENWORK_EVAL_ENGINE=v2 OPENWORK_EVAL_REF=f416b96e21486417261042dd1b878924814c996a pnpm evals:e2e parent-child-permission-approval`

Cold boot; exit 0; **3 passed, 0 failed, 0 skipped**.
`placement: daytona (daytona CLI authenticated)`.

The calibrated request witness holds an unrelated permission endpoint throughout switching and creation. Each operation completes exactly **1 scoped permission read and 0 unrelated reads** among eight seeded roots. Existing parent/child approval and real child-question isolation also pass. Exact-head evidence is published below; screenshots are supplementary.

`pnpm exec bun test --isolate tests/session-sync-permissions.test.ts tests/opencode-v2-adapter.test.ts` from apps/app: **85 passed**, 0 failed, 539 assertions. Browser callback check and diff whitespace check passed.

An earlier runtime attempt failed at an empty-thread sidebar locator before the performance assertions; the final run uses the supported session.open action with explicit surface binding. An initial cancellation assertion was narrowed to account for existing v1 timeout transport behavior.

Repository-wide spec channel/boundary ratchets failed identically in a clean base control at ad9786497; no finding concerned this journey. Broad typechecking, v1 end-to-end and cross-platform runs are deferred, not claimed passed.

No permission is automatically approved, and unrelated sessions are not modified.