### PR TITLE
feat(den): grant organization admin through approved teams

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -1,6 +1,7 @@
 import * as crypto from "node:crypto";
 import { getInitialActiveOrganizationIdForUser } from "./active-organization.js";
 import { db } from "./db.js";
+import { resolveOrganizationMemberAuthority } from "./organization-team-roles.js";
 import { env } from "./env.js";
 import { appLogger } from "./observability/logger.js";
 import {
@@ -320,6 +321,15 @@ const RAW_BETTER_AUTH_MUTATION_DENIALS: readonly (readonly [string, string])[] =
   ["/organization/create-role", "Use the Den roles API to manage organization roles."],
   ["/organization/update-role", "Use the Den roles API to manage organization roles."],
   ["/organization/delete-role", "Use the Den roles API to manage organization roles."],
+  ["/organization/create-team", "Use the Den teams API to manage teams."],
+  ["/organization/update-team", "Use the Den teams API to manage teams."],
+  ["/organization/remove-team", "Use the Den teams API to manage teams."],
+  ["/organization/add-team-member", "Use the Den teams API to manage team membership."],
+  ["/organization/remove-team-member", "Use the Den teams API to manage team membership."],
+  ["/organization/add-member", "Use the Den invitation API to add members."],
+  ["/organization/invite-member", "Use the Den invitation API to invite members."],
+  ["/organization/cancel-invitation", "Use the Den invitation API to cancel invitations."],
+  ["/organization/accept-invitation", "Use the Den invitation API to accept invitations."],
   ["/sso/register", "Use the Den SSO API to manage SSO providers."],
   ["/sso/update-provider", "Use the Den SSO API to manage SSO providers."],
   ["/sso/delete-provider", "Use the Den SSO API to manage SSO providers."],
@@ -341,6 +351,10 @@ export function getRawBetterAuthMutationDenial(path: string) {
     error: "forbidden",
     message: denial[1],
   };
+}
+
+async function denyBetterAuthTeamMutation() {
+  throw new APIError("FORBIDDEN", { message: "Use the Den teams API to manage teams and their membership." });
 }
 
 function readStringProperty(value: unknown, propertyName: string) {
@@ -566,9 +580,15 @@ async function getOrganizationMemberRole(input: {
   if (!member) {
     return null;
   }
+  const authority = await resolveOrganizationMemberAuthority({
+    organizationId: normalizeDenTypeId("organization", input.organizationId),
+    memberId: member.id,
+  });
+  if (!authority) return null;
   return {
-    role: member.role,
-    isOwner: member.isOwner,
+    role: authority.directRole,
+    adminTeams: authority.adminTeams,
+    isOwner: hasRole(authority.directRole, ORGANIZATION_OWNER_ROLE),
   };
 }
 
@@ -757,6 +777,11 @@ export const auth = betterAuth({
             if (member?.isOwner) {
               throw new APIError("FORBIDDEN", {
                 message: "The organization owner cannot leave the workspace. Transfer ownership first.",
+              });
+            }
+            if (member?.adminTeams.length && !hasRole(member.role, ORGANIZATION_SUPER_ADMIN_ROLE)) {
+              throw new APIError("FORBIDDEN", {
+                message: "Ask a workspace owner or super-admin to remove your Admin team membership before leaving.",
               });
             }
           }
@@ -1094,12 +1119,20 @@ export const auth = betterAuth({
         });
       },
       organizationHooks: {
+        beforeCreateTeam: denyBetterAuthTeamMutation,
+        beforeUpdateTeam: denyBetterAuthTeamMutation,
+        beforeDeleteTeam: denyBetterAuthTeamMutation,
+        beforeAddTeamMember: denyBetterAuthTeamMutation,
+        beforeRemoveTeamMember: denyBetterAuthTeamMutation,
         afterCreateOrganization: async ({ organization }) => {
           await seedDefaultOrganizationRoles(
             normalizeDenTypeId("organization", organization.id),
           );
         },
         beforeAddMember: async ({ member }) => {
+          if (readStringProperty(member, "teamId")) {
+            await denyBetterAuthTeamMutation();
+          }
           const role = typeof member.role === "string" ? member.role : "";
           if (hasRole(role, ORGANIZATION_SUPER_ADMIN_ROLE)) {
             throw new APIError("FORBIDDEN", {
@@ -1121,6 +1154,9 @@ export const auth = betterAuth({
           }
         },
         beforeCreateInvitation: async ({ invitation, inviter }) => {
+          if (readStringProperty(invitation, "teamId")) {
+            await denyBetterAuthTeamMutation();
+          }
           const organizationId = readStringProperty(invitation, "organizationId");
           if (!organizationId) {
             return;
@@ -1285,6 +1321,8 @@ export const auth = betterAuth({
       },
     }),
     scim({
+      // Group names are metadata, never organization role assignments.
+      mapGroupToRoles: () => [],
       storeSCIMToken: SCIM_TOKEN_STORAGE_STRATEGY,
       requiredRole: [ORGANIZATION_OWNER_ROLE, ORGANIZATION_SUPER_ADMIN_ROLE, ORGANIZATION_ADMIN_ROLE],
       beforeSCIMTokenGenerated: async ({ member }) => {

--- a/ee/apps/den-api/src/organization-team-roles.ts
+++ b/ee/apps/den-api/src/organization-team-roles.ts
@@ -1,0 +1,93 @@
+import { and, eq, isNotNull, isNull, or } from "@openwork-ee/den-db/drizzle"
+import { InvitationTable, MemberTable, OrganizationTable, ScimGroupMemberTable, ScimGroupTable, ScimProviderTable, TeamMemberTable, TeamTable } from "@openwork-ee/den-db/schema"
+import { db } from "./db.js"
+import { organizationRoleValueSatisfies } from "./organization-role-hierarchy.js"
+
+export type OrganizationAdminTeam = { id: string; name: string }
+
+export type TeamMutationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
+
+// Share this lock with invitations and SCIM teardown so a concurrent grant cannot
+// turn an already-authorized routine membership edit into a role assignment.
+export function withOrganizationTeamMutation<T>(
+  organizationId: typeof TeamTable.$inferSelect.organizationId,
+  mutation: (tx: TeamMutationTransaction) => Promise<T>,
+) {
+  return db.transaction(async (tx) => {
+    await tx.select({ id: OrganizationTable.id }).from(OrganizationTable)
+      .where(eq(OrganizationTable.id, organizationId)).for("update")
+    return mutation(tx)
+  })
+}
+
+export function effectiveOrganizationRole(directRole: string, adminTeams: readonly OrganizationAdminTeam[]) {
+  return adminTeams.length > 0 && !organizationRoleValueSatisfies({ roleValue: directRole, requiredRole: "admin" })
+    ? `${directRole},admin`
+    : directRole
+}
+
+export async function invitationHasAdminTeam(tx: TeamMutationTransaction, invitation: Pick<typeof InvitationTable.$inferSelect, "id" | "organizationId" | "teamId">) {
+  const teams = await tx.select({ id: TeamTable.id }).from(TeamTable)
+    .leftJoin(TeamMemberTable, eq(TeamMemberTable.teamId, TeamTable.id))
+    .leftJoin(MemberTable, and(eq(MemberTable.id, TeamMemberTable.orgMembershipId), isNull(MemberTable.removedAt)))
+    .where(and(
+      eq(TeamTable.organizationId, invitation.organizationId),
+      eq(TeamTable.grantsOrganizationAdmin, true),
+      or(eq(MemberTable.inviteId, invitation.id), invitation.teamId ? eq(TeamTable.id, invitation.teamId) : undefined),
+    )).limit(1)
+  return teams.length > 0
+}
+
+// Never cache authority: IdP removals and designation changes apply on the next check.
+export async function listOrganizationAdminTeamGrants(organizationId: typeof TeamTable.$inferSelect.organizationId) {
+  return db.select({ memberId: MemberTable.id, id: TeamTable.id, name: TeamTable.name })
+    .from(TeamTable)
+    .innerJoin(TeamMemberTable, eq(TeamMemberTable.teamId, TeamTable.id))
+    .innerJoin(MemberTable, and(
+      eq(MemberTable.id, TeamMemberTable.orgMembershipId),
+      eq(MemberTable.organizationId, TeamTable.organizationId),
+      isNull(MemberTable.removedAt),
+    ))
+    .leftJoin(ScimGroupTable, and(eq(ScimGroupTable.teamId, TeamTable.id), eq(ScimGroupTable.organizationId, organizationId)))
+    .leftJoin(ScimProviderTable, and(
+      eq(ScimProviderTable.providerId, ScimGroupTable.providerId),
+      eq(ScimProviderTable.organizationId, organizationId),
+    ))
+    .leftJoin(ScimGroupMemberTable, and(
+      eq(ScimGroupMemberTable.groupId, ScimGroupTable.id),
+      eq(ScimGroupMemberTable.providerId, ScimProviderTable.providerId),
+      eq(ScimGroupMemberTable.organizationId, organizationId),
+      eq(ScimGroupMemberTable.teamMemberId, TeamMemberTable.id),
+      eq(ScimGroupMemberTable.orgMembershipId, MemberTable.id),
+      eq(ScimGroupMemberTable.remoteUserId, MemberTable.userId),
+    ))
+    .where(and(
+      eq(TeamTable.organizationId, organizationId),
+      eq(TeamTable.grantsOrganizationAdmin, true),
+      // A mapped team projection is not itself authority. Orphaned projections
+      // fail closed; disconnected teams require their own manual reapproval.
+      or(
+        isNull(ScimGroupTable.id),
+        eq(ScimProviderTable.groupMappingMode, "metadata_only"),
+        and(eq(ScimProviderTable.groupMappingMode, "create_teams"), isNotNull(ScimGroupMemberTable.id)),
+      ),
+    ))
+}
+
+export async function resolveOrganizationMemberAuthority(input: {
+  organizationId: typeof MemberTable.$inferSelect.organizationId
+  memberId: typeof MemberTable.$inferSelect.id
+}) {
+  const [members, grants] = await Promise.all([
+    db.select().from(MemberTable).where(and(
+      eq(MemberTable.id, input.memberId),
+      eq(MemberTable.organizationId, input.organizationId),
+      isNull(MemberTable.removedAt),
+    )).limit(1),
+    listOrganizationAdminTeamGrants(input.organizationId),
+  ])
+  const member = members[0]
+  if (!member?.userId) return null
+  const adminTeams = grants.filter((grant) => grant.memberId === member.id).map(({ id, name }) => ({ id, name }))
+  return { ...member, directRole: member.role, role: effectiveOrganizationRole(member.role, adminTeams), adminTeams }
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -9,6 +9,7 @@ import {
   MemberTable,
   OrganizationRoleTable,
   OrganizationTable,
+  ScimGroupMemberTable,
   ScimProviderTable,
   ScimUserTombstoneTable,
   SsoConnectionTable,
@@ -32,6 +33,7 @@ import {
 } from "./organization-member-guards.js"
 import { runPostOrganizationMemberChangeHooks } from "./organization-member-hooks.js"
 import { getScimManagedTeamIds } from "./scim-groups.js"
+import { effectiveOrganizationRole, listOrganizationAdminTeamGrants, withOrganizationTeamMutation, type OrganizationAdminTeam } from "./organization-team-roles.js"
 import {
   DEFAULT_ORGANIZATION_LIMITS,
   normalizeOrganizationMetadata,
@@ -45,7 +47,7 @@ import {
   type OrganizationPermissionRecord,
 } from "./organization-access.js"
 import { ensureDefaultDesktopPolicyForOrganization } from "./desktop-policies.js"
-import { isProtectedOrganizationRoleName, shouldRevokeSessionsForRoleChange } from "./organization-role-hierarchy.js"
+import { isProtectedOrganizationRoleName, organizationRoleValueSatisfies, shouldRevokeSessionsForRoleChange } from "./organization-role-hierarchy.js"
 import { appLogger } from "./observability/logger.js"
 import { isSingleOrgOwnerEmailEligible, resolveSingleOrgMembershipRole } from "./single-org-policy.js"
 
@@ -76,7 +78,7 @@ type MemberLifecycleValidationFailure = Extract<MemberLifecycleValidation, { ok:
 
 type MemberMutationFailure = {
   ok: false
-  error: "member_not_found" | MemberLifecycleValidationFailure["error"]
+  error: "member_not_found" | "forbidden" | MemberLifecycleValidationFailure["error"]
   message: string
 }
 
@@ -148,7 +150,10 @@ export type UserOrgSummary = {
   slug: string
   logo: string | null
   metadata: string | null
+  allowedEmailDomains: AllowedEmailDomains
   role: string
+  directRole: string
+  adminTeams: OrganizationAdminTeam[]
   orgMemberId: string
   membershipId: string
   memberCount: number
@@ -171,6 +176,8 @@ export type OrganizationContext = {
     id: MemberId
     userId: UserId
     role: string
+    directRole: string
+    adminTeams: OrganizationAdminTeam[]
     createdAt: Date
     joinedAt: Date | null
     isOwner: boolean
@@ -180,6 +187,8 @@ export type OrganizationContext = {
     userId: UserId | null
     inviteId: InvitationRow["id"] | null
     role: string
+    effectiveRole: string
+    adminTeams: OrganizationAdminTeam[]
     createdAt: Date
     joinedAt: Date | null
     isOwner: boolean
@@ -215,6 +224,7 @@ export type OrganizationContext = {
     updatedAt: Date
     memberIds: MemberId[]
     managedByScim: boolean
+    grantsOrganizationAdmin: boolean
   }>
 }
 
@@ -718,7 +728,7 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
   }
 
   const availableRoles = await listAssignableRoles(invitation.organizationId)
-  return db.transaction(async (tx) => {
+  return withOrganizationTeamMutation(invitation.organizationId, async (tx) => {
     const lockedInvitations = await tx
       .select()
       .from(InvitationTable)
@@ -861,7 +871,7 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
 
     if (currentInvitation.teamId) {
       const teams = await tx
-        .select({ id: TeamTable.id })
+        .select({ id: TeamTable.id, grantsOrganizationAdmin: TeamTable.grantsOrganizationAdmin })
         .from(TeamTable)
         .where(and(
           eq(TeamTable.id, currentInvitation.teamId),
@@ -876,7 +886,15 @@ async function acceptInvitation(invitation: InvitationRow, userId: UserId, optio
           .where(and(eq(TeamMemberTable.teamId, currentInvitation.teamId), eq(TeamMemberTable.orgMembershipId, member.id)))
           .limit(1)
 
-        if (!existingTeamMember[0]) {
+        const inviters = currentInvitation.orgMemberId ? await tx.select({ role: MemberTable.role })
+          .from(MemberTable).where(and(
+            eq(MemberTable.id, currentInvitation.orgMemberId),
+            eq(MemberTable.organizationId, currentInvitation.organizationId),
+            isNull(MemberTable.removedAt),
+          )).limit(1) : []
+        const mayAssignTeam = !teams[0].grantsOrganizationAdmin || (inviters[0] && organizationRoleValueSatisfies({ roleValue: inviters[0].role, requiredRole: "super-admin" }))
+        const scimTeams = await getScimManagedTeamIds(currentInvitation.organizationId, tx)
+        if (!existingTeamMember[0] && mayAssignTeam && !scimTeams.has(teams[0].id)) {
           await tx.insert(TeamMemberTable).values({
             id: createDenTypeId("teamMember"),
             teamId: currentInvitation.teamId,
@@ -1460,20 +1478,26 @@ export async function listUserOrgs(userId: UserId) {
     }
   }
 
-  return memberships.map((row) => ({
-    id: row.organization.id,
-    name: row.organization.name,
-    slug: row.organization.slug,
-    logo: row.organization.logo,
-    allowedEmailDomains: normalizeStoredAllowedEmailDomains(row.organization.allowedEmailDomains),
-    metadata: serializeMemberFacingOrganizationMetadata(row.organization.metadata),
-    role: row.role,
-    orgMemberId: row.membershipId,
-    membershipId: row.membershipId,
-    memberCount: memberCounts.get(row.organization.id) ?? 0,
-    createdAt: row.organization.createdAt,
-    updatedAt: row.organization.updatedAt,
-  })) satisfies UserOrgSummary[]
+  return Promise.all(memberships.map(async (row) => {
+    const grants = await listOrganizationAdminTeamGrants(row.organization.id)
+    const adminTeams = grants.filter((grant) => grant.memberId === row.membershipId).map(({ id, name }) => ({ id, name }))
+    return {
+      id: row.organization.id,
+      name: row.organization.name,
+      slug: row.organization.slug,
+      logo: row.organization.logo,
+      allowedEmailDomains: normalizeStoredAllowedEmailDomains(row.organization.allowedEmailDomains),
+      metadata: serializeMemberFacingOrganizationMetadata(row.organization.metadata),
+      role: effectiveOrganizationRole(row.role, adminTeams),
+      directRole: row.role,
+      adminTeams,
+      orgMemberId: row.membershipId,
+      membershipId: row.membershipId,
+      memberCount: memberCounts.get(row.organization.id) ?? 0,
+      createdAt: row.organization.createdAt,
+      updatedAt: row.organization.updatedAt,
+    } satisfies UserOrgSummary
+  }))
 }
 
 export async function resolveUserOrganizations(input: {
@@ -1567,6 +1591,11 @@ export async function getOrganizationContextForUser(input: {
     .orderBy(asc(OrganizationRoleTable.createdAt))
 
   const teams = await listOrganizationTeams(organization.id)
+  const adminGrants = await listOrganizationAdminTeamGrants(organization.id)
+  const adminTeamsFor = (memberId: MemberId) => adminGrants
+    .filter((grant) => grant.memberId === memberId)
+    .map(({ id, name }) => ({ id, name }))
+  const currentAdminTeams = adminTeamsFor(currentMember.id)
 
   return {
     organization: {
@@ -1582,12 +1611,17 @@ export async function getOrganizationContextForUser(input: {
     currentMember: {
       id: currentMember.id,
       userId: currentMember.userId,
-      role: currentMember.role,
+      role: effectiveOrganizationRole(currentMember.role, currentAdminTeams),
+      directRole: currentMember.role,
+      adminTeams: currentAdminTeams,
       createdAt: currentMember.createdAt,
       joinedAt: currentMember.joinedAt,
       isOwner: roleIncludesOwner(currentMember.role),
     },
-    members,
+    members: members.map((member) => {
+      const adminTeams = adminTeamsFor(member.id)
+      return { ...member, adminTeams, effectiveRole: effectiveOrganizationRole(member.role, adminTeams) }
+    }),
     invitations,
     roles: [
       {
@@ -1624,6 +1658,7 @@ async function listOrganizationTeams(organizationId: OrgId) {
         name: TeamTable.name,
         createdAt: TeamTable.createdAt,
         updatedAt: TeamTable.updatedAt,
+        grantsOrganizationAdmin: TeamTable.grantsOrganizationAdmin,
       })
       .from(TeamTable)
       .where(eq(TeamTable.organizationId, organizationId))
@@ -1969,7 +2004,7 @@ export async function removeOrganizationMember(input: {
   memberId: MemberRow["id"]
   removedByOrgMemberId?: MemberRow["id"]
 }): Promise<MemberMutationResult> {
-  const removed = await db.transaction(async (tx): Promise<MemberMutationResult> => {
+  const removed = await withOrganizationTeamMutation(input.organizationId, async (tx): Promise<MemberMutationResult> => {
     const activeRows = await tx
       .select({ member: MemberTable, userId: AuthUserTable.id })
       .from(MemberTable)
@@ -1996,6 +2031,17 @@ export async function removeOrganizationMember(input: {
 
     const member = memberRow.member
 
+    if (input.removedByOrgMemberId) {
+      const adminTeams = await tx.select({ id: TeamTable.id }).from(TeamTable)
+        .innerJoin(TeamMemberTable, eq(TeamMemberTable.teamId, TeamTable.id))
+        .where(and(eq(TeamTable.organizationId, input.organizationId), eq(TeamTable.grantsOrganizationAdmin, true), eq(TeamMemberTable.orgMembershipId, member.id)))
+        .limit(1)
+      const actor = activeRows.find((row) => row.member.id === input.removedByOrgMemberId)
+      if (adminTeams.length > 0 && (!actor || !organizationRoleValueSatisfies({ roleValue: actor.member.role, requiredRole: "super-admin" }))) {
+        return { ok: false, error: "forbidden", message: "Only workspace owners and super-admins can remove members with Admin team access." }
+      }
+    }
+
     await tx
       .delete(ConnectedAccountTable)
       .where(and(
@@ -2013,6 +2059,10 @@ export async function removeOrganizationMember(input: {
     await tx
       .delete(TeamMemberTable)
       .where(eq(TeamMemberTable.orgMembershipId, member.id))
+
+    await tx.update(ScimGroupMemberTable)
+      .set({ userId: null, orgMembershipId: null, teamMemberId: null, updatedAt: new Date() })
+      .where(and(eq(ScimGroupMemberTable.organizationId, input.organizationId), eq(ScimGroupMemberTable.orgMembershipId, member.id)))
 
     await tx
       .delete(LlmProviderAccessTable)

--- a/ee/apps/den-api/src/routes/auth/scim.ts
+++ b/ee/apps/den-api/src/routes/auth/scim.ts
@@ -6,7 +6,6 @@ import { z } from "zod"
 import { auth } from "../../auth.js"
 import { deleteScimProvisionedAccessForProvider, recordScimSyncFailure, recordScimSyncFailureFromBearerToken, resolveScimProviderFromBearerToken, syncExternalIdentityFromScimResource, syncExternalIdentityFromScimUserId } from "../../scim.js"
 import {
-  applyScimGroupPatch,
   createScimGroup,
   deleteScimGroup,
   getScimGroup,
@@ -468,12 +467,8 @@ export function registerScimAuthRoutes<T extends { Variables: AuthContextVariabl
     if (!parsed.success || (parsed.data.schemas && !parsed.data.schemas.includes(SCIM_PATCH_SCHEMA))) {
       return scimError("Invalid SCIM PATCH request", 400)
     }
-    const group = await getScimGroup({ provider, groupId: c.req.param("groupId") })
-    if (!group) return scimError("Group not found", 404)
     const baseUrl = c.req.url.replace(/\/Groups\/[^/]+$/, "")
-    const current = await serializeScimGroup(group, baseUrl)
-    const value = applyScimGroupPatch({ current, operations: parsed.data.Operations })
-    const result = await updateScimGroup({ provider, groupId: group.id, value })
+    const result = await updateScimGroup({ provider, groupId: c.req.param("groupId"), operations: parsed.data.Operations })
     if (!result.ok) return scimError(result.detail, result.status)
     return scimJson(await serializeScimGroup(result.group, baseUrl))
   })

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -6,6 +6,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { ORGANIZATION_AUDIT_ACTIONS, recordOrganizationAuditEvent } from "../../audit-events.js"
 import { db } from "../../db.js"
+import { invitationHasAdminTeam, withOrganizationTeamMutation } from "../../organization-team-roles.js"
 import { jsonValidator, orgRoleRoute, paramValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { appLogger } from "../../observability/logger.js"
@@ -15,7 +16,7 @@ import { isEmailAllowedForOrganization, listAssignableRoles, removeOrganizationM
 import { getOrganizationSeatAddEligibility } from "../../stripe-billing.js"
 import { DenEmailSendError, sendEmail } from "../../utils/email/send-email.js"
 import type { OrgRouteVariables } from "./shared.js"
-import { buildInvitationLink, createInvitationId, createInvitationToken, ensureInviteManager, idParamSchema, normalizeRoleName, orgAccessFailureStatus } from "./shared.js"
+import { buildInvitationLink, createInvitationId, createInvitationToken, ensureInviteManager, ensureOrganizationSuperAdmin, idParamSchema, normalizeRoleName, orgAccessFailureStatus } from "./shared.js"
 
 const inviteMemberSchema = z.object({
   email: z.string().email(),
@@ -174,6 +175,10 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       }
 
       if (existingInvitation) {
+        if (await invitationHasAdminTeam(tx, existingInvitation)) {
+          const permission = ensureOrganizationSuperAdmin(c, "Only workspace owners and super-admins can manage invitations with Admin team access.")
+          if (!permission.ok) return { status: "team_forbidden" as const, response: permission.response }
+        }
         const refreshRole = validateInvitationRefreshRole({
           existingRole: existingInvitation.role,
           availableRoles,
@@ -274,6 +279,9 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         error: "member_exists",
         message: "That email address is already a member of this organization.",
       }, 409)
+    }
+    if (invitationWrite.status === "team_forbidden") {
+      return c.json(invitationWrite.response, 403)
     }
     if (invitationWrite.status === "role_error") {
       const validation = invitationWrite.validation
@@ -399,13 +407,15 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       return c.json({ error: "invitation_not_found" }, 404)
     }
 
-    const cancellation = await db.transaction(async (tx) => {
+    const cancellation = await withOrganizationTeamMutation(payload.organization.id, async (tx) => {
       const invitationRows = await tx
         .select({
           id: InvitationTable.id,
           email: InvitationTable.email,
           role: InvitationTable.role,
           status: InvitationTable.status,
+          organizationId: InvitationTable.organizationId,
+          teamId: InvitationTable.teamId,
         })
         .from(InvitationTable)
         .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
@@ -416,6 +426,10 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       }
       if (invitation.status !== "pending") {
         return { status: "not_pending" as const, invitation }
+      }
+      if (await invitationHasAdminTeam(tx, invitation)) {
+        const permission = ensureOrganizationSuperAdmin(c, "Only workspace owners and super-admins can cancel invitations with Admin team access.")
+        if (!permission.ok) return { status: "team_forbidden" as const, response: permission.response }
       }
 
       const invitedMemberRows = await tx
@@ -438,6 +452,9 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
 
     if (cancellation.status === "not_found") {
       return c.json({ error: "invitation_not_found" }, 404)
+    }
+    if (cancellation.status === "team_forbidden") {
+      return c.json(cancellation.response, 403)
     }
 
     if (cancellation.status === "not_pending") {

--- a/ee/apps/den-api/src/routes/org/members.ts
+++ b/ee/apps/den-api/src/routes/org/members.ts
@@ -189,6 +189,7 @@ export function registerOrgMemberRoutes<T extends { Variables: OrgRouteVariables
       removedByOrgMemberId: payload.currentMember.id,
     })
     if (!removed.ok) {
+      if (removed.error === "forbidden") return c.json({ error: removed.error, message: removed.message }, 403)
       if (removed.error === "member_not_found") {
         return c.json({ error: removed.error, message: removed.message }, 404)
       }

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -71,6 +71,7 @@ import {
   type DefaultMarketplacePluginEntry,
 } from "./default-marketplaces.js"
 import { db } from "../../../db.js"
+import { resolveOrganizationMemberAuthority } from "../../../organization-team-roles.js"
 import { env } from "../../../env.js"
 import { appLogger } from "../../../observability/logger.js"
 import { roleIncludesOwner } from "../../../orgs.js"
@@ -6019,16 +6020,10 @@ async function buildConnectorAutomationContext(input: { connectorInstance: Conne
     throw new PluginArchRouteFailure(404, "organization_not_found", "Organization not found for connector instance.")
   }
 
-  const memberRows = await db
-    .select()
-    .from(MemberTable)
-    .where(and(
-      eq(MemberTable.organizationId, input.connectorInstance.organizationId),
-      eq(MemberTable.id, input.connectorInstance.createdByOrgMembershipId),
-      isNull(MemberTable.removedAt),
-    ))
-    .limit(1)
-  const member = memberRows[0] as MemberRow | undefined
+  const member = await resolveOrganizationMemberAuthority({
+    organizationId: input.connectorInstance.organizationId,
+    memberId: input.connectorInstance.createdByOrgMembershipId,
+  })
   if (!member) {
     throw new PluginArchRouteFailure(404, "member_not_found", "Connector creator member not found.")
   }
@@ -6048,6 +6043,8 @@ async function buildConnectorAutomationContext(input: { connectorInstance: Conne
         isOwner: roleIncludesOwner(member.role),
         joinedAt: member.joinedAt,
         role: member.role,
+        directRole: member.directRole,
+        adminTeams: member.adminTeams,
         userId: member.userId,
       },
       invitations: [],

--- a/ee/apps/den-api/src/routes/org/teams.ts
+++ b/ee/apps/den-api/src/routes/org/teams.ts
@@ -19,6 +19,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { isScimManagedTeam } from "../../scim-groups.js"
+import { withOrganizationTeamMutation } from "../../organization-team-roles.js"
 import {
   jsonValidator,
   orgRoleRoute,
@@ -28,6 +29,7 @@ import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, 
 import type { OrgRouteVariables } from "./shared.js"
 import {
   ensureTeamManager,
+  ensureOrganizationSuperAdmin,
   idParamSchema,
   orgAccessFailureStatus,
 } from "./shared.js"
@@ -35,13 +37,15 @@ import {
 const createTeamSchema = z.object({
   name: z.string().trim().min(1).max(255),
   memberIds: z.array(denTypeIdSchema("member")).optional().default([]),
+  grantsOrganizationAdmin: z.boolean().optional(),
 })
 
 const updateTeamSchema = z.object({
   name: z.string().trim().min(1).max(255).optional(),
   memberIds: z.array(denTypeIdSchema("member")).optional(),
+  grantsOrganizationAdmin: z.boolean().optional(),
 }).superRefine((value, ctx) => {
-  if (value.name === undefined && value.memberIds === undefined) {
+  if (value.name === undefined && value.memberIds === undefined && value.grantsOrganizationAdmin === undefined) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["name"],
@@ -65,6 +69,7 @@ const teamResponseSchema = z.object({
     updatedAt: z.string().datetime(),
       memberIds: z.array(denTypeIdSchema("member")),
       managedByScim: z.boolean(),
+      grantsOrganizationAdmin: z.boolean(),
   }),
 }).meta({ ref: "TeamResponse" })
 
@@ -79,12 +84,12 @@ function parseMemberIds(memberIds: string[]) {
 async function ensureMembersBelongToOrganization(input: {
   organizationId: typeof TeamTable.$inferSelect.organizationId
   memberIds: MemberId[]
-}) {
+}, database: Pick<typeof db, "select"> = db) {
   if (input.memberIds.length === 0) {
     return true
   }
 
-  const rows = await db
+  const rows = await database
     .select({ id: MemberTable.id })
     .from(MemberTable)
     .where(and(eq(MemberTable.organizationId, input.organizationId), isNull(MemberTable.removedAt)))
@@ -94,9 +99,14 @@ async function ensureMembersBelongToOrganization(input: {
 }
 
 async function createTeam(c: ResourceActionContext, payload: ResourceOrganizationContext, input: z.infer<typeof createTeamSchema>, externalKey?: string) {
+  return withOrganizationTeamMutation(payload.organization.id, async (tx) => {
   const permission = ensureTeamManager(c)
   if (!permission.ok) {
     return c.json(permission.response, orgAccessFailureStatus(permission.response))
+  }
+  if (input.grantsOrganizationAdmin !== undefined) {
+    const rolePermission = ensureOrganizationSuperAdmin(c, "Only workspace owners and super-admins can designate an Admin team.")
+    if (!rolePermission.ok) return c.json(rolePermission.response, orgAccessFailureStatus(rolePermission.response))
   }
 
   let memberIds: MemberId[]
@@ -109,12 +119,12 @@ async function createTeam(c: ResourceActionContext, payload: ResourceOrganizatio
   const membersBelongToOrg = await ensureMembersBelongToOrganization({
     organizationId: payload.organization.id,
     memberIds,
-  })
+  }, tx)
   if (!membersBelongToOrg) {
     return c.json({ error: "member_not_found" }, 404)
   }
 
-  const existingTeam = await db
+  const existingTeam = await tx
     .select({ id: TeamTable.id })
     .from(TeamTable)
     .where(and(eq(TeamTable.organizationId, payload.organization.id), eq(TeamTable.name, input.name)))
@@ -127,12 +137,12 @@ async function createTeam(c: ResourceActionContext, payload: ResourceOrganizatio
   const teamId = createDenTypeId("team")
   const now = new Date()
 
-  await db.transaction(async (tx) => {
     await tx.insert(TeamTable).values({
       externalKey,
       id: teamId,
       name: input.name,
       organizationId: payload.organization.id,
+      grantsOrganizationAdmin: input.grantsOrganizationAdmin ?? false,
       createdAt: now,
       updatedAt: now,
     })
@@ -147,7 +157,6 @@ async function createTeam(c: ResourceActionContext, payload: ResourceOrganizatio
         })),
       )
     }
-  })
 
   return c.json({
     team: {
@@ -159,11 +168,14 @@ async function createTeam(c: ResourceActionContext, payload: ResourceOrganizatio
       updatedAt: now,
       memberIds,
       managedByScim: false,
+      grantsOrganizationAdmin: input.grantsOrganizationAdmin ?? false,
     },
   }, 201)
+  })
 }
 
 async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizationContext, rawId: string, input: z.infer<typeof updateTeamSchema>) {
+  return withOrganizationTeamMutation(payload.organization.id, async (tx) => {
   const permission = ensureTeamManager(c)
   if (!permission.ok) {
     return c.json(permission.response, orgAccessFailureStatus(permission.response))
@@ -176,7 +188,7 @@ async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizatio
     return c.json({ error: "team_not_found" }, 404)
   }
 
-  const teamRows = await db
+  const teamRows = await tx
     .select()
     .from(TeamTable)
     .where(and(eq(TeamTable.id, teamId), eq(TeamTable.organizationId, payload.organization.id)))
@@ -186,8 +198,13 @@ async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizatio
   if (!team) {
     return c.json({ error: "team_not_found" }, 404)
   }
-  if (await isScimManagedTeam({ organizationId: payload.organization.id, teamId: team.id })) {
+  const managedByScim = await isScimManagedTeam({ organizationId: payload.organization.id, teamId: team.id }, tx)
+  if (managedByScim && (input.name !== undefined || input.memberIds !== undefined)) {
     return c.json({ error: "scim_managed_team", message: "Manage this team through the SCIM identity provider." }, 409)
+  }
+  if (input.grantsOrganizationAdmin !== undefined || (team.grantsOrganizationAdmin && input.memberIds !== undefined)) {
+    const rolePermission = ensureOrganizationSuperAdmin(c, "Only workspace owners and super-admins can manage Admin team grants and membership.")
+    if (!rolePermission.ok) return c.json(rolePermission.response, orgAccessFailureStatus(rolePermission.response))
   }
 
   let memberIds: MemberId[] | undefined
@@ -201,14 +218,14 @@ async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizatio
     const membersBelongToOrg = await ensureMembersBelongToOrganization({
       organizationId: payload.organization.id,
       memberIds,
-    })
+    }, tx)
     if (!membersBelongToOrg) {
       return c.json({ error: "member_not_found" }, 404)
     }
   }
 
   const nextName = input.name ?? team.name
-  const duplicate = await db
+  const duplicate = await tx
     .select({ id: TeamTable.id })
     .from(TeamTable)
     .where(and(eq(TeamTable.organizationId, payload.organization.id), eq(TeamTable.name, nextName)))
@@ -219,14 +236,13 @@ async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizatio
   }
 
   const updatedAt = new Date()
-  const responseMemberIds = memberIds ?? (await db
+  const responseMemberIds = memberIds ?? (await tx
     .select({ id: TeamMemberTable.orgMembershipId })
     .from(TeamMemberTable)
     .where(eq(TeamMemberTable.teamId, team.id)))
     .map((row) => row.id)
 
-  await db.transaction(async (tx) => {
-    await tx.update(TeamTable).set({ name: nextName, updatedAt }).where(eq(TeamTable.id, team.id))
+    await tx.update(TeamTable).set({ name: nextName, updatedAt, grantsOrganizationAdmin: input.grantsOrganizationAdmin }).where(eq(TeamTable.id, team.id))
 
     if (memberIds) {
       await tx.delete(TeamMemberTable).where(eq(TeamMemberTable.teamId, team.id))
@@ -241,7 +257,6 @@ async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizatio
         )
       }
     }
-  })
 
   return c.json({
     team: {
@@ -249,12 +264,15 @@ async function updateTeam(c: ResourceActionContext, payload: ResourceOrganizatio
       name: nextName,
       updatedAt,
       memberIds: responseMemberIds,
-      managedByScim: false,
+      managedByScim,
+      grantsOrganizationAdmin: input.grantsOrganizationAdmin ?? team.grantsOrganizationAdmin,
     },
+  })
   })
 }
 
 async function deleteTeam(c: ResourceActionContext, payload: ResourceOrganizationContext, rawId: string) {
+  return withOrganizationTeamMutation(payload.organization.id, async (tx) => {
   const permission = ensureTeamManager(c)
   if (!permission.ok) {
     return c.json(permission.response, orgAccessFailureStatus(permission.response))
@@ -267,7 +285,7 @@ async function deleteTeam(c: ResourceActionContext, payload: ResourceOrganizatio
     return c.json({ error: "team_not_found" }, 404)
   }
 
-  const teamRows = await db
+  const teamRows = await tx
     .select()
     .from(TeamTable)
     .where(and(eq(TeamTable.id, teamId), eq(TeamTable.organizationId, payload.organization.id)))
@@ -277,11 +295,14 @@ async function deleteTeam(c: ResourceActionContext, payload: ResourceOrganizatio
   if (!team) {
     return c.json({ error: "team_not_found" }, 404)
   }
-  if (await isScimManagedTeam({ organizationId: payload.organization.id, teamId: team.id })) {
+  if (await isScimManagedTeam({ organizationId: payload.organization.id, teamId: team.id }, tx)) {
     return c.json({ error: "scim_managed_team", message: "Disable SCIM team mapping before deleting this team." }, 409)
   }
+  if (team.grantsOrganizationAdmin) {
+    const rolePermission = ensureOrganizationSuperAdmin(c, "Only workspace owners and super-admins can delete Admin teams.")
+    if (!rolePermission.ok) return c.json(rolePermission.response, orgAccessFailureStatus(rolePermission.response))
+  }
 
-  await db.transaction(async (tx) => {
     const removedAt = new Date()
 
     await tx
@@ -316,9 +337,9 @@ async function deleteTeam(c: ResourceActionContext, payload: ResourceOrganizatio
 
     await tx.delete(TeamMemberTable).where(eq(TeamMemberTable.teamId, team.id))
     await tx.delete(TeamTable).where(eq(TeamTable.id, team.id))
-  })
 
   return c.body(null, 204)
+  })
 }
 
 export function registerOrgTeamRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {

--- a/ee/apps/den-api/src/scim-groups.ts
+++ b/ee/apps/den-api/src/scim-groups.ts
@@ -10,6 +10,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
+import { withOrganizationTeamMutation, type TeamMutationTransaction } from "./organization-team-roles.js"
 
 export const SCIM_GROUP_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group"
 export const SCIM_LIST_RESPONSE_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
@@ -150,14 +151,23 @@ export function applyScimGroupPatch(input: {
   return { externalId, displayName, members }
 }
 
-async function loadGroupMembers(groupId: ScimGroup["id"]) {
-  return db
+async function loadGroupMembers(groupId: ScimGroup["id"], database: Pick<typeof db, "select"> = db) {
+  return database
     .select()
     .from(ScimGroupMemberTable)
     .where(eq(ScimGroupMemberTable.groupId, groupId))
 }
 
-async function findActiveOrganizationMember(input: {
+async function loadScimProvider(tx: TeamMutationTransaction, provider: ScimProvider) {
+  const rows = await tx.select().from(ScimProviderTable).where(and(
+    eq(ScimProviderTable.id, provider.id),
+    eq(ScimProviderTable.organizationId, provider.organizationId),
+    eq(ScimProviderTable.providerId, provider.providerId),
+  )).limit(1)
+  return rows[0] ?? null
+}
+
+async function findActiveOrganizationMember(tx: TeamMutationTransaction, input: {
   organizationId: ScimProvider["organizationId"]
   remoteUserId: string
 }) {
@@ -168,7 +178,7 @@ async function findActiveOrganizationMember(input: {
     return null
   }
 
-  const rows = await db
+  const rows = await tx
     .select()
     .from(MemberTable)
     .where(and(
@@ -180,12 +190,12 @@ async function findActiveOrganizationMember(input: {
   return rows[0] ?? null
 }
 
-async function chooseScimTeamName(input: {
+async function chooseScimTeamName(tx: TeamMutationTransaction, input: {
   organizationId: ScimProvider["organizationId"]
   displayName: string
   currentTeamId?: typeof TeamTable.$inferSelect.id
 }) {
-  const exactRows = await db
+  const exactRows = await tx
     .select({ id: TeamTable.id })
     .from(TeamTable)
     .where(and(eq(TeamTable.organizationId, input.organizationId), eq(TeamTable.name, input.displayName)))
@@ -195,7 +205,7 @@ async function chooseScimTeamName(input: {
   }
 
   const suffixedName = `${input.displayName} (SCIM)`
-  const suffixedRows = await db
+  const suffixedRows = await tx
     .select({ id: TeamTable.id })
     .from(TeamTable)
     .where(and(eq(TeamTable.organizationId, input.organizationId), eq(TeamTable.name, suffixedName)))
@@ -207,7 +217,7 @@ async function chooseScimTeamName(input: {
   return `${input.displayName} (SCIM ${createDenTypeId("team").slice(-6)})`
 }
 
-async function ensureGroupTeam(provider: ScimProvider, group: ScimGroup) {
+async function ensureGroupTeam(tx: TeamMutationTransaction, provider: ScimProvider, group: ScimGroup) {
   if (normalizeMappingMode(provider.groupMappingMode) !== "create_teams") {
     return group
   }
@@ -217,29 +227,27 @@ async function ensureGroupTeam(provider: ScimProvider, group: ScimGroup) {
 
   const teamId = createDenTypeId("team")
   const now = new Date()
-  const name = await chooseScimTeamName({
+  const name = await chooseScimTeamName(tx, {
     organizationId: provider.organizationId,
     displayName: group.displayName,
   })
 
-  await db.transaction(async (tx) => {
-    await tx.insert(TeamTable).values({
-      id: teamId,
-      organizationId: provider.organizationId,
-      name,
-      createdAt: now,
-      updatedAt: now,
-    })
-    await tx
-      .update(ScimGroupTable)
-      .set({ teamId, updatedAt: now })
-      .where(and(eq(ScimGroupTable.id, group.id), isNull(ScimGroupTable.teamId)))
+  await tx.insert(TeamTable).values({
+    id: teamId,
+    organizationId: provider.organizationId,
+    name,
+    createdAt: now,
+    updatedAt: now,
   })
+  await tx
+    .update(ScimGroupTable)
+    .set({ teamId, updatedAt: now })
+    .where(and(eq(ScimGroupTable.id, group.id), isNull(ScimGroupTable.teamId)))
 
   return { ...group, teamId, updatedAt: now }
 }
 
-async function attachGroupMemberToTeam(input: {
+async function attachGroupMemberToTeam(tx: TeamMutationTransaction, input: {
   provider: ScimProvider
   group: ScimGroup
   member: ScimGroupMember
@@ -248,7 +256,7 @@ async function attachGroupMemberToTeam(input: {
     return
   }
 
-  const organizationMember = await findActiveOrganizationMember({
+  const organizationMember = await findActiveOrganizationMember(tx, {
     organizationId: input.provider.organizationId,
     remoteUserId: input.member.remoteUserId,
   })
@@ -258,7 +266,7 @@ async function attachGroupMemberToTeam(input: {
 
   let teamMemberId: typeof TeamMemberTable.$inferSelect.id | null = null
   if (normalizeMappingMode(input.provider.groupMappingMode) === "create_teams" && input.group.teamId) {
-    const existingRows = await db
+    const existingRows = await tx
       .select({ id: TeamMemberTable.id })
       .from(TeamMemberTable)
       .where(and(
@@ -267,9 +275,10 @@ async function attachGroupMemberToTeam(input: {
       ))
       .limit(1)
 
+    teamMemberId = existingRows[0]?.id ?? null
     if (!existingRows[0]) {
       teamMemberId = createDenTypeId("teamMember")
-      await db.insert(TeamMemberTable).values({
+      await tx.insert(TeamMemberTable).values({
         id: teamMemberId,
         teamId: input.group.teamId,
         orgMembershipId: organizationMember.id,
@@ -279,7 +288,7 @@ async function attachGroupMemberToTeam(input: {
     }
   }
 
-  await db
+  await tx
     .update(ScimGroupMemberTable)
     .set({
       userId: organizationMember.userId,
@@ -290,20 +299,22 @@ async function attachGroupMemberToTeam(input: {
     .where(eq(ScimGroupMemberTable.id, input.member.id))
 }
 
-async function detachOwnedTeamMembership(member: ScimGroupMember) {
-  if (member.teamMemberId) {
-    await db.delete(TeamMemberTable).where(eq(TeamMemberTable.id, member.teamMemberId))
+async function detachOwnedTeamMembership(tx: TeamMutationTransaction, provider: ScimProvider, member: ScimGroupMember) {
+  if (normalizeMappingMode(provider.groupMappingMode) === "create_teams" && member.teamMemberId) {
+    await tx.delete(TeamMemberTable).where(eq(TeamMemberTable.id, member.teamMemberId))
   }
 }
 
-export async function replaceScimGroupMembers(input: {
+// All callers hold the organization lock and pass the same transaction through
+// source reads, projection writes, and ownership updates.
+async function replaceScimGroupMembers(tx: TeamMutationTransaction, input: {
   provider: ScimProvider
   group: ScimGroup
   members: ScimGroupMemberInput[]
 }) {
-  const group = await ensureGroupTeam(input.provider, input.group)
+  const group = await ensureGroupTeam(tx, input.provider, input.group)
   const nextMembers = uniqueMembers(input.members)
-  const existing = await loadGroupMembers(group.id)
+  const existing = await loadGroupMembers(group.id, tx)
   const nextValues = new Set(nextMembers.map((member) => member.value))
   const existingByValue = new Map(
     existing.flatMap((member) => member.remoteUserId ? [[member.remoteUserId, member]] : []),
@@ -314,8 +325,8 @@ export async function replaceScimGroupMembers(input: {
       continue
     }
     if (!nextValues.has(member.remoteUserId)) {
-      await detachOwnedTeamMembership(member)
-      await db.delete(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.id, member.id))
+      await detachOwnedTeamMembership(tx, input.provider, member)
+      await tx.delete(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.id, member.id))
     }
   }
 
@@ -324,7 +335,7 @@ export async function replaceScimGroupMembers(input: {
     if (!member) {
       const memberId = createDenTypeId("scimGroupMember")
       const now = new Date()
-      await db.insert(ScimGroupMemberTable).values({
+      await tx.insert(ScimGroupMemberTable).values({
         id: memberId,
         groupId: group.id,
         organizationId: input.provider.organizationId,
@@ -333,7 +344,7 @@ export async function replaceScimGroupMembers(input: {
         createdAt: now,
         updatedAt: now,
       })
-      const rows = await db
+      const rows = await tx
         .select()
         .from(ScimGroupMemberTable)
         .where(eq(ScimGroupMemberTable.id, memberId))
@@ -341,7 +352,7 @@ export async function replaceScimGroupMembers(input: {
       member = rows[0]
     }
     if (member && !member.teamMemberId) {
-      await attachGroupMemberToTeam({ provider: input.provider, group, member })
+      await attachGroupMemberToTeam(tx, { provider: input.provider, group, member })
     }
   }
 
@@ -352,55 +363,59 @@ export async function createScimGroup(input: {
   provider: ScimProvider
   value: ScimGroupInput
 }): Promise<ScimGroupMutationResult> {
-  const displayName = input.value.displayName.trim()
-  if (!displayName) {
-    return { ok: false, status: 400, detail: "displayName is required" }
-  }
-
-  if (input.value.externalId) {
-    const duplicateRows = await db
-      .select({ id: ScimGroupTable.id })
-      .from(ScimGroupTable)
-      .where(and(
-        eq(ScimGroupTable.providerId, input.provider.providerId),
-        eq(ScimGroupTable.externalId, input.value.externalId),
-      ))
-      .limit(1)
-    if (duplicateRows[0]) {
-      return { ok: false, status: 409, detail: "A group with that externalId already exists" }
+  return withOrganizationTeamMutation(input.provider.organizationId, async (tx): Promise<ScimGroupMutationResult> => {
+    const provider = await loadScimProvider(tx, input.provider)
+    if (!provider) return { ok: false, status: 404, detail: "Provider not found" }
+    const displayName = input.value.displayName.trim()
+    if (!displayName) {
+      return { ok: false, status: 400, detail: "displayName is required" }
     }
-  }
 
-  const now = new Date()
-  const groupId = createDenTypeId("scimGroup")
-  await db.insert(ScimGroupTable).values({
-    id: groupId,
-    organizationId: input.provider.organizationId,
-    providerId: input.provider.providerId,
-    scimGroupId: groupId,
-    externalId: input.value.externalId ?? null,
-    displayName,
-    createdAt: now,
-    updatedAt: now,
-  })
+    if (input.value.externalId) {
+      const duplicateRows = await tx
+        .select({ id: ScimGroupTable.id })
+        .from(ScimGroupTable)
+        .where(and(
+          eq(ScimGroupTable.providerId, provider.providerId),
+          eq(ScimGroupTable.externalId, input.value.externalId),
+        ))
+        .limit(1)
+      if (duplicateRows[0]) {
+        return { ok: false, status: 409, detail: "A group with that externalId already exists" }
+      }
+    }
 
-  const rows = await db.select().from(ScimGroupTable).where(eq(ScimGroupTable.id, groupId)).limit(1)
-  const created = rows[0]
-  if (!created) {
-    throw new Error("SCIM group was created but could not be loaded")
-  }
-  const group = await replaceScimGroupMembers({
-    provider: input.provider,
-    group: created,
-    members: input.value.members ?? [],
+    const now = new Date()
+    const groupId = createDenTypeId("scimGroup")
+    await tx.insert(ScimGroupTable).values({
+      id: groupId,
+      organizationId: provider.organizationId,
+      providerId: provider.providerId,
+      scimGroupId: groupId,
+      externalId: input.value.externalId ?? null,
+      displayName,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const rows = await tx.select().from(ScimGroupTable).where(eq(ScimGroupTable.id, groupId)).limit(1)
+    const created = rows[0]
+    if (!created) {
+      throw new Error("SCIM group was created but could not be loaded")
+    }
+    const group = await replaceScimGroupMembers(tx, {
+      provider,
+      group: created,
+      members: input.value.members ?? [],
+    })
+    return { ok: true, group }
   })
-  return { ok: true, group }
 }
 
 export async function getScimGroup(input: {
   provider: ScimProvider
   groupId: string
-}) {
+}, database: Pick<typeof db, "select"> = db) {
   let groupId: ScimGroup["id"]
   try {
     groupId = normalizeDenTypeId("scimGroup", input.groupId)
@@ -408,7 +423,7 @@ export async function getScimGroup(input: {
     return null
   }
 
-  const rows = await db
+  const rows = await database
     .select()
     .from(ScimGroupTable)
     .where(and(
@@ -420,8 +435,8 @@ export async function getScimGroup(input: {
   return rows[0] ?? null
 }
 
-export async function listScimGroups(provider: ScimProvider) {
-  return db
+export async function listScimGroups(provider: ScimProvider, database: Pick<typeof db, "select"> = db) {
+  return database
     .select()
     .from(ScimGroupTable)
     .where(and(
@@ -433,72 +448,84 @@ export async function listScimGroups(provider: ScimProvider) {
 export async function updateScimGroup(input: {
   provider: ScimProvider
   groupId: string
-  value: ScimGroupInput
-}): Promise<ScimGroupMutationResult> {
-  const group = await getScimGroup({ provider: input.provider, groupId: input.groupId })
-  if (!group) {
-    return { ok: false, status: 404, detail: "Group not found" }
-  }
-  const displayName = input.value.displayName.trim()
-  if (!displayName) {
-    return { ok: false, status: 400, detail: "displayName is required" }
-  }
-  if (input.value.externalId && input.value.externalId !== group.externalId) {
-    const duplicateRows = await db
-      .select({ id: ScimGroupTable.id })
-      .from(ScimGroupTable)
-      .where(and(
-        eq(ScimGroupTable.providerId, input.provider.providerId),
-        eq(ScimGroupTable.externalId, input.value.externalId),
-      ))
-      .limit(1)
-    if (duplicateRows[0]) {
-      return { ok: false, status: 409, detail: "A group with that externalId already exists" }
+} & ({ value: ScimGroupInput } | { operations: ScimGroupPatchOperation[] })): Promise<ScimGroupMutationResult> {
+  return withOrganizationTeamMutation(input.provider.organizationId, async (tx): Promise<ScimGroupMutationResult> => {
+    const provider = await loadScimProvider(tx, input.provider)
+    if (!provider) return { ok: false, status: 404, detail: "Provider not found" }
+    const group = await getScimGroup({ provider, groupId: input.groupId }, tx)
+    if (!group) {
+      return { ok: false, status: 404, detail: "Group not found" }
     }
-  }
-
-  const now = new Date()
-  await db
-    .update(ScimGroupTable)
-    .set({ externalId: input.value.externalId ?? null, displayName, updatedAt: now })
-    .where(eq(ScimGroupTable.id, group.id))
-
-  if (group.teamId && normalizeMappingMode(input.provider.groupMappingMode) === "create_teams") {
-    const teamName = await chooseScimTeamName({
-      organizationId: input.provider.organizationId,
-      displayName,
-      currentTeamId: group.teamId,
+    const value = "value" in input ? input.value : applyScimGroupPatch({
+      current: {
+        displayName: group.displayName,
+        externalId: group.externalId,
+        members: (await loadGroupMembers(group.id, tx)).flatMap((member) => member.remoteUserId ? [{ value: member.remoteUserId }] : []),
+      },
+      operations: input.operations,
     })
-    await db.update(TeamTable).set({ name: teamName, updatedAt: now }).where(eq(TeamTable.id, group.teamId))
-  }
+    const displayName = value.displayName.trim()
+    if (!displayName) {
+      return { ok: false, status: 400, detail: "displayName is required" }
+    }
+    if (value.externalId && value.externalId !== group.externalId) {
+      const duplicateRows = await tx
+        .select({ id: ScimGroupTable.id })
+        .from(ScimGroupTable)
+        .where(and(
+          eq(ScimGroupTable.providerId, provider.providerId),
+          eq(ScimGroupTable.externalId, value.externalId),
+        ))
+        .limit(1)
+      if (duplicateRows[0]) {
+        return { ok: false, status: 409, detail: "A group with that externalId already exists" }
+      }
+    }
 
-  const updated = { ...group, externalId: input.value.externalId ?? null, displayName, updatedAt: now }
-  const replaced = await replaceScimGroupMembers({
-    provider: input.provider,
-    group: updated,
-    members: input.value.members ?? [],
+    const now = new Date()
+    await tx
+      .update(ScimGroupTable)
+      .set({ externalId: value.externalId ?? null, displayName, updatedAt: now })
+      .where(eq(ScimGroupTable.id, group.id))
+
+    if (group.teamId && normalizeMappingMode(provider.groupMappingMode) === "create_teams") {
+      const teamName = await chooseScimTeamName(tx, {
+        organizationId: provider.organizationId,
+        displayName,
+        currentTeamId: group.teamId,
+      })
+      await tx.update(TeamTable).set({ name: teamName, updatedAt: now }).where(eq(TeamTable.id, group.teamId))
+    }
+
+    const updated = { ...group, externalId: value.externalId ?? null, displayName, updatedAt: now }
+    const replaced = await replaceScimGroupMembers(tx, {
+      provider,
+      group: updated,
+      members: value.members ?? [],
+    })
+    return { ok: true, group: replaced }
   })
-  return { ok: true, group: replaced }
 }
 
 export async function deleteScimGroup(input: {
   provider: ScimProvider
   groupId: string
 }): Promise<{ ok: true } | { ok: false; status: 404; detail: string }> {
-  const group = await getScimGroup(input)
-  if (!group) {
-    return { ok: false, status: 404, detail: "Group not found" }
-  }
-
-  const members = await loadGroupMembers(group.id)
-  for (const member of members) {
-    await detachOwnedTeamMembership(member)
-  }
-  await db.transaction(async (tx) => {
+  return withOrganizationTeamMutation(input.provider.organizationId, async (tx): Promise<{ ok: true } | { ok: false; status: 404; detail: string }> => {
+    const provider = await loadScimProvider(tx, input.provider)
+    const group = provider ? await getScimGroup({ provider, groupId: input.groupId }, tx) : null
+    if (!provider || !group) return { ok: false, status: 404, detail: "Group not found" }
+    if (group.teamId && normalizeMappingMode(provider.groupMappingMode) === "create_teams") {
+      await tx.update(TeamTable).set({ grantsOrganizationAdmin: false })
+        .where(and(eq(TeamTable.id, group.teamId), eq(TeamTable.organizationId, input.provider.organizationId)))
+    }
+    const members = await tx.select().from(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.groupId, group.id))
+    const teamMemberIds = members.flatMap((member) => provider.groupMappingMode === "create_teams" && member.teamMemberId ? [member.teamMemberId] : [])
+    if (teamMemberIds.length > 0) await tx.delete(TeamMemberTable).where(inArray(TeamMemberTable.id, teamMemberIds))
     await tx.delete(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.groupId, group.id))
     await tx.delete(ScimGroupTable).where(eq(ScimGroupTable.id, group.id))
+    return { ok: true }
   })
-  return { ok: true }
 }
 
 export async function serializeScimGroup(group: ScimGroup, baseUrl: string): Promise<ScimGroupResource> {
@@ -530,63 +557,88 @@ export async function setScimGroupMappingMode(input: {
   provider: ScimProvider
   mode: ScimGroupMappingMode
 }) {
-  await db
-    .update(ScimProviderTable)
-    .set({ groupMappingMode: input.mode, updatedAt: new Date() })
-    .where(eq(ScimProviderTable.id, input.provider.id))
-
-  if (input.mode === "create_teams") {
-    const provider = { ...input.provider, groupMappingMode: input.mode }
-    const groups = await listScimGroups(provider)
-    for (const group of groups) {
-      const members = await loadGroupMembers(group.id)
-      await replaceScimGroupMembers({
-        provider,
-        group,
-        members: members.flatMap((member) => member.remoteUserId
-          ? [{ value: member.remoteUserId }]
-          : []),
-      })
+  await withOrganizationTeamMutation(input.provider.organizationId, async (tx) => {
+    const provider = await loadScimProvider(tx, input.provider)
+    if (!provider) return
+    if (provider.groupMappingMode !== input.mode) {
+      const groups = await tx.select({ teamId: ScimGroupTable.teamId }).from(ScimGroupTable)
+        .where(and(eq(ScimGroupTable.providerId, input.provider.providerId), eq(ScimGroupTable.organizationId, input.provider.organizationId)))
+      const teamIds = groups.flatMap((group) => group.teamId ? [group.teamId] : [])
+      if (teamIds.length > 0) {
+        await tx.update(TeamTable).set({ grantsOrganizationAdmin: false })
+          .where(and(eq(TeamTable.organizationId, input.provider.organizationId), inArray(TeamTable.id, teamIds)))
+        if (input.mode === "create_teams") {
+          // Re-enabling mapping hands membership back to the IdP, not to the
+          // manual edits made while the retained team was disconnected.
+          await tx.delete(TeamMemberTable).where(inArray(TeamMemberTable.teamId, teamIds))
+        }
+      }
     }
-  }
+    if (input.mode === "metadata_only" || provider.groupMappingMode !== input.mode) {
+      await tx.update(ScimGroupMemberTable).set({ teamMemberId: null })
+        .where(and(eq(ScimGroupMemberTable.providerId, provider.providerId), eq(ScimGroupMemberTable.organizationId, provider.organizationId)))
+    }
+    await tx.update(ScimProviderTable)
+      .set({ groupMappingMode: input.mode, updatedAt: new Date() })
+      .where(eq(ScimProviderTable.id, input.provider.id))
+    if (input.mode === "create_teams") {
+      const nextProvider = { ...provider, groupMappingMode: input.mode }
+      const groups = await listScimGroups(nextProvider, tx)
+      for (const group of groups) {
+        const members = await loadGroupMembers(group.id, tx)
+        await replaceScimGroupMembers(tx, {
+          provider: nextProvider,
+          group,
+          members: members.flatMap((member) => member.remoteUserId
+            ? [{ value: member.remoteUserId }]
+            : []),
+        })
+      }
+    }
+  })
 }
 
 export async function reconcileScimGroupsForUser(input: {
   provider: ScimProvider
   userId: typeof AuthUserTable.$inferSelect.id
 }) {
-  const memberships = await db
-    .select()
-    .from(ScimGroupMemberTable)
-    .where(or(
-      eq(ScimGroupMemberTable.remoteUserId, input.userId),
-      eq(ScimGroupMemberTable.userId, input.userId),
-    ))
-  if (memberships.length === 0) {
-    return
-  }
-
-  const groupIds = [...new Set(memberships.map((member) => member.groupId))]
-  const groups = await db
-    .select()
-    .from(ScimGroupTable)
-    .where(and(
-      inArray(ScimGroupTable.id, groupIds),
-      eq(ScimGroupTable.providerId, input.provider.providerId),
-      eq(ScimGroupTable.organizationId, input.provider.organizationId),
-    ))
-  const groupsById = new Map(groups.map((group) => [group.id, group]))
-
-  for (const member of memberships) {
-    const group = groupsById.get(member.groupId)
-    if (group && !member.teamMemberId) {
-      await attachGroupMemberToTeam({ provider: input.provider, group, member })
+  return withOrganizationTeamMutation(input.provider.organizationId, async (tx) => {
+    const provider = await loadScimProvider(tx, input.provider)
+    if (!provider) return
+    const memberships = await tx
+      .select()
+      .from(ScimGroupMemberTable)
+      .where(and(
+        eq(ScimGroupMemberTable.organizationId, provider.organizationId),
+        eq(ScimGroupMemberTable.providerId, provider.providerId),
+        or(eq(ScimGroupMemberTable.remoteUserId, input.userId), eq(ScimGroupMemberTable.userId, input.userId)),
+      ))
+    if (memberships.length === 0) {
+      return
     }
-  }
+
+    const groupIds = [...new Set(memberships.map((member) => member.groupId))]
+    const groups = await tx
+      .select()
+      .from(ScimGroupTable)
+      .where(and(
+        inArray(ScimGroupTable.id, groupIds),
+        eq(ScimGroupTable.providerId, provider.providerId),
+        eq(ScimGroupTable.organizationId, provider.organizationId),
+      ))
+    const groupsById = new Map(groups.map((group) => [group.id, group]))
+
+    for (const member of memberships) {
+      const group = groupsById.get(member.groupId)
+      if (group && !member.teamMemberId) {
+        await attachGroupMemberToTeam(tx, { provider, group, member })
+      }
+    }
+  })
 }
 
-export async function getScimManagedTeamIds(organizationId: ScimProvider["organizationId"]) {
-  const rows = await db
+export async function getScimManagedTeamIds(organizationId: ScimProvider["organizationId"], database: Pick<typeof db, "select"> = db) {
+  const rows = await database
     .select({ teamId: ScimGroupTable.teamId })
     .from(ScimGroupTable)
     .innerJoin(ScimProviderTable, eq(ScimProviderTable.providerId, ScimGroupTable.providerId))
@@ -600,8 +652,8 @@ export async function getScimManagedTeamIds(organizationId: ScimProvider["organi
 export async function isScimManagedTeam(input: {
   organizationId: ScimProvider["organizationId"]
   teamId: typeof TeamTable.$inferSelect.id
-}) {
-  const rows = await db
+}, database: Pick<typeof db, "select"> = db) {
+  const rows = await database
     .select({ id: ScimGroupTable.id })
     .from(ScimGroupTable)
     .innerJoin(ScimProviderTable, eq(ScimProviderTable.providerId, ScimGroupTable.providerId))

--- a/ee/apps/den-api/src/scim.ts
+++ b/ee/apps/den-api/src/scim.ts
@@ -1,8 +1,10 @@
 import { Buffer } from "node:buffer"
 import { and, count, desc, eq, inArray, isNotNull, isNull, lt, lte, or, sql } from "@openwork-ee/den-db/drizzle"
-import { AuthAccountTable, AuthUserTable, ExternalIdentityTable, MemberTable, ScimGroupMemberTable, ScimGroupTable, ScimProviderTable, ScimSyncEventTable, ScimUserTombstoneTable } from "@openwork-ee/den-db/schema"
+import { AuthAccountTable, AuthUserTable, ExternalIdentityTable, MemberTable, ScimGroupMemberTable, ScimGroupTable, ScimProviderTable, ScimSyncEventTable, ScimUserTombstoneTable, TeamTable } from "@openwork-ee/den-db/schema"
+import { withOrganizationTeamMutation } from "./organization-team-roles.js"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { auth } from "./auth.js"
+import { cache } from "./cache.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
 import { appLogger } from "./observability/logger.js"
@@ -180,6 +182,7 @@ async function syncExternalIdentityForProvider(input: {
       .set(payload)
       .where(eq(ExternalIdentityTable.id, existing.id))
     await reconcileScimGroupsForUser({ provider: input.provider, userId })
+    await cache.org.deleteMemberList(input.provider.organizationId)
     return true
   }
 
@@ -188,6 +191,7 @@ async function syncExternalIdentityForProvider(input: {
     ...payload,
   })
   await reconcileScimGroupsForUser({ provider: input.provider, userId })
+  await cache.org.deleteMemberList(input.provider.organizationId)
   return true
 }
 
@@ -311,7 +315,6 @@ export async function rotateOrganizationScimToken(input: {
 
   if (existing && existing.providerId !== providerId) {
     await cleanupExternalIdentitiesForDeletedScimConnection(existing)
-    await db.delete(ScimProviderTable).where(eq(ScimProviderTable.id, existing.id))
   }
 
   const generated = await auth.api.generateSCIMToken({
@@ -340,58 +343,69 @@ export async function deleteOrganizationScimConnection(organizationId: Organizat
   }
 
   await cleanupExternalIdentitiesForDeletedScimConnection(connection)
-  await db.delete(ScimProviderTable).where(eq(ScimProviderTable.id, connection.id))
   return true
 }
 
 async function cleanupExternalIdentitiesForDeletedScimConnection(connection: typeof ScimProviderTable.$inferSelect) {
-  const groupRows = await db
-    .select({ id: ScimGroupTable.id })
-    .from(ScimGroupTable)
-    .where(eq(ScimGroupTable.providerId, connection.providerId))
-  if (groupRows.length > 0) {
+  await withOrganizationTeamMutation(connection.organizationId, async (db) => {
+    const providers = await db.select().from(ScimProviderTable)
+      .where(and(eq(ScimProviderTable.id, connection.id), eq(ScimProviderTable.organizationId, connection.organizationId), eq(ScimProviderTable.providerId, connection.providerId))).limit(1)
+    const provider = providers[0]
+    if (!provider) return
+    const groupRows = await db
+      .select({ id: ScimGroupTable.id, teamId: ScimGroupTable.teamId })
+      .from(ScimGroupTable)
+      .where(eq(ScimGroupTable.providerId, connection.providerId))
+    if (groupRows.length > 0) {
+      const teamIds = groupRows.flatMap((group) => group.teamId ? [group.teamId] : [])
+      if (teamIds.length > 0 && provider.groupMappingMode === "create_teams") {
+        await db.update(TeamTable).set({ grantsOrganizationAdmin: false })
+          .where(and(eq(TeamTable.organizationId, connection.organizationId), inArray(TeamTable.id, teamIds)))
+      }
+      await db
+        .delete(ScimGroupMemberTable)
+        .where(inArray(ScimGroupMemberTable.groupId, groupRows.map((group) => group.id)))
+    }
+    await db.delete(ScimGroupTable).where(eq(ScimGroupTable.providerId, connection.providerId))
+    await db.delete(ScimUserTombstoneTable).where(eq(ScimUserTombstoneTable.providerId, connection.providerId))
+
     await db
-      .delete(ScimGroupMemberTable)
-      .where(inArray(ScimGroupMemberTable.groupId, groupRows.map((group) => group.id)))
-  }
-  await db.delete(ScimGroupTable).where(eq(ScimGroupTable.providerId, connection.providerId))
-  await db.delete(ScimUserTombstoneTable).where(eq(ScimUserTombstoneTable.providerId, connection.providerId))
+      .update(ExternalIdentityTable)
+      .set({
+        source: "sso",
+        scimProviderId: null,
+        externalId: null,
+        nameJson: null,
+        emailsJson: null,
+        lastScimSyncAt: null,
+      })
+      .where(and(
+        eq(ExternalIdentityTable.organizationId, connection.organizationId),
+        eq(ExternalIdentityTable.scimProviderId, connection.providerId),
+        isNotNull(ExternalIdentityTable.ssoProviderId),
+      ))
 
-  await db
-    .update(ExternalIdentityTable)
-    .set({
-      source: "sso",
-      scimProviderId: null,
-      externalId: null,
-      nameJson: null,
-      emailsJson: null,
-      lastScimSyncAt: null,
-    })
-    .where(and(
-      eq(ExternalIdentityTable.organizationId, connection.organizationId),
-      eq(ExternalIdentityTable.scimProviderId, connection.providerId),
-      isNotNull(ExternalIdentityTable.ssoProviderId),
-    ))
+    await db
+      .update(ExternalIdentityTable)
+      .set({
+        active: false,
+        scimProviderId: null,
+        externalId: null,
+        nameJson: null,
+        emailsJson: null,
+        lastScimSyncAt: null,
+      })
+      .where(and(
+        eq(ExternalIdentityTable.organizationId, connection.organizationId),
+        eq(ExternalIdentityTable.scimProviderId, connection.providerId),
+        isNull(ExternalIdentityTable.ssoProviderId),
+      ))
 
-  await db
-    .update(ExternalIdentityTable)
-    .set({
-      active: false,
-      scimProviderId: null,
-      externalId: null,
-      nameJson: null,
-      emailsJson: null,
-      lastScimSyncAt: null,
-    })
-    .where(and(
-      eq(ExternalIdentityTable.organizationId, connection.organizationId),
-      eq(ExternalIdentityTable.scimProviderId, connection.providerId),
-      isNull(ExternalIdentityTable.ssoProviderId),
-    ))
-
-  await db
-    .delete(AuthAccountTable)
-    .where(eq(AuthAccountTable.providerId, connection.providerId))
+    await db
+      .delete(AuthAccountTable)
+      .where(eq(AuthAccountTable.providerId, connection.providerId))
+    await db.delete(ScimProviderTable).where(eq(ScimProviderTable.id, provider.id))
+  })
 }
 
 export async function deleteScimProvisionedAccessForProvider(input: {
@@ -474,10 +488,6 @@ export async function deleteScimProvisionedAccessForProvider(input: {
         lastScimSyncAt: new Date(),
       })
       .where(and(eq(ExternalIdentityTable.organizationId, input.provider.organizationId), eq(ExternalIdentityTable.userId, input.userId)))
-    await tx
-      .update(ScimGroupMemberTable)
-      .set({ userId: null, orgMembershipId: null, teamMemberId: null, updatedAt: new Date() })
-      .where(eq(ScimGroupMemberTable.userId, input.userId))
   })
 
   const otherActiveMembershipRows = await db

--- a/ee/apps/den-api/src/workflows.ts
+++ b/ee/apps/den-api/src/workflows.ts
@@ -17,7 +17,6 @@ import {
   ConfigObjectAccessGrantTable,
   ConfigObjectTable,
   ConfigObjectVersionTable,
-  MemberTable,
   PluginAccessGrantTable,
   PluginConfigObjectTable,
   PluginTable,
@@ -26,6 +25,7 @@ import {
 import { createDenTypeId, normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { codemodeCodeDigest, parseCodemodeToolCalls } from "./workflow-runs.js"
 import { db } from "./db.js"
+import { resolveOrganizationMemberAuthority } from "./organization-team-roles.js"
 import { parseCodemodeScriptPayload, validateCodemodeScriptInput } from "./mcp/codemode-script-object.js"
 import type { BuiltCodemodeTools } from "./mcp/codemode-tools.js"
 import { executeWorkflow } from "./mcp/workflow-service.js"
@@ -571,12 +571,7 @@ export async function validateWorkflowAutomationAction(input: {
   const pluginId = normalizeDenTypeId("plugin", input.action.script.pluginId)
   const configObjectId = normalizeDenTypeId("configObject", input.action.script.configObjectId)
   const configObjectVersionId = normalizeDenTypeId("configObjectVersion", input.action.script.configObjectVersionId)
-  const members = await db.select({ role: MemberTable.role }).from(MemberTable).where(and(
-    eq(MemberTable.id, ownerMemberId),
-    eq(MemberTable.organizationId, organizationId),
-    isNull(MemberTable.removedAt),
-  )).limit(1)
-  const member = members[0]
+  const member = await resolveOrganizationMemberAuthority({ organizationId, memberId: ownerMemberId })
   if (!member) throw new Error("automation_owner_inactive")
   if (!memberHasRole(member.role, "admin")) {
     const [teams, configObjectGrants, pluginGrants] = await Promise.all([

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -18,6 +18,8 @@ export type DenOrgMember = {
   userId: string | null;
   inviteId: string | null;
   role: string;
+  effectiveRole: string;
+  adminTeams: { id: string; name: string }[];
   createdAt: string | null;
   joinedAt: string | null;
   isOwner: boolean;
@@ -46,6 +48,7 @@ export type DenOrgTeam = {
   updatedAt: string | null;
   memberIds: string[];
   managedByScim: boolean;
+  grantsOrganizationAdmin: boolean;
 };
 
 export type DenCurrentMemberTeam = {
@@ -217,6 +220,8 @@ export type DenOrgContext = {
     role: string;
     createdAt: string | null;
     isOwner: boolean;
+    directRole: string;
+    adminTeams: { id: string; name: string }[];
   };
   members: DenOrgMember[];
   invitations: DenOrgInvitation[];
@@ -298,6 +303,13 @@ function asIsoString(value: unknown): string | null {
 
 function asBoolean(value: unknown): boolean {
   return value === true;
+}
+
+function parseAdminTeams(value: unknown): { id: string; name: string }[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((team) => isRecord(team) && typeof team.id === "string" && typeof team.name === "string"
+    ? [{ id: team.id, name: team.name }]
+    : []);
 }
 
 function asString(value: unknown): string | null {
@@ -792,6 +804,8 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
             userId,
             inviteId: asString(entry.inviteId),
             role,
+            effectiveRole: asString(entry.effectiveRole) ?? role,
+            adminTeams: parseAdminTeams(entry.adminTeams),
             createdAt: asIsoString(entry.createdAt),
             joinedAt: asIsoString(entry.joinedAt),
             isOwner: asBoolean(entry.isOwner),
@@ -878,6 +892,7 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
             updatedAt: asIsoString(entry.updatedAt),
             memberIds,
             managedByScim: asBoolean(entry.managedByScim),
+            grantsOrganizationAdmin: asBoolean(entry.grantsOrganizationAdmin),
           } satisfies DenOrgTeam;
         })
         .filter((entry): entry is DenOrgTeam => entry !== null)
@@ -932,6 +947,8 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
       id: currentMemberId,
       userId: currentMemberUserId,
       role: currentMemberRole,
+      directRole: asString(currentMember.directRole) ?? currentMemberRole,
+      adminTeams: parseAdminTeams(currentMember.adminTeams),
       createdAt: asIsoString(currentMember.createdAt),
       isOwner: asBoolean(currentMember.isOwner),
     },

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { TeamAdminCheckbox } from "./team-admin-checkbox";
 
 import Link from "next/link";
 import { type ElementType, useEffect, useMemo, useState } from "react";
@@ -855,13 +856,14 @@ export function ManageMembersScreen() {
               const isInvited = !member.joinedAt;
               const inviteId = member.inviteId;
               const inviteToken = inviteId ? invitationsById.get(inviteId)?.inviteToken : null;
-              const memberAccess = getOrgAccessFlags(member.role, member.isOwner, orgContext.roles);
-              const canResendInvitation = isInvited && canRefreshInvitationRole(member.role, access);
+              const memberAccess = getOrgAccessFlags(member.effectiveRole, member.isOwner, orgContext.roles);
+              const canManageMemberGrants = access.canManageRoles || member.adminTeams.length === 0;
+              const canResendInvitation = isInvited && canManageMemberGrants && canRefreshInvitationRole(member.role, access);
               const canTransferOwnershipToMember = access.canTransferOwnership && !isInvited && memberAccess.isSuperAdmin;
               const canOpenActions = member.isOwner
                 ? false
                 : isInvited
-                  ? canResendInvitation || access.canCancelInvitations
+                  ? canResendInvitation || (access.canCancelInvitations && canManageMemberGrants)
                   : access.canManageRoles || access.canManageTeams || access.canRemoveMembers || canTransferOwnershipToMember;
 
               return (
@@ -872,6 +874,9 @@ export function ManageMembersScreen() {
                   <OrgMemberIdentity member={member} />
                   <span className="text-[13px] text-gray-500">
                     {splitRoleString(member.role).map(formatRoleLabel).join(", ")}
+                    {member.adminTeams.length > 0 ? (
+                      <span className="mt-1 block text-[12px] text-cyan-700">Admin via {member.adminTeams.map((team) => team.name).join(", ")}</span>
+                    ) : null}
                   </span>
                   <span className="text-[13px] text-gray-400">
                     {member.joinedAt
@@ -929,7 +934,7 @@ export function ManageMembersScreen() {
                                 Resend invite
                               </button>
                             ) : null}
-                            {isInvited && access.canCancelInvitations && inviteId ? (
+                            {isInvited && access.canCancelInvitations && canManageMemberGrants && inviteId ? (
                               <button
                                 type="button"
                                 onClick={async () => {
@@ -993,7 +998,7 @@ export function ManageMembersScreen() {
                                 Manage teams
                               </button>
                             ) : null}
-                            {!isInvited && access.canRemoveMembers ? (
+                            {!isInvited && access.canRemoveMembers && canManageMemberGrants ? (
                               <button
                                 type="button"
                                 onClick={async () => {
@@ -1037,6 +1042,7 @@ export function ManageMembersScreen() {
                               <button
                                 key={team.id}
                                 type="button"
+                                disabled={team.managedByScim || (team.grantsOrganizationAdmin && !access.canManageRoles)}
                                 onClick={() => {
                                   setMemberTeamsDraft((current) => {
                                     const next = new Set(current);
@@ -1154,12 +1160,13 @@ export function ManageMembersScreen() {
                         ? ` +${(teamMemberNames.get(team.id)?.length ?? 0) - 3}`
                         : ""}
                     </p>
+                    <TeamAdminCheckbox team={team} />
                   </div>
                   <span className="text-[13px] text-gray-400">{`${team.memberIds.length} ${team.memberIds.length === 1 ? "member" : "members"}`}</span>
                   <div className="flex items-center justify-end gap-3">
                     {team.managedByScim ? (
                       <span className="text-[12px] font-medium text-cyan-700">Managed by identity provider</span>
-                    ) : access.canManageTeams ? (
+                    ) : access.canManageTeams && (!team.grantsOrganizationAdmin || access.canManageRoles) ? (
                       <>
                         <ActionButton
                           icon={Pencil}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-admin-checkbox.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-admin-checkbox.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { DenNotice } from "../../_components/ui/notice";
+import { getOrgAccessFlags, type DenOrgTeam } from "../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+
+export function TeamAdminCheckbox({ team }: { team: DenOrgTeam }) {
+  const { orgContext, updateTeam, mutationBusy } = useOrgDashboard();
+  const [error, setError] = useState<string | null>(null);
+  const canManageRoles = orgContext && getOrgAccessFlags(orgContext.currentMember.role, orgContext.currentMember.isOwner).canManageRoles;
+  return (
+    <div className="mt-3 grid gap-2 text-[13px]">
+      <label className="flex items-start gap-2 text-gray-700">
+        <input
+          type="checkbox"
+          className="mt-0.5"
+          checked={team.grantsOrganizationAdmin}
+          disabled={!canManageRoles || mutationBusy === "update-team"}
+          onChange={async (event) => {
+            setError(null);
+            try {
+              await updateTeam(team.id, { grantsOrganizationAdmin: event.target.checked });
+            } catch (cause) {
+              setError(cause instanceof Error ? cause.message : "Could not update team Admin access.");
+            }
+          }}
+        />
+        <span>Grant organisation Admin to all members of {team.name}</span>
+      </label>
+      <p className="text-[12px] text-gray-500">
+        Only owners and super-admins can change this. Admin access is inherited while a member belongs to this team; individual roles are unchanged.
+        {team.managedByScim ? " Membership is managed by your identity provider. Disabling SCIM mapping or removing its group or provider clears this grant and requires reapproval." : ""}
+      </p>
+      {error ? <DenNotice tone="error" message={error} /> : null}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/team-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/team-detail-screen.tsx
@@ -11,6 +11,7 @@ import { getMarketplaceRoute, getMembersRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { TeamPermissionsPanel } from "./team-permissions-panel";
 import { OrgMemberIdentity } from "./org-member-identity";
+import { TeamAdminCheckbox } from "./team-admin-checkbox";
 import {
   type TeamPluginAccessItem,
   useRevokeTeamPluginAccess,
@@ -94,6 +95,7 @@ export function TeamDetailScreen({ teamId }: { teamId: string }) {
           {memberCount} {memberCount === 1 ? "member" : "members"}
         </span>
       </header>
+      {team ? <TeamAdminCheckbox team={team} /> : null}
 
       <UnderlineTabs
         className="mt-6"
@@ -114,6 +116,9 @@ export function TeamDetailScreen({ teamId }: { teamId: string }) {
                 {teamMembers.map((member) => (
                   <div key={member.id} className="px-6 py-4">
                     <OrgMemberIdentity member={member} />
+                    {member.adminTeams.length > 0 ? (
+                      <p className="mt-2 text-[12px] text-gray-500">Admin via {member.adminTeams.map((entry) => entry.name).join(", ")}</p>
+                    ) : null}
                   </div>
                 ))}
               </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -49,7 +49,7 @@ type OrgDashboardContextValue = {
   removeMember: (memberId: string) => Promise<void>;
   transferOwnership: (memberId: string) => Promise<void>;
   createTeam: (input: { name: string; memberIds: string[] }) => Promise<void>;
-  updateTeam: (teamId: string, input: { name?: string; memberIds?: string[] }) => Promise<void>;
+  updateTeam: (teamId: string, input: { name?: string; memberIds?: string[]; grantsOrganizationAdmin?: boolean }) => Promise<void>;
   deleteTeam: (teamId: string) => Promise<void>;
   createRole: (input: { roleName: string; permission: Record<string, string[]> }) => Promise<void>;
   updateRole: (roleId: string, input: { roleName?: string; permission?: Record<string, string[]> }) => Promise<void>;
@@ -784,7 +784,7 @@ export function OrgDashboardProvider({
     });
   }
 
-  async function updateTeam(teamId: string, input: { name?: string; memberIds?: string[] }) {
+  async function updateTeam(teamId: string, input: { name?: string; memberIds?: string[]; grantsOrganizationAdmin?: boolean }) {
     if (!getCurrentAccess().canManageTeams) {
       throw new Error("Only workspace admins can manage teams.");
     }

--- a/ee/packages/den-db/drizzle/0093_team_organization_admin.sql
+++ b/ee/packages/den-db/drizzle/0093_team_organization_admin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `team` ADD `grants_organization_admin` boolean DEFAULT false NOT NULL;

--- a/ee/packages/den-db/drizzle/meta/0093_snapshot.json
+++ b/ee/packages/den-db/drizzle/meta/0093_snapshot.json
@@ -1,0 +1,12235 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "9ec171b4-1026-4c3e-8498-b43afccb8a19",
+  "prevId": "96cd2f65-1938-4864-879b-d6a91e781c2c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_account_id_provider_id": {
+          "name": "account_account_id_provider_id",
+          "columns": [
+            "`account_id`(191)",
+            "`provider_id`(191)"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_config_id": {
+          "name": "apikey_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_reference_id": {
+          "name": "apikey_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key": {
+          "name": "apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apikey_id": {
+          "name": "apikey_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jwks_id": {
+          "name": "jwks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "session_token": {
+          "name": "session_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id": {
+          "name": "session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_email": {
+          "name": "user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_created_at_id": {
+          "name": "user_created_at_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "verification_identifier": {
+          "name": "verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_identity": {
+      "name": "external_identity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_json": {
+          "name": "name_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emails_json": {
+          "name": "emails_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes_json": {
+          "name": "attributes_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_scim_sync_at": {
+          "name": "last_scim_sync_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sso_login_at": {
+          "name": "last_sso_login_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_identity_org_user": {
+          "name": "external_identity_org_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_sso_remote": {
+          "name": "external_identity_org_sso_remote",
+          "columns": [
+            "organization_id",
+            "sso_provider_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_scim_external": {
+          "name": "external_identity_org_scim_external",
+          "columns": [
+            "organization_id",
+            "scim_provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "external_identity_org_email": {
+          "name": "external_identity_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        },
+        "external_identity_sso_provider": {
+          "name": "external_identity_sso_provider",
+          "columns": [
+            "sso_provider_id"
+          ],
+          "isUnique": false
+        },
+        "external_identity_scim_provider": {
+          "name": "external_identity_scim_provider",
+          "columns": [
+            "scim_provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_identity_id": {
+          "name": "external_identity_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_token_token": {
+          "name": "oauth_access_token_token",
+          "columns": [
+            "`token`(191)"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_client_id": {
+          "name": "oauth_access_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_session_id": {
+          "name": "oauth_access_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_user_id": {
+          "name": "oauth_access_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_reference_id": {
+          "name": "oauth_access_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_access_token_refresh_id": {
+          "name": "oauth_access_token_refresh_id",
+          "columns": [
+            "refresh_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthAccessToken_id": {
+          "name": "oauthAccessToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClientAssertion": {
+      "name": "oauthClientAssertion",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClientAssertion_id": {
+          "name": "oauthClientAssertion_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClientResource": {
+      "name": "oauthClientResource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "oauth_client_resource_client_id": {
+          "name": "oauth_client_resource_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_resource_resource_id": {
+          "name": "oauth_client_resource_resource_id",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClientResource_id": {
+          "name": "oauthClientResource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthClient": {
+      "name": "oauthClient",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backchannel_logout_uri": {
+          "name": "backchannel_logout_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backchannel_logout_session_required": {
+          "name": "backchannel_logout_session_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dpop_bound_access_tokens": {
+          "name": "dpop_bound_access_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id": {
+          "name": "oauth_client_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "oauth_client_user_id": {
+          "name": "oauth_client_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_client_reference_id": {
+          "name": "oauth_client_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthClient_id": {
+          "name": "oauthClient_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthConsent": {
+      "name": "oauthConsent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id": {
+          "name": "oauth_consent_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_user_id": {
+          "name": "oauth_consent_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_consent_reference_id": {
+          "name": "oauth_consent_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthConsent_id": {
+          "name": "oauthConsent_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthRefreshToken": {
+      "name": "oauthRefreshToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_replay_response": {
+          "name": "rotation_replay_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_replay_expires_at": {
+          "name": "rotation_replay_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token": {
+          "name": "oauth_refresh_token_token",
+          "columns": [
+            "`token`(191)"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_client_id": {
+          "name": "oauth_refresh_token_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_session_id": {
+          "name": "oauth_refresh_token_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_user_id": {
+          "name": "oauth_refresh_token_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_refresh_token_reference_id": {
+          "name": "oauth_refresh_token_reference_id",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthRefreshToken_id": {
+          "name": "oauthRefreshToken_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "oauthResource": {
+      "name": "oauthResource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_ttl": {
+          "name": "access_token_ttl",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_ttl": {
+          "name": "refresh_token_ttl",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signing_algorithm": {
+          "name": "signing_algorithm",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_claims": {
+          "name": "custom_claims",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dpop_bound_access_tokens_required": {
+          "name": "dpop_bound_access_tokens_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "oauth_resource_identifier": {
+          "name": "oauth_resource_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauthResource_id": {
+          "name": "oauthResource_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_provider": {
+      "name": "scim_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_token": {
+          "name": "scim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_mapping_mode": {
+          "name": "group_mapping_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'metadata_only'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_provider_provider_id": {
+          "name": "scim_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "scim_provider_organization_id": {
+          "name": "scim_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_provider_id": {
+          "name": "scim_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_sync_event": {
+      "name": "scim_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "scim_sync_event_org_status": {
+          "name": "scim_sync_event_org_status",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_provider_status": {
+          "name": "scim_sync_event_provider_status",
+          "columns": [
+            "provider_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_next_retry": {
+          "name": "scim_sync_event_next_retry",
+          "columns": [
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "scim_sync_event_user": {
+          "name": "scim_sync_event_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_sync_event_id": {
+          "name": "scim_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_connection": {
+      "name": "sso_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'disabled'"
+        },
+        "sign_in_path": {
+          "name": "sign_in_path",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_revision": {
+          "name": "config_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "test_status": {
+          "name": "test_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tested_revision": {
+          "name": "last_tested_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verification_token": {
+          "name": "domain_verification_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_intent_id": {
+          "name": "active_test_intent_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_user_id": {
+          "name": "active_test_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_provider_id": {
+          "name": "active_test_provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_config_revision": {
+          "name": "active_test_config_revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_expires_at": {
+          "name": "active_test_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_test_started_at": {
+          "name": "active_test_started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id": {
+          "name": "sso_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_provider_id": {
+          "name": "sso_connection_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_connection_domain": {
+          "name": "sso_connection_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_connection_id": {
+          "name": "sso_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sso_provider": {
+      "name": "sso_provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "sso_provider_provider_id": {
+          "name": "sso_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "sso_provider_domain": {
+          "name": "sso_provider_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_organization_id": {
+          "name": "sso_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "sso_provider_user_id": {
+          "name": "sso_provider_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard_access_grant": {
+      "name": "dashboard_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_access_grant_organization_id": {
+          "name": "dashboard_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_org_membership_id": {
+          "name": "dashboard_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_team_id": {
+          "name": "dashboard_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_org_wide": {
+          "name": "dashboard_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "dashboard_access_grant_dashboard_org_membership": {
+          "name": "dashboard_access_grant_dashboard_org_membership",
+          "columns": [
+            "dashboard_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "dashboard_access_grant_dashboard_team": {
+          "name": "dashboard_access_grant_dashboard_team",
+          "columns": [
+            "dashboard_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_access_grant_id": {
+          "name": "dashboard_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard": {
+      "name": "dashboard",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elements_json": {
+          "name": "elements_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_organization_id": {
+          "name": "dashboard_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_created_by_org_membership_id": {
+          "name": "dashboard_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "dashboard_name": {
+          "name": "dashboard_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy_member": {
+      "name": "desktop_policy_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_policy_member_organization_id": {
+          "name": "desktop_policy_member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_org_member_id": {
+          "name": "desktop_policy_member_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_team_id": {
+          "name": "desktop_policy_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_member_policy_org_member": {
+          "name": "desktop_policy_member_policy_org_member",
+          "columns": [
+            "desktop_policy_id",
+            "org_member_id"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_member_policy_team": {
+          "name": "desktop_policy_member_policy_team",
+          "columns": [
+            "desktop_policy_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_member_id": {
+          "name": "desktop_policy_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_policy": {
+      "name": "desktop_policy",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_name": {
+          "name": "policy_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "policy": {
+          "name": "policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "created_by_org_member_id": {
+          "name": "created_by_org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "desktop_policy_org_external_key": {
+          "name": "desktop_policy_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "desktop_policy_created_by_member_id": {
+          "name": "desktop_policy_created_by_member_id",
+          "columns": [
+            "created_by_org_member_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_is_enabled": {
+          "name": "desktop_policy_is_enabled",
+          "columns": [
+            "is_enabled"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_priority": {
+          "name": "desktop_policy_priority",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_deleted_at": {
+          "name": "desktop_policy_deleted_at",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "desktop_policy_org_default": {
+          "name": "desktop_policy_org_default",
+          "columns": [
+            "organization_id",
+            "is_default"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_policy_id": {
+          "name": "desktop_policy_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_diagnostic_credential": {
+      "name": "organization_diagnostic_credential",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_diagnostic_credential_organization_id": {
+          "name": "organization_diagnostic_credential_organization_id",
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_keys": {
+      "name": "inference_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_keys_key_hash": {
+          "name": "inference_keys_key_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "inference_keys_organization_id": {
+          "name": "inference_keys_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_org_membership_id": {
+          "name": "inference_keys_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_keys_status": {
+          "name": "inference_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_keys_id": {
+          "name": "inference_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_limit_policies": {
+      "name": "inference_org_limit_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "enum('five_hour','weekly','monthly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_strategy": {
+          "name": "reset_strategy",
+          "type": "enum('anchored','activity_based')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_bucket_id": {
+          "name": "current_bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_limit_policies_org_window_type": {
+          "name": "inference_org_limit_policies_org_window_type",
+          "columns": [
+            "organization_id",
+            "window_type"
+          ],
+          "isUnique": true
+        },
+        "inference_org_limit_policies_current_bucket_id": {
+          "name": "inference_org_limit_policies_current_bucket_id",
+          "columns": [
+            "current_bucket_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_limit_policies_id": {
+          "name": "inference_org_limit_policies_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_upstream_provider_keys": {
+      "name": "inference_org_upstream_provider_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openrouter'"
+        },
+        "external_key_hash": {
+          "name": "external_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_workspace_id": {
+          "name": "external_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','revoked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_upstream_provider_keys_external_key_hash": {
+          "name": "inference_org_upstream_provider_keys_external_key_hash",
+          "columns": [
+            "external_key_hash"
+          ],
+          "isUnique": false
+        },
+        "inference_org_upstream_provider_keys_org_provider": {
+          "name": "inference_org_upstream_provider_keys_org_provider",
+          "columns": [
+            "organization_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "inference_org_upstream_provider_keys_status": {
+          "name": "inference_org_upstream_provider_keys_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_upstream_provider_keys_id": {
+          "name": "inference_org_upstream_provider_keys_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_org_usage_buckets": {
+      "name": "inference_org_usage_buckets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_amount": {
+          "name": "used_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "inference_org_usage_buckets_org_window": {
+          "name": "inference_org_usage_buckets_org_window",
+          "columns": [
+            "organization_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        },
+        "inference_org_usage_buckets_policy_window": {
+          "name": "inference_org_usage_buckets_policy_window",
+          "columns": [
+            "policy_id",
+            "window_start_at",
+            "window_end_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_org_usage_buckets_id": {
+          "name": "inference_org_usage_buckets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_bucket_charges": {
+      "name": "inference_usage_ledger_bucket_charges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ledger_entry_id": {
+          "name": "ledger_entry_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_bucket_charges_bucket_id": {
+          "name": "inference_usage_ledger_bucket_charges_bucket_id",
+          "columns": [
+            "bucket_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_bucket_charges_entry_bucket": {
+          "name": "inference_usage_ledger_bucket_charges_entry_bucket",
+          "columns": [
+            "ledger_entry_id",
+            "bucket_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_bucket_charges_id": {
+          "name": "inference_usage_ledger_bucket_charges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "inference_usage_ledger_entries": {
+      "name": "inference_usage_ledger_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inference_key_id": {
+          "name": "inference_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "inference_usage_ledger_entries_organization_id": {
+          "name": "inference_usage_ledger_entries_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_org_membership_id": {
+          "name": "inference_usage_ledger_entries_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_inference_key_id": {
+          "name": "inference_usage_ledger_entries_inference_key_id",
+          "columns": [
+            "inference_key_id"
+          ],
+          "isUnique": false
+        },
+        "inference_usage_ledger_entries_external_event_id": {
+          "name": "inference_usage_ledger_entries_external_event_id",
+          "columns": [
+            "external_event_id"
+          ],
+          "isUnique": true
+        },
+        "inference_usage_ledger_entries_job_event_type": {
+          "name": "inference_usage_ledger_entries_job_event_type",
+          "columns": [
+            "external_job_id",
+            "event_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inference_usage_ledger_entries_id": {
+          "name": "inference_usage_ledger_entries_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_connect_grant": {
+      "name": "desktop_connect_grant",
+      "columns": {
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "install_link_id": {
+          "name": "install_link_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claims": {
+          "name": "claims",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_nonce": {
+          "name": "consumed_nonce",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_connect_grant_install_link_id": {
+          "name": "desktop_connect_grant_install_link_id",
+          "columns": [
+            "install_link_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_connect_grant_expires_at": {
+          "name": "desktop_connect_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_connect_grant_code_hash": {
+          "name": "desktop_connect_grant_code_hash",
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_handoff_grant": {
+      "name": "desktop_handoff_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_handoff_grant_user_id": {
+          "name": "desktop_handoff_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_handoff_grant_expires_at": {
+          "name": "desktop_handoff_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_handoff_grant_id": {
+          "name": "desktop_handoff_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "install_link": {
+      "name": "install_link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "install_link_token_hash": {
+          "name": "install_link_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "install_link_organization_id": {
+          "name": "install_link_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "install_link_created_by_user_id": {
+          "name": "install_link_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "install_link_revoked_at": {
+          "name": "install_link_revoked_at",
+          "columns": [
+            "revoked_at"
+          ],
+          "isUnique": false
+        },
+        "install_link_expires_at": {
+          "name": "install_link_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "install_link_id": {
+          "name": "install_link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_member_id": {
+          "name": "org_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id": {
+          "name": "invitation_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email": {
+          "name": "invitation_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_status": {
+          "name": "invitation_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "invitation_team_id": {
+          "name": "invitation_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_inviter_id": {
+          "name": "invitation_inviter_id",
+          "columns": [
+            "inviter_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_member_id": {
+          "name": "invitation_org_member_id",
+          "columns": [
+            "org_member_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_invite_token": {
+          "name": "invitation_invite_token",
+          "columns": [
+            "invite_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by_org_member": {
+          "name": "invited_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by_org_member": {
+          "name": "removed_by_org_member",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "member_user_id": {
+          "name": "member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_invite_id": {
+          "name": "member_invite_id",
+          "columns": [
+            "invite_id"
+          ],
+          "isUnique": false
+        },
+        "member_invited_by_org_member": {
+          "name": "member_invited_by_org_member",
+          "columns": [
+            "invited_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_removed_at": {
+          "name": "member_removed_at",
+          "columns": [
+            "removed_at"
+          ],
+          "isUnique": false
+        },
+        "member_removed_by_org_member": {
+          "name": "member_removed_by_org_member",
+          "columns": [
+            "removed_by_org_member"
+          ],
+          "isUnique": false
+        },
+        "member_organization_user": {
+          "name": "member_organization_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "member_id": {
+          "name": "member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_brand_asset": {
+      "name": "organization_brand_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extension": {
+          "name": "extension",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "mediumblob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "organization_brand_asset_version": {
+          "name": "organization_brand_asset_version",
+          "columns": [
+            "organization_id",
+            "kind",
+            "version",
+            "extension"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_brand_asset_id": {
+          "name": "organization_brand_asset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_role": {
+      "name": "organization_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_role_name": {
+          "name": "organization_role_name",
+          "columns": [
+            "organization_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_role_id": {
+          "name": "organization_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_email_domains": {
+          "name": "allowed_email_domains",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_app_restrictions": {
+          "name": "desktop_app_restrictions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(json_object())"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_slug": {
+          "name": "organization_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_created_at_id": {
+          "name": "organization_created_at_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_id": {
+          "name": "organization_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_bootstrap": {
+      "name": "workspace_bootstrap",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "setup_member_id": {
+          "name": "setup_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_public_key": {
+          "name": "device_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_key_fingerprint": {
+          "name": "device_key_fingerprint",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisional'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_bootstrap_organization_id": {
+          "name": "workspace_bootstrap_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_status": {
+          "name": "workspace_bootstrap_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_bootstrap_expires_at": {
+          "name": "workspace_bootstrap_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_bootstrap_id": {
+          "name": "workspace_bootstrap_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workspace_claim": {
+      "name": "workspace_claim",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bootstrap_id": {
+          "name": "bootstrap_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workspace_claim_token_hash": {
+          "name": "workspace_claim_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "workspace_claim_bootstrap_id": {
+          "name": "workspace_claim_bootstrap_id",
+          "columns": [
+            "bootstrap_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_organization_id": {
+          "name": "workspace_claim_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_status": {
+          "name": "workspace_claim_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "workspace_claim_expires_at": {
+          "name": "workspace_claim_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workspace_claim_id": {
+          "name": "workspace_claim_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "remote_mcp_app": {
+      "name": "remote_mcp_app",
+      "columns": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_source_url": {
+          "name": "resolved_source_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','retired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_mcp_app_organization_id": {
+          "name": "remote_mcp_app_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "remote_mcp_app_plugin_id": {
+          "name": "remote_mcp_app_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": true
+        },
+        "remote_mcp_app_active_version_id": {
+          "name": "remote_mcp_app_active_version_id",
+          "columns": [
+            "active_version_id"
+          ],
+          "isUnique": false
+        },
+        "remote_mcp_app_status": {
+          "name": "remote_mcp_app_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remote_mcp_app_config_object_id": {
+          "name": "remote_mcp_app_config_object_id",
+          "columns": [
+            "config_object_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "remote_session_command": {
+      "name": "remote_session_command",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','claimed','delivered','failed','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_model_id": {
+          "name": "model_model_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "claimed_by_runner_id": {
+          "name": "claimed_by_runner_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "remote_session_command_idempotency_key": {
+          "name": "remote_session_command_idempotency_key",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "remote_session_command_owner_status": {
+          "name": "remote_session_command_owner_status",
+          "columns": [
+            "org_id",
+            "owner_member_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "remote_session_command_status_expires": {
+          "name": "remote_session_command_status_expires",
+          "columns": [
+            "status",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remote_session_command_id": {
+          "name": "remote_session_command_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_member": {
+      "name": "scim_group_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_user_id": {
+          "name": "remote_user_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_member_group_remote_user": {
+          "name": "scim_group_member_group_remote_user",
+          "columns": [
+            "group_id",
+            "remote_user_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_member_membership_key": {
+          "name": "scim_group_member_membership_key",
+          "columns": [
+            "membership_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_member_user_id": {
+          "name": "scim_group_member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_org_membership_id": {
+          "name": "scim_group_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_team_member_id": {
+          "name": "scim_group_member_team_member_id",
+          "columns": [
+            "team_member_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_member_provider_org": {
+          "name": "scim_group_member_provider_org",
+          "columns": [
+            "provider_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_member_id": {
+          "name": "scim_group_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_role_grant": {
+      "name": "scim_group_role_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_grant_key": {
+          "name": "role_grant_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_role_projected": {
+          "name": "is_role_projected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_role_grant_role_grant_key": {
+          "name": "scim_group_role_grant_role_grant_key",
+          "columns": [
+            "role_grant_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_role_grant_group_id": {
+          "name": "scim_group_role_grant_group_id",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_role_grant_provider_org": {
+          "name": "scim_group_role_grant_provider_org",
+          "columns": [
+            "provider_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scim_group_role_grant_user_id": {
+          "name": "scim_group_role_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_role_grant_id": {
+          "name": "scim_group_role_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group_role": {
+      "name": "scim_group_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_key": {
+          "name": "role_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_role_role_key": {
+          "name": "scim_group_role_role_key",
+          "columns": [
+            "role_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_role_group_id": {
+          "name": "scim_group_role_group_id",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_role_id": {
+          "name": "scim_group_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_group": {
+      "name": "scim_group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scim_group_id": {
+          "name": "scim_group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id_key": {
+          "name": "external_id_key",
+          "type": "varchar(768)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_group_scim_group_id": {
+          "name": "scim_group_scim_group_id",
+          "columns": [
+            "scim_group_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_provider_external_id": {
+          "name": "scim_group_provider_external_id",
+          "columns": [
+            "provider_id",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_external_id_key": {
+          "name": "scim_group_external_id_key",
+          "columns": [
+            "external_id_key"
+          ],
+          "isUnique": true
+        },
+        "scim_group_team_id": {
+          "name": "scim_group_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true
+        },
+        "scim_group_organization_id": {
+          "name": "scim_group_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_group_id": {
+          "name": "scim_group_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scim_user_tombstone": {
+      "name": "scim_user_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deprovisioned_user_id": {
+          "name": "deprovisioned_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deprovisioned_at": {
+          "name": "deprovisioned_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "scim_user_tombstone_org_user": {
+          "name": "scim_user_tombstone_org_user",
+          "columns": [
+            "organization_id",
+            "deprovisioned_user_id"
+          ],
+          "isUnique": true
+        },
+        "scim_user_tombstone_org_external_id": {
+          "name": "scim_user_tombstone_org_external_id",
+          "columns": [
+            "organization_id",
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "scim_user_tombstone_org_email": {
+          "name": "scim_user_tombstone_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scim_user_tombstone_id": {
+          "name": "scim_user_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_revision": {
+      "name": "automation_revision",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_kind": {
+          "name": "schedule_kind",
+          "type": "enum('once','daily','weekly')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "enum('desktop','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maximum_runtime_ms": {
+          "name": "maximum_runtime_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "digest": {
+          "name": "digest",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_revision_version": {
+          "name": "automation_revision_version",
+          "columns": [
+            "automation_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_revision_id": {
+          "name": "automation_revision_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_run_event": {
+      "name": "automation_run_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engine_event_id": {
+          "name": "engine_event_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_idempotency_key": {
+          "name": "engine_idempotency_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_execution_id": {
+          "name": "engine_execution_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('user','assistant','capability_search','capability_execution','usage','warning','terminal')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_run_event_sequence": {
+          "name": "automation_run_event_sequence",
+          "columns": [
+            "run_id",
+            "attempt",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "automation_run_engine_event": {
+          "name": "automation_run_engine_event",
+          "columns": [
+            "run_id",
+            "engine_idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "automation_run_event_created": {
+          "name": "automation_run_event_created",
+          "columns": [
+            "run_id",
+            "attempt",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_run_event_id": {
+          "name": "automation_run_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_run": {
+      "name": "automation_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "enum('scheduled','recovery','manual')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('queued','claimed','running','succeeded','failed','cancelled','skipped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "execution_target": {
+          "name": "execution_target",
+          "type": "enum('desktop','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "claim_deadline_at": {
+          "name": "claim_deadline_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cloud_thread_id": {
+          "name": "cloud_thread_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engine_kind": {
+          "name": "engine_kind",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_receipt": {
+          "name": "engine_receipt",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_sequence": {
+          "name": "engine_sequence",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "engine_admitted_at": {
+          "name": "engine_admitted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_variant": {
+          "name": "model_variant",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codemode_receipt_id": {
+          "name": "codemode_receipt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_result": {
+          "name": "validated_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_token_hash": {
+          "name": "mcp_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_token_expires_at": {
+          "name": "mcp_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_run_occurrence": {
+          "name": "automation_run_occurrence",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "automation_run_cloud_thread": {
+          "name": "automation_run_cloud_thread",
+          "columns": [
+            "cloud_thread_id"
+          ],
+          "isUnique": true
+        },
+        "automation_run_claimable": {
+          "name": "automation_run_claimable",
+          "columns": [
+            "status",
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        },
+        "automation_run_history": {
+          "name": "automation_run_history",
+          "columns": [
+            "automation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_runner_notification": {
+      "name": "automation_runner_notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('work_available','cancellation')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_runner_notification_owner_cursor": {
+          "name": "automation_runner_notification_owner_cursor",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_runner_notification_id": {
+          "name": "automation_runner_notification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation_runner": {
+      "name": "automation_runner",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supported_execution_targets": {
+          "name": "supported_execution_targets",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "enum('darwin','win32','linux')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concurrency": {
+          "name": "concurrency",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_runner_owner_seen": {
+          "name": "automation_runner_owner_seen",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_runner_id": {
+          "name": "automation_runner_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "automation": {
+      "name": "automation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('active','inactive','needs_attention','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_run_at": {
+          "name": "latest_run_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "needs_attention_reason": {
+          "name": "needs_attention_reason",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_successful_run_id": {
+          "name": "latest_successful_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_successful_result": {
+          "name": "latest_successful_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "automation_org_owner_state": {
+          "name": "automation_org_owner_state",
+          "columns": [
+            "organization_id",
+            "owner_member_id",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "automation_due": {
+          "name": "automation_due",
+          "columns": [
+            "state",
+            "next_due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "automation_id": {
+          "name": "automation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "artifact_view_revision": {
+      "name": "artifact_view_revision",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_member_id": {
+          "name": "created_by_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "react_source": {
+          "name": "react_source",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "css_source": {
+          "name": "css_source",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiled_html": {
+          "name": "compiled_html",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "build_diagnostics": {
+          "name": "build_diagnostics",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "build_status": {
+          "name": "build_status",
+          "type": "enum('ready','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_digest": {
+          "name": "source_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_digest": {
+          "name": "resource_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema_digest": {
+          "name": "output_schema_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csp": {
+          "name": "csp",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiler_name": {
+          "name": "compiler_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiler_version": {
+          "name": "compiler_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "react_version": {
+          "name": "react_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compiled_html_bytes": {
+          "name": "compiled_html_bytes",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "artifact_view_revision_view_created": {
+          "name": "artifact_view_revision_view_created",
+          "columns": [
+            "artifact_view_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_revision_org_status": {
+          "name": "artifact_view_revision_org_status",
+          "columns": [
+            "organization_id",
+            "build_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "artifact_view_revision_id": {
+          "name": "artifact_view_revision_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "artifact_view": {
+      "name": "artifact_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','retired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "active_revision_id": {
+          "name": "active_revision_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_in_workflow": {
+          "name": "use_in_workflow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "artifact_view_org_script": {
+          "name": "artifact_view_org_script",
+          "columns": [
+            "organization_id",
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_org_owner": {
+          "name": "artifact_view_org_owner",
+          "columns": [
+            "organization_id",
+            "owner_member_id"
+          ],
+          "isUnique": false
+        },
+        "artifact_view_active_revision": {
+          "name": "artifact_view_active_revision",
+          "columns": [
+            "active_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "dashboard_app": {
+      "name": "dashboard_app",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_view_id": {
+          "name": "artifact_view_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "dashboard_app_organization_id_member_id_artifact_view_id_pk": {
+          "name": "dashboard_app_organization_id_member_id_artifact_view_id_pk",
+          "columns": [
+            "organization_id",
+            "member_id",
+            "artifact_view_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workflow_run": {
+      "name": "workflow_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "automation_run_id": {
+          "name": "automation_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('succeeded','failed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_kind": {
+          "name": "error_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "script_input": {
+          "name": "script_input",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "script_input_digest": {
+          "name": "script_input_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_schema_digest": {
+          "name": "input_schema_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_result": {
+          "name": "validated_result",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_markdown": {
+          "name": "result_markdown",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_digest": {
+          "name": "result_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema_digest": {
+          "name": "output_schema_digest",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_content_deleted_at": {
+          "name": "artifact_content_deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "workflow_run_org_created": {
+          "name": "workflow_run_org_created",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "workflow_run_automation": {
+          "name": "workflow_run_automation",
+          "columns": [
+            "automation_run_id"
+          ],
+          "isUnique": false
+        },
+        "workflow_run_artifact_history": {
+          "name": "workflow_run_artifact_history",
+          "columns": [
+            "config_object_id",
+            "finished_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connected_account": {
+      "name": "connected_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_health": {
+          "name": "credential_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connected_account_organization_id": {
+          "name": "connected_account_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connected_account_member_provider": {
+          "name": "connected_account_member_provider",
+          "columns": [
+            "org_membership_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection_access_grant": {
+      "name": "external_mcp_connection_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_mcp_requirement_binding_id": {
+          "name": "plugin_mcp_requirement_binding_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "emc_access_grant_organization_id": {
+          "name": "emc_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_connection_id": {
+          "name": "emc_access_grant_connection_id",
+          "columns": [
+            "external_mcp_connection_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_plugin_mcp_binding_id": {
+          "name": "emc_access_grant_plugin_mcp_binding_id",
+          "columns": [
+            "plugin_mcp_requirement_binding_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_org_membership_id": {
+          "name": "emc_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_team_id": {
+          "name": "emc_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "emc_access_grant_connection_member": {
+          "name": "emc_access_grant_connection_member",
+          "columns": [
+            "external_mcp_connection_id",
+            "org_membership_id",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "emc_access_grant_connection_team": {
+          "name": "emc_access_grant_connection_team",
+          "columns": [
+            "external_mcp_connection_id",
+            "team_id",
+            "source_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_access_grant_id": {
+          "name": "external_mcp_connection_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "external_mcp_connection": {
+      "name": "external_mcp_connection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum('external_mcp','native_provider')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'external_mcp'"
+        },
+        "native_provider_key": {
+          "name": "native_provider_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_configuration": {
+          "name": "oauth_configuration",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_policy": {
+          "name": "tool_policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expose_directly": {
+          "name": "expose_directly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "enum('shared','per_member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_code_verifier": {
+          "name": "pending_code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_health": {
+          "name": "credential_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_issuer_review_required_at": {
+          "name": "oauth_issuer_review_required_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "external_mcp_connection_organization_id": {
+          "name": "external_mcp_connection_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "external_mcp_connection_org_external_key": {
+          "name": "external_mcp_connection_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_oauth_client": {
+      "name": "org_oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_oauth_client_org_provider": {
+          "name": "org_oauth_client_org_provider",
+          "columns": [
+            "organization_id",
+            "provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_oauth_client_id": {
+          "name": "org_oauth_client_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_mcp_requirement_binding": {
+      "name": "plugin_mcp_requirement_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_mcp_connection_id": {
+          "name": "external_mcp_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "required_auth_type": {
+          "name": "required_auth_type",
+          "type": "enum('oauth','apikey','none')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connection_owned_by_plugin": {
+          "name": "connection_owned_by_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "plugin_mcp_req_binding_plugin_id": {
+          "name": "plugin_mcp_req_binding_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_config_object_id": {
+          "name": "plugin_mcp_req_binding_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_connection_id": {
+          "name": "plugin_mcp_req_binding_connection_id",
+          "columns": [
+            "external_mcp_connection_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_mcp_req_binding_org_plugin_object_server": {
+          "name": "plugin_mcp_req_binding_org_plugin_object_server",
+          "columns": [
+            "organization_id",
+            "plugin_id",
+            "config_object_id",
+            "server_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_mcp_requirement_binding_id": {
+          "name": "plugin_mcp_requirement_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_access": {
+      "name": "llm_provider_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_access_org_membership_id": {
+          "name": "llm_provider_access_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_team_id": {
+          "name": "llm_provider_access_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_access_provider_org_membership": {
+          "name": "llm_provider_access_provider_org_membership",
+          "columns": [
+            "llm_provider_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_access_provider_team": {
+          "name": "llm_provider_access_provider_team",
+          "columns": [
+            "llm_provider_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_access_id": {
+          "name": "llm_provider_access_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_member_credential": {
+      "name": "llm_provider_member_credential",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_principal_id": {
+          "name": "external_principal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_credential_id": {
+          "name": "external_credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum('active','blocked','stale','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "enum('member','admin','provisioner')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_member_credential_organization_id": {
+          "name": "llm_provider_member_credential_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_member_credential_member_provider": {
+          "name": "llm_provider_member_credential_member_provider",
+          "columns": [
+            "org_membership_id",
+            "llm_provider_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_member_credential_id": {
+          "name": "llm_provider_member_credential_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider_model": {
+      "name": "llm_provider_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_config": {
+          "name": "model_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "llm_provider_model_model_id": {
+          "name": "llm_provider_model_model_id",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_model_provider_model": {
+          "name": "llm_provider_model_provider_model",
+          "columns": [
+            "llm_provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_model_id": {
+          "name": "llm_provider_model_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "llm_provider": {
+      "name": "llm_provider",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum('models_dev','custom','openwork')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "enum('shared','per_member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'shared'"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "llm_provider_org_external_key": {
+          "name": "llm_provider_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "llm_provider_organization_id": {
+          "name": "llm_provider_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_created_by_org_membership_id": {
+          "name": "llm_provider_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_source": {
+          "name": "llm_provider_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_provider_provider_id": {
+          "name": "llm_provider_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "llm_provider_id": {
+          "name": "llm_provider_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_access_grant": {
+      "name": "config_object_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_access_grant_organization_id": {
+          "name": "config_object_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_membership_id": {
+          "name": "config_object_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_team_id": {
+          "name": "config_object_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_org_wide": {
+          "name": "config_object_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "config_object_access_grant_object_org_membership": {
+          "name": "config_object_access_grant_object_org_membership",
+          "columns": [
+            "config_object_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "config_object_access_grant_object_team": {
+          "name": "config_object_access_grant_object_team",
+          "columns": [
+            "config_object_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_access_grant_id": {
+          "name": "config_object_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object": {
+      "name": "config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom','script','workflow','app')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_mode": {
+          "name": "source_mode",
+          "type": "enum('cloud','import','connector')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_name": {
+          "name": "current_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_file_extension": {
+          "name": "current_file_extension",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_relative_path": {
+          "name": "current_relative_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "config_object_organization_id": {
+          "name": "config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_type": {
+          "name": "config_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "config_object_source_mode": {
+          "name": "config_object_source_mode",
+          "columns": [
+            "source_mode"
+          ],
+          "isUnique": false
+        },
+        "config_object_status": {
+          "name": "config_object_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "config_object_created_by_org_membership_id": {
+          "name": "config_object_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_connector_instance_id": {
+          "name": "config_object_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_current_relative_path": {
+          "name": "config_object_current_relative_path",
+          "columns": [
+            "current_relative_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_id": {
+          "name": "config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "config_object_version": {
+      "name": "config_object_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_payload_json": {
+          "name": "normalized_payload_json",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_source_text": {
+          "name": "raw_source_text",
+          "type": "mediumtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "enum('cloud','import','connector','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted_version": {
+          "name": "is_deleted_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "config_object_version_organization_id": {
+          "name": "config_object_version_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_created_by_org_membership_id": {
+          "name": "config_object_version_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_connector_sync_event_id": {
+          "name": "config_object_version_connector_sync_event_id",
+          "columns": [
+            "connector_sync_event_id"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_source_revision_ref": {
+          "name": "config_object_version_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "config_object_version_lookup_latest": {
+          "name": "config_object_version_lookup_latest",
+          "columns": [
+            "config_object_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "config_object_version_id": {
+          "name": "config_object_version_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_account": {
+      "name": "connector_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_account_ref": {
+          "name": "external_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','disconnected','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_account_created_by_org_membership_id": {
+          "name": "connector_account_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_connector_type": {
+          "name": "connector_account_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "idx_connector_account_on_remote_id": {
+          "name": "idx_connector_account_on_remote_id",
+          "columns": [
+            "remote_id"
+          ],
+          "isUnique": false
+        },
+        "connector_account_status": {
+          "name": "connector_account_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_account_org_type_remote_id": {
+          "name": "connector_account_org_type_remote_id",
+          "columns": [
+            "organization_id",
+            "connector_type",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance_access_grant": {
+      "name": "connector_instance_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instance_access_grant_organization_id": {
+          "name": "connector_instance_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_membership_id": {
+          "name": "connector_instance_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_team_id": {
+          "name": "connector_instance_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_org_wide": {
+          "name": "connector_instance_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_access_grant_instance_org_membership": {
+          "name": "connector_instance_access_grant_instance_org_membership",
+          "columns": [
+            "connector_instance_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "connector_instance_access_grant_instance_team": {
+          "name": "connector_instance_access_grant_instance_team",
+          "columns": [
+            "connector_instance_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_access_grant_id": {
+          "name": "connector_instance_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_instance": {
+      "name": "connector_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','disabled','archived','error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "instance_config_json": {
+          "name": "instance_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_cursor": {
+          "name": "last_sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_instance_connector_account_id": {
+          "name": "connector_instance_connector_account_id",
+          "columns": [
+            "connector_account_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_created_by_org_membership_id": {
+          "name": "connector_instance_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_connector_type": {
+          "name": "connector_instance_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_status": {
+          "name": "connector_instance_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_instance_org_name": {
+          "name": "connector_instance_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_mapping": {
+      "name": "connector_mapping",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mapping_kind": {
+          "name": "mapping_kind",
+          "type": "enum('path','api','custom')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "enum('skill','agent','command','tool','mcp','hook','context','custom','script','workflow','app')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_add_to_plugin": {
+          "name": "auto_add_to_plugin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "mapping_config_json": {
+          "name": "mapping_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_mapping_organization_id": {
+          "name": "connector_mapping_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_connector_instance_id": {
+          "name": "connector_mapping_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_object_type": {
+          "name": "connector_mapping_object_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_plugin_id": {
+          "name": "connector_mapping_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "connector_mapping_target_selector_object_type": {
+          "name": "connector_mapping_target_selector_object_type",
+          "columns": [
+            "connector_target_id",
+            "selector",
+            "object_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_binding": {
+      "name": "connector_source_binding",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_stable_ref": {
+          "name": "external_stable_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_source_revision_ref": {
+          "name": "last_seen_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived','ingestion_error')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_source_binding_organization_id": {
+          "name": "connector_source_binding_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_instance_id": {
+          "name": "connector_source_binding_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_target_id": {
+          "name": "connector_source_binding_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_connector_mapping_id": {
+          "name": "connector_source_binding_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_external_locator": {
+          "name": "connector_source_binding_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_binding_config_object": {
+          "name": "connector_source_binding_config_object",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_binding_id": {
+          "name": "connector_source_binding_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_source_tombstone": {
+      "name": "connector_source_tombstone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_locator": {
+          "name": "external_locator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "former_config_object_id": {
+          "name": "former_config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_in_sync_event_id": {
+          "name": "deleted_in_sync_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_source_revision_ref": {
+          "name": "deleted_source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "connector_source_tombstone_organization_id": {
+          "name": "connector_source_tombstone_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_instance_id": {
+          "name": "connector_source_tombstone_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_target_id": {
+          "name": "connector_source_tombstone_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_connector_mapping_id": {
+          "name": "connector_source_tombstone_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_external_locator": {
+          "name": "connector_source_tombstone_external_locator",
+          "columns": [
+            "external_locator"
+          ],
+          "isUnique": false
+        },
+        "connector_source_tombstone_former_config_object_id": {
+          "name": "connector_source_tombstone_former_config_object_id",
+          "columns": [
+            "former_config_object_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_source_tombstone_id": {
+          "name": "connector_source_tombstone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_sync_event": {
+      "name": "connector_sync_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum('push','installation','installation_repositories','repository','manual_resync')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_event_ref": {
+          "name": "external_event_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_revision_ref": {
+          "name": "source_revision_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','queued','running','completed','failed','partial','ignored')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_sync_event_organization_id": {
+          "name": "connector_sync_event_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_instance_id": {
+          "name": "connector_sync_event_connector_instance_id",
+          "columns": [
+            "connector_instance_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_connector_target_id": {
+          "name": "connector_sync_event_connector_target_id",
+          "columns": [
+            "connector_target_id"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_target_status": {
+          "name": "connector_sync_event_target_status",
+          "columns": [
+            "connector_target_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_event_type": {
+          "name": "connector_sync_event_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status": {
+          "name": "connector_sync_event_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_status_next_attempt_at": {
+          "name": "connector_sync_event_status_next_attempt_at",
+          "columns": [
+            "status",
+            "next_attempt_at"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_source_revision_ref": {
+          "name": "connector_sync_event_source_revision_ref",
+          "columns": [
+            "source_revision_ref"
+          ],
+          "isUnique": false
+        },
+        "connector_sync_event_external_event_ref": {
+          "name": "connector_sync_event_external_event_ref",
+          "columns": [
+            "external_event_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_sync_event_id": {
+          "name": "connector_sync_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "connector_target": {
+      "name": "connector_target",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_instance_id": {
+          "name": "connector_instance_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "enum('github')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "enum('repository_branch')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_target_ref": {
+          "name": "external_target_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_config_json": {
+          "name": "target_config_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "connector_target_organization_id": {
+          "name": "connector_target_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_connector_type": {
+          "name": "connector_target_connector_type",
+          "columns": [
+            "connector_type"
+          ],
+          "isUnique": false
+        },
+        "connector_target_type_created_id": {
+          "name": "connector_target_type_created_id",
+          "columns": [
+            "connector_type",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "connector_target_target_kind": {
+          "name": "connector_target_target_kind",
+          "columns": [
+            "target_kind"
+          ],
+          "isUnique": false
+        },
+        "connector_target_instance_remote_id": {
+          "name": "connector_target_instance_remote_id",
+          "columns": [
+            "connector_instance_id",
+            "remote_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_target_id": {
+          "name": "connector_target_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_access_grant": {
+      "name": "marketplace_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_access_grant_organization_id": {
+          "name": "marketplace_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_membership_id": {
+          "name": "marketplace_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_team_id": {
+          "name": "marketplace_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_org_wide": {
+          "name": "marketplace_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "marketplace_access_grant_marketplace_org_membership": {
+          "name": "marketplace_access_grant_marketplace_org_membership",
+          "columns": [
+            "marketplace_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "marketplace_access_grant_marketplace_team": {
+          "name": "marketplace_access_grant_marketplace_team",
+          "columns": [
+            "marketplace_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_access_grant_id": {
+          "name": "marketplace_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace_plugin": {
+      "name": "marketplace_plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_plugin_organization_id": {
+          "name": "marketplace_plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_plugin_id": {
+          "name": "marketplace_plugin_plugin_id",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_plugin_marketplace_plugin": {
+          "name": "marketplace_plugin_marketplace_plugin",
+          "columns": [
+            "marketplace_id",
+            "plugin_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_plugin_id": {
+          "name": "marketplace_plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "marketplace": {
+      "name": "marketplace",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "marketplace_org_external_key": {
+          "name": "marketplace_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "marketplace_organization_id": {
+          "name": "marketplace_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_created_by_org_membership_id": {
+          "name": "marketplace_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "marketplace_status": {
+          "name": "marketplace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "marketplace_id": {
+          "name": "marketplace_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_access_grant": {
+      "name": "plugin_access_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_wide": {
+          "name": "org_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('viewer','editor','manager')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_access_grant_organization_id": {
+          "name": "plugin_access_grant_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_membership_id": {
+          "name": "plugin_access_grant_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_team_id": {
+          "name": "plugin_access_grant_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_org_wide": {
+          "name": "plugin_access_grant_org_wide",
+          "columns": [
+            "org_wide"
+          ],
+          "isUnique": false
+        },
+        "plugin_access_grant_plugin_org_membership": {
+          "name": "plugin_access_grant_plugin_org_membership",
+          "columns": [
+            "plugin_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "plugin_access_grant_plugin_team": {
+          "name": "plugin_access_grant_plugin_team",
+          "columns": [
+            "plugin_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_access_grant_id": {
+          "name": "plugin_access_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin_config_object": {
+      "name": "plugin_config_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_object_id": {
+          "name": "config_object_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_source": {
+          "name": "membership_source",
+          "type": "enum('manual','connector','api','system')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "connector_mapping_id": {
+          "name": "connector_mapping_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_config_object_organization_id": {
+          "name": "plugin_config_object_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_config_object_id": {
+          "name": "plugin_config_object_config_object_id",
+          "columns": [
+            "config_object_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_connector_mapping_id": {
+          "name": "plugin_config_object_connector_mapping_id",
+          "columns": [
+            "connector_mapping_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_config_object_plugin_config_object": {
+          "name": "plugin_config_object_plugin_config_object",
+          "columns": [
+            "plugin_id",
+            "config_object_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_config_object_id": {
+          "name": "plugin_config_object_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plugin": {
+      "name": "plugin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_repository_url": {
+          "name": "source_repository_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_format": {
+          "name": "source_format",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_schema_version": {
+          "name": "source_schema_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','inactive','deleted','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_organization_id": {
+          "name": "plugin_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_created_by_org_membership_id": {
+          "name": "plugin_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_status": {
+          "name": "plugin_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "org_subscriptions": {
+      "name": "org_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('inference','seat','web')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('incomplete','incomplete_expired','trialing','active','past_due','canceled','unpaid','paused','expired')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "payment_failed": {
+          "name": "payment_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_customer_id": {
+          "name": "org_subscriptions_customer_id",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": false
+        },
+        "org_subscriptions_subscription_id": {
+          "name": "org_subscriptions_subscription_id",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_org_type": {
+          "name": "org_subscriptions_org_type",
+          "columns": [
+            "organization_id",
+            "type"
+          ],
+          "isUnique": true
+        },
+        "org_subscriptions_status": {
+          "name": "org_subscriptions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_subscriptions_id": {
+          "name": "org_subscriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_member": {
+      "name": "team_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "membership_key": {
+          "name": "membership_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_member_org_membership_id": {
+          "name": "team_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_user_id": {
+          "name": "team_member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_membership_key": {
+          "name": "team_member_membership_key",
+          "columns": [
+            "membership_key"
+          ],
+          "isUnique": true
+        },
+        "team_member_team_org_membership": {
+          "name": "team_member_team_org_membership",
+          "columns": [
+            "team_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_member_id": {
+          "name": "team_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grants_organization_admin": {
+          "name": "grants_organization_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "team_org_external_key": {
+          "name": "team_org_external_key",
+          "columns": [
+            "organization_id",
+            "external_key"
+          ],
+          "isUnique": true
+        },
+        "team_organization_name": {
+          "name": "team_organization_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_id": {
+          "name": "team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "temp_file": {
+      "name": "temp_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upload_token_hash": {
+          "name": "upload_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_token_hash": {
+          "name": "download_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'application/octet-stream'"
+        },
+        "max_bytes": {
+          "name": "max_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "enum('volume','s3')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','uploaded')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expected_sha256": {
+          "name": "expected_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "temp_file_upload_token_hash": {
+          "name": "temp_file_upload_token_hash",
+          "columns": [
+            "upload_token_hash"
+          ],
+          "isUnique": true
+        },
+        "temp_file_download_token_hash": {
+          "name": "temp_file_download_token_hash",
+          "columns": [
+            "download_token_hash"
+          ],
+          "isUnique": true
+        },
+        "temp_file_organization_id": {
+          "name": "temp_file_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "temp_file_expires_at": {
+          "name": "temp_file_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "temp_file_id": {
+          "name": "temp_file_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_event": {
+      "name": "audit_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_event_org_id": {
+          "name": "audit_event_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "audit_event_worker_id": {
+          "name": "audit_event_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "daytona_sandbox": {
+      "name": "daytona_sandbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_volume_id": {
+          "name": "workspace_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_volume_id": {
+          "name": "data_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url": {
+          "name": "signed_preview_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url_expires_at": {
+          "name": "signed_preview_url_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "daytona_sandbox_worker_id": {
+          "name": "daytona_sandbox_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": true
+        },
+        "daytona_sandbox_sandbox_id": {
+          "name": "daytona_sandbox_sandbox_id",
+          "columns": [
+            "sandbox_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daytona_sandbox_id": {
+          "name": "daytona_sandbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_bundle": {
+      "name": "worker_bundle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "worker_bundle_worker_id": {
+          "name": "worker_bundle_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_bundle_id": {
+          "name": "worker_bundle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_instance": {
+      "name": "worker_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_instance_worker_id": {
+          "name": "worker_instance_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "enum('local','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_backend": {
+          "name": "sandbox_backend",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_code": {
+          "name": "cloud_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_stage": {
+          "name": "cloud_failure_stage",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_reference": {
+          "name": "cloud_failure_reference",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloud_failure_at": {
+          "name": "cloud_failure_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_org_id": {
+          "name": "worker_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "worker_created_by_user_id": {
+          "name": "worker_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "worker_status": {
+          "name": "worker_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "worker_last_heartbeat_at": {
+          "name": "worker_last_heartbeat_at",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        },
+        "worker_last_active_at": {
+          "name": "worker_last_active_at",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        },
+        "worker_claimable_updated": {
+          "name": "worker_claimable_updated",
+          "columns": [
+            "destination",
+            "sandbox_backend",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_id": {
+          "name": "worker_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_token": {
+      "name": "worker_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('client','host','activity')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worker_token_worker_id": {
+          "name": "worker_token_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        },
+        "worker_token_token": {
+          "name": "worker_token_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_token_id": {
+          "name": "worker_token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_allowlist": {
+      "name": "admin_allowlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "admin_allowlist_email": {
+          "name": "admin_allowlist_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_allowlist_id": {
+          "name": "admin_allowlist_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit": {
+      "name": "rate_limit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_key": {
+          "name": "rate_limit_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_id": {
+          "name": "rate_limit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_event": {
+      "name": "telemetry_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_event_org_id_type_ts": {
+          "name": "telemetry_event_org_id_type_ts",
+          "columns": [
+            "org_id",
+            "event_type",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_id_member_id": {
+          "name": "telemetry_event_org_id_member_id",
+          "columns": [
+            "org_id",
+            "member_id"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_member_ts": {
+          "name": "telemetry_event_member_ts",
+          "columns": [
+            "member_id",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        },
+        "telemetry_event_org_session_ts": {
+          "name": "telemetry_event_org_session_ts",
+          "columns": [
+            "org_id",
+            "session_id",
+            "event_timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_event_id": {
+          "name": "telemetry_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "telemetry_session_dimension": {
+      "name": "telemetry_session_dimension",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_type": {
+          "name": "dimension_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_value": {
+          "name": "dimension_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_label": {
+          "name": "dimension_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "telemetry_session_dimension_org_source_session_type": {
+          "name": "telemetry_session_dimension_org_source_session_type",
+          "columns": [
+            "org_id",
+            "source",
+            "session_id",
+            "dimension_type"
+          ],
+          "isUnique": true
+        },
+        "telemetry_session_dimension_filter": {
+          "name": "telemetry_session_dimension_filter",
+          "columns": [
+            "org_id",
+            "dimension_type",
+            "dimension_value",
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telemetry_session_dimension_id": {
+          "name": "telemetry_session_dimension_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "models_analytics_event": {
+      "name": "models_analytics_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_complete": {
+          "name": "usage_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "models_analytics_dedup": {
+          "name": "models_analytics_dedup",
+          "columns": [
+            "org_id",
+            "member_id",
+            "source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "models_analytics_activity": {
+          "name": "models_analytics_activity",
+          "columns": [
+            "org_id",
+            "timestamp",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_task": {
+          "name": "models_analytics_task",
+          "columns": [
+            "org_id",
+            "member_id",
+            "session_id",
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_consumption": {
+          "name": "models_analytics_consumption",
+          "columns": [
+            "org_id",
+            "type",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "models_analytics_export": {
+          "name": "models_analytics_export",
+          "columns": [
+            "org_id",
+            "exported_at",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "models_analytics_event_id": {
+          "name": "models_analytics_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "models_analytics_settings": {
+      "name": "models_analytics_settings",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consented_by": {
+          "name": "consented_by",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "export_enabled": {
+          "name": "export_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "export_enabled_at": {
+          "name": "export_enabled_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_host": {
+          "name": "langfuse_host",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_public_key": {
+          "name": "langfuse_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "langfuse_secret_key": {
+          "name": "langfuse_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "models_analytics_settings_org_id": {
+          "name": "models_analytics_settings_org_id",
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "account_account_id_provider_id": {
+        "columns": {
+          "`account_id`(191)": {
+            "isExpression": true
+          },
+          "`provider_id`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "oauth_access_token_token": {
+        "columns": {
+          "`token`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "oauth_refresh_token_token": {
+        "columns": {
+          "`token`(191)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1788675287930,
       "tag": "0092_models_task_analytics",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "5",
+      "when": 1788863483979,
+      "tag": "0093_team_organization_admin",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/teams.ts
+++ b/ee/packages/den-db/src/schema/teams.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from "drizzle-orm"
-import { index, int, mysqlTable, timestamp, uniqueIndex, varchar } from "drizzle-orm/mysql-core"
+import { boolean, index, int, mysqlTable, timestamp, uniqueIndex, varchar } from "drizzle-orm/mysql-core"
 import { denTypeIdColumn } from "../columns"
 import { MemberTable, OrganizationTable } from "./org"
 
@@ -11,6 +11,7 @@ export const TeamTable = mysqlTable(
     name: varchar("name", { length: 255 }).notNull(),
     organizationId: denTypeIdColumn("organization", "organization_id").notNull(),
     memberCount: int("member_count").notNull().default(0),
+    grantsOrganizationAdmin: boolean("grants_organization_admin").notNull().default(false),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })
       .notNull()

--- a/evals/specs/helpers/scim-fixture.ts
+++ b/evals/specs/helpers/scim-fixture.ts
@@ -4,12 +4,13 @@ import { createRequire } from "node:module";
 // authentication-test/enable flow is a separate journey, not proof claimed here.
 export async function enableScimFixtureSso(database: { url: string } | undefined, organizationId: string) {
   if (!database) throw new Error("SCIM fixture requires an isolated local testkit database");
+  const require = createRequire(import.meta.url);
   const mysql: {
     createConnection(url: string): Promise<{
       execute(query: string, values: unknown[]): Promise<unknown>;
       end(): Promise<void>;
     }>;
-  } = createRequire(import.meta.resolve("@openwork/env"))("mysql2/promise");
+  } = createRequire(require.resolve("@openwork/env"))("mysql2/promise");
   const connection = await mysql.createConnection(database.url);
   try {
     await connection.execute("UPDATE sso_connection SET status = 'enabled' WHERE organization_id = ?", [organizationId]);

--- a/evals/specs/helpers/scim-fixture.ts
+++ b/evals/specs/helpers/scim-fixture.ts
@@ -1,0 +1,19 @@
+import { createRequire } from "node:module";
+
+// SCIM journeys require an already-enabled SSO installation. Its interactive
+// authentication-test/enable flow is a separate journey, not proof claimed here.
+export async function enableScimFixtureSso(database: { url: string } | undefined, organizationId: string) {
+  if (!database) throw new Error("SCIM fixture requires an isolated local testkit database");
+  const mysql: {
+    createConnection(url: string): Promise<{
+      execute(query: string, values: unknown[]): Promise<unknown>;
+      end(): Promise<void>;
+    }>;
+  } = createRequire(import.meta.resolve("@openwork/env"))("mysql2/promise");
+  const connection = await mysql.createConnection(database.url);
+  try {
+    await connection.execute("UPDATE sso_connection SET status = 'enabled' WHERE organization_id = ?", [organizationId]);
+  } finally {
+    await connection.end();
+  }
+}

--- a/evals/specs/helpers/team-admin-context.ts
+++ b/evals/specs/helpers/team-admin-context.ts
@@ -1,0 +1,48 @@
+// Validate the public response, independently of the implementation's parser.
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected object");
+  return Object.fromEntries(Object.entries(value));
+}
+
+function text(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Expected string");
+  return value;
+}
+
+function list(value: unknown): unknown[] {
+  if (!Array.isArray(value)) throw new Error("Expected array");
+  return value;
+}
+
+function adminTeams(value: unknown) {
+  return list(value).map((entry) => {
+    const row = record(entry);
+    return { id: text(row.id), name: text(row.name) };
+  });
+}
+
+export function parseTeamAdminContext(value: unknown) {
+  const body = record(value);
+  const organization = record(body.organization);
+  const current = record(body.currentMember);
+  return {
+    organization: { id: text(organization.id), name: text(organization.name) },
+    currentMember: {
+      id: text(current.id), userId: text(current.userId), role: text(current.role),
+      directRole: text(current.directRole), isOwner: current.isOwner === true, adminTeams: adminTeams(current.adminTeams),
+    },
+    members: list(body.members).map((entry) => {
+      const row = record(entry);
+      const user = record(row.user);
+      return { id: text(row.id), userId: row.userId === null ? null : text(row.userId), inviteId: row.inviteId === null ? null : text(row.inviteId), role: text(row.role), effectiveRole: text(row.effectiveRole), user: { email: text(user.email), name: text(user.name) } };
+    }),
+    teams: list(body.teams).map((entry) => {
+      const row = record(entry);
+      return { id: text(row.id), name: text(row.name), memberIds: list(row.memberIds).map(text), grantsOrganizationAdmin: row.grantsOrganizationAdmin === true, managedByScim: row.managedByScim === true };
+    }),
+    invitations: list(body.invitations).map((entry) => {
+      const row = record(entry);
+      return { id: text(row.id), status: text(row.status) };
+    }),
+  };
+}

--- a/evals/specs/role-change-session-survival.e2e.test.ts
+++ b/evals/specs/role-change-session-survival.e2e.test.ts
@@ -1,0 +1,119 @@
+import { expect } from "vitest";
+import { denFetch, freshSession } from "@openwork/behaviors";
+import type { DenSession } from "@openwork/behaviors";
+import { eventually, localMysqlIsRunning, needs, server, test } from "@openwork/testkit";
+
+const ORGANIZATION_NAME = "Role Change Session Survival";
+const e2eTestsEnabled = process.env.OPENWORK_EVAL_E2E_TESTS === "1";
+const localPlacement = process.env.OPENWORK_EVAL_DAYTONA !== "1" && !process.env.OPENWORK_EVAL_DEN_API_URL?.trim();
+const mysqlOpen = await localMysqlIsRunning();
+const title = !e2eTestsEnabled
+  ? "role change session survival skipped — needs: set OPENWORK_EVAL_E2E_TESTS=1"
+  : !localPlacement
+    ? "role change session survival skipped — needs local placement without OPENWORK_EVAL_DEN_API_URL"
+    : !mysqlOpen
+      ? "role change session survival skipped — needs MySQL on 127.0.0.1:3306"
+      : "role upgrades preserve live sessions while demotions revoke them";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(session: DenSession): Record<string, string> {
+  return { authorization: `Bearer ${session.token}` };
+}
+
+async function organizationId(admin: DenSession): Promise<string> {
+  const result = await denFetch(admin, "/v1/me/orgs", { headers: auth(admin) });
+  const organizations = isRecord(result.body) && Array.isArray(result.body.orgs)
+    ? result.body.orgs.filter(isRecord)
+    : [];
+  const organization = organizations.find((entry) => entry.name === ORGANIZATION_NAME);
+  const id = organization && typeof organization.id === "string" ? organization.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the test organization failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function memberIdByEmail(admin: DenSession, orgId: string, email: string): Promise<string> {
+  const result = await denFetch(admin, "/v1/org", {
+    headers: {
+      ...auth(admin),
+      "x-openwork-org-id": orgId,
+    },
+  });
+  const members = isRecord(result.body) && Array.isArray(result.body.members)
+    ? result.body.members.filter(isRecord)
+    : [];
+  const member = members.find((entry) => isRecord(entry.user) && entry.user.email === email);
+  const id = member && typeof member.id === "string" ? member.id : "";
+  if (!result.response.ok || !id) {
+    throw new Error(`Finding the teammate membership failed: HTTP ${result.response.status} ${result.text.slice(0, 500)}`);
+  }
+  return id;
+}
+
+async function updateMemberRole(admin: DenSession, orgId: string, memberId: string, role: "admin" | "member"): Promise<void> {
+  const privilegedAdmin = await freshSession(admin);
+  const result = await denFetch(privilegedAdmin, `/v1/members/${encodeURIComponent(memberId)}/role`, {
+    method: "POST",
+    headers: {
+      ...auth(privilegedAdmin),
+      "x-openwork-org-id": orgId,
+    },
+    body: JSON.stringify({ role }),
+  });
+  expect(result.response.status).toBe(200);
+}
+
+async function sessionStatus(member: DenSession): Promise<number> {
+  const result = await denFetch(member, "/v1/me", { headers: auth(member) });
+  return result.response.status;
+}
+
+test.skipIf(!e2eTestsEnabled || !localPlacement || !mysqlOpen)(title, async ({ evidence, place }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+
+  await using den = await server({
+    place,
+    org: {
+      name: ORGANIZATION_NAME,
+      members: {
+        teammate: { name: "Role Change Teammate" },
+      },
+    },
+  });
+  const teammate = den.members.teammate;
+  if (!teammate) throw new Error("The testkit did not provision the teammate session.");
+
+  expect(await sessionStatus(teammate)).toBe(200);
+  const orgId = await organizationId(den.admin);
+  const teammateMemberId = await memberIdByEmail(den.admin, orgId, teammate.email);
+
+  await updateMemberRole(den.admin, orgId, teammateMemberId, "admin");
+  const promotedSessionStatus = await eventually(() => sessionStatus(teammate), {
+    within: 10_000,
+    label: "original member session after promotion",
+    until: (status) => status === 200,
+  });
+  expect(promotedSessionStatus).toBe(200);
+  evidence.recordAssertionEvidence(
+    "A privilege upgrade preserves the member's live session",
+    "The original member bearer token still returned HTTP 200 from /v1/me after promotion to admin.",
+    promotedSessionStatus === 200,
+  );
+
+  await updateMemberRole(den.admin, orgId, teammateMemberId, "member");
+  const demotedSessionStatus = await eventually(() => sessionStatus(teammate), {
+    within: 10_000,
+    label: "original member session revocation after demotion",
+    until: (status) => status === 401,
+  });
+  expect(demotedSessionStatus).toBe(401);
+  evidence.recordAssertionEvidence(
+    "A privilege demotion revokes the member's live session",
+    "The original member bearer token returned HTTP 401 from /v1/me after demotion to member.",
+    demotedSessionStatus === 401,
+  );
+});

--- a/evals/specs/scim-okta-lifecycle.e2e.test.ts
+++ b/evals/specs/scim-okta-lifecycle.e2e.test.ts
@@ -1,0 +1,533 @@
+import { expect } from "vitest";
+import { denFetch, signIn } from "@openwork/behaviors";
+import { eventually, inviteMember, needs, server, test, unmetNeeds } from "@openwork/testkit";
+import type { TestNeeds } from "@openwork/testkit";
+
+const requirements: TestNeeds = {
+  optIn: ["OPENWORK_EVAL_E2E_TESTS"],
+};
+const missingRequirements = unmetNeeds(requirements, process.env);
+const title = missingRequirements.length > 0
+  ? `Okta-shaped SCIM lifecycle skipped — needs: ${missingRequirements.join(", ")}`
+  : "an Okta-shaped SCIM client provisions, renames, deprovisions, and reactivates a member without ever granting password access";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  return typeof field === "string" ? field : null;
+}
+
+function numberField(value: unknown, key: string): number | null {
+  if (!isRecord(value)) return null;
+  const field = value[key];
+  return typeof field === "number" ? field : null;
+}
+
+function recordsField(value: unknown, key: string): Record<string, unknown>[] {
+  if (!isRecord(value) || !Array.isArray(value[key])) return [];
+  return value[key].filter(isRecord);
+}
+
+async function scimFetch(
+  apiUrl: string,
+  path: string,
+  bearer: string,
+  init: RequestInit = {},
+): Promise<{ response: Response; body: unknown; text: string }> {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${bearer}`);
+  headers.set("accept", "application/scim+json, application/json");
+  headers.set("content-type", "application/scim+json");
+  const response = await fetch(`${apiUrl.replace(/\/+$/, "")}${path}`, {
+    ...init,
+    headers,
+    signal: init.signal ?? AbortSignal.timeout(30_000),
+  });
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = text.trim() ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+function orgHasJoinedMember(body: unknown, email: string): boolean {
+  return recordsField(body, "members").some((member) => {
+    const user = member.user;
+    return typeof member.userId === "string" && isRecord(user) && user.email === email;
+  });
+}
+
+function formattedName(body: unknown): string | null {
+  if (!isRecord(body)) return null;
+  return stringField(body.name, "formatted");
+}
+
+test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
+  needs(requirements);
+
+  const runId = `${Date.now().toString(36)}${process.pid.toString(36)}`;
+  const orgName = `Okta SCIM Lifecycle ${runId}`;
+  const managedDomain = "okta-scim.test";
+  const managedEmail = `avery.${runId}@${managedDomain}`;
+  const controlPassword = "OpenWorkEval123!";
+
+  await using den = await server({
+    place,
+    org: {
+      name: orgName,
+      admin: { name: "SCIM Admin" },
+    },
+  });
+  const control = await inviteMember(den, "control", {
+    email: `control.${runId}@openwork.test`,
+    name: "Control Member",
+    password: controlPassword,
+  });
+  const controlSession = await signIn(den.ref, { email: control.email, password: controlPassword });
+
+  const organizations = await denFetch(den.ref, "/v1/me/orgs", {
+    headers: { authorization: `Bearer ${den.admin.token}` },
+  });
+  const organization = recordsField(organizations.body, "orgs").find((entry) => entry.name === orgName);
+  const organizationId = stringField(organization, "id");
+  if (!organizations.response.ok || !organizationId) {
+    throw new Error(`Organization lookup failed: HTTP ${organizations.response.status} ${organizations.text.slice(0, 500)}`);
+  }
+
+  // The org-scoped token route requires a verified, enabled SSO connection.
+  // Den's dev-loopback issuer path makes domain verification deterministic in
+  // the eval while the Okta-shaped entry point, certificate, and ACS contract
+  // remain real.
+  const adminSignIn = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: den.admin.email, password: den.admin.password }),
+  });
+  const sessionCookie = adminSignIn.response.headers.get("set-cookie")?.split(";")[0]?.trim() ?? "";
+  if (!adminSignIn.response.ok || !sessionCookie) {
+    throw new Error(`Admin cookie sign-in failed: HTTP ${adminSignIn.response.status} ${adminSignIn.text.slice(0, 500)}`);
+  }
+  const adminHeaders = {
+    authorization: `Bearer ${den.admin.token}`,
+    cookie: sessionCookie,
+    "x-openwork-org-id": organizationId,
+  };
+  const sso = await denFetch(den.ref, "/v1/sso/saml", {
+    method: "POST",
+    headers: adminHeaders,
+    body: JSON.stringify({
+      issuer: `http://127.0.0.1/okta/exk-${runId}`,
+      domain: managedDomain,
+      entryPoint: `https://okta.example.test/app/openwork/exk-${runId}/sso/saml`,
+      cert: "okta-test-signing-certificate",
+      audience: den.ref.apiUrl,
+    }),
+  });
+  if (!sso.response.ok) {
+    throw new Error(`SSO prerequisite failed: HTTP ${sso.response.status} ${sso.text.slice(0, 500)}`);
+  }
+
+  const ssoConnection = isRecord(sso.body) && isRecord(sso.body.connection) ? sso.body.connection : null;
+  expect(ssoConnection?.domainVerified).toBe(true);
+  expect(stringField(ssoConnection, "status")).toBe("enabled");
+  const acsUrl = stringField(ssoConnection, "acsUrl");
+  if (!acsUrl) {
+    throw new Error(`SAML registration did not advertise an ACS URL: ${sso.text.slice(0, 500)}`);
+  }
+  const malformedSaml = await fetch(acsUrl, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ SAMLResponse: "not-base64-xml" }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const malformedSamlBody: unknown = await malformedSaml.json();
+  expect(stringField(malformedSamlBody, "error")).toBe("invalid_encoding");
+  expect(stringField(malformedSamlBody, "error")).not.toBe("invalid_saml_configuration");
+  evidence.recordAssertionEvidence(
+    "Okta SAML registration persists a usable ACS callback configuration",
+    `POSTing a deliberately malformed assertion to the advertised ACS URL reached response-policy validation and returned invalid_encoding, not invalid_saml_configuration.`,
+    malformedSaml.status === 400
+      && stringField(malformedSamlBody, "error") === "invalid_encoding",
+  );
+
+  // ── Frame 1: Den issues the org's Okta bearer, never a raw BA token ──────
+  const scimBasePath = "/api/auth/scim/v2";
+  const garbage = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, "nonsense");
+  expect(garbage.response.status).toBe(401);
+
+  const tokenResult = await denFetch(den.ref, "/v1/scim/token", {
+    method: "POST",
+    headers: adminHeaders,
+  });
+  const scimToken = stringField(tokenResult.body, "scimToken");
+  const advertisedBaseUrl = stringField(tokenResult.body, "baseUrl");
+  if (tokenResult.response.status !== 201 || !scimToken || !advertisedBaseUrl) {
+    throw new Error(`SCIM token creation failed: HTTP ${tokenResult.response.status} ${tokenResult.text.slice(0, 500)}`);
+  }
+  expect(new URL(advertisedBaseUrl).pathname).toBe(scimBasePath);
+  const emptyAfterGarbage = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken);
+  expect(emptyAfterGarbage.response.status).toBe(200);
+  expect(
+    numberField(emptyAfterGarbage.body, "totalResults"),
+    `list after garbage bearer: HTTP ${emptyAfterGarbage.response.status} ${emptyAfterGarbage.text.slice(0, 300)}`,
+  ).toBe(0);
+  evidence.recordAssertionEvidence(
+    "Den issues an org-scoped SCIM bearer and rejects the garbage bearer without mutation",
+    `POST /v1/scim/token advertised ${advertisedBaseUrl}; Bearer nonsense returned ${garbage.response.status}, and the new real bearer then listed totalResults=0.`,
+    tokenResult.response.status === 201
+      && new URL(advertisedBaseUrl).pathname === scimBasePath
+      && garbage.response.status === 401
+      && emptyAfterGarbage.response.status === 200
+      && numberField(emptyAfterGarbage.body, "totalResults") === 0,
+  );
+
+  // ── Frame 2: Okta checks for an existing assignment before creating it ───
+  const lookup = await scimFetch(
+    den.ref.apiUrl,
+    `${scimBasePath}/Users?filter=${encodeURIComponent(`userName eq "${managedEmail}"`)}`,
+    scimToken,
+  );
+  expect(lookup.response.status).toBe(200);
+  expect(
+    numberField(lookup.body, "totalResults"),
+    `pre-create lookup totalResults: HTTP ${lookup.response.status} ${lookup.text.slice(0, 300)}`,
+  ).toBe(0);
+  expect(
+    recordsField(lookup.body, "Resources"),
+    `pre-create lookup Resources: HTTP ${lookup.response.status} ${lookup.text.slice(0, 300)}`,
+  ).toHaveLength(0);
+  evidence.recordAssertionEvidence(
+    "Okta's pre-create lookup finds no existing assignment",
+    `GET Users?filter=userName eq ${managedEmail} returned 200 with totalResults=0 and no Resources, so the later create cannot be mistaken for an update.`,
+    lookup.response.status === 200
+      && numberField(lookup.body, "totalResults") === 0
+      && recordsField(lookup.body, "Resources").length === 0,
+  );
+
+  const oktaUser = {
+    schemas: [SCIM_USER_SCHEMA],
+    userName: managedEmail,
+    name: { givenName: "Avery", familyName: "Morgan" },
+    emails: [{ primary: true, value: managedEmail, type: "work" }],
+    externalId: `00u-${runId}`,
+    active: true,
+    displayName: "Avery Morgan",
+  };
+
+  // ── Frame 3: Okta provisions membership, not a password credential ───────
+  const created = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken, {
+    method: "POST",
+    body: JSON.stringify(oktaUser),
+  });
+  const scimUserId = stringField(created.body, "id");
+  if (created.response.status !== 201 || !scimUserId) {
+    throw new Error(`SCIM user creation failed: HTTP ${created.response.status} ${created.text.slice(0, 500)}`);
+  }
+  // SCIM writes bypass the 60s organizationContext cache TTL.
+  const orgAfterCreate = await eventually(
+    () => denFetch(den.ref, "/v1/org", { headers: adminHeaders }),
+    {
+      within: 90_000,
+      label: "SCIM-created member to appear in organization context",
+      until: ({ response, body }) => response.ok && orgHasJoinedMember(body, managedEmail),
+    },
+  );
+  const passwordAfterCreate = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: managedEmail, password: "not-a-scim-password" }),
+  });
+  const allAfterCreate = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken);
+  expect(orgAfterCreate.response.ok).toBe(true);
+  expect(orgHasJoinedMember(orgAfterCreate.body, managedEmail)).toBe(true);
+  expect(passwordAfterCreate.response.ok).toBe(false);
+  expect(
+    numberField(allAfterCreate.body, "totalResults"),
+    `list after create: HTTP ${allAfterCreate.response.status} ${allAfterCreate.text.slice(0, 300)}`,
+  ).toBe(1);
+  evidence.recordAssertionEvidence(
+    "Okta creates only federated access",
+    `After the zero-user baseline, the real token lists exactly one SCIM resource (${managedEmail}), /v1/org includes that member within the 60s org-context cache window, and password sign-in returned ${passwordAfterCreate.response.status}; the rejected garbage call therefore added no extra resource.`,
+    numberField(allAfterCreate.body, "totalResults") === 1
+      && orgHasJoinedMember(orgAfterCreate.body, managedEmail)
+      && !passwordAfterCreate.response.ok,
+  );
+
+  // ── Frame 4: Okta's full profile replacement changes only that profile ───
+  const renamedUser = {
+    ...oktaUser,
+    name: { givenName: "Avery", familyName: "Nguyen" },
+    displayName: "Avery Nguyen",
+  };
+  const renamed = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users/${encodeURIComponent(scimUserId)}`, scimToken, {
+    method: "PUT",
+    body: JSON.stringify(renamedUser),
+  });
+  const renamedGet = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users/${encodeURIComponent(scimUserId)}`, scimToken);
+  expect(renamed.response.status).toBe(200);
+  expect(renamedGet.response.status).toBe(200);
+  expect(
+    formattedName(renamedGet.body),
+    `renamed user formatted name: HTTP ${renamedGet.response.status} ${renamedGet.text.slice(0, 300)}`,
+  ).toBe("Avery Nguyen");
+  expect(
+    formattedName(renamedGet.body),
+    `renamed user old formatted name: HTTP ${renamedGet.response.status} ${renamedGet.text.slice(0, 300)}`,
+  ).not.toBe("Avery Morgan");
+  evidence.recordAssertionEvidence(
+    "Okta's full replace updates the family name without retaining the old profile",
+    `PUT and GET returned ${renamed.response.status}/${renamedGet.response.status}; GET formatted the name as ${formattedName(renamedGet.body)}, not Avery Morgan.`,
+    renamed.response.status === 200
+      && renamedGet.response.status === 200
+      && formattedName(renamedGet.body) === "Avery Nguyen",
+  );
+
+  // ── Frame 5: deprovisioning blocks resurrection and leaves others alone ──
+  const deactivated = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users/${encodeURIComponent(scimUserId)}`, scimToken, {
+    method: "PATCH",
+    body: JSON.stringify({
+      schemas: [SCIM_PATCH_SCHEMA],
+      Operations: [{ op: "replace", value: { active: false } }],
+    }),
+  });
+  expect(
+    deactivated.response.status,
+    `deactivate user: HTTP ${deactivated.response.status} ${deactivated.text.slice(0, 300)}`,
+  ).toBe(204);
+
+  // SCIM writes bypass the 60s organizationContext cache TTL.
+  const orgAfterDeprovision = await eventually(
+    () => denFetch(den.ref, "/v1/org", { headers: adminHeaders }),
+    {
+      within: 90_000,
+      label: "SCIM-deprovisioned member to leave organization context",
+      until: ({ response, body }) => response.ok && !orgHasJoinedMember(body, managedEmail),
+    },
+  );
+  const passwordAfterDeprovision = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: managedEmail, password: "still-not-a-scim-password" }),
+  });
+  const resurrectionInvite = await denFetch(den.ref, "/v1/invitations", {
+    method: "POST",
+    headers: adminHeaders,
+    body: JSON.stringify({ email: managedEmail, role: "member" }),
+  });
+  const resurrectionToken = stringField(resurrectionInvite.body, "inviteToken");
+  if (!resurrectionInvite.response.ok || !resurrectionToken) {
+    throw new Error(`Resurrection invitation failed to mint: HTTP ${resurrectionInvite.response.status} ${resurrectionInvite.text.slice(0, 500)}`);
+  }
+  const resurrectionSignUp = await denFetch(
+    den.ref,
+    `/api/auth/sign-up/email?invite=${encodeURIComponent(resurrectionToken)}`,
+    {
+      method: "POST",
+      body: JSON.stringify({ email: managedEmail, name: "Avery Nguyen", password: "PasswordMustNotWork123!" }),
+    },
+  );
+  const resurrectionSessionToken = stringField(resurrectionSignUp.body, "token");
+  const explicitResurrection = resurrectionSessionToken
+    ? await denFetch(den.ref, "/v1/orgs/invitations/accept", {
+        method: "POST",
+        headers: { authorization: `Bearer ${resurrectionSessionToken}` },
+        body: JSON.stringify({ id: resurrectionToken }),
+      })
+    : null;
+  const orgAfterInvite = await denFetch(den.ref, "/v1/org", { headers: adminHeaders });
+  const pendingInvitation = recordsField(orgAfterInvite.body, "invitations")
+    .find((invitation) => invitation.email === managedEmail);
+  const pendingInvitationMember = recordsField(orgAfterInvite.body, "members")
+    .find((member) => isRecord(member.user) && member.user.email === managedEmail);
+  const controlMe = await denFetch(den.ref, "/v1/me", {
+    headers: { authorization: `Bearer ${controlSession.token}` },
+  });
+  const controlMeEmail = isRecord(controlMe.body) && isRecord(controlMe.body.user)
+    ? stringField(controlMe.body.user, "email")
+    : null;
+  expect(passwordAfterDeprovision.response.ok).toBe(false);
+  if (explicitResurrection) {
+    expect(
+      explicitResurrection.response.status,
+      `explicit resurrection refusal: HTTP ${explicitResurrection.response.status} ${explicitResurrection.text.slice(0, 300)}`,
+    ).toBe(409);
+    expect(stringField(explicitResurrection.body, "error")).toBe("scim_deprovisioned");
+  }
+  expect(orgHasJoinedMember(orgAfterDeprovision.body, managedEmail)).toBe(false);
+  expect(orgHasJoinedMember(orgAfterInvite.body, managedEmail)).toBe(false);
+  expect(stringField(pendingInvitation, "status")).not.toBe("accepted");
+  expect(pendingInvitationMember?.userId).toBe(null);
+  expect(orgHasJoinedMember(orgAfterInvite.body, control.email)).toBe(true);
+  expect(controlMe.response.status).toBe(200);
+  expect(controlMeEmail).toBe(control.email);
+  evidence.recordAssertionEvidence(
+    "Okta deprovisioning cannot be bypassed and does not touch the control member",
+    `PATCH active=false returned 204; ${managedEmail} has no joined membership after invite-backed sign-up returned ${resurrectionSignUp.response.status}${explicitResurrection ? ` and explicit acceptance was refused with ${stringField(explicitResurrection.body, "error")}` : ""}. Invitations cannot resurrect an IdP-deprovisioned member: the refusal is org-scoped, the invitation remains unaccepted with userId null, and ${control.email}'s existing session and membership remain intact.`,
+    deactivated.response.status === 204
+      && !passwordAfterDeprovision.response.ok
+      && (!explicitResurrection
+        || (explicitResurrection.response.status === 409
+          && stringField(explicitResurrection.body, "error") === "scim_deprovisioned"))
+      && !orgHasJoinedMember(orgAfterInvite.body, managedEmail)
+      && stringField(pendingInvitation, "status") !== "accepted"
+      && pendingInvitationMember?.userId === null
+      && orgHasJoinedMember(orgAfterInvite.body, control.email)
+      && controlMe.response.status === 200
+      && controlMeEmail === control.email,
+  );
+
+  // ── Frame 6A: Okta cannot absorb an existing personal account ────────────
+  const averyReprovision = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken, {
+    method: "POST",
+    body: JSON.stringify(oktaUser),
+  });
+  expect(
+    averyReprovision.response.status,
+    `re-provision existing personal account: HTTP ${averyReprovision.response.status} ${averyReprovision.text.slice(0, 300)}`,
+  ).toBe(409);
+  expect(
+    stringField(averyReprovision.body, "scimType"),
+    `re-provision existing personal account semantics: HTTP ${averyReprovision.response.status} ${averyReprovision.text.slice(0, 300)}`,
+  ).toBe("uniqueness");
+  evidence.recordAssertionEvidence(
+    "The IdP cannot silently absorb a pre-existing personal account",
+    `Re-provisioning ${managedEmail}, now owned by a self-created account, returned SCIM ${averyReprovision.response.status} with scimType=${stringField(averyReprovision.body, "scimType")}.`,
+    averyReprovision.response.status === 409
+      && stringField(averyReprovision.body, "scimType") === "uniqueness",
+  );
+
+  // ── Frame 6B: Okta re-provisioning is the only way back in ───────────────
+  const blakeEmail = `blake.${runId}@${managedDomain}`;
+  const blakeUser = {
+    schemas: [SCIM_USER_SCHEMA],
+    userName: blakeEmail,
+    name: { givenName: "Blake", familyName: "Morgan" },
+    emails: [{ primary: true, value: blakeEmail, type: "work" }],
+    externalId: `00u-blake-${runId}`,
+    active: true,
+    displayName: "Blake Morgan",
+  };
+  const blakeCreated = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken, {
+    method: "POST",
+    body: JSON.stringify(blakeUser),
+  });
+  const blakeUserId = stringField(blakeCreated.body, "id");
+  expect(
+    blakeCreated.response.status,
+    `create fresh SCIM user: HTTP ${blakeCreated.response.status} ${blakeCreated.text.slice(0, 300)}`,
+  ).toBe(201);
+  if (!blakeUserId) {
+    throw new Error(`Fresh SCIM user creation omitted id: HTTP ${blakeCreated.response.status} ${blakeCreated.text.slice(0, 500)}`);
+  }
+  // SCIM writes bypass the 60s organizationContext cache TTL.
+  await eventually(
+    () => denFetch(den.ref, "/v1/org", { headers: adminHeaders }),
+    {
+      within: 90_000,
+      label: "fresh SCIM member to join organization context",
+      until: ({ response, body }) => response.ok && orgHasJoinedMember(body, blakeEmail),
+    },
+  );
+  const blakeDeactivated = await scimFetch(
+    den.ref.apiUrl,
+    `${scimBasePath}/Users/${encodeURIComponent(blakeUserId)}`,
+    scimToken,
+    {
+      method: "PATCH",
+      body: JSON.stringify({
+        schemas: [SCIM_PATCH_SCHEMA],
+        Operations: [{ op: "replace", value: { active: false } }],
+      }),
+    },
+  );
+  expect(
+    blakeDeactivated.response.status,
+    `deactivate fresh SCIM user: HTTP ${blakeDeactivated.response.status} ${blakeDeactivated.text.slice(0, 300)}`,
+  ).toBe(204);
+  // SCIM writes bypass the 60s organizationContext cache TTL.
+  await eventually(
+    () => denFetch(den.ref, "/v1/org", { headers: adminHeaders }),
+    {
+      within: 90_000,
+      label: "deactivated fresh SCIM member to leave organization context",
+      until: ({ response, body }) => response.ok && !orgHasJoinedMember(body, blakeEmail),
+    },
+  );
+  const oldBlakeGet = await scimFetch(
+    den.ref.apiUrl,
+    `${scimBasePath}/Users/${encodeURIComponent(blakeUserId)}`,
+    scimToken,
+  );
+  expect(
+    oldBlakeGet.response.status,
+    `old fresh-user id after deprovision: HTTP ${oldBlakeGet.response.status} ${oldBlakeGet.text.slice(0, 300)}`,
+  ).toBe(404);
+  const blakeReprovisioned = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken, {
+    method: "POST",
+    body: JSON.stringify(blakeUser),
+  });
+  const blakeReprovisionedId = stringField(blakeReprovisioned.body, "id");
+  expect(
+    blakeReprovisioned.response.status,
+    `re-provision fresh SCIM user: HTTP ${blakeReprovisioned.response.status} ${blakeReprovisioned.text.slice(0, 300)}`,
+  ).toBe(201);
+  expect(
+    blakeReprovisionedId,
+    `re-provisioned fresh-user id: HTTP ${blakeReprovisioned.response.status} ${blakeReprovisioned.text.slice(0, 300)}`,
+  ).not.toBe(blakeUserId);
+  if (!blakeReprovisionedId) {
+    throw new Error(`SCIM re-provisioning omitted id: HTTP ${blakeReprovisioned.response.status} ${blakeReprovisioned.text.slice(0, 500)}`);
+  }
+  // Re-provisioning clears removal memory; the 60s organizationContext cache still applies.
+  const orgAfterBlakeReprovision = await eventually(
+    () => denFetch(den.ref, "/v1/org", { headers: adminHeaders }),
+    {
+      within: 90_000,
+      label: "re-provisioned fresh SCIM member to join organization context",
+      until: ({ response, body }) => response.ok && orgHasJoinedMember(body, blakeEmail),
+    },
+  );
+  const blakeReprovisionedGet = await scimFetch(
+    den.ref.apiUrl,
+    `${scimBasePath}/Users/${encodeURIComponent(blakeReprovisionedId)}`,
+    scimToken,
+  );
+  const blakePassword = await denFetch(den.ref, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: blakeEmail, password: "PasswordMustStillNotWork123!" }),
+  });
+  const allAfterBlakeReprovision = await scimFetch(den.ref.apiUrl, `${scimBasePath}/Users`, scimToken);
+  expect(orgHasJoinedMember(orgAfterBlakeReprovision.body, blakeEmail)).toBe(true);
+  expect(
+    blakeReprovisionedGet.response.status,
+    `get re-provisioned fresh user: HTTP ${blakeReprovisionedGet.response.status} ${blakeReprovisionedGet.text.slice(0, 300)}`,
+  ).toBe(200);
+  expect(
+    isRecord(blakeReprovisionedGet.body) && blakeReprovisionedGet.body.active,
+    `re-provisioned fresh user active shape: HTTP ${blakeReprovisionedGet.response.status} ${blakeReprovisionedGet.text.slice(0, 300)}`,
+  ).toBe(true);
+  expect(
+    numberField(allAfterBlakeReprovision.body, "totalResults"),
+    `list after fresh-user re-provisioning: HTTP ${allAfterBlakeReprovision.response.status} ${allAfterBlakeReprovision.text.slice(0, 300)}`,
+  ).toBe(1);
+  expect(blakePassword.response.ok).toBe(false);
+  evidence.recordAssertionEvidence(
+    "Okta re-provisioning is the only way back in and still grants no password access",
+    `Okta deprovisioned ${blakeEmail}, leaving old id ${blakeUserId} at 404, then POSTed the same userName/externalId into new id ${blakeReprovisionedId}; the new identity joined active with totalResults=1, while password sign-in returned ${blakePassword.response.status}.`,
+    oldBlakeGet.response.status === 404
+      && blakeReprovisioned.response.status === 201
+      && blakeReprovisionedId !== blakeUserId
+      && orgHasJoinedMember(orgAfterBlakeReprovision.body, blakeEmail)
+      && isRecord(blakeReprovisionedGet.body)
+      && blakeReprovisionedGet.body.active === true
+      && numberField(allAfterBlakeReprovision.body, "totalResults") === 1
+      && !blakePassword.response.ok,
+  );
+});

--- a/evals/specs/scim-okta-lifecycle.e2e.test.ts
+++ b/evals/specs/scim-okta-lifecycle.e2e.test.ts
@@ -2,6 +2,7 @@ import { expect } from "vitest";
 import { denFetch, signIn } from "@openwork/behaviors";
 import { eventually, inviteMember, needs, server, test, unmetNeeds } from "@openwork/testkit";
 import type { TestNeeds } from "@openwork/testkit";
+import { enableScimFixtureSso } from "./helpers/scim-fixture.ts";
 
 const requirements: TestNeeds = {
   optIn: ["OPENWORK_EVAL_E2E_TESTS"],
@@ -136,7 +137,9 @@ test(title, { timeout: 1_800_000 }, async ({ evidence, place }) => {
     throw new Error(`SSO prerequisite failed: HTTP ${sso.response.status} ${sso.text.slice(0, 500)}`);
   }
 
-  const ssoConnection = isRecord(sso.body) && isRecord(sso.body.connection) ? sso.body.connection : null;
+  await enableScimFixtureSso(den.database, organizationId);
+  const enabledSso = await denFetch(den.ref, "/v1/sso", { headers: adminHeaders });
+  const ssoConnection = isRecord(enabledSso.body) && isRecord(enabledSso.body.connection) ? enabledSso.body.connection : null;
   expect(ssoConnection?.domainVerified).toBe(true);
   expect(stringField(ssoConnection, "status")).toBe("enabled");
   const acsUrl = stringField(ssoConnection, "acsUrl");

--- a/evals/specs/scim-team-membership-atomicity.test.ts
+++ b/evals/specs/scim-team-membership-atomicity.test.ts
@@ -70,7 +70,9 @@ test("SCIM projection ownership is atomic and detached manual teams reject later
       const deadline = Date.now() + 10000;
       while (Date.now() < deadline) {
         if (databaseVersion.version.includes('MariaDB')) {
-          // Read each live catalog once: self-joining INNODB_TRX can miss edges.
+          // InnoDB catalog snapshots are cached briefly; allow refresh before
+          // observing an edge rather than repeatedly reading the first snapshot.
+          await delay(250);
           const [transactions] = await db.query('SELECT trx_id, trx_mysql_thread_id, trx_query FROM information_schema.INNODB_TRX');
           const [waits] = await db.query('SELECT requesting_trx_id, blocking_trx_id FROM information_schema.INNODB_LOCK_WAITS');
           const blocker = transactions.find((row) => Number(row.trx_mysql_thread_id) === Number(id));

--- a/evals/specs/scim-team-membership-atomicity.test.ts
+++ b/evals/specs/scim-team-membership-atomicity.test.ts
@@ -66,14 +66,21 @@ test("SCIM projection ownership is atomic and detached manual teams reject later
     const [[databaseVersion]] = await db.query('SELECT VERSION() AS version');
     // Daytona's server snapshot uses MariaDB; retain the same wait-edge proof
     // using its InnoDB catalog rather than MySQL 8's performance-schema catalog.
-    const waitQuery = databaseVersion.version.includes('MariaDB')
-      ? 'SELECT r.trx_mysql_thread_id AS connectionId, r.trx_query AS query FROM information_schema.INNODB_LOCK_WAITS w JOIN information_schema.INNODB_TRX r ON r.trx_id = w.requesting_trx_id JOIN information_schema.INNODB_TRX b ON b.trx_id = w.blocking_trx_id WHERE b.trx_mysql_thread_id = ?'
-      : 'SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID WHERE b.PROCESSLIST_ID = ?';
     const waitForBlocker = async (id) => {
       const deadline = Date.now() + 10000;
       while (Date.now() < deadline) {
-        const [rows] = await db.execute(waitQuery, [id]);
-        if (rows.length) return rows[0];
+        if (databaseVersion.version.includes('MariaDB')) {
+          // Read each live catalog once: self-joining INNODB_TRX can miss edges.
+          const [transactions] = await db.query('SELECT trx_id, trx_mysql_thread_id, trx_query FROM information_schema.INNODB_TRX');
+          const [waits] = await db.query('SELECT requesting_trx_id, blocking_trx_id FROM information_schema.INNODB_LOCK_WAITS');
+          const blocker = transactions.find((row) => Number(row.trx_mysql_thread_id) === Number(id));
+          const edge = blocker && waits.find((row) => String(row.blocking_trx_id) === String(blocker.trx_id));
+          const requester = edge && transactions.find((row) => String(row.trx_id) === String(edge.requesting_trx_id));
+          if (requester) return { connectionId: requester.trx_mysql_thread_id, query: requester.trx_query };
+        } else {
+          const [rows] = await db.execute('SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID WHERE b.PROCESSLIST_ID = ?', [id]);
+          if (rows.length) return rows[0];
+        }
         await delay(25);
       }
       throw new Error('Expected blocked transaction behind connection ' + id);

--- a/evals/specs/scim-team-membership-atomicity.test.ts
+++ b/evals/specs/scim-team-membership-atomicity.test.ts
@@ -4,182 +4,150 @@ import { fileURLToPath } from "node:url";
 import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import { server, test } from "@openwork/testkit";
-import { parseOrgContextPayload } from "../../ee/apps/den-web/app/(den)/_lib/den-org.ts";
+import { parseTeamAdminContext } from "./helpers/team-admin-context.ts";
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected object");
+  return Object.fromEntries(Object.entries(value));
+}
 
 test("SCIM projection ownership is atomic and detached manual teams reject later IdP mutations", { timeout: 180_000 }, async ({ place, evidence }) => {
   await using den = await server({ place, web: false, org: { name: "SCIM Transaction Regression", members: { target: {}, control: {} } } });
   if (!den.database) throw new Error("This MySQL lock-witness test requires an isolated local testkit database.");
-  const response = await denFetch(den.admin, "/v1/org", { headers: { authorization: `Bearer ${den.admin.token}` } });
-  const context = parseOrgContextPayload(response.body);
-  if (!context) throw new Error("Missing organization context");
+  const headers = { authorization: `Bearer ${den.admin.token}` };
+  const response = await denFetch(den.admin, "/v1/org", { headers });
+  const context = parseTeamAdminContext(response.body);
   const target = context.members.find((member) => member.user.email === den.members.target?.email);
   const control = context.members.find((member) => member.user.email === den.members.control?.email);
   if (!target?.userId || !control?.userId) throw new Error("Missing test members");
+  const login = await denFetch(den.admin, "/api/auth/sign-in/email", { method: "POST", body: JSON.stringify({ email: den.admin.email, password: den.admin.password }) });
+  const cookie = login.response.headers.get("set-cookie")?.split(";")[0];
+  if (!cookie) throw new Error("Missing cookie");
+  const privilegedHeaders = { ...headers, cookie, "x-openwork-org-id": context.organization.id };
+  const sso = await denFetch(den.admin, "/v1/sso/saml", { method: "POST", headers: privilegedHeaders, body: JSON.stringify({ issuer: `http://127.0.0.1/atomic-${Date.now()}`, domain: "atomic-scim.test", entryPoint: "https://idp.example.test/sso", cert: "test-signing-certificate", audience: den.ref.apiUrl }) });
+  expect(sso.response.status, sso.text).toBe(201);
+  const tokenResult = await denFetch(den.admin, "/v1/scim/token", { method: "POST", headers: privilegedHeaders });
+  expect(tokenResult.response.status, tokenResult.text).toBe(201);
+  const scimToken = record(tokenResult.body).scimToken;
+  if (typeof scimToken !== "string") throw new Error("Missing SCIM token");
 
-  // The child imports the real service and uses the testkit's disposable MySQL.
-  // A held source-row lock stops reconciliation at its ownership UPDATE, after
-  // the projection INSERT. MySQL's wait graph witnesses the competing org lock.
-  const run = await promisify(execFile)(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
+  // The fixture controls only disposable MySQL locks/data. Every mutation under
+  // test crosses Den's HTTP boundary; no product modules or test runners load here.
+  const run = await promisify(execFile)(process.execPath, ["--input-type=module", "-e", `
     import assert from 'node:assert/strict';
+    import { createRequire } from 'node:module';
     import { setTimeout as delay } from 'node:timers/promises';
-    import { db } from './src/db.ts';
-    import { eq, sql } from '@openwork-ee/den-db/drizzle';
-    import { MemberTable, ScimProviderTable, ScimGroupTable, ScimGroupMemberTable, TeamTable, TeamMemberTable } from '@openwork-ee/den-db/schema';
-    import { createDenTypeId } from '@openwork-ee/utils/typeid';
-    import { createScimGroup, updateScimGroup, deleteScimGroup, reconcileScimGroupsForUser, setScimGroupMappingMode } from './src/scim-groups.ts';
-    import { deleteOrganizationScimConnection } from './src/scim.ts';
-    import { resolveOrganizationMemberAuthority } from './src/organization-team-roles.ts';
+    const { createPool } = createRequire(import.meta.resolve('@openwork/env'))('mysql2/promise');
+    const db = createPool(process.env.DATABASE_URL);
     const input = JSON.parse(process.env.SCIM_ATOMICITY_INPUT);
-    const providerId = createDenTypeId('scimProvider');
-    await db.insert(ScimProviderTable).values({ id: providerId, providerId: 'test-atomic-scim', scimToken: 'test-only', organizationId: input.orgId, groupMappingMode: 'create_teams' });
-    const [provider] = await db.select().from(ScimProviderTable).where(eq(ScimProviderTable.id, providerId));
-    const created = await createScimGroup({ provider, value: { displayName: 'Atomic Admins', members: [] } });
-    assert.equal(created.ok, true);
-    const group = created.group;
-    assert.ok(group.teamId);
-    await db.update(TeamTable).set({ grantsOrganizationAdmin: true }).where(eq(TeamTable.id, group.teamId));
-    const members = () => db.select().from(TeamMemberTable).where(eq(TeamMemberTable.teamId, group.teamId));
-    const sources = () => db.select().from(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.groupId, group.id));
-    const authority = () => resolveOrganizationMemberAuthority({ organizationId: input.orgId, memberId: input.memberId });
-    const addPendingSource = async () => {
-      const id = createDenTypeId('scimGroupMember');
-      await db.insert(ScimGroupMemberTable).values({ id, groupId: group.id, providerId: provider.providerId, organizationId: input.orgId, remoteUserId: input.userId });
-      return id;
+    const http = async (path, method = 'GET', body, token = input.token) => {
+      const response = await fetch(input.apiUrl + path, { method, headers: { authorization: 'Bearer ' + token, 'x-openwork-org-id': input.orgId, origin: input.webUrl, 'content-type': 'application/json' }, body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(30000) });
+      const text = await response.text();
+      return { status: response.status, body: text ? JSON.parse(text) : null, text };
     };
-    const waitForBlocker = async (connectionId) => {
-      const deadline = Date.now() + 10_000;
+    const scim = (path, method, body) => http('/api/auth/scim/v2/Groups' + path, method, body, input.scimToken);
+    const requireStatus = (result, status = 200) => { assert.equal(result.status, status, result.text); return result.body; };
+    requireStatus(await http('/v1/scim', 'PATCH', { groupMappingMode: 'create_teams' }));
+    const group = requireStatus(await scim('', 'POST', { displayName: 'Atomic Admins', members: [] }), 201);
+    const org = () => http('/v1/org').then((result) => requireStatus(result));
+    const team = (await org()).teams.find((team) => team.name === 'Atomic Admins');
+    const approve = async (id) => requireStatus(await http('/v1/teams/' + id, 'PATCH', { grantsOrganizationAdmin: true }));
+    await approve(team.id);
+    const members = async () => (await db.execute('SELECT * FROM team_member WHERE team_id = ? ORDER BY id', [team.id]))[0];
+    const sources = async () => (await db.execute('SELECT * FROM scim_group_member WHERE group_id = ? ORDER BY id', [group.id]))[0];
+    const authority = async () => (await org()).members.find((member) => member.id === input.memberId).effectiveRole;
+    const [[provider]] = await db.execute('SELECT * FROM scim_provider WHERE organization_id = ?', [input.orgId]);
+    const sourceId = group.id.replace('scg_', 'sgm_');
+    const addPendingSource = () => db.execute('INSERT INTO scim_group_member (id, group_id, provider_id, organization_id, remote_user_id) VALUES (?, ?, ?, ?, ?)', [sourceId, group.id, provider.provider_id, input.orgId, input.userId]);
+    const patch = (operations) => scim('/' + group.id, 'PATCH', { schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'], Operations: operations });
+    const add = (value) => patch([{ op: 'add', path: 'members', value: [{ value }] }]);
+    const waitForBlocker = async (id) => {
+      const deadline = Date.now() + 10000;
       while (Date.now() < deadline) {
-        const [rows] = await db.execute(sql.raw(
-          'SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w ' +
-          'JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID ' +
-          'JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID ' +
-          'WHERE b.PROCESSLIST_ID = ' + Number(connectionId)
-        ));
+        const [rows] = await db.execute('SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID WHERE b.PROCESSLIST_ID = ?', [id]);
         if (rows.length) return rows[0];
         await delay(25);
       }
-      const [waits] = await db.execute(sql.raw('SELECT * FROM performance_schema.data_lock_waits'));
-      throw new Error('Expected blocked transaction behind connection ' + connectionId + '; waits: ' + JSON.stringify(waits));
+      throw new Error('Expected blocked transaction behind connection ' + id);
     };
-
-    const sourceId = await addPendingSource();
-    let adding;
-    let removing;
-    await db.transaction(async (sourceLock) => {
-      await sourceLock.select().from(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.id, sourceId)).for('update');
-      const [[connection]] = await sourceLock.execute(sql.raw('SELECT CONNECTION_ID() AS id'));
-      adding = reconcileScimGroupsForUser({ provider, userId: input.userId }).then(() => null, (error) => error);
+    await addPendingSource();
+    const sourceLock = await db.getConnection();
+    let adding, removing;
+    try {
+      await sourceLock.beginTransaction();
+      await sourceLock.execute('SELECT id FROM scim_group_member WHERE id = ? FOR UPDATE', [sourceId]);
+      const [[connection]] = await sourceLock.execute('SELECT CONNECTION_ID() AS id');
+      adding = add(input.userId);
       const ownerUpdate = await waitForBlocker(connection.id);
       assert.match(ownerUpdate.query, /update .*scim_group_member/i);
-      assert.equal((await sources())[0].teamMemberId, null);
-      assert.deepEqual(await members(), [], 'projection INSERT must remain uncommitted while ownership UPDATE is blocked');
-      assert.equal((await authority()).role, 'member');
-      removing = updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'remove', path: 'members' }] });
+      assert.equal((await sources())[0].team_member_id, null);
+      assert.deepEqual(await members(), [], 'uncommitted projection must not escape ownership transaction');
+      assert.equal(await authority(), 'member');
+      removing = patch([{ op: 'remove', path: 'members' }]);
       const removalWait = await waitForBlocker(ownerUpdate.connectionId);
-      assert.match(removalWait.query, /organization.*for update/i, 'removal must wait on the reconciler org lock, not delete the stale source');
-    });
-    assert.equal(await adding, null);
-    assert.equal((await removing).ok, true);
+      assert.match(removalWait.query, /organization.*for update/i);
+      await sourceLock.commit();
+    } finally { await sourceLock.rollback(); sourceLock.release(); }
+    requireStatus(await adding);
+    requireStatus(await removing);
     assert.deepEqual(await sources(), []);
     assert.deepEqual(await members(), []);
-    assert.equal((await authority()).role, 'member');
-
-    // Source UPDATE failure rolls back the already-executed TeamMember INSERT.
+    assert.equal(await authority(), 'member');
     await addPendingSource();
-    await db.execute(sql.raw("CREATE TRIGGER scim_source_failure BEFORE UPDATE ON scim_group_member FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected ownership failure'"));
+    await db.query("CREATE TRIGGER scim_source_failure BEFORE UPDATE ON scim_group_member FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected ownership failure'");
     try {
-      await assert.rejects(reconcileScimGroupsForUser({ provider, userId: input.userId }), (error) => error.cause?.sqlMessage === 'injected ownership failure');
+      assert.equal((await add(input.userId)).status, 500);
       assert.deepEqual(await members(), []);
-      assert.equal((await sources())[0].teamMemberId, null);
-    } finally {
-      await db.execute(sql.raw('DROP TRIGGER scim_source_failure'));
-    }
-
-    // A historical orphan projection must never be sufficient for mapped Admin.
-    const orphanId = createDenTypeId('teamMember');
-    await db.insert(TeamMemberTable).values({ id: orphanId, teamId: group.teamId, orgMembershipId: input.memberId, userId: input.userId });
-    assert.equal((await authority()).role, 'member');
-    await reconcileScimGroupsForUser({ provider, userId: input.userId });
-    assert.equal((await sources())[0].teamMemberId, orphanId);
-    assert.equal((await authority()).role, 'member,admin');
-
-    // Concurrent PATCH additions read their current membership inside the lock.
-    const patched = await Promise.all([
-      updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'add', path: 'members', value: [{ value: input.userId }] }] }),
-      updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'add', path: 'members', value: [{ value: input.controlUserId }] }] }),
-    ]);
-    assert.ok(patched.every((result) => result.ok));
-    assert.deepEqual((await members()).map((member) => member.orgMembershipId).sort(), [input.memberId, input.controlId].sort());
-
-    const second = await createScimGroup({ provider, value: { displayName: 'Detached Provider Team', members: [{ value: input.controlUserId }] } });
-    assert.equal(second.ok, true);
-    await setScimGroupMappingMode({ provider, mode: 'metadata_only' });
-    assert.ok((await sources()).every((source) => source.teamMemberId === null));
+      assert.equal((await sources())[0].team_member_id, null);
+    } finally { await db.query('DROP TRIGGER scim_source_failure'); }
+    const orphanId = team.id.replace('tem_', 'tmb_');
+    await db.execute('INSERT INTO team_member (id, team_id, org_membership_id, user_id) VALUES (?, ?, ?, ?)', [orphanId, team.id, input.memberId, input.userId]);
+    assert.equal(await authority(), 'member');
+    requireStatus(await add(input.userId));
+    assert.equal((await sources())[0].team_member_id, orphanId);
+    assert.equal(await authority(), 'member,admin');
+    for (const result of await Promise.all([add(input.userId), add(input.controlUserId)])) requireStatus(result);
+    assert.deepEqual((await members()).map((member) => member.org_membership_id).sort(), [input.memberId, input.controlId].sort());
+    requireStatus(await scim('', 'POST', { displayName: 'Detached Provider Team', members: [{ value: input.controlUserId }] }), 201);
+    const secondTeam = (await org()).teams.find((team) => team.name === 'Detached Provider Team');
+    requireStatus(await http('/v1/scim', 'PATCH', { groupMappingMode: 'metadata_only' }));
+    assert.ok((await sources()).every((source) => source.team_member_id === null));
     const preserved = await members();
     assert.equal(preserved.length, 2);
-    assert.equal((await authority()).role, 'member');
-    // Owner reapproval uses the real role-management route, not a fabricated role.
-    const approve = async (teamId) => {
-      const response = await fetch(input.apiUrl + '/v1/teams/' + teamId, { method: 'PATCH', headers: { authorization: 'Bearer ' + input.token, 'x-openwork-org-id': input.orgId, 'content-type': 'application/json' }, body: JSON.stringify({ grantsOrganizationAdmin: true }), signal: AbortSignal.timeout(10_000) });
-      assert.equal(response.status, 200, await response.text());
-    };
-    await approve(group.teamId);
-    await approve(second.group.teamId);
-    assert.equal((await authority()).role, 'member,admin');
-    // Deliberately keep passing the stale create_teams provider object.
-    assert.equal((await updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'remove', path: 'members' }] })).ok, true);
+    assert.equal(await authority(), 'member');
+    await approve(team.id);
+    await approve(secondTeam.id);
+    requireStatus(await patch([{ op: 'remove', path: 'members' }]));
     assert.deepEqual(await sources(), []);
     assert.deepEqual(await members(), preserved);
-    assert.equal((await authority()).role, 'member,admin');
-    assert.equal((await updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'add', path: 'members', value: [{ value: input.ownerUserId }] }] })).ok, true);
-    assert.equal((await sources())[0].teamMemberId, null);
-    assert.deepEqual(await members(), preserved, 'metadata-only additions cannot project new manual memberships');
-    await reconcileScimGroupsForUser({ provider, userId: input.ownerUserId });
+    assert.equal(await authority(), 'member,admin');
+    requireStatus(await add(input.ownerUserId));
+    assert.equal((await sources())[0].team_member_id, null);
     assert.deepEqual(await members(), preserved);
-    await reconcileScimGroupsForUser({ provider, userId: input.userId });
-    await setScimGroupMappingMode({ provider, mode: 'metadata_only' });
+    requireStatus(await http('/v1/scim', 'PATCH', { groupMappingMode: 'metadata_only' }));
+    assert.equal(await authority(), 'member,admin');
+    requireStatus(await scim('/' + group.id, 'DELETE'), 204);
     assert.deepEqual(await members(), preserved);
-    assert.equal((await authority()).role, 'member,admin', 'idempotent disable must not revoke manual reapproval');
-    assert.equal((await deleteScimGroup({ provider, groupId: group.id })).ok, true);
-    assert.deepEqual(await members(), preserved);
-    assert.equal((await authority()).role, 'member,admin', 'detached group deletion cannot revoke manual authority');
-    const secondMembers = await db.select().from(TeamMemberTable).where(eq(TeamMemberTable.teamId, second.group.teamId));
-    assert.equal(await deleteOrganizationScimConnection(input.orgId), true);
-    assert.deepEqual(await db.select().from(TeamMemberTable).where(eq(TeamMemberTable.teamId, second.group.teamId)), secondMembers);
-    const [manualTeam] = await db.select().from(TeamTable).where(eq(TeamTable.id, second.group.teamId));
-    assert.equal(manualTeam.grantsOrganizationAdmin, true, 'detached provider deletion cannot revoke manual reapproval');
-    assert.deepEqual(await db.select().from(ScimProviderTable).where(eq(ScimProviderTable.id, provider.id)), []);
-    const stale = await createScimGroup({ provider, value: { displayName: 'Deleted provider cannot recreate mappings' } });
-    assert.equal(stale.ok, false);
-    assert.equal(stale.status, 404);
-    await reconcileScimGroupsForUser({ provider, userId: input.userId });
-    assert.deepEqual(await db.select().from(ScimGroupTable).where(eq(ScimGroupTable.providerId, provider.providerId)), []);
-    const [directMember] = await db.select().from(MemberTable).where(eq(MemberTable.id, input.memberId));
-    assert.equal(directMember.role, 'member');
+    assert.equal(await authority(), 'member,admin');
+    const [secondMembers] = await db.execute('SELECT * FROM team_member WHERE team_id = ? ORDER BY id', [secondTeam.id]);
+    requireStatus(await http('/v1/scim', 'DELETE'), 204);
+    assert.deepEqual((await db.execute('SELECT * FROM team_member WHERE team_id = ? ORDER BY id', [secondTeam.id]))[0], secondMembers);
+    assert.equal((await org()).teams.find((team) => team.id === secondTeam.id).grantsOrganizationAdmin, true);
+    assert.equal((await scim('', 'POST', { displayName: 'Stale provider' })).status, 401);
+    assert.deepEqual((await db.execute('SELECT id FROM scim_group WHERE provider_id = ?', [provider.provider_id]))[0], []);
+    assert.equal((await org()).members.find((member) => member.id === input.memberId).role, 'member');
+    await db.end();
     console.log(JSON.stringify({ serializedRemoval: true, rollback: true, orphanDenied: true, patchUnion: true, detachedMembershipPreserved: true, detachedDeletionPreserved: true, staleProviderDenied: true }));
-    process.exit(0);
   `], {
-    cwd: fileURLToPath(new URL("../../ee/apps/den-api", import.meta.url)),
-    timeout: 60_000,
-    env: {
-      ...process.env,
-      DATABASE_URL: den.database.url,
-      DB_MODE: "mysql",
-      DATABASE_REDIS_URL: "",
-      DEN_DB_ENCRYPTION_KEY: "local-dev-db-encryption-key-please-change-1234567890",
-      BETTER_AUTH_SECRET: "local-testkit-secret-not-for-production-use!!",
-      DEN_BASE_URL: den.ref.apiUrl,
-      OPENWORK_DEV_MODE: "1",
-      SCIM_ATOMICITY_INPUT: JSON.stringify({ orgId: context.organization.id, memberId: target.id, userId: target.userId, controlId: control.id, controlUserId: control.userId, ownerUserId: context.currentMember.userId, apiUrl: den.ref.apiUrl, token: den.admin.token }),
-    },
+    cwd: fileURLToPath(new URL("..", import.meta.url)), timeout: 90_000,
+    env: { ...process.env, DATABASE_URL: den.database.url, SCIM_ATOMICITY_INPUT: JSON.stringify({ orgId: context.organization.id, memberId: target.id, userId: target.userId, controlId: control.id, controlUserId: control.userId, ownerUserId: context.currentMember.userId, apiUrl: den.ref.apiUrl, webUrl: den.ref.webUrl, token: den.admin.token, scimToken }) },
   }).catch((error: unknown) => {
     if (error instanceof Error && "stderr" in error && typeof error.stderr === "string") throw new Error(error.stderr);
     throw error;
   });
   const output = run.stdout.trim().split("\n").at(-1);
   if (!output) throw new Error("No transaction witness result");
-  const result: unknown = JSON.parse(output);
-  expect(result).toEqual({ serializedRemoval: true, rollback: true, orphanDenied: true, patchUnion: true, detachedMembershipPreserved: true, detachedDeletionPreserved: true, staleProviderDenied: true });
-  evidence.recordAssertionEvidence("SCIM reconciliation and removal share one atomic ownership transaction", "MySQL's wait graph proved removal blocked on the reconciler's org lock while source UPDATE was paused after projection INSERT. Neither uncommitted authority nor an orphan survived; an injected source-update error rolled back the projection, and a historical orphan was denied until reconciled.", true);
-  evidence.recordAssertionEvidence("Metadata-only IdP operations cannot mutate manually reapproved teams", "Disable cleared source ownership pointers without deleting memberships. Owner reapproval survived stale-provider membership removal, repeated disable, group deletion, and provider deletion. Deleted providers could not create or reconcile mappings.", true);
+  expect(JSON.parse(output)).toEqual({ serializedRemoval: true, rollback: true, orphanDenied: true, patchUnion: true, detachedMembershipPreserved: true, detachedDeletionPreserved: true, staleProviderDenied: true });
+  evidence.recordAssertionEvidence("SCIM HTTP add/remove uses one ownership transaction", "MySQL's wait graph proves removal waits on the add transaction's org lock while source UPDATE is blocked after projection INSERT. A trigger-induced ownership failure rolls back the insert, and a historical orphan grants nothing until reconciled.", true);
+  evidence.recordAssertionEvidence("Detached manual teams survive later IdP mutations", "Disable clears ownership pointers without deleting memberships. Real Owner reapproval survives IdP member removal/addition, repeated disable, group deletion and provider deletion; the deleted provider token cannot recreate mappings.", true);
 });

--- a/evals/specs/scim-team-membership-atomicity.test.ts
+++ b/evals/specs/scim-team-membership-atomicity.test.ts
@@ -1,0 +1,185 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { denFetch } from "@openwork/behaviors";
+import { server, test } from "@openwork/testkit";
+import { parseOrgContextPayload } from "../../ee/apps/den-web/app/(den)/_lib/den-org.ts";
+
+test("SCIM projection ownership is atomic and detached manual teams reject later IdP mutations", { timeout: 180_000 }, async ({ place, evidence }) => {
+  await using den = await server({ place, web: false, org: { name: "SCIM Transaction Regression", members: { target: {}, control: {} } } });
+  if (!den.database) throw new Error("This MySQL lock-witness test requires an isolated local testkit database.");
+  const response = await denFetch(den.admin, "/v1/org", { headers: { authorization: `Bearer ${den.admin.token}` } });
+  const context = parseOrgContextPayload(response.body);
+  if (!context) throw new Error("Missing organization context");
+  const target = context.members.find((member) => member.user.email === den.members.target?.email);
+  const control = context.members.find((member) => member.user.email === den.members.control?.email);
+  if (!target?.userId || !control?.userId) throw new Error("Missing test members");
+
+  // The child imports the real service and uses the testkit's disposable MySQL.
+  // A held source-row lock stops reconciliation at its ownership UPDATE, after
+  // the projection INSERT. MySQL's wait graph witnesses the competing org lock.
+  const run = await promisify(execFile)(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
+    import assert from 'node:assert/strict';
+    import { setTimeout as delay } from 'node:timers/promises';
+    import { db } from './src/db.ts';
+    import { eq, sql } from '@openwork-ee/den-db/drizzle';
+    import { MemberTable, ScimProviderTable, ScimGroupTable, ScimGroupMemberTable, TeamTable, TeamMemberTable } from '@openwork-ee/den-db/schema';
+    import { createDenTypeId } from '@openwork-ee/utils/typeid';
+    import { createScimGroup, updateScimGroup, deleteScimGroup, reconcileScimGroupsForUser, setScimGroupMappingMode } from './src/scim-groups.ts';
+    import { deleteOrganizationScimConnection } from './src/scim.ts';
+    import { resolveOrganizationMemberAuthority } from './src/organization-team-roles.ts';
+    const input = JSON.parse(process.env.SCIM_ATOMICITY_INPUT);
+    const providerId = createDenTypeId('scimProvider');
+    await db.insert(ScimProviderTable).values({ id: providerId, providerId: 'test-atomic-scim', scimToken: 'test-only', organizationId: input.orgId, groupMappingMode: 'create_teams' });
+    const [provider] = await db.select().from(ScimProviderTable).where(eq(ScimProviderTable.id, providerId));
+    const created = await createScimGroup({ provider, value: { displayName: 'Atomic Admins', members: [] } });
+    assert.equal(created.ok, true);
+    const group = created.group;
+    assert.ok(group.teamId);
+    await db.update(TeamTable).set({ grantsOrganizationAdmin: true }).where(eq(TeamTable.id, group.teamId));
+    const members = () => db.select().from(TeamMemberTable).where(eq(TeamMemberTable.teamId, group.teamId));
+    const sources = () => db.select().from(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.groupId, group.id));
+    const authority = () => resolveOrganizationMemberAuthority({ organizationId: input.orgId, memberId: input.memberId });
+    const addPendingSource = async () => {
+      const id = createDenTypeId('scimGroupMember');
+      await db.insert(ScimGroupMemberTable).values({ id, groupId: group.id, providerId: provider.providerId, organizationId: input.orgId, remoteUserId: input.userId });
+      return id;
+    };
+    const waitForBlocker = async (connectionId) => {
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        const [rows] = await db.execute(sql.raw(
+          'SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w ' +
+          'JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID ' +
+          'JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID ' +
+          'WHERE b.PROCESSLIST_ID = ' + Number(connectionId)
+        ));
+        if (rows.length) return rows[0];
+        await delay(25);
+      }
+      const [waits] = await db.execute(sql.raw('SELECT * FROM performance_schema.data_lock_waits'));
+      throw new Error('Expected blocked transaction behind connection ' + connectionId + '; waits: ' + JSON.stringify(waits));
+    };
+
+    const sourceId = await addPendingSource();
+    let adding;
+    let removing;
+    await db.transaction(async (sourceLock) => {
+      await sourceLock.select().from(ScimGroupMemberTable).where(eq(ScimGroupMemberTable.id, sourceId)).for('update');
+      const [[connection]] = await sourceLock.execute(sql.raw('SELECT CONNECTION_ID() AS id'));
+      adding = reconcileScimGroupsForUser({ provider, userId: input.userId }).then(() => null, (error) => error);
+      const ownerUpdate = await waitForBlocker(connection.id);
+      assert.match(ownerUpdate.query, /update .*scim_group_member/i);
+      assert.equal((await sources())[0].teamMemberId, null);
+      assert.deepEqual(await members(), [], 'projection INSERT must remain uncommitted while ownership UPDATE is blocked');
+      assert.equal((await authority()).role, 'member');
+      removing = updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'remove', path: 'members' }] });
+      const removalWait = await waitForBlocker(ownerUpdate.connectionId);
+      assert.match(removalWait.query, /organization.*for update/i, 'removal must wait on the reconciler org lock, not delete the stale source');
+    });
+    assert.equal(await adding, null);
+    assert.equal((await removing).ok, true);
+    assert.deepEqual(await sources(), []);
+    assert.deepEqual(await members(), []);
+    assert.equal((await authority()).role, 'member');
+
+    // Source UPDATE failure rolls back the already-executed TeamMember INSERT.
+    await addPendingSource();
+    await db.execute(sql.raw("CREATE TRIGGER scim_source_failure BEFORE UPDATE ON scim_group_member FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'injected ownership failure'"));
+    try {
+      await assert.rejects(reconcileScimGroupsForUser({ provider, userId: input.userId }), (error) => error.cause?.sqlMessage === 'injected ownership failure');
+      assert.deepEqual(await members(), []);
+      assert.equal((await sources())[0].teamMemberId, null);
+    } finally {
+      await db.execute(sql.raw('DROP TRIGGER scim_source_failure'));
+    }
+
+    // A historical orphan projection must never be sufficient for mapped Admin.
+    const orphanId = createDenTypeId('teamMember');
+    await db.insert(TeamMemberTable).values({ id: orphanId, teamId: group.teamId, orgMembershipId: input.memberId, userId: input.userId });
+    assert.equal((await authority()).role, 'member');
+    await reconcileScimGroupsForUser({ provider, userId: input.userId });
+    assert.equal((await sources())[0].teamMemberId, orphanId);
+    assert.equal((await authority()).role, 'member,admin');
+
+    // Concurrent PATCH additions read their current membership inside the lock.
+    const patched = await Promise.all([
+      updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'add', path: 'members', value: [{ value: input.userId }] }] }),
+      updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'add', path: 'members', value: [{ value: input.controlUserId }] }] }),
+    ]);
+    assert.ok(patched.every((result) => result.ok));
+    assert.deepEqual((await members()).map((member) => member.orgMembershipId).sort(), [input.memberId, input.controlId].sort());
+
+    const second = await createScimGroup({ provider, value: { displayName: 'Detached Provider Team', members: [{ value: input.controlUserId }] } });
+    assert.equal(second.ok, true);
+    await setScimGroupMappingMode({ provider, mode: 'metadata_only' });
+    assert.ok((await sources()).every((source) => source.teamMemberId === null));
+    const preserved = await members();
+    assert.equal(preserved.length, 2);
+    assert.equal((await authority()).role, 'member');
+    // Owner reapproval uses the real role-management route, not a fabricated role.
+    const approve = async (teamId) => {
+      const response = await fetch(input.apiUrl + '/v1/teams/' + teamId, { method: 'PATCH', headers: { authorization: 'Bearer ' + input.token, 'x-openwork-org-id': input.orgId, 'content-type': 'application/json' }, body: JSON.stringify({ grantsOrganizationAdmin: true }), signal: AbortSignal.timeout(10_000) });
+      assert.equal(response.status, 200, await response.text());
+    };
+    await approve(group.teamId);
+    await approve(second.group.teamId);
+    assert.equal((await authority()).role, 'member,admin');
+    // Deliberately keep passing the stale create_teams provider object.
+    assert.equal((await updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'remove', path: 'members' }] })).ok, true);
+    assert.deepEqual(await sources(), []);
+    assert.deepEqual(await members(), preserved);
+    assert.equal((await authority()).role, 'member,admin');
+    assert.equal((await updateScimGroup({ provider, groupId: group.id, operations: [{ op: 'add', path: 'members', value: [{ value: input.ownerUserId }] }] })).ok, true);
+    assert.equal((await sources())[0].teamMemberId, null);
+    assert.deepEqual(await members(), preserved, 'metadata-only additions cannot project new manual memberships');
+    await reconcileScimGroupsForUser({ provider, userId: input.ownerUserId });
+    assert.deepEqual(await members(), preserved);
+    await reconcileScimGroupsForUser({ provider, userId: input.userId });
+    await setScimGroupMappingMode({ provider, mode: 'metadata_only' });
+    assert.deepEqual(await members(), preserved);
+    assert.equal((await authority()).role, 'member,admin', 'idempotent disable must not revoke manual reapproval');
+    assert.equal((await deleteScimGroup({ provider, groupId: group.id })).ok, true);
+    assert.deepEqual(await members(), preserved);
+    assert.equal((await authority()).role, 'member,admin', 'detached group deletion cannot revoke manual authority');
+    const secondMembers = await db.select().from(TeamMemberTable).where(eq(TeamMemberTable.teamId, second.group.teamId));
+    assert.equal(await deleteOrganizationScimConnection(input.orgId), true);
+    assert.deepEqual(await db.select().from(TeamMemberTable).where(eq(TeamMemberTable.teamId, second.group.teamId)), secondMembers);
+    const [manualTeam] = await db.select().from(TeamTable).where(eq(TeamTable.id, second.group.teamId));
+    assert.equal(manualTeam.grantsOrganizationAdmin, true, 'detached provider deletion cannot revoke manual reapproval');
+    assert.deepEqual(await db.select().from(ScimProviderTable).where(eq(ScimProviderTable.id, provider.id)), []);
+    const stale = await createScimGroup({ provider, value: { displayName: 'Deleted provider cannot recreate mappings' } });
+    assert.equal(stale.ok, false);
+    assert.equal(stale.status, 404);
+    await reconcileScimGroupsForUser({ provider, userId: input.userId });
+    assert.deepEqual(await db.select().from(ScimGroupTable).where(eq(ScimGroupTable.providerId, provider.providerId)), []);
+    const [directMember] = await db.select().from(MemberTable).where(eq(MemberTable.id, input.memberId));
+    assert.equal(directMember.role, 'member');
+    console.log(JSON.stringify({ serializedRemoval: true, rollback: true, orphanDenied: true, patchUnion: true, detachedMembershipPreserved: true, detachedDeletionPreserved: true, staleProviderDenied: true }));
+    process.exit(0);
+  `], {
+    cwd: fileURLToPath(new URL("../../ee/apps/den-api", import.meta.url)),
+    timeout: 60_000,
+    env: {
+      ...process.env,
+      DATABASE_URL: den.database.url,
+      DB_MODE: "mysql",
+      DATABASE_REDIS_URL: "",
+      DEN_DB_ENCRYPTION_KEY: "local-dev-db-encryption-key-please-change-1234567890",
+      BETTER_AUTH_SECRET: "local-testkit-secret-not-for-production-use!!",
+      DEN_BASE_URL: den.ref.apiUrl,
+      OPENWORK_DEV_MODE: "1",
+      SCIM_ATOMICITY_INPUT: JSON.stringify({ orgId: context.organization.id, memberId: target.id, userId: target.userId, controlId: control.id, controlUserId: control.userId, ownerUserId: context.currentMember.userId, apiUrl: den.ref.apiUrl, token: den.admin.token }),
+    },
+  }).catch((error: unknown) => {
+    if (error instanceof Error && "stderr" in error && typeof error.stderr === "string") throw new Error(error.stderr);
+    throw error;
+  });
+  const output = run.stdout.trim().split("\n").at(-1);
+  if (!output) throw new Error("No transaction witness result");
+  const result: unknown = JSON.parse(output);
+  expect(result).toEqual({ serializedRemoval: true, rollback: true, orphanDenied: true, patchUnion: true, detachedMembershipPreserved: true, detachedDeletionPreserved: true, staleProviderDenied: true });
+  evidence.recordAssertionEvidence("SCIM reconciliation and removal share one atomic ownership transaction", "MySQL's wait graph proved removal blocked on the reconciler's org lock while source UPDATE was paused after projection INSERT. Neither uncommitted authority nor an orphan survived; an injected source-update error rolled back the projection, and a historical orphan was denied until reconciled.", true);
+  evidence.recordAssertionEvidence("Metadata-only IdP operations cannot mutate manually reapproved teams", "Disable cleared source ownership pointers without deleting memberships. Owner reapproval survived stale-provider membership removal, repeated disable, group deletion, and provider deletion. Deleted providers could not create or reconcile mappings.", true);
+});

--- a/evals/specs/scim-team-membership-atomicity.test.ts
+++ b/evals/specs/scim-team-membership-atomicity.test.ts
@@ -5,6 +5,7 @@ import { expect } from "vitest";
 import { denFetch } from "@openwork/behaviors";
 import { server, test } from "@openwork/testkit";
 import { parseTeamAdminContext } from "./helpers/team-admin-context.ts";
+import { enableScimFixtureSso } from "./helpers/scim-fixture.ts";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected object");
@@ -26,6 +27,7 @@ test("SCIM projection ownership is atomic and detached manual teams reject later
   const privilegedHeaders = { ...headers, cookie, "x-openwork-org-id": context.organization.id };
   const sso = await denFetch(den.admin, "/v1/sso/saml", { method: "POST", headers: privilegedHeaders, body: JSON.stringify({ issuer: `http://127.0.0.1/atomic-${Date.now()}`, domain: "atomic-scim.test", entryPoint: "https://idp.example.test/sso", cert: "test-signing-certificate", audience: den.ref.apiUrl }) });
   expect(sso.response.status, sso.text).toBe(201);
+  await enableScimFixtureSso(den.database, context.organization.id);
   const tokenResult = await denFetch(den.admin, "/v1/scim/token", { method: "POST", headers: privilegedHeaders });
   expect(tokenResult.response.status, tokenResult.text).toBe(201);
   const scimToken = record(tokenResult.body).scimToken;

--- a/evals/specs/scim-team-membership-atomicity.test.ts
+++ b/evals/specs/scim-team-membership-atomicity.test.ts
@@ -63,10 +63,16 @@ test("SCIM projection ownership is atomic and detached manual teams reject later
     const addPendingSource = () => db.execute('INSERT INTO scim_group_member (id, group_id, provider_id, organization_id, remote_user_id) VALUES (?, ?, ?, ?, ?)', [sourceId, group.id, provider.provider_id, input.orgId, input.userId]);
     const patch = (operations) => scim('/' + group.id, 'PATCH', { schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'], Operations: operations });
     const add = (value) => patch([{ op: 'add', path: 'members', value: [{ value }] }]);
+    const [[databaseVersion]] = await db.query('SELECT VERSION() AS version');
+    // Daytona's server snapshot uses MariaDB; retain the same wait-edge proof
+    // using its InnoDB catalog rather than MySQL 8's performance-schema catalog.
+    const waitQuery = databaseVersion.version.includes('MariaDB')
+      ? 'SELECT r.trx_mysql_thread_id AS connectionId, r.trx_query AS query FROM information_schema.INNODB_LOCK_WAITS w JOIN information_schema.INNODB_TRX r ON r.trx_id = w.requesting_trx_id JOIN information_schema.INNODB_TRX b ON b.trx_id = w.blocking_trx_id WHERE b.trx_mysql_thread_id = ?'
+      : 'SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID WHERE b.PROCESSLIST_ID = ?';
     const waitForBlocker = async (id) => {
       const deadline = Date.now() + 10000;
       while (Date.now() < deadline) {
-        const [rows] = await db.execute('SELECT r.PROCESSLIST_ID AS connectionId, r.PROCESSLIST_INFO AS query FROM performance_schema.data_lock_waits w JOIN performance_schema.threads r ON r.THREAD_ID = w.REQUESTING_THREAD_ID JOIN performance_schema.threads b ON b.THREAD_ID = w.BLOCKING_THREAD_ID WHERE b.PROCESSLIST_ID = ?', [id]);
+        const [rows] = await db.execute(waitQuery, [id]);
         if (rows.length) return rows[0];
         await delay(25);
       }

--- a/evals/specs/team-organization-admin-ui.e2e.test.ts
+++ b/evals/specs/team-organization-admin-ui.e2e.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "vitest";
 import { denFetch, evalIn, fill, waitFor, type DenSession } from "@openwork/behaviors";
-import { navigate } from "@openwork/cdp";
+import { browserScript, navigate } from "@openwork/cdp";
 import { chrome } from "@openwork/hosts";
 import { eventually, needs, server, test } from "@openwork/testkit";
-import { parseOrgContextPayload } from "../../ee/apps/den-web/app/(den)/_lib/den-org.ts";
+import { parseTeamAdminContext } from "./helpers/team-admin-context.ts";
 
 test("owners toggle team Admin in Den Web while inherited admins see a disabled checkbox and provenance", { timeout: 600_000 }, async ({ place, evidence }) => {
   needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
@@ -13,9 +13,7 @@ test("owners toggle team Admin in Den Web while inherited admins see a disabled 
   const org = async (session = den.admin) => {
     const result = await denFetch(session, "/v1/org", { headers: { authorization: `Bearer ${session.token}` } });
     expect(result.response.status, result.text).toBe(200);
-    const context = parseOrgContextPayload(result.body);
-    if (!context) throw new Error("Invalid org context");
-    return context;
+    return parseTeamAdminContext(result.body);
   };
   const initial = await org();
   const member = initial.members.find((entry) => entry.user.email === teammate.email);
@@ -27,55 +25,63 @@ test("owners toggle team Admin in Den Web while inherited admins see a disabled 
   if (!team) throw new Error("Missing team");
   await using browser = await chrome({ name: "team-admin-ui", host: place.host(), startUrl: den.ref.webUrl, headless: true });
   await navigate(browser.client, den.ref.webUrl);
-  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, { timeoutMs: 60_000, label: "Den Web origin loaded" });
+  await waitFor(browser, browserScript((url) => location.href.startsWith(url) && document.readyState === "complete", [den.ref.webUrl]), { timeoutMs: 60_000, label: "Den Web origin loaded" });
   const teamPath = `/dashboard/members/teams/${team.id}`;
-  const checkbox = `document.querySelector('input[type="checkbox"]')`;
+  const clickButton = (label: string) => evalIn(browser, browserScript((label) => {
+    const button = [...document.querySelectorAll("button")].find((entry) => entry.textContent?.includes(label));
+    if (!button) throw new Error(`Missing button ${label}`);
+    button.click();
+  }, [label]));
+  const clickCheckbox = () => evalIn(browser, () => {
+    const input = document.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!input) throw new Error("Missing checkbox");
+    input.click();
+  });
+  const checkboxState = () => evalIn(browser, () => {
+    const input = document.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!input) throw new Error("Missing checkbox");
+    return { disabled: input.disabled, checked: input.checked };
+  });
   const showAs = async (session: DenSession) => {
-    await evalIn(browser, `(async () => {
-      await fetch('/api/auth/sign-out', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json' }, body: '{}' });
-      localStorage.removeItem('openwork:web:auth-token');
-    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    await evalIn(browser, async () => {
+      await fetch("/api/auth/sign-out", { method: "POST", credentials: "include", headers: { "content-type": "application/json" }, body: "{}" });
+      localStorage.removeItem("openwork:web:auth-token");
+    }, { awaitPromise: true, timeoutMs: 30_000 });
     await navigate(browser.client, den.ref.webUrl);
-    await waitFor(browser, `Boolean(document.querySelector('input[type="email"]'))`, { timeoutMs: 30_000, label: "email sign-in step" });
+    await waitFor(browser, () => Boolean(document.querySelector('input[type="email"]')), { timeoutMs: 30_000, label: "email sign-in step" });
     await fill(browser, 'input[type="email"]', session.email);
-    await evalIn(browser, `[...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Next').click()`);
-    await waitFor(browser, `Boolean(document.querySelector('input[type="password"]'))`, { timeoutMs: 30_000, label: "password sign-in step" });
+    await clickButton("Next");
+    await waitFor(browser, () => Boolean(document.querySelector('input[type="password"]')), { timeoutMs: 30_000, label: "password sign-in step" });
     await fill(browser, 'input[type="password"]', session.password);
-    await evalIn(browser, `[...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Sign in').click()`);
-    await waitFor(browser, `location.pathname.startsWith('/dashboard') && Boolean(document.querySelector('a[href="/dashboard/members"]'))`, { timeoutMs: 30_000, label: "signed-in dashboard navigation" });
-    await evalIn(browser, `document.querySelector('a[href="/dashboard/members"]').click()`);
-    await waitFor(browser, `Boolean([...document.querySelectorAll('button')].find((button) => button.textContent.includes('Teams')))`, { timeoutMs: 30_000, label: "Members page" });
-    await evalIn(browser, `[...document.querySelectorAll('button')].find((button) => button.textContent.includes('Teams')).click()`);
-    await waitFor(browser, `Boolean(document.querySelector('a[href="${teamPath}"]'))`, { timeoutMs: 30_000, label: "Teams list" });
-    await evalIn(browser, `document.querySelector('a[href="${teamPath}"]').click()`);
-    await waitFor(browser, `location.pathname === "${teamPath}" && document.body.innerText.includes("Grant organisation Admin to all members of UI Operations") && Boolean(document.querySelector('[role="tablist"]')) && Boolean(${checkbox})`, { timeoutMs: 60_000, label: "team detail Admin checkbox visible" });
+    await clickButton("Sign in");
+    await waitFor(browser, () => location.pathname.startsWith("/dashboard") && Boolean(document.querySelector('a[href="/dashboard/members"]')), { timeoutMs: 30_000, label: "signed-in dashboard navigation" });
+    await evalIn(browser, () => document.querySelector<HTMLAnchorElement>('a[href="/dashboard/members"]')?.click());
+    await waitFor(browser, () => [...document.querySelectorAll("button")].some((button) => button.textContent?.includes("Teams")), { timeoutMs: 30_000, label: "Members page" });
+    await clickButton("Teams");
+    await waitFor(browser, browserScript((path) => Boolean(document.querySelector(`a[href="${path}"]`)), [teamPath]), { timeoutMs: 30_000, label: "Teams list" });
+    await evalIn(browser, browserScript((path) => document.querySelector<HTMLAnchorElement>(`a[href="${path}"]`)?.click(), [teamPath]));
+    await waitFor(browser, browserScript((path) => location.pathname === path && document.body.innerText.includes("Grant organisation Admin to all members of UI Operations") && Boolean(document.querySelector('[role="tablist"]')) && Boolean(document.querySelector('input[type="checkbox"]')), [teamPath]), { timeoutMs: 60_000, label: "team detail Admin checkbox visible" });
   };
   await showAs(den.admin);
-  expect(await evalIn(browser, `({ disabled: ${checkbox}.disabled, checked: ${checkbox}.checked })`)).toEqual({ disabled: false, checked: false });
-  await evalIn(browser, `${checkbox}.click()`);
+  expect(await checkboxState()).toEqual({ disabled: false, checked: false });
+  await clickCheckbox();
   await eventually(async () => (await org(teammate)).currentMember.role, { within: 15_000, until: (role) => role === "member,admin", label: "owner checkbox saved Admin grant" });
-  await waitFor(browser, `${checkbox}.checked && !${checkbox}.disabled`, { timeoutMs: 15_000, label: "saved checkbox reloaded" });
+  await eventually(checkboxState, { within: 15_000, until: (state) => state.checked && !state.disabled, label: "saved checkbox reloaded" });
   await showAs(teammate);
-  expect(await evalIn(browser, `({ disabled: ${checkbox}.disabled, checked: ${checkbox}.checked })`)).toEqual({ disabled: true, checked: true });
-  expect(await evalIn(browser, `(() => {
-    const tab = [...document.querySelectorAll('[role="tab"]')].find((button) => button.textContent.trim() === 'Overview');
-    if (!tab) return false;
-    tab.click();
-    return true;
-  })()`)).toBe(true);
-  await waitFor(browser, `document.body.innerText.includes("Admin via UI Operations")`, { timeoutMs: 15_000, label: "inherited role provenance visible" });
+  expect(await checkboxState()).toEqual({ disabled: true, checked: true });
+  await clickButton("Overview");
+  await waitFor(browser, () => document.body.innerText.includes("Admin via UI Operations"), { timeoutMs: 15_000, label: "inherited role provenance visible" });
   expect((await org(teammate)).currentMember.directRole).toBe("member");
   for (const width of [1280, 390]) {
     await browser.client.send("Emulation.setDeviceMetricsOverride", { width, height: 900, deviceScaleFactor: 1, mobile: width < 600 });
-    await waitFor(browser, `window.innerWidth === ${width}`, { timeoutMs: 10_000, label: `viewport ${width}` });
-    expect(await evalIn(browser, `(() => {
-      const input = ${checkbox};
-      const label = input.closest('label').getBoundingClientRect();
-      return label.left >= 0 && label.right <= window.innerWidth && document.documentElement.scrollWidth <= window.innerWidth;
-    })()`), `checkbox fits viewport ${width}`).toBe(true);
+    await waitFor(browser, browserScript((width) => window.innerWidth === width, [width]), { timeoutMs: 10_000, label: `viewport ${width}` });
+    expect(await evalIn(browser, () => {
+      const label = document.querySelector('input[type="checkbox"]')?.closest("label")?.getBoundingClientRect();
+      return Boolean(label && label.left >= 0 && label.right <= window.innerWidth && document.documentElement.scrollWidth <= window.innerWidth);
+    }), `checkbox fits viewport ${width}`).toBe(true);
   }
   await showAs(den.admin);
-  await evalIn(browser, `${checkbox}.click()`);
+  await clickCheckbox();
   await eventually(async () => (await org(teammate)).currentMember.role, { within: 15_000, until: (role) => role === "member", label: "owner unchecked Admin grant" });
   expect((await org(teammate)).currentMember.adminTeams).toEqual([]);
   evidence.recordAssertionEvidence("Team Admin checkbox persists grants and displays provenance without granting role management", "The owner checked and unchecked the real checkbox; API authority changed both times. The inherited admin saw it checked but disabled, saw Admin via UI Operations, and the control fit desktop and mobile viewports without horizontal overflow.", true);

--- a/evals/specs/team-organization-admin-ui.e2e.test.ts
+++ b/evals/specs/team-organization-admin-ui.e2e.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "vitest";
+import { denFetch, evalIn, fill, waitFor, type DenSession } from "@openwork/behaviors";
+import { navigate } from "@openwork/cdp";
+import { chrome } from "@openwork/hosts";
+import { eventually, needs, server, test } from "@openwork/testkit";
+import { parseOrgContextPayload } from "../../ee/apps/den-web/app/(den)/_lib/den-org.ts";
+
+test("owners toggle team Admin in Den Web while inherited admins see a disabled checkbox and provenance", { timeout: 600_000 }, async ({ place, evidence }) => {
+  needs({ optIn: ["OPENWORK_EVAL_E2E_TESTS"] });
+  await using den = await server({ place, web: true, org: { name: "Team Admin UI", members: { teammate: { name: "Inherited Teammate" } } } });
+  const teammate = den.members.teammate;
+  if (!teammate) throw new Error("Missing teammate");
+  const org = async (session = den.admin) => {
+    const result = await denFetch(session, "/v1/org", { headers: { authorization: `Bearer ${session.token}` } });
+    expect(result.response.status, result.text).toBe(200);
+    const context = parseOrgContextPayload(result.body);
+    if (!context) throw new Error("Invalid org context");
+    return context;
+  };
+  const initial = await org();
+  const member = initial.members.find((entry) => entry.user.email === teammate.email);
+  if (!member) throw new Error("Missing member");
+  const teamName = "UI Operations";
+  const created = await denFetch(den.admin, "/v1/teams", { method: "POST", headers: { authorization: `Bearer ${den.admin.token}` }, body: JSON.stringify({ name: teamName, memberIds: [member.id] }) });
+  expect(created.response.status, created.text).toBe(201);
+  const team = (await org()).teams.find((entry) => entry.name === teamName);
+  if (!team) throw new Error("Missing team");
+  await using browser = await chrome({ name: "team-admin-ui", host: place.host(), startUrl: den.ref.webUrl, headless: true });
+  await navigate(browser.client, den.ref.webUrl);
+  await waitFor(browser, `location.href.startsWith(${JSON.stringify(den.ref.webUrl)}) && document.readyState === "complete"`, { timeoutMs: 60_000, label: "Den Web origin loaded" });
+  const teamPath = `/dashboard/members/teams/${team.id}`;
+  const checkbox = `document.querySelector('input[type="checkbox"]')`;
+  const showAs = async (session: DenSession) => {
+    await evalIn(browser, `(async () => {
+      await fetch('/api/auth/sign-out', { method: 'POST', credentials: 'include', headers: { 'content-type': 'application/json' }, body: '{}' });
+      localStorage.removeItem('openwork:web:auth-token');
+    })()`, { awaitPromise: true, timeoutMs: 30_000 });
+    await navigate(browser.client, den.ref.webUrl);
+    await waitFor(browser, `Boolean(document.querySelector('input[type="email"]'))`, { timeoutMs: 30_000, label: "email sign-in step" });
+    await fill(browser, 'input[type="email"]', session.email);
+    await evalIn(browser, `[...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Next').click()`);
+    await waitFor(browser, `Boolean(document.querySelector('input[type="password"]'))`, { timeoutMs: 30_000, label: "password sign-in step" });
+    await fill(browser, 'input[type="password"]', session.password);
+    await evalIn(browser, `[...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Sign in').click()`);
+    await waitFor(browser, `location.pathname.startsWith('/dashboard') && Boolean(document.querySelector('a[href="/dashboard/members"]'))`, { timeoutMs: 30_000, label: "signed-in dashboard navigation" });
+    await evalIn(browser, `document.querySelector('a[href="/dashboard/members"]').click()`);
+    await waitFor(browser, `Boolean([...document.querySelectorAll('button')].find((button) => button.textContent.includes('Teams')))`, { timeoutMs: 30_000, label: "Members page" });
+    await evalIn(browser, `[...document.querySelectorAll('button')].find((button) => button.textContent.includes('Teams')).click()`);
+    await waitFor(browser, `Boolean(document.querySelector('a[href="${teamPath}"]'))`, { timeoutMs: 30_000, label: "Teams list" });
+    await evalIn(browser, `document.querySelector('a[href="${teamPath}"]').click()`);
+    await waitFor(browser, `location.pathname === "${teamPath}" && document.body.innerText.includes("Grant organisation Admin to all members of UI Operations") && Boolean(document.querySelector('[role="tablist"]')) && Boolean(${checkbox})`, { timeoutMs: 60_000, label: "team detail Admin checkbox visible" });
+  };
+  await showAs(den.admin);
+  expect(await evalIn(browser, `({ disabled: ${checkbox}.disabled, checked: ${checkbox}.checked })`)).toEqual({ disabled: false, checked: false });
+  await evalIn(browser, `${checkbox}.click()`);
+  await eventually(async () => (await org(teammate)).currentMember.role, { within: 15_000, until: (role) => role === "member,admin", label: "owner checkbox saved Admin grant" });
+  await waitFor(browser, `${checkbox}.checked && !${checkbox}.disabled`, { timeoutMs: 15_000, label: "saved checkbox reloaded" });
+  await showAs(teammate);
+  expect(await evalIn(browser, `({ disabled: ${checkbox}.disabled, checked: ${checkbox}.checked })`)).toEqual({ disabled: true, checked: true });
+  expect(await evalIn(browser, `(() => {
+    const tab = [...document.querySelectorAll('[role="tab"]')].find((button) => button.textContent.trim() === 'Overview');
+    if (!tab) return false;
+    tab.click();
+    return true;
+  })()`)).toBe(true);
+  await waitFor(browser, `document.body.innerText.includes("Admin via UI Operations")`, { timeoutMs: 15_000, label: "inherited role provenance visible" });
+  expect((await org(teammate)).currentMember.directRole).toBe("member");
+  for (const width of [1280, 390]) {
+    await browser.client.send("Emulation.setDeviceMetricsOverride", { width, height: 900, deviceScaleFactor: 1, mobile: width < 600 });
+    await waitFor(browser, `window.innerWidth === ${width}`, { timeoutMs: 10_000, label: `viewport ${width}` });
+    expect(await evalIn(browser, `(() => {
+      const input = ${checkbox};
+      const label = input.closest('label').getBoundingClientRect();
+      return label.left >= 0 && label.right <= window.innerWidth && document.documentElement.scrollWidth <= window.innerWidth;
+    })()`), `checkbox fits viewport ${width}`).toBe(true);
+  }
+  await showAs(den.admin);
+  await evalIn(browser, `${checkbox}.click()`);
+  await eventually(async () => (await org(teammate)).currentMember.role, { within: 15_000, until: (role) => role === "member", label: "owner unchecked Admin grant" });
+  expect((await org(teammate)).currentMember.adminTeams).toEqual([]);
+  evidence.recordAssertionEvidence("Team Admin checkbox persists grants and displays provenance without granting role management", "The owner checked and unchecked the real checkbox; API authority changed both times. The inherited admin saw it checked but disabled, saw Admin via UI Operations, and the control fit desktop and mobile viewports without horizontal overflow.", true);
+});

--- a/evals/specs/team-organization-admin.test.ts
+++ b/evals/specs/team-organization-admin.test.ts
@@ -1,0 +1,272 @@
+import { expect } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { denFetch, type DenSession } from "@openwork/behaviors";
+import { server, test } from "@openwork/testkit";
+import { getOrgAccessFlags, parseOrgContextPayload } from "../../ee/apps/den-web/app/(den)/_lib/den-org.ts";
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected an object");
+  return Object.fromEntries(Object.entries(value));
+}
+
+function text(value: unknown): string {
+  if (typeof value !== "string" || !value) throw new Error("Expected a nonempty string");
+  return value;
+}
+
+test("team Admin grants are live, scoped, protected, and cleared across SCIM lifecycles", { timeout: 600_000 }, async ({ place, evidence }) => {
+  await using den = await server({
+    place,
+    web: false,
+    org: { name: "Team Admin Grants", members: { inherited: {}, direct: {}, superadmin: {}, control: {} } },
+  });
+  const owner = den.admin;
+  const inherited = den.members.inherited;
+  const direct = den.members.direct;
+  const superadmin = den.members.superadmin;
+  const control = den.members.control;
+  if (!inherited || !direct || !superadmin || !control) throw new Error("Missing test members");
+
+  const orgs = record((await denFetch(owner, "/v1/me/orgs", { headers: { authorization: `Bearer ${owner.token}` } })).body).orgs;
+  if (!Array.isArray(orgs)) throw new Error("Missing organizations");
+  const orgId = text(record(orgs.find((org) => record(org).name === "Team Admin Grants")).id);
+  const request = (session: DenSession, path: string, method = "GET", body?: unknown) => denFetch(session, path, {
+    method,
+    headers: { authorization: `Bearer ${session.token}`, "x-openwork-org-id": orgId },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const context = async (session = owner) => {
+    const result = await request(session, "/v1/org");
+    expect(result.response.status, result.text).toBe(200);
+    const parsed = parseOrgContextPayload(result.body);
+    if (!parsed) throw new Error("Invalid org context");
+    return parsed;
+  };
+  const initial = await context();
+  const memberId = (email: string) => text(initial.members.find((member) => member.user.email === email)?.id);
+  const inheritedId = memberId(inherited.email);
+  const directId = memberId(direct.email);
+  const controlId = memberId(control.email);
+  for (const [id, role] of [[directId, "admin"], [memberId(superadmin.email), "super-admin"]]) {
+    const result = await request(owner, `/v1/members/${id}/role`, "POST", { role });
+    expect(result.response.status, result.text).toBe(200);
+  }
+  const createTeam = async (name: string, memberIds: string[], grantsOrganizationAdmin?: boolean, session = owner) => {
+    const result = await request(session, "/v1/teams", "POST", { name, memberIds, grantsOrganizationAdmin });
+    expect(result.response.status, result.text).toBe(201);
+    return text(record(record(result.body).team).id);
+  };
+  const patchTeam = async (id: string, body: unknown, session = owner, status = 200) => {
+    const result = await request(session, `/v1/teams/${id}`, "PATCH", body);
+    expect(result.response.status, result.text).toBe(status);
+  };
+  const canReadAdmin = async (session: DenSession, expected: number) => {
+    const result = await request(session, "/v1/scim");
+    expect(result.response.status, result.text).toBe(expected);
+  };
+
+  // The member list is already warm before granting authority.
+  await canReadAdmin(inherited, 403);
+  const primary = await createTeam("Operations", [inheritedId, directId]);
+  await patchTeam(primary, { grantsOrganizationAdmin: true }, direct, 403);
+  await patchTeam(primary, { grantsOrganizationAdmin: false }, direct, 403);
+  const deniedCreate = await request(direct, "/v1/teams", "POST", { name: "Escalation", grantsOrganizationAdmin: true });
+  expect(deniedCreate.response.status).toBe(403);
+  await patchTeam(primary, { grantsOrganizationAdmin: true }, superadmin);
+  const granted = await context(inherited);
+  expect(granted.currentMember.role).toBe("member,admin");
+  expect(granted.currentMember.directRole).toBe("member");
+  expect(granted.currentMember.adminTeams).toEqual([{ id: primary, name: "Operations" }]);
+  expect(granted.members.find((member) => member.id === inheritedId)?.role).toBe("member");
+  expect(getOrgAccessFlags(granted.currentMember.role, granted.currentMember.isOwner)).toMatchObject({ isAdmin: true, canManageRoles: false, canManageScim: false, canTransferOwnership: false });
+  await canReadAdmin(inherited, 200);
+  await canReadAdmin(control, 403);
+  await patchTeam(primary, { memberIds: [inheritedId, directId, controlId] }, inherited, 403);
+  await patchTeam(primary, { grantsOrganizationAdmin: false, memberIds: [] }, inherited, 403);
+  expect((await request(inherited, `/v1/teams/${primary}`, "DELETE")).response.status).toBe(403);
+  expect((await request(direct, `/v1/members/${inheritedId}`, "DELETE")).response.status).toBe(403);
+  expect((await request(inherited, `/v1/members/${controlId}/role`, "POST", { role: "owner" })).response.status).toBe(403);
+  expect((await request(inherited, "/v1/invitations", "POST", { email: "escalated@openwork.test", role: "admin" })).response.status).toBe(403);
+  const ordinary = await createTeam("Ordinary", [controlId], undefined, inherited);
+  await patchTeam(ordinary, { memberIds: [] }, inherited);
+
+  const secondary = await createTeam("Second Grant", [inheritedId], true);
+  await patchTeam(primary, { memberIds: [directId] });
+  await canReadAdmin(inherited, 200);
+  expect((await context(inherited)).currentMember.adminTeams).toEqual([{ id: secondary, name: "Second Grant" }]);
+  await patchTeam(secondary, { grantsOrganizationAdmin: false });
+  await canReadAdmin(inherited, 403);
+  expect((await context(inherited)).currentMember.role).toBe("member");
+  await patchTeam(primary, { grantsOrganizationAdmin: false });
+  await canReadAdmin(direct, 200);
+  expect((await context(direct)).currentMember.directRole).toBe("admin");
+  await patchTeam(secondary, { grantsOrganizationAdmin: true });
+  expect((await request(superadmin, `/v1/teams/${secondary}`, "DELETE")).response.status).toBe(204);
+  await canReadAdmin(inherited, 403);
+  evidence.recordAssertionEvidence("Live team grants preserve direct roles and other grants", "The original bearer gains and loses Admin without re-login; stored member role remains member, a second team survives the first removal, direct Admin survives team revocation, and control stays unprivileged.", true);
+
+  // Pending placeholders can already belong to a team; refreshing/canceling their
+  // invitation is also a privileged mutation even though its direct role is member.
+  const pendingEmail = `pending-${Date.now()}@openwork.test`;
+  const invitation = await request(owner, "/v1/invitations", "POST", { email: pendingEmail, role: "member" });
+  expect([201, 502]).toContain(invitation.response.status);
+  const pending = (await context()).members.find((member) => member.user.email === pendingEmail);
+  if (!pending?.inviteId) throw new Error("Missing pending member");
+  const pendingTeam = await createTeam("Pending Admins", [pending.id], true);
+  expect((await request(direct, "/v1/invitations", "POST", { email: pendingEmail, role: "member" })).response.status).toBe(403);
+  expect((await request(direct, `/v1/invitations/${pending.inviteId}/cancel`, "POST")).response.status).toBe(403);
+  expect((await context()).invitations.find((entry) => entry.id === pending.inviteId)?.status).toBe("pending");
+  await patchTeam(pendingTeam, { grantsOrganizationAdmin: false });
+  expect((await request(direct, `/v1/invitations/${pending.inviteId}/cancel`, "POST")).response.status).toBe(200);
+
+  const signedIn = await denFetch(direct, "/api/auth/sign-in/email", { method: "POST", body: JSON.stringify({ email: direct.email, password: direct.password }) });
+  const cookie = signedIn.response.headers.get("set-cookie")?.split(";")[0];
+  if (!cookie) throw new Error("Missing raw BetterAuth session cookie");
+  await patchTeam(primary, { grantsOrganizationAdmin: true });
+  for (const [route, body] of [
+    ["create-team", { name: "Raw", organizationId: orgId }],
+    ["update-team", { teamId: primary, data: { name: "Raw" } }],
+    ["remove-team", { teamId: primary }],
+    ["add-team-member", { teamId: primary, userId: initial.currentMember.userId }],
+    ["remove-team-member", { teamId: primary, userId: initial.currentMember.userId }],
+    ["invite-member", { email: "raw@openwork.test", role: "member", organizationId: orgId, teamId: primary }],
+    ["cancel-invitation", { invitationId: pending.inviteId }],
+    ["accept-invitation", { invitationId: pending.inviteId }],
+    ["add-member", { userId: initial.currentMember.userId, organizationId: orgId, role: "member", teamId: primary }],
+    ["leave", { organizationId: orgId }],
+  ]) {
+    const result = await denFetch(direct, `/api/auth/organization/${route}`, { method: "POST", headers: { cookie }, body: JSON.stringify(body) });
+    // BetterAuth's addMember has no HTTP path; the other routes are explicitly denied.
+    expect(result.response.status, `${route}: ${result.text}`).toBe(route === "add-member" ? 404 : 403);
+  }
+  await patchTeam(primary, { grantsOrganizationAdmin: false });
+  expect((await context(direct)).currentMember.directRole).toBe("admin");
+  evidence.recordAssertionEvidence("Admin-team invitation and raw route bypasses are denied", "A direct Admin cannot refresh or cancel the privileged pending invitation; raw team/invitation writes and leaving an Admin team through organization leave return 403. Server-only addMember is not exposed over HTTP (404).", true);
+
+  // A separate organization cannot use its memberships to gain authority here.
+  const foreignOrg = await denFetch(control, "/v1/org", { method: "POST", headers: { authorization: `Bearer ${control.token}` }, body: JSON.stringify({ name: "Foreign Control" }) });
+  expect(foreignOrg.response.status, foreignOrg.text).toBe(201);
+  const foreignOrgId = text(record(record(foreignOrg.body).organization).id);
+  const foreignContext = await denFetch(control, "/v1/org", { headers: { authorization: `Bearer ${control.token}`, "x-openwork-org-id": foreignOrgId } });
+  const foreignMemberId = text(record(record(foreignContext.body).currentMember).id);
+  await patchTeam(primary, { memberIds: [foreignMemberId] }, owner, 404);
+  const foreignEdit = await denFetch(control, `/v1/teams/${primary}`, { method: "PATCH", headers: { authorization: `Bearer ${control.token}`, "x-openwork-org-id": foreignOrgId }, body: JSON.stringify({ grantsOrganizationAdmin: true }) });
+  expect(foreignEdit.response.status).toBe(404);
+
+  const ownerSignIn = await denFetch(owner, "/api/auth/sign-in/email", { method: "POST", body: JSON.stringify({ email: owner.email, password: owner.password }) });
+  const ownerCookie = ownerSignIn.response.headers.get("set-cookie")?.split(";")[0];
+  if (!ownerCookie) throw new Error("Missing owner cookie");
+  const ownerHeaders = { authorization: `Bearer ${owner.token}`, cookie: ownerCookie, "x-openwork-org-id": orgId };
+  const sso = await denFetch(owner, "/v1/sso/saml", { method: "POST", headers: ownerHeaders, body: JSON.stringify({ issuer: `http://127.0.0.1/team-admin-${Date.now()}`, domain: "team-scim.test", entryPoint: "https://okta.example.test/sso", cert: "test-signing-certificate", audience: den.ref.apiUrl }) });
+  expect(sso.response.status, sso.text).toBe(201);
+  const tokenResult = await denFetch(owner, "/v1/scim/token", { method: "POST", headers: ownerHeaders });
+  expect(tokenResult.response.status, tokenResult.text).toBe(201);
+  const token = text(record(tokenResult.body).scimToken);
+  const scim = (path: string, method: string, body?: unknown) => denFetch(den.ref, `/api/auth/scim/v2/${path}`, { method, headers: { authorization: `Bearer ${token}`, "content-type": "application/scim+json" }, body: body === undefined ? undefined : JSON.stringify(body) });
+  const mapping = async (groupMappingMode: string) => {
+    const result = await request(owner, "/v1/scim", "PATCH", { groupMappingMode });
+    expect(result.response.status, result.text).toBe(200);
+  };
+  await mapping("create_teams");
+  const managedUserId = text(initial.members.find((member) => member.id === inheritedId)?.userId);
+  const groupBody = (members = [managedUserId]) => ({ schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"], displayName: "super-admin", members: members.map((value) => ({ value })) });
+  const created = await scim("Groups", "POST", groupBody());
+  expect(created.response.status, created.text).toBe(201);
+  const groupId = text(record(created.body).id);
+  const managedTeam = (await context()).teams.find((team) => team.name === "super-admin");
+  if (!managedTeam) throw new Error("Missing SCIM team");
+  expect(managedTeam.grantsOrganizationAdmin).toBe(false);
+  await canReadAdmin(inherited, 403);
+  await patchTeam(managedTeam.id, { grantsOrganizationAdmin: true });
+  await canReadAdmin(inherited, 200);
+  expect(getOrgAccessFlags((await context(inherited)).currentMember.role, false).canManageRoles).toBe(false);
+  await patchTeam(managedTeam.id, { memberIds: [] }, owner, 409);
+  await patchTeam(managedTeam.id, { name: "manual rename" }, owner, 409);
+  expect((await request(owner, `/v1/teams/${managedTeam.id}`, "DELETE")).response.status).toBe(409);
+  const remove = await scim(`Groups/${groupId}`, "PATCH", { schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], Operations: [{ op: "remove", path: `members[value eq "${managedUserId}"]` }] });
+  expect(remove.response.status, remove.text).toBe(200);
+  await canReadAdmin(inherited, 403);
+  expect((await scim(`Groups/${groupId}`, "PUT", groupBody())).response.status).toBe(200);
+  await canReadAdmin(inherited, 200);
+  await mapping("metadata_only");
+  await canReadAdmin(inherited, 403);
+  const retained = (await context()).teams.find((team) => team.id === managedTeam.id);
+  expect(retained).toMatchObject({ grantsOrganizationAdmin: false, managedByScim: false });
+  expect(retained?.memberIds).toContain(inheritedId);
+  await mapping("create_teams");
+  await canReadAdmin(inherited, 403);
+  await patchTeam(managedTeam.id, { grantsOrganizationAdmin: true }, superadmin);
+  expect((await scim(`Groups/${groupId}`, "PUT", groupBody([]))).response.status).toBe(200);
+  await canReadAdmin(inherited, 403);
+  expect((await scim(`Groups/${groupId}`, "PUT", groupBody())).response.status).toBe(200);
+  await canReadAdmin(inherited, 200);
+  expect((await scim(`Groups/${groupId}`, "DELETE")).response.status).toBe(204);
+  await canReadAdmin(inherited, 403);
+  expect((await context()).teams.find((team) => team.id === managedTeam.id)?.grantsOrganizationAdmin).toBe(false);
+
+  const nextGroup = await scim("Groups", "POST", { ...groupBody(), displayName: "Provider Removal" });
+  expect(nextGroup.response.status, nextGroup.text).toBe(201);
+  const nextTeam = (await context()).teams.find((team) => team.name === "Provider Removal");
+  if (!nextTeam) throw new Error("Missing second SCIM team");
+  await patchTeam(nextTeam.id, { grantsOrganizationAdmin: true });
+  await canReadAdmin(inherited, 200);
+  expect((await request(owner, "/v1/scim", "DELETE")).response.status).toBe(204);
+  await canReadAdmin(inherited, 403);
+  expect((await context()).teams.find((team) => team.id === nextTeam.id)).toMatchObject({ grantsOrganizationAdmin: false, managedByScim: false, memberIds: [inheritedId] });
+  await canReadAdmin(direct, 200);
+  expect((await context(inherited)).currentMember.directRole).toBe("member");
+  evidence.recordAssertionEvidence("SCIM controls membership but never derives roles from group names", "An IdP group named super-admin grants nothing until approved, then only Admin. PATCH/PUT removals revoke immediately. Mapping disable/re-enable, group deletion, and provider removal clear designation; retained teams and direct roles do not retain inherited authority.", true);
+
+  if (!den.database) throw new Error("The in-process background authorization check requires a fresh local testkit database.");
+  await patchTeam(nextTeam.id, { grantsOrganizationAdmin: true });
+  const background = await promisify(execFile)(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
+    import { db } from './src/db.ts';
+    import { eq } from '@openwork-ee/den-db/drizzle';
+    import { TeamTable } from '@openwork-ee/den-db/schema';
+    import { createDenTypeId } from '@openwork-ee/utils/typeid';
+    import { resolveOrganizationMemberAuthority } from './src/organization-team-roles.ts';
+    import { validateWorkflowAutomationAction } from './src/workflows.ts';
+    const input = JSON.parse(process.env.TEAM_ADMIN_TEST_INPUT);
+    const action = { kind: 'saved_script', script: {
+      pluginId: createDenTypeId('plugin'), configObjectId: createDenTypeId('configObject'),
+      configObjectVersionId: createDenTypeId('configObjectVersion'),
+    }, input: {} };
+    const check = async (memberId) => {
+      const authority = await resolveOrganizationMemberAuthority({ organizationId: input.organizationId, memberId });
+      let outcome = 'unexpected_success';
+      try { await validateWorkflowAutomationAction({ organizationId: input.organizationId, ownerMemberId: memberId, action }); }
+      catch (error) { outcome = error.message; }
+      return { role: authority?.role, directRole: authority?.directRole, outcome };
+    };
+    const granted = await check(input.memberId);
+    await db.update(TeamTable).set({ grantsOrganizationAdmin: false }).where(eq(TeamTable.id, input.teamId));
+    const revoked = await check(input.memberId);
+    const direct = await check(input.directId);
+    console.log(JSON.stringify({ granted, revoked, direct }));
+    process.exit(0);
+  `], {
+    cwd: fileURLToPath(new URL("../../ee/apps/den-api", import.meta.url)),
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      DATABASE_URL: den.database.url,
+      DB_MODE: "mysql",
+      DATABASE_REDIS_URL: "",
+      DEN_DB_ENCRYPTION_KEY: "local-dev-db-encryption-key-please-change-1234567890",
+      BETTER_AUTH_SECRET: "local-testkit-secret-not-for-production-use!!",
+      DEN_BASE_URL: den.ref.apiUrl,
+      OPENWORK_DEV_MODE: "1",
+      TEAM_ADMIN_TEST_INPUT: JSON.stringify({ organizationId: orgId, memberId: inheritedId, teamId: nextTeam.id, directId }),
+    },
+  });
+  const backgroundResult: unknown = JSON.parse(text(background.stdout.trim().split("\n").at(-1)));
+  expect(backgroundResult).toEqual({
+    granted: { role: "member,admin", directRole: "member", outcome: "automation_saved_script_version_not_found" },
+    revoked: { role: "member", directRole: "member", outcome: "automation_saved_script_forbidden" },
+    direct: { role: "admin", directRole: "admin", outcome: "automation_saved_script_version_not_found" },
+  });
+  await canReadAdmin(inherited, 403);
+  evidence.recordAssertionEvidence("Background workflow checks resolve current team authority", "In one server-side process, inherited Admin reaches version validation; clearing its team grant makes the next check forbidden. Direct Admin still reaches version validation without any team grant.", true);
+});

--- a/evals/specs/team-organization-admin.test.ts
+++ b/evals/specs/team-organization-admin.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { denFetch, type DenSession } from "@openwork/behaviors";
 import { server, test } from "@openwork/testkit";
 import { parseTeamAdminContext } from "./helpers/team-admin-context.ts";
+import { enableScimFixtureSso } from "./helpers/scim-fixture.ts";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected an object");
@@ -168,6 +169,7 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
   const ownerHeaders = { authorization: `Bearer ${owner.token}`, cookie: ownerCookie, "x-openwork-org-id": orgId };
   const sso = await denFetch(owner, "/v1/sso/saml", { method: "POST", headers: ownerHeaders, body: JSON.stringify({ issuer: `http://127.0.0.1/team-admin-${Date.now()}`, domain: "team-scim.test", entryPoint: "https://okta.example.test/sso", cert: "test-signing-certificate", audience: den.ref.apiUrl }) });
   expect(sso.response.status, sso.text).toBe(201);
+  await enableScimFixtureSso(den.database, orgId);
   const tokenResult = await denFetch(owner, "/v1/scim/token", { method: "POST", headers: ownerHeaders });
   expect(tokenResult.response.status, tokenResult.text).toBe(201);
   const token = text(record(tokenResult.body).scimToken);

--- a/evals/specs/team-organization-admin.test.ts
+++ b/evals/specs/team-organization-admin.test.ts
@@ -4,7 +4,7 @@ import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { denFetch, type DenSession } from "@openwork/behaviors";
 import { server, test } from "@openwork/testkit";
-import { getOrgAccessFlags, parseOrgContextPayload } from "../../ee/apps/den-web/app/(den)/_lib/den-org.ts";
+import { parseTeamAdminContext } from "./helpers/team-admin-context.ts";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected an object");
@@ -20,6 +20,7 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
   await using den = await server({
     place,
     web: false,
+    env: { DEN_AUTOMATIONS_RUNTIME_ENABLED: "true" },
     org: { name: "Team Admin Grants", members: { inherited: {}, direct: {}, superadmin: {}, control: {} } },
   });
   const owner = den.admin;
@@ -40,7 +41,7 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
   const context = async (session = owner) => {
     const result = await request(session, "/v1/org");
     expect(result.response.status, result.text).toBe(200);
-    const parsed = parseOrgContextPayload(result.body);
+    const parsed = parseTeamAdminContext(result.body);
     if (!parsed) throw new Error("Invalid org context");
     return parsed;
   };
@@ -75,12 +76,18 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
   const deniedCreate = await request(direct, "/v1/teams", "POST", { name: "Escalation", grantsOrganizationAdmin: true });
   expect(deniedCreate.response.status).toBe(403);
   await patchTeam(primary, { grantsOrganizationAdmin: true }, superadmin);
+  const keyed = await request(owner, "/v1/teams/by-key/admin-boundary", "PUT", { name: "Keyed Admins", memberIds: [inheritedId], grantsOrganizationAdmin: true });
+  expect(keyed.response.status, keyed.text).toBe(201);
+  expect((await request(direct, "/v1/teams/by-key/admin-boundary", "PUT", { name: "Keyed Admins", memberIds: [controlId] })).response.status).toBe(403);
+  expect((await request(direct, "/v1/teams/by-key/admin-boundary", "DELETE")).response.status).toBe(403);
+  expect((await request(owner, "/v1/teams/by-key/admin-boundary", "DELETE")).response.status).toBe(200);
   const granted = await context(inherited);
   expect(granted.currentMember.role).toBe("member,admin");
   expect(granted.currentMember.directRole).toBe("member");
   expect(granted.currentMember.adminTeams).toEqual([{ id: primary, name: "Operations" }]);
   expect(granted.members.find((member) => member.id === inheritedId)?.role).toBe("member");
-  expect(getOrgAccessFlags(granted.currentMember.role, granted.currentMember.isOwner)).toMatchObject({ isAdmin: true, canManageRoles: false, canManageScim: false, canTransferOwnership: false });
+  expect(granted.currentMember.isOwner).toBe(false);
+  expect(granted.currentMember.role.split(",")).not.toContain("super-admin");
   await canReadAdmin(inherited, 200);
   await canReadAdmin(control, 403);
   await patchTeam(primary, { memberIds: [inheritedId, directId, controlId] }, inherited, 403);
@@ -181,7 +188,7 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
   await canReadAdmin(inherited, 403);
   await patchTeam(managedTeam.id, { grantsOrganizationAdmin: true });
   await canReadAdmin(inherited, 200);
-  expect(getOrgAccessFlags((await context(inherited)).currentMember.role, false).canManageRoles).toBe(false);
+  expect((await context(inherited)).currentMember.role.split(",")).not.toContain("super-admin");
   await patchTeam(managedTeam.id, { memberIds: [] }, owner, 409);
   await patchTeam(managedTeam.id, { name: "manual rename" }, owner, 409);
   expect((await request(owner, `/v1/teams/${managedTeam.id}`, "DELETE")).response.status).toBe(409);
@@ -221,33 +228,33 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
 
   if (!den.database) throw new Error("The in-process background authorization check requires a fresh local testkit database.");
   await patchTeam(nextTeam.id, { grantsOrganizationAdmin: true });
-  const background = await promisify(execFile)(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
-    import { db } from './src/db.ts';
-    import { eq } from '@openwork-ee/den-db/drizzle';
-    import { TeamTable } from '@openwork-ee/den-db/schema';
-    import { createDenTypeId } from '@openwork-ee/utils/typeid';
-    import { resolveOrganizationMemberAuthority } from './src/organization-team-roles.ts';
-    import { validateWorkflowAutomationAction } from './src/workflows.ts';
+  const background = await promisify(execFile)(process.execPath, ["--input-type=module", "-e", `
+    import { createRequire } from 'node:module';
+    const { createConnection } = createRequire(import.meta.resolve('@openwork/env'))('mysql2/promise');
+    const db = await createConnection(process.env.DATABASE_URL);
     const input = JSON.parse(process.env.TEAM_ADMIN_TEST_INPUT);
+    await db.execute("UPDATE organization SET metadata = JSON_SET(metadata, '$.complimentaryAccess', JSON_OBJECT('openworkWeb', true)) WHERE id = ?", [input.organizationId]);
+    const suffix = input.teamId.slice(4);
     const action = { kind: 'saved_script', script: {
-      pluginId: createDenTypeId('plugin'), configObjectId: createDenTypeId('configObject'),
-      configObjectVersionId: createDenTypeId('configObjectVersion'),
+      pluginId: 'plg_' + suffix, configObjectId: 'cob_' + suffix,
+      configObjectVersionId: 'cov_' + suffix,
     }, input: {} };
-    const check = async (memberId) => {
-      const authority = await resolveOrganizationMemberAuthority({ organizationId: input.organizationId, memberId });
-      let outcome = 'unexpected_success';
-      try { await validateWorkflowAutomationAction({ organizationId: input.organizationId, ownerMemberId: memberId, action }); }
-      catch (error) { outcome = error.message; }
-      return { role: authority?.role, directRole: authority?.directRole, outcome };
+    const check = async (token) => {
+      const headers = { authorization: 'Bearer ' + token, 'x-openwork-org-id': input.organizationId, 'content-type': 'application/json' };
+      const context = await (await fetch(input.apiUrl + '/v1/org', { headers })).json();
+      const response = await fetch(input.apiUrl + '/v1/cloud-automations', { method: 'POST', headers, body: JSON.stringify({ name: 'Authorization boundary', schedule: { kind: 'once', timezone: 'UTC', at: Date.now() + 86400000 }, action }) });
+      const result = await response.json();
+      return { role: context.currentMember.role, directRole: context.currentMember.directRole, outcome: result.error };
     };
-    const granted = await check(input.memberId);
-    await db.update(TeamTable).set({ grantsOrganizationAdmin: false }).where(eq(TeamTable.id, input.teamId));
-    const revoked = await check(input.memberId);
-    const direct = await check(input.directId);
+    const granted = await check(input.memberToken);
+    await db.execute('UPDATE team SET grants_organization_admin = false WHERE id = ?', [input.teamId]);
+    const revoked = await check(input.memberToken);
+    const direct = await check(input.directToken);
+    await db.end();
     console.log(JSON.stringify({ granted, revoked, direct }));
     process.exit(0);
   `], {
-    cwd: fileURLToPath(new URL("../../ee/apps/den-api", import.meta.url)),
+    cwd: fileURLToPath(new URL("..", import.meta.url)),
     timeout: 30_000,
     env: {
       ...process.env,
@@ -258,7 +265,7 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
       BETTER_AUTH_SECRET: "local-testkit-secret-not-for-production-use!!",
       DEN_BASE_URL: den.ref.apiUrl,
       OPENWORK_DEV_MODE: "1",
-      TEAM_ADMIN_TEST_INPUT: JSON.stringify({ organizationId: orgId, memberId: inheritedId, teamId: nextTeam.id, directId }),
+      TEAM_ADMIN_TEST_INPUT: JSON.stringify({ organizationId: orgId, teamId: nextTeam.id, apiUrl: den.ref.apiUrl, memberToken: inherited.token, directToken: direct.token }),
     },
   });
   const backgroundResult: unknown = JSON.parse(text(background.stdout.trim().split("\n").at(-1)));
@@ -268,5 +275,5 @@ test("team Admin grants are live, scoped, protected, and cleared across SCIM lif
     direct: { role: "admin", directRole: "admin", outcome: "automation_saved_script_version_not_found" },
   });
   await canReadAdmin(inherited, 403);
-  evidence.recordAssertionEvidence("Background workflow checks resolve current team authority", "In one server-side process, inherited Admin reaches version validation; clearing its team grant makes the next check forbidden. Direct Admin still reaches version validation without any team grant.", true);
+  evidence.recordAssertionEvidence("Workflow automation admission resolves current team authority", "The live Automation API reaches version validation for inherited Admin; clearing the team grant makes the next request forbidden. Direct Admin still reaches version validation without a team grant. No Automation is created.", true);
 });


### PR DESCRIPTION
## Summary

- Add a default-off organisation Admin designation to manual and SCIM-managed teams, editable only by Owners/Super-admins.
- Resolve inherited Admin live, preserve direct roles, and display the granting teams. Protect membership, invitation, deletion and stable-key API paths from privilege escalation.
- Make SCIM projection/removal atomic and source-backed. Detaching SCIM clears inherited designation; subsequent IdP operations cannot mutate a manually reapproved team.

## Migration

`0093_team_organization_admin` adds `team.grants_organization_admin` (boolean, NOT NULL, default false). Includes generated Drizzle snapshot/journal. No deployed database was changed. Existing teams gain no permissions automatically.

## Verification

Feature verification: **Passed** on HEAD `98aa9bcfe30b36779b25da7a1ba6d6fa741b3628` in Daytona. Five tests, each exit 0, 1 passed / 0 failed / 0 skipped. Evidence is published in the PR comments.

Run from the repository root in the provisioned Daytona sandbox:

```sh
pnpm evals:pr specs/scim-team-membership-atomicity.test.ts
pnpm evals:pr specs/team-organization-admin.test.ts
OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/team-organization-admin-ui.e2e.test.ts
OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/role-change-session-survival.e2e.test.ts
OPENWORK_EVAL_E2E_TESTS=1 pnpm --dir evals exec vitest run --config vitest.config.ts --project e2e specs/scim-okta-lifecycle.e2e.test.ts
```

Also passed (exit 0):

```sh
pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false
pnpm --filter @openwork-ee/den-web exec tsc --noEmit --pretty false --incremental false
node evals/scripts/check-browser-code.mjs
git diff --check origin/dev...HEAD
```

Coverage includes checkbox persistence and inherited-role display, forbidden role/membership mutations, live grant/revoke, multiple/direct grant preservation, cross-org rejection, SCIM teardown, deterministic concurrent add/remove and PATCH behavior, rollback, orphan denial, and session/lifecycle regressions.

## Known limits / unrelated check

- `node evals/scripts/spec-boundary-ratchet.mjs` exits 1 for five unrelated engine/benchmark specs. The same command reproduced identical errors in a clean worktree at base `4d0e30ab67a0c82a347dd7a1d4d190de22e81a78`; none of this feature's specs are reported.
- Populated-deployment migration execution and the PlanetScale serverless driver were not exercised. Tests use isolated databases in Daytona.
- Browser proof covers normal Members → Teams navigation, not direct-load authentication; the SCIM checkbox is covered by the shared UI component and SCIM API tests rather than a separate SCIM browser journey.
- Full GitHub webhook/import execution and broad concurrency stress remain outside this focused proof.
