### PR TITLE
docs: explain team-inherited organization admin access

### DIFF
--- a/packages/docs/cloud/members-and-rbac.mdx
+++ b/packages/docs/cloud/members-and-rbac.mdx
@@ -1,26 +1,27 @@
 ---
 title: "Managing members and RBAC"
-description: "Invite teammates, create teams, and control Cloud access with owners, admins, members, and custom roles"
+description: "Manage owners, super-admins, admins, members, custom roles, and team-inherited Admin access, including SCIM groups"
 ---
 
-OpenWork Cloud separates org membership from team assignment. Teams are used for Collection and provider access; roles control what a person can manage across the org.
+OpenWork Cloud separates org membership from team assignment. Teams are used for Collection and provider access; roles control what a person can manage across the org. An explicitly approved team can also grant organization-wide `Admin` access to its members.
 
 ## Default roles
 
-OpenWork Cloud comes with three default roles:
+OpenWork Cloud comes with four default roles:
 
 - `Owner`: full org control, including member roles and custom roles.
-- `Admin`: can invite people, manage teams, and manage most shared Cloud resources.
+- `Super Admin` (`super-admin`): can manage organization settings, SSO, SCIM, API keys, member roles, and custom roles, as well as routine administration.
+- `Admin`: can invite `Member` users, manage ordinary teams, remove members subject to access safeguards, and manage shared Cloud resources. Cannot assign roles or change organization security settings.
 - `Member`: can use resources shared with them but cannot manage org administration.
 
-Only `Owner` can change member roles, remove members, or create, edit, and delete custom roles.
+Only owners and super-admins can change member roles, manage custom roles, or designate teams that grant `Admin`. Ownership transfer and organization deletion remain owner-only; `Owner` cannot be assigned through an invitation or the ordinary role editor.
 
 ## Invite members
 
 1. Open `Members`.
 2. On the `Members` or `Invitations` tab, click `Add member` or `Invite member`.
 3. Enter the teammate `Email`.
-4. Choose the initial `Role`.
+4. If you are an owner or super-admin, choose the initial `Role`. Admins can invite only `Member` users.
 5. Click `Send invite`.
 
 <Frame>
@@ -33,7 +34,7 @@ Invites are tied to the invited email address.
 
 When SSO just-in-time provisioning adds someone to an organization on first sign-in, OpenWork assigns the baseline `Member` role. IdP attributes such as `role`, `groups`, or `admin` are not used to grant OpenWork organization roles.
 
