### PR TITLE
perf(app): avoid reprocessing settled history during v1 streaming

### DIFF
--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -11,7 +11,7 @@ function message(id: string, role: "user" | "assistant", text: string): UIMessag
   return { id, role, parts: [{ type: "text", text, state: "done" }] };
 }
 
-function toolMessage(id: string, toolName: string, input: Record<string, unknown>, output: unknown) {
+function toolMessage(id: string, toolName: string, input: Record<string, unknown>, output: unknown): UIMessage {
   return {
     id,
     role: "assistant",
@@ -27,6 +27,153 @@ function toolMessage(id: string, toolName: string, input: Record<string, unknown
 }
 
 describe("deriveOpenTargets", () => {
+  it("serializes 100 tool outputs of 10000 characters only at warmup across 20 growing text frames", () => {
+    let serializations = 0;
+    const tools = Array.from({ length: 100 }, (_, index) => toolMessage(`tool_${index}`, "read", {}, {
+      toJSON() {
+        serializations += 1;
+        return `https://example.com/tool-${index} `.padEnd(10000, "x");
+      },
+    }));
+    const history = tools.slice(0, 50);
+    const activeParts = tools.slice(50).flatMap((tool) => tool.parts);
+    const active: UIMessage = { id: "active", role: "assistant", parts: activeParts };
+    const warm = deriveOpenTargets([...history, active]);
+    expect(warm).toHaveLength(100);
+    expect(serializations).toBe(100);
+
+    for (let frame = 1; frame <= 20; frame += 1) {
+      const streaming: UIMessage = {
+        ...active,
+        parts: [...activeParts, { type: "text", text: "Working ".repeat(frame), state: "streaming" }],
+      };
+      expect(deriveOpenTargets([...history, streaming])).toEqual(warm);
+    }
+    expect(serializations).toBe(100);
+  });
+
+  it("re-extracts replaced tool parts and changed outputs without invalidating old references", () => {
+    let serializations = 0;
+    const output = (url: string) => ({
+      toJSON() {
+        serializations += 1;
+        return url;
+      },
+    });
+    const original = toolMessage("tool", "read", {}, output("https://example.com/old"));
+    const warm = deriveOpenTargets([original]);
+    expect(deriveOpenTargets([original])).toEqual(warm);
+    expect(serializations).toBe(1);
+
+    const changed = toolMessage("tool", "read", {}, output("https://example.com/new"));
+    const updated = deriveOpenTargets([changed]);
+    expect(updated.map((target) => target.value)).toEqual(["https://example.com/new"]);
+    expect(serializations).toBe(2);
+    expect(deriveOpenTargets([changed])).toEqual(updated);
+    expect(serializations).toBe(2);
+
+    const replaced = { ...changed, parts: changed.parts.map((part) => ({ ...part })) };
+    expect(deriveOpenTargets([replaced])).toEqual(updated);
+    expect(serializations).toBe(3);
+    expect(deriveOpenTargets([original])).toEqual(warm);
+    expect(serializations).toBe(3);
+  });
+
+  it("separates text confidence and file-mention options while sharing role-independent tool extraction", () => {
+    let serializations = 0;
+    const parts: UIMessage["parts"] = [
+      { type: "text", text: "Review reports/mentioned.md at https://example.com/review" },
+      { type: "text", text: "Created reports/generated.csv" },
+      ...toolMessage("tool", "read", {}, {
+        toJSON() {
+          serializations += 1;
+          return "https://example.com/tool";
+        },
+      }).parts,
+    ];
+    const roles: UIMessage["role"][] = ["assistant", "user", "system", "assistant"];
+    for (const role of roles) {
+      for (const includeFileMentions of [undefined, true, false, true, undefined]) {
+        const targets = deriveOpenTargets([{ id: role, role, parts }], { includeFileMentions });
+        expect(targets.find((target) => target.value === "https://example.com/review")?.confidence)
+          .toBe(role === "assistant" ? 65 : 40);
+        expect(targets.some((target) => target.value === "reports/mentioned.md")).toBe(includeFileMentions === true);
+        expect(targets.some((target) => target.value === "reports/generated.csv"))
+          .toBe(includeFileMentions === true || role === "assistant");
+        expect(targets.find((target) => target.value === "https://example.com/tool")?.confidence).toBe(75);
+      }
+    }
+    expect(serializations).toBe(1);
+  });
+
+  it("preserves first-seen dedup order and later equal-confidence winners on cold and warm extraction", () => {
+    const written = toolMessage("write", "apply_patch", {
+      path: "/reports/Report.md",
+      files: ["/reports/second.csv"],
+      patchText: "*** Update File: /reports/REPORT.md",
+    }, "Created /reports/report.md and /reports/third.pdf");
+    const attachment: UIMessage = {
+      id: "attachment", role: "user", parts: [{
+        type: "file", url: "file:///reports/report.md", filename: "Final report", mediaType: "text/markdown",
+      }],
+    };
+    for (let pass = 0; pass < 2; pass += 1) {
+      const withinPart = deriveOpenTargets([written]);
+      expect(withinPart[0]).toMatchObject({ value: "/reports/REPORT.md", confidence: 95, reason: "patch metadata" });
+      const targets = deriveOpenTargets([
+        written, attachment, message("later", "assistant", "Updated /reports/report.md"),
+      ]);
+      expect(targets.map((target) => target.value)).toEqual([
+        "/reports/report.md", "/reports/second.csv", "/reports/third.pdf",
+      ]);
+      expect(targets[0]).toMatchObject({ name: "Final report", confidence: 95, reason: "chat attachment" });
+    }
+  });
+
+  it("does not expose cached targets to caller mutation or change previously verified results", () => {
+    const messages = [toolMessage("write", "write", { path: "reports/report.md" }, {})];
+    const first = deriveOpenTargets(messages);
+    const pristine = first.map((target) => ({ ...target }));
+    const target = first[0];
+    if (!target) throw new Error("Expected a file target");
+    target.exists = true;
+    target.size = 42;
+    target.updatedAt = 123;
+    target.value = "changed.md";
+    target.name = "Changed";
+    target.confidence = 1;
+    target.id = "changed";
+    const verified = { ...target };
+    const second = deriveOpenTargets(messages);
+    expect(second).toEqual(pristine);
+    expect(second[0]).not.toBe(target);
+    expect(first[0]).toEqual(verified);
+    first.length = 0;
+    expect(deriveOpenTargets(messages)).toEqual(pristine);
+  });
+
+  it("finds newly arriving files and URLs while keeping discovery outputs excluded after warmup", () => {
+    let discoverySerializations = 0;
+    const discovery = ["glob", "grep", "search", "find"].map((name) => toolMessage(name, `functions.${name}`, {}, {
+      path: "reports/discovered.md",
+      toJSON() {
+        discoverySerializations += 1;
+        return "Created reports/discovered.md at https://example.com/discovery";
+      },
+    }));
+    const active = message("active", "assistant", "Working");
+    expect(deriveOpenTargets([...discovery, active])).toEqual([]);
+    const arrived = message("active", "assistant", "Created reports/new.csv at https://example.com/new");
+    for (let pass = 0; pass < 2; pass += 1) {
+      const targets = deriveOpenTargets([...discovery, arrived], { includeFileMentions: true });
+      expect(targets.map((target) => target.value)).toContain("reports/new.csv");
+      expect(targets.map((target) => target.value)).toContain("https://example.com/new");
+      expect(targets.map((target) => target.value)).not.toContain("reports/discovered.md");
+      expect(targets.map((target) => target.value)).not.toContain("https://example.com/discovery");
+    }
+    expect(discoverySerializations).toBe(0);
+  });
+
   it("extracts file and localhost URL targets from recent assistant output", () => {
     const targets = deriveOpenTargets([
       toolMessage("msg_tool", "write", { filePath: "reports/revenue.xlsx" }, { filePath: "reports/revenue.xlsx" }),

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -342,76 +342,93 @@ function addFileValues(map: Map<string, OpenTarget>, values: string[], confidenc
   }
 }
 
+// Session sync replaces changed parts; unchanged tools survive text-only deltas.
+const partOpenTargets = new WeakMap<UIMessage["parts"][number], Map<string, OpenTarget[]>>();
+
+function extractPartOpenTargets(part: UIMessage["parts"][number], confidence: number, includeFileMentions: boolean) {
+  // Only text extraction depends on message role or file-mention options.
+  const key = part.type === "text" ? `${confidence}:${includeFileMentions}` : "default";
+  let variants = partOpenTargets.get(part);
+  const cached = variants?.get(key);
+  if (cached) return cached;
+
+  const targets = new Map<string, OpenTarget>();
+  if (part.type === "text" && typeof part.text === "string") {
+    scanText(targets, part.text, confidence, "message", {
+      includeFiles: includeFileMentions || (confidence === 65 && shouldScanAssistantFileMentions(part.text)),
+    });
+  } else if (part.type === "file") {
+    const path = filePathFromFileUrl(part.url);
+    if (path) {
+      const target = targetFromFile(path, 95, "chat attachment");
+      addTarget(targets, target && part.filename ? { ...target, name: part.filename } : target);
+    }
+  } else if (part.type === "source-document") {
+    addTarget(
+      targets,
+      part.filename
+        ? targetFromFile(part.filename, 95, "attachment source")
+        : URI_PATTERN.test(part.title)
+          ? targetFromUrl(part.title, 95, "attachment source")
+          : targetFromFile(part.title, 95, "attachment source"),
+    );
+  } else if (part.type === "dynamic-tool") {
+    const discoveryTool = isDiscoveryTool(part.toolName);
+    const writeTool = isWriteTool(part.toolName);
+    const artifactMetadataTool = isArtifactMetadataTool(part.toolName);
+
+    if (writeTool) {
+      addFileValues(
+        targets,
+        [part.input, part.output].flatMap(collectFileMetadataValues),
+        95,
+        "write tool metadata",
+      );
+      addFileValues(targets, collectPatchFileValues(part.input), 95, "patch metadata");
+      if (typeof part.output === "string") {
+        scanText(targets, part.output, 90, "write tool output", { includeFiles: true });
+      }
+    }
+
+    if (artifactMetadataTool) {
+      addFileValues(
+        targets,
+        [part.input, part.output].flatMap(collectNestedFileMetadataValues),
+        95,
+        "artifact tool metadata",
+      );
+    }
+
+    if (!discoveryTool) {
+      scanText(targets, JSON.stringify(part.output ?? part.input ?? ""), 75, "tool output", { includeFiles: false });
+    }
+  }
+
+  const extracted = Array.from(targets.values());
+  if (!variants) {
+    variants = new Map();
+    partOpenTargets.set(part, variants);
+  }
+  variants.set(key, extracted);
+  return extracted;
+}
+
 export function deriveOpenTargets(messages: UIMessage[], options: DeriveOpenTargetsOptions = {}): OpenTarget[] {
   const targets = new Map<string, OpenTarget>();
+  const includeFileMentions = options.includeFileMentions === true;
 
   for (const message of messages) {
+    const confidence = message.role === "assistant" ? 65 : 40;
     for (const part of message.parts) {
-      if (part.type === "text" && typeof part.text === "string") {
-        scanText(targets, part.text, message.role === "assistant" ? 65 : 40, "message", {
-          includeFiles: options.includeFileMentions === true || (message.role === "assistant" && shouldScanAssistantFileMentions(part.text)),
-        });
-        continue;
-      }
-
-      if (part.type === "file") {
-        const path = filePathFromFileUrl(part.url);
-        if (path) {
-          const target = targetFromFile(path, 95, "chat attachment");
-          addTarget(targets, target && part.filename ? { ...target, name: part.filename } : target);
-        }
-        continue;
-      }
-
-      if (part.type === "source-document") {
-        addTarget(
-          targets,
-          part.filename
-            ? targetFromFile(part.filename, 95, "attachment source")
-            : URI_PATTERN.test(part.title)
-              ? targetFromUrl(part.title, 95, "attachment source")
-              : targetFromFile(part.title, 95, "attachment source"),
-        );
-        continue;
-      }
-
-      if (part.type !== "dynamic-tool") {
-        continue;
-      }
-
-      const discoveryTool = isDiscoveryTool(part.toolName);
-      const writeTool = isWriteTool(part.toolName);
-      const artifactMetadataTool = isArtifactMetadataTool(part.toolName);
-
-      if (writeTool) {
-        addFileValues(
-          targets,
-          [part.input, part.output].flatMap(collectFileMetadataValues),
-          95,
-          "write tool metadata",
-        );
-        addFileValues(targets, collectPatchFileValues(part.input), 95, "patch metadata");
-        if (typeof part.output === "string") {
-          scanText(targets, part.output, 90, "write tool output", { includeFiles: true });
-        }
-      }
-
-      if (artifactMetadataTool) {
-        addFileValues(
-          targets,
-          [part.input, part.output].flatMap(collectNestedFileMetadataValues),
-          95,
-          "artifact tool metadata",
-        );
-      }
-
-      if (!discoveryTool) {
-        scanText(targets, JSON.stringify(part.output ?? part.input ?? ""), 75, "tool output", { includeFiles: false });
+      for (const target of extractPartOpenTargets(part, confidence, includeFileMentions)) {
+        addTarget(targets, target);
       }
     }
   }
 
   return Array.from(targets.values())
     .filter(isArtifactTarget)
-    .sort((left, right) => right.confidence - left.confidence);
+    .sort((left, right) => right.confidence - left.confidence)
+    // Callers may attach verification metadata or otherwise mutate their targets.
+    .map((target) => ({ ...target }));
 }

--- a/apps/app/src/react-app/domains/session/sync/message-merge.ts
+++ b/apps/app/src/react-app/domains/session/sync/message-merge.ts
@@ -111,6 +111,27 @@ function sortFullyTimestampedMessages(messages: UIMessage[]) {
     .map((item) => item.message);
 }
 
+function mergeMissingMessagesByChronology(messages: UIMessage[], missing: UIMessage[], sourceOrder: UIMessage[]) {
+  if (missing.length > 0) {
+    const byCreated = new Map<number, UIMessage>();
+    for (const message of [...messages, ...missing]) {
+      const created = messageCreated(message);
+      if (created === null || !Number.isFinite(created) || byCreated.has(created)) break;
+      byCreated.set(created, message);
+    }
+    // Unique finite timestamps make the final order independent of insertion order.
+    // Ties and missing/invalid timestamps must retain the source-neighbor insertion rules.
+    if (byCreated.size === messages.length + missing.length) {
+      return [...byCreated]
+        .sort(([a], [b]) => a - b)
+        .map(([, message]) => message);
+    }
+  }
+
+  for (const message of missing) insertMessageByChronology(messages, message, sourceOrder);
+  return sortFullyTimestampedMessages(messages);
+}
+
 export function messageListContainsAll(container: UIMessage[], required: UIMessage[]) {
   if (required.length === 0) return true;
   const ids = new Set(container.map((message) => message.id));
@@ -132,13 +153,10 @@ export function mergeSnapshotAndLiveMessages(
     return liveMessage ? mergeSnapshotMessageWithCached(snapshotMessage, liveMessage) : snapshotMessage;
   });
 
-  if (options.appendLiveOnlyMessages) {
-    for (const liveMessage of liveMessages) {
-      if (!snapshotIds.has(liveMessage.id)) insertMessageByChronology(merged, liveMessage, liveMessages);
-    }
-  }
-
-  return sortFullyTimestampedMessages(merged);
+  const missing = options.appendLiveOnlyMessages
+    ? liveMessages.filter((message) => !snapshotIds.has(message.id))
+    : [];
+  return mergeMissingMessagesByChronology(merged, missing, liveMessages);
 }
 
 export function mergeSnapshotIntoCachedMessages(snapshotMessages: UIMessage[], cachedMessages: UIMessage[]) {
@@ -157,11 +175,12 @@ export function mergeSnapshotIntoCachedMessages(snapshotMessages: UIMessage[], c
       : message;
   });
 
+  const missing: UIMessage[] = [];
   for (const message of cachedMessages) {
     if (seen.has(message.id)) continue;
     seen.add(message.id);
-    insertMessageByChronology(merged, message, cachedMessages);
+    missing.push(message);
   }
 
-  return sortFullyTimestampedMessages(merged);
+  return mergeMissingMessagesByChronology(merged, missing, cachedMessages);
 }

--- a/apps/app/tests/session-render-state.test.ts
+++ b/apps/app/tests/session-render-state.test.ts
@@ -3,6 +3,10 @@ import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import {
+  mergeSnapshotAndLiveMessages,
+  mergeSnapshotIntoCachedMessages,
+} from "../src/react-app/domains/session/sync/message-merge";
 
 function snapshotWithHistory(): OpenworkSessionSnapshot {
   const sessionId = "session-render-cycle";
@@ -44,6 +48,173 @@ function message(id: string, role: "user" | "assistant", text: string, created: 
     parts: [{ type: "text", text, state: "done" }],
   };
 }
+
+for (const { name, merge } of [
+  {
+    name: "mergeSnapshotAndLiveMessages",
+    merge: (snapshot: UIMessage[], cached: UIMessage[]) =>
+      mergeSnapshotAndLiveMessages(snapshot, cached, { appendLiveOnlyMessages: true }),
+  },
+  { name: "mergeSnapshotIntoCachedMessages", merge: mergeSnapshotIntoCachedMessages },
+]) {
+  describe(name, () => {
+    for (const historySize of [200, 400, 800]) {
+      test(`bounds timestamp reads for a 140-message snapshot over ${historySize} cached messages`, () => {
+        let reads = 0;
+        function countedMessage(index: number, text = `answer-${index}`): UIMessage {
+          return {
+            ...message(`msg-${index}`, "assistant", text, index),
+            metadata: { opencode: { get created() { reads += 1; return index; } } },
+          };
+        }
+        const cached = Array.from({ length: historySize }, (_, index) => countedMessage(index));
+        const snapshot = Array.from({ length: 140 }, (_, index) => countedMessage(historySize - 140 + index));
+        const first = merge(snapshot, cached);
+        const active = countedMessage(historySize - 1, `answer-${historySize - 1} live delta`);
+        const current = [...first.slice(0, -1), active];
+        reads = 0;
+
+        const result = merge(snapshot, current);
+        const timestampReads = reads;
+        console.info(`${name}: history=${historySize}, snapshot=140, timestampReads=${timestampReads}`);
+        expect(result.map((item) => item.id)).toEqual(cached.map((item) => item.id));
+        for (let index = 0; index < historySize - 1; index += 1) {
+          expect(first[index]).toBe(cached[index]);
+          expect(result[index]).toBe(first[index]);
+        }
+        expect(result.at(-1)).toBe(active);
+        expect(current.at(-1)).toBe(active);
+        expect(snapshot.at(-1)?.parts).toEqual([
+          { type: "text", text: `answer-${historySize - 1}`, state: "done" },
+        ]);
+        // A bounded snapshot must not make each missing message scan the growing history.
+        expect(timestampReads).toBeLessThanOrEqual(historySize + 2 * snapshot.length);
+      });
+    }
+
+    test("preserves empty-input array identity", () => {
+      const messages = [message("one", "user", "one", 1)];
+      expect(merge([], messages)).toBe(messages);
+      expect(merge(messages, [])).toBe(messages);
+    });
+
+    test("sorts unique timestamps without losing snapshot history, live parts, or references", () => {
+      const historical = message("history", "user", "old prompt", 0);
+      const snapshotActive = message("active", "assistant", "short", 3);
+      snapshotActive.parts.push({ type: "reasoning", text: "thinking", state: "done" });
+      const liveActive = message("active", "assistant", "short plus live text", 30);
+      liveActive.parts.push(
+        { type: "reasoning", text: "thinking more", state: "done" },
+        { type: "text", text: "extra part", state: "done" },
+      );
+      const middle = message("middle", "user", "next prompt", 2);
+      const tail = message("tail", "assistant", "tail", 4);
+      const snapshot = [snapshotActive, historical];
+      const cached = [tail, liveActive, middle];
+      const result = merge(snapshot, cached);
+
+      expect(result.map((item) => item.id)).toEqual(["history", "middle", "active", "tail"]);
+      expect(result[0]).toBe(historical);
+      expect(result[1]).toBe(middle);
+      expect(result[3]).toBe(tail);
+      expect(result[2]?.metadata).toBe(snapshotActive.metadata);
+      expect(result[2]?.parts).toEqual(liveActive.parts);
+      expect(merge(snapshot, cached)[2]).toBe(result[2]);
+      expect(snapshot).toEqual([snapshotActive, historical]);
+      expect(cached).toEqual([tail, liveActive, middle]);
+      expect(snapshotActive.parts[0]).toEqual({ type: "text", text: "short", state: "done" });
+    });
+
+    for (const created of [2, undefined, NaN, Infinity, -Infinity, "2"]) {
+      test(`preserves source-neighbor ordering for tied or invalid timestamps (${String(created)})`, () => {
+        const before = message("before", "user", "before", 2);
+        const anchor = message("anchor", "assistant", "anchor", 2);
+        const after = message("after", "user", "after", 2);
+        for (const item of [before, anchor, after]) {
+          item.metadata = { opencode: { created } };
+        }
+
+        const result = merge([anchor], [before, anchor, after]);
+        expect(result.map((item) => item.id)).toEqual(["before", "anchor", "after"]);
+        expect(result[0]).toBe(before);
+        expect(result[1]).toBe(anchor);
+        expect(result[2]).toBe(after);
+      });
+    }
+
+    test("keeps timestamp insertion precedence over source neighbors when timestamps tie", () => {
+      const before = message("before", "user", "before", 2);
+      const anchor = message("anchor", "assistant", "anchor", 2);
+      const later = message("later", "assistant", "later", 3);
+      expect(merge([anchor, later], [before, anchor]).map((item) => item.id)).toEqual([
+        "anchor", "before", "later",
+      ]);
+      expect(merge([later, anchor], [before, anchor]).map((item) => item.id)).toEqual([
+        "before", "anchor", "later",
+      ]);
+    });
+
+    test("does not sort mixed missing timestamps away from their source anchors", () => {
+      const before = message("before", "user", "before", 1);
+      delete before.metadata;
+      const anchor = message("anchor", "assistant", "anchor", 2);
+      const later = message("later", "assistant", "later", 3);
+      const result = merge([later, anchor], [before, anchor]);
+      expect(result.map((item) => item.id)).toEqual(["later", "before", "anchor"]);
+      expect(result[0]).toBe(later);
+      expect(result[1]).toBe(before);
+      expect(result[2]).toBe(anchor);
+    });
+  });
+}
+
+describe("message merge duplicate and inclusion semantics", () => {
+  test("only appends live-only messages when requested", () => {
+    const snapshot = [message("history", "user", "history", 1)];
+    const live = [message("tail", "assistant", "tail", 2)];
+    expect(mergeSnapshotAndLiveMessages(snapshot, live)).toEqual(snapshot);
+    expect(mergeSnapshotAndLiveMessages(snapshot, live, { appendLiveOnlyMessages: false })).toEqual(snapshot);
+  });
+
+  for (const created of [2, 3]) {
+    test(`retains live duplicates but deduplicates cached-only ids (second timestamp ${created})`, () => {
+      const anchor = message("anchor", "user", "anchor", 1);
+      const first = message("duplicate", "assistant", "first", 2);
+      const second = message("duplicate", "assistant", "second", created);
+      const cached = [first, anchor, second];
+      const liveResult = mergeSnapshotAndLiveMessages([anchor], cached, { appendLiveOnlyMessages: true });
+      expect(liveResult.map((item) => item.id)).toEqual(["anchor", "duplicate", "duplicate"]);
+      expect(liveResult[1]).toBe(first);
+      expect(liveResult[2]).toBe(second);
+      const cachedResult = mergeSnapshotIntoCachedMessages([anchor], cached);
+      expect(cachedResult).toHaveLength(2);
+      expect(cachedResult[1]).toBe(first);
+    });
+  }
+
+  test("preserves each function's existing duplicate snapshot selection and last cached match", () => {
+    const first = message("duplicate", "assistant", "first", 1);
+    const second = message("duplicate", "assistant", "second", 2);
+    const liveFirst = message("duplicate", "assistant", "short", 2);
+    const liveLast = message("duplicate", "assistant", "longest live answer", 2);
+    const tail = message("tail", "assistant", "tail", 3);
+    const snapshot = [first, second];
+    const cached = [liveFirst, liveLast, tail];
+    const liveResult = mergeSnapshotAndLiveMessages(snapshot, cached, { appendLiveOnlyMessages: true });
+    const cachedResult = mergeSnapshotIntoCachedMessages(snapshot, cached);
+    expect(liveResult).toHaveLength(3);
+    expect(cachedResult).toHaveLength(3);
+    expect(liveResult[0]?.metadata).toBe(first.metadata);
+    expect(liveResult[1]).toBe(liveLast);
+    expect(cachedResult[0]).toBe(liveLast);
+    expect(cachedResult[1]).toBe(liveLast);
+    for (const result of [liveResult, cachedResult]) {
+      expect(result[0]?.parts).toEqual(liveLast.parts);
+      expect(result[1]?.parts).toEqual(liveLast.parts);
+      expect(result[2]).toBe(tail);
+    }
+  });
+});
 
 describe("session render state", () => {
   test("preserves completed message references while the active answer advances", () => {

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -198,11 +198,15 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     await agent.run("session.open", { sessionId: world.neighbor.sessionId });
     await user.see("composer", { editable: true });
     await user.notSee({ text: world.opening });
-    await expectTargets([...oldTargets, world.latestTool], false);
+    // Return before the inactive transcript's 15-second GC window. The slower
+    // palette isolation checks below deliberately belong to the cold path.
     await agent.run("session.open", { sessionId: world.session.sessionId });
     await user.see({ text: world.closing });
     expect(await orderedHistory()).toEqual(world.history);
     await expectTargets([...oldTargets, world.latestTool]);
+    await agent.run("session.open", { sessionId: world.neighbor.sessionId });
+    await user.see("composer", { editable: true });
+    await expectTargets([...oldTargets, world.latestTool], false);
   });
 
   await step("cold reload keeps the bounded history tail ordered and old and new tool links usable", async () => {
@@ -212,6 +216,7 @@ historyTest("v1 keeps long tool-rich history ordered and its detected links avai
     const retainedHistory = world.history.filter(text => JSON.stringify(bounded.body).includes(text));
     expect(retainedHistory.length).toBeGreaterThan(0);
     expect(retainedHistory.length).toBeLessThan(world.history.length);
+    await agent.run("session.open", { sessionId: world.session.sessionId });
     await user.reload();
     await user.see({ text: world.closing }, { timeoutMs: 60_000 });
     expect(await orderedHistory()).toEqual(retainedHistory);

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
-import { eventually, observeTranscript, spec } from "@openwork/testkit";
-import { streamedMarkdown, streamedMarkdownMarker, streamedMarkdownReasoning } from "../worlds/chat.ts";
+import { eventually, observeTranscript, readTranscriptMessages, spec } from "@openwork/testkit";
+import { streamedMarkdown, streamedMarkdownMarker, streamedMarkdownReasoning, streamedToolHistory } from "../worlds/chat.ts";
 
 const test = spec.world(streamedMarkdown, { timeout: 420_000 });
 const prompt = `Write the streamed markdown answer. ${streamedMarkdownMarker}`;
@@ -123,5 +123,101 @@ test("a streaming answer renders as markdown block by block and settles to the s
     await user.see({ text: streamedMarkdownReasoning });
     expect(occurrences(await probe.text(), streamedMarkdownReasoning)).toBe(1);
     expectSettledDocument(await probe.text());
+  });
+});
+
+const historyTest = spec.world(streamedToolHistory, { timeout: 420_000 });
+
+historyTest("v1 keeps long tool-rich history ordered and its detected links available as the answer advances", async ({ world, user, agent, probe, step, place }) => {
+  const orderedHistory = async () => (await readTranscriptMessages(probe, "user"))
+    .flatMap(text => text.match(/Settled history \d{3}\./g) ?? []);
+  const expectTargets = async (names: string[], present = true) => {
+    await user.press(place.kind === "local" && process.platform === "darwin" ? "Meta+K" : "Control+K");
+    const rootSearch = { placeholder: "Search actions, settings, and sessions…" };
+    await user.type(rootSearch, "Accessible items", { replace: true });
+    await user.click({ role: "option", label: /^Accessible items/ });
+    const search = { placeholder: "Search servers and artifacts..." };
+    for (const name of names) {
+      await user.type(search, name, { replace: true });
+      if (present) await user.see({ role: "option", label: new RegExp(`^${name}\\b`) });
+      else await user.notSee({ role: "option", label: new RegExp(`^${name}\\b`) });
+    }
+    await user.press("Escape");
+    await user.notSee(search);
+    await user.press("Escape");
+    await user.notSee(rootSearch);
+  };
+  const oldTargets = [world.toolNames[0]!, world.toolNames.at(-1)!];
+
+  await step("the live cache retains history older than the native 140-message snapshot", async () => {
+    expect(await orderedHistory()).toEqual(world.history);
+    const bounded = await probe.desktopApi(`${world.historyPath}?limit=140`);
+    expect(bounded.status).toBe(200);
+    expect(bounded.body).toHaveLength(140);
+    expect(JSON.stringify(bounded.body)).not.toContain(world.history[0]);
+    expect(JSON.stringify(bounded.body)).toContain(world.history.at(-1));
+    await expectTargets(oldTargets);
+    await expectTargets([world.latestTool], false);
+  });
+
+  await using transcript = await observeTranscript(probe, [
+    ...[world.history[0]!, world.history[74]!, world.history[149]!].map((text): { role: "user"; text: string } => ({ role: "user", text })),
+    { role: "user", text: world.prompt },
+    { role: "assistant", text: world.opening },
+  ]);
+  await user.type("composer", world.prompt);
+  await user.click("Run task");
+
+  await step("new tool output becomes accessible without losing old targets while text grows", async () => {
+    await user.see({ text: world.opening }, { timeoutMs: 90_000 });
+    await user.notSee({ text: world.closing });
+    expect(await orderedHistory()).toEqual(world.history);
+    // These options come from detected tool output, not markdown links in the answer.
+    await expectTargets([...oldTargets, world.latestTool]);
+    await user.see({ text: world.middle }, { timeoutMs: 90_000 });
+    await user.notSee({ text: world.closing });
+    expect(await orderedHistory()).toEqual(world.history);
+  });
+
+  await step("settled history and the advancing answer never disappear or duplicate", async () => {
+    await user.see({ text: world.closing }, { timeoutMs: 120_000 });
+    await user.see("Run task", { timeoutMs: 60_000 });
+    expect(await orderedHistory()).toEqual(world.history);
+    const answers = await readTranscriptMessages(probe, "assistant");
+    const answer = answers.filter(text => text.includes(world.opening));
+    expect(answer).toHaveLength(1);
+    for (const sentinel of [world.opening, world.middle, world.closing]) {
+      expect(occurrences(answers.join("\n"), sentinel)).toBe(1);
+    }
+    expect(answer[0]!.indexOf(world.opening)).toBeLessThan(answer[0]!.indexOf(world.middle));
+    expect(answer[0]!.indexOf(world.middle)).toBeLessThan(answer[0]!.indexOf(world.closing));
+    expect(await transcript.finish()).toMatchObject({ seen: [true, true, true, true, true], violations: [], stopped: false });
+  });
+
+  await step("switching conversations preserves the full cached history and keeps targets scoped", async () => {
+    await agent.run("session.open", { sessionId: world.neighbor.sessionId });
+    await user.see("composer", { editable: true });
+    await user.notSee({ text: world.opening });
+    await expectTargets([...oldTargets, world.latestTool], false);
+    await agent.run("session.open", { sessionId: world.session.sessionId });
+    await user.see({ text: world.closing });
+    expect(await orderedHistory()).toEqual(world.history);
+    await expectTargets([...oldTargets, world.latestTool]);
+  });
+
+  await step("cold reload keeps the bounded history tail ordered and old and new tool links usable", async () => {
+    const bounded = await probe.desktopApi(`${world.historyPath}?limit=140`);
+    expect(bounded.status).toBe(200);
+    expect(bounded.body).toHaveLength(140);
+    const retainedHistory = world.history.filter(text => JSON.stringify(bounded.body).includes(text));
+    expect(retainedHistory.length).toBeGreaterThan(0);
+    expect(retainedHistory.length).toBeLessThan(world.history.length);
+    await user.reload();
+    await user.see({ text: world.closing }, { timeoutMs: 60_000 });
+    expect(await orderedHistory()).toEqual(retainedHistory);
+    expect(occurrences((await readTranscriptMessages(probe, "user")).join("\n"), world.prompt)).toBe(1);
+    expect(occurrences((await readTranscriptMessages(probe, "assistant")).join("\n"), world.closing)).toBe(1);
+    await expectTargets([...oldTargets, world.latestTool]);
+    await user.notSee({ text: /Something went wrong/ });
   });
 });

--- a/evals/specs/streamed-markdown-answer.e2e.test.ts
+++ b/evals/specs/streamed-markdown-answer.e2e.test.ts
@@ -128,7 +128,7 @@ test("a streaming answer renders as markdown block by block and settles to the s
 
 const historyTest = spec.world(streamedToolHistory, { timeout: 420_000 });
 
-historyTest("v1 keeps long tool-rich history ordered and its detected links available as the answer advances", async ({ world, user, agent, probe, step, place }) => {
+historyTest("v1 keeps long tool-rich history ordered and its detected links available as the answer advances", { timeout: 15 * 60_000 }, async ({ world, user, agent, probe, step, place }) => {
   const orderedHistory = async () => (await readTranscriptMessages(probe, "user"))
     .flatMap(text => text.match(/Settled history \d{3}\./g) ?? []);
   const expectTargets = async (names: string[], present = true) => {

--- a/evals/worlds/chat.ts
+++ b/evals/worlds/chat.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { join, resolve } from "node:path";
 import { evalIn, assertNoLiveSecret, liveOpenAiEnabled, liveOpenAiModel, liveProviderId, provisionLiveOpenAi } from "@openwork/behaviors";
-import { resolveEvalEngine, type Seed } from "@openwork/env";
+import { resolveEvalEngine, SkipError, type Seed } from "@openwork/env";
 import type { MockAgentWorkload } from "@openwork/labs";
 import { chatContinuity } from "./chat-continuity.ts";
 
@@ -617,6 +617,75 @@ export async function renderCycle(seed: Seed) {
     await close(provider);
     throw error;
   }
+}
+
+export async function streamedToolHistory(seed: Seed) {
+  if (resolveEvalEngine() !== "v1") throw new SkipError("native v1 transcript history (OPENWORK_EVAL_ENGINE=v1)");
+  const providerId = "streamed-history-mock";
+  const modelId = "streamed-history-model";
+  const prompt = "Continue the history review and report the latest tool result.";
+  const opening = "History review is advancing.";
+  const middle = "The next review section is arriving.";
+  const closing = "History review is complete.";
+  const answer = [opening, "Earlier work remains available. ".repeat(16), middle,
+    "The current answer continues to grow. ".repeat(20), closing].join("\n\n");
+  const history = Array.from({ length: 150 }, (_, index) => `Settled history ${String(index + 1).padStart(3, "0")}.`);
+  const toolNames = Array.from({ length: 20 }, (_, index) => `history-tool-${String(index + 1).padStart(2, "0")}`);
+  const latestTool = "latest-tool-result";
+  // The complete URL exists only in output, not in the tool input or final reply.
+  const command = (name: string) => `printf '%s%s/%s\\n' 'http://' '127.0.0.1:43123' '${name}'`;
+  const mock = seed.mock({ agentWorkloads: [{
+    promptMarker: prompt, latestUserTurn: true, finalReply: answer, finalReplyChunkSize: 2,
+    steps: [{ tool: "bash", arguments: { command: command(latestTool), description: "Read the latest history result" } }],
+  }] });
+  const den = await seed.den({ mocks: { agent: mock } });
+  const app = await seed.desktop({ name: "streamed-tool-history", den, as: "admin", model: `${providerId}/${modelId}` });
+  const workspace = await seed.workspace(app, seed.tmpPath("streamed-tool-history"));
+  await configureProvider(seed, app, workspace.workspaceId, providerId, modelId, {
+    permission: { bash: "allow" },
+    provider: { [providerId]: {
+      npm: "@ai-sdk/openai-compatible", name: "Streamed history mock",
+      options: { baseURL: `${den.mocks.agent.url}/v1`, apiKey: "sk-streamed-history" },
+      models: { [modelId]: { name: "Streamed history model" } },
+    } },
+  });
+  const neighbor = await seedSessionRetry(seed, app, { title: "Unrelated history review" });
+  const session = await seedSessionRetry(seed, app, { title: "Long tool history" });
+  const historyPath = `/workspace/${encodeURIComponent(workspace.workspaceId)}/opencode/session/${encodeURIComponent(session.sessionId)}/message`;
+  // Persist through native HTTP boundaries while the real SSE subscriber builds
+  // its cache. Never inject renderer messages or import the merge implementation.
+  await seed.evalIn(app, browserScript(async (historyPath, history, commands, providerId, modelId) => {
+    const base = "http://127.0.0.1:" + localStorage.getItem("openwork.server.port");
+    const headers = { Authorization: "Bearer " + localStorage.getItem("openwork.server.token"), "Content-Type": "application/json" };
+    const deadline = Date.now() + 150000;
+    const post = async (path: string, body: unknown) => {
+      if (Date.now() >= deadline) throw new Error("Native history arrangement exceeded 150 seconds");
+      const response = await fetch(base + path, {
+        method: "POST", headers, body: JSON.stringify(body), signal: AbortSignal.timeout(30000),
+      });
+      if (!response.ok) throw new Error("Native history arrangement failed: " + response.status);
+      return response.json();
+    };
+    for (const text of history) {
+      await post(historyPath, { noReply: true, model: { providerID: providerId, modelID: modelId }, parts: [{ type: "text", text }] });
+      // Wait for each native event to reach the transcript, including the oldest
+      // entries that will no longer fit in a later bounded snapshot.
+      const visibleDeadline = Math.min(deadline, Date.now() + 10000);
+      while (![...document.querySelectorAll<HTMLElement>('[data-message-role="user"]')].some(node => node.innerText.includes(text))) {
+        if (Date.now() >= visibleDeadline) throw new Error("Native history event did not render: " + text);
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+    }
+    for (const command of commands) {
+      const result = await post(historyPath.replace(/\/message$/, "/shell"), {
+        agent: "build", model: { providerID: providerId, modelID: modelId }, command,
+      });
+      if (!Array.isArray(result.parts) || !result.parts.some((part: { type?: string; state?: { status?: string } }) => part.type === "tool" && part.state?.status === "completed")) {
+        throw new Error("Native shell history did not complete");
+      }
+    }
+  }, [historyPath, history, toolNames.map(command), providerId, modelId]), { awaitPromise: true, timeoutMs: 185_000 });
+  return { app, workspace, session, neighbor, historyPath, history, toolNames, latestTool, prompt, opening, middle, closing };
 }
 
 export const streamedMarkdownMarker = "STREAM_MARKDOWN_ANSWER";


### PR DESCRIPTION
## Problem
V1 text streaming updates the transcript array every render flush. Two preparation paths repeated work over unchanged history before React could reuse the message rows:

- Snapshot/live merging inserted cached-only messages one by one into a growing array, then sorted again. Long caches beyond the 140-message snapshot incurred quadratic chronology scans.
- Artifact/link extraction rescanned unchanged text and serialized every completed tool result on each update, including completed tools in the active answer.

## Change
- Collect and sort once when message timestamps are unique and finite. Ties, absent/invalid timestamps retain the existing source-neighbor insertion rules. Preserve history, duplicate-ID semantics, and unchanged message references.
- Cache extraction by immutable part reference, with distinct text role/file-mention variants. Changed parts are rescanned; dedup order and confidence rules remain unchanged. Return fresh target objects to isolate caller mutations.
- Extend existing unit and streaming journeys. No Markdown renderer, permissions, cache-lifetime, or v2 transport changes.

## Deterministic work measurements
Fixed 140-message snapshot, one delta after warming the merge cache. Both merge functions have the same counts:

| Cached messages | Timestamp reads before | After |
| --- | ---: | ---: |
| 200 | 2,092 | 202 |
| 400 | 34,592 | 402 |
| 800 | 219,592 | 802 |

100 unchanged 10,000-character tool outputs across 20 text-only updates: **2,000 repeated serializations before; zero after warmup**. Initial extraction still runs once. These are operation counts, not claims about frame rate or total app speed. History iteration, target merging, sorting, and changed-text scanning remain.

## Verification — Passed (v1)
Exact head: `a95dda45850974a55d3109d9e0310902dc2504aa`.

```sh
OPENWORK_EVAL_ENGINE=v1 OPENWORK_EVAL_REF=a95dda45850974a55d3109d9e0310902dc2504aa pnpm evals:e2e streamed-markdown-answer
```

Cold-boot: **2 passed, 0 failed, 0 skipped**, exit 0.
`placement: daytona (daytona CLI authenticated)`.

- Existing streaming Markdown, reasoning, active-stream reload, settled history and video controls passed.
- Added v1 journey persists 150 native no-reply messages and 20 shell results through HTTP while the actual SSE subscriber builds history. It verifies ordered/nonduplicated history beyond the 140-message snapshot, advancing answer continuity, old/new tool-output targets, quick-switch cache continuity, target isolation, and the bounded tail after cold reload.
- Exact-head receipts are published below. Native history is not injected into renderer state.
- Focused unit checks: **64 passed**, 0 failed, 5,917 assertions.
- `pnpm --filter @openwork/app typecheck`: passed.
- Browser callback validation and diff whitespace check: passed.

Earlier attempts: the added journey first exhausted its overall timeout after completing streaming assertions; it now explicitly allows 15 minutes including cold resource setup. A later assertion assumed full cache retention after lengthy palette checks; the existing inactive cache expires at 15 seconds. The final journey separates immediate warm returns from cold reload instead of changing cache policy. All owned sandboxes were deleted.

Broader eval typecheck/ratchet checks were not green during authoring and are not classified as pre-existing. A separate scripts render-state suite could not load a missing export; focused maintained tests above passed. Cross-platform, v2 E2E, frame-time profiling, composer memoization, Markdown tail payload reuse, and cache-lifetime changes remain deferred.

The new journey is an independent addition to the existing streaming spec; it leaves #4585 video/recovery sections unchanged.