### PR TITLE
fix(app): prevent new-task flashes when opening existing threads

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1094,7 +1094,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
     : Boolean(props.modelUnavailable);
   const [error, setError] = useState<SessionError | null>(null);
   const [restoringRevertedMessages, setRestoringRevertedMessages] = useState(false);
-  const [showDelayedLoading, setShowDelayedLoading] = useState(false);
+  const [delayedLoadingTarget, setDelayedLoadingTarget] = useState<{ workspaceId: string; sessionId: string } | null>(null);
+  const showDelayedLoading = delayedLoadingTarget?.workspaceId === props.workspaceId &&
+    delayedLoadingTarget.sessionId === props.sessionId;
   const [awaitingAssistantBaseline, setAwaitingAssistantBaseline] = useState<number | null>(null);
   // Terminal invariant: an accepted admission that reached idle with no
   // assistant result surfaces a bounded recovery card instead of plain idle.
@@ -1137,7 +1139,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const lastObservationProbeAtRef = useRef<number | null>(null);
   const [observationProbeVersion, setObservationProbeVersion] = useState(0);
   const composerShellRef = useRef<HTMLDivElement>(null);
-  const hydratedKeyRef = useRef<string | null>(null);
   const autoOpenedTargetRef = useRef<string | null>(null);
   const initializedAutoOpenSessionRef = useRef<string | null>(null);
   const opencodeClient = useMemo(
@@ -1198,11 +1199,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     evalSnapshotFailureRef.current = false;
-    hydratedKeyRef.current = null;
     setSteering(false);
     setError(null);
     setRestoringRevertedMessages(false);
-    setShowDelayedLoading(false);
     setAwaitingAssistantBaseline(null);
     setAdmissionOutcomeUnresolved(false);
     // Composer draft state lives in the shared store keyed by session id, so
@@ -1271,14 +1270,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
     if (!currentSnapshot) return;
     seedSessionState(props.workspaceId, currentSnapshot);
   }, [currentSnapshot, props.sessionId, props.workspaceId]);
-
-  useEffect(() => {
-    if (!currentSnapshot) return;
-    const key = `${props.sessionId}:${currentSnapshot.session.time?.updated ?? currentSnapshot.session.time?.created ?? 0}:${currentSnapshot.messages.length}`;
-    if (hydratedKeyRef.current === key) return;
-    hydratedKeyRef.current = key;
-    seedSessionState(props.workspaceId, currentSnapshot);
-  }, [props.sessionId, currentSnapshot, props.workspaceId]);
 
   const snapshot = resolveRenderedSessionSnapshot({
     sessionId: props.sessionId,
@@ -1661,13 +1652,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, verifiedOpenTargets]);
 
   useEffect(() => {
-    if (!pendingSessionLoad) {
-      setShowDelayedLoading(false);
-      return;
-    }
-    const id = window.setTimeout(() => setShowDelayedLoading(true), 2000);
+    setDelayedLoadingTarget(null);
+    if (!pendingSessionLoad) return;
+    const id = window.setTimeout(() => setDelayedLoadingTarget({
+      workspaceId: props.workspaceId,
+      sessionId: props.sessionId,
+    }), 2000);
     return () => window.clearTimeout(id);
-  }, [pendingSessionLoad]);
+  }, [pendingSessionLoad, props.workspaceId, props.sessionId]);
 
   // Terminal invariant for accepted admissions: idle with no assistant result
   // must never silently clear the task. The transcript-length check alone is
@@ -2822,7 +2814,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       showThinking={showThinking}
                       highlightQuery={findHighlightQuery}
                       developerMode={props.developerMode}
-                      displaySuggestions={shellConfig.starterCards}
+                      displaySuggestions={shellConfig.starterCards && snapshot !== null && snapshot.messages.length === 0}
                       providerConnectedCount={props.providerConnectedCount ?? 0}
                       connectorIdentities={connectorIdentities}
                       syncDegraded={runSyncHealth.degraded}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2152,7 +2152,6 @@ export function SessionRoute() {
           workbench.setSideChat(sideChatOwner, tab);
         }
       }