-Treat `Admin`, `Owner`, and custom-role elevation as explicit access changes made inside OpenWork. Review those changes in the member list and audit trail instead of relying on unvalidated IdP attributes for authorization.
+Elevated access requires an explicit OpenWork role assignment, ownership transfer, or [approved Admin team](#team-admin-access). A SAML group attribute or an identity-provider group named `Admins` does not grant a role on its own.
 
 ## Restrict who can join
 
@@ -66,6 +67,46 @@ To connect an identity provider, follow
 
 When SCIM deprovisions a user, OpenWork retains a disconnected member record for organization history. The global user is deleted only when they have no other active organization memberships. Reactivate the user through SCIM before they can regain SAML access.
 
+## Team Admin access
+
+An Admin team grants the built-in organization `Admin` role, not just administration of that team. It can be a manually managed OpenWork team or a team synchronized from a SCIM Group. Creating or syncing a team does not enable this grant automatically.
+
+### Approve an Admin team
+
+1. Sign in as an organization owner or super-admin.
+2. Open **Members -> Teams** and review the team's members.
+3. Select `Grant organisation Admin to all members of {team name}` beneath the team in the list. The same checkbox is available directly below the heading on the team's detail page, above **Overview** and **Access**.
+4. The checkbox saves immediately. In **Members**, check `Admin via {team name}` to see the source of inherited access.
+
+Only owners and super-admins can enable or clear this checkbox. Admins, including people who inherit Admin from a team, cannot designate another Admin team or change the designation of their own team.
+
+### Direct and inherited roles
+
+- A **direct role** is assigned to the person in OpenWork. Team membership does not rewrite it.
+- **Inherited Admin** is added while the person is an active organization member of an approved Admin team. Their direct role and other grants still apply.
+- Teams never grant `Owner`, `Super Admin`, or a custom role. Inherited Admin does not unlock owner/super-admin-only settings or role management.
+- Removing someone from one Admin team, or clearing that team's checkbox, removes only that source of Admin access. A direct `Admin` role or another approved Admin team still grants Admin. Changing a direct role to `Member` does not remove an existing team grant.
+
+For access reviews, inspect both the person's direct role and every team named in **Admin via**. OpenWork checks current team authority on subsequent requests; the person does not need a new sign-in for team access changes to apply.
+
+### Who manages membership
+
+For a **manually managed Admin team**, only owners and super-admins can add or remove members or delete the team. This applies whether membership is edited from the team or the member list. Admins also cannot remove an organization member with Admin team access or refresh or cancel an invitation carrying that access.
+
+For a team labeled **Managed by SCIM**, change its name and membership in the identity provider, not in OpenWork. Owners and super-admins still control the Admin checkbox in OpenWork. Approving it means trusting the identity provider's group-membership administrators to determine who receives organization Admin through that group.
+
+SCIM changes apply only after the identity provider sends them and OpenWork processes them successfully. A removal still waiting in an Entra provisioning cycle or Okta group push has not yet revoked access in OpenWork. Check provider provisioning logs, OpenWork SCIM health, and **Admin via** rather than assuming an IdP edit has taken effect. SCIM user deprovisioning removes active organization access, not just one team's grant.
+
+### SCIM mapping changes and reapproval
+
+When **Create teams from SCIM groups** is switched off in **Settings -> SCIM**, OpenWork clears the affected teams' Admin grants but retains the teams and their current memberships as manually managed teams. Retaining a team does not retain its approval to grant Admin. An owner or super-admin must review the retained membership and select the Admin checkbox again if manual Admin access is intended.
+
+While team sync is off, subsequent SCIM group renames, membership updates, or group deletion do not change the retained manual team's name, membership, or reapproved Admin grant. This does not disable SCIM user deprovisioning. Saving the already-disabled mapping mode (`metadata_only`) again does not clear a manual reapproval.
+
+Re-enabling team sync clears the Admin grant again and replaces retained manual membership with the SCIM group's membership. Review the synchronized membership before approving the team again.
+
+While team sync is enabled, deleting the SCIM Group or connector also clears the affected Admin grant. Any retained team needs explicit owner or super-admin reapproval before it can grant Admin as a manual team. Deleting the Group removes its synchronized team memberships; do not use retained team records as proof of continuing access.
+
 ## Use custom roles when needed
 
 1. Open `Members -> Roles`.
@@ -74,20 +115,21 @@ When SCIM deprovisions a user, OpenWork retains a disconnected member record for
 4. Choose the permissions that role should have.
 5. Click `Create role`.
 
-Use `security_configuration.manage` for the identity/security operator role that manages SSO, SCIM, and organization API keys. Keep it separate from day-to-day `Admin` membership operations when your organization needs separation of duties.
+Custom permissions do not bypass built-in role requirements. Managing SSO, SCIM, organization API keys, or Admin team designation requires an owner or super-admin; a custom role with `security_configuration.manage` alone is not sufficient.
 
 ## Practical access pattern
 
 A simple setup that works well for most orgs:
 
-- keep 1-2 `Owner` users
-- give day-to-day operators `Admin`
+- keep ownership with a designated, protected `Owner` account
+- reserve `Super Admin` for trusted settings and access administrators
+- give day-to-day operators direct `Admin` or membership in an approved Admin team
 - keep most people as `Member`
 - use `Teams` to decide who can see specific Collections or providers
 
 ## Notes
 
-- You cannot change the org owner's role or remove the owner.
-- Owners and admins can manage teams and invitations, but only owners can handle the sensitive RBAC changes.
-- Only owners can change `Org settings`, including allowed email domains and desktop restrictions.
+- You cannot change the org owner's role through the ordinary role editor or remove the owner; use ownership transfer when handing over control.
+- Owners, super-admins, and admins can manage ordinary teams and member invitations. Admin team access has the stricter rules described above.
+- Only owners and super-admins can change `Org settings`, including allowed email domains and desktop restrictions.
 - You cannot delete a custom role while members or pending invitations still use it.

--- a/packages/docs/cloud/scim-microsoft-entra.mdx
+++ b/packages/docs/cloud/scim-microsoft-entra.mdx
@@ -12,7 +12,7 @@ whose membership is managed by Entra.
 You need:
 
 - An OpenWork organization with Enterprise SSO and SCIM.
-- An OpenWork owner, or a member who can manage security configuration.
+- An OpenWork owner or super-admin.
 - A working, domain-verified, tested, and enabled OpenWork SAML connection.
   Complete and test
   [Microsoft Entra SAML SSO](/cloud/sso-microsoft-entra) first.
@@ -160,6 +160,19 @@ Before expanding the assignment scope, verify the complete lifecycle:
 
 Change SCIM-managed teams in Entra, not in OpenWork. OpenWork keeps manually
 created teams separate from identity-provider-managed teams.
+
+### Optional: grant organization Admin through an Entra group
+
+After verifying the synchronized membership, an OpenWork owner or super-admin
+can approve the team to grant organization `Admin`. The Entra group name and
+SAML group attributes do not grant elevated access by themselves. Follow
+[Team Admin access](/cloud/members-and-rbac#team-admin-access) for the checkbox,
+membership controls, and reapproval rules when team sync is disabled or re-enabled.
+
+Test with a member who has no direct Admin role or other Admin team grant:
+confirm `Admin via {team name}`, remove them from the Entra group, wait for
+successful provisioning, and confirm that inherited access is gone. Review
+**Provisioning logs** if the change is still pending.
 
 ## Troubleshooting
 

--- a/packages/docs/cloud/scim-okta.mdx
+++ b/packages/docs/cloud/scim-okta.mdx
@@ -12,7 +12,7 @@ You need:
 
 - A working, domain-verified, tested, and enabled
   [Okta SAML SSO](/cloud/sso-okta) connection.
-- An OpenWork owner, or a member who can manage security configuration.
+- An OpenWork owner or super-admin.
 - An Okta administrator who can configure provisioning for the SAML app.
 - An Okta plan that supports the provisioning and group-push features you
   intend to use.
@@ -147,6 +147,19 @@ After user provisioning works:
 
 Manage pushed groups in Okta, not in OpenWork. Manually created OpenWork teams
 remain independent.
+
+### Optional: grant organization Admin through an Okta group
+
+After verifying the pushed membership, an OpenWork owner or super-admin can
+approve the team to grant organization `Admin`. Neither the Okta group name nor
+SAML group attributes grant elevated access by themselves. Follow
+[Team Admin access](/cloud/members-and-rbac#team-admin-access) for the checkbox,
+membership controls, and reapproval rules when team sync is disabled or re-enabled.
+
+Test with a member who has no direct Admin role or other Admin team grant:
+confirm `Admin via {team name}`, remove them from the Okta group, wait for a
+successful group push, and confirm that inherited access is gone. Inspect the
+Okta **System Log** and OpenWork SCIM health if the change has not arrived.
 
 ## 7. Expand scope and enforce SSO
 

--- a/packages/docs/cloud/security-and-operations.mdx
+++ b/packages/docs/cloud/security-and-operations.mdx
@@ -39,13 +39,16 @@ OpenWork stores organization API keys and SCIM bearer tokens as hashes. SSO prov
 
 Use the Cloud member model as the source of truth for organization access:
 
-- Keep at least two `Owner` members.
+- Protect the `Owner` account and maintain a tested recovery path.
+- Reserve `Super Admin` for trusted settings and access administrators.
 - Use `Admin` for day-to-day operators.
 - Keep most people as `Member`.
 - Use custom roles only when the built-in roles are too broad.
 - Use teams for resource access to Collections and providers.
 
-SSO just-in-time provisioning uses `Member` as the safe default for first-login users after successful SAML authentication. The standard sign-in flow routes email addresses from verified, enabled SSO domains to SSO. A standalone email/password signup with the same domain does not grant organization membership by itself. OpenWork does not convert IdP attributes such as `role`, `groups`, or `admin` into organization roles during SSO sign-in. Elevation to `Admin`, `Owner`, or a custom role should be an explicit, reviewed, and audited change in OpenWork.
+SSO just-in-time provisioning uses `Member` as the safe default for first-login users after successful SAML authentication. The standard sign-in flow routes email addresses from verified, enabled SSO domains to SSO. A standalone email/password signup with the same domain does not grant organization membership by itself. OpenWork does not convert IdP attributes such as `role`, `groups`, or `admin` into organization roles during SSO sign-in. Elevated access requires an explicit OpenWork role assignment, ownership transfer, or approved Admin team.
+
+An owner or super-admin can approve a manual or SCIM-managed team to grant organization `Admin`. Review both direct roles and **Admin via** sources: removing one grant does not remove the others. For SCIM Admin teams, include IdP group-management permissions and provisioning delays in access reviews. See [Team Admin access](/cloud/members-and-rbac#team-admin-access) for approval, revocation, and mapping-reset safeguards.
 
 For access reviews, export the current member list, roles, teams, pending invitations, API keys, SSO configuration, and SCIM configuration on a regular cadence. Reconfirm that each member still needs their current role and team access.
 
@@ -55,8 +58,8 @@ For production organizations, use SSO with identity-provider MFA as the primary 
 
 - Enable enforced SSO for organizations that have owners, admins, SCIM, SSO, API keys, or shared production providers.
 - Require MFA, phishing-resistant factors where available, and conditional-access policy in the identity provider before users reach OpenWork Cloud.
-- Keep SSO, SCIM, and API-key management behind the `security_configuration.manage` permission. Owners receive that permission by default and can delegate it through a custom role; default admins do not receive it automatically.
-- Invitation role assignment is bounded by the inviter's own permissions, so default admins can invite standard admins or members but cannot grant delegated security-configuration access unless they already hold that permission.
+- Keep SSO, SCIM, API-key management, and Admin team designation with owners and super-admins. Direct or inherited `Admin`, or a custom role with `security_configuration.manage` alone, does not satisfy those role requirements.
+- Admins can invite only `Member` users. Owners and super-admins can assign other permitted invitation roles, but not `Owner`; ownership requires transfer.
 - The server requires a session created in the last 15 minutes before privileged routes can change SSO, SCIM, API keys, organization settings, custom roles, member roles, billing, or inference settings.
 - Do not rely on standalone email/password accounts for production owner access unless the deployment has an equivalent MFA and recovery control outside OpenWork.
 

--- a/packages/docs/cloud/sso-google-workspace.mdx
+++ b/packages/docs/cloud/sso-google-workspace.mdx
@@ -14,7 +14,7 @@ complete a real authentication test, and explicitly enable SSO.
 You need:
 
 - An OpenWork organization with the Enterprise SSO entitlement.
-- An OpenWork owner, or a member who can manage security configuration.
+- An OpenWork owner or super-admin.
 - A Google Workspace super administrator who can create custom SAML apps.
 - Control of DNS for the email domain you will associate with the connection.
 - The final OpenWork auth origin, for example `https://app.openworklabs.com`.
@@ -114,8 +114,9 @@ unless your organization needs them. OpenWork's baseline SSO identity comes from
 NameID / primary email.
 
 If Google shows **Group membership (optional)**, leave it blank for the SSO
-test. Use SCIM-managed teams or another documented team-management process for
-authorization after SSO is working.
+test. This mapping does not create OpenWork teams or grant organization roles.
+Google custom SAML apps do not provide a generic outbound SCIM connector; see
+[Google Workspace SCIM support](/cloud/scim-google-workspace).
 
 Select **Finish**.
 
@@ -186,8 +187,10 @@ profile or suspension changes. If that user later completes SSO, OpenWork can
 link the matching account and provision the organization membership through SSO.
 
 OpenWork does not convert SAML attributes such as `role`, `groups`, or `admin`
-into elevated organization roles. Assign `Admin`, `Owner`, or custom roles in
-OpenWork after review, or through an invitation that grants the intended role.
+into elevated organization roles. Owners and super-admins assign roles in
+OpenWork; ownership changes require ownership transfer. You can use a manually
+managed OpenWork team for [Team Admin access](/cloud/members-and-rbac#team-admin-access),
+but its membership will not synchronize from Google groups through SAML.
 
 ## Troubleshooting
 

--- a/packages/docs/cloud/sso-microsoft-entra.mdx
+++ b/packages/docs/cloud/sso-microsoft-entra.mdx
@@ -15,7 +15,7 @@ members and groups automatically.
 You need:
 
 - An OpenWork organization with the Enterprise SSO entitlement.
-- Owner or admin access in that OpenWork organization.
+- Owner or super-admin access in that OpenWork organization.
 - Admin access to a Microsoft Entra enterprise application.
 - The final OpenWork auth origin, for example `https://app.openworklabs.com`.
 
@@ -140,8 +140,11 @@ SSO, OpenWork can link the matching account and provision the organization
 membership through SSO.
 
 OpenWork does not convert SAML attributes such as `role`, `groups`, or `admin`
-into elevated organization roles. Assign `Admin`, `Owner`, or custom roles in
-OpenWork after review, or through an invitation that grants the intended role.
+into elevated organization roles. Owners and super-admins assign roles in
+OpenWork; ownership changes require ownership transfer. For group-based Admin,
+first configure [Entra SCIM provisioning](/cloud/scim-microsoft-entra), then
+explicitly approve the synchronized team using
+[Team Admin access](/cloud/members-and-rbac#team-admin-access).
 
 ## Troubleshooting
 

--- a/packages/docs/cloud/sso-okta.mdx
+++ b/packages/docs/cloud/sso-okta.mdx
@@ -14,7 +14,7 @@ synchronize members and groups.
 
 You need:
 
-- An OpenWork owner, or a member who can manage security configuration.
+- An OpenWork owner or super-admin.
 - An Okta administrator who can create and assign application integrations.
 - Control of DNS for the email domain you will associate with the connection.
 - The final HTTPS OpenWork web origin, for example
@@ -185,8 +185,11 @@ SSO, OpenWork can link the matching account and provision the organization
 membership through SSO.
 
 OpenWork does not convert SAML attributes such as `role`, `groups`, or `admin`
-into elevated organization roles. Assign `Admin`, `Owner`, or custom roles in
-OpenWork after review, or through an invitation that grants the intended role.
+into elevated organization roles. Owners and super-admins assign roles in
+OpenWork; ownership changes require ownership transfer. For group-based Admin,
+first configure [Okta SCIM provisioning](/cloud/scim-okta), then explicitly
+approve the synchronized team using
+[Team Admin access](/cloud/members-and-rbac#team-admin-access).
 
 ## Troubleshooting
 

--- a/packages/docs/cloud/team-quickstart.mdx
+++ b/packages/docs/cloud/team-quickstart.mdx
@@ -47,7 +47,7 @@ You land in the admin dashboard with a short setup checklist. You can follow it 
 
 ## 2. Invite teammates and create teams
 
-Open **Members** in the sidebar. Click **Add member**, enter your teammate's email, pick a role (Member or Admin), and hit **Send invite**.
+Open **Members** in the sidebar. Click **Add member**, enter your teammate's email, pick a role (usually Member), and hit **Send invite**. Owners and super-admins can choose elevated roles; admins can invite only members.
 
 <Frame>
   ![Invite a teammate](/images/cloud-team-quickstart/05-invite-member-form.png)
@@ -80,6 +80,11 @@ Teams show up with their members at a glance:
 <Frame>
   ![Teams list](/images/cloud-team-quickstart/10-teams-list.png)
 </Frame>
+
+Leave the organization Admin checkbox off for ordinary resource-sharing teams
+such as `Sales`. If a team should grant organization-wide administration, an
+owner or super-admin must explicitly approve it. See
+[Team Admin access](/cloud/members-and-rbac#team-admin-access).
 
 ## 3. Create a plugin with a test skill
 


### PR DESCRIPTION
## Summary

Follow-up to #4617, scoped entirely to `packages/docs`.

- Add the canonical Team Admin access section in Members and RBAC, covering checkbox setup, direct vs inherited roles, protected membership, revocation, and SCIM disable/reapproval/re-enable behavior.
- Link it from Entra and Okta SCIM and SSO guides, Google Workspace SSO, security operations, and the team quickstart.
- Correct related Owner/Super-admin/Admin permission descriptions and distinguish explicit group approval from SAML attributes. Preserve the Google Workspace SCIM limitation.

## Verification — Passed

Both commands ran from `packages/docs`, exit 0:

```sh
pnpm --config.node-linker=hoisted --config.enable-global-virtual-store=false --package=mint@4.2.868 --package=openapi-types@12.1.3 dlx mint validate
pnpm --config.node-linker=hoisted --config.enable-global-virtual-store=false --package=mint@4.2.868 --package=openapi-types@12.1.3 dlx mint broken-links
```

Build validation passed; no broken links found. `git diff --check` passed. Checked the canonical anchor and seven incoming links against the merged implementation.

Runtime proof skipped under the docs-only exception; no application behavior or dependencies changed. The explicit CLI package parameters resolve a missing `openapi-types` dependency in the plain Mintlify launch without modifying repository dependencies.