### PR TITLE
fix(markdown): wrap table output in horizontal scroll container

### DIFF
--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -262,6 +262,7 @@ function sanitizeMarkdownHtml(value: string) {
       "data-openwork-code-copy-label",
       "data-openwork-code-scroll",
       "data-openwork-code-wrap",
+      "data-openwork-table-scroll",
       "aria-label",
       "aria-pressed",
       "data-openwork-image-preview",
@@ -442,7 +443,7 @@ function createMarkedOptions(profile: MarkdownProfile, presentation: MarkdownPre
         const header = token.header.map((cell) => this.tablecell({ ...cell, header: true })).join("");
         const body = token.rows.map((row) => this.tablerow({ text: row.map((cell) => this.tablecell(cell)).join("") })).join("");
 
-        return `<table class="my-4 w-full border-collapse"><thead>${this.tablerow({ text: header })}</thead><tbody>${body}</tbody></table>`;
+        return `<div data-openwork-table-scroll="" class="overflow-x-auto"><table class="my-4 w-full border-collapse"><thead>${this.tablerow({ text: header })}</thead><tbody>${body}</tbody></table></div>`;
       },
       tablerow({ text }) {
         return `<tr>${text}</tr>`;

--- a/apps/app/tests/markdown-table.test.ts
+++ b/apps/app/tests/markdown-table.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { renderMarkdownHtml } from "../src/components/markdown/markdown";
+
+const MARKDOWN = `| Name | Status |
+| --- | --- |
+| Artifact | Ready |`;
+
+describe("markdown tables", () => {
+  test("renders wide tables in a sanitized horizontal scroll container", () => {
+    const html = renderMarkdownHtml(MARKDOWN);
+
+    expect(html).toContain("data-openwork-table-scroll");
+    expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("Name");
+    expect(html).toContain("Status");
+    expect(html).toContain("Artifact");
+    expect(html).toContain("Ready");
+  });
+});


### PR DESCRIPTION
## Summary
- Wide markdown tables in the Artifact preview pane no longer flip into edit mode when you try to scroll them.

## Why
- The table's scrollbar wasn't actually attached to the table — so dragging it hit the pane behind it instead, which triggered edit mode by accident. Annoying and confusing for anyone reading a wide table.

## Issue
- Closes #3741

## Scope
- One file: `markdown-primitive.ts`, the renderer that turns markdown tables into HTML for the read-only preview pane.
- Wrapped the table output in its own scrollable container, and added the new attribute to the sanitizer's allowlist.
- Added a test so this doesn't silently break again later.

## Out of scope
- The live-preview-while-editing view (a different file, `markdown-live-preview.ts`) already had this fixed back in July — this PR just brings the same fix to the read-only preview, which had been missed.
- No changes to table parsing, styling, or content — purely the scroll behavior.

## Testing
### Ran
- `bun test --isolate tests/markdown-table.test.ts`
- `bun test --isolate tests/` (full app test suite)
- `pnpm typecheck`

### Result
- New test: 1 pass, 6 assertions, consistent across multiple runs on two different machines.
- Full suite: everything passes except a small set of pre-existing failures unrelated to markdown or tables (confirmed these exist on unmodified `dev` too, before this change).
- Typecheck: clean.

## CI status
- pass: typecheck, focused test, full local test suite (aside from pre-existing unrelated failures noted above)
- code-related failures: none
- external/env/auth blockers: couldn't run the project's Daytona-based end-to-end pipeline — no Daytona/infisical access in this environment. Everything else in this checklist substitutes for that.

## Manual verification
1. Opened a markdown file with a wide table in the Artifact preview pane.
2. Dragged the table's own horizontal scrollbar.
3. Table scrolled left/right smoothly; the pane stayed in preview mode the whole time — no flip into editing.

## Evidence
- https://github.com/user-attachments/assets/f36bb8e7-e3fb-4ed7-aa80-f61cca49c77b


- 

## Risk
- Low. Change is scoped to one rendering function, mirrors a pattern already used elsewhere in the same file for code blocks, and is covered by a new automated test.

## Rollback
- Revert this single commit — no schema, config, or dependency changes involved.