-      void refreshRouteState();
       return session.id;
     } catch (error) {
       const message = describeTaskCreateError(error);

--- a/evals/specs/new-split-session.e2e.test.ts
+++ b/evals/specs/new-split-session.e2e.test.ts
@@ -107,11 +107,31 @@ test("side chats keep questions, replies, and saved splits attached to their own
     });
   };
   const before = await ids();
+  await step("only a genuinely empty main conversation offers starters", async () => {
+    await probe.eventually(() => world.continuity.surfaceState("primary"), {
+      within: 15_000, label: "loaded empty primary offers starters",
+      until: value => value.sessionId === primary && value.starters && value.messages === 0,
+    });
+  });
   await user.rightClick({ text: world.session.title });
+  await using initialCreation = await world.continuity.observeCreation();
+  await using emptySide = await world.continuity.observeSurface({ pane: "secondary" });
   await user.click({ role: "menuitem", label: /^Open (a second|side) chat$/ });
   const first = await waitSplit(primary);
   expect(before).not.toContain(first.secondary);
   expect(await ids()).toEqual([...before, first.secondary].sort());
+
+  await step("a new empty side conversation never offers main-conversation starters", async () => {
+    await probe.eventually(() => emptySide.read(), {
+      within: 10_000, label: "empty side stays free of starters beyond the loading delay",
+      until: value => value.longSamples > 0,
+    });
+    expect(await emptySide.read()).toMatchObject({ violations: [], expired: false, text: "" });
+    expect(await world.continuity.surfaceState("secondary")).toMatchObject({ starters: false, messages: 0 });
+    expect(await initialCreation.read()).toMatchObject({ workspaceLists: 0, creates: 1, reblocked: false, expired: false });
+  });
+  await emptySide[Symbol.asyncDispose]();
+  await initialCreation[Symbol.asyncDispose]();
 
   await step("a real side-chat question appears and both panes can await different answers", async () => {
     try {
@@ -211,16 +231,29 @@ test("side chats keep questions, replies, and saved splits attached to their own
   });
 
   await step("palette creation replaces the focused side pane without moving the main conversation", async () => {
+    await using creation = await world.continuity.observeCreation();
     await palette("new split", /^Open side chat/);
     const second = await waitSplit(primary);
     expect(second.secondary).not.toBe(first.secondary);
     expect(await ids()).toContain(first.secondary);
     await user.click({ placeholder: "Describe your task...", nth: 1 });
+    await using mainHistory = await world.continuity.observeSurface({
+      sessionId: primary, pane: "primary", required: [world.primaryQuestionPrompt, "Main outline"],
+      forbidden: [world.secondaryQuestionPrompt],
+    });
     await palette("new task", /^New session/);
     const third = await probe.eventually(facts, { within: 30_000, label: "New session replaces only the focused side conversation",
       until: (value) => value.primary === primary && value.secondary !== second.secondary && value.panes === 1,
     });
     expect(await ids()).toContain(second.secondary);
+    await probe.eventually(() => mainHistory.read(), {
+      within: 10_000, label: "main history remains usable while side creation settles",
+      until: value => value.longSamples > 0,
+    });
+    expect(await mainHistory.read()).toMatchObject({ violations: [], expired: false });
+    expect(await creation.read()).toMatchObject({ workspaceLists: 0, creates: 2, reblocked: false, expired: false });
+    await mainHistory[Symbol.asyncDispose]();
+    await creation[Symbol.asyncDispose]();
     await send("secondary", world.secondaryPrompt);
     await answer("secondary", "Secondary split received", "Primary split received");
     await send("primary", world.primaryPrompt);
@@ -228,10 +261,22 @@ test("side chats keep questions, replies, and saved splits attached to their own
     const context = await world.agentContextViaServer();
     expect(context).toMatchObject({ ok: true, context: { conversations: { layout: { primarySessionId: primary, secondarySessionId: third.secondary } } } });
     await user.click({ placeholder: "Describe your task...", nth: 0 });
+    await using mainCreation = await world.continuity.observeCreation();
     await palette("new task", /^New session/);
     await probe.eventually(facts, { within: 30_000, label: "New session in the main pane starts a separate conversation",
       until: (value) => value.primary !== primary && value.panes === 0,
     });
+    await user.type("composer", "Draft stays editable after creating a conversation", { verify: true });
+    await probe.eventually(() => world.continuity.surfaceState("primary"), {
+      within: 15_000, label: "the newly created empty main thread offers starters without a workspace refresh",
+      until: value => value.starters && value.messages === 0,
+    });
+    await probe.eventually(() => mainCreation.read(), {
+      within: 10_000, label: "creation settles without a delayed full refresh or loading hint",
+      until: value => value.elapsedMs > 2500,
+    });
+    expect(await mainCreation.read()).toMatchObject({ workspaceLists: 0, creates: 1, reblocked: false, expired: false });
+    await mainCreation[Symbol.asyncDispose]();
     await user.click({ role: "button", label: `Side chat · ${world.session.title}` });
     await waitSplit(primary, third.secondary);
     const saved = await ids();
@@ -246,6 +291,92 @@ test("side chats keep questions, replies, and saved splits attached to their own
     await reopen(primary);
     await preservedHistory(primary, world.primaryQuestionPrompt, "Main outline", world.primaryPrompt, "Primary split received");
     await user.screenshot();
+  });
+
+  await step("cold history stays free of starters and foreign messages before and after the delayed loader", async () => {
+    // Reload away from this thread to discard renderer snapshots, not persisted history.
+    await reopen(world.switchSession.sessionId);
+    await send("primary", world.switchPrompt);
+    await answer("primary", "Switched session received", "Primary split received");
+    await user.reload();
+    await preservedHistory(world.switchSession.sessionId, world.switchPrompt, "Switched session received");
+    await using history = await world.continuity.holdHistory(primary);
+    await using visible = await world.continuity.observeSurface({
+      sessionId: primary, pane: "primary",
+      forbidden: [world.switchPrompt, "Switched session received", world.secondaryQuestionPrompt, "Secondary split received"],
+    });
+    await reopen(primary);
+    await probe.eventually(() => history.read(), {
+      within: 15_000, label: "the native history GET is actually held", until: value => value.pending,
+    });
+    await probe.eventually(() => visible.read(), {
+      within: 10_000, label: "observe the cold selection on both sides of the two-second delay",
+      until: value => value.shortSamples > 0 && value.longSamples > 0 && value.loaderSeen,
+    });
+    expect(history.read()).toMatchObject({ pending: true });
+    expect(history.read().elapsedMs).toBeGreaterThan(2000);
+    expect(await visible.read()).toMatchObject({ violations: [], expired: false, text: "" });
+    expect((await visible.read()).frames).toBeGreaterThan(1);
+    expect((await visible.read()).mutations).toBeGreaterThan(0);
+    await history.release();
+    await preservedHistory(primary, world.primaryQuestionPrompt, "Main outline", world.primaryPrompt, "Primary split received");
+    expect(await visible.read()).toMatchObject({ violations: [], expired: false });
+  });
+
+  await step("a warm revisit displays cached history throughout a held native refetch", async () => {
+    await reopen(world.switchSession.sessionId);
+    await preservedHistory(world.switchSession.sessionId, world.primaryPrompt, "Primary split received");
+    await using history = await world.continuity.holdHistory(primary);
+    await using visible = await world.continuity.observeSurface({
+      sessionId: primary, pane: "primary", required: [world.primaryQuestionPrompt, "Main outline"],
+      forbidden: [world.switchPrompt, "Switched session received", world.secondaryQuestionPrompt, "Secondary split received"],
+    });
+    await reopen(primary);
+    await probe.eventually(() => history.read(), {
+      within: 15_000, label: "the warm revisit refetch is held rather than skipped", until: value => value.pending,
+    });
+    await probe.eventually(() => visible.read(), {
+      within: 10_000, label: "cached history stays visible beyond the loader delay", until: value => value.longSamples > 0,
+    });
+    expect(history.read()).toMatchObject({ pending: true });
+    expect(await visible.read()).toMatchObject({ violations: [], expired: false });
+    await history.release();
+    await preservedHistory(primary, world.primaryQuestionPrompt, "Main outline");
+    expect(await visible.read()).toMatchObject({ violations: [], expired: false });
+  });
+
+  await step("switching between two pending histories starts a fresh loader delay for the destination", async () => {
+    await reopen(world.switchSession.sessionId);
+    await user.reload();
+    await preservedHistory(world.switchSession.sessionId, world.switchPrompt, "Switched session received");
+    await using histories = await world.continuity.holdHistory(primary, first.secondary);
+    await using main = await world.continuity.observeSurface({ sessionId: primary, pane: "primary" });
+    await reopen(primary);
+    await probe.eventually(() => main.read(), {
+      within: 15_000, label: "the first pending history reaches its delayed loader",
+      until: value => value.longSamples > 0 && value.loaderSeen,
+    });
+    expect(histories.read(primary).pending).toBe(true);
+    expect(await main.read()).toMatchObject({ violations: [], expired: false });
+    await main[Symbol.asyncDispose]();
+
+    await using destination = await world.continuity.observeSurface({
+      sessionId: first.secondary, pane: "primary",
+      forbidden: [world.primaryQuestionPrompt, world.switchPrompt, "Switched session received"],
+    });
+    await reopen(first.secondary);
+    await probe.eventually(() => destination.read(), {
+      within: 15_000, label: "the second pending history gets its own short and delayed loading windows",
+      until: value => value.shortSamples > 0 && value.longSamples > 0 && value.loaderSeen,
+    });
+    expect(histories.read(first.secondary).pending).toBe(true);
+    expect(await destination.read()).toMatchObject({ violations: [], expired: false, text: "" });
+    await histories.release();
+    await preservedHistory(first.secondary, world.secondaryQuestionPrompt, "Side checklist");
+    expect(await destination.read()).toMatchObject({ violations: [], expired: false });
+    await destination[Symbol.asyncDispose]();
+    await reopen(primary);
+    await preservedHistory(primary, world.primaryQuestionPrompt, "Main outline");
   });
 
   await step("deleting a conversation clears its saved split and keeps the other conversation usable", async () => {

--- a/evals/worlds/chat-continuity.ts
+++ b/evals/worlds/chat-continuity.ts
@@ -1,0 +1,249 @@
+import { browserScript, evaluate, type Surface } from "@openwork/cdp";
+
+type SurfaceExpectation = {
+  sessionId?: string;
+  pane: "primary" | "secondary";
+  required?: string[];
+  forbidden?: string[];
+};
+type SurfaceObservation = {
+  frames: number;
+  mutations: number;
+  shortSamples: number;
+  longSamples: number;
+  elapsedMs: number;
+  loaderSeen: boolean;
+  text: string;
+  violations: string[];
+  expired: boolean;
+};
+
+declare global {
+  interface Window {
+    __chatContinuity?: { state: SurfaceObservation; stop(): void };
+    __chatCreation?: {
+      workspaceLists: number; creates: number; reblocked: boolean; expired: boolean;
+      lastCreateAt: number | null; restore(): void;
+    };
+  }
+}
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Faults and observers only; navigation and creation remain trusted user actions. */
+export function chatContinuity(app: Surface, workspaceId: string) {
+  return {
+    async observeSurface(expected: SurfaceExpectation) {
+      await evaluate(app.client, browserScript((workspaceId, expected) => {
+        if (window.__chatContinuity) throw new Error("A chat continuity observer is already active");
+        const state: SurfaceObservation = {
+          frames: 0, mutations: 0, shortSamples: 0, longSamples: 0, elapsedMs: 0,
+          loaderSeen: false, text: "", violations: [], expired: false,
+        };
+        let selectedAt: number | undefined;
+        let frame = 0;
+        const visible = (node: HTMLElement) => node.getClientRects().length > 0
+          && getComputedStyle(node).visibility !== "hidden" && getComputedStyle(node).display !== "none";
+        const sample = () => {
+          const pane = document.querySelector<HTMLElement>('[data-workbench-pane="' + expected.pane + '"]');
+          const surface = pane?.querySelector<HTMLElement>('[data-session-surface-id]');
+          // Arm before the click. Inspect the pane as soon as the route OR its
+          // surface adopts the destination, including stale content in that pane.
+          const selected = surface && (!expected.sessionId || surface.dataset.sessionSurfaceId === expected.sessionId)
+            && surface.dataset.sessionSurfaceWorkspaceId === workspaceId;
+          if (selectedAt === undefined && !selected
+            && !(expected.pane === "primary" && expected.sessionId && location.hash.includes(expected.sessionId))) return;
+          selectedAt ??= performance.now();
+          state.elapsedMs = performance.now() - selectedAt;
+          if (state.elapsedMs < 1500) state.shortSamples++;
+          if (state.elapsedMs > 2200) state.longSamples++;
+          state.text = [...(pane?.querySelectorAll<HTMLElement>('[data-message-role]') ?? [])]
+            .filter(visible).map(node => node.innerText).join("\n");
+          const text = pane?.innerText ?? "";
+          const starters = ["Try one of these:", "Try one of your organization's prompts:", "Connect a model provider to get started:"]
+            .some(label => text.includes(label));
+          const loader = text.includes("Opening session") || text.includes("Switching session");
+          state.loaderSeen ||= loader;
+          const violations = [
+            ...(starters ? ["starters in pending or historical conversation"] : []),
+            ...(loader && state.elapsedMs < 1500 ? ["loader appeared before its own delay"] : []),
+            ...(expected.forbidden ?? []).filter(text => state.text.includes(text)).map(text => "foreign message: " + text),
+            ...(expected.required ?? []).filter(text => !state.text.includes(text)).map(text => "cached message missing: " + text),
+          ];
+          for (const violation of violations) {
+            if (!state.violations.includes(violation)) state.violations.push(violation);
+          }
+        };
+        const paint = () => { state.frames++; sample(); frame = requestAnimationFrame(paint); };
+        const observer = new MutationObserver(() => { state.mutations++; sample(); });
+        observer.observe(document.documentElement, { subtree: true, childList: true, characterData: true, attributes: true });
+        frame = requestAnimationFrame(paint);
+        sample();
+        const timer = setTimeout(() => { state.expired = true; stop(); }, 60000);
+        function stop() { clearTimeout(timer); observer.disconnect(); cancelAnimationFrame(frame); }
+        window.__chatContinuity = { state, stop };
+      }, [workspaceId, expected]));
+      let disposed = false;
+      return {
+        read: () => evaluate(app.client, () => {
+          if (!window.__chatContinuity) throw new Error("Chat observer lost its document");
+          return window.__chatContinuity.state;
+        }),
+        async [Symbol.asyncDispose]() {
+          if (disposed) return;
+          disposed = true;
+          await evaluate(app.client, () => { window.__chatContinuity?.stop(); delete window.__chatContinuity; });
+        },
+      };
+    },
+
+    async surfaceState(pane: "primary" | "secondary") {
+      return evaluate(app.client, browserScript((pane) => {
+        const root = document.querySelector<HTMLElement>('[data-workbench-pane="' + pane + '"]');
+        return {
+          sessionId: root?.querySelector<HTMLElement>('[data-session-surface-id]')?.dataset.sessionSurfaceId,
+          starters: (root?.innerText ?? "").includes("Try one of these:"),
+          messages: root?.querySelectorAll('[data-message-role]').length ?? 0,
+        };
+      }, [pane]));
+    },
+
+    async observeCreation() {
+      await evaluate(app.client, () => {
+        if (window.__chatCreation) throw new Error("A creation observer is already active");
+        const originalFetch = window.fetch;
+        let frame = 0;
+        const state: NonNullable<Window["__chatCreation"]> = {
+          workspaceLists: 0, creates: 0, reblocked: false, expired: false, lastCreateAt: null,
+          restore() { window.fetch = originalFetch; observer.disconnect(); cancelAnimationFrame(frame); clearTimeout(timer); },
+        };
+        const sample = () => {
+          if (state.creates > 0 && document.body.innerText.includes("Pulling in the latest messages for this task.")) state.reblocked = true;
+        };
+        const paint = () => { sample(); frame = requestAnimationFrame(paint); };
+        const observer = new MutationObserver(sample);
+        observer.observe(document.documentElement, { subtree: true, childList: true, characterData: true, attributes: true });
+        frame = requestAnimationFrame(paint);
+        const timer = setTimeout(() => { state.expired = true; state.restore(); }, 60000);
+        window.fetch = function (...args) {
+          const request = args[0];
+          const path = new URL(request instanceof Request ? request.url : String(request), location.href).pathname;
+          const method = args[1]?.method ?? (request instanceof Request ? request.method : "GET");
+          if (method === "GET" && path === "/workspaces") state.workspaceLists++;
+          if (method === "POST" && /\/(?:opencode|opencode2\/api)\/session$/.test(path)) {
+            state.creates++;
+            state.lastCreateAt = performance.now();
+          }
+          return originalFetch.apply(this, args);
+        };
+        window.__chatCreation = state;
+      });
+      let disposed = false;
+      return {
+        read: () => evaluate(app.client, () => {
+          const state = window.__chatCreation;
+          if (!state) throw new Error("Creation observer lost its document");
+          return { workspaceLists: state.workspaceLists, creates: state.creates, reblocked: state.reblocked, expired: state.expired,
+            elapsedMs: state.lastCreateAt === null ? 0 : performance.now() - state.lastCreateAt };
+        }),
+        async [Symbol.asyncDispose]() {
+          if (disposed) return;
+          disposed = true;
+          await evaluate(app.client, () => { window.__chatCreation?.restore(); delete window.__chatCreation; });
+        },
+      };
+    },
+
+    async holdHistory(sessionId: string, ...otherSessionIds: string[]) {
+      const endpoint = app.client.webSocketDebuggerUrl;
+      if (!endpoint) throw new Error("History fault requires the desktop CDP endpoint");
+      const origin = await evaluate(app.client, () => "http://127.0.0.1:" + localStorage.getItem("openwork.server.port"));
+      const sessionIds = [sessionId, ...otherSessionIds];
+      const paths = sessionIds.flatMap(id => ["workspace", "w"].flatMap(mount => ["opencode", "opencode2/api"].map(engine =>
+        `/${mount}/${encodeURIComponent(workspaceId)}/${engine}/session/${encodeURIComponent(id)}/message`)));
+      const socket = new WebSocket(endpoint);
+      const ready = deferred();
+      const commands = new Map<number, ReturnType<typeof deferred>>();
+      const held = new Map<string, { networkId: string; startedAt: number; snapshot: boolean; sessionId: string }>();
+      const ended = new Set<string>();
+      let nextId = 1;
+      let released = false;
+      let disposed = false;
+      let failure: Error | undefined;
+      const command = async (method: string, params = {}) => {
+        const id = nextId++;
+        const result = deferred();
+        commands.set(id, result);
+        const timer = setTimeout(() => result.reject(new Error(`History fault timed out: ${method}`)), 15000);
+        try { socket.send(JSON.stringify({ id, method, params })); await result.promise; }
+        finally { clearTimeout(timer); commands.delete(id); }
+      };
+      const fail = () => {
+        if (disposed) return;
+        failure = new Error("History fault lost its CDP connection");
+        ready.reject(failure);
+        for (const result of commands.values()) result.reject(failure);
+      };
+      socket.addEventListener("open", () => ready.resolve());
+      socket.addEventListener("error", fail);
+      socket.addEventListener("close", fail);
+      socket.addEventListener("message", event => {
+        const message: unknown = JSON.parse(String(event.data));
+        if (!message || typeof message !== "object") return;
+        if ("id" in message && typeof message.id === "number") {
+          const result = commands.get(message.id);
+          if ("error" in message) result?.reject(new Error("History fault CDP command failed"));
+          else result?.resolve();
+        }
+        if (!("method" in message) || !("params" in message) || !message.params || typeof message.params !== "object") return;
+        const params = message.params;
+        if (!("requestId" in params) || typeof params.requestId !== "string") return;
+        if (message.method === "Network.loadingFailed" || message.method === "Network.loadingFinished") ended.add(params.requestId);
+        if (message.method !== "Fetch.requestPaused") return;
+        const request = "request" in params ? params.request : null;
+        if (!released && request && typeof request === "object" && "method" in request && request.method === "GET"
+          && "url" in request && typeof request.url === "string" && paths.includes(new URL(request.url).pathname)) {
+          if (!("networkId" in params) || typeof params.networkId !== "string") { fail(); return; }
+          const path = new URL(request.url).pathname;
+          const heldSessionId = sessionIds.find(id => path.endsWith(`/${encodeURIComponent(id)}/message`));
+          if (!heldSessionId) { fail(); return; }
+          // Distinguish the surface snapshot (140) from background sync reads (20).
+          held.set(params.requestId, { networkId: params.networkId, startedAt: performance.now(), sessionId: heldSessionId,
+            snapshot: new URL(request.url).searchParams.get("limit") === "140" });
+        } else void command("Fetch.continueRequest", { requestId: params.requestId }).catch((error: Error) => { failure = error; });
+      });
+      const timer = setTimeout(() => ready.reject(new Error("History fault could not connect")), 15000);
+      try {
+        await ready.promise;
+        await command("Network.enable");
+        await command("Fetch.enable", { patterns: paths.map(path => ({ urlPattern: origin + path + "*", requestStage: "Request" })) });
+      } catch (error) { disposed = true; socket.close(); throw error; }
+      finally { clearTimeout(timer); }
+      return {
+        read(id = sessionId) {
+          if (failure) throw failure;
+          const snapshots = [...held.values()].filter(item => item.sessionId === id && item.snapshot && !ended.has(item.networkId));
+          return { held: held.size, pending: !released && snapshots.length > 0,
+            elapsedMs: snapshots.length ? Math.max(...snapshots.map(item => performance.now() - item.startedAt)) : 0 };
+        },
+        async release() {
+          released = true;
+          await Promise.all([...held].filter(([, item]) => !ended.has(item.networkId))
+            .map(([requestId]) => command("Fetch.continueRequest", { requestId })));
+        },
+        async [Symbol.asyncDispose]() {
+          try { await command("Fetch.disable"); }
+          finally { disposed = true; socket.close(); }
+        },
+      };
+    },
+  };
+}

--- a/evals/worlds/chat-continuity.ts
+++ b/evals/worlds/chat-continuity.ts
@@ -55,12 +55,12 @@ export function chatContinuity(app: Surface, workspaceId: string) {
         const sample = () => {
           const pane = document.querySelector<HTMLElement>('[data-workbench-pane="' + expected.pane + '"]');
           const surface = pane?.querySelector<HTMLElement>('[data-session-surface-id]');
-          // Arm before the click. Inspect the pane as soon as the route OR its
-          // surface adopts the destination, including stale content in that pane.
+          // Arm before the click and inspect the destination's first DOM commit.
+          // The URL can change before React commits navigation; the outgoing
+          // surface still belongs to the previous conversation during that time.
           const selected = surface && (!expected.sessionId || surface.dataset.sessionSurfaceId === expected.sessionId)
             && surface.dataset.sessionSurfaceWorkspaceId === workspaceId;
-          if (selectedAt === undefined && !selected
-            && !(expected.pane === "primary" && expected.sessionId && location.hash.includes(expected.sessionId))) return;
+          if (selectedAt === undefined && !selected) return;
           selectedAt ??= performance.now();
           state.elapsedMs = performance.now() - selectedAt;
           if (state.elapsedMs < 1500) state.shortSamples++;

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { evalIn, assertNoLiveSecret, liveOpenAiEnabled, liveOpenAiModel, liveProviderId, provisionLiveOpenAi } from "@openwork/behaviors";
 import { resolveEvalEngine, type Seed } from "@openwork/env";
 import type { MockAgentWorkload } from "@openwork/labs";
+import { chatContinuity } from "./chat-continuity.ts";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
@@ -360,7 +361,7 @@ export async function newSplitPrimary(seed: Seed) {
     });
     return response.json();
   }, { awaitPromise: true, timeoutMs: 15_000 });
-  return { app, workspace, session, splitFacts, agentContextViaServer, primaryPrompt, secondaryPrompt, switchSession, switchPrompt, primaryQuestionPrompt, secondaryQuestionPrompt, contextPrompt };
+  return { app, workspace, session, continuity: chatContinuity(app, workspace.workspaceId), splitFacts, agentContextViaServer, primaryPrompt, secondaryPrompt, switchSession, switchPrompt, primaryQuestionPrompt, secondaryQuestionPrompt, contextPrompt };
 }
 
 export async function shimmerChat(seed: Seed) {


### PR DESCRIPTION
## Problem
Switching to an old conversation initially has neither cached messages nor a resolved snapshot. The surface delays its loader for two seconds, but MessageList interpreted the empty array as an empty conversation and displayed starter templates in that gap.

Thread activation also seeded the same snapshot twice, and successful palette/split creation refreshed the entire workspace route after already inserting and opening the returned session.

## Change
- Show starter cards only after a matching snapshot confirms that the conversation has no history. A cold existing thread never masquerades as a new task.
- Keep warm cached transcripts visible during background refresh. Keep genuine empty-thread starters, the editable composer, error behavior, and secondary-pane empty behavior intact.
- Scope the delayed loading indicator to workspace and session so a pending destination gets its own timer rather than inheriting the previous thread deadline.
- Remove the duplicate snapshot-seeding effect; keep the effect that responds to every actual snapshot change, including tool-part updates.
- Remove the success-path full route refresh after palette/split creation; the returned session is already merged locally. Recovery refreshes remain unchanged.

## Verification — Passed
Exact head: `fc09615dd62512a5124a96ba113a4e74c2dec774`.

| Cold-boot journey | Passed | Failed | Skipped | Exit |
| --- | --- | --- | --- | --- |
| new-split-session, v2 | 1 | 0 | 0 | 0 |
| new-split-session, v1 | 1 | 0 | 0 | 0 |

Both: `placement: daytona (daytona CLI authenticated)`.

```sh
OPENWORK_EVAL_ENGINE=v2 OPENWORK_EVAL_REF=fc09615dd62512a5124a96ba113a4e74c2dec774 pnpm evals:e2e new-split-session
OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_REF=fc09615dd62512a5124a96ba113a4e74c2dec774 pnpm evals:e2e new-split-session
```

The existing journey now holds real native history requests and observes DOM mutations/frames starting at the destination surface commit. It checks no starter/foreign-message flash before and after the two-second loader delay, cached history throughout a warm refetch, pending-to-pending timer ownership, and history after release. Genuine empty primary/secondary controls and palette/split creation pass; creation requests produce zero workspace-list GETs and no renewed loading hint. Existing question, reply, saved-split, and deletion assertions remain.

Focused session-render-state/route-refresh unit checks: 17 passed, 0 failed, 44 assertions. Browser callback validation and diff whitespace check passed. Exact-head runtime evidence for both engines is published below; screenshots are supplementary, not vision claims.

Earlier v2 attempt failed because the observer started at the URL change, before React had committed the destination, and counted the outgoing conversation. The observer now starts at the destination DOM commit; product behavior was not weakened to fit the test.

Repository-wide layer/spec-ratchet checks were not green during coverage authoring and are not claimed passed. Cross-workspace timer coverage, direct bootstrap IPC counts, broad typechecking, and CPU benchmarks are deferred. Removing duplicate seeding avoids work; no numerical latency or CPU speedup is claimed.

Independent of the scoped v2 permission-refresh fix in #4609. No changes to the overlapping live-running-session journey in #4599/#4601.